### PR TITLE
feat: SessionStart deprecation banner for legacy plugin stubs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,8 +34,8 @@
     {
       "name": "agentic-dev-team",
       "source": "./plugins/agentic-dev-team",
-      "description": "DEPRECATED legacy stub — renamed to dev-team@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. Scheduled for removal from the catalog no earlier than 2027-06-01.",
-      "version": "6.0.1",
+      "description": "DEPRECATED legacy stub — renamed to dev-team@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. A SessionStart banner surfaces the half-migrated state. Scheduled for removal from the catalog no earlier than 2027-06-01.",
+      "version": "6.0.2",
       "author": {
         "name": "Bryan Finster"
       },
@@ -46,8 +46,8 @@
     {
       "name": "agentic-security-assessment",
       "source": "./plugins/agentic-security-assessment",
-      "description": "DEPRECATED legacy stub — renamed to security-assessment@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. Scheduled for removal from the catalog no earlier than 2027-06-01.",
-      "version": "3.0.1",
+      "description": "DEPRECATED legacy stub — renamed to security-assessment@bfinster. Run /upgrade to migrate; the stub installs the new plugin then removes itself. A SessionStart banner surfaces the half-migrated state. Scheduled for removal from the catalog no earlier than 2027-06-01.",
+      "version": "3.0.2",
       "author": {
         "name": "Bryan Finster"
       },

--- a/plugins/agentic-dev-team/.claude-plugin/plugin.json
+++ b/plugins/agentic-dev-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-dev-team",
-  "version": "6.0.1",
-  "description": "DEPRECATED — renamed to dev-team@bfinster. This stub auto-migrates legacy installs on /upgrade. Will be removed from the marketplace catalog in v7.0.0 (planned: 2027-06-01).",
+  "version": "6.0.2",
+  "description": "DEPRECATED — renamed to dev-team@bfinster. This stub auto-migrates legacy installs on /upgrade and surfaces a SessionStart banner so the half-migrated state is impossible to miss. Will be removed from the marketplace catalog no earlier than 2027-06-01.",
   "author": {
     "name": "finsterb",
     "email": ""

--- a/plugins/agentic-dev-team/CHANGELOG.md
+++ b/plugins/agentic-dev-team/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The real changelog lives at [`plugins/dev-team/CHANGELOG.md`](../dev-team/CHANGELOG.md). This file only tracks the deprecation stub.
 
+## [6.0.2] - 2026-06-02
+
+### Added
+
+- SessionStart hook (`hooks/deprecation-banner.sh`) that fires on every Claude Code launch and prints a high-visibility deprecation notice naming the destination plugin and the exact restart-then-`/upgrade` flow. Closes a gap where users running the pre-rename `/upgrade` twice without restarting in between would land on this stub, see "already at latest" on the second run, and walk away thinking migration was complete.
+
+### Changed
+
+- Updated `commands/upgrade.md` opening prose to explicitly call out the "if you just got here from running the pre-rename `/upgrade`, restart first" case.
+
 ## [6.0.1] - 2026-06-02
 
 ### Changed

--- a/plugins/agentic-dev-team/commands/upgrade.md
+++ b/plugins/agentic-dev-team/commands/upgrade.md
@@ -18,6 +18,18 @@ uninstall this stub. After it runs, restart Claude Code; you'll be on
 `dev-team@bfinster` (the real plugin) with all the agents, skills,
 commands, and hooks intact under their new home.
 
+## Are you in the half-migrated state?
+
+If you just ran `/upgrade` from a pre-rename install (v5.6.0 or earlier),
+that `/upgrade` updated you to this stub — but the running Claude Code
+session is still bound to the **previous** plugin's `/upgrade` code,
+not this stub's. Running `/upgrade` again before restarting will
+correctly report "already at the latest" against the stub, but it will
+NOT migrate you to `dev-team@bfinster`.
+
+**Restart Claude Code first.** Then run `/upgrade` — that invocation
+will be THIS file, and it will finish the migration.
+
 ## Steps
 
 ### 1. Detect install scope

--- a/plugins/agentic-dev-team/hooks/deprecation-banner.sh
+++ b/plugins/agentic-dev-team/hooks/deprecation-banner.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# plugins/agentic-dev-team/hooks/deprecation-banner.sh
+#
+# SessionStart hook for the agentic-dev-team DEPRECATION STUB.
+#
+# Fires on every Claude Code session start. Prints a high-visibility
+# notice that the user is on a deprecation stub, names the real plugin,
+# and shows the exact /upgrade flow to finish migrating.
+#
+# Why this hook exists: in the wild we saw users running the pre-rename
+# /upgrade twice without restarting in between — the first run installed
+# this stub, the second run was still the pre-rename code (not the stub's
+# /upgrade) and reported "already at latest." Users walked away thinking
+# they were done. This banner makes the half-migrated state impossible
+# to miss on the next session start.
+#
+# Output format: the hook emits a single JSON object on stdout, per the
+# Claude Code SessionStart hook contract. The `additionalContext` field
+# is shown to the model and the user.
+
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "DEPRECATION NOTICE — agentic-dev-team@bfinster is a deprecation stub. The real plugin has been renamed to dev-team@bfinster.\n\nTo finish migrating:\n  1. Run /upgrade (this stub will install dev-team@bfinster and remove itself)\n  2. Restart Claude Code\n\nAfter migration you'll have the full team back: orchestrator, software-engineer, qa-engineer, all reviewers, /code-review, /plan, /build, /pr, and every skill — under the new plugin id.\n\nIf you've already run /upgrade in this session and it reported 'already at latest', that was the pre-rename code running against this stub. Restart Claude Code first, then run /upgrade once more — that second /upgrade is THIS stub's command, and it WILL migrate you."
+  }
+}
+EOF

--- a/plugins/agentic-dev-team/settings.json
+++ b/plugins/agentic-dev-team/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": ["Read", "Bash"],
+    "deny": []
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash hooks/deprecation-banner.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agentic-security-assessment/.claude-plugin/plugin.json
+++ b/plugins/agentic-security-assessment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-security-assessment",
-  "version": "3.0.1",
-  "description": "DEPRECATED — renamed to security-assessment@bfinster. This stub auto-migrates legacy installs on /upgrade. Will be removed from the marketplace catalog in v4.0.0 (planned: 2027-06-01).",
+  "version": "3.0.2",
+  "description": "DEPRECATED — renamed to security-assessment@bfinster. This stub auto-migrates legacy installs on /upgrade and surfaces a SessionStart banner so the half-migrated state is impossible to miss. Will be removed from the marketplace catalog no earlier than 2027-06-01.",
   "author": {
     "name": "finsterb",
     "email": ""

--- a/plugins/agentic-security-assessment/CHANGELOG.md
+++ b/plugins/agentic-security-assessment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The real changelog lives at [`plugins/security-assessment/CHANGELOG.md`](../security-assessment/CHANGELOG.md). This file only tracks the deprecation stub.
 
+## [3.0.2] - 2026-06-02
+
+### Added
+
+- SessionStart hook (`hooks/deprecation-banner.sh`) that fires on every Claude Code launch and prints a high-visibility deprecation notice. Same rationale as `agentic-dev-team@6.0.2`.
+
+### Changed
+
+- Updated `commands/upgrade.md` opening prose to address the half-migrated session state.
+
 ## [3.0.1] - 2026-06-02
 
 ### Changed

--- a/plugins/agentic-security-assessment/commands/upgrade.md
+++ b/plugins/agentic-security-assessment/commands/upgrade.md
@@ -19,6 +19,18 @@ uninstall this stub. After it runs, restart Claude Code; you'll be on
 SARIF-first pipeline, red-team harness, and all agents and skills
 intact under their new home.
 
+## Are you in the half-migrated state?
+
+If you just ran `/upgrade` from a pre-rename install (v2.2.2 or
+earlier), that `/upgrade` updated you to this stub — but the running
+Claude Code session is still bound to the **previous** plugin's
+`/upgrade` code, not this stub's. Running `/upgrade` again before
+restarting will correctly report "already at the latest" against the
+stub, but it will NOT migrate you to `security-assessment@bfinster`.
+
+**Restart Claude Code first.** Then run `/upgrade` — that invocation
+will be THIS file, and it will finish the migration.
+
 ## Steps
 
 ### 1. Detect install scope

--- a/plugins/agentic-security-assessment/hooks/deprecation-banner.sh
+++ b/plugins/agentic-security-assessment/hooks/deprecation-banner.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# plugins/agentic-security-assessment/hooks/deprecation-banner.sh
+#
+# SessionStart hook for the agentic-security-assessment DEPRECATION STUB.
+# Mirrors plugins/agentic-dev-team/hooks/deprecation-banner.sh; see that
+# file for the rationale and design notes.
+
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "DEPRECATION NOTICE — agentic-security-assessment@bfinster is a deprecation stub. The real plugin has been renamed to security-assessment@bfinster.\n\nTo finish migrating:\n  1. Run /upgrade (this stub will install security-assessment@bfinster and remove itself)\n  2. Restart Claude Code\n\nAfter migration you'll have the full security companion back: /security-assessment, /cross-repo-analysis, /redteam-model, /export-pdf, the SARIF-first pipeline, and every FP-reduction / compliance-mapping skill — under the new plugin id.\n\nIf you've already run /upgrade in this session and it reported 'already at latest', that was the pre-rename code running against this stub. Restart Claude Code first, then run /upgrade once more — that second /upgrade is THIS stub's command, and it WILL migrate you."
+  }
+}
+EOF

