### PR TITLE
feat(security-assessment): add /upgrade command

### DIFF
--- a/plugins/security-assessment/CLAUDE.md
+++ b/plugins/security-assessment/CLAUDE.md
@@ -81,8 +81,10 @@ See `install.sh`. It performs four checks:
 | `/cross-repo-analysis <paths>` | orchestrator | Shared credentials + service-comm analysis across multiple repos |
 | `/redteam-model <target>` | orchestrator | Adversarial ML red-team probes against a self-owned target |
 | `/export-pdf <report.md>` | worker | PDF export via pandoc/weasyprint |
+| `/upgrade` | worker | Update the security-assessment plugin and optionally enable marketplace auto-update |
 
 **Agents** (12 opus):
+
 - `fp-reduction` (opus) — 6-stage FP-reduction rubric (Stage 0 devil's advocate + Stages 1–5); disposition register with confidence field
 - `business-logic-domain-review` (opus) — fraud-domain anti-patterns
 - `deep-code-reasoning` (opus) — RECON surface-scoped freeform vulnerability reasoning; novel context-dependent issues beyond static rules
@@ -98,27 +100,33 @@ See `install.sh`. It performs four checks:
 - `compliance-edge-annotator` (opus) — LLM edge judgment for ambiguous mappings
 
 **Skills** (3):
+
 - `false-positive-reduction` — 5-stage rubric + joern / LLM-fallback
 - `compliance-mapping` — pattern-table first with LLM edge annotation
 - `security-assessment-pipeline` — declarative phase graph for `/security-assessment`
 
-**Commands** (4):
+**Commands** (5):
+
 - `/security-assessment <path>` — full static-analysis pipeline
 - `/cross-repo-analysis <paths>` — cross-repo attack-chain analysis
 - `/redteam-model <target>` — adversarial ML red-team
 - `/export-pdf <report.md>` — PDF export
+- `/upgrade` — plugin update + auto-update opt-in
 
 **Hooks** (2):
+
 - `PreToolUse:Bash` → `redteam-guard.sh` (blocks direct orchestrator invocation)
 - `PostToolUse:Edit|Write` → `static-scan-on-edit.sh` (auto-scan on writes)
 
 **Knowledge** (4):
+
 - `domain-logic-patterns.md` — fraud domain anti-pattern reference
 - `compliance-patterns.yaml` — 11-pattern regulatory mapping table
 - `redteam-authorization.md` — self-cert artifact format
 - `semgrep-rules/{ml-patterns,llm-safety,fraud-domain,crypto-anti-patterns}.yaml` — 18 custom rules across 4 rulesets
 
 **Harness** (Python, under `harness/`):
+
 - `redteam/orchestrator.py` + `config.py` + `lib/{http_client,result_store,scoring,feature_dict,scope_check}.py`
 - 8 probes: `redteam/probes/{01..08}_*.py`
 - `tools/{service-comm-parser,shared-cred-hash-match}.py`

--- a/plugins/security-assessment/README.md
+++ b/plugins/security-assessment/README.md
@@ -104,6 +104,25 @@ The check validates:
 | `/cross-repo-analysis <paths>` | Shared credentials and service-communication analysis across multiple repos |
 | `/redteam-model <target>` | Adversarial ML red-team probes against a self-owned target |
 | `/export-pdf <report.md>` | PDF export via pandoc / weasyprint |
+| `/upgrade` | Update the plugin to the latest marketplace release; offer to enable marketplace-level auto-update |
+
+## Update
+
+Run `/upgrade` from any Claude Code session with this plugin loaded. It:
+
+1. Reads the installed version from `claude plugin list`.
+2. Checks the auto-update flag on the `bfinster` marketplace and asks for consent before enabling it (the same flag the `/plugin` UI toggles).
+3. Detects the install scope and passes `--scope <scope>` to `claude plugin update` so project- and local-scope installs upgrade correctly.
+4. Warns if the companion `dev-team` plugin is not installed (it provides primitives this plugin depends on).
+5. Reports the previous and new version, and prompts a restart.
+
+Migration from the pre-rename `agentic-security-assessment@bfinster` id is handled by the legacy deprecation stub published in the marketplace catalog — install or `/upgrade` from that stub and it will install `security-assessment@bfinster` then remove itself.
+
+Manual fallback when `/upgrade` is unavailable:
+
+```bash
+claude plugin update --scope <scope> security-assessment@bfinster
+```
 
 ## Safety defaults
 

--- a/plugins/security-assessment/commands/upgrade.md
+++ b/plugins/security-assessment/commands/upgrade.md
@@ -1,0 +1,241 @@
+---
+name: upgrade
+description: >-
+  Check for and apply security-assessment plugin updates using the
+  official Claude Code plugin update mechanism.
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Upgrade
+
+Role: worker. This command updates the security-assessment plugin to
+the latest version and ensures its marketplace is set to auto-update
+going forward.
+
+You have been invoked with the `/upgrade` command.
+
+## Steps
+
+### 1. Read current version
+
+```bash
+claude plugin list
+```
+
+Parse the output to find `security-assessment` and its current version.
+Also read the installed `plugin.json` directly:
+
+```
+~/.claude/plugins/cache/*/security-assessment/*/.claude-plugin/plugin.json
+```
+
+Report:
+
+> **Current version**: security-assessment v{version} (installed from {marketplace})
+
+### 2. Check auto-update status and ask the user
+
+First, check the current auto-update status by running the script below
+and reporting it to the user.
+
+```bash
+python3 - <<'PY'
+import json, os
+
+PLUGIN = "security-assessment"
+home = os.path.expanduser("~")
+cwd = os.getcwd()
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        print(f"unknown ({path} is not valid JSON)")
+        raise SystemExit(0)
+
+installed = (load(os.path.join(home, ".claude", "plugins", "installed_plugins.json")) or {}).get("plugins", {})
+market = next((pid.split("@", 1)[1] for pid in installed if pid.split("@", 1)[0] == PLUGIN and "@" in pid), None)
+if not market:
+    print("unknown (marketplace not found)")
+    raise SystemExit(0)
+
+candidates = [
+    os.path.join(cwd, ".claude", "settings.json"),
+    os.path.join(cwd, ".claude", "settings.local.json"),
+    os.path.join(home, ".claude", "settings.json"),
+]
+for path in candidates:
+    data = load(path)
+    if data and market in (data.get("extraKnownMarketplaces") or {}):
+        flag = data["extraKnownMarketplaces"][market].get("autoUpdate")
+        print("enabled" if flag is True else "disabled")
+        raise SystemExit(0)
+
+print("disabled")
+PY
+```
+
+Then ask the user:
+
+> Auto-update for the `{marketplace}` marketplace is currently **{enabled/disabled}**.
+> Would you like to enable auto-update so future releases install automatically? (yes/no)
+>
+> Note: this flag is **marketplace-level** and affects every plugin
+> published from `{marketplace}` — including the companion dev-team
+> plugin if you have it installed.
+
+Wait for the user's answer before continuing. If they say **yes**, run
+the enable block below. If they say **no**, skip to step 3.
+
+**Enable block** (run only if the user consents):
+
+```bash
+python3 - <<'PY'
+import json, os
+
+PLUGIN = "security-assessment"
+home = os.path.expanduser("~")
+cwd = os.getcwd()
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        print(f"  ! {path} is not valid JSON ({e}); skipping")
+        return None
+
+installed = (load(os.path.join(home, ".claude", "plugins", "installed_plugins.json")) or {}).get("plugins", {})
+market = next((pid.split("@", 1)[1] for pid in installed if pid.split("@", 1)[0] == PLUGIN and "@" in pid), None)
+if not market:
+    print(f"  ! Could not resolve the marketplace for '{PLUGIN}'; skipping.")
+    raise SystemExit(0)
+
+candidates = [
+    os.path.join(cwd, ".claude", "settings.json"),
+    os.path.join(cwd, ".claude", "settings.local.json"),
+    os.path.join(home, ".claude", "settings.json"),
+]
+target = None
+for path in candidates:
+    data = load(path)
+    if data and market in (data.get("extraKnownMarketplaces") or {}):
+        target = [path, data]
+        break
+
+if target is None:
+    reg = load(os.path.join(home, ".claude", "plugins", "known_marketplaces.json")) or {}
+    entry = reg.get(market)
+    if not entry:
+        print(f"  ! Marketplace '{market}' not found in settings or registry; skipping.")
+        raise SystemExit(0)
+    path = os.path.join(home, ".claude", "settings.json")
+    data = load(path) or {}
+    data.setdefault("extraKnownMarketplaces", {})[market] = {"source": entry["source"]}
+    target = [path, data]
+
+path, data = target
+mk = data["extraKnownMarketplaces"][market]
+if mk.get("autoUpdate") is True:
+    print(f"  auto-update already enabled for '{market}' ({path})")
+else:
+    mk["autoUpdate"] = True
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    print(f"  enabled auto-update for '{market}' in {path}")
+    print("  (takes effect on next Claude Code launch / plugin operation)")
+PY
+```
+
+Report the one-line result to the user, then continue to step 3.
+
+### 3. Run the update
+
+First, determine the install scope from `claude plugin list` output
+(the `Scope:` line for `security-assessment`). It will be one of:
+`user`, `project`, `local`, `managed`.
+
+```bash
+claude plugin update --scope {scope} security-assessment@{marketplace}
+```
+
+Where `{scope}` is the detected install scope (e.g., `project`) and
+`{marketplace}` is the marketplace name (e.g., `bfinster`). The
+`--scope` flag is required — the CLI defaults to `user`, which will
+fail if the plugin is installed at a different scope.
+
+If the command succeeds with a version change, proceed to step 4.
+
+If the output indicates already up to date:
+
+> Already running the latest version (v{version}).
+
+Exit.
+
+If the command fails, report the error and suggest:
+
+> Update failed. You can try a manual reinstall:
+>
+> ```
+> claude plugin uninstall --scope {scope} security-assessment@{marketplace}
+> claude plugin install --scope {scope} security-assessment@{marketplace}
+> ```
+
+Exit.
+
+### 4. Check companion dependency
+
+If `dev-team@{marketplace}` is **not** installed, surface the dependency:
+
+> WARNING: `dev-team@{marketplace}` is not installed but is required by
+> `security-assessment` (primitives contract, codebase-recon agent,
+> SARIF parser). Install it with:
+>
+> ```
+> claude plugin install --scope {scope} dev-team@{marketplace}
+> ```
+
+This is informational — the security-assessment update has already
+succeeded. The user can act on it after restart.
+
+### 5. Confirm the update
+
+```bash
+claude plugin list
+```
+
+Report:
+
+```
+## Upgrade Complete
+
+Previous: security-assessment v{old_version}
+Updated:  security-assessment v{new_version}
+
+Restart Claude Code to apply the update.
+```
+
+## Notes
+
+- The `claude plugin update` command handles fetching, caching, and
+  version management. Previous versions are kept for 7 days so active
+  sessions continue working.
+- A restart of Claude Code is required for the new version to take
+  effect.
+- Step 2 enables marketplace-level auto-update by writing
+  `extraKnownMarketplaces.<marketplace>.autoUpdate: true` to
+  `settings.json` — the same flag the `/plugin` UI toggles. With it on,
+  routine releases for **both** plugins in the marketplace (`dev-team`
+  and `security-assessment`) land without running `/upgrade` again.
+- For migrating from the pre-rename `agentic-security-assessment@bfinster`
+  id, the legacy deprecation stub (`agentic-security-assessment` v3.0.1
+  in the marketplace catalog) has its own `/upgrade` that installs
+  `security-assessment@bfinster` then removes itself. This command is
+  the steady-state upgrade for users already on the new id.

--- a/tests/commands/security_upgrade_tests.bats
+++ b/tests/commands/security_upgrade_tests.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+#
+# tests/commands/security_upgrade_tests.bats — structural invariants for
+# the security-assessment plugin's /upgrade command. The plugin ships its
+# own /upgrade (parallel to dev-team's) so users with only the security
+# plugin installed have an in-session update path.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  UPGRADE="$REPO_ROOT/plugins/security-assessment/commands/upgrade.md"
+}
+
+@test "security-assessment ships an upgrade.md command" {
+  [ -f "$UPGRADE" ]
+}
+
+@test "security-assessment /upgrade frontmatter declares name=upgrade and user-invocable" {
+  # YAML frontmatter is between the first two '---' lines.
+  local frontmatter
+  frontmatter=$(awk '/^---$/{c++; next} c==1' "$UPGRADE")
+  echo "$frontmatter" | grep -qE '^name:[[:space:]]*upgrade$'
+  echo "$frontmatter" | grep -qE '^user-invocable:[[:space:]]*true$'
+}
+
+@test "security-assessment /upgrade targets the correct plugin id" {
+  # The Python detection block must pin PLUGIN to security-assessment.
+  grep -qE 'PLUGIN[[:space:]]*=[[:space:]]*"security-assessment"' "$UPGRADE"
+  # And the install/update commands must reference security-assessment, not dev-team.
+  grep -q 'security-assessment@{marketplace}' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade uses --scope on plugin update" {
+  # Same scope-detection contract as dev-team's /upgrade — must not let
+  # the CLI default to user-scope against a project-scope install.
+  grep -qE 'claude plugin update --scope \{scope\} security-assessment@\{marketplace\}' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade asks before enabling auto-update" {
+  # No silent enablement: the consent prompt + yes-branch wording must be present.
+  grep -qE 'Would you like to enable auto-update' "$UPGRADE"
+  grep -qiE 'enable block.*run only if the user consents' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade warns about marketplace-scope of auto-update flag" {
+  # Auto-update is per-marketplace, not per-plugin — users must understand
+  # consenting here also affects dev-team.
+  grep -qiE 'marketplace-level' "$UPGRADE"
+  grep -qE 'dev-team' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade surfaces companion dependency check" {
+  # If dev-team isn't installed, the user should be told.
+  grep -qE '(dev-team@.* is not installed|claude plugin install --scope \{scope\} dev-team@\{marketplace\})' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade prompts a restart" {
+  grep -qE 'Restart Claude Code' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade references the legacy deprecation stub" {
+  # Documents the migration path for users coming from the pre-rename name.
+  grep -qE 'agentic-security-assessment' "$UPGRADE"
+}
+
+@test "security-assessment /upgrade is registered in CLAUDE.md dispatch table" {
+  local claude_md="$REPO_ROOT/plugins/security-assessment/CLAUDE.md"
+  # Must appear in the dispatch registry table.
+  grep -qE '\| \`/upgrade\` \|' "$claude_md"
+  # And in the Commands list (count bumped from 4 to 5).
+  grep -qE '\*\*Commands\*\* \(5\)' "$claude_md"
+}
+
+@test "security-assessment /upgrade is documented in README" {
+  local readme="$REPO_ROOT/plugins/security-assessment/README.md"
+  grep -qE '^## Update' "$readme"
+  grep -qE '\| \`/upgrade\` \|' "$readme"
+}


