### PR TITLE
feat: republish agentic-* plugin ids as deprecation stubs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,30 @@
       "homepage": "https://github.com/bdfinst/agentic-dev-team",
       "repository": "https://github.com/bdfinst/agentic-dev-team",
       "license": "MIT"
+    },
+    {
+      "name": "agentic-dev-team",
+      "source": "./plugins/agentic-dev-team",
+      "description": "DEPRECATED legacy stub — renamed to dev-team@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. Scheduled for removal from the catalog no earlier than 2027-06-01.",
+      "version": "6.0.1",
+      "author": {
+        "name": "Bryan Finster"
+      },
+      "homepage": "https://github.com/bdfinst/agentic-dev-team",
+      "repository": "https://github.com/bdfinst/agentic-dev-team",
+      "license": "MIT"
+    },
+    {
+      "name": "agentic-security-assessment",
+      "source": "./plugins/agentic-security-assessment",
+      "description": "DEPRECATED legacy stub — renamed to security-assessment@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. Scheduled for removal from the catalog no earlier than 2027-06-01.",
+      "version": "3.0.1",
+      "author": {
+        "name": "Bryan Finster"
+      },
+      "homepage": "https://github.com/bdfinst/agentic-dev-team",
+      "repository": "https://github.com/bdfinst/agentic-dev-team",
+      "license": "MIT"
     }
   ]
 }

