### PR TITLE
fix: update skill file references to include SKILL.md path

### DIFF
--- a/plugins/agentic-dev-team/commands/agent-skill-authoring.md
+++ b/plugins/agentic-dev-team/commands/agent-skill-authoring.md
@@ -6,6 +6,6 @@ argument-hint: "<description>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/agent-skill-authoring.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/agent-skill-authoring/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/api-design.md
+++ b/plugins/agentic-dev-team/commands/api-design.md
@@ -6,6 +6,6 @@ argument-hint: "<endpoint-or-service>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/api-design.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/api-design/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/code-review.md
+++ b/plugins/agentic-dev-team/commands/code-review.md
@@ -344,7 +344,7 @@ orchestrator direction.
 **Static analysis context**: If the static analysis pre-pass (step 2b)
 produced findings, inject them into **every** review agent's prompt
 using the agent context injection format defined in
-`skills/static-analysis-integration.md`. This tells agents:
+`skills/static-analysis-integration/SKILL.md`. This tells agents:
 "These issues were detected by static analysis tools. Do not re-report
 them. Focus on semantic and architectural concerns."
 

--- a/plugins/agentic-dev-team/commands/competitive-analysis.md
+++ b/plugins/agentic-dev-team/commands/competitive-analysis.md
@@ -10,6 +10,6 @@ user-invocable: true
 allowed-tools: Read, Glob, Grep, Write, WebFetch, WebSearch, Bash(date *), Bash(ls *)
 ---
 
-Apply the guidelines defined in skills/competitive-analysis.md to the current task. Read the skill file and follow its analysis framework, steps, and output format.
+Apply the guidelines defined in skills/competitive-analysis/SKILL.md to the current task. Read the skill file and follow its analysis framework, steps, and output format.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/context-loading-protocol.md
+++ b/plugins/agentic-dev-team/commands/context-loading-protocol.md
@@ -6,6 +6,6 @@ argument-hint: "<task-description>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/context-loading-protocol.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/context-loading-protocol/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/context-summarization.md
+++ b/plugins/agentic-dev-team/commands/context-summarization.md
@@ -6,6 +6,6 @@ argument-hint: ""
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/context-summarization.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/context-summarization/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/domain-analysis.md
+++ b/plugins/agentic-dev-team/commands/domain-analysis.md
@@ -6,6 +6,6 @@ argument-hint: "<scope-or-question>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/domain-analysis.md to the current task. Read the skill file and follow its analysis framework, steps, and output format.
+Apply the guidelines defined in skills/domain-analysis/SKILL.md to the current task. Read the skill file and follow its analysis framework, steps, and output format.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/domain-driven-design.md
+++ b/plugins/agentic-dev-team/commands/domain-driven-design.md
@@ -6,6 +6,6 @@ argument-hint: "<domain-or-context>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/domain-driven-design.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/domain-driven-design/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/feedback-learning.md
+++ b/plugins/agentic-dev-team/commands/feedback-learning.md
@@ -6,6 +6,6 @@ argument-hint: "<feedback>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/feedback-learning.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/feedback-learning/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/governance-compliance.md
+++ b/plugins/agentic-dev-team/commands/governance-compliance.md
@@ -6,6 +6,6 @@ argument-hint: "<scope>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/governance-compliance.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/governance-compliance/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/hexagonal-architecture.md
+++ b/plugins/agentic-dev-team/commands/hexagonal-architecture.md
@@ -6,6 +6,6 @@ argument-hint: "<scope-or-question>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/hexagonal-architecture.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/hexagonal-architecture/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/human-oversight-protocol.md
+++ b/plugins/agentic-dev-team/commands/human-oversight-protocol.md
@@ -6,6 +6,6 @@ argument-hint: "<scope>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/human-oversight-protocol.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/human-oversight-protocol/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/legacy-code.md
+++ b/plugins/agentic-dev-team/commands/legacy-code.md
@@ -6,6 +6,6 @@ argument-hint: "<file-or-module>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/legacy-code.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/legacy-code/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/mutation-testing.md
+++ b/plugins/agentic-dev-team/commands/mutation-testing.md
@@ -6,7 +6,7 @@ argument-hint: "<source-file-or-module>"
 user-invocable: true
 ---
 
-Read skills/mutation-testing.md and follow its 5-step procedure exactly:
+Read skills/mutation-testing/SKILL.md and follow its 5-step procedure exactly:
 
 1. **Detect tooling** — find the project's mutation testing tool (Stryker, pitest, mutmut). If none is installed, help set one up. Do NOT proceed without a real tool.
 2. **Run the tool** — scoped to the target files. Capture full output.