### PR DESCRIPTION
## Summary

The `security-assessment` plugin shipped no `/upgrade` command — users with only this plugin installed (no `dev-team`) had no in-session update path. After PR #43 (rename) + #44 (release), this became more visible: in a security-only project, the only `/upgrade` available comes from `dev-team`, and it targets the `dev-team` plugin id.

This PR adds `/upgrade` to `security-assessment` with the same shape as `dev-team`'s steady-state command.

## What `/upgrade` does

1. Read current installed version from `claude plugin list`.
2. Check the marketplace auto-update flag and **ask before enabling**. The prompt explicitly notes that the flag is marketplace-scoped — consenting affects `dev-team` too if it's installed from the same marketplace.
3. Detect install scope from `claude plugin list` and pass `--scope <scope>` to `claude plugin update security-assessment@bfinster`. Without this, the CLI defaults to `user` and fails against project/local installs.
4. Companion-dependency check: warn if `dev-team@bfinster` isn't installed. The security plugin depends on it for primitives, codebase-recon, and the SARIF parser.
5. Report previous + new version, prompt for restart.

## What this is NOT

- **Not a legacy-migration command.** Legacy-id migration (`agentic-security-assessment` → `security-assessment`) is handled by the deprecation stub published in PR #45. This `/upgrade` is the steady-state update for users already on the new plugin id.
- **Not a duplication of `dev-team`'s `/upgrade`.** The two are intentionally parallel — each plugin updates itself, but the consent prompt for marketplace-level auto-update is shared awareness so a user doesn't toggle it twice without realizing it's the same flag.

