### PR TITLE
feat(dev-team): add test-strategy knowledge file (xUnit Test Strategy patterns)

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -47,7 +47,7 @@ Full registry tables with token counts, model tiers, and used-by mappings are in
 
 **Subagent prompt templates** (8): `prompts/implementer.md`, `prompts/spec-reviewer.md`, `prompts/quality-reviewer.md`, `prompts/plan-reviewer.md`, `prompts/plan-review-acceptance.md`, `prompts/plan-review-design.md`, `prompts/plan-review-ux.md`, `prompts/plan-review-strategic.md`
 
-**Knowledge files** (17): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns, test-smells, test-doubles, test-pyramid, microservice-testing, cd-test-architecture, component-test-patterns
+**Knowledge files** (18): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns, test-smells, test-doubles, test-pyramid, test-strategy, microservice-testing, cd-test-architecture, component-test-patterns
 
 **Agent templates** (9): ts-enforcer, esm-enforcer, react-testing, front-end-testing, twelve-factor-audit, python-quality, go-quality, csharp-quality, angular-testing (in `templates/agents/`, scaffolded by `/setup`)
 

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -56,7 +56,7 @@ Code smells (single test):
 - **Conditional Test Logic** — `if`/`switch`/loops/try-catch around assertions; the test verifies different things on different runs
 - **Hard-Coded / Magic Values** in assertions with no stated meaning
 - **Test Code Duplication** — copy-pasted arrange/assert blocks that should be a builder or custom assertion (not two genuinely different boundary cases)
-- **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code
+- **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code (distinct from a *test* using Back Door Manipulation to reach SUT-owned state — see `knowledge/test-strategy.md`; only the production-code form is a smell)
 
 Behavior smells (only visible on run):
 

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -126,6 +126,7 @@ Knowledge files in `knowledge/` provide progressive disclosure — agents read t
 | Test Smells | `knowledge/test-smells.md` | ~900 | test-smell-review, test-review, test-design-advisor |
 | Test Doubles | `knowledge/test-doubles.md` | ~700 | test-smell-review, test-design-advisor |
 | Test Pyramid | `knowledge/test-pyramid.md` | ~700 | test-smell-review, test-review, test-design-advisor |
+| Test Strategy | `knowledge/test-strategy.md` | ~900 | test-design-advisor, test-smell-review, test-review |
 | Microservice Testing | `knowledge/microservice-testing.md` | ~700 | test-smell-review, test-design-advisor |
 | CD Test Architecture | `knowledge/cd-test-architecture.md` | ~1,100 | cd-test-architecture, test-design-advisor |
 | Component Test Patterns | `knowledge/component-test-patterns.md` | ~1,600 | cd-test-architecture |

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -673,6 +673,24 @@
       "anchor": "boundaries"
     }
   },