--- a/plugins/agentic-dev-team/commands/performance-metrics.md
+++ b/plugins/agentic-dev-team/commands/performance-metrics.md
@@ -6,6 +6,6 @@ argument-hint: ""
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/performance-metrics.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/performance-metrics/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/quality-gate-pipeline.md
+++ b/plugins/agentic-dev-team/commands/quality-gate-pipeline.md
@@ -6,6 +6,6 @@ argument-hint: "<scope>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/quality-gate-pipeline.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/quality-gate-pipeline/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/specs.md
+++ b/plugins/agentic-dev-team/commands/specs.md
@@ -9,6 +9,6 @@ argument-hint: "<feature-description>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/specs.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/specs/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/threat-modeling.md
+++ b/plugins/agentic-dev-team/commands/threat-modeling.md
@@ -6,6 +6,6 @@ argument-hint: "<system-or-endpoint>"
 user-invocable: true
 ---
 
-Apply the guidelines defined in skills/threat-modeling.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
+Apply the guidelines defined in skills/threat-modeling/SKILL.md to the current task. Read the skill file and follow its procedures, checklists, and protocols.
 
 Apply this skill to: $ARGUMENTS

--- a/plugins/agentic-dev-team/commands/triage.md
+++ b/plugins/agentic-dev-team/commands/triage.md
@@ -24,7 +24,7 @@ Arguments: $ARGUMENTS
 
 ### 2. Investigate
 
-Apply the systematic debugging protocol from `skills/systematic-debugging.md`:
+Apply the systematic debugging protocol from `skills/systematic-debugging/SKILL.md`:
 
 1. **Reproduce**: Run the failing test or trigger the error
 2. **Investigate**: Trace data flow, check recent changes, find working reference code

--- a/plugins/agentic-dev-team/knowledge/agent-registry.md
+++ b/plugins/agentic-dev-team/knowledge/agent-registry.md
@@ -51,36 +51,36 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 
 | Skill | File | ~Tokens | Used By |
 |-------|------|---------|---------|