--- a/docs/specs/legacy-plugin-stubs.md
+++ b/docs/specs/legacy-plugin-stubs.md
@@ -1,0 +1,146 @@
+# Spec: Legacy Plugin Deprecation Stubs
+
+## Intent Description
+
+When the marketplace plugin ids were renamed in PR #43 (`agentic-dev-team` → `dev-team`, `agentic-security-assessment` → `security-assessment`), the new plugins shipped a Step 0 migration in `/upgrade` that walks installed users to the new ids. The migration ships in the **destination** plugin — useful only to someone already on the new plugin.
+
+Users still installed on the **source** plugins (`agentic-dev-team@5.6.0` and earlier) run an `/upgrade` whose first action is `claude plugin update agentic-dev-team@bfinster`. That call now fails because the marketplace catalog no longer lists either old name. Those users are stranded with no auto-migration path.
+
+This spec republishes both old plugin ids back into the marketplace catalog as **deprecation stubs** — minimal plugins whose entire purpose is to provide a working `/upgrade` that installs the new plugin and then removes the stub.
+
+The stubs are intentionally narrow:
+
+- One command (`/upgrade`), one README, one CHANGELOG, one `plugin.json`, no agents, no skills, no hooks, no knowledge, no templates.
+- Version bumped from `5.6.0` → `6.0.1` (and `2.2.2` → `3.0.1`) so `claude plugin update` sees a newer version than what installed users have and fetches the stub.
+- Marked DEPRECATED in description so anyone browsing the catalog sees the deprecation immediately.
+
+The stubs are scheduled for removal from the marketplace catalog no earlier than 2027-06-01 — twelve months after rename — to give all installed users a chance to migrate.
+
+## User-Facing Behavior
+
+```gherkin
+Feature: Legacy plugin id deprecation stubs
+
+  Scenario: Pre-rename installed user runs /upgrade
+    Given a user has "agentic-dev-team@bfinster" v5.6.0 (pre-rename) installed
+    And the marketplace catalog now lists "agentic-dev-team@bfinster" v6.0.1 (stub)
+    When they run "/upgrade" from a Claude Code session with the legacy plugin loaded
+    Then the existing /upgrade calls "claude plugin update agentic-dev-team@bfinster"
+    And the update succeeds (catalog resolves to the stub)
+    And the user's installed plugin is replaced with v6.0.1 (stub)
+    And the user is prompted to restart Claude Code
+
+  Scenario: User runs /upgrade from inside the stub
+    Given a user has just been upgraded to the v6.0.1 stub
+    And they have restarted Claude Code
+    When they run "/upgrade"
+    Then /upgrade detects the install scope from "claude plugin list"
+    And runs "claude plugin install --scope <scope> dev-team@bfinster"
+    And only after the install succeeds, runs "claude plugin uninstall --scope <scope> agentic-dev-team@bfinster"
+    And reports the migration in a single summary block
+    And ends with an ACTION REQUIRED line prompting restart
+
+  Scenario: Install of dev-team fails during stub /upgrade
+    Given a user is on the v6.0.1 stub
+    When they run "/upgrade"
+    And the install of "dev-team@bfinster" fails (network / marketplace error)
+    Then the stub is NOT uninstalled
+    And the failure is reported with the exact retry command
+    And /upgrade exits non-zero
+    And the user retains a working stub (with its /upgrade) to retry
+
+  Scenario: Fresh user accidentally installs the deprecated stub
+    Given a new user runs "claude plugin install agentic-dev-team@bfinster"
+    When the install completes
+    Then they have the v6.0.1 stub installed
+    And the stub README clearly states this is a deprecation stub
+    And running "/upgrade" migrates them to the real plugin
+
+  Scenario: Stub structure is minimal
+    Given the deprecation stubs ship in plugins/agentic-dev-team/ and plugins/agentic-security-assessment/
+    When inspecting the stub directories
+    Then each contains only plugin.json, /upgrade, README.md, CHANGELOG.md
+    And contains no agents/, no skills/, no knowledge/, no templates/, no hooks/, no harness/, no prompts/
+
+  Scenario: Marketplace catalog lists stubs alongside real plugins
+    When fetching .claude-plugin/marketplace.json
+    Then plugins[].name includes all four: dev-team, security-assessment, agentic-dev-team, agentic-security-assessment
+    And the two agentic-* descriptions contain "DEPRECATED"
+    And neither legacy stub appears as a depended-on plugin
+
+  Scenario: Release-please ignores the stubs
+    Given release-please-config.json is configured
+    When release-please runs
+    Then it tracks only "plugins/dev-team" and "plugins/security-assessment"
+    And does not propose releases for the legacy stub directories
+    And the stub versions are manually bumped if ever changed
+```
+
+## Architecture Specification
+
+### Files added (under `plugins/agentic-dev-team/`)
+
+| Path | Purpose |
+|---|---|
+| `.claude-plugin/plugin.json` | Manifest: name `agentic-dev-team`, version `6.0.1`, description marked DEPRECATED |
+| `commands/upgrade.md` | The migration command: scope detection → install new → uninstall self → restart prompt |
+| `README.md` | Explains the stub, the migration, and the sunset date |
+| `CHANGELOG.md` | Records the 6.0.1 deprecation release; points at `plugins/dev-team/CHANGELOG.md` for the real history |
+
+Mirror under `plugins/agentic-security-assessment/` with name `agentic-security-assessment`, version `3.0.1`.
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `.claude-plugin/marketplace.json` | Append two stub entries to `plugins[]` with DEPRECATED descriptions; preserve the existing real-plugin entries |
+| `scripts/assert-rename.sh` | New invariants: stub directories are shape-correct (only `/upgrade`, README, CHANGELOG, plugin.json — no agents/skills/etc.); marketplace catalog includes both real + stub; stub descriptions contain "DEPRECATED"; release-please consistency check excludes stub paths |
+
+### Files explicitly NOT modified
+
+- `release-please-config.json`: stubs are manually versioned, short-lived, and tracked outside the release-please workflow. Adding them would create perpetual release PRs for code that should be deleted, not iterated.
+- `.release-please-manifest.json`: same reason.
+- `plugins/dev-team/**` and `plugins/security-assessment/**`: the real plugins are unchanged. The existing migration in `plugins/dev-team/commands/upgrade.md` Step 0 remains in place (it's the second leg of the migration for users who already have both old and new installed, or who arrived via the stub).
+
+### Behavior contract for `/upgrade` in each stub
+
+1. Detect install scope via `claude plugin list`. Default to `user` if undetected.
+2. `claude plugin install --scope <scope> <new-name>@bfinster`.
+3. **Hard gate**: if the install fails, STOP. The stub is not uninstalled — the user has a working fallback. Surface the exact retry command.
+4. `claude plugin uninstall --scope <scope> <self>@bfinster`. On failure, warn but continue.
+5. Print a migration summary and an `ACTION REQUIRED: restart` line.
+
+### Sunset
+
+A future commit (no earlier than 2027-06-01) deletes:
+
+- `plugins/agentic-dev-team/`
+- `plugins/agentic-security-assessment/`
+- The two stub entries in `.claude-plugin/marketplace.json`
+- The stub-related assertions in `scripts/assert-rename.sh`
+
+The companion sunset tracker `docs/decisions/upgrade-step-0-sunset.md` (introduced in PR #43) covers the broader cleanup timeline, including the `/upgrade` Step 0 block in the real plugin.
+
+## Acceptance Criteria
+
+| ID | Criterion | Measurement |
+|---|---|---|
+| LSAC-1 | Both stub directories exist with the four required files | `[ -f plugins/agentic-dev-team/{.claude-plugin/plugin.json,commands/upgrade.md,README.md,CHANGELOG.md} ]` and same for `agentic-security-assessment` |
+| LSAC-2 | Stub `plugin.json` declares the old name and a version newer than the last real release (`6.0.1` > `5.6.0`; `3.0.1` > `2.2.2`) | `jq -r .name && jq -r .version` |
+| LSAC-3 | Stub descriptions in `plugin.json` AND in `marketplace.json` contain `DEPRECATED` | grep |
+| LSAC-4 | Stub directories contain NO agents/, skills/, knowledge/, templates/, prompts/, harness/, hooks/ subdirectories | `find` |
+| LSAC-5 | `.claude-plugin/marketplace.json` `plugins[]` lists all four ids in any order | `jq` |
+| LSAC-6 | `release-please-config.json` does NOT include the stub directories | `jq -e '.packages | has("plugins/agentic-dev-team") | not'` |
+| LSAC-7 | Each stub's `/upgrade` command body documents install-first-then-uninstall ordering, the hard gate on install failure, scope detection, and the restart message | grep for keywords |
+| LSAC-8 | `scripts/assert-rename.sh` passes all assertions including the new stub-shape invariants | exits zero |
+| LSAC-9 | The existing `evals/upgrade-migration/run.sh` still passes (PR #43 evals not regressed) | exits zero |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — stubs solve a specific stranded-user problem; they are not the real plugins and explicitly state so.
+- [x] Every behavior has a corresponding BDD scenario — fresh install-of-stub, upgrade-from-stub, install-failure path, structure invariants, marketplace listing, release-please scope.
+- [x] Architecture constrains without over-engineering — four files per stub, two marketplace entries, no release-please involvement, explicit sunset.
+- [x] Terminology consistent — "stub", "deprecation", "migration", "real plugin" used uniformly.
+- [x] No contradictions — stub `/upgrade` and real `/upgrade` Step 0 are not duplicates; they're sequential legs of the same migration when both exist.
+
+**Verdict: PASS**

--- a/plugins/agentic-dev-team/.claude-plugin/plugin.json
+++ b/plugins/agentic-dev-team/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentic-dev-team",
+  "version": "6.0.1",
+  "description": "DEPRECATED — renamed to dev-team@bfinster. This stub auto-migrates legacy installs on /upgrade. Will be removed from the marketplace catalog in v7.0.0 (planned: 2027-06-01).",
+  "author": {
+    "name": "finsterb",
+    "email": ""
+  }
+}

--- a/plugins/agentic-dev-team/CHANGELOG.md
+++ b/plugins/agentic-dev-team/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — agentic-dev-team (legacy stub)
+
+The real changelog lives at [`plugins/dev-team/CHANGELOG.md`](../dev-team/CHANGELOG.md). This file only tracks the deprecation stub.
+
+## [6.0.1] - 2026-06-02
+
+### Changed
+
+- **DEPRECATED**: this plugin id was renamed to `dev-team@bfinster` in v6.0.0. This release republishes the old name as a deprecation stub whose `/upgrade` command auto-migrates the install to the new id (install `dev-team@bfinster` first, then uninstall this stub).
+- All agents, skills, commands (except `/upgrade`), hooks, knowledge, prompts, and templates removed — they live in `dev-team@bfinster` now.
+
+### Why
+
+The pre-rename `/upgrade` (shipped in v5.6.0 and earlier) calls `claude plugin update agentic-dev-team@bfinster`, which the marketplace catalog no longer serves under that name after the rename. Without this stub, pre-rename users would be stranded with no auto-migration path.
+
+### Sunset
+
+This stub is scheduled for removal from the marketplace catalog no earlier than 2027-06-01. See `plugins/dev-team/docs/decisions/upgrade-step-0-sunset.md` (when present in the dev-team plugin) for the full rename-cleanup timeline.
+
+## Pre-deprecation history
+
+For releases 5.6.0 and earlier under this plugin id, see [`plugins/dev-team/CHANGELOG.md`](../dev-team/CHANGELOG.md) — the file history is preserved there under the new plugin id.

--- a/plugins/agentic-dev-team/README.md
+++ b/plugins/agentic-dev-team/README.md
@@ -1,0 +1,44 @@
+# agentic-dev-team — DEPRECATED legacy stub
+
+> **This plugin has been renamed.** The full development team now lives at
+> `dev-team@bfinster`. This stub exists only to migrate installs of the
+> old plugin id.
+
+## What this stub does
+
+This is **not** the real plugin. It contains exactly one command — `/upgrade` —
+whose job is to install `dev-team@bfinster` and then uninstall itself.
+
+If you're seeing this README, you're either:
+
+- **An installed user on a pre-rename version** whose marketplace
+  auto-resolved to this stub when `/upgrade` ran — perfect, just run
+  `/upgrade` again from this stub and you'll land on the real plugin.
+- **A fresh installer who picked the old id by mistake** — uninstall this
+  stub and install `dev-team@bfinster` instead.
+
+## Migrate now
+
+From any Claude Code session with this stub loaded:
+
+```
+/upgrade
+```
+
+That's it. The command installs `dev-team@bfinster`, removes this stub,
+and tells you to restart Claude Code. After restart you have the full
+team back: orchestrator, software-engineer, qa-engineer, all reviewers,
+the four-command workflow (`/specs → /plan → /build → /pr`), and every
+skill.
+
+## Sunset
+
+This stub will be removed from the marketplace catalog no earlier than
+**2027-06-01**. Migrate before then.
+
+## Real plugin
+
+→ [`dev-team@bfinster`](https://github.com/bdfinst/agentic-dev-team/tree/main/plugins/dev-team)
+
+The repository name on GitHub (`bdfinst/agentic-dev-team`) is unchanged
+— only the marketplace plugin id was renamed.

--- a/plugins/agentic-dev-team/commands/upgrade.md
+++ b/plugins/agentic-dev-team/commands/upgrade.md
@@ -1,0 +1,99 @@
+---
+name: upgrade
+description: >-
+  DEPRECATED stub: this plugin was renamed to dev-team@bfinster. /upgrade
+  migrates the install in place.
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Upgrade — Legacy Plugin Stub
+
+This plugin (`agentic-dev-team@bfinster`) has been renamed to
+`dev-team@bfinster`. The new name has been live in the bfinster
+marketplace since v6.0.0.
+
+`/upgrade` in this stub does one thing: install the new plugin, then
+uninstall this stub. After it runs, restart Claude Code; you'll be on
+`dev-team@bfinster` (the real plugin) with all the agents, skills,
+commands, and hooks intact under their new home.
+
+## Steps
+
+### 1. Detect install scope
+
+Read `claude plugin list` and find the `Scope:` line for
+`agentic-dev-team@bfinster`. It will be one of `user`, `project`,
+`local`, `managed`.
+
+```bash
+claude plugin list
+```
+
+Capture the scope into `{scope}`. If detection fails, default to `user`.
+
+### 2. Install the renamed plugin
+
+```bash
+claude plugin install --scope {scope} dev-team@bfinster
+```
+
+**Hard gate**: if this command exits non-zero, STOP. Report the failure
+and the exact retry command:
+
+> Migration failed: could not install dev-team@bfinster (network /
+> marketplace / version conflict). The legacy plugin is still installed
+> and functional. Retry with:
+>
+> ```
+> claude plugin install --scope {scope} dev-team@bfinster
+> ```
+
+Do NOT proceed to step 3 — the user must keep the working stub until
+the new plugin is in place.
+
+### 3. Uninstall this stub
+
+The install succeeded. Now remove the legacy stub:
+
+```bash
+claude plugin uninstall --scope {scope} agentic-dev-team@bfinster
+```
+
+If this fails, the new plugin is already installed — report the warning
+and let the user clean up later:
+
+> WARNING: dev-team@bfinster is now installed, but the legacy stub
+> could not be uninstalled. You may have both plugins loaded. Remove
+> the stub manually:
+> claude plugin uninstall --scope {scope} agentic-dev-team@bfinster
+
+### 4. Report and prompt for restart
+
+```
+## Migration Complete
+
+  agentic-dev-team@bfinster (stub)  →  dev-team@bfinster
+
+ACTION REQUIRED: restart Claude Code to load the renamed plugin.
+
+After restart you'll have the full team (agents, skills, /code-review,
+/plan, /build, /pr, …) under the new plugin id. Run /upgrade from
+dev-team to enable auto-update.
+```
+
+## Why this stub exists
+
+When the marketplace plugin id was renamed (`agentic-dev-team` →
+`dev-team`), users running the pre-rename `/upgrade` were stranded:
+the command called `claude plugin update agentic-dev-team@bfinster`,
+which the marketplace catalog no longer served. This stub is
+republished under the **old name** with the **same id but a higher
+version**, so the old `/upgrade` resolves, fetches this code, and
+hands control to the stub's `/upgrade` (above), which finishes the
+migration.
+
+Sunset: this stub is scheduled for removal from the marketplace catalog
+no earlier than 2027-06-01 to give all installed users a chance to
+migrate. See `docs/decisions/upgrade-step-0-sunset.md` (lives in the
+real dev-team plugin) for the broader rename-cleanup timeline.

--- a/plugins/agentic-security-assessment/.claude-plugin/plugin.json
+++ b/plugins/agentic-security-assessment/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentic-security-assessment",
+  "version": "3.0.1",
+  "description": "DEPRECATED — renamed to security-assessment@bfinster. This stub auto-migrates legacy installs on /upgrade. Will be removed from the marketplace catalog in v4.0.0 (planned: 2027-06-01).",
+  "author": {
+    "name": "finsterb",
+    "email": ""
+  }
+}

--- a/plugins/agentic-security-assessment/CHANGELOG.md
+++ b/plugins/agentic-security-assessment/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — agentic-security-assessment (legacy stub)
+
+The real changelog lives at [`plugins/security-assessment/CHANGELOG.md`](../security-assessment/CHANGELOG.md). This file only tracks the deprecation stub.
+
+## [3.0.1] - 2026-06-02
+
+### Changed
+
+- **DEPRECATED**: this plugin id was renamed to `security-assessment@bfinster` in v3.0.0. This release republishes the old name as a deprecation stub whose `/upgrade` command auto-migrates the install to the new id.
+- All agents, skills, commands (except `/upgrade`), hooks, knowledge, harness, and prompts removed — they live in `security-assessment@bfinster` now.
+
+### Why
+
+The pre-rename `/upgrade` was shipped only in `agentic-dev-team`, but anyone with both legacy plugins installed needs a path to migrate this one too. After running `/upgrade` from the renamed `dev-team`, this stub catches the second leg of the migration.
+
+### Sunset
+
+Scheduled for removal from the marketplace catalog no earlier than 2027-06-01.
+
+## Pre-deprecation history
+
+See [`plugins/security-assessment/CHANGELOG.md`](../security-assessment/CHANGELOG.md).

--- a/plugins/agentic-security-assessment/README.md
+++ b/plugins/agentic-security-assessment/README.md
@@ -1,0 +1,33 @@
+# agentic-security-assessment — DEPRECATED legacy stub
+
+> **This plugin has been renamed.** The security companion now lives at
+> `security-assessment@bfinster`. This stub exists only to migrate
+> installs of the old plugin id.
+
+## What this stub does
+
+This is **not** the real plugin. It contains exactly one command —
+`/upgrade` — whose job is to install `security-assessment@bfinster` and
+then uninstall itself.
+
+## Migrate now
+
+From any Claude Code session with this stub loaded:
+
+```
+/upgrade
+```
+
+After it finishes, restart Claude Code. You'll have the full security
+companion back: the `/security-assessment` pipeline, `/cross-repo-analysis`,
+the adversarial-ML red-team harness (`/redteam-model`), FP-reduction,
+compliance mapping, and all custom semgrep rulesets.
+
+## Sunset
+
+This stub will be removed from the marketplace catalog no earlier than
+**2027-06-01**. Migrate before then.
+
+## Real plugin
+
+→ [`security-assessment@bfinster`](https://github.com/bdfinst/agentic-dev-team/tree/main/plugins/security-assessment)

--- a/plugins/agentic-security-assessment/commands/upgrade.md
+++ b/plugins/agentic-security-assessment/commands/upgrade.md
@@ -1,0 +1,86 @@
+---
+name: upgrade
+description: >-
+  DEPRECATED stub: this plugin was renamed to security-assessment@bfinster.
+  /upgrade migrates the install in place.
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Upgrade — Legacy Plugin Stub
+
+This plugin (`agentic-security-assessment@bfinster`) has been renamed
+to `security-assessment@bfinster`. The new name has been live in the
+bfinster marketplace since v3.0.0.
+
+`/upgrade` in this stub does one thing: install the new plugin, then
+uninstall this stub. After it runs, restart Claude Code; you'll be on
+`security-assessment@bfinster` (the real plugin) with the full
+SARIF-first pipeline, red-team harness, and all agents and skills
+intact under their new home.
+
+## Steps
+
+### 1. Detect install scope
+
+```bash
+claude plugin list
+```
+
+Find the `Scope:` line for `agentic-security-assessment@bfinster` and
+capture it into `{scope}`. Default to `user` if detection fails.
+
+### 2. Install the renamed plugin
+
+```bash
+claude plugin install --scope {scope} security-assessment@bfinster
+```
+
+**Hard gate**: if this exits non-zero, STOP. Report:
+
+> Migration failed: could not install security-assessment@bfinster. The
+> legacy plugin is still installed and functional. Retry with:
+>
+> ```
+> claude plugin install --scope {scope} security-assessment@bfinster
+> ```
+
+Do NOT proceed to step 3.
+
+### 3. Uninstall this stub
+
+```bash
+claude plugin uninstall --scope {scope} agentic-security-assessment@bfinster
+```
+
+On failure:
+
+> WARNING: security-assessment@bfinster is now installed, but the
+> legacy stub could not be uninstalled. Remove manually:
+> claude plugin uninstall --scope {scope} agentic-security-assessment@bfinster
+
+### 4. Report and prompt for restart
+
+```
+## Migration Complete
+
+  agentic-security-assessment@bfinster (stub)  →  security-assessment@bfinster
+
+ACTION REQUIRED: restart Claude Code to load the renamed plugin.
+```
+
+If `dev-team@bfinster` is also installed but the user still has
+`agentic-dev-team@bfinster`, suggest:
+
+> The companion plugin agentic-dev-team has also been renamed. Run
+> /upgrade from agentic-dev-team to migrate it.
+
+## Why this stub exists
+
+See `plugins/agentic-dev-team/commands/upgrade.md` § "Why this stub
+exists" for the rationale. Same pattern: the old `/upgrade` called
+`claude plugin update agentic-security-assessment@bfinster`, which the
+catalog no longer serves under that name; this stub satisfies the
+resolution and hands control to a migration command.
+
+Sunset: scheduled for removal no earlier than 2027-06-01.

--- a/scripts/assert-rename.sh
+++ b/scripts/assert-rename.sh
@@ -47,10 +47,15 @@ pass() {
 
 # --- Consistency checks (always run) -------------------------------------
 
+# Deprecation stubs are deliberately NOT in release-please-config.json —
+# they're manually versioned and short-lived. The consistency check
+# excludes them.
+LEGACY_STUB_DIRS="plugins/agentic-dev-team plugins/agentic-security-assessment"
+
 # AC-14: every package key in release-please-config.json must correspond to
 # an extant plugin directory, and every plugins/* directory that ships a
-# plugin.json must be a known release-please package. This invariant must
-# hold at every commit on the branch.
+# plugin.json (excluding deprecation stubs) must be a known release-please
+# package. This invariant must hold at every commit on the branch.
 check_release_please_consistency() {
   if [ ! -f release-please-config.json ]; then
     fail "release-please-config.json missing"
@@ -63,15 +68,15 @@ check_release_please_consistency() {
     fail "release-please-config.json has no packages"
     return
   fi
-  # Directories that look like plugins (carry a plugin.json). Portable across
-  # GNU and BSD find: use -path, no -printf.
+  # Directories that look like plugins (carry a plugin.json), minus
+  # explicitly excluded deprecation stubs. Portable across GNU and BSD find.
   local actual
   actual=$(find plugins -mindepth 3 -maxdepth 3 -type f -path 'plugins/*/.claude-plugin/plugin.json' 2>/dev/null \
     | sed -e 's|/\.claude-plugin/plugin\.json$||' \
+    | grep -vE "^($(printf '%s' "$LEGACY_STUB_DIRS" | tr ' ' '|'))$" \
     | sort)
-  # Normalize: release-please paths are repo-relative without trailing slash.
   if [ "$declared" = "$actual" ]; then
-    pass "release-please packages match plugins/ layout"
+    pass "release-please packages match plugins/ layout (excluding deprecation stubs)"
   else
     fail "release-please packages diverge from plugins/ layout"
     printf '        declared: %s\n' "$declared" | tr '\n' ' '; echo
@@ -90,19 +95,10 @@ fi
 # --- Full assertion suite (added to as later steps land) -----------------
 
 # Step 2 invariants (manifest names, depends-on, marketplace catalog, dirs).
+# After the deprecation-stub work landed, plugins/agentic-* directories are
+# allowed to exist as long as they are stub-shaped (no agents/, no skills/,
+# only an /upgrade command).
 check_manifest_names() {
-  if [ -d plugins/agentic-dev-team ]; then
-    fail "plugins/agentic-dev-team still exists (expected: plugins/dev-team)"
-  else
-    pass "plugins/agentic-dev-team is gone"
-  fi
-
-  if [ -d plugins/agentic-security-assessment ]; then
-    fail "plugins/agentic-security-assessment still exists (expected: plugins/security-assessment)"
-  else
-    pass "plugins/agentic-security-assessment is gone"
-  fi
-
   if [ ! -d plugins/dev-team ]; then
     fail "plugins/dev-team missing"
   else
@@ -114,6 +110,32 @@ check_manifest_names() {
   else
     pass "plugins/security-assessment exists"
   fi
+
+  # Deprecation stubs must remain narrow: only /upgrade, no agents, no skills,
+  # no hooks beyond a settings.json stub if any. This prevents the stub from
+  # silently regrowing into a duplicate of the real plugin.
+  check_stub_is_minimal() {
+    local stub_dir="$1"
+    if [ ! -d "$stub_dir" ]; then
+      return  # stub directory absent is fine — already migrated/removed
+    fi
+    local forbidden
+    forbidden=$(find "$stub_dir" -mindepth 1 -maxdepth 2 -type d \
+      \( -name agents -o -name skills -o -name knowledge -o -name templates -o -name prompts -o -name harness -o -name hooks \) 2>/dev/null)
+    if [ -n "$forbidden" ]; then
+      fail "$stub_dir has non-stub subdirectories: $(printf '%s ' "$forbidden")"
+    else
+      pass "$stub_dir is stub-shaped (no agents/skills/knowledge/etc.)"
+    fi
+    # The stub MUST ship /upgrade — that's its entire reason to exist.
+    if [ -f "$stub_dir/commands/upgrade.md" ]; then
+      pass "$stub_dir/commands/upgrade.md present"
+    else
+      fail "$stub_dir/commands/upgrade.md missing — stub has no migration command"
+    fi
+  }
+  check_stub_is_minimal plugins/agentic-dev-team
+  check_stub_is_minimal plugins/agentic-security-assessment
 
   if [ -f plugins/dev-team/.claude-plugin/plugin.json ]; then
     local name
@@ -155,11 +177,23 @@ check_marketplace_catalog() {
   fi
   local names
   names=$(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort | tr '\n' ' ')
-  local expected="dev-team security-assessment "
+  # Real plugins + deprecation stubs are both expected. Order is alphabetical
+  # after `sort`: agentic-dev-team, agentic-security-assessment, dev-team,
+  # security-assessment.
+  local expected="agentic-dev-team agentic-security-assessment dev-team security-assessment "
   if [ "$names" = "$expected" ]; then
-    pass "marketplace.json lists exactly: dev-team, security-assessment"
+    pass "marketplace.json lists real plugins + deprecation stubs"
   else
     fail "marketplace.json plugin names = '$names' (expected '$expected')"
+  fi
+  # Stubs MUST be marked deprecated in their description so anyone browsing
+  # the catalog sees the deprecation immediately.
+  local stub_descs
+  stub_descs=$(jq -r '.plugins[] | select(.name == "agentic-dev-team" or .name == "agentic-security-assessment") | .description' .claude-plugin/marketplace.json)
+  if printf '%s' "$stub_descs" | grep -q -i 'DEPRECATED'; then
+    pass "marketplace stub descriptions mark them DEPRECATED"
+  else
+    fail "marketplace stub descriptions do not contain 'DEPRECATED'"
   fi
 }
 
@@ -225,8 +259,10 @@ check_release_please_manifest
 # except CHANGELOG.md (history) and commands/upgrade.md (migration block).
 check_dev_team_body_clean() {
   local hits
+  # Skip the deprecation stub directory — legitimate home for the legacy name.
   hits=$(grep -rln "agentic-dev-team" plugins/dev-team/ \
-    --exclude=CHANGELOG.md --exclude=upgrade.md 2>/dev/null || true)
+    --exclude=CHANGELOG.md --exclude=upgrade.md 2>/dev/null \
+    | grep -v '^plugins/agentic-dev-team/' || true)
   if [ -z "$hits" ]; then
     pass "plugins/dev-team/ free of agentic-dev-team references"
   else
@@ -308,8 +344,8 @@ check_no_live_legacy_references() {
   fi
   local hits
   hits=$(printf '%s\n' "$raw_hits" \
-    | grep -vE '(github\.com/bdfinst/agentic-dev-team|Previously published as)' \
-    | grep -vE '^(CHANGELOG\.md|.*/CHANGELOG\.md|metrics/config-changelog\.jsonl|memory/decisions\.md|plans/|docs/adr/|docs/specs/rename-plugins\.md|docs/decisions/upgrade-step-0-sunset\.md|evals/security-review-adapter/|evals/upgrade-migration/|plugins/dev-team/commands/upgrade\.md|plugins/security-assessment/install\.sh|scripts/assert-rename\.sh|scripts/sweep-rename\.sh|README\.md)' \
+    | grep -vE '(github\.com/bdfinst/agentic-dev-team|Previously published as|DEPRECATED|"name": "agentic-(dev-team|security-assessment)"|"source": "\./plugins/agentic-(dev-team|security-assessment)")' \
+    | grep -vE '^(CHANGELOG\.md|.*/CHANGELOG\.md|metrics/config-changelog\.jsonl|memory/decisions\.md|plans/|docs/adr/|docs/specs/rename-plugins\.md|docs/specs/legacy-plugin-stubs\.md|docs/decisions/upgrade-step-0-sunset\.md|evals/security-review-adapter/|evals/upgrade-migration/|plugins/dev-team/commands/upgrade\.md|plugins/security-assessment/install\.sh|plugins/agentic-dev-team/|plugins/agentic-security-assessment/|scripts/assert-rename\.sh|scripts/sweep-rename\.sh|README\.md)' \
     || true)
   if [ -z "$hits" ]; then
     pass "no live references to legacy plugin names in tracked files"

--- a/tests/repo/legacy_plugin_stubs.bats
+++ b/tests/repo/legacy_plugin_stubs.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+#
+# tests/repo/legacy_plugin_stubs.bats — invariants for the deprecation
+# stubs published under the old plugin ids (agentic-dev-team,
+# agentic-security-assessment).
+#
+# Spec: docs/specs/legacy-plugin-stubs.md
+# Acceptance criteria LSAC-1 through LSAC-7.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  STUB_DEV="$REPO_ROOT/plugins/agentic-dev-team"
+  STUB_SEC="$REPO_ROOT/plugins/agentic-security-assessment"
+}
+
+# LSAC-1: required files present in each stub
+@test "LSAC-1: agentic-dev-team stub has plugin.json, upgrade.md, README, CHANGELOG" {
+  [ -f "$STUB_DEV/.claude-plugin/plugin.json" ]
+  [ -f "$STUB_DEV/commands/upgrade.md" ]
+  [ -f "$STUB_DEV/README.md" ]
+  [ -f "$STUB_DEV/CHANGELOG.md" ]
+}
+
+@test "LSAC-1: agentic-security-assessment stub has plugin.json, upgrade.md, README, CHANGELOG" {
+  [ -f "$STUB_SEC/.claude-plugin/plugin.json" ]
+  [ -f "$STUB_SEC/commands/upgrade.md" ]
+  [ -f "$STUB_SEC/README.md" ]
+  [ -f "$STUB_SEC/CHANGELOG.md" ]
+}
+
+# LSAC-2: plugin.json declares old name + version newer than last real release
+@test "LSAC-2: agentic-dev-team stub plugin.json declares legacy name and bumped version" {
+  local name version
+  name=$(jq -r .name "$STUB_DEV/.claude-plugin/plugin.json")
+  version=$(jq -r .version "$STUB_DEV/.claude-plugin/plugin.json")
+  [ "$name" = "agentic-dev-team" ]
+  # Stub version must be newer than the last pre-rename release (5.6.0)
+  # so `claude plugin update` sees the catalog version as newer than
+  # what the user has installed.
+  case "$version" in
+    6.*|7.*|8.*|9.*) ;;
+    *) printf 'stub version %s is not >= 6.x\n' "$version" >&2; return 1 ;;
+  esac
+}
+
+@test "LSAC-2: agentic-security-assessment stub plugin.json declares legacy name and bumped version" {
+  local name version
+  name=$(jq -r .name "$STUB_SEC/.claude-plugin/plugin.json")
+  version=$(jq -r .version "$STUB_SEC/.claude-plugin/plugin.json")
+  [ "$name" = "agentic-security-assessment" ]
+  # Stub version must be newer than the last pre-rename release (2.2.2).
+  case "$version" in
+    3.*|4.*|5.*|6.*|7.*|8.*|9.*) ;;
+    *) printf 'stub version %s is not >= 3.x\n' "$version" >&2; return 1 ;;
+  esac
+}
+
+# LSAC-3: descriptions marked DEPRECATED in BOTH plugin.json and marketplace.json
+@test "LSAC-3: agentic-dev-team stub plugin.json marks itself DEPRECATED" {
+  local desc
+  desc=$(jq -r .description "$STUB_DEV/.claude-plugin/plugin.json")
+  echo "$desc" | grep -qi 'DEPRECATED'
+}
+
+@test "LSAC-3: agentic-security-assessment stub plugin.json marks itself DEPRECATED" {
+  local desc
+  desc=$(jq -r .description "$STUB_SEC/.claude-plugin/plugin.json")
+  echo "$desc" | grep -qi 'DEPRECATED'
+}
+
+@test "LSAC-3: marketplace.json stub entries marked DEPRECATED" {
+  local mp="$REPO_ROOT/.claude-plugin/marketplace.json"
+  jq -e '.plugins[] | select(.name == "agentic-dev-team") | .description' "$mp" | grep -qi 'DEPRECATED'
+  jq -e '.plugins[] | select(.name == "agentic-security-assessment") | .description' "$mp" | grep -qi 'DEPRECATED'
+}
+
+# LSAC-4: stub directories contain NO non-stub subdirectories
+@test "LSAC-4: agentic-dev-team stub has no agents/skills/knowledge/templates/prompts/harness/hooks" {
+  for forbidden in agents skills knowledge templates prompts harness hooks; do
+    if [ -d "$STUB_DEV/$forbidden" ]; then
+      printf 'forbidden subdirectory present: %s/%s\n' "$STUB_DEV" "$forbidden" >&2
+      return 1
+    fi
+  done
+}
+
+@test "LSAC-4: agentic-security-assessment stub has no agents/skills/knowledge/templates/prompts/harness/hooks" {
+  for forbidden in agents skills knowledge templates prompts harness hooks; do
+    if [ -d "$STUB_SEC/$forbidden" ]; then
+      printf 'forbidden subdirectory present: %s/%s\n' "$STUB_SEC" "$forbidden" >&2
+      return 1
+    fi
+  done
+}
+
+# LSAC-5: marketplace.json lists all four ids
+@test "LSAC-5: marketplace.json plugins[] contains both stubs and both real plugins" {
+  local mp="$REPO_ROOT/.claude-plugin/marketplace.json"
+  local names
+  names=$(jq -r '.plugins[].name' "$mp" | sort | tr '\n' ' ')
+  [ "$names" = "agentic-dev-team agentic-security-assessment dev-team security-assessment " ]
+}
+
+# LSAC-6: release-please does NOT track the stubs
+@test "LSAC-6: release-please-config.json excludes the stub directories" {
+  local cfg="$REPO_ROOT/release-please-config.json"
+  jq -e '.packages | (has("plugins/agentic-dev-team") | not) and (has("plugins/agentic-security-assessment") | not)' "$cfg" >/dev/null
+}
+
+@test "LSAC-6: .release-please-manifest.json excludes the stub directories" {
+  local m="$REPO_ROOT/.release-please-manifest.json"
+  jq -e '(has("plugins/agentic-dev-team") | not) and (has("plugins/agentic-security-assessment") | not)' "$m" >/dev/null
+}
+
+# LSAC-7: each stub's /upgrade body documents the migration contract
+@test "LSAC-7: agentic-dev-team /upgrade documents install-first-then-uninstall + scope + restart" {
+  local up="$STUB_DEV/commands/upgrade.md"
+  # Install must appear BEFORE uninstall in the document body.
+  local install_line uninstall_line
+  install_line=$(grep -n 'claude plugin install --scope' "$up" | head -1 | cut -d: -f1)
+  uninstall_line=$(grep -n 'claude plugin uninstall --scope' "$up" | head -1 | cut -d: -f1)
+  [ -n "$install_line" ] && [ -n "$uninstall_line" ] && [ "$install_line" -lt "$uninstall_line" ]
+  # Hard gate language on install failure.
+  grep -qi 'STOP' "$up"
+  grep -qi 'Retry with' "$up"
+  # Scope detection.
+  grep -qi 'claude plugin list' "$up"
+  # Restart prompt.
+  grep -qi 'restart Claude Code' "$up"
+  # Names the destination plugin.
+  grep -q 'dev-team@bfinster' "$up"
+}
+
+@test "LSAC-7: agentic-security-assessment /upgrade documents install-first-then-uninstall + scope + restart" {
+  local up="$STUB_SEC/commands/upgrade.md"
+  local install_line uninstall_line
+  install_line=$(grep -n 'claude plugin install --scope' "$up" | head -1 | cut -d: -f1)
+  uninstall_line=$(grep -n 'claude plugin uninstall --scope' "$up" | head -1 | cut -d: -f1)
+  [ -n "$install_line" ] && [ -n "$uninstall_line" ] && [ "$install_line" -lt "$uninstall_line" ]
+  grep -qi 'STOP' "$up"
+  grep -qi 'Retry with' "$up"
+  grep -qi 'claude plugin list' "$up"
+  grep -qi 'restart Claude Code' "$up"
+  grep -q 'security-assessment@bfinster' "$up"
+}


### PR DESCRIPTION
## Summary

Closes the stranded-user gap left by PR #43.

After the rename, users on `agentic-dev-team@5.x` who run `/upgrade` hit `claude plugin update agentic-dev-team@bfinster` → "Plugin not found" because the marketplace catalog no longer lists that name. The Step 0 migration I added in PR #43 lives in the *destination* plugin (`dev-team`), unreachable from the stranded source.

This PR republishes both old ids back into the catalog as **minimal deprecation stubs**.

- `agentic-dev-team@bfinster` v6.0.1 (stub)
- `agentic-security-assessment@bfinster` v3.0.1 (stub)

Each stub contains only `plugin.json`, `commands/upgrade.md`, README, CHANGELOG — no agents, skills, knowledge, hooks, etc. Those live in the real plugins. The stub's `/upgrade` installs the real plugin, then removes itself.

## Migration flow (any starting version)

```
agentic-dev-team@5.x  →  /upgrade  →  agentic-dev-team@6.0.1 (stub)  →  restart
                                  →  /upgrade  →  dev-team@bfinster  →  restart  →  done
```

Two cycles, zero manual commands. Works for any pre-rename version (5.3.0, 5.4.0, 5.5.0, 5.6.0) — semver ordering jumps everyone to 6.0.1 on the first `/upgrade`.

## What this is NOT

- Not a code change to the real plugins (`dev-team`, `security-assessment`) — they're untouched.
- Not added to `release-please-config.json` — stubs are manually versioned, short-lived, deletable. Tracking them in release-please would create perpetual release PRs for code we want to delete.
- Not an agent/skill duplication — the assertion harness now enforces that the stubs stay stub-shaped (no `agents/`, no `skills/`, etc.).

## Quality Gate

- [x] `scripts/assert-rename.sh` → 26 passed, 0 failed (was 23; new invariants added for stub shape, marketplace listing, release-please scope)
- [x] `bats tests/repo/legacy_plugin_stubs.bats` → 14 passed, 0 failed (new test suite covering LSAC-1 through LSAC-7)
- [x] `bash evals/upgrade-migration/run.sh` → 44 passed, 0 failed (PR #43 evals not regressed)
- [x] shellcheck clean

## Sunset

The stubs are scheduled for removal from the marketplace catalog no earlier than **2027-06-01**, matching the `/upgrade` Step 0 sunset tracker in `docs/decisions/upgrade-step-0-sunset.md`.

## Files

**Added**:
- `plugins/agentic-dev-team/{.claude-plugin/plugin.json, commands/upgrade.md, README.md, CHANGELOG.md}`
- `plugins/agentic-security-assessment/{.claude-plugin/plugin.json, commands/upgrade.md, README.md, CHANGELOG.md}`
- `docs/specs/legacy-plugin-stubs.md`
- `tests/repo/legacy_plugin_stubs.bats`

**Modified**:
- `.claude-plugin/marketplace.json` — appends both stub entries with `DEPRECATED` in descriptions
- `scripts/assert-rename.sh` — new invariants for stubs; existing checks adjusted to accept stubs

## Test plan

- [ ] CI plugin-tests workflow passes on this branch
- [ ] After merge, the marketplace catalog lists all four ids: `dev-team`, `security-assessment`, `agentic-dev-team`, `agentic-security-assessment`
- [ ] Manual smoke test: install `agentic-dev-team@bfinster` fresh in a sandbox project, run `/upgrade`, confirm it installs `dev-team@bfinster` and uninstalls the stub
- [ ] Manual smoke test: simulate the install-failure path with no network — `/upgrade` should not uninstall the stub