--- a/plugins/agentic-security-assessment/settings.json
+++ b/plugins/agentic-security-assessment/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": ["Read", "Bash"],
+    "deny": []
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash hooks/deprecation-banner.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/assert-rename.sh
+++ b/scripts/assert-rename.sh
@@ -120,8 +120,9 @@ check_manifest_names() {
       return  # stub directory absent is fine — already migrated/removed
     fi
     local forbidden
+    # hooks/ is allowed but must contain ONLY the deprecation banner.
     forbidden=$(find "$stub_dir" -mindepth 1 -maxdepth 2 -type d \
-      \( -name agents -o -name skills -o -name knowledge -o -name templates -o -name prompts -o -name harness -o -name hooks \) 2>/dev/null)
+      \( -name agents -o -name skills -o -name knowledge -o -name templates -o -name prompts -o -name harness \) 2>/dev/null)
     if [ -n "$forbidden" ]; then
       fail "$stub_dir has non-stub subdirectories: $(printf '%s ' "$forbidden")"
     else
@@ -277,10 +278,13 @@ check_dev_team_body_clean
 # plugins/security-assessment/ except CHANGELOG.md (history) and install.sh
 # (intentional legacy-detection migration notice).
 check_security_assessment_body_clean() {
+  # The plugin's /upgrade and README intentionally describe the legacy
+  # migration path; the deprecation stub does the actual migration.
   local hits
   hits=$(grep -rln 'agentic-security-assessment\|agentic-dev-team' \
     plugins/security-assessment/ \
-    --exclude=CHANGELOG.md --exclude=install.sh 2>/dev/null || true)
+    --exclude=CHANGELOG.md --exclude=install.sh \
+    --exclude=upgrade.md --exclude=README.md 2>/dev/null || true)
   if [ -z "$hits" ]; then
     pass "plugins/security-assessment/ free of legacy plugin names"
   else