-| Context Loading Protocol | `skills/context-loading-protocol.md` | 600 | Orchestrator |
-| Context Summarization | `skills/context-summarization.md` | 500 | Orchestrator |
-| Feedback & Learning | `skills/feedback-learning.md` | 1,010 | Orchestrator |
-| Human Oversight Protocol | `skills/human-oversight-protocol.md` | 1,020 | Orchestrator, Product Manager |
-| Performance Metrics | `skills/performance-metrics.md` | 890 | Orchestrator |
-| Quality Gate Pipeline | `skills/quality-gate-pipeline.md` | 900 | All agents |
-| Governance & Compliance | `skills/governance-compliance.md` | 990 | QA Engineer, Technical Writer |
-| Agent & Skill Authoring | `skills/agent-skill-authoring.md` | 990 | Orchestrator |
-| Hexagonal Architecture | `skills/hexagonal-architecture.md` | 420 | Architect, Software Engineer |
-| Domain-Driven Design | `skills/domain-driven-design.md` | 710 | Architect, Software Engineer, Product Manager |
-| Domain Analysis | `skills/domain-analysis.md` | 650 | Architect, Product Manager, Orchestrator |
-| Specs | `skills/specs.md` | 800 | Product Manager, Architect, QA Engineer, Orchestrator |
-| Threat Modeling | `skills/threat-modeling.md` | 600 | Security Engineer, Architect |
-| API Design | `skills/api-design.md` | 600 | Architect, Software Engineer |
-| Legacy Code | `skills/legacy-code.md` | 700 | Software Engineer, QA Engineer, Architect |
-| Mutation Testing | `skills/mutation-testing.md` | 700 | QA Engineer, Software Engineer |
+| Context Loading Protocol | `skills/context-loading-protocol/SKILL.md` | 600 | Orchestrator |
+| Context Summarization | `skills/context-summarization/SKILL.md` | 500 | Orchestrator |
+| Feedback & Learning | `skills/feedback-learning/SKILL.md` | 1,010 | Orchestrator |
+| Human Oversight Protocol | `skills/human-oversight-protocol/SKILL.md` | 1,020 | Orchestrator, Product Manager |
+| Performance Metrics | `skills/performance-metrics/SKILL.md` | 890 | Orchestrator |
+| Quality Gate Pipeline | `skills/quality-gate-pipeline/SKILL.md` | 900 | All agents |
+| Governance & Compliance | `skills/governance-compliance/SKILL.md` | 990 | QA Engineer, Technical Writer |
+| Agent & Skill Authoring | `skills/agent-skill-authoring/SKILL.md` | 990 | Orchestrator |
+| Hexagonal Architecture | `skills/hexagonal-architecture/SKILL.md` | 420 | Architect, Software Engineer |
+| Domain-Driven Design | `skills/domain-driven-design/SKILL.md` | 710 | Architect, Software Engineer, Product Manager |
+| Domain Analysis | `skills/domain-analysis/SKILL.md` | 650 | Architect, Product Manager, Orchestrator |
+| Specs | `skills/specs/SKILL.md` | 800 | Product Manager, Architect, QA Engineer, Orchestrator |
+| Threat Modeling | `skills/threat-modeling/SKILL.md` | 600 | Security Engineer, Architect |
+| API Design | `skills/api-design/SKILL.md` | 600 | Architect, Software Engineer |
+| Legacy Code | `skills/legacy-code/SKILL.md` | 700 | Software Engineer, QA Engineer, Architect |
+| Mutation Testing | `skills/mutation-testing/SKILL.md` | 700 | QA Engineer, Software Engineer |
 
 
-| Test-Driven Development | `skills/test-driven-development.md` | 600 | Software Engineer, QA Engineer, Orchestrator |
-| Systematic Debugging | `skills/systematic-debugging.md` | 600 | Software Engineer, QA Engineer |
-| Design Doc | `skills/design-doc.md` | 500 | Architect, Product Manager, Orchestrator |
-| Branch Workflow | `skills/branch-workflow.md` | 450 | Orchestrator, Software Engineer |
-| CI Debugging | `skills/ci-debugging.md` | 550 | DevOps/SRE Engineer, Software Engineer, QA Engineer |
-| Test Design Reviewer | `skills/test-design-reviewer.md` | 600 | QA Engineer, test-review |
-| Browser Testing | `skills/browser-testing.md` | 700 | QA Engineer |
-| Competitive Analysis | `skills/competitive-analysis.md` | 600 | Orchestrator, Product Manager |
-| Design Interrogation | `skills/design-interrogation.md` | 500 | Architect, Product Manager, Orchestrator |
-| Design It Twice | `skills/design-it-twice.md` | 550 | Architect, Software Engineer |
-| Static Analysis Integration | `skills/static-analysis-integration.md` | 650 | Orchestrator, `/code-review` |
-| Feature File Validation | `skills/feature-file-validation.md` | 700 | test-review, QA Engineer, spec-compliance-review |
+| Test-Driven Development | `skills/test-driven-development/SKILL.md` | 600 | Software Engineer, QA Engineer, Orchestrator |
+| Systematic Debugging | `skills/systematic-debugging/SKILL.md` | 600 | Software Engineer, QA Engineer |
+| Design Doc | `skills/design-doc/SKILL.md` | 500 | Architect, Product Manager, Orchestrator |
+| Branch Workflow | `skills/branch-workflow/SKILL.md` | 450 | Orchestrator, Software Engineer |
+| CI Debugging | `skills/ci-debugging/SKILL.md` | 550 | DevOps/SRE Engineer, Software Engineer, QA Engineer |
+| Test Design Reviewer | `skills/test-design-reviewer/SKILL.md` | 600 | QA Engineer, test-review |
+| Browser Testing | `skills/browser-testing/SKILL.md` | 700 | QA Engineer |
+| Competitive Analysis | `skills/competitive-analysis/SKILL.md` | 600 | Orchestrator, Product Manager |
+| Design Interrogation | `skills/design-interrogation/SKILL.md` | 500 | Architect, Product Manager, Orchestrator |
+| Design It Twice | `skills/design-it-twice/SKILL.md` | 550 | Architect, Software Engineer |
+| Static Analysis Integration | `skills/static-analysis-integration/SKILL.md` | 650 | Orchestrator, `/code-review` |
+| Feature File Validation | `skills/feature-file-validation/SKILL.md` | 700 | test-review, QA Engineer, spec-compliance-review |
 | Docker Image Create | `skills/docker-image-create/SKILL.md` | 800 | DevOps/SRE Engineer, Software Engineer |
 | Docker Image Audit | `skills/docker-image-audit/SKILL.md` | 750 | Orchestrator (inline review), DevOps/SRE Engineer, Security Engineer |
 | Performance Benchmark | `skills/performance-benchmark/SKILL.md` | 800 | QA Engineer, DevOps/SRE Engineer, `/benchmark` command |