+  "plugins/dev-team/knowledge/test-strategy.md": {
+    "1. Test Fixture Strategy": {
+      "summary": "The fixture is everything the test needs in place before it acts.",
+      "anchor": "1-test-fixture-strategy"
+    },
+    "2. Test Automation Strategy": {
+      "summary": "How the test is written and driven.",
+      "anchor": "2-test-automation-strategy"
+    },
+    "3. SUT Interaction Strategy": {
+      "summary": "How the test reaches the system under test.",
+      "anchor": "3-sut-interaction-strategy"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "**`test-doubles.md`** — once Layer Test or Back Door Manipulation needs a collaborator stand-in, choose the double there.",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
+    }
+  },
   "plugins/dev-team/knowledge/testability-patterns.md": {
     "\"I Can't Test This Class\" Decision Flow": {
       "summary": "---",
@@ -2507,6 +2525,10 @@
     "3. Choose doubles": {
       "summary": "For each collaborator at each test, recommend the simplest double using the decision flow in `knowledge/test-doubles.md` (dummy/stub/spy/mock/fake) and whether to verify by state or behavior.",
       "anchor": "3-choose-doubles"
+    },
+    "3b. Recommend fixture and interaction strategy": {
+      "summary": "Using `knowledge/test-strategy.md`, recommend per test group: fixture design + lifecycle (default Minimal + Fresh; escalate to Immutable Shared → Shared only under measured speed pressure), how the test is driven (scripted default; data-driven when variation is purely data), and SUT interaction (front-door by default; Layer Test for layered code; Back Door Manipulation only when the front door obscures intent).",
+      "anchor": "3b-recommend-fixture-and-interaction-strategy"
     },
     "4. Propose a behavior-preserving refactor sequence (only if blockers exist)": {
       "summary": "If Step 1 found blockers, produce an ordered sequence that makes the code testable without changing behavior:",

--- a/plugins/dev-team/knowledge/test-strategy.md
+++ b/plugins/dev-team/knowledge/test-strategy.md
@@ -1,0 +1,70 @@
+# Test Strategy
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. Where `test-smells.md` catalogues what to *avoid* and `test-doubles.md` covers *which collaborator stand-in* to use, this file covers the **up-front strategic choices** made before and while building a test: how the fixture is organized, how the test is driven, and how it reaches the system under test (SUT).
+
+Source taxonomy: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com), "Test Strategy" patterns. Language- and framework-agnostic — described by role, not by any tool's API.
+
+Core principle: **default to the simplest, most isolated strategy, and only trade isolation away under measured pressure.** Minimal + Fresh fixtures, scripted tests, and front-door interaction are the defaults; every step away from them buys speed or reach at the cost of clarity or coupling, and must be justified.
+
+---
+
+## 1. Test Fixture Strategy
+
+The fixture is everything the test needs in place before it acts. Two independent decisions:
+
+**A. Design — how much fixture?**
+
+| Strategy | What it is | Use when | Cost / risk |
+|---|---|---|---|
+| **Minimal Fixture** | Build only what *this* test uses | **Default.** Always start here | — (this is the safe choice) |
+| **Standard Fixture** | One fixture *design* reused across many tests (a "big design up front" for the suite) | Many tests genuinely share the same shape and a common design reduces duplication | Drifts into the **General Fixture** smell if it builds more than each test needs (see `test-smells.md`) |
+
+**B. Lifecycle — how long does the instance live?** (orthogonal to A)
+
+| Strategy | What it is | Use when | Cost / risk |
+|---|---|---|---|
+| **Fresh Fixture** | A new instance built and torn down per test — every test starts from a clean slate | **Default.** Guarantees isolation | Slow if setup is heavy (esp. persistent/DB fixtures) |
+| **Immutable Shared Fixture** | One instance reused across tests but never mutated (read-only) | Fresh is too slow *and* tests only read the fixture | Requires discipline that nothing writes to it |
+| **Shared Fixture** | One mutable instance reused across many tests / runs | Last resort, when even an immutable shared fixture won't do | Inter-test coupling, order-dependence, **Interacting Tests / Unrepeatable Test / Test Run War** (see `test-smells.md`) |
+
+**Decision flow:** Minimal + Fresh → if too slow, make it an **Immutable Shared Fixture** → only then a mutable **Shared Fixture**, and if shared+persistent, isolate it (per-test DB sandbox / partition scheme) so runs can't collide. Standard vs ad-hoc is a separate axis: a Shared Fixture is always Standard, but a Standard Fixture can still be built Fresh per test.
+
+---
+
+## 2. Test Automation Strategy
+
+How the test is written and driven.
+
+| Strategy | What it is | Use when | Cost / risk |
+|---|---|---|---|
+| **Scripted Test** | Test programs written by hand (the test code you write in any xUnit) | **Default**, and the only option that can *drive* development (TDD) — there's nothing to record before the code exists | Needs programming skill; not for non-technical authors |
+| **Data-Driven Test** | A common interpreter holds the logic; cases live as rows in an external data table (one line per case) | Many cases vary only by input/expected data; lets non-programmers add cases (e.g. Fit/Fitnesse) | Interpreter is itself code to maintain; failures can be opaque; easy to over-build |
+| **Recorded Test** | Capture interactions with a running SUT (usually through the UI) and replay them | Regression-testing a **finished, stable** app where little will change | Brittle to UI/behavior change; can't drive development; high re-record cost |
+| **Test Automation Framework** | The harness that discovers, runs, verifies, and reports tests; you supply only test-specific logic | You **use** one (xUnit, etc.) — rarely build one | Building your own is almost always wasted effort |
+
+Rule of thumb: **scripted by default; data-driven when the variation is purely data; recorded only for regression on something already done.**
+
+---
+
+## 3. SUT Interaction Strategy
+
+How the test reaches the system under test.
+
+| Strategy | What it is | Use when | Cost / risk |
+|---|---|---|---|
+| **Layer Test** | Treat each layer of a layered architecture as its own SUT; test layer *n* with tests standing in for *n+1* and (optionally) a Test Double for *n-1* | The system is layered and you want precise per-layer coverage | Requires real layer boundaries (see `hexagonal-architecture`); misses cross-layer integration bugs unless complemented by broader tests |
+| **Back Door Manipulation** | Set up pre-state or verify post-state by bypassing the SUT's public API — direct DB/file/registry access | Front-door setup/verification is impractical, slow, or so verbose it obscures the test's intent | Couples the test to the SUT's internal state representation; can mask real integration defects — use sparingly and deliberately |
+
+**Front-door first.** Prefer driving and checking the SUT through its real API; reach for a back door only when the front door makes the test unclear or infeasible.
+
+> **Reconciling with the "Test Logic in Production" smell.** `test-smell-review` flags back doors *baked into shipped code* (`if (testMode)`, test-only endpoints) — that is always a smell. **Back Door Manipulation is different:** it is the *test* reaching around the API to touch state the SUT owns, with no change to production code. The first is production code that knows it's being tested; the second is a test that knows the SUT's internals. The former is banned; the latter is a costed trade-off. Don't conflate them in review.
+
+---
+
+## How this connects to the rest of the toolkit
+
+- **`test-doubles.md`** — once Layer Test or Back Door Manipulation needs a collaborator stand-in, choose the double there.
+- **`test-smells.md`** — the failure modes these strategies guard against (General Fixture, Interacting Tests, Mystery Guest, Test Logic in Production).
+- **`test-pyramid.md`** — *where* a check belongs (granularity); this file is *how* the test at that layer is built.
+- **`testability-patterns.md`** — the seams (dependency injection, etc.) that make Fresh Fixtures and front-door interaction possible without back doors.
+- **`cd-test-architecture.md` / `microservice-testing.md`** — applying fixture and interaction strategy in a CD / distributed context.

--- a/plugins/dev-team/skills/test-design-advisor/SKILL.md
+++ b/plugins/dev-team/skills/test-design-advisor/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 
 An **advisory** skill: it recommends how to test code and how to make untestable code testable. It does not write tests or refactor code — it produces a design the human (or `/build`) then implements. Use it before writing a test suite for an untested or hard-to-test module, or when a test is hard to write and you suspect the design is the cause.
 
-Grounded in four knowledge references: `knowledge/test-smells.md`, `knowledge/test-doubles.md`, `knowledge/test-pyramid.md`, `knowledge/microservice-testing.md`, and `knowledge/testability-patterns.md` for production-code seams.
+Grounded in these knowledge references: `knowledge/test-smells.md`, `knowledge/test-doubles.md`, `knowledge/test-pyramid.md`, `knowledge/microservice-testing.md`, `knowledge/testability-patterns.md` for production-code seams, and `knowledge/test-strategy.md` for fixture and SUT-interaction strategy.
 
 ## Constraints
 
@@ -38,6 +38,10 @@ Using `knowledge/test-pyramid.md`, assign each behavior to the lowest layer that
 ### 3. Choose doubles
 
 For each collaborator at each test, recommend the simplest double using the decision flow in `knowledge/test-doubles.md` (dummy/stub/spy/mock/fake) and whether to verify by state or behavior. Default to state verification + stub/fake; reserve mock/spy for true side-effect boundaries.
+
+### 3b. Recommend fixture and interaction strategy
+
+Using `knowledge/test-strategy.md`, recommend per test group: fixture design + lifecycle (default Minimal + Fresh; escalate to Immutable Shared → Shared only under measured speed pressure), how the test is driven (scripted default; data-driven when variation is purely data), and SUT interaction (front-door by default; Layer Test for layered code; Back Door Manipulation only when the front door obscures intent). Flag any reliance on a mutable Shared Fixture as an Interacting-Tests risk.
 
 ### 4. Propose a behavior-preserving refactor sequence (only if blockers exist)
 


### PR DESCRIPTION
## Summary

Adds `knowledge/test-strategy.md`, closing the gap identified against xunitpatterns.com's **"Test Strategy"** category — the one part of the xUnit Test Patterns strategic taxonomy the toolkit didn't cover (doubles, smells, pyramid, testability were already present; the *strategy* patterns were not).

Covers the page's 10 patterns in 3 decision axes, with flows and trade-offs:
- **Test Fixture Strategy** — Minimal / Standard / Fresh / Shared (+ Immutable Shared middle ground); default Minimal+Fresh, escalate only under measured speed pressure.
- **Test Automation Strategy** — Scripted (default) / Data-Driven / Recorded / Test Automation Framework.
- **SUT Interaction Strategy** — Layer Test, Back Door Manipulation (front-door first).

## Wiring

- **`test-design-advisor`** — added to its grounding references + a new **Step 3b** (recommend fixture + interaction strategy).
- **`test-smell-review`** — cross-reference reconciling the **"Test Logic in Production"** smell (back doors in *shipped* code = bad) vs **Back Door Manipulation** (a *test* reaching SUT-owned state = a costed, valid strategy). Previously the agent would flag both alike.
- `agent-registry.md` row, `CLAUDE.md` knowledge count 17→18, `knowledge/index.json` regenerated (builder `--check` passes).

Content grounded in Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)