### PR TITLE
feat(knowledge): adversarial review protocol, design smells, object calisthenics, testability patterns

### DIFF
--- a/plugins/agentic-dev-team/CLAUDE.md
+++ b/plugins/agentic-dev-team/CLAUDE.md
@@ -43,11 +43,11 @@ Full registry tables with token counts, model tiers, and used-by mappings are in
 
 **Review agents** (19): spec-compliance-review, a11y-review, arch-review, claude-setup-review, complexity-review, concurrency-review, doc-review, domain-review, js-fp-review, naming-review, performance-review, security-review, structure-review, svelte-review, test-review, token-efficiency-review, refactoring-review, progress-guardian, data-flow-tracer
 
-**Skills** (33): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Browser Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming
+**Skills** (34): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Browser Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming, Ubiquitous Language
 
 **Subagent prompt templates** (8): `prompts/implementer.md`, `prompts/spec-reviewer.md`, `prompts/quality-reviewer.md`, `prompts/plan-reviewer.md`, `prompts/plan-review-acceptance.md`, `prompts/plan-review-design.md`, `prompts/plan-review-ux.md`, `prompts/plan-review-strategic.md`
 
-**Knowledge files** (6): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment
+**Knowledge files** (11): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns
 
 **Agent templates** (9): ts-enforcer, esm-enforcer, react-testing, front-end-testing, twelve-factor-audit, python-quality, go-quality, csharp-quality, angular-testing (in `templates/agents/`, scaffolded by `/setup`)
 