@@ -345,7 +349,7 @@ check_no_live_legacy_references() {
   local hits
   hits=$(printf '%s\n' "$raw_hits" \
     | grep -vE '(github\.com/bdfinst/agentic-dev-team|Previously published as|DEPRECATED|"name": "agentic-(dev-team|security-assessment)"|"source": "\./plugins/agentic-(dev-team|security-assessment)")' \
-    | grep -vE '^(CHANGELOG\.md|.*/CHANGELOG\.md|metrics/config-changelog\.jsonl|memory/decisions\.md|plans/|docs/adr/|docs/specs/rename-plugins\.md|docs/specs/legacy-plugin-stubs\.md|docs/decisions/upgrade-step-0-sunset\.md|evals/security-review-adapter/|evals/upgrade-migration/|plugins/dev-team/commands/upgrade\.md|plugins/security-assessment/install\.sh|plugins/agentic-dev-team/|plugins/agentic-security-assessment/|scripts/assert-rename\.sh|scripts/sweep-rename\.sh|README\.md)' \
+    | grep -vE '^(CHANGELOG\.md|.*/CHANGELOG\.md|metrics/config-changelog\.jsonl|memory/decisions\.md|plans/|docs/adr/|docs/specs/rename-plugins\.md|docs/specs/legacy-plugin-stubs\.md|docs/decisions/upgrade-step-0-sunset\.md|evals/security-review-adapter/|evals/upgrade-migration/|plugins/dev-team/commands/upgrade\.md|plugins/security-assessment/install\.sh|plugins/security-assessment/commands/upgrade\.md|plugins/security-assessment/README\.md|plugins/agentic-dev-team/|plugins/agentic-security-assessment/|scripts/assert-rename\.sh|scripts/sweep-rename\.sh|tests/repo/legacy_plugin_stubs\.bats|tests/commands/security_upgrade_tests\.bats|README\.md)' \
     || true)
   if [ -z "$hits" ]; then
     pass "no live references to legacy plugin names in tracked files"

--- a/tests/repo/legacy_plugin_stubs.bats
+++ b/tests/repo/legacy_plugin_stubs.bats
@@ -74,9 +74,12 @@ setup() {
   jq -e '.plugins[] | select(.name == "agentic-security-assessment") | .description' "$mp" | grep -qi 'DEPRECATED'
 }
 
-# LSAC-4: stub directories contain NO non-stub subdirectories
-@test "LSAC-4: agentic-dev-team stub has no agents/skills/knowledge/templates/prompts/harness/hooks" {
-  for forbidden in agents skills knowledge templates prompts harness hooks; do
+# LSAC-4: stub directories contain NO non-stub subdirectories.
+# hooks/ is allowed but ONLY for the deprecation-banner.sh SessionStart
+# hook — nothing else. agents/, skills/, knowledge/, etc. would mean the
+# stub regrew into something pretending to be the real plugin.
+@test "LSAC-4: agentic-dev-team stub has no agents/skills/knowledge/templates/prompts/harness" {
+  for forbidden in agents skills knowledge templates prompts harness; do
     if [ -d "$STUB_DEV/$forbidden" ]; then
       printf 'forbidden subdirectory present: %s/%s\n' "$STUB_DEV" "$forbidden" >&2
       return 1
@@ -84,13 +87,67 @@ setup() {
   done
 }
 
-@test "LSAC-4: agentic-security-assessment stub has no agents/skills/knowledge/templates/prompts/harness/hooks" {
-  for forbidden in agents skills knowledge templates prompts harness hooks; do
+@test "LSAC-4: agentic-security-assessment stub has no agents/skills/knowledge/templates/prompts/harness" {
+  for forbidden in agents skills knowledge templates prompts harness; do
     if [ -d "$STUB_SEC/$forbidden" ]; then
       printf 'forbidden subdirectory present: %s/%s\n' "$STUB_SEC" "$forbidden" >&2
       return 1
     fi
   done
+}
+
+@test "LSAC-4: agentic-dev-team stub hooks/ contains only deprecation-banner.sh" {
+  if [ -d "$STUB_DEV/hooks" ]; then
+    local files
+    files=$(find "$STUB_DEV/hooks" -mindepth 1 -maxdepth 1 -type f | sort)
+    [ "$files" = "$STUB_DEV/hooks/deprecation-banner.sh" ]
+  fi
+}
+
+@test "LSAC-4: agentic-security-assessment stub hooks/ contains only deprecation-banner.sh" {
+  if [ -d "$STUB_SEC/hooks" ]; then
+    local files
+    files=$(find "$STUB_SEC/hooks" -mindepth 1 -maxdepth 1 -type f | sort)
+    [ "$files" = "$STUB_SEC/hooks/deprecation-banner.sh" ]
+  fi
+}
+
+# LSAC-8: SessionStart deprecation banner wired correctly.
+@test "LSAC-8: agentic-dev-team stub ships a deprecation banner SessionStart hook" {
+  [ -x "$STUB_DEV/hooks/deprecation-banner.sh" ]
+  # Output must be valid JSON with SessionStart hookEventName.
+  local out
+  out=$(bash "$STUB_DEV/hooks/deprecation-banner.sh")
+  echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName'] == 'SessionStart'; assert 'agentic-dev-team' in d['hookSpecificOutput']['additionalContext']; assert 'dev-team@bfinster' in d['hookSpecificOutput']['additionalContext']; assert 'restart' in d['hookSpecificOutput']['additionalContext'].lower()"
+}
+
+@test "LSAC-8: agentic-security-assessment stub ships a deprecation banner SessionStart hook" {
+  [ -x "$STUB_SEC/hooks/deprecation-banner.sh" ]
+  local out
+  out=$(bash "$STUB_SEC/hooks/deprecation-banner.sh")
+  echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName'] == 'SessionStart'; assert 'agentic-security-assessment' in d['hookSpecificOutput']['additionalContext']; assert 'security-assessment@bfinster' in d['hookSpecificOutput']['additionalContext']"
+}
+
+# LSAC-8: settings.json registers the SessionStart hook on each stub.
+@test "LSAC-8: agentic-dev-team stub settings.json registers SessionStart hook" {
+  [ -f "$STUB_DEV/settings.json" ]
+  jq -e '.hooks.SessionStart[0].hooks[0].command' "$STUB_DEV/settings.json" | grep -q 'deprecation-banner.sh'
+}
+
+@test "LSAC-8: agentic-security-assessment stub settings.json registers SessionStart hook" {
+  [ -f "$STUB_SEC/settings.json" ]
+  jq -e '.hooks.SessionStart[0].hooks[0].command' "$STUB_SEC/settings.json" | grep -q 'deprecation-banner.sh'
+}
+
+# LSAC-8: stub /upgrade prose calls out the half-migrated session state.
+@test "LSAC-8: agentic-dev-team /upgrade documents the half-migrated state" {
+  grep -qi 'half-migrated' "$STUB_DEV/commands/upgrade.md"
+  grep -qi 'restart Claude Code first' "$STUB_DEV/commands/upgrade.md"
+}
+
+@test "LSAC-8: agentic-security-assessment /upgrade documents the half-migrated state" {
+  grep -qi 'half-migrated' "$STUB_SEC/commands/upgrade.md"
+  grep -qi 'restart Claude Code first' "$STUB_SEC/commands/upgrade.md"
 }
 
 # LSAC-5: marketplace.json lists all four ids


### PR DESCRIPTION
## Summary

Closes a UX gap in the rename migration discovered in a real session.

A user upgraded from `agentic-dev-team@5.5.0` and ran `/upgrade` a second time **without restarting Claude Code in between**. The second `/upgrade` was still the pre-rename code (the running session is bound to the previous plugin's command surface until restart), so it reported "already at the latest version (6.0.1)" against the stub. Correct from the CLI's perspective — but misleading: the stub's `/upgrade`, which would have installed `dev-team@bfinster`, never executed. The user walked away thinking migration was complete.

## Fix

Three layers, each independently useful:

1. **SessionStart hook** (`hooks/deprecation-banner.sh`) on each stub. Fires on every Claude Code launch and emits a `additionalContext` payload via the official `SessionStart` hook contract — names the destination plugin and gives the exact `restart → /upgrade → restart` flow. The banner also covers the specific "I just saw already-at-latest" case.
2. **Updated `/upgrade` prose** with a new "Are you in the half-migrated state?" section that explains the session-binding issue and the restart-first requirement in plain language.
3. **Stub version bumps** (`6.0.1 → 6.0.2`, `3.0.1 → 3.0.2`) so users already on the v6.0.1/v3.0.1 stubs pick up the banner when they next run `/upgrade` to finish migrating.

## What it looks like

On Claude Code startup with the stub installed, the model sees:

```
DEPRECATION NOTICE — agentic-dev-team@bfinster is a deprecation stub. The real plugin has been renamed to dev-team@bfinster.

To finish migrating:
  1. Run /upgrade (this stub will install dev-team@bfinster and remove itself)
  2. Restart Claude Code

After migration you'll have the full team back: orchestrator, software-engineer, qa-engineer, all reviewers, /code-review, /plan, /build, /pr, and every skill — under the new plugin id.

If you've already run /upgrade in this session and it reported 'already at latest', that was the pre-rename code running against this stub. Restart Claude Code first, then run /upgrade once more — that second /upgrade is THIS stub's command, and it WILL migrate you.
```

## Quality Gate

- [x] `bats tests/repo/legacy_plugin_stubs.bats` → 22 passed, 0 failed (was 14 — 8 new LSAC-8 assertions covering hook executable, JSON validity, `SessionStart` event, settings.json registration, prose half-migrated callout)
- [x] `bats -r tests/` → 354 passed, 0 failed (no regressions)
- [x] `bash scripts/assert-rename.sh` → 26 passed, 0 failed
- [x] `shellcheck` on the new hook scripts → clean

## Files

**Added**:
- `plugins/agentic-dev-team/hooks/deprecation-banner.sh`
- `plugins/agentic-dev-team/settings.json` (just enough to register the SessionStart hook)
- `plugins/agentic-security-assessment/hooks/deprecation-banner.sh`
- `plugins/agentic-security-assessment/settings.json`

**Modified**:
- `plugins/agentic-dev-team/.claude-plugin/plugin.json` — version 6.0.1 → 6.0.2, description mentions banner
- `plugins/agentic-dev-team/CHANGELOG.md` — adds 6.0.2 entry
- `plugins/agentic-dev-team/commands/upgrade.md` — new "Are you in the half-migrated state?" section
- `plugins/agentic-security-assessment/*` — same set of changes as the dev-team stub
- `.claude-plugin/marketplace.json` — stub versions and descriptions bumped
- `scripts/assert-rename.sh` — stub-shape check permits `hooks/` (but only the banner); exclusion list grows to cover intentional legacy-name documentation
- `tests/repo/legacy_plugin_stubs.bats` — LSAC-4 split into two checks (no other dirs allowed; hooks/ may contain ONLY the banner); 8 new LSAC-8 assertions

## Related

- PR #43 — plugin rename (merged)
- PR #44 — release-please cut v6.0.0/v3.0.0 (merged)
- PR #45 — legacy deprecation stubs (merged)
- PR #46 — `/upgrade` for security plugin (merged)

This PR is a hotfix on top of #45 to close the half-migrated UX gap.

## Test plan

- [ ] CI plugin-tests workflow passes
- [ ] Manual smoke test: install `agentic-dev-team@bfinster` at v6.0.1, then `claude plugin update agentic-dev-team@bfinster`, restart Claude Code → confirm banner fires on startup
- [ ] Manual smoke test: run `/upgrade` from the stub → confirm it installs `dev-team@bfinster` and uninstalls the stub (existing path, unchanged)

## For the user who triggered this

Restart Claude Code now, then run `/upgrade` again. That run will be the v6.0.1 stub's `/upgrade` (the one that's never executed for you yet), and it'll install `dev-team@bfinster` and remove the stub. One more restart after that and you're done. Once this PR merges and releases, anyone in your situation will also see the SessionStart banner pointing them to the same flow.
