### PR TITLE
feat(dev-team): test design + CD test architecture capabilities

### DIFF
--- a/evals/expected/test-assertion-roulette.test.json
+++ b/evals/expected/test-assertion-roulette.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-assertion-roulette.test",
+  "description": "One test method asserts many unrelated behaviors with bare, message-less assertions",
+  "applicableAgents": ["test-smell-review"],
+  "agents": {
+    "test-smell-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 5 },
+      "severities": { "warning": { "min": 1, "max": 4 } },
+      "mustMention": ["Assertion Roulette", "Eager Test"],
+      "mustNotMention": ["Mystery Guest"]
+    }
+  }
+}

--- a/evals/expected/test-clean-doubles.test.json
+++ b/evals/expected/test-clean-doubles.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-clean-doubles.test",
+  "description": "Clean control — stub-driven state verification, one behavior per test, no smells",
+  "applicableAgents": ["test-smell-review"],
+  "agents": {
+    "test-smell-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 1 },
+      "severities": {},
+      "mustMention": [],
+      "mustNotMention": ["Assertion Roulette", "Mystery Guest", "Overspecified"]
+    }
+  }
+}

--- a/evals/expected/test-mystery-guest.test.json
+++ b/evals/expected/test-mystery-guest.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-mystery-guest.test",
+  "description": "Test depends on an external fixture file it does not create or show, with magic expected values",
+  "applicableAgents": ["test-smell-review"],
+  "agents": {
+    "test-smell-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "warning": { "min": 1, "max": 3 } },
+      "mustMention": ["Mystery Guest"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/test-overspecified-mocks.test.json
+++ b/evals/expected/test-overspecified-mocks.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-overspecified-mocks.test",
+  "description": "Mock-heavy test asserting exact internal call order/count instead of the resulting price",
+  "applicableAgents": ["test-smell-review"],
+  "agents": {
+    "test-smell-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "warning": { "min": 1, "max": 3 } },
+      "mustMention": ["Overspecified", "state"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/fixtures/test-assertion-roulette.test.ts
+++ b/evals/fixtures/test-assertion-roulette.test.ts
@@ -1,0 +1,23 @@
+import { OrderSummary } from "../domain/OrderSummary";
+
+// Smell: Assertion Roulette (many bare assertions, no messages) +
+// Eager Test (one test exercises many unrelated behaviors).
+describe("OrderSummary", () => {
+  it("works", () => {
+    const summary = new OrderSummary([
+      { sku: "A", qty: 2, price: 10 },
+      { sku: "B", qty: 1, price: 5 },
+    ]);
+
+    // Many unrelated behaviors crammed into one test; on failure you
+    // cannot tell which assertion broke — no messages, no isolation.
+    expect(summary.itemCount).toBe(3);
+    expect(summary.subtotal).toBe(25);
+    expect(summary.tax).toBe(2.5);
+    expect(summary.total).toBe(27.5);
+    expect(summary.isEmpty).toBe(false);
+    expect(summary.heaviestLine().sku).toBe("A");
+    expect(summary.format()).toContain("27.50");
+    expect(summary.discountApplied).toBe(false);
+  });
+});

--- a/evals/fixtures/test-clean-doubles.test.ts
+++ b/evals/fixtures/test-clean-doubles.test.ts
@@ -1,0 +1,32 @@
+import { PricingService } from "../domain/PricingService";
+
+// Clean control: a stub supplies controlled inputs and the test asserts on
+// the SUT's returned state (state verification). One behavior per test,
+// clear arrange-act-assert, named expected values. No smells to flag.
+describe("PricingService", () => {
+  const fixedTax = { calculate: (n: number) => n * 0.1 };
+  const noDiscount = { calculate: () => 0 };
+  const exactRounding = { round: (n: number) => n };
+
+  function makeService() {
+    return new PricingService(fixedTax, noDiscount, exactRounding);
+  }
+
+  it("adds tax to the subtotal", () => {
+    const price = makeService().priceOrder({ subtotal: 100 });
+
+    expect(price.total).toBe(110);
+  });
+
+  it("returns the subtotal unchanged when tax is zero", () => {
+    const taxFree = new PricingService(
+      { calculate: () => 0 },
+      noDiscount,
+      exactRounding,
+    );
+
+    const price = taxFree.priceOrder({ subtotal: 100 });
+
+    expect(price.total).toBe(100);
+  });
+});

--- a/evals/fixtures/test-mystery-guest.test.ts
+++ b/evals/fixtures/test-mystery-guest.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+import { InvoiceParser } from "../domain/InvoiceParser";
+
+// Smell: Mystery Guest — the test depends on external data it does not
+// create or show. The reader cannot see the inputs; the file on disk and
+// the seeded DB row can drift and silently break the test.
+describe("InvoiceParser", () => {
+  it("parses the sample invoice", () => {
+    // Where does this file come from? What's in it? Invisible to the reader.
+    const raw = readFileSync("./test/fixtures/sample-invoice.xml", "utf8");
+
+    const invoice = new InvoiceParser().parse(raw);
+
+    // Magic expected values tied to an unseen external file.
+    expect(invoice.total).toBe(1499.0);
+    expect(invoice.lineItems).toHaveLength(7);
+  });
+});

--- a/evals/fixtures/test-overspecified-mocks.test.ts
+++ b/evals/fixtures/test-overspecified-mocks.test.ts
@@ -1,0 +1,23 @@
+import { PricingService } from "../domain/PricingService";
+
+// Smell: Overspecified Software — the test pins down the exact internal
+// call sequence via mocks instead of asserting the outcome. A Stub plus a
+// state assertion on the returned price would verify the real behavior
+// without coupling to how PricingService is implemented.
+describe("PricingService", () => {
+  it("prices an order", () => {
+    const taxCalc = { calculate: jest.fn().mockReturnValue(5) };
+    const discountCalc = { calculate: jest.fn().mockReturnValue(2) };
+    const rounding = { round: jest.fn((n: number) => n) };
+
+    const service = new PricingService(taxCalc, discountCalc, rounding);
+    service.priceOrder({ subtotal: 100 });
+
+    // Asserting internal mechanics, not the result:
+    expect(discountCalc.calculate).toHaveBeenCalledBefore(taxCalc.calculate);
+    expect(taxCalc.calculate).toHaveBeenCalledTimes(1);
+    expect(taxCalc.calculate).toHaveBeenCalledWith(98);
+    expect(rounding.round).toHaveBeenCalledTimes(1);
+    // Nowhere is the actual final price asserted.
+  });
+});

--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -41,13 +41,13 @@ Full registry tables with token counts, model tiers, and used-by mappings are in
 
 **Team agents** (11): Orchestrator, Software Engineer, QA Engineer, UI/UX Designer, Architect, Product Manager, Technical Writer, Security Engineer, Platform Engineer, ADR Author, Codebase Recon (~4,510 tokens total)
 
-**Review agents** (19): spec-compliance-review, a11y-review, arch-review, claude-setup-review, complexity-review, concurrency-review, doc-review, domain-review, js-fp-review, naming-review, performance-review, security-review, structure-review, svelte-review, test-review, token-efficiency-review, refactor-opportunity-review, progress-guardian, data-flow-tracer
+**Review agents** (20): spec-compliance-review, a11y-review, arch-review, claude-setup-review, complexity-review, concurrency-review, doc-review, domain-review, js-fp-review, naming-review, performance-review, security-review, structure-review, svelte-review, test-review, test-smell-review, token-efficiency-review, refactor-opportunity-review, progress-guardian, data-flow-tracer
 
-**Skills** (34): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Browser Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming, Ubiquitous Language
+**Skills** (36): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Test Design Advisor, CD Test Architecture, Browser Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming, Ubiquitous Language
 
 **Subagent prompt templates** (8): `prompts/implementer.md`, `prompts/spec-reviewer.md`, `prompts/quality-reviewer.md`, `prompts/plan-reviewer.md`, `prompts/plan-review-acceptance.md`, `prompts/plan-review-design.md`, `prompts/plan-review-ux.md`, `prompts/plan-review-strategic.md`
 
-**Knowledge files** (11): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns
+**Knowledge files** (17): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns, test-smells, test-doubles, test-pyramid, microservice-testing, cd-test-architecture, component-test-patterns
 
 **Agent templates** (9): ts-enforcer, esm-enforcer, react-testing, front-end-testing, twelve-factor-audit, python-quality, go-quality, csharp-quality, angular-testing (in `templates/agents/`, scaffolded by `/setup`)
 
@@ -63,6 +63,7 @@ User-invocable workflows in `.claude/commands/`. All review commands are execute
 |---------|------|------|--------------|
 | `/code-review` | `commands/code-review.md` | orchestrator | Run review agents, auto-fix actionable issues, re-run until clean (up to 5 iterations) |
 | `/review-agent` | `commands/review-agent.md` | worker | Run a single review agent (used for inline checkpoints) |
+| `/test-design` | `commands/test-design.md` | orchestrator | Deep test-design review: dispatch test-review + test-smell-review, then run test-design-advisor for testability/refactor recommendations (advisory) |
 | `/agent-audit` | `commands/agent-audit.md` | orchestrator | Audit agents/commands/hooks for structural compliance |
 | `/agent-eval` | `commands/agent-eval.md` | orchestrator | Run eval fixtures, grade accuracy, detect regressions |
 | `/agent-add` | `commands/agent-add.md` | implementation | Create a new review or team agent following the official schema with token-efficiency budgets |

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -1,0 +1,88 @@
+---
+name: test-smell-review
+description: xUnit test smells, test double selection, and test-pyramid layer placement
+tools: Read, Grep, Glob, Skill
+model: sonnet
+---
+
+# Test Smell Review
+
+Output JSON:
+
+```json
+{"status": "pass|warn|fail|skip", "issues": [{"severity": "error|warning|suggestion", "confidence": "high|medium|none", "file": "", "line": 0, "smell": "", "message": "", "suggestedFix": ""}], "summary": ""}
+```
+
+Status: pass=no smells, warn=minor smells, fail=behavior/project smell that undermines trust in the suite
+Severity: error=smell that makes the suite untrustworthy or unmaintainable (flaky, buggy test, false confidence), warning=should fix (fragile, obscure, overspecified), suggestion=improvement
+Confidence: high=named smell with a mechanical fix (add assertion message, inline mystery guest, downgrade mock to stub); medium=smell is clear but the redesign has options (split strategy, layer choice); none=requires human judgment (intended test level, whether a behavior is worth testing)
+
+Model tier: mid
+Context needs: full-file
+
+## Scope
+
+The design-level companion to test-review. This agent names xUnit test smells, judges test-double choice, and checks pyramid-layer placement. `test-review` owns the tactical per-file gate (missing assertions, missing await, mock-reset hygiene). When both run, defer mechanical findings to test-review and report the design smell here. Some overlap on non-determinism is expected — frame it as the **Erratic Test** smell with its root cause.
+
+## Knowledge Files
+
+Load on demand by finding type — do not load all four unless the target needs them:
+
+- `knowledge/test-smells.md` — the canonical xUnit smell taxonomy (code/behavior/project smells). Primary reference; load for every run.
+- `knowledge/test-doubles.md` — dummy/stub/spy/mock/fake selection and state-vs-behavior verification. Load when the target uses mocking.
+- `knowledge/test-pyramid.md` — layer responsibilities and shape anti-patterns. Load when judging test level.
+- `knowledge/microservice-testing.md` — contract/CDC testing. Load only when the target spans independently-deployable services.
+- `knowledge/testability-patterns.md` — load when a smell's root cause is untestable production code (recommend the production-code change, never a test workaround).
+
+## Skip
+
+Return `{"status": "skip", "issues": [], "summary": "No test files in target"}` when no test files are found. `.feature` files count as tests — do not skip if present.
+
+Test file indicators by language:
+
+- **JS/TS**: `*.test.*`, `*.spec.*`, or files inside `__tests__/`
+- **C#**: `.cs` files with `[Fact]`, `[Theory]`, `[Test]`, `[TestCase]`, `[TestMethod]`, `[TestClass]`
+- **Java**: `.java` files with `@Test`, `@ParameterizedTest`, `@TestFactory`, or class names ending `Test`, `Tests`, `TestCase`, `Spec`
+- **BDD/Gherkin**: `.feature` files, step definition files
+
+## Detect
+
+Always read `knowledge/test-smells.md` first; report each finding by its named smell. Detect across the three levels:
+
+Code smells (single test):
+
+- **Obscure Test** — behavior under test not statable from the test alone; sub-types: **Eager Test** (many behaviors/asserts in one method), **Mystery Guest** (depends on external data the test doesn't create), **General Fixture** (shared setup builds more than the test needs), **Irrelevant Information** (setup exposes values that don't affect the assertion)
+- **Assertion Roulette** — multiple bare assertions, no messages, failure can't be localized
+- **Conditional Test Logic** — `if`/`switch`/loops/try-catch around assertions; the test verifies different things on different runs
+- **Hard-Coded / Magic Values** in assertions with no stated meaning
+- **Test Code Duplication** — copy-pasted arrange/assert blocks that should be a builder or custom assertion (not two genuinely different boundary cases)
+- **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code
+
+Behavior smells (only visible on run):
+
+- **Erratic Test** (flaky) — non-deterministic; sub-types: interacting tests (order-dependent shared state), test run war (shared external resource), nondeterministic timing (clock/RNG/sleep/real timers), resource leakage
+- **Fragile Test** — breaks on changes unrelated to the behavior; **Overspecified Software** — mock-heavy tests asserting exact internal call sequences instead of outcomes
+- **Slow Tests** — real I/O (DB, network, disk, sleep) at the unit level
+
+Project smells (suite-wide):
+
+- **Buggy Tests** (pass when code is broken — recommend mutation testing), **Manual Intervention** (human step needed to run), **High Test Maintenance Cost**, **Production Bugs** slipping a green suite
+
+Test double misuse (load `knowledge/test-doubles.md`):
+
+- Mock where a Stub + state assertion would do; mocking value objects/pure functions; mocking the type under test; asserting call order/count that doesn't matter; mocking concrete classes instead of ports
+
+Pyramid placement (load `knowledge/test-pyramid.md`):
+
+- Unit test doing real I/O (mis-layered → Slow Tests); E2E asserting a single edge case (belongs at unit); suite-level ice-cream-cone / hourglass / cupcake shape
+
+## Self-Challenge
+
+After producing findings, run the test-review challenge pass in `knowledge/adversarial-review-protocol.md#test-smell-review`. Append confidence level (High/Medium/Low) to the `summary` field.
+
+## Ignore
+
+Tactical mechanics owned by test-review (missing assertion entirely, missing await, mock-reset calls) — defer those there.
+Code style, naming, complexity of production code (handled by other agents).
+Integration/E2E tests touching real resources by design — confirm the intended test level before flagging Slow Tests or Erratic Test.
+A single Mock at a true side-effect boundary, or a Fake in-memory dependency — these are correct, not smells.

--- a/plugins/dev-team/commands/test-design.md
+++ b/plugins/dev-team/commands/test-design.md
@@ -1,0 +1,102 @@
+---
+name: test-design
+description: >-
+  Deep test-design review: dispatch test-review (tactical quality) and
+  test-smell-review (xUnit smells, double selection, pyramid placement) in
+  parallel, then run the test-design-advisor skill to recommend how to test
+  hard-to-test code. Use when the user says "review my tests", "how should I
+  test this", "is this testable", "test design review", or before writing a
+  suite for an untested module. Advisory — it recommends, it does not edit.
+argument-hint: "[--path <dir>] [--since <ref>] [--advise]"
+user-invocable: true
+allowed-tools: Read, Grep, Glob, Bash(git diff *), Skill, Agent
+---
+
+# Test Design
+
+Role: orchestrator. This command dispatches the two test review agents as
+sub-agents and the test-design-advisor skill, then aggregates one report. It
+does not review files itself — it coordinates.
+
+This command is executed under orchestrator direction. Dispatch each agent with
+its tier alias (from its `model:` frontmatter); the PreToolUse hook
+`hooks/agent-model-resolve.sh` resolves it to the active snapshot per the
+Resolution Procedure in `agents/orchestrator.md`.
+
+## Orchestrator constraints
+
+1. **Advisory only.** Aggregate findings and recommendations. Do not edit
+   production code or write test files. Hand actionable fixes to `/apply-fixes`
+   or `/build`.
+2. **Dispatch in parallel.** `test-review` and `test-smell-review` are
+   independent — spawn them in one batch for context isolation; each returns
+   structured JSON, not file dumps.
+3. **No double-reporting.** `test-smell-review` defers tactical mechanics to
+   `test-review`. When the same line appears in both, keep the design-level
+   framing and drop the duplicate.
+4. **Be concise.** One aggregated report. Issue messages one sentence;
+   recommendations map to a concrete next edit.
+
+## Parse Arguments
+
+Arguments: $ARGUMENTS
+
+Optional:
+
+- `--path <dir>`: target directory (default: current working directory)
+- `--since <ref>`: target files changed since a git ref (`git diff --name-only <ref>...HEAD`)
+- `--advise`: also run the test-design-advisor skill for forward-looking design (default on when the target has untested production code or few/no test files)
+
+## Steps
+
+### 1. Determine target files
+
+Same auto-scope logic as `/code-review`: uncommitted changes if present, else
+all source files; honor `--since` and `--path`. Identify test files and the
+production code they cover.
+
+### 2. Dispatch review agents (parallel)
+
+Spawn both as sub-agents in one batch:
+
+- `test-review` — tactical quality gate (assertions, hygiene, non-determinism mechanics, testability blockers)
+- `test-smell-review` — xUnit smells, test-double selection, pyramid-layer placement
+
+Each returns its standard JSON (`status`/`issues`/`summary`). If no test files
+exist, both skip — proceed to Step 3 with `--advise`.
+
+### 3. Run the advisor (when applicable)
+
+If `--advise` is set (or auto-triggered), invoke the `test-design-advisor`
+skill on the production code to produce testability assessment, pyramid
+placement, double strategy, and a behavior-preserving refactor sequence for
+any untestable units.
+
+### 4. Aggregate and de-duplicate
+
+Merge findings. Resolve overlaps per constraint 3. Group by file. Rank:
+behavior/project smells and testability blockers first (they undermine the
+whole suite), then fragile/obscure smells, then suggestions.
+
+### 5. Report
+
+Produce one report (chat for a small target; `reports/test-design-<date>.md`
+for a module):
+
+```markdown
+## Test Design Review — <target>
+
+**Health**: <pass|attention|critical>   **Test files**: N   **Findings**: N
+
+### Findings (by severity)
+| File:line | Smell / Issue | Severity | Source | Suggested fix |
+
+### Design recommendations (advisor)
+<testability table · pyramid placement · double strategy · refactor sequence>
+
+### Next steps
+- Mechanical fixes → /apply-fixes
+- Refactor sequence → /plan or /build
+```
+
+Surface only what's actionable. If everything is clean, say so in one line.

--- a/plugins/dev-team/docs/agent_info.md
+++ b/plugins/dev-team/docs/agent_info.md
@@ -28,6 +28,7 @@ Review agents run as sub-agents during Phase 3 inline checkpoints and full `/cod
 | --- | --- | --- | --- |
 | `spec-compliance-review` | [`spec-compliance-review.md`](../agents/spec-compliance-review.md) | sonnet | Spec-to-code matching — first gate before quality review |
 | `test-review` | [`test-review.md`](../agents/test-review.md) | sonnet | Coverage gaps, assertion quality, test hygiene |
+| `test-smell-review` | [`test-smell-review.md`](../agents/test-smell-review.md) | sonnet | xUnit test smells, test-double selection, pyramid placement |
 | `security-review` | [`security-review.md`](../agents/security-review.md) | opus | Injection, auth, data exposure |
 | `domain-review` | [`domain-review.md`](../agents/domain-review.md) | opus | Abstraction leaks, boundary violations |
 | `structure-review` | [`structure-review.md`](../agents/structure-review.md) | sonnet | SRP, DRY, coupling, file organization |

--- a/plugins/dev-team/docs/skills.md
+++ b/plugins/dev-team/docs/skills.md
@@ -43,6 +43,8 @@ Enforce rigorous development practices:
 | Branch Workflow | [`branch-workflow.md`](../skills/branch-workflow/SKILL.md) | PR creation, merge strategy, and branch cleanup after Phase 3 |
 | CI Debugging | [`ci-debugging.md`](../skills/ci-debugging/SKILL.md) | CI pipeline failure investigation and resolution |
 | Test Design Reviewer | [`test-design-reviewer.md`](../skills/test-design-reviewer/SKILL.md) | Test quality patterns and anti-patterns |
+| Test Design Advisor | [`test-design-advisor.md`](../skills/test-design-advisor/SKILL.md) | Advise on testability, pyramid layer, double strategy, and behavior-preserving refactor sequences |
+| CD Test Architecture | [`cd-test-architecture.md`](../skills/cd-test-architecture/SKILL.md) | Evaluate an app's tests and recommend a CD-aligned architecture: deterministic, config-free CI gate with UI/service/batch patterns |
 | Browser Testing | [`browser-testing.md`](../skills/browser-testing/SKILL.md) | Playwright-based browser QA for visual verification |
 | Feature File Validation | [`feature-file-validation.md`](../skills/feature-file-validation/SKILL.md) | Gherkin quality, determinism, implementation independence, test automation coverage |
 
@@ -149,7 +151,7 @@ Team agent personas (orchestrator, architect, software-engineer, qa-engineer, se
 
 ### Skill Invocation
 
-Skills are user-invocable directly as `/<skill-name>` — there are no per-skill command wrappers. The available skills (specs, threat-modeling, hexagonal-architecture, domain-driven-design, domain-analysis, api-design, legacy-code, mutation-testing, governance-compliance, feedback-learning, context-loading-protocol, context-summarization, performance-metrics, quality-gate-pipeline, human-oversight-protocol, agent-skill-authoring, competitive-analysis, design-doc, branch-workflow, browser-testing, ci-debugging, design-interrogation, design-it-twice, feature-file-validation, performance-benchmark, static-analysis-integration, systematic-debugging, test-design-reviewer, test-driven-development, docker-image-audit, docker-image-create, js-project-init) load their `SKILL.md` content into the current context and apply it to the task. See [`skills/`](../skills/) for full definitions.
+Skills are user-invocable directly as `/<skill-name>` — there are no per-skill command wrappers. The available skills (specs, threat-modeling, hexagonal-architecture, domain-driven-design, domain-analysis, api-design, legacy-code, mutation-testing, governance-compliance, feedback-learning, context-loading-protocol, context-summarization, performance-metrics, quality-gate-pipeline, human-oversight-protocol, agent-skill-authoring, competitive-analysis, design-doc, branch-workflow, browser-testing, ci-debugging, design-interrogation, design-it-twice, feature-file-validation, performance-benchmark, static-analysis-integration, systematic-debugging, test-design-reviewer, test-design-advisor, cd-test-architecture, test-driven-development, docker-image-audit, docker-image-create, js-project-init) load their `SKILL.md` content into the current context and apply it to the task. See [`skills/`](../skills/) for full definitions.
 
 ### Utility Commands
 

--- a/plugins/dev-team/docs/skills.md
+++ b/plugins/dev-team/docs/skills.md
@@ -48,6 +48,8 @@ Enforce rigorous development practices:
 | Browser Testing | [`browser-testing.md`](../skills/browser-testing/SKILL.md) | Playwright-based browser QA for visual verification |
 | Feature File Validation | [`feature-file-validation.md`](../skills/feature-file-validation/SKILL.md) | Gherkin quality, determinism, implementation independence, test automation coverage |
 
+> For the full test evaluation workflow — how Test Design Advisor, CD Test Architecture, `/test-design`, and `test-smell-review` relate, the out-of-repo anti-pattern, and sample invocations — see [Test Evaluation and Architecture](test-evaluation.md).
+
 ### Research & Design Skills
 
 Used during the Research phase to explore alternatives and stress-test designs:

--- a/plugins/dev-team/docs/test-evaluation.md
+++ b/plugins/dev-team/docs/test-evaluation.md
@@ -1,0 +1,208 @@
+# Test Evaluation and Architecture
+
+This document explains how to evaluate how an existing application is tested and design a path toward a fast, deterministic, config-free CI gate that fully validates behavior — including cross-service interaction — without standing up the rest of the system.
+
+## Purpose
+
+The test evaluation workflow answers two questions: "how well is this application tested today?" and "what would a CD-aligned test architecture look like?" The result is an assessed gap list and a concrete migration path, not generated test code. Implementation of the migration goes to `/plan` or `/build`.
+
+---
+
+## Tools and Their Altitudes
+
+Three tools operate at different scopes. Use the one that matches what you need.
+
+| What you want | Tool | Altitude |
+|---|---|---|
+| Review test files in a changeset for smells and quality | `/test-design` | Per-file / changeset |
+| Advise on how to test a specific module or hard-to-test unit | `test-design-advisor` skill | Unit / module |
+| Assess the whole application's test strategy and pipeline alignment | `cd-test-architecture` skill | Whole application |
+
+**`/test-design`** is the orchestrator command for the changeset-level workflow. It dispatches `test-review` (tactical quality: missing assertions, non-determinism mechanics, mock hygiene) and `test-smell-review` (design-level smells: xUnit smell taxonomy, double selection, pyramid placement) in parallel, then optionally runs `test-design-advisor` for production code that has no tests or hard-to-test units.
+
+**`test-design-advisor`** works at the module level: assess testability blockers, place each behavior on the pyramid, choose the right test double, and produce a behavior-preserving refactor sequence to introduce seams. It does not write tests.
+
+**`cd-test-architecture`** works at the application level: inventory components and test suites, classify against the six MinimumCD test types, identify CD-fitness gaps, recommend a per-component target architecture, and produce a migration path. It does not write tests or edit code.
+
+---
+
+## The Evaluation Workflow
+
+The `cd-test-architecture` skill follows these steps. Run it with `/cd-test-architecture <path>`.
+
+### Step 1: Inventory the application's components
+
+Map each deployable or testable surface and assign it a pattern from `knowledge/component-test-patterns.md`:
+
+- **UI** — User Interface
+- **Services** — API Provider, API Consumer, Event Consumer, Event Producer, Stateful Service, CLI/Library
+- **Batch** — Scheduled Job
+
+A real system is usually several of these. Each surface is assessed separately.
+
+### Step 2: Inventory and classify existing tests
+
+Find every test suite in the repo. For each, record: MinimumCD type, what it actually exercises, whether it is deterministic, and what it requires to run (DB URL, broker, downstream service, secrets, sleep, real clock).
+
+If in-repo tests are sparse, the application is not necessarily untested — see Step 2b before concluding.
+
+### Step 2b: Locate and harvest out-of-repo tests
+
+When `--external-tests <path-or-repo-or-description>` is given, treat the external location as the current specification of intended behavior:
+
+- **Other-repo suites** — read and classify just like in-repo tests; note they can't gate this component's merges.
+- **Postman/Insomnia/`.http` collections** — extract each request + assertion as an API contract and scenario.
+- **Manual scripts or spreadsheets** — extract each step as a behavior to automate.
+
+This produces a behavior inventory that becomes the basis for improvement, not the destination.
+
+### Step 3: Diagnose CD-fitness gaps
+
+Flag, with evidence:
+
+- Out-of-repo or third-party-runner testing (anti-pattern — see below)
+- Manual / non-repeatable testing
+- Tests mistyped as "unit" that require real dependencies
+- Configured-dependency tests that can't run in a clean CI gate
+- Coverage gaps (success + failure modes not covered at any deterministic layer)
+- Doubles with no validation loop (drift risk)
+- No consumer resilience tests (the component assumes the provider holds)
+- Inverted pyramid shape (integration/E2E doing what component tests should)
+
+### Step 4: Recommend the target architecture
+
+Per component: which test types cover which layers, what to double to run pre-merge without configuration, which success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each test type (pre-merge gate, Stage 1/2, out-of-band, or post-deploy).
+
+### Step 5: Produce a migration path
+
+Ordered lowest-risk first, each step independently shippable. When tests are out-of-repo, the path starts by bringing behavior in (see "When the tests aren't in the repo" below). Typical full sequence:
+
+1. Harvest external coverage into an in-repo behavior inventory
+2. Introduce owned adapters over third-party clients
+3. Add in-memory doubles + component tests for each harvested behavior
+4. Add contract tests pinning request/response boundaries
+5. Add consumer resilience tests (verify the component survives a provider break)
+6. Add scheduled provider-contract verification against a test environment
+7. Move real-dependency tests off the gate to adapter integration or out-of-band
+8. Add post-deploy checks
+9. Decommission out-of-repo and manual suites as their behaviors land in the gate
+
+### Step 6: Report
+
+Output goes to `reports/cd-test-architecture-<app>.md`. Tables, not prose: components and patterns, current tests and their CD-fitness, gaps, target architecture, pre-merge gate composition, migration path, next steps.
+
+---
+
+## When the Tests Aren't in the Repo
+
+An application may have little or no in-repo testing and instead be covered by suites in another repo, a third-party runner, Postman or Insomnia collections, or manual scripts. This is an **anti-pattern** regardless of how thorough the external coverage is:
+
+- The tests **cannot gate the component's own merges** — the build can go green while behavior is broken.
+- The tests are **not versioned with the code** they verify; a code change and its test change can't move together.
+- External suites are usually **non-deterministic and environment-coupled**, so they could never serve as a pre-merge gate anyway.
+- **Manual scripts are not repeatable** — they're a checklist, not a regression net.
+
+This does not mean the external coverage is worthless. It is the **current specification of intended behavior** — the best available basis for improvement.
+
+To include it in the assessment, point the skill at it:
+
+```
+/cd-test-architecture <path> --external-tests <postman-collection.json>
+/cd-test-architecture <path> --external-tests <path-to-other-repo>
+/cd-test-architecture <path> --external-tests "manual regression scripts in Confluence, linked here: ..."
+```
+
+The skill harvests those sources as a behavior inventory (Step 2b) and builds the migration path around re-expressing each behavior as a deterministic, in-repo, gated test:
+
+| External source | Re-expressed as |
+|---|---|
+| Postman request + assertion | Component or contract test |
+| Manual UI script | UI component test (real browser, network stubbed) |
+| Other-repo E2E covering this component | In-repo component test + thin post-deploy smoke |
+
+Each external case is decommissioned once its behavior lands in the gate.
+
+If in-repo tests are sparse but no `--external-tests` location is given, the skill will **ask** where the application is actually tested before drawing any conclusions.
+
+---
+
+## Key Principles
+
+### Pre-merge gate: deterministic tests only
+
+The gate that blocks a merge may contain **only** static analysis, unit, component, and contract tests. These are deterministic and need nothing configured. Integration and end-to-end tests are non-deterministic by nature and never gate a merge. A test that needs a database URL, broker, downstream service, or environment secrets to run is mis-typed — re-classify or convert it.
+
+### Run CI without configuring dependencies
+
+The component test is the workhorse of a CD gate. The pattern is consistent across every component type:
+
+1. Assemble the **real component** — actual handlers, domain logic, orchestration — in-process.
+2. Replace only what the team doesn't control with **in-memory doubles**: in-memory repository for the database, in-memory bus for the broker, stubbed adapter for downstream services, injected fixed clock.
+3. Drive it through its **public interface** — HTTP handlers, message handler, job entrypoint, UI via a real browser with the network stubbed.
+4. Assert **observable outcomes** — status, persisted state, emitted event, rendered output — never internal call sequences.
+
+The result: fast (no I/O), deterministic (no real systems, controlled clock), zero configuration of the surrounding system — while still validating real behavior end-to-end within the component boundary.
+
+### The adapter rule
+
+Wrap every third-party client (SDK, HTTP client, broker client, DB driver) in a thin adapter the team owns. Double the adapter in component tests — never mock the third-party SDK directly. Adapter integration tests then exercise the real adapter against a real container to confirm the adapter's correctness.
+
+### Do not depend on provider cooperation
+
+Consumer-driven contract verification where the provider runs your contract in their pipeline only works with close collaboration and enforced tooling. Assume you do not have that. The defense you own:
+
+1. **Contract tests** (pre-merge) pin the request you send and the response shape you depend on, against the adapter double.
+2. **Scheduled provider-contract verification in a test environment** — you run your pinned contract against the provider's real non-prod endpoint on a schedule, out-of-band, owned by your team. This detects a provider break when it happens, not at your next unrelated deploy.
+3. **Resilience component tests** (pre-merge) verify the consumer survives a broken contract: timeouts enforce, retries and circuit breakers behave, malformed responses are handled, the caller gets a documented response with no partial state.
+
+Provider-side verification of your contract is a bonus if they offer it — not the mechanism to rely on.
+
+---
+
+## Sample Invocations
+
+```bash
+# Full application assessment
+/cd-test-architecture ./src
+
+# Scope to one component
+/cd-test-architecture ./src --component payment-service
+
+# Include existing CI config in the assessment
+/cd-test-architecture ./src --ci .github/workflows/ci.yml
+
+# Application tested primarily via Postman collections
+/cd-test-architecture ./src --external-tests ./test-collections/api-tests.postman_collection.json
+
+# Application tested in another repo
+/cd-test-architecture ./src --external-tests "../qa-repo/e2e/payment-service"
+
+# Per-file / changeset review (current working tree or staged changes)
+/test-design
+
+# Per-file review scoped to a directory
+/test-design --path src/payments
+
+# Per-file review of changes since a branch
+/test-design --since main
+
+# Unit/module design advice (advisory — does not write tests)
+/test-design-advisor src/payments/PaymentProcessor.ts
+```
+
+---
+
+## Reference Files
+
+| File | What it defines |
+|---|---|
+| [`knowledge/cd-test-architecture.md`](../knowledge/cd-test-architecture.md) | Six MinimumCD test types, the pre-merge gate rule, out-of-repo anti-pattern, component test pattern, adapter rule, double validation, determinism techniques |
+| [`knowledge/component-test-patterns.md`](../knowledge/component-test-patterns.md) | Per-component patterns: UI, API Provider, API Consumer, Event Consumer, Event Producer, Stateful Service, CLI/Library, Scheduled Job |
+| [`knowledge/test-smells.md`](../knowledge/test-smells.md) | xUnit smell taxonomy: code, behavior, and project smells |
+| [`knowledge/test-doubles.md`](../knowledge/test-doubles.md) | Dummy / stub / spy / mock / fake selection and state-vs-behavior verification |
+| [`knowledge/test-pyramid.md`](../knowledge/test-pyramid.md) | Pyramid layer responsibilities and shape anti-patterns |
+| [`knowledge/microservice-testing.md`](../knowledge/microservice-testing.md) | Contract and CDC testing across independently-deployable services |
+| [`skills/cd-test-architecture/SKILL.md`](../skills/cd-test-architecture/SKILL.md) | The application-level assessment skill |
+| [`skills/test-design-advisor/SKILL.md`](../skills/test-design-advisor/SKILL.md) | The unit/module design advisor skill |
+| [`commands/test-design.md`](../commands/test-design.md) | The `/test-design` orchestrator command |
+| [`agents/test-smell-review.md`](../agents/test-smell-review.md) | The smell-detection review agent |

--- a/plugins/dev-team/docs/test-evaluation.md
+++ b/plugins/dev-team/docs/test-evaluation.md
@@ -75,17 +75,17 @@ Per component: which test types cover which layers, what to double to run pre-me
 
 ### Step 5: Produce a migration path
 
-Ordered lowest-risk first, each step independently shippable. When tests are out-of-repo, the path starts by bringing behavior in (see "When the tests aren't in the repo" below). Typical full sequence:
+Ordered lowest-risk first, each step independently shippable. The spine is **baseline before refactor**: get behavior under test at existing seams *without changing code*, then refactor under that green baseline. When tests are out-of-repo, the harvested behaviors feed that baseline. Typical full sequence:
 
-1. Harvest external coverage into an in-repo behavior inventory
-2. Introduce owned adapters over third-party clients
-3. Add in-memory doubles + component tests for each harvested behavior
+1. **Characterization baseline (no refactoring)** — outside-in tests at the outermost reachable seam that lock in current behavior; reproduce any harvested out-of-repo/manual behaviors here. Get green.
+2. Introduce owned adapters and seams **under the baseline** (DDD skills suggest where boundaries belong)
+3. Add in-memory doubles + component tests reproducing the baselined behaviors
 4. Add contract tests pinning request/response boundaries
 5. Add consumer resilience tests (verify the component survives a provider break)
 6. Add scheduled provider-contract verification against a test environment
 7. Move real-dependency tests off the gate to adapter integration or out-of-band
 8. Add post-deploy checks
-9. Decommission out-of-repo and manual suites as their behaviors land in the gate
+9. Decommission out-of-repo/manual suites and the coarse characterization tests as their behaviors land in the deterministic gate
 
 ### Step 6: Report
 
@@ -157,6 +157,18 @@ Consumer-driven contract verification where the provider runs your contract in t
 
 Provider-side verification of your contract is a bonus if they offer it — not the mechanism to rely on.
 
+### Baseline before refactor (legacy code)
+
+Legacy code is code without tests (regardless of age). When a component is poorly tested, **do not lead with refactoring**:
+
+1. **Find the testable seams** — places where behavior can be observed or substituted without editing the code (HTTP handler, CLI entrypoint, message handler, exported function, existing injection points).
+2. **Write the best outside-in tests achievable now, without refactoring** — characterization tests at the outermost reachable seam that lock in current behavior. This is a behavior baseline, not yet a clean gate.
+3. **Get the baseline green** — your safety net.
+4. **Refactor to improve testability under green** — introduce adapters and seams, push checks down to deterministic component/unit tests. Never change behavior and structure in the same step.
+5. **Let the domain guide the target** — the `domain-driven-design` and `domain-analysis` skills suggest where boundaries and seams should land.
+
+The mechanics live in the [`legacy-code`](../skills/legacy-code/SKILL.md) skill; this workflow places it in the CD test architecture. An assessment of an under-tested component therefore returns two things: the outside-in baseline writable today, and the refactor sequence that improves testability afterward.
+
 ---
 
 ## Sample Invocations
@@ -204,5 +216,7 @@ Provider-side verification of your contract is a bonus if they offer it — not 
 | [`knowledge/microservice-testing.md`](../knowledge/microservice-testing.md) | Contract and CDC testing across independently-deployable services |
 | [`skills/cd-test-architecture/SKILL.md`](../skills/cd-test-architecture/SKILL.md) | The application-level assessment skill |
 | [`skills/test-design-advisor/SKILL.md`](../skills/test-design-advisor/SKILL.md) | The unit/module design advisor skill |
+| [`skills/legacy-code/SKILL.md`](../skills/legacy-code/SKILL.md) | Characterization testing + dependency-breaking: the baseline-before-refactor procedure |
+| [`skills/domain-driven-design/SKILL.md`](../skills/domain-driven-design/SKILL.md) | Suggests target boundaries/seams for the post-baseline refactor |
 | [`commands/test-design.md`](../commands/test-design.md) | The `/test-design` orchestrator command |
 | [`agents/test-smell-review.md`](../agents/test-smell-review.md) | The smell-detection review agent |

--- a/plugins/dev-team/knowledge/adversarial-review-protocol.md
+++ b/plugins/dev-team/knowledge/adversarial-review-protocol.md
@@ -35,6 +35,15 @@ Repeat until the challenger finds no new issues, or a maximum of 3 rounds is rea
 - Did you check for shared mutable state between tests (static fields, module-level singletons)?
 - Are there non-determinism sources (unstubbed clock, real network, file I/O) that weren't flagged as flakiness risks?
 
+### test-smell-review
+
+- For every smell flagged, did you name the specific xUnit smell (not just "this test is bad")?
+- For each "Slow Tests" or "Erratic Test" finding, did you confirm the test's *intended* level — integration/E2E tests touch real resources by design?
+- For each mock-related finding, did you verify a Stub + state assertion couldn't replace it, rather than assuming all mocking is a smell?
+- Did you distinguish Test Code Duplication (extractable) from two tests covering genuinely different boundary conditions?
+- For smells rooted in untestable production code, did you recommend the production-code change (per testability-patterns.md), not a test workaround?
+- Did you defer tactical mechanics (missing assertion, missing await) to test-review instead of double-reporting them?
+
 ### structure-review
 
 - Did you check every module/class for SRP violations, including small ones?

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -40,6 +40,7 @@ Spawned by the orchestrator during Phase 3 inline checkpoints and full `/code-re
 | structure-review | `agents/structure-review.md` | mid | SRP violations, DRY, coupling, file organization |
 | svelte-review | `agents/svelte-review.md` | mid | Svelte reactivity pitfalls, closure state leaks |
 | test-review | `agents/test-review.md` | mid | Coverage gaps, assertion quality, test hygiene |
+| test-smell-review | `agents/test-smell-review.md` | mid | xUnit test smells, test-double selection, test-pyramid layer placement |
 | token-efficiency-review | `agents/token-efficiency-review.md` | small | File/function size, LLM anti-patterns, token usage |
 | progress-guardian | `agents/progress-guardian.md` | mid | Plan adherence, commit discipline, scope creep detection |
 | refactor-opportunity-review | `agents/refactor-opportunity-review.md` | mid | Post-GREEN refactoring opportunities, semantic vs structural duplication |
@@ -73,6 +74,8 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | Branch Workflow | `skills/branch-workflow/SKILL.md` | 450 | Orchestrator, Software Engineer |
 | CI Debugging | `skills/ci-debugging/SKILL.md` | 550 | Platform Engineer, Software Engineer, QA Engineer |
 | Test Design Reviewer | `skills/test-design-reviewer/SKILL.md` | 600 | QA Engineer, test-review |
+| Test Design Advisor | `skills/test-design-advisor/SKILL.md` | ~700 | QA Engineer, Software Engineer, `/test-design` command |
+| CD Test Architecture | `skills/cd-test-architecture/SKILL.md` | ~900 | QA Engineer, Architect, Platform Engineer, Software Engineer |
 | Browser Testing | `skills/browser-testing/SKILL.md` | 700 | QA Engineer |
 | Competitive Analysis | `skills/competitive-analysis/SKILL.md` | 600 | Orchestrator, Product Manager |
 | Design Interrogation | `skills/design-interrogation/SKILL.md` | 500 | Architect, Product Manager, Orchestrator |
@@ -116,10 +119,16 @@ Knowledge files in `knowledge/` provide progressive disclosure — agents read t
 | Domain Modeling | `knowledge/domain-modeling.md` | 500 | domain-review |
 | Architecture Assessment | `knowledge/architecture-assessment.md` | 450 | arch-review |
 | Exploratory Testing Field Guide | `knowledge/exploratory-testing-field-guide.md` | ~900 | QA Engineer, `skills/exploratory-testing/SKILL.md` |
-| Adversarial Review Protocol | `knowledge/adversarial-review-protocol.md` | ~500 | security-review, test-review, structure-review, complexity-review, arch-review, domain-review |
+| Adversarial Review Protocol | `knowledge/adversarial-review-protocol.md` | ~500 | security-review, test-review, test-smell-review, structure-review, complexity-review, arch-review, domain-review |
 | Design Smells | `knowledge/design-smells.md` | ~600 | structure-review, complexity-review, naming-review |
 | Object Calisthenics | `knowledge/object-calisthenics.md` | ~400 | structure-review, complexity-review |
-| Testability Patterns | `knowledge/testability-patterns.md` | ~500 | test-review, legacy-code |
+| Testability Patterns | `knowledge/testability-patterns.md` | ~500 | test-review, test-smell-review, test-design-advisor, legacy-code |
+| Test Smells | `knowledge/test-smells.md` | ~900 | test-smell-review, test-review, test-design-advisor |
+| Test Doubles | `knowledge/test-doubles.md` | ~700 | test-smell-review, test-design-advisor |
+| Test Pyramid | `knowledge/test-pyramid.md` | ~700 | test-smell-review, test-review, test-design-advisor |
+| Microservice Testing | `knowledge/microservice-testing.md` | ~700 | test-smell-review, test-design-advisor |
+| CD Test Architecture | `knowledge/cd-test-architecture.md` | ~1,100 | cd-test-architecture, test-design-advisor |
+| Component Test Patterns | `knowledge/component-test-patterns.md` | ~1,600 | cd-test-architecture |
 
 ## Agent Templates
 

--- a/plugins/dev-team/knowledge/cd-test-architecture.md
+++ b/plugins/dev-team/knowledge/cd-test-architecture.md
@@ -1,0 +1,115 @@
+# CD Test Architecture
+
+Reference file for the `cd-test-architecture` skill and the `test-design-advisor` skill. Defines a test architecture aligned to a Continuous Delivery pipeline: **fast, deterministic tests, with minimal tooling, that fully validate behavior — including how a component interacts with other services — and run in CI without configuring the rest of the system the component depends on.**
+
+Source vocabulary: MinimumCD Practice Guide — Test Types (beyond.minimumcd.org/docs/testing/test-types/) and Applied Testing Strategies (beyond.minimumcd.org/docs/testing/applied-testing-strategies/). Component-specific patterns are in `component-test-patterns.md`.
+
+Core principle: **a pre-merge gate may contain only deterministic tests.** A test that depends on a system the team doesn't control — or that must be configured to run — is non-deterministic and belongs out of the merge path. The way to keep behavior coverage in the gate anyway is to replace uncontrolled systems with test doubles, and to keep those doubles honest with a separate validation loop.
+
+---
+
+## The Six Test Types
+
+| Type | Verifies | Dependencies | Deterministic? | Pre-merge gate? | Pipeline stage |
+|------|----------|--------------|----------------|-----------------|----------------|
+| **Static analysis** | Non-running code: security, complexity, best-practice | none | yes | **yes** | Stage 1 |
+| **Unit** | A unit of behavior through its public interface (what it does, not how) | isolated (doubles) | yes | **yes** | Stage 1 |
+| **Component** | A single component through its public interface, with systems the team doesn't control replaced by doubles | doubles for uncontrolled systems | yes | **yes** | Stage 1 |
+| **Contract** | Interface boundaries with external systems, using doubles (a.k.a. narrow integration). Pins the request sent + response shape depended on | doubles; *validated by integration* | yes | **yes** | Stage 1 |
+| **Integration** | That the contract's doubles still match the real system. Exercises real external dependencies | real systems | **no** | **never** | Stage 1/2 for team-controlled containers; out-of-band/scheduled for third-party |
+| **End-to-end** | Two or more real components up to the full system | real components | **no** | **never** | Post-deploy smoke; never gates the build |
+
+**Unit** has two shapes: *solitary* (all collaborators doubled) and *sociable* (real in-process collaborators, only true boundaries doubled). Both are deterministic and pre-merge.
+
+---
+
+## The Pre-Merge Gate Rule
+
+Pre-merge (the gate that blocks a merge) contains **only**: static analysis, unit, component, and contract tests. These are deterministic and need nothing configured.
+
+Integration and end-to-end tests are non-deterministic by nature (real systems, real network, shared state) and **never gate a merge**. They run:
+
+- **Stage 1/2 (still in CI)** when the dependency is a *team-controlled* container (testcontainers/WireMock) the build spins up itself.
+- **Out-of-band / scheduled** when the dependency is a *third-party API, managed broker, or another team's service*.
+- **Post-deploy** for end-to-end smoke of critical journeys against real backends — blocking rollout, not the build.
+
+If a "unit test" needs a database URL, a broker, a downstream service, or environment secrets to run, it is mis-typed — it's an integration test wearing a unit test's name. Re-type it or convert it to a component test with doubles.
+
+---
+
+## How Component Tests Run Without Configuring Dependencies
+
+The component test is the workhorse of a CD gate. The pattern, consistent across every component type:
+
+1. **Assemble the real component** — the actual handlers, domain logic, and orchestration — in-process.
+2. **Replace only what the team doesn't control** with in-memory doubles: the database (in-memory repository), the message broker (in-memory bus), downstream services (stubbed adapter), the clock (injected fixed clock), the scheduler.
+3. **Drive it through its public interface** — HTTP handlers, the message handler, the job entrypoint, the UI via a real browser with the network stubbed.
+4. **Assert on observable outcomes** — status, persisted state, emitted event, rendered output — never on internal call sequences or private methods.
+
+This yields tests that are fast (no I/O, no network), deterministic (no real systems, controlled clock), and need zero configuration of the surrounding system — while still validating real behavior end to end *within the component boundary*, including how it would interact with its collaborators (verified by contract, made real by integration).
+
+---
+
+## The Adapter Rule (own your boundaries)
+
+Wrap every third-party client (SDK, HTTP client, broker client, DB driver) in **a thin adapter the team owns**, then double the *adapter* in component tests — never mock the third-party SDK directly. The adapter is the seam:
+
+- **Component tests** double the adapter → fast, deterministic, no real dependency.
+- **Adapter integration tests** exercise the real adapter against a real container → assert the *adapter's* correctness (it speaks the protocol, builds the right request), not the dependency's behavior.
+
+This keeps the mock surface small, stable, and owned, and localizes every "the real thing changed" failure to one place.
+
+---
+
+## Double Validation (keeping doubles honest)
+
+A double that drifts from reality gives false confidence — the central risk of double-based isolation. Keeping a double honest has two independent jobs: **detect** when reality diverges, and **survive** the divergence when it happens.
+
+### Do not depend on provider cooperation
+
+Consumer-driven contract verification — where the *provider* runs your contract in *their* pipeline and is blocked from deploying a breaking change — only works when teams collaborate closely and use tooling that enforces it. **Assume you do not have that.** Design the strategy for the realistic case:
+
+- The provider can break the contract **without versioning**, at any time, with no notice.
+- Their production contract is **assumed broken until proven otherwise** — and you typically discover the break during your *next unrelated deploy*, which then wrongly implicates your change and burns an incident investigating the wrong thing.
+
+So provider-side verification is a *nice-to-have if the provider offers it* — never the mechanism you rely on.
+
+### The defense you own
+
+1. **Contract test** (pre-merge) pins the request the consumer sends and the response shape it depends on, against the adapter double. Blocks the build. This keeps *your* side stable and documents exactly what you assume of the provider.
+2. **Scheduled provider-contract verification in a test environment** — *you* run your pinned contract against the provider's real (non-prod) endpoint **on a schedule, out-of-band**, decoupled from your deploy cadence. This is the primary defense: it detects a provider break **when it happens**, not when you next ship, so the break is attributed to the provider and not to your undelivered changes. Owned and run by your team; requires no provider cooperation.
+3. **Adapter integration test** (Stage 1/2) runs the adapter against a real container of the production engine/broker (matching version + extensions) to confirm the double's protocol assumptions hold for dependencies you control.
+4. **Resilience verified by component tests** (pre-merge) — because you assume the provider *will* break, the consumer must be tested to **survive** it: timeouts enforce, retries/backoff/circuit-breaker behave, malformed or drifted responses are handled per Postel's Law, and the caller gets a documented response with no partial state. Detection (step 2) tells you it broke; resilience keeps you up until it's fixed.
+
+Doubles without steps 2 and 4 are a smell (see `microservice-testing.md` → "Stubs that lie", `test-smells.md` → behavior smells). The classic failure is a hand-written double that the team *assumes* still matches a provider nobody is checking.
+
+---
+
+## Determinism Techniques (minimal tooling)
+
+- **Inject the clock.** Replace system time with a fixed clock in every time-dependent test (`Clock.fixed(...)`). Keep exactly one out-of-band real-clock check to confirm production wiring (catches "tests use UTC, prod uses container local time").
+- **Inject randomness.** Same discipline for RNG and ID generation.
+- **No sleeps.** Never `sleep` to await; drive time and async deterministically.
+- **Real browser, stubbed network (UI).** Run UI component tests in a real engine (Chromium/Firefox/WebKit) with the backend stubbed at the network layer — not an in-memory DOM shim, which trades accuracy for speed and produces false positives on layout/timing.
+- **In-memory doubles over heavyweight test infra** for the gate. Reserve containers for adapter integration, off the merge path.
+
+---
+
+## Terminology Reconciliation (read this if you also use the Fowler files)
+
+This file uses **MinimumCD vocabulary**, which differs from the Fowler-based `test-pyramid.md` and `microservice-testing.md`:
+
+| Term | MinimumCD (this file) | Fowler (`test-pyramid.md`) |
+|------|----------------------|----------------------------|
+| **Component test** | Whole component through its public interface, uncontrolled systems doubled, **deterministic, pre-merge** | "Component / Service" — similar intent |
+| **Contract test** | Doubles that pin the boundary, **pre-merge**, validated by integration | Consumer-driven contract — same idea |
+| **Integration test** | Exercises real deps **specifically to validate the doubles**, non-deterministic, **post-merge only** | Broader: any test of a unit + one real external |
+| **Pre-merge gate** | Determinism is the gating criterion | Implicit in "fast tests at the base" |
+
+When advising for a CD pipeline, **prefer this file's framing** — the determinism→pre-merge axis is the organizing principle. Use the Fowler files for the general layering heuristic and the doubles taxonomy (`test-doubles.md`).
+
+## Boundaries
+
+- "Minimal tooling" means prefer in-memory doubles + a real browser + testcontainers for adapter checks — not a sprawl of test frameworks. Don't recommend heavyweight orchestration (full docker-compose of the system) for the gate; that's exactly the configured-dependency dependency this architecture removes.
+- These are starting points, not mandates. Real components have details these layers don't capture; drop items that don't apply and add what a component clearly needs.
+- This file defines the *architecture*. Per-component specifics (what to double, which failure modes) are in `component-test-patterns.md`.

--- a/plugins/dev-team/knowledge/cd-test-architecture.md
+++ b/plugins/dev-team/knowledge/cd-test-architecture.md
@@ -80,6 +80,20 @@ This keeps the mock surface small, stable, and owned, and localizes every "the r
 
 ---
 
+## Outside-In First: Baseline Before Refactor
+
+You rarely start from a clean slate. When a component is poorly tested or untested ("legacy" = code without tests, regardless of age), **do not lead with refactoring.** The sequence that protects behavior:
+
+1. **Find the testable seams.** A seam is a place where behavior can be observed or substituted *without editing the code under test* — an HTTP handler, a CLI entrypoint, a message handler, an exported function, an existing injection point (object seams via interfaces/polymorphism; link seams via DI/module substitution). The outermost seam you can drive is usually the best starting point.
+2. **Write the best outside-in tests achievable now, without refactoring.** At the outermost reachable seam, write characterization tests that exercise the component as fully as possible and lock in its *current* observable behavior — even if you must tolerate some real dependencies or coarse assertions at first. The goal is a **behavior baseline**, not yet a clean CD gate.
+3. **Get the baseline green.** This is the safety net.
+4. **Now refactor to improve testability — under green.** Introduce adapters and seams (the Adapter Rule, `testability-patterns.md`), push checks down to deterministic component/unit tests, and tighten assertions. **Never change behavior and structure in the same step** (`legacy-code` skill). The baseline catches regressions the refactor might introduce.
+5. **Let the domain guide the target structure.** Use the DDD skills (`domain-driven-design`, `domain-analysis`) to suggest where boundaries, ports, and seams *should* go — so the refactor moves toward a sound domain model, not just toward testability.
+
+So an assessment recommends two things per under-tested component: **(a) the best outside-in test we can write today without touching the code** (immediate baseline), and **(b) the refactor sequence that improves testability afterward**, gated by that baseline. The full procedure lives in the `legacy-code` skill; this is its place in the CD test architecture.
+
+---
+
 ## Double Validation (keeping doubles honest)
 
 A double that drifts from reality gives false confidence — the central risk of double-based isolation. Keeping a double honest has two independent jobs: **detect** when reality diverges, and **survive** the divergence when it happens.

--- a/plugins/dev-team/knowledge/cd-test-architecture.md
+++ b/plugins/dev-team/knowledge/cd-test-architecture.md
@@ -37,6 +37,25 @@ If a "unit test" needs a database URL, a broker, a downstream service, or enviro
 
 ---
 
+## Tests Must Live With the Code (out-of-repo testing is an anti-pattern)
+
+A component's tests belong **in the component's repository and pipeline**. When a component has little or no in-repo testing and is instead verified by suites in another repo, a separate QA runner, Postman/Insomnia collections, or manual scripts, that is an **anti-pattern — regardless of how thorough the external coverage is** — because:
+
+- It **cannot gate the component's own merges** — the build can go green while the behavior is broken.
+- It is **not versioned with the code** it verifies, so the two drift; a code change and its test change can't move together.
+- It is usually **non-deterministic and environment-coupled** (shared environments, real dependencies, human steps), so it could never be a pre-merge gate anyway.
+- **Manual scripts are not repeatable** — they're a checklist, not a regression net.
+
+This does not mean the external coverage is worthless — it is the **current specification of intended behavior** and the best available basis for improvement. The move is:
+
+1. **Harvest** the external coverage into an in-repo behavior inventory: each Postman request → an API contract + scenario; each manual step → a behavior to automate; each other-repo test → a behavior to reproduce locally.
+2. **Re-express** each behavior as the lowest-layer deterministic in-repo test that covers it (see `component-test-patterns.md`), running in the component's own gate.
+3. **Decommission** the external/manual case once its behavior is covered in the gate.
+
+A user should be able to point the assessment at where the external tests live (`--external-tests`); treat that location as source material, not as the destination.
+
+---
+
 ## How Component Tests Run Without Configuring Dependencies
 
 The component test is the workhorse of a CD gate. The pattern, consistent across every component type:

--- a/plugins/dev-team/knowledge/component-test-patterns.md
+++ b/plugins/dev-team/knowledge/component-test-patterns.md
@@ -1,0 +1,138 @@
+# Component Test Patterns
+
+Reference file for the `cd-test-architecture` skill. Per-component-type testing patterns for a CD pipeline. Builds on `cd-test-architecture.md` (the six test types, the pre-merge determinism rule, the adapter rule, and double validation) — read that first.
+
+Source: MinimumCD Applied Testing Strategies — component patterns (beyond.minimumcd.org/docs/testing/applied-testing-strategies/patterns/). These are recommended starting points, not mandates: drop items that don't apply, add what a component clearly needs.
+
+Core principle for every pattern: **assemble the real component, double only the systems the team doesn't control, drive through the public interface, assert observable outcomes.** Everything below is a specialization of that.
+
+---
+
+## Identify the Component's Pattern
+
+| If the component… | Pattern | Group |
+|---|---|---|
+| renders data and accepts user interaction against backend APIs | **User Interface** | UI |
+| exposes endpoints and owns its data store, no outbound internal calls | **API Provider** | Services |
+| exposes endpoints **and** calls upstream services | **API Consumer** | Services |
+| consumes messages from a broker | **Event Consumer** | Services |
+| publishes messages to a broker | **Event Producer** | Services |
+| holds long-lived in-memory state (cache, aggregate, coordinator, websocket gateway) | **Stateful Service** | Services |
+| is a binary/package invoked via CLI or imported API | **CLI / Library** | Services |
+| is triggered by cron/queue/scheduler to process data and write output | **Scheduled Job** | Batch |
+
+A real system is often several of these; test each surface by its pattern.
+
+---
+
+## UI
+
+### User Interface
+
+Renders data and accepts interaction against backend APIs.
+
+- **Coverage layers:** pure rendering (solitary unit) → component composition (sociable unit) → feature behavior in the DOM (component tests in a real browser, backend stubbed at the network layer) → backend HTTP client (consumer-side contract tests) → a small set of E2E happy paths against real backends (post-deploy).
+- **Isolation (run without the backend configured):** drive the UI in a real browser engine; stub the backend **at the network layer** (e.g. Playwright `page.route`). The same fixtures later serve E2E smoke. Do **not** use an in-memory DOM shim (JSDOM) for feature tests — it trades accuracy for false positives on layout/event timing.
+- **Success scenarios:** critical flows via keyboard + mouse; valid input submits; loading states; empty/populated/overflow states; i18n (long translations, RTL); responsive breakpoints.
+- **Failure modes:** every API call's 4xx/5xx/network/timeout; validation messages (screen-reader announced); token expiry mid-session → re-auth; permission denied; stale data after cross-tab deletes; slow (3G) network; concurrent-edit/optimistic-lock UX; back-button nav; automated WCAG scan.
+- **Double validation:** backend stubs must match real endpoints — pin them with contract tests pre-merge, then run **scheduled verification of those contracts against the real backend in a test environment** to detect drift when it happens (not at your next deploy). If the backend is the same team's, provider-side verification in its pipeline is a bonus; don't depend on it for backends you don't control. Post-deploy E2E smoke catches drift the contracts didn't pin.
+- **Pipeline:** unit + component (headless browser) + consumer contract tests in Stage 1; visual regression Stage 1/2; E2E smoke post-deploy (blocks rollout, not build); RUM + synthetics in prod.
+
+---
+
+## Services
+
+### API Provider
+
+Exposes endpoints, owns its data store, no outbound internal calls.
+
+- **Coverage layers:** HTTP/API surface (component + provider contract) → domain logic (solitary/sociable unit + component) → persistence adapter (sociable unit + adapter integration + component) → external database (doubled in component; real engine in adapter integration).
+- **Isolation:** assemble the full app with an **in-memory repository** and in-memory event bus; drive through HTTP handlers; assert status, persisted state, emitted events.
+- **Success scenarios:** documented endpoints return expected shape/status for valid input; auth succeeds for valid creds/tokens; pagination/filter/sort; idempotent ops idempotent, non-idempotent create exactly one; success-path side effects (events, audit).
+- **Failure modes:** malformed input (bad JSON, missing/extra fields, type errors); out-of-range/unicode; authz failures (missing/expired token, insufficient scope, cross-tenant); not-found returns 404 not 500; concurrency conflicts with correct status; persistence failure without partial commit; rate-limit/size enforcement; idempotency under retry.
+- **Double validation:** adapter integration tests run against a real instance of the **production database engine** via testcontainers (matching version + extensions) — never an SQLite shim for a Postgres prod; provider contract verification confirms the API still satisfies every consumer expectation.
+- **Pipeline:** unit + sociable unit pre-commit/Stage 1; component Stage 1; adapter integration Stage 1 (if fast) or 2; provider contract verification in CD contract/boundary stage.
+
+### API Consumer
+
+Exposes endpoints **and** calls upstream services. The most failure-prone distributed pattern — give it the most attention.
+
+- **Coverage layers:** inbound HTTP surface → domain/orchestration (composes calls) → **resilience policy** (retry, circuit breaker, timeout, fallback) → outbound HTTP client (request build, response parse, headers, deadlines) → persistence adapter → external DB (doubled/real) → downstream service (doubled in pipeline, real out-of-band).
+- **Isolation (run without the upstream configured):** wrap the upstream client in a **team-owned thin adapter**; double the adapter in component tests. Drive each failure through the client double.
+- **Success scenarios:** constructs right URL/headers/body/auth/timeout; parses success incl. optional/unknown fields; composes multiple downstream calls (sequence/parallel); caching within TTL + refresh after expiry; trace-context propagation.
+- **Failure modes:** **timeout** (deadline enforces, caller gets documented response e.g. 504, no partial commit); connection refused (retry count + backoff → fallback/error); 5xx retried only when retryable; 4xx mapped to documented behavior, generally not retried, 429 respects `Retry-After`; malformed/drifted response per Postel's Law; circuit breaker opens under sustained failure, fast-fails, recovers on half-open probe; partial multi-call failure → compensation/rollback/documented partial success.
+- **Double validation (do not depend on provider cooperation):** assume the provider can break the contract without versioning and that you won't know until an incident. (1) consumer-side contract tests pin request + response shape, block the build; (2) **scheduled provider-contract verification in a test environment** — *you* run your pinned contract against the provider's real non-prod endpoint on a schedule, out-of-band, decoupled from your deploys — this is the primary defense, attributing a break to the provider when it happens rather than to your next unrelated change; (3) adapter integration tests exercise the real outbound client against controlled states (testcontainers) — asserts the *adapter*, not the dependency; (4) resilience component tests (above) prove the consumer **survives** a broken contract, not just detects it. Provider-side verification of your contract is a bonus *if* they offer it — never relied upon.
+- **Anti-pattern:** mocking the third-party SDK directly instead of wrapping + doubling an owned adapter.
+- **Pipeline:** consumer contract + resilience component tests (fault injection) Stage 1; adapter integration for **in-house** deps Stage 1/2; adapter integration for **third-party/other-team** deps out-of-band on schedule, never in-band; post-deploy checks scheduled.
+
+### Event Consumer
+
+Consumes messages from a broker (Kafka/SQS/RabbitMQ/PubSub).
+
+- **Coverage layers:** message handler (solitary unit) → idempotency & ordering (component) → dead-letter / poison-message (component) → backpressure (resilience component) → broker client (adapter integration vs real broker container) → external broker & schema registry (doubled in component; contract + post-deploy synthetic publish).
+- **Isolation (run without the broker):** replace the broker with a double; drive the handler with messages directly.
+- **Success scenarios:** well-formed message → expected state change + documented downstream event; batch policy honored; replay from offset reproduces identical end state; documented schema versions accepted.
+- **Failure modes:** poison message → DLQ with correlation id, consumer survives; duplicate delivery → exactly one record (idempotency); out-of-order per documented policy; mid-batch failure → offsets uncommitted, no data loss; schema skew per version policy; backpressure (slow, don't OOM); rebalancing strands no in-flight messages.
+- **Double validation:** adapter integration tests vs a real broker container the team controls (Docker Kafka, ElasticMQ, Redpanda) assert the adapter speaks the protocol (not broker ordering — that's the broker's job); schema-registry doubles validated via contract tests + post-deploy checks vs the real registry.
+- **Pipeline:** handler unit + component Stage 1; adapter integration vs team-controlled broker Stage 1/2; managed-broker tests + post-deploy synthetic publishes out-of-band.
+
+### Event Producer
+
+Publishes messages to a broker (often paired with a consumer in the same service).
+
+- **Coverage layers:** publish logic (unit) → publish contract (contract test pins message schema) → broker client adapter (adapter integration) → external broker (doubled; post-deploy synthetic).
+- **Isolation:** double the broker adapter; assert the message that *would* be published (shape, key, headers, idempotency).
+- **Success/failure:** correct schema/partition-key/headers on the happy path; publish failure → documented retry/outbox behavior, no silent drop; transactional outbox prevents loss on crash between state-write and publish.
+- **Double validation:** message schema pinned by contract (consumers verify); adapter integration vs real broker container; post-deploy synthetic publish.
+- **Pipeline:** unit + contract Stage 1; adapter integration Stage 1/2; post-deploy synthetic.
+
+### Stateful Service
+
+Long-lived in-memory state: caches, aggregates, coordinators, websocket gateways, real-time engines.
+
+- **Coverage layers:** state-machine logic (solitary unit) → persistence & recovery (component with real or in-memory persistence) → single-node concurrency (component) → replication & leader election (cluster tests with real consensus library) → memory bounds (soak) → connection lifecycle (component).
+- **Isolation:** double persistence; control time and event ordering to make concurrency deterministic.
+- **Success scenarios:** transitions follow documented state machine; state rebuilds identically after restart; replication lag within budget.
+- **Failure modes:** crash mid-write → consistent state on restart, no torn writes; concurrent mutations serialize without lost updates; network partition → minority steps down with documented reconciliation; memory pressure → evicts per policy, no OOM; idle connections close cleanly with documented reconnect.
+- **Double validation:** persistence doubles validated by adapter integration vs production engine; consensus doubles validated by cluster testcontainer tests.
+- **Pipeline:** unit + component Stage 1; cluster tests Stage 2; soak + chaos out-of-pipeline vs deployed instances.
+
+### CLI / Library
+
+Binary or package consumed via CLI or an exported API.
+
+- **Coverage layers:** public-interface behavior (unit/component invoking the real surface) → process startup for a CLI (deployed-binary test invoking the real artifact) → any external deps via owned adapters.
+- **Isolation:** test through the public invocation surface (args/stdin/stdout/exit codes for a CLI; exported functions for a library); double external deps via adapters.
+- **Success/failure:** documented commands/flags produce documented output + exit code; bad args → documented error + non-zero exit; stdin/stdout/stderr contracts; backward-compatible public API (the consumer's contract).
+- **Double validation:** a small set of deployed-binary tests invoke the real built artifact to catch packaging/startup gaps unit tests miss.
+- **Pipeline:** unit + component Stage 1; deployed-binary smoke Stage 1/2.
+
+---
+
+## Batch
+
+### Scheduled Job
+
+Triggered by cron/queue/scheduler to process data and write output/state.
+
+- **Coverage layers:** pure transformation (solitary unit, no I/O) → job orchestration (component: idempotency, partial-failure recovery, checkpointing, time-window logic) → source/sink adapters (adapter integration vs real container or WireMock) → process startup (deployed-binary test invoking the real artifact) → scheduling integration (out-of-band vs the real scheduler in non-prod) → observability (assertions in component tests).
+- **Isolation (run without real data stores or the scheduler):** field-level in-memory fakes for sources/sinks seeded in the test; **inject the clock** (`Clock.fixed(Instant.parse(...), ZoneOffset.UTC)`); invoke the job entrypoint directly rather than via the scheduler.
+- **Success scenarios:** representative input → expected output (report/db update/published message); idempotency (running twice for the same logical period → same result, no duplicates); checkpoint resume without reprocessing; time-window correctness across DST and month/year boundaries; empty input → valid empty report; output conforms to documented schema.
+- **Failure modes:** source unavailable → clean failure with documented exit code, no partial output, safely re-runnable; sink unavailable → no source state change; partial-write → idempotency keys / transactional outbox prevent duplicates on retry; slow run → alertable, locking prevents overlapping runs; malformed records → log context + configured policy (skip/dead-letter/fail); timezone bugs tested via injected clock; concurrent runs → locking/partitioning; mid-run crash → resume from consistent checkpoint.
+- **Double validation:** one out-of-band real-clock check validates production clock wiring (catches "tests UTC, prod container-local"); source/sink contracts pin the shape, post-deploy checks confirm ongoing alignment; a real-scheduler check in non-prod confirms entrypoint discovery, cron timing, env/secret resolution, concurrency policy.
+- **Pipeline:** unit + component + contract Stage 1; adapter integration Stage 1/2; small deployed-binary set Stage 1/2; real-clock + real-scheduler checks out-of-band scheduled vs non-prod; post-deploy synthetic invocation verifies it ran, processed records, met SLO.
+
+---
+
+## Quick Reference: Isolation Strategy by Pattern
+
+| Pattern | Double to run pre-merge without config | Validated by |
+|---------|----------------------------------------|--------------|
+| User Interface | Network-layer backend stub (real browser) | Consumer contracts + post-deploy E2E |
+| API Provider | In-memory repository + event bus | Adapter integration (real DB container) + provider contracts |
+| API Consumer | Owned adapter over upstream client | 4-layer: consumer contract + adapter integration + provider verify + post-deploy |
+| Event Consumer | Broker double | Adapter integration (real broker container) + schema contracts |
+| Event Producer | Broker adapter double | Message contract + adapter integration + post-deploy synthetic |
+| Stateful Service | Persistence double + controlled time/ordering | Adapter integration + cluster testcontainers |
+| CLI / Library | Adapters over external deps | Deployed-binary smoke |
+| Scheduled Job | In-memory source/sink fakes + injected clock | Adapter integration + real-clock + real-scheduler out-of-band |

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -170,6 +170,10 @@
       "summary": "Pre-merge (the gate that blocks a merge) contains **only**: static analysis, unit, component, and contract tests.",
       "anchor": "the-pre-merge-gate-rule"
     },
+    "Tests Must Live With the Code (out-of-repo testing is an anti-pattern)": {
+      "summary": "A component's tests belong **in the component's repository and pipeline**.",
+      "anchor": "tests-must-live-with-the-code-out-of-repo-testing-is-an-anti-pattern"
+    },
     "How Component Tests Run Without Configuring Dependencies": {
       "summary": "The component test is the workhorse of a CD gate.",
       "anchor": "how-component-tests-run-without-configuring-dependencies"
@@ -1009,8 +1013,12 @@
       "anchor": "1-inventory-the-applications-components"
     },
     "2. Inventory the existing tests and classify them": {
-      "summary": "Find the test suites and classify each against the six types in `cd-test-architecture.md`.",
+      "summary": "Find the test suites **in the repo** and classify each against the six types in `cd-test-architecture.md`.",
       "anchor": "2-inventory-the-existing-tests-and-classify-them"
+    },
+    "2b. Locate and harvest out-of-repo tests": {
+      "summary": "When `--external-tests` is given (or in-repo tests are sparse and the user points you to external coverage), treat the external location as the **current specification of intended behavior** and harvest it:",
+      "anchor": "2b-locate-and-harvest-out-of-repo-tests"
     },
     "3. Diagnose CD-fitness gaps": {
       "summary": "Flag, with evidence:",
@@ -1021,7 +1029,7 @@
       "anchor": "4-recommend-the-target-architecture"
     },
     "5. Produce a migration path": {
-      "summary": "Order the moves from current → target, lowest-risk first (typically: introduce owned adapters → add in-memory doubles + component tests → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks).",
+      "summary": "Order the moves from current → target, lowest-risk first.",
       "anchor": "5-produce-a-migration-path"
     },
     "6. Report": {

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -182,6 +182,10 @@
       "summary": "Wrap every third-party client (SDK, HTTP client, broker client, DB driver) in **a thin adapter the team owns**, then double the *adapter* in component tests — never mock the third-party SDK directly.",
       "anchor": "the-adapter-rule-own-your-boundaries"
     },
+    "Outside-In First: Baseline Before Refactor": {
+      "summary": "You rarely start from a clean slate.",
+      "anchor": "outside-in-first-baseline-before-refactor"
+    },
     "Double Validation (keeping doubles honest)": {
       "summary": "A double that drifts from reality gives false confidence — the central risk of double-based isolation.",
       "anchor": "double-validation-keeping-doubles-honest"
@@ -1023,6 +1027,10 @@
     "3. Diagnose CD-fitness gaps": {
       "summary": "Flag, with evidence:",
       "anchor": "3-diagnose-cd-fitness-gaps"
+    },
+    "3b. Find testable seams and the achievable outside-in baseline": {
+      "summary": "For each under-tested or untested component, identify the **testable seams** — places where behavior can be observed or substituted without editing the code (HTTP handler, CLI entrypoint, message handler, exported function, existing injection points; object seams via interfaces/polymorphism, link seams via DI/module substitution).",
+      "anchor": "3b-find-testable-seams-and-the-achievable-outside-in-baseline"
     },
     "4. Recommend the target architecture": {
       "summary": "Per component, using its pattern: which test types cover which layers, **what to double to run pre-merge without configuration**, the success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each (pre-merge gate vs Stage 1/2 vs out-of-band vs post-deploy).",

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -76,6 +76,10 @@
       "summary": "For every class below 90% effective coverage, did you identify the SPECIFIC uncovered behavior?",
       "anchor": "test-review"
     },
+    "test-smell-review": {
+      "summary": "For every smell flagged, did you name the specific xUnit smell (not just \"this test is bad\")?",
+      "anchor": "test-smell-review"
+    },
     "structure-review": {
       "summary": "Did you check every module/class for SRP violations, including small ones?",
       "anchor": "structure-review"
@@ -155,6 +159,102 @@
     "MCP-Enhanced Analysis": {
       "summary": "If a code knowledge graph MCP is available (e.g., GitNexus):",
       "anchor": "mcp-enhanced-analysis"
+    }
+  },
+  "plugins/dev-team/knowledge/cd-test-architecture.md": {
+    "The Six Test Types": {
+      "summary": "| Type | Verifies | Dependencies | Deterministic?",
+      "anchor": "the-six-test-types"
+    },
+    "The Pre-Merge Gate Rule": {
+      "summary": "Pre-merge (the gate that blocks a merge) contains **only**: static analysis, unit, component, and contract tests.",
+      "anchor": "the-pre-merge-gate-rule"
+    },
+    "How Component Tests Run Without Configuring Dependencies": {
+      "summary": "The component test is the workhorse of a CD gate.",
+      "anchor": "how-component-tests-run-without-configuring-dependencies"
+    },
+    "The Adapter Rule (own your boundaries)": {
+      "summary": "Wrap every third-party client (SDK, HTTP client, broker client, DB driver) in **a thin adapter the team owns**, then double the *adapter* in component tests — never mock the third-party SDK directly.",
+      "anchor": "the-adapter-rule-own-your-boundaries"
+    },
+    "Double Validation (keeping doubles honest)": {
+      "summary": "A double that drifts from reality gives false confidence — the central risk of double-based isolation.",
+      "anchor": "double-validation-keeping-doubles-honest"
+    },
+    "Do not depend on provider cooperation": {
+      "summary": "Consumer-driven contract verification — where the *provider* runs your contract in *their* pipeline and is blocked from deploying a breaking change — only works when teams collaborate closely and use tooling that enforces it.",
+      "anchor": "do-not-depend-on-provider-cooperation"
+    },
+    "The defense you own": {
+      "summary": "1.",
+      "anchor": "the-defense-you-own"
+    },
+    "Determinism Techniques (minimal tooling)": {
+      "summary": "**Inject the clock.** Replace system time with a fixed clock in every time-dependent test (`Clock.fixed(...)`).",
+      "anchor": "determinism-techniques-minimal-tooling"
+    },
+    "Terminology Reconciliation (read this if you also use the Fowler files)": {
+      "summary": "This file uses **MinimumCD vocabulary**, which differs from the Fowler-based `test-pyramid.md` and `microservice-testing.md`:",
+      "anchor": "terminology-reconciliation-read-this-if-you-also-use-the-fowler-files"
+    },
+    "Boundaries": {
+      "summary": "\"Minimal tooling\" means prefer in-memory doubles + a real browser + testcontainers for adapter checks — not a sprawl of test frameworks.",
+      "anchor": "boundaries"
+    }
+  },
+  "plugins/dev-team/knowledge/component-test-patterns.md": {
+    "Identify the Component's Pattern": {
+      "summary": "| If the component… | Pattern | Group |",
+      "anchor": "identify-the-components-pattern"
+    },
+    "UI": {
+      "summary": "Renders data and accepts interaction against backend APIs.",
+      "anchor": "ui"
+    },
+    "User Interface": {
+      "summary": "Renders data and accepts interaction against backend APIs.",
+      "anchor": "user-interface"
+    },
+    "Services": {
+      "summary": "Exposes endpoints, owns its data store, no outbound internal calls.",
+      "anchor": "services"
+    },
+    "API Provider": {
+      "summary": "Exposes endpoints, owns its data store, no outbound internal calls.",
+      "anchor": "api-provider"
+    },
+    "API Consumer": {
+      "summary": "Exposes endpoints **and** calls upstream services.",
+      "anchor": "api-consumer"
+    },
+    "Event Consumer": {
+      "summary": "Consumes messages from a broker (Kafka/SQS/RabbitMQ/PubSub).",
+      "anchor": "event-consumer"
+    },
+    "Event Producer": {
+      "summary": "Publishes messages to a broker (often paired with a consumer in the same service).",
+      "anchor": "event-producer"
+    },
+    "Stateful Service": {
+      "summary": "Long-lived in-memory state: caches, aggregates, coordinators, websocket gateways, real-time engines.",
+      "anchor": "stateful-service"
+    },
+    "CLI / Library": {
+      "summary": "Binary or package consumed via CLI or an exported API.",
+      "anchor": "cli-library"
+    },
+    "Batch": {
+      "summary": "Triggered by cron/queue/scheduler to process data and write output/state.",
+      "anchor": "batch"
+    },
+    "Scheduled Job": {
+      "summary": "Triggered by cron/queue/scheduler to process data and write output/state.",
+      "anchor": "scheduled-job"
+    },
+    "Quick Reference: Isolation Strategy by Pattern": {
+      "summary": "| Pattern | Double to run pre-merge without config | Validated by |",
+      "anchor": "quick-reference-isolation-strategy-by-pattern"
     }
   },
   "plugins/dev-team/knowledge/design-smells.md": {
@@ -261,6 +361,28 @@
     "5. Implicit Expectations": {
       "summary": "Stakeholders never state these because they assume they're obvious — highest-value adversarial targets:",
       "anchor": "5-implicit-expectations"
+    }
+  },
+  "plugins/dev-team/knowledge/microservice-testing.md": {
+    "The Layers (per service)": {
+      "summary": "| Layer | Scope | What it verifies | Doubles |",
+      "anchor": "the-layers-per-service"
+    },
+    "Consumer-Driven Contracts (CDC)": {
+      "summary": "The mechanism that lets services deploy independently:",
+      "anchor": "consumer-driven-contracts-cdc"
+    },
+    "What to test where (microservice heuristics)": {
+      "summary": "**Business logic** → unit, in the owning service.",
+      "anchor": "what-to-test-where-microservice-heuristics"
+    },
+    "Smells specific to distributed testing (flag these)": {
+      "summary": "| Smell | Signal | Fix |",
+      "anchor": "smells-specific-to-distributed-testing-flag-these"
+    },
+    "Boundaries": {
+      "summary": "Not every codebase is microservices.",
+      "anchor": "boundaries"
     }
   },
   "plugins/dev-team/knowledge/object-calisthenics.md": {
@@ -467,6 +589,80 @@
     "1.0.0 (2026-04-21)": {
       "summary": "Initial contract.",
       "anchor": "100-2026-04-21"
+    }
+  },
+  "plugins/dev-team/knowledge/test-doubles.md": {
+    "The Five Doubles": {
+      "summary": "| Double | What it does | Verification style | Use when |",
+      "anchor": "the-five-doubles"
+    },
+    "State Verification vs. Behavior Verification": {
+      "summary": "| | State verification | Behavior verification |",
+      "anchor": "state-verification-vs-behavior-verification"
+    },
+    "Choosing a Double (decision flow)": {
+      "summary": "---",
+      "anchor": "choosing-a-double-decision-flow"
+    },
+    "Common Misuses (flag these)": {
+      "summary": "| Misuse | Why it's wrong | Fix |",
+      "anchor": "common-misuses-flag-these"
+    },
+    "Relationship to testability": {
+      "summary": "If a collaborator can't be substituted at all (new-ed up internally, static singleton, hidden global), that's a **production-code** problem, not a test problem — introduce a seam per `testability-patterns.md` (constructor injection, interface extraction) before choosing a double.",
+      "anchor": "relationship-to-testability"
+    },
+    "Boundaries": {
+      "summary": "Don't flag a Fake (in-memory repo/DB) as \"not testing the real thing\" — at unit/integration level a Fake is a legitimate, often *better*, choice than a heavily-stubbed real dependency.",
+      "anchor": "boundaries"
+    }
+  },
+  "plugins/dev-team/knowledge/test-pyramid.md": {
+    "The Layers": {
+      "summary": "| Layer | Scope | Speed | Doubles | What it proves |",
+      "anchor": "the-layers"
+    },
+    "Layer-Selection Heuristics": {
+      "summary": "Ask, for each thing you want to verify:",
+      "anchor": "layer-selection-heuristics"
+    },
+    "Anti-Patterns": {
+      "summary": "| Anti-pattern | Shape | Symptom | Fix |",
+      "anchor": "anti-patterns"
+    },
+    "How to use this during review": {
+      "summary": "A unit-level test doing **real I/O** (DB, network, disk, sleep) is mis-layered → flag as **Slow Tests** smell; move the I/O to an integration test and double the boundary at unit level.",
+      "anchor": "how-to-use-this-during-review"
+    },
+    "Boundaries": {
+      "summary": "The pyramid is a heuristic, not a quota.",
+      "anchor": "boundaries"
+    }
+  },
+  "plugins/dev-team/knowledge/test-smells.md": {
+    "Smell Categories": {
+      "summary": "xUnit Test Patterns groups smells into three levels.",
+      "anchor": "smell-categories"
+    },
+    "Code Smells (single test, readable now)": {
+      "summary": "| Smell | Detection signal | Why it hurts | Fix |",
+      "anchor": "code-smells-single-test-readable-now"
+    },
+    "Behavior Smells (only visible when tests run)": {
+      "summary": "| Smell | Detection signal | Why it hurts | Fix |",
+      "anchor": "behavior-smells-only-visible-when-tests-run"
+    },
+    "Project Smells (visible across the suite over time)": {
+      "summary": "| Smell | Detection signal | Why it hurts | Fix |",
+      "anchor": "project-smells-visible-across-the-suite-over-time"
+    },
+    "Detection Workflow": {
+      "summary": "1.",
+      "anchor": "detection-workflow"
+    },
+    "Boundaries": {
+      "summary": "A single behavior asserted with several related assertions on one object is **not** Eager Test or Assertion Roulette — that's normal.",
+      "anchor": "boundaries"
     }
   },
   "plugins/dev-team/knowledge/testability-patterns.md": {
@@ -789,6 +985,56 @@
     "Visual Verification Guidelines": {
       "summary": "When interpreting screenshots, describe:",
       "anchor": "visual-verification-guidelines"
+    }
+  },
+  "plugins/dev-team/skills/cd-test-architecture/SKILL.md": {
+    "Overview": {
+      "summary": "An **advisory, application-level** skill: it assesses how an existing application is tested, classifies that against a CD-aligned test taxonomy, finds the tests that can't run in a clean CI gate, and recommends a target architecture plus a migration path.",
+      "anchor": "overview"
+    },
+    "Constraints": {
+      "summary": "Advisory only.",
+      "anchor": "constraints"
+    },
+    "Parse Arguments": {
+      "summary": "Arguments: a target application/repo path or description.",
+      "anchor": "parse-arguments"
+    },
+    "Steps": {
+      "summary": "Map the deployable/testable surfaces and assign each its pattern from `component-test-patterns.md` (User Interface; API Provider / API Consumer / Event Consumer / Event Producer / Stateful Service / CLI-Library; Scheduled Job).",
+      "anchor": "steps"
+    },
+    "1. Inventory the application's components": {
+      "summary": "Map the deployable/testable surfaces and assign each its pattern from `component-test-patterns.md` (User Interface; API Provider / API Consumer / Event Consumer / Event Producer / Stateful Service / CLI-Library; Scheduled Job).",
+      "anchor": "1-inventory-the-applications-components"
+    },
+    "2. Inventory the existing tests and classify them": {
+      "summary": "Find the test suites and classify each against the six types in `cd-test-architecture.md`.",
+      "anchor": "2-inventory-the-existing-tests-and-classify-them"
+    },
+    "3. Diagnose CD-fitness gaps": {
+      "summary": "Flag, with evidence:",
+      "anchor": "3-diagnose-cd-fitness-gaps"
+    },
+    "4. Recommend the target architecture": {
+      "summary": "Per component, using its pattern: which test types cover which layers, **what to double to run pre-merge without configuration**, the success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each (pre-merge gate vs Stage 1/2 vs out-of-band vs post-deploy).",
+      "anchor": "4-recommend-the-target-architecture"
+    },
+    "5. Produce a migration path": {
+      "summary": "Order the moves from current → target, lowest-risk first (typically: introduce owned adapters → add in-memory doubles + component tests → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks).",
+      "anchor": "5-produce-a-migration-path"
+    },
+    "6. Report": {
+      "summary": "Write the assessment (see Output).",
+      "anchor": "6-report"
+    },
+    "Output": {
+      "summary": "Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component):",
+      "anchor": "output"
+    },
+    "Integration": {
+      "summary": "Pairs with `test-design-advisor` (unit/module design) and the `test-smell-review` / `test-review` agents (per-file findings).",
+      "anchor": "integration"
     }
   },
   "plugins/dev-team/skills/ci-debugging/SKILL.md": {
@@ -2215,6 +2461,52 @@
     "Output": {
       "summary": "Root cause analysis with evidence: reproduction output, investigation findings, root cause statement, fix applied, and verification output showing the fix works without regressions.",
       "anchor": "output"
+    }
+  },
+  "plugins/dev-team/skills/test-design-advisor/SKILL.md": {
+    "Overview": {
+      "summary": "An **advisory** skill: it recommends how to test code and how to make untestable code testable.",
+      "anchor": "overview"
+    },
+    "Constraints": {
+      "summary": "Advisory only.",
+      "anchor": "constraints"
+    },
+    "Parse Arguments": {
+      "summary": "Arguments: target file(s), module, or a description of the code to test.",
+      "anchor": "parse-arguments"
+    },
+    "Steps": {
+      "summary": "Read the target.",
+      "anchor": "steps"
+    },
+    "1. Assess testability": {
+      "summary": "Read the target.",
+      "anchor": "1-assess-testability"
+    },
+    "2. Place each behavior on the pyramid": {
+      "summary": "Using `knowledge/test-pyramid.md`, assign each behavior to the lowest layer that can meaningfully verify it (unit / integration / component / contract / E2E).",
+      "anchor": "2-place-each-behavior-on-the-pyramid"
+    },
+    "3. Choose doubles": {
+      "summary": "For each collaborator at each test, recommend the simplest double using the decision flow in `knowledge/test-doubles.md` (dummy/stub/spy/mock/fake) and whether to verify by state or behavior.",
+      "anchor": "3-choose-doubles"
+    },
+    "4. Propose a behavior-preserving refactor sequence (only if blockers exist)": {
+      "summary": "If Step 1 found blockers, produce an ordered sequence that makes the code testable without changing behavior:",
+      "anchor": "4-propose-a-behavior-preserving-refactor-sequence-only-if-blockers-exist"
+    },
+    "5. Report": {
+      "summary": "Write the recommendation (see Output).",
+      "anchor": "5-report"
+    },
+    "Output": {
+      "summary": "A concise advisory report (to chat for a single unit, or to `reports/test-design-<target>.md` for a module):",
+      "anchor": "output"
+    },
+    "Integration": {
+      "summary": "Pairs with the `test-smell-review` agent (which *detects* smells) and the `test-design-reviewer` skill (which *scores* an existing suite).",
+      "anchor": "integration"
     }
   },
   "plugins/dev-team/skills/test-design-reviewer/SKILL.md": {

--- a/plugins/dev-team/knowledge/microservice-testing.md
+++ b/plugins/dev-team/knowledge/microservice-testing.md
@@ -1,0 +1,71 @@
+# Microservice Testing Strategy
+
+Reference file for `test-smell-review` and the `test-design-advisor` skill. Distributed systems add failure modes a single-process pyramid doesn't cover: the network between services, and the *agreement* between a service and its consumers. This file covers the layers and the contract-testing discipline that keep independently-deployable services from breaking each other.
+
+Source: Martin Fowler / Toby Clemson, "Testing Strategies in a Microservice Architecture" (martinfowler.com/articles/microservice-testing/). Complements `test-pyramid.md`.
+
+> For CD-pipeline framing — the determinism→pre-merge-gate rule, running CI without configuring dependencies, and per-component (UI/service/batch) patterns — see `cd-test-architecture.md` and `component-test-patterns.md`. Note those use MinimumCD vocabulary, where "integration test" specifically means *validating that contract doubles still match reality* (post-merge), which is narrower than this file's usage.
+
+Core principle: **independent deployability requires that no service can be broken by another service's change without a test catching it first.** End-to-end tests are too slow and flaky to be that safety net at scale. Contract tests are — but only when paired with *scheduled verification of those contracts against the real provider* (because you cannot depend on the provider to honor or verify a contract; see the reality check below).
+
+---
+
+## The Layers (per service)
+
+| Layer | Scope | What it verifies | Doubles |
+|-------|-------|------------------|---------|
+| **Unit** | A single class/function | Internal logic, branches, edge cases | Collaborators doubled |
+| **Integration** | A module + one external it owns | The adapter works against a real DB/broker/HTTP peer (test container) | Real external, isolated instance |
+| **Component** | One whole service, in isolation | The service meets *its own* API contract end to end, internals real | The service's downstream deps stubbed (in-process or network-level) |
+| **Contract** | The consumer↔provider agreement | Both sides still agree on request/response shape & semantics | A pact, verified independently on each side |
+| **End-to-end** | Several real services together | A critical cross-service journey works | None — real deployments |
+
+The shape is the same pyramid: lots of unit/integration, a layer of component tests per service, a thin layer of E2E for journeys. The new and load-bearing layer is **Contract**.
+
+---
+
+## Consumer-Driven Contracts (CDC)
+
+The mechanism that lets services deploy independently:
+
+1. The **consumer** writes tests describing exactly the requests it makes and the responses it depends on → this produces a **contract** (a "pact").
+2. The contract is shared with the **provider** (a broker, a repo, an artifact).
+3. The **provider** runs the contract against itself in *its* CI. If a provider change would break that consumer, the provider's build goes red — before deploy, without the consumer present.
+4. Each side tests against the contract in **isolation**: the consumer stubs the provider per the contract; the provider replays the contract against the real implementation.
+
+Why this beats E2E for integration safety:
+
+- Fast and deterministic — no shared environment, no orchestrating N services.
+- Failure points at the exact broken expectation, not "something in the journey failed."
+- The provider learns it broke a consumer **at build time**, which is what makes independent deploys safe.
+
+> **Reality check — don't depend on step 3.** The full CDC loop above only works when teams collaborate closely *and* use tooling that enforces provider-side verification. For any provider you don't control, **assume that doesn't exist**: assume the provider can break the contract without versioning and that you won't discover it until an incident — usually during your next unrelated deploy, which then takes the blame. The defense you actually own is to run *your* pinned contract against the provider's real endpoint **in a test environment on a schedule, out-of-band**, so a break is detected when it happens and attributed to the provider, not to your undelivered changes. And because you assume the provider *will* break, test that your consumer **survives** it (timeouts, retries, circuit breaker, drifted-response handling). Provider-side verification is a bonus when available, never the mechanism you rely on. See `cd-test-architecture.md` → Double Validation for the CD-pipeline formulation.
+
+---
+
+## What to test where (microservice heuristics)
+
+- **Business logic** → unit, in the owning service. Never via another service.
+- **Serialization / DB mapping / broker plumbing** → integration tests with a real instance (test container), not mocks of the driver.
+- **"Does my service honor its own API?"** → component test, internals real, downstreams stubbed.
+- **"Do I and the service I call still agree?"** → a contract test you own (pins what you send/expect), plus **scheduled verification of it against the provider's real test endpoint**. Provider-side verification too, if available. This replaces most cross-service E2E.
+- **"Does this critical journey work end to end?"** → a *small number* of E2E tests for the highest-value journeys only.
+
+---
+
+## Smells specific to distributed testing (flag these)
+
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **E2E as the integration net** | Cross-service correctness relies on a large E2E suite; no contract tests | Introduce contract tests + scheduled provider verification; shrink E2E to journeys |
+| **Unmonitored provider contract** | Consumer stubs a provider's response, but nobody runs that contract against the real provider on a schedule | Run *your* contract against the provider's real test endpoint on a schedule, out-of-band — don't wait for your next deploy (or the provider's cooperation) to discover a break |
+| **Consumer can't survive a break** | Consumer assumes the provider's contract holds; no timeout/retry/circuit-breaker/drifted-response tests | Test that the consumer degrades gracefully — assume the provider *will* break without versioning |
+| **Stubs that lie** | Hand-written stubs of a downstream that aren't derived from / checked against the real contract | Pin the stub with a contract test; verify it against the real provider on a schedule |
+| **Shared integration environment for correctness** | Tests pass/fail based on the state of a shared staging system | Isolate: component tests with stubbed downstreams + contract tests |
+| **Cross-service unit test** | A "unit" test spins up or calls a second real service to check this service's logic | Double the boundary; move true cross-service checks to contract/E2E |
+
+## Boundaries
+
+- Not every codebase is microservices. For a monolith or library, `test-pyramid.md` is sufficient — apply this file only when there are independently-deployable services with network boundaries between them.
+- Contract testing is the recommendation for service↔service agreements; don't flag the *absence* of E2E tests as a defect when contracts cover the integration. The point is independent deployability, achieved by whichever combination provides it.
+- A small, curated E2E suite is healthy. Flag E2E *over-reliance* (it's the integration safety net), not E2E existence.

--- a/plugins/dev-team/knowledge/test-doubles.md
+++ b/plugins/dev-team/knowledge/test-doubles.md
@@ -1,0 +1,77 @@
+# Test Doubles
+
+Reference file for `test-smell-review`, `test-review`, and the `test-design-advisor` skill. A test double is any object that stands in for a real collaborator in a test. Choosing the wrong kind of double is the most common cause of fragile, over-specified tests.
+
+Source taxonomy: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com). Language-agnostic — described by role, not by any mocking library's API.
+
+Core principle: **prefer the simplest double that lets the test verify the behavior.** Reach for a Mock only when the interaction *is* the behavior under test. Over-mocking couples tests to implementation and produces the Overspecified Software smell (see `test-smells.md`).
+
+---
+
+## The Five Doubles
+
+| Double | What it does | Verification style | Use when |
+|--------|-------------|-------------------|----------|
+| **Dummy** | Passed but never used; fills a required parameter | none | A constructor/method signature demands an argument the test path never touches |
+| **Stub** | Returns canned answers to calls made during the test | **state** (assert on the SUT's output/state) | The SUT *reads* from a collaborator and you need to control what it reads (config, query result, clock) |
+| **Spy** | A stub that also records how it was called, for later inspection | **behavior** (assert after the act) | You need to confirm an outgoing call happened, but want to assert *after* the action, not pre-program expectations |
+| **Mock** | Pre-programmed with expectations; fails the test if calls don't match | **behavior** (expectations verified) | The interaction itself is the observable behavior (e.g., "an email *is sent*") and there's no state to assert on |
+| **Fake** | A working but lightweight implementation (in-memory DB, in-memory queue) | **state** | A stub/mock would need so much call-by-call setup that a real-ish implementation is simpler and more faithful |
+
+A **Test Spy** and a **Mock** both do behavior verification; the difference is *when* and *how* you specify expectations. Spy = act, then assert on recorded calls. Mock = set expectations up front, library verifies them. Spies usually read better and fail less cryptically.
+
+---
+
+## State Verification vs. Behavior Verification
+
+| | State verification | Behavior verification |
+|---|---|---|
+| **Asserts on** | The SUT's return value or resulting state | The calls the SUT made to collaborators |
+| **Doubles used** | Stub, Fake | Mock, Spy |
+| **Coupling** | Low — survives refactors that preserve outcome | High — breaks when the *how* changes, even if outcome is identical |
+| **Default?** | **Yes — prefer this** | Only when there's no observable state to assert |
+
+Rule of thumb: if you *can* assert on a result or a state change, do that and use a Stub/Fake. Use a Mock/Spy only for genuine side-effect-only boundaries — sending a message, writing to a log/queue, calling a payment gateway — where the call is the whole point.
+
+---
+
+## Choosing a Double (decision flow)
+
+```
+Does the SUT READ from the collaborator (needs a controlled answer)?
+├─ YES → can you then assert on the SUT's output or state?
+│        ├─ YES → Stub (state verification). Done.
+│        └─ NO, the read drives a side effect you must confirm → Spy
+│
+Does the SUT only WRITE to the collaborator (side-effect-only boundary)?
+├─ YES → is the call itself the behavior under test (email sent, event published)?
+│        ├─ YES → Mock or Spy (behavior verification)
+│        └─ NO, it's incidental → Dummy or a no-op Stub; don't assert on it
+│
+Is per-call stub/mock setup so heavy it obscures the test?
+└─ YES → Fake (in-memory implementation), assert on its resulting state
+```
+
+---
+
+## Common Misuses (flag these)
+
+| Misuse | Why it's wrong | Fix |
+|--------|---------------|-----|
+| Mocking a value object or pure function | Nothing to verify; adds coupling for zero benefit | Use the real object |
+| Mocking the type under test | You're testing the mock, not the code | Use the real SUT; double only its *collaborators* |
+| Asserting exact call order/count when order doesn't matter | Overspecified Software smell; fragile | State verification, or assert only the call that matters |
+| Stub returns drive an `if` that's never asserted | Dead control; the test proves nothing about that branch | Assert the branch's effect, or remove the setup |
+| A Mock where a Stub would do (no side-effect being verified) | Tests implementation detail instead of outcome | Downgrade to Stub + state assertion |
+| Mocking a concrete class instead of an interface/port | Couples to the implementation type; see `testability-patterns.md` | Extract an interface/port; double that |
+
+---
+
+## Relationship to testability
+
+If a collaborator can't be substituted at all (new-ed up internally, static singleton, hidden global), that's a **production-code** problem, not a test problem — introduce a seam per `testability-patterns.md` (constructor injection, interface extraction) before choosing a double. The double taxonomy assumes the collaborator is already injectable.
+
+## Boundaries
+
+- Don't flag a Fake (in-memory repo/DB) as "not testing the real thing" — at unit/integration level a Fake is a legitimate, often *better*, choice than a heavily-stubbed real dependency. Real-dependency fidelity is the job of contract and integration tests (see `test-pyramid.md`, `microservice-testing.md`).
+- A single Mock at a true side-effect boundary is correct, not a smell. The smell is *pervasive* mocking that pins down internal call sequences.

--- a/plugins/dev-team/knowledge/test-pyramid.md
+++ b/plugins/dev-team/knowledge/test-pyramid.md
@@ -1,0 +1,59 @@
+# The Test Pyramid
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. The test pyramid is a heuristic for *where* a given check belongs: many fast, isolated tests at the base; progressively fewer, slower, broader tests toward the top.
+
+Source: Martin Fowler, "The Practical Test Pyramid" (martinfowler.com/articles/practical-test-pyramid.html), building on Mike Cohn's original. Language- and stack-agnostic.
+
+Core principle: **push each check to the lowest layer that can meaningfully verify it.** A bug catchable by a unit test should be caught by a unit test — it's faster, more precise, and more stable there. Reserve higher layers for what genuinely needs integration.
+
+---
+
+## The Layers
+
+| Layer | Scope | Speed | Doubles | What it proves |
+|-------|-------|-------|---------|----------------|
+| **Unit** | One unit (class/function/module) in isolation | ms | Stub/Fake collaborators | Logic, branches, edge cases of that unit |
+| **Integration** | The unit + one real external it talks to (DB, queue, HTTP client, filesystem) | 10s–100s ms | Real adapter, often a test container | The adapter/serialization/wiring actually works |
+| **Component / Service** | One deployable service in isolation, internals real, *its* externals stubbed | 100s ms–s | Stub the service's own external deps | The service satisfies its own contract end to end, in-process |
+| **Contract** | The agreement between a consumer and a provider | fast | n/a (verifies a pact) | Two services still agree on the interface (see `microservice-testing.md`) |
+| **End-to-End** | The whole system through real entry points (UI/API) | s–min | none (real everything) | Critical user journeys work when wired together |
+
+"Unit" can be **solitary** (all collaborators doubled) or **sociable** (real collaborators used, only true boundaries doubled). Both are legitimate; sociable unit tests catch wiring bugs solitary ones miss, at the cost of broader blast radius on failure. Prefer sociable for cohesive collaborators, solitary across architectural boundaries.
+
+---
+
+## Layer-Selection Heuristics
+
+Ask, for each thing you want to verify:
+
+1. **Is it pure logic / a branch / an edge case?** → Unit. Always.
+2. **Does it depend on real serialization, SQL, or a third-party client behaving a certain way?** → Integration (test the adapter, not the logic around it).
+3. **Does it cross a service boundary you don't own?** → Contract test, not E2E.
+4. **Is it a business-critical journey a user actually performs?** → one E2E test. Not every permutation — just the journey.
+
+If a check could live at two layers, choose the **lower** one. Duplicating the same assertion at a higher layer is redundant coverage (a project smell — see `test-smells.md`).
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Shape | Symptom | Fix |
+|--------------|-------|---------|-----|
+| **Ice-cream cone** | Inverted pyramid — mostly E2E/manual, few unit | Slow suite, flaky CI, slow feedback, hard failure triage | Push logic checks down to unit; keep E2E for journeys only |
+| **Hourglass** | Many unit + many E2E, no integration middle | Wiring/serialization bugs slip the gap between layers | Add integration tests for adapters and boundaries |
+| **Cupcake** | Same scenarios re-tested at every layer | Maintenance multiplied; one behavior change breaks N tests | De-duplicate; each behavior verified at exactly one layer |
+| **Testing through the UI for logic** | Driving a browser to check a calculation | Slow, fragile, obscures the real assertion | Unit-test the calculation; UI test only the rendering/journey |
+
+---
+
+## How to use this during review
+
+- A unit-level test doing **real I/O** (DB, network, disk, sleep) is mis-layered → flag as **Slow Tests** smell; move the I/O to an integration test and double the boundary at unit level.
+- An **E2E test asserting a single edge case** (e.g., validation of one field) → flag as mis-layered; that's a unit concern.
+- A suite that is **all E2E with little/no unit coverage** → flag the ice-cream-cone shape at the suite level.
+- Before flagging "wrong level," confirm the *intended* level of the file (path, naming, framework markers). Integration/E2E tests are *supposed* to touch real resources — don't flag them as slow or non-deterministic for doing their job.
+
+## Boundaries
+
+- The pyramid is a heuristic, not a quota. Don't invent a numeric ratio and flag suites for missing it. Flag *shape pathologies* (inverted, gap in the middle, pervasive duplication), not arithmetic.
+- Some domains legitimately carry more integration/E2E weight (thin-logic integration glue, data pipelines). Judge by "is this check at the lowest layer that can verify it," not by silhouette alone.

--- a/plugins/dev-team/knowledge/test-smells.md
+++ b/plugins/dev-team/knowledge/test-smells.md
@@ -1,0 +1,78 @@
+# Test Smells
+
+Reference file for `test-smell-review` and `test-review` agents. A test smell is a symptom in test code that signals a design problem in the test or in the code under test. Each smell below gives a **detection signal** (what to grep/read for), **why it hurts**, and the **fix** — which is sometimes a test change and sometimes a production-code change.
+
+Source taxonomy: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com). Language-agnostic — signals are described by behavior, not syntax.
+
+Core principle: a test smell is never fixed by suppressing the test. If a test is hard to write, hard to read, or flaky, the test is reporting a real design problem. Fix the cause.
+
+---
+
+## Smell Categories
+
+xUnit Test Patterns groups smells into three levels. Detect at all three:
+
+- **Code smells** — visible in a single test method (readability, assertions).
+- **Behavior smells** — visible only when tests run (flakiness, fragility, slowness).
+- **Project smells** — visible across the suite over time (manual intervention, production bugs slipping through).
+
+---
+
+## Code Smells (single test, readable now)
+
+| Smell | Detection signal | Why it hurts | Fix |
+|-------|-----------------|--------------|-----|
+| **Obscure Test** | Reader cannot tell what behavior is verified without running it; setup buried in `beforeEach`, helpers, or shared fixtures far from the assertion | Test stops being executable documentation; maintenance becomes guesswork | Inline the relevant setup; name intent; one clear arrange-act-assert. Sub-types below. |
+| → Eager Test | One test method exercises many behaviors / many asserts on unrelated outcomes | A failure doesn't pinpoint which behavior broke | Split into one behavior per test |
+| → Mystery Guest | Test depends on external data it doesn't create (a file on disk, a seeded DB row, a fixture in another module) | Reader can't see the inputs; data drift breaks the test silently | Create the data in-test (Fresh Fixture) or via a Test Data Builder |
+| → General Fixture | A shared setup builds far more than this test needs | Reader can't tell which parts matter; coupling across tests | Build only what each test uses (Minimal Fixture) |
+| → Irrelevant Information | Setup exposes values that don't affect the assertion | Noise hides the cause-effect the test proves | Hide irrelevants behind builders with sensible defaults |
+| **Assertion Roulette** | Multiple bare assertions with no messages; on failure you can't tell which line failed | Failure triage requires a debugger | Give assertions descriptive messages, or split tests; use single-behavior assertions |
+| **Conditional Test Logic** | `if`/`switch`/loops/try-catch around assertions; test takes different paths | Some assertions may never run; the test verifies different things on different runs | Remove branching; use parameterized tests or separate cases; assert unconditionally |
+| **Hard-Coded / Magic Values** | Unexplained literals in assertions (`expect(x).toBe(42)`) | Reader can't tell why 42 is correct; fragile to legitimate change | Name the constant for its meaning, or derive it visibly from inputs |
+| **Test Code Duplication** | Copy-pasted arrange or assert blocks across tests | A behavior change forces edits in N places; drift | Extract Creation/Custom Assertion methods or a Test Data Builder |
+| **Test Logic in Production** | Production code contains `if (testMode)`, test-only hooks, or back doors | Tested code path ≠ shipped code path; false confidence | Remove; achieve control via dependency injection / seams (see `testability-patterns.md`) |
+
+---
+
+## Behavior Smells (only visible when tests run)
+
+| Smell | Detection signal | Why it hurts | Fix |
+|-------|-----------------|--------------|-----|
+| **Erratic Test** (flaky) | Passes/fails non-deterministically across runs | Destroys trust in the suite; teams start ignoring red | Eliminate the non-determinism source — see sub-types |
+| → Interacting Tests | Test passes alone, fails in suite (or vice versa); order-dependent | Shared mutable state between tests | Fresh Fixture per test; no shared writable state |
+| → Test Run War | Intermittent failures only when suite runs concurrently / on CI | Tests share an external resource (same DB, same file, same port) | Isolate resources per test run (unique schema, temp dir, ephemeral port) |
+| → Nondeterministic timing | `Date.now()`/`now()`, `Math.random()`/`Random`, `sleep`, real timers in assertions | Clock/RNG/scheduler drift | Inject a clock/RNG; use fake timers; never `sleep` to await |
+| → Resource Leakage / Optimism | Test assumes a resource exists or is clean; leaves state behind | Cascading failures, slow degradation | Set up and tear down own resources; assert preconditions |
+| **Fragile Test** | A change unrelated to the behavior under test breaks the test | Maintenance tax; discourages refactoring | Test through stable public behavior, not internals — see sub-types |
+| → Interface Sensitivity | Renaming/reshaping an API breaks many tests | Tests bound to signatures, not behavior | Centralize creation/interaction in helpers (one place to update) |
+| → Behavior Sensitivity | Changing unrelated behavior breaks the test | Over-specified expectations | Assert only what this behavior guarantees |
+| → Overspecified Software (mock-heavy) | Test asserts exact internal call sequences via mocks | Tests the implementation, not the outcome | Prefer state verification; mock only true boundaries (see `test-doubles.md`) |
+| → Context/Data Sensitivity | Breaks when run in a different timezone, locale, or with different seed data | Hidden environmental coupling | Pin locale/timezone; control all inputs explicitly |
+| **Slow Tests** | Unit-level tests taking seconds; real I/O (DB, network, disk) in unit tests | Feedback loop collapses; tests get skipped | Replace boundaries with doubles; push slow checks down the pyramid (see `test-pyramid.md`) |
+
+---
+
+## Project Smells (visible across the suite over time)
+
+| Smell | Detection signal | Why it hurts | Fix |
+|-------|-----------------|--------------|-----|
+| **Production Bugs** | Defects reach prod despite a green suite | Tests verify the wrong things, or coverage gaps | Add tests at the level the bug lived (often a missing unit/contract test) |
+| **High Test Maintenance Cost** | Every feature change forces large test rewrites | Accumulated Fragile/Obscure smells | Address the underlying code & behavior smells; introduce builders & custom assertions |
+| **Manual Intervention** | A human must edit config, seed data, or run a step for tests to pass | Tests aren't repeatable or CI-able | Automate setup; make the suite hermetic |
+| **Buggy Tests** | Tests pass when the code is broken (or fail when it's correct) | Negative confidence — worse than no test | Verify the test fails for the right reason (mutation testing surfaces these — see `mutation-testing` skill) |
+
+---
+
+## Detection Workflow
+
+1. **Read each test method** for code smells — can you state the behavior under test in one sentence from the test alone? If not → Obscure Test.
+2. **Scan for behavior-smell signals** — clock/RNG/sleep/real-I/O, shared mutable state, exact-call-sequence mock assertions.
+3. **Scan the suite shape** for project smells — heavy `beforeAll` shared state, manual setup steps, fixtures referenced but not created in-test.
+4. For each finding, decide: **test fix** (rename, split, add message, build fresh fixture) or **production fix** (introduce a seam — defer to `testability-patterns.md`).
+
+## Boundaries
+
+- A single behavior asserted with several related assertions on one object is **not** Eager Test or Assertion Roulette — that's normal.
+- Integration/E2E tests are *expected* to touch real resources; "Slow Tests" applies when that work happens at the **unit** level. Confirm the intended test level before flagging (see `test-pyramid.md`).
+- Do not flag duplication between two tests that assert genuinely different boundary conditions — that's coverage, not Test Code Duplication.

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cd-test-architecture
+description: Evaluate an existing application's tests and recommend a CD-pipeline-aligned test architecture — fast, deterministic tests with minimal tooling that fully validate behavior (including cross-service interaction) and run in CI without configuring the rest of the system. Use when the user says "evaluate how this app is tested", "design a test architecture", "align our tests for CD", "make our CI tests deterministic", "our tests need the whole system configured", or asks for UI/service/batch test patterns.
+role: worker
+user-invocable: true
+---
+
+# CD Test Architecture
+
+## Overview
+
+An **advisory, application-level** skill: it assesses how an existing application is tested, classifies that against a CD-aligned test taxonomy, finds the tests that can't run in a clean CI gate, and recommends a target architecture plus a migration path. It does not write tests or refactor code.
+
+Where `test-design-advisor` works at the unit/module level and `test-smell-review` finds smells in test files, this skill works at the **whole-application** level: test types, pipeline stages, and per-component patterns.
+
+Grounded in two knowledge references — read both before assessing:
+
+- `knowledge/cd-test-architecture.md` — the six test types, the determinism→pre-merge-gate rule, the adapter rule, double validation, pipeline stages, and MinimumCD-vs-Fowler terminology.
+- `knowledge/component-test-patterns.md` — per-component patterns (UI / Services / Batch) with isolation strategy and pipeline placement.
+
+## Constraints
+
+- Advisory only. Assess and recommend; do not edit production or test code. Hand the migration steps to `/plan` or `/build`.
+- Use MinimumCD vocabulary (unit / component / contract / integration / E2E / static analysis) consistently; when the codebase uses other names, map them explicitly.
+- The pre-merge gate may contain **only deterministic** tests (static, unit, component, contract). Any test that needs a database, broker, downstream service, or environment secrets configured to run is, by definition, not a pre-merge test — flag it.
+- Recommend isolation via in-memory doubles + owned adapters, validated by the double-validation loop. Do **not** recommend standing up the whole system (docker-compose of dependencies) for the gate — that is the configured-dependency problem this architecture removes.
+- **Do not assume provider cooperation.** For dependencies the team doesn't control, the defense against contract breakage is consumer-owned, scheduled verification against the provider's test environment (out-of-band) plus consumer resilience — not provider-side CDC verification. Recommend accordingly.
+- Minimal tooling: prefer in-memory doubles, one real browser for UI, testcontainers only for off-gate adapter integration. Don't recommend a sprawl of frameworks.
+- Be concise: tables and ordered steps, not prose. Cite the knowledge file instead of restating it.
+
+## Parse Arguments
+
+Arguments: a target application/repo path or description. Optional `--component <name>` to scope to one component, `--ci <path>` to point at the existing pipeline config. If no target is given, ask for one.
+
+## Steps
+
+### 1. Inventory the application's components
+
+Map the deployable/testable surfaces and assign each its pattern from `component-test-patterns.md` (User Interface; API Provider / API Consumer / Event Consumer / Event Producer / Stateful Service / CLI-Library; Scheduled Job). A real system is usually several — list each surface.
+
+### 2. Inventory the existing tests and classify them
+
+Find the test suites and classify each against the six types in `cd-test-architecture.md`. For each, record: type, what it actually exercises, whether it is deterministic, and **what it requires to run** (DB URL, broker, downstream service, secrets, sleep, real clock).
+
+### 3. Diagnose CD-fitness gaps
+
+Flag, with evidence:
+
+- **Mis-typed gate tests** — "unit/component" tests that require a real dependency or are non-deterministic (real clock/RNG/network/sleep). These cannot be a pre-merge gate.
+- **Configured-dependency tests** — tests that need the rest of the system stood up to run.
+- **Coverage gaps** — behavior (success + failure modes per the component pattern) not covered at any deterministic layer.
+- **Drift risk** — doubles with no validation loop. In particular, assume **no provider cooperation**: a contract that nobody runs against the real provider on a schedule is undefended. Flag the absence of *consumer-owned, scheduled provider-contract verification in a test environment* — relying on provider-side CDC verification is not sufficient for providers you don't control.
+- **No resilience to a broken contract** — the consumer assumes the provider holds; no tests that it survives a provider break (timeout, retry/backoff, circuit breaker, drifted/malformed response). Assume the provider *will* break without versioning.
+- **Inverted shape** — reliance on integration/E2E where component/contract tests would gate deterministically.
+
+### 4. Recommend the target architecture
+
+Per component, using its pattern: which test types cover which layers, **what to double to run pre-merge without configuration**, the success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each (pre-merge gate vs Stage 1/2 vs out-of-band vs post-deploy). Show the resulting pre-merge gate is deterministic and config-free.
+
+### 5. Produce a migration path
+
+Order the moves from current → target, lowest-risk first (typically: introduce owned adapters → add in-memory doubles + component tests → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks). Each step is behavior-preserving and independently shippable.
+
+### 6. Report
+
+Write the assessment (see Output). Keep every recommendation tied to a concrete next action.
+
+## Output
+
+Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component):
+
+```markdown
+## CD Test Architecture — <app>
+
+### Components & patterns
+| Component | Pattern | Surfaces |
+
+### Current tests
+| Suite | MinimumCD type | Deterministic? | Requires to run | Pre-merge-safe? |
+
+### CD-fitness gaps
+| Gap | Type | Evidence (file) | Impact |
+
+### Target architecture (per component)
+| Component | Layer | Test type | Double (to run config-free) | Pipeline stage |
+
+### Pre-merge gate (deterministic, config-free)
+<the set of suites that will gate merges, and why each is deterministic>
+
+### Migration path
+1. … → 2. … (lowest-risk first, each independently shippable)
+
+### Next steps
+- Refactor/seams → /plan or /build
+- Per-file smells → /test-design
+```
+
+## Integration
+
+- Pairs with `test-design-advisor` (unit/module design) and the `test-smell-review` / `test-review` agents (per-file findings). This skill sets the application-level target those operate within.
+- Hand the migration path to `/plan` or `/build` for TDD implementation. This skill stops at the architecture and plan.

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cd-test-architecture
-description: Evaluate an existing application's tests and recommend a CD-pipeline-aligned test architecture — fast, deterministic tests with minimal tooling that fully validate behavior (including cross-service interaction) and run in CI without configuring the rest of the system. Use when the user says "evaluate how this app is tested", "design a test architecture", "align our tests for CD", "make our CI tests deterministic", "our tests need the whole system configured", or asks for UI/service/batch test patterns.
+description: Evaluate an existing application's tests and recommend a CD-pipeline-aligned test architecture — fast, deterministic tests with minimal tooling that fully validate behavior (including cross-service interaction) and run in CI without configuring the rest of the system. Use when the user says "evaluate how this app is tested", "design a test architecture", "align our tests for CD", "make our CI tests deterministic", "our tests need the whole system configured", "our tests live in another repo / Postman / manual scripts", or asks for UI/service/batch test patterns.
 role: worker
 user-invocable: true
 ---
@@ -30,7 +30,7 @@ Grounded in two knowledge references — read both before assessing:
 
 ## Parse Arguments
 
-Arguments: a target application/repo path or description. Optional `--component <name>` to scope to one component, `--ci <path>` to point at the existing pipeline config. If no target is given, ask for one.
+Arguments: a target application/repo path or description. Optional `--component <name>` to scope to one component, `--ci <path>` to point at the existing pipeline config, and **`--external-tests <path-or-repo-or-description>`** to point at tests that live outside this repo (another repo's suite, a third-party runner, Postman/Insomnia collections, manual test scripts, recorded UI flows, spreadsheets of test cases). If little or no in-repo testing is found and no external location is given, **ask** where the application is actually tested before concluding it is untested. If no target is given, ask for one.
 
 ## Steps
 
@@ -40,12 +40,26 @@ Map the deployable/testable surfaces and assign each its pattern from `component
 
 ### 2. Inventory the existing tests and classify them
 
-Find the test suites and classify each against the six types in `cd-test-architecture.md`. For each, record: type, what it actually exercises, whether it is deterministic, and **what it requires to run** (DB URL, broker, downstream service, secrets, sleep, real clock).
+Find the test suites **in the repo** and classify each against the six types in `cd-test-architecture.md`. For each, record: type, what it actually exercises, whether it is deterministic, and **what it requires to run** (DB URL, broker, downstream service, secrets, sleep, real clock).
+
+If in-repo tests are sparse or absent, the application is not necessarily untested — it may be tested out-of-repo (see Step 2b). Do not conclude "no tests" without checking.
+
+### 2b. Locate and harvest out-of-repo tests
+
+When `--external-tests` is given (or in-repo tests are sparse and the user points you to external coverage), treat the external location as the **current specification of intended behavior** and harvest it:
+
+- **Other-repo automated suites** — read the suites; classify them by type just like in-repo tests; note that they live outside the component's repo and pipeline.
+- **Postman / Insomnia / `.http` collections** — each request + its assertions describes an API contract and a scenario. Extract: endpoint, request shape, expected response, and which success/failure scenario it covers.
+- **Manual test scripts / spreadsheets / recorded UI flows** — extract each step as a behavior the team cares about (a candidate component/E2E scenario), and note it is currently human-executed and non-repeatable.
+
+Produce a behavior inventory from these sources, mapped to the component patterns from Step 1. This becomes the **basis for improvement** — the behaviors to re-express as deterministic, in-repo, gated tests.
 
 ### 3. Diagnose CD-fitness gaps
 
 Flag, with evidence:
 
+- **Out-of-repo / third-party-runner testing** — the component's tests live in another repo, a separate QA runner, Postman collections, or manual scripts rather than alongside the code. **This is an anti-pattern**, even when that external coverage is extensive: the tests cannot gate the component's own merges, are not versioned with the code they verify, are usually non-deterministic and environment-coupled, and silently drift from the code. The goal state is deterministic tests co-located with the code and run in its pipeline. Flag this explicitly and treat the external suite as the *source material* (Step 2b), not the destination.
+- **Manual / non-repeatable testing** — behavior verified only by humans following scripts. Non-repeatable, unsuitable for any gate; each such script is a behavior to automate.
 - **Mis-typed gate tests** — "unit/component" tests that require a real dependency or are non-deterministic (real clock/RNG/network/sleep). These cannot be a pre-merge gate.
 - **Configured-dependency tests** — tests that need the rest of the system stood up to run.
 - **Coverage gaps** — behavior (success + failure modes per the component pattern) not covered at any deterministic layer.
@@ -59,7 +73,7 @@ Per component, using its pattern: which test types cover which layers, **what to
 
 ### 5. Produce a migration path
 
-Order the moves from current → target, lowest-risk first (typically: introduce owned adapters → add in-memory doubles + component tests → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks). Each step is behavior-preserving and independently shippable.
+Order the moves from current → target, lowest-risk first. When tests are out-of-repo (Step 2b), the path **starts by bringing the behavior in**: for each harvested behavior, re-express it as the lowest-layer deterministic in-repo test that covers it (Postman request → component/contract test; manual UI script → UI component test with the backend network-stubbed; other-repo E2E → in-repo component test + a thin post-deploy smoke), then retire the external case once its behavior is covered in the gate. Typical full sequence: harvest external coverage into an in-repo behavior inventory → introduce owned adapters → add in-memory doubles + component tests reproducing the harvested behaviors → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks → decommission the out-of-repo/manual suites as their behaviors land in the gate. Each step is behavior-preserving and independently shippable.
 
 ### 6. Report
 
@@ -75,8 +89,11 @@ Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component
 ### Components & patterns
 | Component | Pattern | Surfaces |
 
-### Current tests
+### Current tests (in-repo)
 | Suite | MinimumCD type | Deterministic? | Requires to run | Pre-merge-safe? |
+
+### Out-of-repo / external test sources (if any)
+| Source (repo / Postman / manual / …) | Location | Behaviors it covers | Why it's an anti-pattern here |
 
 ### CD-fitness gaps
 | Gap | Type | Evidence (file) | Impact |

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -25,6 +25,7 @@ Grounded in two knowledge references — read both before assessing:
 - The pre-merge gate may contain **only deterministic** tests (static, unit, component, contract). Any test that needs a database, broker, downstream service, or environment secrets configured to run is, by definition, not a pre-merge test — flag it.
 - Recommend isolation via in-memory doubles + owned adapters, validated by the double-validation loop. Do **not** recommend standing up the whole system (docker-compose of dependencies) for the gate — that is the configured-dependency problem this architecture removes.
 - **Do not assume provider cooperation.** For dependencies the team doesn't control, the defense against contract breakage is consumer-owned, scheduled verification against the provider's test environment (out-of-band) plus consumer resilience — not provider-side CDC verification. Recommend accordingly.
+- **Baseline before refactor (don't lead with refactoring).** For under-tested or legacy components, first recommend the best outside-in test achievable *at existing seams without changing the code* — a characterization baseline — then the refactor that improves testability under that green baseline. Never change behavior and structure in the same step. Defer the procedure to the `legacy-code` skill and use the DDD skills (`domain-driven-design`, `domain-analysis`) to suggest the target structure for the refactor.
 - Minimal tooling: prefer in-memory doubles, one real browser for UI, testcontainers only for off-gate adapter integration. Don't recommend a sprawl of frameworks.
 - Be concise: tables and ordered steps, not prose. Cite the knowledge file instead of restating it.
 
@@ -67,13 +68,29 @@ Flag, with evidence:
 - **No resilience to a broken contract** — the consumer assumes the provider holds; no tests that it survives a provider break (timeout, retry/backoff, circuit breaker, drifted/malformed response). Assume the provider *will* break without versioning.
 - **Inverted shape** — reliance on integration/E2E where component/contract tests would gate deterministically.
 
+### 3b. Find testable seams and the achievable outside-in baseline
+
+For each under-tested or untested component, identify the **testable seams** — places where behavior can be observed or substituted without editing the code (HTTP handler, CLI entrypoint, message handler, exported function, existing injection points; object seams via interfaces/polymorphism, link seams via DI/module substitution). Then state the **best outside-in test achievable right now without refactoring** — a characterization test at the outermost reachable seam that locks in current behavior. This is the immediate, zero-risk baseline, distinct from the (later) clean CD gate. See `cd-test-architecture.md` → Outside-In First, and the `legacy-code` skill.
+
 ### 4. Recommend the target architecture
 
-Per component, using its pattern: which test types cover which layers, **what to double to run pre-merge without configuration**, the success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each (pre-merge gate vs Stage 1/2 vs out-of-band vs post-deploy). Show the resulting pre-merge gate is deterministic and config-free.
+Per component, using its pattern: which test types cover which layers, **what to double to run pre-merge without configuration**, the success scenarios and failure modes to cover, the double-validation loop, and the pipeline stage for each (pre-merge gate vs Stage 1/2 vs out-of-band vs post-deploy). Show the resulting pre-merge gate is deterministic and config-free. For under-tested components, separate the recommendation into **(a) the outside-in characterization baseline writable today without refactoring** and **(b) the post-baseline refactor** toward this target (use the DDD skills to suggest where boundaries/seams should land).
 
 ### 5. Produce a migration path
 
-Order the moves from current → target, lowest-risk first. When tests are out-of-repo (Step 2b), the path **starts by bringing the behavior in**: for each harvested behavior, re-express it as the lowest-layer deterministic in-repo test that covers it (Postman request → component/contract test; manual UI script → UI component test with the backend network-stubbed; other-repo E2E → in-repo component test + a thin post-deploy smoke), then retire the external case once its behavior is covered in the gate. Typical full sequence: harvest external coverage into an in-repo behavior inventory → introduce owned adapters → add in-memory doubles + component tests reproducing the harvested behaviors → add contract tests → add consumer resilience tests (survive a provider break) → add scheduled provider-contract verification against a test environment → move real-dependency tests off the gate to adapter-integration/out-of-band → add post-deploy checks → decommission the out-of-repo/manual suites as their behaviors land in the gate. Each step is behavior-preserving and independently shippable.
+Order the moves from current → target, lowest-risk first. The spine is **baseline before refactor**: get behavior under test at existing seams *without changing code*, then refactor under that green baseline (never behavior + structure in one step). When tests are out-of-repo (Step 2b), the harvested behaviors feed that baseline. Typical full sequence:
+
+1. **Characterization baseline (no refactoring)** — at the outermost reachable seam, write outside-in tests that lock in current behavior; harvest any out-of-repo/manual behaviors into this inventory and reproduce them here. Get green.
+2. **Introduce owned adapters and seams — under the baseline** (Adapter Rule; `testability-patterns.md`; DDD skills suggest where boundaries/seams belong). Refactor only with the baseline green.
+3. Add in-memory doubles + deterministic **component tests** reproducing the baselined behaviors.
+4. Add **contract tests** pinning request/response boundaries.
+5. Add **consumer resilience tests** (survive a provider break).
+6. Add **scheduled provider-contract verification** against a test environment.
+7. Move real-dependency tests **off the gate** to adapter-integration / out-of-band.
+8. Add **post-deploy checks**.
+9. **Decommission** the out-of-repo/manual suites and the coarse characterization tests as their behaviors land in the deterministic gate.
+
+Each step is behavior-preserving and independently shippable.
 
 ### 6. Report
 
@@ -98,6 +115,9 @@ Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component
 ### CD-fitness gaps
 | Gap | Type | Evidence (file) | Impact |
 
+### Testable seams & achievable baseline (under-tested components)
+| Component | Outermost seam | Best outside-in test writable today (no refactor) |
+
 ### Target architecture (per component)
 | Component | Layer | Test type | Double (to run config-free) | Pipeline stage |
 
@@ -115,4 +135,6 @@ Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component
 ## Integration
 
 - Pairs with `test-design-advisor` (unit/module design) and the `test-smell-review` / `test-review` agents (per-file findings). This skill sets the application-level target those operate within.
+- For under-tested/legacy components, the characterization-baseline-then-refactor procedure is the **`legacy-code`** skill (Feathers' algorithm: change points → test points/seams → break dependencies → characterization tests → refactor under green). Defer the mechanics to it.
+- Use the **`domain-driven-design`** and **`domain-analysis`** skills to suggest the target structure for the post-baseline refactor — where bounded contexts, ports, and seams should land — so refactoring improves the domain model, not just testability.
 - Hand the migration path to `/plan` or `/build` for TDD implementation. This skill stops at the architecture and plan.

--- a/plugins/dev-team/skills/test-design-advisor/SKILL.md
+++ b/plugins/dev-team/skills/test-design-advisor/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: test-design-advisor
+description: Advise on test design — assess testability, recommend the right test-pyramid layer and test-double strategy, and propose a behavior-preserving refactor sequence to make hard-to-test code testable. Use when the user says "how should I test this", "is this testable", "design tests for this", "what's the right test for X", or before writing tests for an untested module.
+role: worker
+user-invocable: true
+---
+
+# Test Design Advisor
+
+## Overview
+
+An **advisory** skill: it recommends how to test code and how to make untestable code testable. It does not write tests or refactor code — it produces a design the human (or `/build`) then implements. Use it before writing a test suite for an untested or hard-to-test module, or when a test is hard to write and you suspect the design is the cause.
+
+Grounded in four knowledge references: `knowledge/test-smells.md`, `knowledge/test-doubles.md`, `knowledge/test-pyramid.md`, `knowledge/microservice-testing.md`, and `knowledge/testability-patterns.md` for production-code seams.
+
+## Constraints
+
+- Advisory only. Do not edit production code or write test files — output a recommendation.
+- A hard-to-test design is a production-code problem. Recommend the seam (constructor injection, interface extraction), never a test workaround (reflection, `InternalsVisibleTo`, mocking concrete classes).
+- Prefer the lowest test-pyramid layer that can verify the behavior; prefer state verification and the simplest double.
+- Refactor sequences must be behavior-preserving and start with characterization tests when the code is currently untested.
+- Be concise: tables and ordered steps, not prose. No restating the source material — cite the knowledge file.
+
+## Parse Arguments
+
+Arguments: target file(s), module, or a description of the code to test. If no target is given, ask for one. Detect language and whether the target crosses independently-deployable service boundaries (load `microservice-testing.md` only if so).
+
+## Steps
+
+### 1. Assess testability
+
+Read the target. For each unit, determine whether it can be constructed and driven through its public API with controlled inputs. Use the decision flow in `knowledge/testability-patterns.md`. Record blockers: static factories/singletons, new-ed-up dependencies, hidden global/clock/RNG access, concrete-class coupling, private logic with no public path.
+
+### 2. Place each behavior on the pyramid
+
+Using `knowledge/test-pyramid.md`, assign each behavior to the lowest layer that can meaningfully verify it (unit / integration / component / contract / E2E). Flag anything currently mis-layered. For service boundaries, apply contract testing per `knowledge/microservice-testing.md` instead of E2E.
+
+### 3. Choose doubles
+
+For each collaborator at each test, recommend the simplest double using the decision flow in `knowledge/test-doubles.md` (dummy/stub/spy/mock/fake) and whether to verify by state or behavior. Default to state verification + stub/fake; reserve mock/spy for true side-effect boundaries.
+
+### 4. Propose a behavior-preserving refactor sequence (only if blockers exist)
+
+If Step 1 found blockers, produce an ordered sequence that makes the code testable without changing behavior:
+
+1. Add characterization tests around current behavior (if untested) — pin existing behavior first.
+2. Introduce the seam (the specific pattern from `testability-patterns.md`).
+3. Write the now-possible tests at the layer from Step 2.
+4. Refactor under green.
+
+Each step names the pattern and the exact production change required.
+
+### 5. Report
+
+Write the recommendation (see Output). Keep it actionable — every recommendation maps to a concrete next edit.
+
+## Output
+
+A concise advisory report (to chat for a single unit, or to `reports/test-design-<target>.md` for a module):
+
+```markdown
+## Test Design — <target>
+
+### Testability
+| Unit | Testable as-is? | Blocker | Seam (testability-patterns.md) |
+
+### Pyramid placement
+| Behavior | Layer | Why this layer |
+
+### Double strategy
+| Test | Collaborator | Double | Verify by |
+
+### Refactor sequence (if blockers)
+1. <characterization tests> → 2. <seam> → 3. <tests> → 4. <refactor>
+
+### Next edit
+<the single concrete first action>
+```
+
+## Integration
+
+- Pairs with the `test-smell-review` agent (which *detects* smells) and the `test-design-reviewer` skill (which *scores* an existing suite). This skill *designs* tests forward.
+- For application-level test architecture (CD pipeline alignment, deterministic config-free CI gate, per-component UI/service/batch patterns), defer to the `cd-test-architecture` skill and its knowledge files (`cd-test-architecture.md`, `component-test-patterns.md`). This skill stays at unit/module altitude.
+- Hand the refactor sequence to `/plan` or `/build` for TDD implementation. This skill stops at the design.


### PR DESCRIPTION
## Summary

Extends the **dev-team** plugin with deep, advisory-only test-design tooling and a CD-pipeline test-architecture workflow. All additions are advisory (they recommend; they don't edit code), language-agnostic, and grounded in cited sources (xUnit Test Patterns, Fowler's test pyramid & microservice testing, MinimumCD).

### New capabilities
- **`test-smell-review` agent** — xUnit smell taxonomy, test-double selection, pyramid-layer placement. Auto-discovered by `/code-review`; self-skips when no test files.
- **`/test-design` command** — dispatches `test-review` + `test-smell-review`, then the `test-design-advisor` skill; aggregates a report.
- **`test-design-advisor` skill** — unit/module testability, layer choice, double strategy, behavior-preserving refactor sequences.
- **`cd-test-architecture` skill** — application-level assessment → CD-aligned target architecture (deterministic, config-free CI gate; UI/service/batch patterns; migration path).

### Knowledge (distilled + cited, language-agnostic)
`test-smells`, `test-doubles`, `test-pyramid`, `microservice-testing`, `cd-test-architecture`, `component-test-patterns`.

### Strategy stances baked in
- **Pre-merge gate = deterministic only** (static/unit/component/contract); run CI **without configuring dependencies** (assemble component + in-memory doubles + drive public interface + assert observable outcomes); the **adapter rule** (own the boundary, double the adapter).
- **Do not depend on provider cooperation** — assume providers break contracts without versioning; defend with **consumer-owned, scheduled provider-contract verification** in a test environment + **consumer resilience** tests, not provider-side CDC.
- **Out-of-repo / third-party-runner / Postman / manual-script testing is an anti-pattern** — supported via `--external-tests`, harvested as the behavior inventory that seeds the in-repo gate.
- **Baseline before refactor** — find testable seams, write the best outside-in characterization test achievable *without refactoring*, get it green, then refactor under that baseline (reusing the `legacy-code` and DDD skills).

### Docs & evals
- `docs/test-evaluation.md` — full evaluation workflow, tool altitudes, the out-of-repo anti-pattern, key principles, sample invocations; cross-linked from `docs/skills.md`.
- Eval fixtures + expected JSON for `test-smell-review` (assertion roulette, mystery guest, overspecified mocks, clean control).
- Registries synced (CLAUDE.md, agent-registry, adversarial-review-protocol, docs); knowledge index regenerated.

## Verification
- `test-smell-review` dry-run on a fixture: matched expected status/severities/keywords.
- `/cd-test-architecture` dry-run on a real repo (cutlist): produced an evidence-cited assessment, correctly applying the adapter rule, the no-provider-cooperation stance, and the inverted-shape/missing-layer findings.
- New agent + command pass the structural compliance hook; all expected JSON valid.

## Notes
- `feat:` commits → release-please will cut a minor version bump for dev-team on merge.
- 3 commits: capabilities → out-of-repo + docs → outside-in baseline-before-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)