--- a/plugins/agentic-dev-team/agents/arch-review.md
+++ b/plugins/agentic-dev-team/agents/arch-review.md
@@ -96,6 +96,10 @@ Grep for patterns that architecture documentation explicitly bans:
 - Direct `fetch`/`axios`/`HttpClient` calls outside designated HTTP adapter layer
 - Direct DB client calls outside designated repository layer
 
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (arch-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
+
 ## Ignore
 
 Code style, naming conventions, test coverage, domain modeling correctness (handled by other agents)

--- a/plugins/agentic-dev-team/agents/complexity-review.md
+++ b/plugins/agentic-dev-team/agents/complexity-review.md
@@ -67,7 +67,7 @@ Cognitive load:
 
 ## Self-Challenge
 
-After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (structure-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md`. Use the structure-review challenge questions (the nearest applicable section — no complexity-specific section exists). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/agents/complexity-review.md
+++ b/plugins/agentic-dev-team/agents/complexity-review.md
@@ -20,6 +20,10 @@ Confidence: high=threshold violation (function >N lines, nesting >N levels); med
 Model tier: small
 Context needs: full-file
 
+## Knowledge Files
+
+Read `knowledge/object-calisthenics.md` before analysis. The nine rules provide design pressure thresholds that complement the numeric limits below (especially rule 1: one indentation level, rule 7: small entities, rule 2: no else).
+
 ## Skip
 
 Return `{"status": "skip", "issues": [], "summary": "No code files in target"}` when:
@@ -60,6 +64,10 @@ Cognitive load:
 
 - Too many concepts per function
 - Non-obvious control flow
+
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (structure-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/agents/domain-review.md
+++ b/plugins/agentic-dev-team/agents/domain-review.md
@@ -1,7 +1,7 @@
 ---
 name: domain-review
 description: Domain boundaries, abstraction leaks, business logic placement
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Skill
 model: opus
 ---
 
@@ -80,6 +80,14 @@ Anemic domain model:
 
 - Entities or aggregates that are pure data holders (only getters/setters, no behavior) while all logic lives in services — suggest moving invariant enforcement and state transitions onto the entity
 - Entities that allow external callers to set internal state directly instead of through intention-revealing methods (e.g., setting a status field directly rather than calling a method like `markPaid()` or `Submit()`)
+
+## Skills
+
+- [Ubiquitous Language](../skills/ubiquitous-language/SKILL.md) — invoke when the user asks to "build the glossary", "extract domain terms", or "document the ubiquitous language". Also invoke when domain-review findings show pervasive terminology inconsistency (3+ different names for the same concept across the codebase).
+
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (domain-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/agents/naming-review.md
+++ b/plugins/agentic-dev-team/agents/naming-review.md
@@ -20,6 +20,10 @@ Confidence: high=mechanical (add is/has prefix, extract magic value to constant)
 Model tier: small
 Context needs: diff-only
 
+## Knowledge Files
+
+Read the "Naming Offender Catalog" section of `knowledge/design-smells.md` before analysis. It contains: abbreviation anti-patterns with fix pairs, generic verb offenders, misleading name patterns, and type-encoded name examples — as well as the "What NOT to flag" list to avoid false positives.
+
 ## Skip
 
 Return `{"status": "skip", "issues": [], "summary": "No code files with nameable symbols"}` when:

--- a/plugins/agentic-dev-team/agents/security-review.md
+++ b/plugins/agentic-dev-team/agents/security-review.md
@@ -97,7 +97,7 @@ Return `{"status": "skip", "issues": [], "summary": "No source files with securi
 
 Every review run examines these file classes in addition to the primary source tree, because security-relevant content in them often escapes the `src/` tree walk:
 
-- CI/CD workflow files: `.github/workflows/*.{yml,yaml}`, `.gitlab-ci.yml`, `.gitlab/**/*.{yml,yaml}`, `.circleci/config.yml`, `azure-pipelines.yml`, `bitbucket-pipelines.yml`, `Jenkinsfile`, `jenkinsfile.d/**`. Check each for: `printenv` / `env | ` in `run:` blocks, `continue-on-error: true` on security-scanning steps, excessive `permissions:` (especially `contents: write` + `id-token: write` combined), hardcoded PAT / API-key patterns, `npm audit` / `pip audit` behind `continue-on-error`, auto-version commit steps with write permissions.
+- CI/CD workflow files: `.github/workflows/*.{yml,yaml}`, `.gitlab-ci.yml`, `.gitlab/**/*.{yml,yaml}`, `.circleci/config.yml`, `azure-pipelines.yml`, `bitbucket-pipelines.yml`, `Jenkinsfile`, `jenkinsfile.d/**`. Check each for: `printenv` / `env |` in `run:` blocks, `continue-on-error: true` on security-scanning steps, excessive `permissions:` (especially `contents: write` + `id-token: write` combined), hardcoded PAT / API-key patterns, `npm audit` / `pip audit` behind `continue-on-error`, auto-version commit steps with write permissions.
 - Dockerfiles: `Dockerfile`, `Dockerfile.*`, `*.dockerfile`. Check for: final-stage `USER` directive absent, unpinned base images (no `@sha256:` or `:<version>`), secrets COPYed from build context, `--trusted-host *` in pip invocations, apt-get / curl pipelines running as root.
 - Infrastructure manifests: `docker-compose*.yml`, `helm/**/*.yaml`, `k8s/**/*.yaml`, `terraform/**/*.tf`. Check for: hardcoded credentials, overly permissive RBAC, missing resource limits, missing NetworkPolicy, container security context (privileged, allowPrivilegeEscalation).
 
@@ -165,6 +165,10 @@ Input:
 - Unsafe file uploads
 - Insecure deserialization
 - Open redirects
+
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (security-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/agents/spec-compliance-review.md
+++ b/plugins/agentic-dev-team/agents/spec-compliance-review.md
@@ -18,21 +18,25 @@ This agent answers one question: **does the code do what the spec says?** It run
 ## Detection Patterns
 
 ### Unmet acceptance criteria
+
 - Read acceptance criteria from the design doc and/or feature file
 - For each criterion, locate the implementation that satisfies it
 - For each criterion, locate the test that validates it
 - Flag criteria with no implementation or no test
 
 ### Uncovered scenarios
+
 - Read BDD scenarios from feature files
 - For each scenario, locate the corresponding test
 - Flag scenarios with no test or with a test that doesn't match the scenario steps
 
 ### Scope violations
+
 - Identify code changes not traceable to any acceptance criterion
 - Flag unrequested features, refactoring, or behavior changes beyond spec
 
 ### Plan deviation
+
 - Compare the implementation to the plan's file-change list
 - Flag files modified that aren't in the plan (unless trivially related)
 - Flag planned changes that weren't made
@@ -60,6 +64,13 @@ This agent answers one question: **does the code do what the spec says?** It run
   "summary": "<one line>"
 }
 ```
+
+## Skip
+
+Return `{"status": "skip", "issues": [], "summary": "No spec artifacts found"}` when:
+
+- No plan file, feature file, design doc, or acceptance criteria can be located for the target
+- Target is a standalone script or utility with no associated specification
 
 ## Severity Rules
 

--- a/plugins/agentic-dev-team/agents/structure-review.md
+++ b/plugins/agentic-dev-team/agents/structure-review.md
@@ -20,6 +20,10 @@ Confidence: high=mechanical extraction (duplicate block → shared function); me
 Model tier: mid
 Context needs: full-file
 
+## Knowledge Files
+
+Read `knowledge/design-smells.md` and `knowledge/object-calisthenics.md` before analysis.
+
 ## Skip
 
 Return `{"status": "skip", "issues": [], "summary": "No multi-module code to analyze"}` when:
@@ -60,6 +64,15 @@ Organization:
 - Non-functional assets in API projects — static web assets (CSS, JS,
   images, fonts) shipped in projects that serve only JSON/XML API
   responses with no UI
+
+Design smells:
+
+- For SRP violations and coupling issues, map to the smell → pattern table in `knowledge/design-smells.md`. Every finding should name the smell, quote the code, and include a refactor sketch.
+- For method-level issues (nesting, long methods, flag arguments), check Object Calisthenics rules 1-2 and 7 in `knowledge/object-calisthenics.md`.
+
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (structure-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/agents/test-review.md
+++ b/plugins/agentic-dev-team/agents/test-review.md
@@ -20,6 +20,10 @@ Confidence: high=mechanical fix (add missing await, stub clock, extract constant
 Model tier: mid
 Context needs: full-file
 
+## Knowledge Files
+
+Read `knowledge/testability-patterns.md` before analysis. When flagging untestable code (missing interfaces, static factories, concrete class coupling), use the decision flow and anti-patterns table to specify the required production code change — never recommend a test workaround (reflection, InternalsVisibleTo, mocking concrete classes).
+
 ## Skills
 
 - [Feature File Validation](../skills/feature-file-validation/SKILL.md) - invoke when `.feature` files or step definition files are in the target; validates Gherkin quality, determinism, implementation independence, and test automation coverage
@@ -81,6 +85,16 @@ Test code quality:
 - Copy-pasted assertion blocks that should be extracted into a helper
 - Magic literal values in assertions with no explanation of their significance
 - Dead test utilities or helpers that are defined but never called
+
+Testability blockers:
+
+- Code under test that cannot be constructed with known values (static factories, singletons, no injectable constructor) — flag as error; per `knowledge/testability-patterns.md`, the production code must change, not the test approach
+- Mocking of concrete classes (not interfaces) — flag as warning; extract an interface for the dependency
+- Tests using reflection into private members as primary strategy — flag as warning; the public API surface needs expanding
+
+## Self-Challenge
+
+After producing findings, run the adversarial challenge pass from `knowledge/adversarial-review-protocol.md` (test-review challenge questions). Append confidence level (High/Medium/Low) to the `summary` field.
 
 ## Ignore
 

--- a/plugins/agentic-dev-team/commands/build.md
+++ b/plugins/agentic-dev-team/commands/build.md
@@ -45,11 +45,13 @@ Read the plan file. If the status is not `approved`, ask the user: "This plan ha
 Before implementation begins, dispatch a spec-compliance-review subagent in **criteria verification mode** (see `prompts/spec-reviewer.md` § Pre-build criteria verification mode). Pass the plan's acceptance criteria and per-step test expectations.
 
 The reviewer evaluates each criterion for:
+
 - **Specificity**: Could two developers independently verify this criterion and agree on pass/fail?
 - **Testability**: Can this criterion be validated with a test or observable output?
 - **Completeness**: Are edge cases and error conditions addressed?
 
 If any criteria are flagged:
+
 1. Present the findings to the user with the reviewer's suggested improvements
 2. Ask: "Revise these criteria before building, or proceed anyway?"
 3. If the user overrides, log the override in the build output and continue
@@ -68,7 +70,11 @@ For each step in the plan, dispatch implementation following the implementer tem
    - **complex**: Run `/review-agent spec-compliance-review`, then the full quality agent suite including opus-tier agents (security-review, domain-review, arch-review). Same review-fix loop applies.
    - If no complexity is specified, default to **standard**.
    - **UI changes (any complexity)**: After quality review passes, run browser verification via `/browse` in automated smoke test mode. Skip with warning if the dev server is not running. See `agents/orchestrator.md` Stage 3.
-5. **Mark step done** — Update the plan file: check off the step's acceptance criteria, set the step as completed.
+5. **Mark step done** — Use the Edit tool to update the plan file's `## Build Progress` section on disk:
+   - Change `- [ ] Step N: <title>` to `- [x] Step N: <title>` for the completed step.
+   - For each acceptance criterion verified by this step, change `- [ ]` to `- [x]` in the Build Progress `### Acceptance Criteria` subsection.
+   - After all steps are `[x]`, change `**Status**: approved` to `**Status**: in-progress`.
+   - This disk write is the durable commit. If a `/clear` occurs, `/continue` reads `## Build Progress` to determine the resume point without needing conversation history.
 
 ### 5. Run full test suite
 
@@ -80,11 +86,12 @@ Run `/code-review` against all files modified during the build.
 
 ### 7. Update plan status
 
-Update the plan status to `implemented`. Briefly confirm completion and direct the user to `/pr`.
+Use the Edit tool to change `**Status**: in-progress` to `**Status**: implemented` in the plan file. Briefly confirm completion and direct the user to `/pr`.
 
 ## Escalation
 
 Stop and ask the user when:
+
 - A test fails for an unexpected reason after 3 attempts
 - The plan requires architectural decisions not covered by the plan
 - A review checkpoint fails after 2 correction iterations

--- a/plugins/agentic-dev-team/commands/plan.md
+++ b/plugins/agentic-dev-team/commands/plan.md
@@ -108,11 +108,26 @@ When in doubt, classify up (standard rather than trivial, complex rather than st
 ## Risks & Open Questions
 
 - <Risk or question, with mitigation or who should answer>
+
+## Build Progress
+
+This section is the machine-parseable recovery handle. `/build` updates checkboxes here via Edit tool so progress survives a `/clear` or session restart. `/continue` reads this section to determine the resume point.
+
+### Steps
+
+- [ ] Step 1: <title>
+- [ ] Step 2: <title>
+
+### Acceptance Criteria
+
+- [ ] <Criterion 1 — mirrors the Acceptance Criteria section above>
+- [ ] <Criterion 2>
+- [ ] <Criterion 3>
 ```
 
 ### 4. Create the plans directory
 
-Create `plans/` if it doesn't exist.
+Create `plans/` if it doesn't exist. When writing the plan file, populate the `## Build Progress` section by copying step titles from `## Steps` and criteria from `## Acceptance Criteria`. These are the checkboxes `/build` will update on disk as each step completes.
 
 ### 5. Run plan review personas
 

--- a/plugins/agentic-dev-team/knowledge/adversarial-review-protocol.md
+++ b/plugins/agentic-dev-team/knowledge/adversarial-review-protocol.md
@@ -44,6 +44,14 @@ Repeat until the challenger finds no new issues, or a maximum of 3 rounds is rea
 - Did you check constructor parameter counts? >5 parameters usually signals SRP violation.
 - Are there God objects/Megaclasses you walked past because they're "just how the code is"?
 
+### complexity-review
+
+- Did you check ALL methods and functions, not just the visibly large ones?
+- For each nesting-depth finding, did you count the actual levels rather than estimating by appearance?
+- Are there methods just under the threshold (19 lines, 3 levels) that warrant a warning?
+- Did you distinguish between genuine cognitive complexity (multiple concepts) and mechanical repetition (defensive null checks)?
+- For async findings, did you verify the pattern is actually problematic in context (library vs. application code)?
+
 ### arch-review
 
 - Did you read the ADRs before reviewing? Every finding should reference whether it contradicts an ADR.

--- a/plugins/agentic-dev-team/knowledge/adversarial-review-protocol.md
+++ b/plugins/agentic-dev-team/knowledge/adversarial-review-protocol.md
@@ -1,0 +1,73 @@
+# Adversarial Review Protocol
+
+Reference file for all review agents. Run the challenger pass after producing initial findings to prevent incomplete analysis, unjustified severities, and premature exits.
+
+## The Loop
+
+After the initial review pass, re-examine findings with the following questions. Address each challenge before delivering the report.
+
+1. **Completeness** — Did the reviewer examine every file in scope? List files NOT examined and state why.
+2. **Evidence** — Does every finding quote actual code? Flag any finding without a direct code citation.
+3. **Severity justification** — Is each error/high-severity rating backed by concrete impact (data loss, security breach, test suite failing silently, production breakage)? Downgrade if not.
+4. **Blind spots** — What categories of issues are ABSENT from the findings? Absence in async code with no concurrency findings, or complex business logic with no domain findings, is suspicious. State the absent category and why it isn't an issue (or add a finding).
+5. **False-negative pass** — Re-read the 3 largest files independently. Are there issues the initial pass walked past?
+6. **Lazy exits** — Any finding with "could not assess because..." — is that actually true, or is it a shortcut?
+
+Repeat until the challenger finds no new issues, or a maximum of 3 rounds is reached.
+
+## Challenge Questions by Agent
+
+### security-review
+
+- Did you check EVERY source file, not just files with suspicious names?
+- Did you trace user-controlled input all the way to its sink (query, shell, template, redirect)?
+- Did you distinguish between `throw` (error handling) and silent swallow?
+- Are hardcoded secrets in `.env` files actually committed (check `git ls-files`)? If not, do NOT flag them.
+- Did you check CI/CD workflow files and Dockerfiles, which are in scope even for small changesets?
+- Is every "missing auth check" finding verified against the actual middleware chain, not just the handler?
+
+### test-review
+
+- For every class below 90% effective coverage, did you identify the SPECIFIC uncovered behavior?
+- For each "can't test because of static coupling" — did you verify there's no injectable constructor or interface available?
+- Are there tests with no assertion (just "didn't crash")? These provide zero regression protection.
+- Are there tests that verify test infrastructure instead of business logic (CanBeMocked, ImplementsInterface, ConstructorSetsField)?
+- Did you check for shared mutable state between tests (static fields, module-level singletons)?
+- Are there non-determinism sources (unstubbed clock, real network, file I/O) that weren't flagged as flakiness risks?
+
+### structure-review
+
+- Did you check every module/class for SRP violations, including small ones?
+- Did you trace dependency direction? Does business logic depend on infrastructure (not just vice versa)?
+- Are there hidden static singletons or global state that aren't injected?
+- For every "duplicate code" finding, did you verify it's semantic duplication and not just structural similarity?
+- Did you check constructor parameter counts? >5 parameters usually signals SRP violation.
+- Are there God objects/Megaclasses you walked past because they're "just how the code is"?
+
+### arch-review
+
+- Did you read the ADRs before reviewing? Every finding should reference whether it contradicts an ADR.
+- Did you check cross-boundary imports in BOTH directions (not just infrastructure → domain)?
+- For each "inconsistent pattern" finding, did you verify the established pattern exists in at least 2 other locations?
+- Did you check for circular dependencies introduced by the changeset?
+- Are there new abstractions that duplicate existing ones?
+
+### domain-review
+
+- Did you check every entity/aggregate for anemic domain model patterns (data bags with all behavior in services)?
+- For each "business logic in wrong layer" finding, did you quote the specific rule and its location?
+- Did you check for ubiquitous language drift: same concept with 3+ different names across modules?
+- Are domain objects leaking persistence annotations, HTTP concerns, or infrastructure types?
+- Did you check aggregate boundary enforcement — are child entities accessed directly by external callers?
+
+## Output
+
+After the challenger pass, append to the `summary` field in your JSON output:
+
+```
+Challenge: N round(s). Revisions: <count>. Blind spots examined: <list>. Confidence: High|Medium|Low.
+```
+
+- **High**: all files examined, every finding has a code citation, no suspicious absences
+- **Medium**: 1-2 files not examined or 1 finding revised downward
+- **Low**: >2 files not examined, multiple revisions, or a finding was retracted

--- a/plugins/agentic-dev-team/knowledge/agent-registry.md
+++ b/plugins/agentic-dev-team/knowledge/agent-registry.md
@@ -85,6 +85,8 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | Semantic Duplication Scan | `skills/semantic-duplication-scan/SKILL.md` | ~4,500 | Orchestrator, Software Engineer, Architect |
 | Agent Create | `skills/agent-create/SKILL.md` | ~2,100 | Orchestrator, Software Engineer, all team agents |
 | ADR Tools | `skills/adr-tools/SKILL.md` | ~1,350 | Orchestrator, adr-author, Software Engineer, Architect |
+| Mermaid Diagramming | `skills/mermaid-diagramming/SKILL.md` | ~400 | Architect, Software Engineer, Tech Writer |
+| Ubiquitous Language | `skills/ubiquitous-language/SKILL.md` | ~800 | Architect, domain-review, Product Manager |
 
 ## Subagent Prompt Templates
 
@@ -114,6 +116,10 @@ Knowledge files in `knowledge/` provide progressive disclosure — agents read t
 | Domain Modeling | `knowledge/domain-modeling.md` | 500 | domain-review |
 | Architecture Assessment | `knowledge/architecture-assessment.md` | 450 | arch-review |
 | Exploratory Testing Field Guide | `knowledge/exploratory-testing-field-guide.md` | ~900 | QA Engineer, `skills/exploratory-testing/SKILL.md` |
+| Adversarial Review Protocol | `knowledge/adversarial-review-protocol.md` | ~500 | security-review, test-review, structure-review, complexity-review, arch-review, domain-review |
+| Design Smells | `knowledge/design-smells.md` | ~600 | structure-review, complexity-review, naming-review |
+| Object Calisthenics | `knowledge/object-calisthenics.md` | ~400 | structure-review, complexity-review |
+| Testability Patterns | `knowledge/testability-patterns.md` | ~500 | test-review, legacy-code |
 
 ## Agent Templates
 

--- a/plugins/agentic-dev-team/knowledge/agent-registry.md
+++ b/plugins/agentic-dev-team/knowledge/agent-registry.md
@@ -107,8 +107,8 @@ Concrete prompt templates in `prompts/` that the orchestrator and `/code-review`
 
 Knowledge files in `knowledge/` provide progressive disclosure — agents read them on demand during analysis rather than carrying all detection patterns inline.
 
-| File | ~Tokens | Used By |
-|------|---------|---------|
+| Name | File | ~Tokens | Used By |
+|------|------|---------|---------|
 | Agent Registry | `knowledge/agent-registry.md` | 1,200 | Orchestrator (routing decisions) |
 | Review Template | `knowledge/review-template.md` | 400 | `/code-review` (report assembly) |
 | Review Rubric | `knowledge/review-rubric.md` | 300 | `/code-review` (health scoring) |

--- a/plugins/agentic-dev-team/knowledge/design-smells.md
+++ b/plugins/agentic-dev-team/knowledge/design-smells.md
@@ -1,0 +1,96 @@
+# Design Smells
+
+Reference file for structure-review, complexity-review, and naming-review agents. Use the smell → pattern table to make findings actionable: every finding should name the smell, quote the code, name the remediation pattern, and include a refactor sketch.
+
+---
+
+## Design Smells → Pattern Mapping
+
+| Smell | Signature in code | Remediation pattern |
+|---|---|---|
+| **Switch on type discriminator** | `switch (type) { case A: ...; case B: ...; }` or `if (x is A) ... else if (x is B) ...` repeated across multiple methods | **Replace Conditional with Polymorphism** → Strategy (behavior-driven) or State (lifecycle-driven) |
+| **If/else cascade on type/state** | Same shape as above in `if`/`elif` form | Same: Replace Conditional with Polymorphism |
+| **Long parameter list** | Function with 5+ parameters; reader can't recall positional meanings | **Introduce Parameter Object** — bundle related params into a named request/options type |
+| **Data clumps** | Same group of 3+ parameters or fields travels together everywhere (`firstName, lastName, dob`) | **Extract Class / Value Object** — the clump is an unnamed concept |
+| **Primitive obsession** | Business concepts modeled as raw strings/numbers (`string customerId`, `int amount`) | **Value Object** — typed wrapper with validation and equality |
+| **Magic number / magic string** | Literals like `if (retries > 3)` or `if (status == "PND")` | **Replace Magic Literal** — extract named constant or enum; promote to Value Object when it carries business meaning |
+| **Flag argument** | `process(true, false)` — boolean params that switch method behavior | **Split Method** — one method per branch; the flag is hiding two operations |
+| **Long method** | Method >20 lines, often readable only with sub-section comments | **Extract Method** — each sub-section comment becomes a named method call |
+| **Feature envy** | Method on class A reaches deeply into class B's data (`b.x.y.z`) | **Move Method** — relocate to class B where the data lives |
+| **Shotgun surgery** | One conceptual change requires edits in 5+ unrelated classes | **Move Method / Move Field** — consolidate responsibility into one class |
+| **Divergent change** | One class changes for many different reasons (auth, persistence, formatting) | **Extract Class** along the change axes — one class per reason-to-change |
+| **Refused bequest** | Subclass overrides many parent methods to no-op or throw "not supported" | **Replace Inheritance with Composition** — the subclass needs *some* of the parent API; expose those via a member |
+| **Speculative generality** | Abstract base classes or interfaces with only one implementation and no near-term plan for a second | **Inline Class** — collapse the abstraction; re-introduce when a second implementation appears |
+| **Megaclass** | Class with 30+ public methods, multiple responsibilities, `*Manager`/`*Service`/`*Helper` suffix | **Extract Class** along responsibility lines; apply SRP |
+
+## What NOT to Flag
+
+- A `switch` over a closed enumeration where adding a case is rare (e.g., `DayOfWeek`, `HttpMethod`) — polymorphism adds ceremony without benefit
+- A method whose extraction would only add a name without reducing cognitive load
+- A 6-parameter constructor in a DI-injected class where all 6 are collaborators (not data clumps) — Parameter Object applies to *data* clumps, not dependency lists
+- Speculative generality concerns on code that *will* gain a second adapter this sprint (per the team's roadmap)
+
+---
+
+## Finding Format
+
+When surfacing a design smell as a finding:
+
+```
+Severity: error (blocks testing or hides a bug) | warning (impedes change) | suggestion (stylistic)
+Smell: <smell name from table above>
+File: path/to/file.ext:LINE
+Code: <2-5 line quote of actual code>
+Pattern: <recommended pattern>
+Fix: <refactor sketch — 1-3 sentences on what the change looks like>
+```
+
+---
+
+## Naming Offender Catalog
+
+### Abbreviations that obscure intent
+
+| Offender | Fix | Notes |
+|---|---|---|
+| `getEffDate` | `getEffectiveDate` | `Eff` is an internal abbreviation |
+| `calcAmt` | `calculateAmount` | Two abbreviations + missing what amount |
+| `OrderMgr` | `OrderRepository` or `OrderShippingService` | `Mgr` is vacuous — replace with the actual role |
+| `tmpResult` | `intermediateTotal` | `tmp` reveals nothing about what it holds |
+| `proc` / `Proc` | `processor` / `PaymentProcessor` | Spell out domain roles |
+| `m_orderId` / `g_orderId` | `_orderId` (private) / `orderId` (local) | Hungarian prefix residue |
+
+### Generic verbs that hide intent
+
+| Offender | Fix | Reason |
+|---|---|---|
+| `processOrder` | `submitOrder` / `confirmOrder` / `cancelOrder` | "Process" hides which lifecycle step |
+| `handleException` | `logAndSwallow` / `rethrowAsFault` / `retryWithBackoff` | "Handle" hides the actual policy |
+| `doWork` | (the verb that names the work) | "Do" reveals nothing |
+| `manage*` (`manageCart`, `manageInventory`) | Split into named operations: `addItem`, `removeItem` | "Manage" at class level is a smell; split into named methods |
+| `update*` without qualifier | `markAsShipped` / `recordPayment` | "Update" hides which fields change and why |
+| `execute` (outside Command/Strategy pattern) | The specific action | OK on `ICommand.execute()`; suspect elsewhere |
+
+### Misleading names
+
+| Offender | Why it misleads | Fix |
+|---|---|---|
+| `getCustomerOrThrow` returning null | Name says throw, code says null | Use `tryGetCustomer(out)` or actually throw |
+| `isValid` that mutates state | "is" implies pure query | Split: `validate()` (mutates) + `isValid` (pure) |
+| `save()` that may no-op | Name implies always-persists | `persistIfDirty()` or `flushPendingChanges()` |
+| `cancel*` that emits an event but doesn't cancel state | Misnamed | `requestCancellation()` |
+
+### Type-encoded names
+
+| Offender | Fix |
+|---|---|
+| `stringList`, `intCount`, `boolIsActive` | `names` / `list`, `count`, `isActive` |
+| `ICustomerInterface`, `OrderClass` | `ICustomer`, `Order` |
+
+### What NOT to flag
+
+- Loop counters: `i`, `j`, `k` are conventional
+- Lambda parameters with single use: `x => x.id` doesn't need `customer => customer.id`
+- Industry-standard acronyms: `HttpClient`, `XmlReader`, `JsonSerializer`, `SqlConnection`, `JWT`
+- Domain-standard acronyms defined in the project's glossary (`.plans/domain/`)
+- Test method names following `MethodName_Scenario_ExpectedResult` convention

--- a/plugins/agentic-dev-team/knowledge/object-calisthenics.md
+++ b/plugins/agentic-dev-team/knowledge/object-calisthenics.md
@@ -1,0 +1,147 @@
+# Object Calisthenics
+
+Nine rules for writing clean, maintainable, testable object-oriented code. Apply to **business domain code** — exempt DTOs, config classes, test builders, and framework boilerplate.
+
+Source: Jeff Bay, "Object Calisthenics" (*The ThoughtWorks Anthology*, Pragmatic Bookshelf, 2008)
+
+---
+
+## The Rules
+
+### 1. One Level of Indentation Per Method
+
+If a method has nested `if`/`for`/`while`, extract the inner block into a named method.
+
+```
+// BAD
+function processPayments(payments) {
+  for payment in payments:
+    if payment.isEligible:
+      if payment.amount > 0:
+        submit(payment)
+}
+
+// GOOD
+function processPayments(payments) {
+  for payment in payments:
+    processIfEligible(payment)
+}
+```
+
+### 2. Don't Use the ELSE Keyword
+
+Replace `if/else` with guard clauses (early returns) or polymorphism.
+
+```
+// BAD
+function calculateShipping(method):
+  if method == "express": return weight * 2.5
+  else if method == "overnight": return 25.0
+  else: return 0
+
+// GOOD — guard clauses
+function calculateShipping(method):
+  if method == "express": return weight * 2.5
+  if method == "overnight": return 25.0
+  return 0
+```
+
+### 3. Wrap All Primitives and Strings
+
+Domain-meaningful primitives become value objects with validation.
+
+```
+// BAD
+createOrder(customerId: string, amount: decimal, email: string)
+
+// GOOD
+createOrder(customerId: CustomerId, amount: Money, email: EmailAddress)
+```
+
+### 4. First-Class Collections
+
+Any class with a collection field should contain no other fields. The collection gets its own class with domain behavior.
+
+```
+// BAD
+class BatchProcessor:
+  payments: List<Payment>
+  batchId: string   // mixing concerns
+
+// GOOD
+class PaymentBatch:
+  payments: List<Payment>   // the ONLY field
+  total(): Money
+  eligiblePayments(): List<Payment>
+```
+
+### 5. One Dot Per Line (Law of Demeter)
+
+Don't chain through object graphs. Each method call should be on the immediate collaborator.
+
+```
+// BAD — reaching through the graph
+city = order.customer.address.city
+
+// GOOD — ask the immediate object
+city = order.shippingCity   // Order delegates to its own data
+```
+
+### 6. Don't Abbreviate
+
+Names should be intention-revealing. If a name is too long, the class may have too many responsibilities.
+
+```
+// BAD
+proc = new Proc()
+txn = getTxn(id)
+amt = calcAmt(txn)
+
+// GOOD
+processor = new PaymentProcessor()
+transaction = getTransaction(id)
+amount = calculateAmount(transaction)
+```
+
+### 7. Keep All Entities Small
+
+- Classes: under 200 lines
+- Methods: under 20 lines
+- Packages/modules: under 15 classes
+
+If a class exceeds these limits, it likely violates SRP — extract responsibilities.
+
+### 8. No Classes with More Than Two Instance Variables
+
+The spirit: classes should be small and focused. In practice, aim for fewer than five fields. More than five is a strong signal for Extract Class.
+
+### 9. No Getters/Setters/Properties (Tell, Don't Ask)
+
+Move behavior into the object that owns the data instead of exposing data for others to operate on.
+
+```
+// BAD — asking for data, deciding externally
+if account.balance >= amount:
+  account.balance -= amount
+
+// GOOD — telling the object what to do
+account.withdraw(amount)   // Account enforces its own invariants
+```
+
+---
+
+## Applying Pragmatically
+
+These are training exercises, not absolute laws. Use them as design pressure:
+
+| Rule | Always Apply | Pragmatic Exceptions |
+|---|---|---|
+| One indentation level | Yes | Complex LINQ / stream expressions |
+| No ELSE | Yes | Simple boolean returns |
+| Wrap primitives | For domain values | Infrastructure code, DTOs |
+| First-class collections | When collection has behavior | Simple DTOs |
+| One dot per line | At domain boundaries | Fluent APIs, builders |
+| Don't abbreviate | Yes | Industry-standard acronyms (HTTP, SQL, ID, JWT) |
+| Small classes | Yes | EF/ORM configurations, test fixtures |
+| Few instance variables | As design pressure | Aggregate roots may need more |
+| No getters | At domain boundaries | DTOs, serialization, view models |

--- a/plugins/agentic-dev-team/knowledge/testability-patterns.md
+++ b/plugins/agentic-dev-team/knowledge/testability-patterns.md
@@ -1,0 +1,157 @@
+# Testability Design Patterns
+
+Reference file for test-review and structure-review agents. When flagging untestable code, use the patterns below to specify the required **production code change** — not a test workaround. Tests never hack around untestable designs; the design must change.
+
+Core principle: if code can't be tested through its public API, the production code's design must change. Per Seemann: "The hallmark of a testable design is that it's also a good design."
+
+---
+
+## "I Can't Test This Class" Decision Flow
+
+```
+Can I construct the object with the values I need for the test?
+│
+├─ YES → Write the test using the public constructor.
+│
+├─ NO: it has private-set properties with no public constructor
+│   └─ Add a constructor that accepts values directly.
+│      For 5+ parameters: apply Test Data Builder (Pattern 2).
+│
+├─ NO: it only has a static factory that calls a real database/service
+│   └─ Add a constructor alongside the factory.
+│      The factory uses the constructor internally.
+│
+├─ NO: the method I need to verify is protected/private
+│   └─ Extract the logic into a public method or invoke through the
+│      public behavior that calls it.
+│
+└─ NO: it depends on a concrete class I can't replace
+    └─ Extract an interface for what this class needs.
+       Mock the interface in tests, wire the concrete in production.
+
+Each NO branch requires a production code change. That IS the work.
+```
+
+---
+
+## Pattern 1: Constructor Injection (Replace Static Factories / Singletons)
+
+**Problem**: A class creates its own dependencies internally — `new ConcreteService()`, `ServiceLocator.get(T)`, static calls. The production code can't be given test doubles.
+
+**Solution**: Accept collaborators as constructor parameters. Static factories and singletons remain for production wiring; they delegate to the constructor internally.
+
+```
+// BEFORE — untestable
+class OrderProcessor:
+  def process(orderId):
+    db = Database.getInstance()     // static singleton
+    logger = new FileLogger()       // new-ed up
+    ...
+
+// AFTER — injectable
+class OrderProcessor:
+  constructor(db: IDatabase, logger: ILogger):
+    self.db = db
+    self.logger = logger
+
+  def process(orderId):
+    ...
+```
+
+**When to apply**: class instantiates its own collaborators; class has no constructor that accepts its dependencies; production code works but tests can't isolate the unit.
+
+---
+
+## Pattern 2: Test Data Builder
+
+**Problem**: Domain objects with many properties are painful to construct in every test. Most tests only care about 1-2 properties.
+
+**Solution**: A builder in the test project with sensible defaults and a fluent API.
+
+```
+// Builder lives in the test project
+class OrderBuilder:
+  customerId = "TEST-CUST"
+  amount = 100
+  status = "pending"
+
+  withCustomer(id): self.customerId = id; return self
+  withAmount(amt): self.amount = amt; return self
+  withStatus(s): self.status = s; return self
+  build(): return Order(customerId, amount, status)
+
+// In tests — only set what the test cares about
+order = new OrderBuilder().withStatus("cancelled").build()
+```
+
+**When to apply**: domain object has 5+ properties; multiple tests need variants of the same object; default values work for most tests.
+
+---
+
+## Pattern 3: Interface Extraction for Large Contexts
+
+**Problem**: Classes depend on a large context object with many properties. Mocking the full context is impractical and fragile.
+
+**Solution**: Extract an interface for what each consumer actually needs.
+
+```
+// BEFORE — consumer takes the whole context
+class FileProcessor:
+  constructor(context: ProcessingContext)  // 40-field object
+
+// AFTER — consumer takes only what it needs
+interface IFileProcessorContext:
+  tempFilePath(): string
+  isReprocess: bool
+  fileNames: List<string>
+
+class FileProcessor:
+  constructor(context: IFileProcessorContext)
+```
+
+The full context class implements this interface. Tests mock only the interface.
+
+**When to apply**: context has 30+ properties but any given consumer uses 5-10; creating a full context for each test is excessive.
+
+---
+
+## Pattern 4: Fake Data Generators (Test Data with Variation)
+
+**Problem**: Tests need realistic but controlled test data across many scenarios.
+
+**Solution**: A typed faker or factory in the test project that generates valid domain values.
+
+```
+// Instead of magic literals
+order = new Order(customerId="ABC123", amount=150.00, ...)
+
+// Use a generator that makes intent clear
+order = OrderFaker.pending()
+order = OrderFaker.withAmount(5000)
+orders = OrderFaker.generateBatch(100)
+```
+
+**When to apply**: tests need multiple records with varied data; domain validation rules constrain acceptable values; tests should not use unexplained magic numbers.
+
+---
+
+## Anti-Patterns Table
+
+| Anti-Pattern | Why It's Wrong | Correct Alternative |
+|---|---|---|
+| `InternalsVisibleTo` + `internal set` for tests | Weakens encapsulation for test convenience | Add a public constructor that accepts values |
+| Reflection into private members as primary strategy | Fragile; breaks on rename; masks coupling | Extract to public API or create a proper test entry point |
+| Static test helper that mutates private state | Bypasses object invariants | Use Test Data Builder with public construction |
+| Mocking concrete classes | Fragile; requires virtual/open methods; masks design issues | Extract interface; mock the interface |
+| Tests configuring global/static state | Shared state causes order-dependent failures | Inject dependencies through constructors |
+| Changing `private set` to `public set` for test access | Removes invariant protection | Add constructor parameter instead |
+| `[InternalsVisibleTo]` / `@VisibleForTesting` as the primary testability mechanism | Couples test and production assemblies | Redesign the API surface so tests don't need access to internals |
+
+---
+
+## References
+
+- Michael Feathers, *Working Effectively with Legacy Code* — seam insertion, Parameterize Constructor, Extract Interface
+- Mark Seemann & Steven van Deursen, *Dependency Injection: Principles, Practices, and Patterns* — Pure DI, Composition Root
+- Steve Freeman & Nat Pryce, *Growing Object-Oriented Software, Guided by Tests* — outside-in TDD, mock-roles-not-objects
+- Vladimir Khorikov, *Unit Testing: Principles, Practices, and Patterns* — resilient vs. fragile tests

--- a/plugins/agentic-dev-team/skills/legacy-code/SKILL.md
+++ b/plugins/agentic-dev-team/skills/legacy-code/SKILL.md
@@ -12,6 +12,7 @@ user-invocable: true
 Techniques for safely modifying code that lacks tests or has poor structure. Based on the principle that legacy code is code without tests (Michael Feathers' definition) — regardless of age. The goal is to get code under test before changing it, then improve structure incrementally.
 
 ## Constraints
+
 - Never change behavior and structure in the same step; refactor under green tests only
 - Write characterization tests before modifying legacy code — not after
 - Prefer the smallest dependency break that gets code under test
@@ -20,9 +21,11 @@ Techniques for safely modifying code that lacks tests or has poor structure. Bas
 ## Core Concepts
 
 ### Legacy Code Definition
+
 Code without tests. A well-structured 6-month-old codebase with no tests is legacy. A messy 10-year-old codebase with comprehensive tests is not. The presence or absence of tests determines whether you can change code safely.
 
 ### The Legacy Code Change Algorithm
+
 1. **Identify change points** — where in the code does the change need to happen?
 2. **Find test points** — where can you observe the effects of the change?
 3. **Break dependencies** — make the code testable without changing its behavior
@@ -30,17 +33,21 @@ Code without tests. A well-structured 6-month-old codebase with no tests is lega
 5. **Make changes and refactor** — now that tests protect you, modify behavior and improve structure
 
 ### Seams
+
 A seam is a place where behavior can be altered without editing the code under test:
+
 - **Object seams** — use polymorphism to substitute behavior (interfaces, subclasses)
 - **Link seams** — substitute dependencies at the linking/import level (dependency injection, module mocking)
 - **Preprocessing seams** — alter behavior via build configuration, feature flags, or compile-time substitution
 
 ### Characterization Tests
+
 Tests that document what the code *actually does*, not what it *should do*. They lock down existing behavior so you can detect unintended changes. Characterization tests answer: "If I make a change here, what breaks?"
 
 ## Patterns
 
 ### Characterization Test Procedure
+
 1. Find the code area you need to change
 2. Write a test that calls the code and lets it fail to reveal actual output
 3. Update the test assertion to match observed behavior
@@ -62,11 +69,14 @@ Tests that document what the code *actually does*, not what it *should do*. They
 | Adapt Parameter | Method depends on a type you can't use in tests | Medium |
 
 ### Sprout vs. Wrap Decision
+
 - **Sprout** (new method/class called from existing code): use when the new behavior is an addition that existing code needs to invoke at a specific point. The existing code changes minimally — it gains one call to the new method.
 - **Wrap** (new code that calls existing code): use when existing callers must see the new behavior transparently without modification. The new code sits between callers and the original code.
 
 ### Strangler Pattern
+
 Incrementally replace legacy components by routing new behavior through new code while old code remains operational:
+
 1. Identify a bounded area of legacy functionality
 2. Build new implementation alongside the old
 3. Route new requests/features through new code
@@ -74,6 +84,7 @@ Incrementally replace legacy components by routing new behavior through new code
 5. Remove old code only when fully replaced and verified
 
 ## Output
+
 Report the legacy code analysis: identified change points, test points, dependency breaks needed, characterization test targets, and the recommended refactoring sequence. Be concise — bullet list format; skip background explanation.
 
 ## When to Apply
@@ -103,3 +114,4 @@ Report the legacy code analysis: identified change points, test points, dependen
 - **[Hexagonal Architecture](../hexagonal-architecture/SKILL.md)** — dependency breaking techniques move legacy code toward port/adapter separation incrementally
 - **[Quality Gate Pipeline](../quality-gate-pipeline/SKILL.md)** — verify characterization tests match observed behavior (Phase 1); legacy code changes have higher defect risk, apply review-correction with increased scrutiny (Phase 3)
 - **[Mutation Testing](../mutation-testing/SKILL.md)** — after writing characterization tests, use mutation testing to verify those tests catch behavioral changes
+- **[Testability Patterns](../../knowledge/testability-patterns.md)** — constructor injection, Test Data Builder, interface extraction, and the "I Can't Test This Class" decision flow complement the dependency-breaking techniques here; read it when the dependency break needed is a design change (extract interface, add constructor) rather than a seam insertion

--- a/plugins/agentic-dev-team/skills/ubiquitous-language/SKILL.md
+++ b/plugins/agentic-dev-team/skills/ubiquitous-language/SKILL.md
@@ -25,7 +25,7 @@ Produces a queryable per-concept glossary at `.plans/domain/`. Each concept gets
 Run the colocated gather script. It collects raw candidates; it does not decide what is domain language (that is Phase 3's job).
 
 ```bash
-bash skills/ubiquitous-language/scripts/collect-domain-signals.sh "$ARGUMENTS"
+bash .claude/skills/ubiquitous-language/scripts/collect-domain-signals.sh "$ARGUMENTS"
 ```
 
 The script writes to `.plans/raw/domain-language/`:

--- a/plugins/agentic-dev-team/skills/ubiquitous-language/SKILL.md
+++ b/plugins/agentic-dev-team/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: ubiquitous-language
+description: Build or refresh the project's ubiquitous language glossary — one markdown file per business concept at `.plans/domain/<Concept>.md` plus a `_index.md`. Mines grep-based signals (class names, enum values, interface names, domain-event names, BDD scenario names, validator rules) and applies a four-gate filter to keep only genuine business concepts. Optional interactive interview phase to refine definitions and capture behavior (state transitions, invariants, synonyms to avoid). Language-agnostic — works for JS/TS, C#, Java, Python, Go, or any mix. Use whenever the user says "build the glossary", "extract domain terms", "document the ubiquitous language", "what are the domain concepts", or when domain-review surfaces pervasive terminology inconsistency (3+ names for the same concept).
+role: worker
+user-invocable: true
+argument-hint: "[path-to-source-root]"
+---
+
+# Ubiquitous Language
+
+Produces a queryable per-concept glossary at `.plans/domain/`. Each concept gets its own file (one-sentence definition, classification, related terms). The glossary feeds `domain-review` as classification ground truth — run this skill before `domain-review` for sharper findings.
+
+**This skill never modifies source files.** It writes only to `.plans/domain/` and `.plans/domain-language-plan.md`.
+
+---
+
+## Announce on start
+
+"Running ubiquitous-language. Gathering domain signals from `$ARGUMENTS` (or cwd if empty). I'll apply a four-gate filter and write one file per approved business concept to `.plans/domain/`. Existing files are append-mostly — previous definitions are preserved."
+
+---
+
+## Phase 1: Gather signals (grep-based, no build required)
+
+Run the colocated gather script. It collects raw candidates; it does not decide what is domain language (that is Phase 3's job).
+
+```bash
+bash skills/ubiquitous-language/scripts/collect-domain-signals.sh "$ARGUMENTS"
+```
+
+The script writes to `.plans/raw/domain-language/`:
+
+- `class-names.txt` — PascalCase class/struct/record/interface names from domain and application layers
+- `enum-values.txt` — enum declarations with their values
+- `domain-events.txt` — type names ending in `Created`, `Updated`, `Submitted`, `Approved`, `Cancelled`, `Rejected`, `Completed`, `Failed`, `Requested`
+- `bdd-names.txt` — BDD scenario and step names from `.feature` files (`Given_`, `When_`, `Then_`, `Should_`)
+- `validator-rules.txt` — validation rule method names and error messages
+- `interface-names.txt` — interface/protocol names from domain and application layers
+
+If the script is unavailable, gather manually using `Grep` with the patterns documented in the script's comments.
+
+---
+
+## Phase 2: Load existing glossary (if present)
+
+Check for `.plans/domain/_index.md`. If it exists, read the current term list so new terms can be diffed against what already exists. Do not regenerate files for terms already in the glossary unless the definition is missing or clearly wrong.
+
+---
+
+## Phase 3: Apply the four-gate filter
+
+For each candidate term from Phase 1, apply all four gates. Promote only terms that pass all four.
+
+| Gate | Question | Fail condition |
+|---|---|---|
+| 1. Business concept | Would a domain expert (not a developer) recognize this term as part of the business vocabulary? | Pure technical terms: `Repository`, `Controller`, `Factory`, `Builder`, `Manager`, `Handler`, `Util`, `Helper`, `Config`, `Base`, `Abstract` |
+| 2. Non-generic | Does the name carry specific business meaning beyond "thing that does stuff"? | Single-word generics: `Item`, `Data`, `Info`, `Record`, `Object`, `Entity`, `Model` (unless qualified: `OrderLineItem` passes) |
+| 3. Appears in ≥2 signal sources | Is the term used in at least two different signal types (e.g., class name AND BDD scenario name)? | Terms that appear only once in a single file with no corroborating evidence |
+| 4. Domain expert would recognize it | Would a domain expert, reading only the name, understand roughly what it refers to? | Portmanteaus, internal jargon, or abbreviations not explainable without context |
+
+When in doubt on gate 3, lean toward including the term — false positives are cheap (the user can remove a file); false negatives mean silent glossary gaps.
+
+---
+
+## Phase 4: Write concept files
+
+For each approved term, write (or update) `.plans/domain/<Concept>.md` using this format:
+
+```markdown
+---
+classification: Aggregate | Entity | Value Object | Domain Event | Domain Service | Policy | Concept
+context: <bounded context name, if multi-context repo>
+---
+
+# <ConceptName>
+
+<One to two sentence definition in plain business language. Avoid technical terms.>
+
+## Lifecycle / State Transitions
+<!-- Optional: fill in during interview phase or when state-transition signals are present -->
+
+## Invariants
+<!-- Optional: business rules that must always hold for this concept -->
+
+## Related
+<!-- Optional: link to related concepts -->
+- [[RelatedConcept]]
+
+## Avoid
+<!-- Optional: synonyms the codebase uses that should be consolidated to this term -->
+- `PurchaseOrder` (use `Order` instead)
+
+## Sources
+<!-- Optional: where this definition came from -->
+```
+
+**Append-mostly**: if the file already exists, preserve existing content. Add new sections; do not overwrite human-curated definitions. Update only if the existing definition is blank or contradicted by new evidence.
+
+---
+
+## Phase 5: Regenerate index
+
+After writing all concept files, regenerate `.plans/domain/_index.md`:
+
+```markdown
+# Domain Glossary Index
+
+_Last updated: <date>_
+
+## Aggregates
+- [Order](Order.md)
+- [Payment](Payment.md)
+
+## Entities
+- [OrderLine](OrderLine.md)
+
+## Value Objects
+- [Money](Money.md)
+- [Address](Address.md)
+
+## Domain Events
+- [OrderSubmitted](OrderSubmitted.md)
+
+## Domain Services
+- [PricingPolicy](PricingPolicy.md)
+
+## Concepts
+- [FulfillmentWindow](FulfillmentWindow.md)
+```
+
+Preserve human-curated categorical structure if it exists. Only the term links are auto-maintained; section headings and ordering are owned by the human.
+
+---
+
+## Phase 6: Optional interview (interactive sessions only)
+
+If running interactively (not in a non-interactive CI context), ask: "Would you like to interview to refine definitions and capture behavior (state transitions, invariants, synonyms to avoid)? This usually takes 5-10 minutes."
+
+If yes, for each aggregate and entity in the glossary:
+
+1. Ask: "How would you describe `<Term>` to a new team member in one sentence?"
+2. Ask: "What states can a `<Term>` be in? What triggers transitions between them?"
+3. Ask: "What must always be true about a `<Term>` (invariants)?"
+4. Ask: "Are there other names in the codebase for `<Term>` that we should consolidate?"
+
+Update the concept files with answers. Record the interview transcript in `.plans/domain-language-plan.md`.
+
+---
+
+## Output
+
+Write a run summary to `.plans/domain-language-plan.md`:
+
+```markdown
+# Domain Language — Run Summary
+
+**Date**: <date>
+**Scope**: <path>
+**Mode**: grep-fallback | roslyn (if available)
+
+## New concepts written
+- `Payment` (Aggregate) — new
+- `Money` (Value Object) — new
+
+## Updated concepts
+- `Order` (Aggregate) — added Invariants section
+
+## Skipped (already current)
+- `Customer` — definition present, no changes
+
+## Filtered out
+- `Repository` — gate 1 fail (technical term)
+- `Data` — gate 2 fail (generic)
+
+## Open questions
+- Is `Transaction` the same concept as `Payment`? Found both in codebase.
+
+## Interview transcript
+<!-- appended if Phase 6 ran -->
+```
+
+Tell the user: "Glossary written to `.plans/domain/`. Run `/code-review` or `domain-review` for domain boundary analysis using these terms as ground truth."
+
+---
+
+## Integration
+
+- **[Domain Analysis](../domain-analysis/SKILL.md)** — run domain-analysis after this skill to get architectural coupling findings annotated with canonical terms
+- **[Domain-Driven Design](../domain-driven-design/SKILL.md)** — use the glossary as input when designing bounded contexts or aggregate boundaries
+- **[Specs](../specs/SKILL.md)** — when writing BDD scenarios, pull term names from `.plans/domain/` to ensure scenario language matches the glossary

--- a/plugins/agentic-dev-team/skills/ubiquitous-language/scripts/collect-domain-signals.sh
+++ b/plugins/agentic-dev-team/skills/ubiquitous-language/scripts/collect-domain-signals.sh
@@ -16,7 +16,7 @@ echo "Collecting domain signals from: $ROOT"
 # Helper: grep with fallback (ignore errors on binary/missing files)
 # ---------------------------------------------------------------------------
 safe_grep() {
-  grep -rn --include="$1" "$2" "$ROOT" 2>/dev/null || true
+  grep -rn --include="$1" "$2" -- "$ROOT" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/agentic-dev-team/skills/ubiquitous-language/scripts/collect-domain-signals.sh
+++ b/plugins/agentic-dev-team/skills/ubiquitous-language/scripts/collect-domain-signals.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# collect-domain-signals.sh
+# Gathers grep-based domain signals for the ubiquitous-language skill.
+# Usage: bash collect-domain-signals.sh [source-root]
+# Output: .plans/raw/domain-language/{class-names,enum-values,domain-events,bdd-names,validator-rules,interface-names}.txt
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+OUT=".plans/raw/domain-language"
+mkdir -p "$OUT"
+
+echo "Collecting domain signals from: $ROOT"
+
+# ---------------------------------------------------------------------------
+# Helper: grep with fallback (ignore errors on binary/missing files)
+# ---------------------------------------------------------------------------
+safe_grep() {
+  grep -rn --include="$1" "$2" "$ROOT" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Class / struct / record names from domain and application layers
+# Targets directories commonly named: domain, application, app, core, model, models
+# ---------------------------------------------------------------------------
+echo "  → class names..."
+{
+  safe_grep "*.ts"   "^export (abstract )?class [A-Z][a-zA-Z]+"
+  safe_grep "*.ts"   "^export (abstract )?interface [A-Z][a-zA-Z]+"
+  safe_grep "*.cs"   "^\s*(public|internal|sealed|abstract) (partial )?(class|record|struct) [A-Z][a-zA-Z]+"
+  safe_grep "*.java" "^public (abstract |final )?(class|interface|enum|record) [A-Z][a-zA-Z]+"
+  safe_grep "*.py"   "^class [A-Z][a-zA-Z]+"
+  safe_grep "*.go"   "^type [A-Z][a-zA-Z]+ struct"
+  safe_grep "*.go"   "^type [A-Z][a-zA-Z]+ interface"
+  safe_grep "*.rb"   "^class [A-Z][a-zA-Z]+"
+} | grep -v "Test\|Spec\|Mock\|Fake\|Stub\|Builder\|Factory\|Repository\|Controller\|Handler\|Middleware\|Config\|Settings\|Helper\|Util\|Base\|Abstract\|Migration" \
+  | sed 's/.*class \([A-Z][a-zA-Z]*\).*/\1/' \
+  | sed 's/.*interface \([A-Z][a-zA-Z]*\).*/\1/' \
+  | sed 's/.*struct \([A-Z][a-zA-Z]*\).*/\1/' \
+  | sed 's/.*record \([A-Z][a-zA-Z]*\).*/\1/' \
+  | sort -u > "$OUT/class-names.txt"
+echo "    $(wc -l < "$OUT/class-names.txt") candidates"
+
+# ---------------------------------------------------------------------------
+# Enum declarations and their values
+# ---------------------------------------------------------------------------
+echo "  → enum values..."
+{
+  safe_grep "*.ts"   "^export (const )?enum [A-Z]"
+  safe_grep "*.cs"   "^\s*(public|internal) enum [A-Z]"
+  safe_grep "*.java" "^public enum [A-Z]"
+  safe_grep "*.py"   "class [A-Z][a-zA-Z]*(Enum|Status|Type|State)\b"
+  safe_grep "*.go"   "// [A-Z][a-zA-Z]+ (is|represents|indicates)"
+} | sort -u > "$OUT/enum-values.txt"
+echo "    $(wc -l < "$OUT/enum-values.txt") candidates"
+
+# ---------------------------------------------------------------------------
+# Domain event names: types ending in past-tense business verbs
+# ---------------------------------------------------------------------------
+echo "  → domain events..."
+{
+  safe_grep "*.ts"   "class [A-Z][a-zA-Z]*(Created|Updated|Submitted|Approved|Cancelled|Rejected|Completed|Failed|Requested|Issued|Revoked|Expired|Activated|Deactivated|Shipped|Delivered|Refunded|Disputed)"
+  safe_grep "*.cs"   "class [A-Z][a-zA-Z]*(Created|Updated|Submitted|Approved|Cancelled|Rejected|Completed|Failed|Requested|Issued|Revoked|Expired|Activated|Deactivated|Shipped|Delivered|Refunded|Disputed)"
+  safe_grep "*.java" "class [A-Z][a-zA-Z]*(Created|Updated|Submitted|Approved|Cancelled|Rejected|Completed|Failed|Requested|Issued|Revoked|Expired|Activated|Deactivated|Shipped|Delivered|Refunded|Disputed)"
+  safe_grep "*.go"   "type [A-Z][a-zA-Z]*(Created|Updated|Submitted|Approved|Cancelled|Rejected|Completed|Failed|Requested|Issued|Revoked|Expired|Activated|Deactivated|Shipped|Delivered|Refunded|Disputed) struct"
+} | sed 's/.*class \([A-Z][a-zA-Z]*\).*/\1/' \
+  | sed 's/.*type \([A-Z][a-zA-Z]*\) struct.*/\1/' \
+  | sort -u > "$OUT/domain-events.txt"
+echo "    $(wc -l < "$OUT/domain-events.txt") candidates"
+
+# ---------------------------------------------------------------------------
+# BDD scenario and step names from .feature files
+# ---------------------------------------------------------------------------
+echo "  → BDD names..."
+{
+  safe_grep "*.feature" "^\s*(Scenario|Given|When|Then|And)\s"
+  # Also catch xUnit/Jest test names with business-language patterns
+  safe_grep "*.ts"   "it\(['\"].*['\"]"
+  safe_grep "*.ts"   "describe\(['\"].*['\"]"
+  safe_grep "*.cs"   "\[Fact\]|public void (Given|When|Then|Should)[A-Z]"
+  safe_grep "*.java" "@Test.*\n.*void (given|when|then|should)[A-Z]"
+} | sort -u > "$OUT/bdd-names.txt"
+echo "    $(wc -l < "$OUT/bdd-names.txt") candidates"
+
+# ---------------------------------------------------------------------------
+# Validator rule names and error messages (business invariants expressed in validation)
+# ---------------------------------------------------------------------------
+echo "  → validator rules..."
+{
+  safe_grep "*.ts"   "\.withMessage\|\.mustBe\|\.isRequired\|z\.string\(\)\.refine\|yup\."
+  safe_grep "*.cs"   "RuleFor\|\.Must\|\.WithMessage\|\.NotNull\|\.NotEmpty"
+  safe_grep "*.java" "@NotNull\|@NotBlank\|@Size\|@Min\|@Max\|@Pattern\|@Valid\|@Constraint"
+  safe_grep "*.py"   "raise ValueError\|raise TypeError\|assert .*, ['\"]"
+} | sort -u > "$OUT/validator-rules.txt"
+echo "    $(wc -l < "$OUT/validator-rules.txt") candidates"
+
+# ---------------------------------------------------------------------------
+# Interface / protocol names from domain and application layers
+# ---------------------------------------------------------------------------
+echo "  → interface names..."
+{
+  safe_grep "*.ts"   "^export interface [A-Z][a-zA-Z]+"
+  safe_grep "*.cs"   "^\s*(public|internal) interface I[A-Z][a-zA-Z]+"
+  safe_grep "*.java" "^public interface [A-Z][a-zA-Z]+"
+  safe_grep "*.go"   "type [A-Z][a-zA-Z]+ interface"
+} | grep -v "Repository\|Controller\|Handler\|Middleware\|Factory\|Builder\|Config\|Logger\|Cache\|Queue\|Bus\|Mapper\|Serializer\|Parser" \
+  | sed 's/.*interface \(I\?\)\([A-Z][a-zA-Z]*\).*/\2/' \
+  | sort -u > "$OUT/interface-names.txt"
+echo "    $(wc -l < "$OUT/interface-names.txt") candidates"
+
+echo ""
+echo "Signal collection complete. Results in $OUT/"
+echo "Total raw candidates: $(cat "$OUT"/*.txt | sort -u | wc -l)"


### PR DESCRIPTION
## Summary

- Adds 4 new language-agnostic knowledge files surfaced by competitive analysis against the `code-craft` plugin: adversarial-review-protocol, design-smells (14-row smell→pattern table + naming offender catalog), object-calisthenics (9 rules), and testability-patterns (decision flow + anti-patterns)
- Wires new knowledge into 7 review agents via `## Knowledge Files` and `## Self-Challenge` sections; adds `## Build Progress` to plan template + disk-write step to `/build` for session-reset durability
- Adds `ubiquitous-language` skill (6-phase grep-based glossary extraction with 4-gate filter, append-mostly per-concept files, optional interview phase) and registers mermaid-diagramming + ubiquitous-language in agent-registry

## Quality Gate

- [x] Tests: 237 passed, 0 failed
- [x] Type check: N/A (shell/markdown project)
- [x] Lint: N/A
- [x] Code review: 6 actionable issues found and fixed before commit (table header, CLAUDE.md counts, script path, grep injection hardening, self-challenge label clarity)

## Test Plan

- [ ] Install plugin locally and verify `/code-review` on a project — review agents should load `knowledge/adversarial-review-protocol.md` and append confidence level to their summaries
- [ ] Run `/plan` on a task — output plan should include `## Build Progress` section with checkboxes
- [ ] Run `/build` on an approved plan — verify it edits the plan file checkboxes on disk
- [ ] Run `/ubiquitous-language src/` on a project with domain entities — verify `.plans/domain/` is populated with per-concept files and `_index.md`
- [ ] Verify `agent-registry.md` Knowledge Files table renders correctly (11 entries, 4-column header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)