## Quality Gate

- [x] `bats tests/commands/security_upgrade_tests.bats` → 11 passed, 0 failed
- [x] `bats -r tests/` → 346 passed, 0 failed (no regressions)
- [x] 11 structural invariants cover frontmatter, plugin-id targeting, scope handling, consent prompt, marketplace-scope warning, companion check, restart prompt, README + CLAUDE.md registration

## Files

**Added**:
- `plugins/security-assessment/commands/upgrade.md`
- `tests/commands/security_upgrade_tests.bats`

**Modified**:
- `plugins/security-assessment/CLAUDE.md` — dispatch table row, Commands count 4 → 5
- `plugins/security-assessment/README.md` — new "Update" section between Commands and Safety defaults

## Test plan

- [ ] CI plugin-tests workflow passes on this branch
- [ ] Manual smoke test: in a project with `security-assessment` only (no `dev-team`), run `/upgrade` and verify the companion-dependency warning fires
- [ ] Manual smoke test: in a project with both plugins, run `/upgrade` from each and verify the auto-update consent prompt does not double-toggle (it's the same marketplace flag)

## Related

- PR #43 — plugin rename (merged)
- PR #44 — release-please cut v6.0.0/v3.0.0 (merged)
- PR #45 — legacy deprecation stubs (open)