--- a/plugins/agentic-dev-team/skills/context-loading-protocol/SKILL.md
+++ b/plugins/agentic-dev-team/skills/context-loading-protocol/SKILL.md
@@ -40,21 +40,21 @@ These are the measured sizes of each loadable file. CLAUDE.md is always loaded a
 
 | Skill | File | ~Tokens |
 | --- | --- | --- |
-| Context Loading Protocol | `skills/context-loading-protocol.md` | ~600 |
-| Context Summarization | `skills/context-summarization.md` | ~500 |
-| Feedback & Learning | `skills/feedback-learning.md` | ~1,010 |
-| Human Oversight Protocol | `skills/human-oversight-protocol.md` | ~1,020 |
-| Performance Metrics | `skills/performance-metrics.md` | ~890 |
-| Quality Gate Pipeline | `skills/quality-gate-pipeline.md` | ~900 |
-| Governance & Compliance | `skills/governance-compliance.md` | ~990 |
-| Agent & Skill Authoring | `skills/agent-skill-authoring.md` | ~990 |
-| Hexagonal Architecture | `skills/hexagonal-architecture.md` | ~420 |
-| Domain-Driven Design | `skills/domain-driven-design.md` | ~710 |
-| Specs | `skills/specs.md` | ~800 |
-| Threat Modeling | `skills/threat-modeling.md` | ~600 |
-| API Design | `skills/api-design.md` | ~600 |
-| Legacy Code | `skills/legacy-code.md` | ~700 |
-| Mutation Testing | `skills/mutation-testing.md` | ~700 |
+| Context Loading Protocol | `skills/context-loading-protocol/SKILL.md` | ~600 |
+| Context Summarization | `skills/context-summarization/SKILL.md` | ~500 |
+| Feedback & Learning | `skills/feedback-learning/SKILL.md` | ~1,010 |
+| Human Oversight Protocol | `skills/human-oversight-protocol/SKILL.md` | ~1,020 |
+| Performance Metrics | `skills/performance-metrics/SKILL.md` | ~890 |
+| Quality Gate Pipeline | `skills/quality-gate-pipeline/SKILL.md` | ~900 |
+| Governance & Compliance | `skills/governance-compliance/SKILL.md` | ~990 |
+| Agent & Skill Authoring | `skills/agent-skill-authoring/SKILL.md` | ~990 |
+| Hexagonal Architecture | `skills/hexagonal-architecture/SKILL.md` | ~420 |
+| Domain-Driven Design | `skills/domain-driven-design/SKILL.md` | ~710 |
+| Specs | `skills/specs/SKILL.md` | ~800 |
+| Threat Modeling | `skills/threat-modeling/SKILL.md` | ~600 |
+| API Design | `skills/api-design/SKILL.md` | ~600 |
+| Legacy Code | `skills/legacy-code/SKILL.md` | ~700 |
+| Mutation Testing | `skills/mutation-testing/SKILL.md` | ~700 |
 
 ### Always-Loaded Baseline
 | Item | ~Tokens |
@@ -117,7 +117,7 @@ Instruct the Orchestrator to load files using the Read tool:
 
 ```
 Read agents/software-engineer.md    → load persona
-Read skills/hexagonal-architecture.md → load skill
+Read skills/hexagonal-architecture/SKILL.md → load skill
 ```
 
 Do NOT load files by copy-pasting their contents into the system prompt or conversation. Use tool-based file reads so the content is available but retrievable on demand.

--- a/plugins/agentic-dev-team/skills/domain-analysis/SKILL.md
+++ b/plugins/agentic-dev-team/skills/domain-analysis/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 
 Assess the domain health of an existing multi-component system. Produce a structured report covering bounded context boundaries, context map relationships, domain event flows, value stream throughput, and a friction report identifying where the architecture inhibits continuous delivery.
 
-This skill is analytical, not prescriptive. It describes what *is*, not what should be built. For greenfield design, use `skills/domain-driven-design.md`. For code-level violations (anemic model, missing DTOs, wrong layer), use `agents/domain-review.md`.
+This skill is analytical, not prescriptive. It describes what *is*, not what should be built. For greenfield design, use `skills/domain-driven-design/SKILL.md`. For code-level violations (anemic model, missing DTOs, wrong layer), use `agents/domain-review.md`.
 
 ## Scope
 


### PR DESCRIPTION
Bugfix for this issue:
https://github.com/bdfinst/agentic-dev-team/issues/15
Where skills were referenced at a path that didnt exist physically causing the commands to sometimes fail depending on how hard the ai look for the skill files.
