### PR TITLE
chore(dev-team): resolve agent-audit compliance gaps

### DIFF
--- a/plugins/dev-team/agents/spec-compliance-review.md
+++ b/plugins/dev-team/agents/spec-compliance-review.md
@@ -46,12 +46,12 @@ This agent answers one question: **does the code do what the spec says?** It run
 ```json
 {
   "agentName": "spec-compliance-review",
-  "status": "pass|warn|fail",
+  "status": "pass|warn|fail|skip",
   "issues": [
     {
       "file": "<file path>",
       "line": null,
-      "severity": "error|warning",
+      "severity": "error|warning|suggestion",
       "message": "<what's wrong>",
       "category": "unmet-criterion|uncovered-scenario|scope-violation|plan-deviation",
       "criterion": "<the acceptance criterion or scenario name>",
@@ -78,3 +78,4 @@ Return `{"status": "skip", "issues": [], "summary": "No spec artifacts found"}` 
 - Uncovered scenario → `error` (always)
 - Scope violation → `warning` (may be intentional)
 - Plan deviation → `warning` (may be justified)
+- Cosmetic divergence from the plan that meets every criterion (naming, file placement, ordering) → `suggestion`

--- a/plugins/dev-team/commands/agent-add.md
+++ b/plugins/dev-team/commands/agent-add.md
@@ -15,6 +15,30 @@ user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, WebFetch, Skill(agent-audit *)
 ---
 
+# Agent Add
+
+Role: implementation.
+
+## Implementation constraints
+
+1. Follow the official sub-agent schema and token budgets.
+2. Delegate the build to the agent-create skill; do not improvise structure.
+3. **Be concise.** Report the created agent file, no narration.
+
+## Steps
+
+### 1. Parse arguments
+
+Capture the agent name/spec or URL from `$ARGUMENTS`.
+
+### 2. Delegate
+
+Invoke the agent-create skill with the arguments.
+
+### 3. Report
+
+Output the created file path.
+
 Apply the guidelines defined in skills/agent-create/SKILL.md to the current
 task. Read the skill file and follow its steps exactly.
 
@@ -23,6 +47,7 @@ WebFetch first and extract the relevant guidance, then use that content as
 the agent description.
 
 Pass these flags through to the skill as context:
+
 - `--name <name>` → set agent name (skips name prompt)
 - `--type review|team` → set agent type (skips type prompt)
 - `--tier small|mid|frontier` → maps to model: small→haiku, mid→sonnet, frontier→opus

--- a/plugins/dev-team/commands/benchmark.md
+++ b/plugins/dev-team/commands/benchmark.md
@@ -16,6 +16,12 @@ Role: worker. This command measures runtime performance of web pages using Playw
 
 You have been invoked with the `/benchmark` command.
 
+## Worker constraints
+
+1. Measure only; do not modify the page or app under test.
+2. Compare against the declared budget; do not invent thresholds.
+3. **Be concise.** Report the metrics table and verdict, no narration.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -44,6 +50,7 @@ Read `skills/performance-benchmark/SKILL.md` for the full metric definitions, ou
 ### 2. Generate and run the benchmark script
 
 Generate a Node.js script based on the template that:
+
 - Navigates to the target URL
 - Collects Core Web Vitals (LCP, FCP, CLS, INP) via Performance Observer
 - Collects Navigation Timing (TTFB, DOM Interactive, Load Complete)
@@ -57,11 +64,13 @@ Run the script with `node` and capture the JSON output.
 ### 3. Compare against baseline (unless --baseline)
 
 If `--baseline` is set:
+
 - Save the metrics to `benchmarks/<page-slug>/baseline.json`
 - Create the directory if needed
 - Report: "Baseline saved for <url>"
 
 If `--baseline` is NOT set:
+
 - Read `benchmarks/<page-slug>/baseline.json` if it exists
 - Compare each metric: regression (>10% worse) → `fail`, degradation (5-10%) → `warn`, stable (±5%) → `pass`, improvement (>10% better) → noted
 - If no baseline exists, report metrics without comparison and suggest: "No baseline found. Run `/benchmark <url> --baseline` to establish one."
@@ -81,6 +90,7 @@ If `--trend` is set, read the history file and produce a trend summary showing m
 Write a markdown report to `benchmarks/<page-slug>/report.md` using the report format from the skill file.
 
 Display in chat:
+
 - Core Web Vitals table with pass/warn/fail status
 - Resource budget table
 - Any regressions with severity

--- a/plugins/dev-team/commands/browse.md
+++ b/plugins/dev-team/commands/browse.md
@@ -14,6 +14,12 @@ Role: worker. This command provides browser-based interaction for visual verific
 
 You have been invoked with the `/browse` command.
 
+## Worker constraints
+
+1. Drive the browser only; do not edit source.
+2. Capture evidence (screenshots/logs); do not assert pass/fail beyond what was observed.
+3. **Be concise.** Report observations and artifacts, no preamble.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -30,12 +36,14 @@ Arguments: $ARGUMENTS
 ### 1. Check Playwright availability
 
 Run:
+
 ```bash
 npx playwright --version 2>/dev/null
 ```
 
 If Playwright is not available, ask the user:
 > Playwright is required for browser interaction. Install it now?
+>
 > ```
 > npx playwright install chromium
 > ```
@@ -94,6 +102,7 @@ const { chromium } = require('playwright');
 ```
 
 Write the script to a temp file, execute it, then clean up:
+
 ```bash
 node /tmp/browse-action.js && rm /tmp/browse-action.js
 ```
@@ -103,6 +112,7 @@ node /tmp/browse-action.js && rm /tmp/browse-action.js
 Use the Read tool to view the screenshot image. Claude's multimodal capabilities will interpret the visual content.
 
 Describe what you see:
+
 - Page layout and structure
 - Key visible content (headings, text, images)
 - State of interactive elements (forms, buttons, error messages)
@@ -111,6 +121,7 @@ Describe what you see:
 ### 5. Report results
 
 Provide a summary:
+
 ```
 ## Browse Results
 - **URL**: <final URL after any redirects>
@@ -145,6 +156,7 @@ In this mode:
 3. For each selector, verify it exists and is visible
 4. Take a full-page screenshot as verification evidence
 5. Return a structured result:
+
    ```
    - url: <final URL>
    - selectors_found: [list of selectors that were visible]
@@ -155,6 +167,7 @@ In this mode:
    ```
 
 If the connection times out or refuses (dev server not running), return:
+
 ```
 - status: skipped
 - reason: "Dev server not reachable at <URL>"

--- a/plugins/dev-team/commands/build.md
+++ b/plugins/dev-team/commands/build.md
@@ -23,6 +23,7 @@ You have been invoked with the `/build` command.
 3. **Incremental.** Each step must leave the codebase in a working, committable state.
 4. **Verification evidence required.** Paste fresh test output before claiming a step is done.
 5. **Review checkpoints.** After each unit of work, run inline review (spec-compliance first, then quality agents). Max 2 correction iterations before escalating.
+6. **Be concise.** Report step status and verification evidence, no narration.
 
 ## Parse Arguments
 

--- a/plugins/dev-team/commands/careful.md
+++ b/plugins/dev-team/commands/careful.md
@@ -14,6 +14,12 @@ Role: worker. This command toggles destructive command blocking.
 
 You have been invoked with the `/careful` command.
 
+## Worker constraints
+
+1. Toggle state only; do not modify code or other config.
+2. Do not block legitimate commands beyond the destructive set.
+3. **Be concise.** Confirm the new mode in one line, no preamble.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -26,6 +32,7 @@ Arguments: $ARGUMENTS
 ### Enable (no arguments or any argument except "off")
 
 1. Write the following JSON to `hooks/careful-state.json`:
+
 ```json
 {
   "active": true,
@@ -33,17 +40,20 @@ Arguments: $ARGUMENTS
 }
 ```
 
-2. Display:
+1. Display:
+
 > Careful mode ON. Destructive commands will be blocked until `/careful off`.
 
 ### Disable (`off`)
 
 1. Remove `hooks/careful-state.json`:
+
 ```bash
 rm -f hooks/careful-state.json
 ```
 
-2. Display:
+1. Display:
+
 > Careful mode OFF. Destructive commands will show warnings but not be blocked.
 
 ## Notes

--- a/plugins/dev-team/commands/continue.md
+++ b/plugins/dev-team/commands/continue.md
@@ -14,19 +14,29 @@ allowed-tools: Read, Glob, Grep, Bash(git log *), Bash(git branch *), Bash(git s
 
 Role: orchestrator. This command resumes work from a prior session — it does not start new work.
 
+Arguments: optional — a phase or plan name to resume; defaults to the most recent.
+
 You have been invoked with the `/continue` command.
+
+## Orchestrator constraints
+
+1. Resume from memory/ progress files; do not restart completed phases.
+2. Summarize prior state; do not replay full history.
+3. **Be concise.** Report where work resumes, no narration.
 
 ## Steps
 
 ### 1. Scan for in-progress work
 
 Read all files in `memory/` looking for phase progress files. These follow the pattern:
+
 - `memory/research-progress-*.md` — Research phase output
 - `memory/plan-progress-*.md` — Plan phase output
 - `memory/implementation-progress-*.md` — Implementation phase output
 - `memory/decisions.md` — Accumulated decision log
 
 Also check:
+
 - `plans/` directory for active plan files
 - `docs/specs/` for design documents without corresponding implementation
 - `.claude/review-summaries/` for recent review results
@@ -35,6 +45,7 @@ Also check:
 ### 2. Check git state
 
 Run `git status` and `git log --oneline -5` to understand:
+
 - Current branch and its relationship to main
 - Any uncommitted changes
 - Recent commit messages for context
@@ -71,6 +82,7 @@ If the user confirms, load the appropriate phase context and continue execution.
 ### 5. Load phase context
 
 Based on the identified phase:
+
 - **Research**: Load research progress file + relevant design doc
 - **Plan**: Load plan progress file + design doc
 - **Implement**: Load implementation progress file + plan + any review corrections

--- a/plugins/dev-team/commands/freeze.md
+++ b/plugins/dev-team/commands/freeze.md
@@ -14,6 +14,12 @@ Role: worker. This command restricts Write/Edit operations to files matching a g
 
 You have been invoked with the `/freeze` command.
 
+## Worker constraints
+
+1. Write only the freeze-state file; do not edit source.
+2. Do not enforce the lock yourself — the pre-tool-guard hook does.
+3. **Be concise.** Confirm the locked scope in one line.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS

--- a/plugins/dev-team/commands/guard.md
+++ b/plugins/dev-team/commands/guard.md
@@ -15,6 +15,12 @@ Role: worker. Combined safety mode: careful + freeze.
 
 You have been invoked with the `/guard` command.
 
+## Worker constraints
+
+1. Compose /careful + /freeze; introduce no new blocking behavior.
+2. Do not edit source.
+3. **Be concise.** Confirm both modes in one line each.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -27,6 +33,7 @@ If no pattern is provided, display usage and exit:
 > Use `/careful off` and `/unfreeze` separately to disable, or pass `off` to disable both.
 
 If argument is `off`:
+
 1. Remove `hooks/careful-state.json` and `hooks/freeze-state.json`
 2. Display: "Guard mode OFF. All safety restrictions lifted."
 
@@ -35,6 +42,7 @@ If argument is `off`:
 ### 1. Enable careful mode
 
 Write to `hooks/careful-state.json`:
+
 ```json
 {
   "active": true,
@@ -45,6 +53,7 @@ Write to `hooks/careful-state.json`:
 ### 2. Enable freeze mode
 
 Write to `hooks/freeze-state.json`:
+
 ```json
 {
   "active": true,
@@ -57,6 +66,7 @@ Write to `hooks/freeze-state.json`:
 
 Display:
 > Guard mode ON.
+>
 > - Destructive commands: BLOCKED
 > - File editing: Locked to `<pattern>`
 >

--- a/plugins/dev-team/commands/help.md
+++ b/plugins/dev-team/commands/help.md
@@ -12,6 +12,14 @@ Role: worker. This command lists all available slash commands.
 
 You have been invoked with the `/help` command.
 
+Arguments: none.
+
+## Worker constraints
+
+1. List commands only; do not execute any.
+2. Read from the command registry; do not invent commands.
+3. **Be concise.** One line per command, no preamble.
+
 ## Steps
 
 ### 1. Find all command files

--- a/plugins/dev-team/commands/init-dev-team.md
+++ b/plugins/dev-team/commands/init-dev-team.md
@@ -16,7 +16,15 @@ Role: worker. Installs tools required by the dev-team plugin, with a
 focus on the mutation gate. Run after the plugin is installed, or when the
 mutation gate reports a missing dependency.
 
+Arguments: none — interactive prompts drive selection.
+
 You have been invoked with the `/init-dev-team` command.
+
+## Worker constraints
+
+1. Install prerequisites and write config only where the user confirms.
+2. Be OS-aware; do not assume a package manager.
+3. **Be concise.** Report what was installed/skipped, no narration.
 
 ## Step 1 — Detect OS
 

--- a/plugins/dev-team/commands/issues-from-plan.md
+++ b/plugins/dev-team/commands/issues-from-plan.md
@@ -11,13 +11,22 @@ allowed-tools: Read, Glob, Grep, Bash, Write
 
 # Issues from Plan
 
+Role: orchestrator.
+
 Break an implementation plan into GitHub issues that can be worked independently.
+
+## Orchestrator constraints
+
+1. Decompose the plan into issues; do not implement.
+2. Preserve plan ordering and dependencies as issue links.
+3. **Be concise.** Report created issue numbers, no narration.
 
 ## Process
 
 ### 1. Find the Plan
 
 If a path is provided in arguments, read that file. Otherwise, look for the most recent plan in:
+
 - Active plan in conversation context
 - `memory/` directory (phase progress files)
 - `plans/` directory
@@ -29,6 +38,7 @@ If no plan is found, ask the user to point you to one.
 ### 2. Analyze the Plan
 
 Read the plan and identify:
+
 - Each discrete unit of work (implementation step, vertical slice, or phase)
 - Dependencies between units (which must complete before others can start)
 - Acceptance criteria for each unit

--- a/plugins/dev-team/commands/model-routing-check.md
+++ b/plugins/dev-team/commands/model-routing-check.md
@@ -18,6 +18,14 @@ during triage at any time.
 
 You have been invoked with the `/model-routing-check` command.
 
+Arguments: none.
+
+## Worker constraints
+
+1. Read-only diagnostic; touch no files, no side effects.
+2. Report resolved state only; do not change routing.
+3. **Be concise.** Tables only, no narration.
+
 ## What it shows
 
 Four sections, in order:

--- a/plugins/dev-team/commands/plan.md
+++ b/plugins/dev-team/commands/plan.md
@@ -23,6 +23,7 @@ You have been invoked with the `/plan` command.
 2. **Every step must be TDD.** Each step follows RED → GREEN → REFACTOR.
 3. **Incremental.** Each step must leave the codebase in a working, committable state.
 4. **Human approval required.** Present the plan for approval before any implementation begins.
+5. **Be concise.** The plan is the artifact; keep chat to decisions and gaps.
 
 ## Parse Arguments
 

--- a/plugins/dev-team/commands/pr.md
+++ b/plugins/dev-team/commands/pr.md
@@ -16,6 +16,12 @@ Role: orchestrator. This command enforces quality gates before creating a PR.
 
 You have been invoked with the `/pr` command.
 
+## Orchestrator constraints
+
+1. Run the quality gate and open the PR; do not bypass failing gates.
+2. Delegate review to the review agents; do not review code yourself.
+3. **Be concise.** Report gate results and the PR URL, no preamble.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -29,6 +35,7 @@ Arguments: $ARGUMENTS
 ### 1. Pre-flight checks
 
 Verify:
+
 - Current branch is not `main` or `master`
 - There are commits ahead of the base branch
 - Working tree is clean (no uncommitted changes) — if dirty, ask whether to commit or stash
@@ -59,6 +66,7 @@ Run each check sequentially. Stop on first failure:
    - If review returns `fail`, show the results and ask the user whether to proceed or fix
 
 Report results as a checklist:
+
 ```
 ## Quality Gate
 - [x] Tests pass (42 passed, 0 failed)

--- a/plugins/dev-team/commands/review.md
+++ b/plugins/dev-team/commands/review.md
@@ -18,7 +18,21 @@ allowed-tools: >-
 
 # Review (alias)
 
+Role: orchestrator.
+
+## Orchestrator constraints
+
+1. Pure alias — change no behavior.
+2. Pass all arguments through to /code-review unchanged.
+3. **Be concise.** Defer all output to code-review.md.
+
 This is an alias for `/code-review`. Read and follow
 `commands/code-review.md` with all arguments passed through.
 
 Arguments: $ARGUMENTS
+
+## Steps
+
+### 1. Pass through
+
+Read and follow `commands/code-review.md` with `$ARGUMENTS` unchanged.

--- a/plugins/dev-team/commands/semantic-scan.md
+++ b/plugins/dev-team/commands/semantic-scan.md
@@ -11,6 +11,30 @@ argument-hint: "[path] [--full] [--no-opus]"
 user-invocable: true
 ---
 
+# Semantic Scan
+
+Role: worker.
+
+## Worker constraints
+
+1. Detect and report duplicates; do not refactor.
+2. Run incrementally (git-diff based) after the first scan.
+3. **Be concise.** Report the duplicate table with file:line refs, no narration.
+
+## Steps
+
+### 1. Parse arguments
+
+Capture the optional path and flags from `$ARGUMENTS`.
+
+### 2. Delegate
+
+Invoke the semantic-duplication-scan skill.
+
+### 3. Report
+
+Output the duplicate report.
+
 Apply the guidelines defined in skills/semantic-duplication-scan/SKILL.md to the current task. Read the skill file and follow its process flow, pre-filter rules, annotation procedure, clustering strategy, and report format.
 
 ## Flags

--- a/plugins/dev-team/commands/setup.md
+++ b/plugins/dev-team/commands/setup.md
@@ -16,6 +16,12 @@ Role: orchestrator. This command bootstraps project-level configuration by detec
 
 You have been invoked with the `/setup` command.
 
+## Orchestrator constraints
+
+1. Detect and scaffold; delegate generation, do not review code yourself.
+2. Do not overwrite existing project config without confirming.
+3. **Be concise.** Report detected stack and generated artifacts, no narration.
+
 ## Parse Arguments
 
 Arguments: $ARGUMENTS
@@ -42,6 +48,7 @@ Search the project root for manifest files and record findings:
 | `Dockerfile`, `docker-compose.yml` | Container |
 
 Also detect frameworks within each stack:
+
 - **Node**: check `package.json` dependencies for `react`, `vue`, `svelte`, `@angular/core`, `express`, `fastify`, `nestjs`, `next`, `vitest`, `jest`, `mocha`
 - **Python**: check for `django`, `flask`, `fastapi`, `pytest` in deps
 - **Go**: check for `gin`, `echo`, `fiber` in `go.mod`

--- a/plugins/dev-team/commands/triage.md
+++ b/plugins/dev-team/commands/triage.md
@@ -12,7 +12,15 @@ allowed-tools: Read, Glob, Grep, Bash, Write, Agent
 
 # Bug Triage
 
+Role: worker.
+
 Investigate a bug hands-off, find root cause, and file a GitHub issue with a TDD fix plan.
+
+## Worker constraints
+
+1. Investigate and file an issue; do not fix the bug.
+2. Find root cause before filing; do not file on symptoms alone.
+3. **Be concise.** Issue body is structured; chat is a one-line summary + URL.
 
 ## Process
 
@@ -31,6 +39,7 @@ Apply the systematic debugging protocol from `skills/systematic-debugging/SKILL.
 3. **Root cause**: Form and test a hypothesis
 
 Use the Agent tool with `subagent_type: "Explore"` to deeply investigate the codebase. Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log`)

--- a/plugins/dev-team/commands/unfreeze.md
+++ b/plugins/dev-team/commands/unfreeze.md
@@ -12,6 +12,14 @@ Role: worker. This command removes the file editing scope lock.
 
 You have been invoked with the `/unfreeze` command.
 
+Arguments: none — operates on the current freeze state.
+
+## Worker constraints
+
+1. Clear only the freeze-state file.
+2. Do not edit source.
+3. **Be concise.** Confirm the lock is lifted in one line.
+
 ## Steps
 
 ### 1. Remove freeze state

--- a/plugins/dev-team/commands/upgrade.md
+++ b/plugins/dev-team/commands/upgrade.md
@@ -11,7 +11,15 @@ allowed-tools: Read, Glob, Grep, Bash
 
 Role: worker. This command updates the dev-team plugin to the latest version and ensures its marketplace is set to auto-update going forward.
 
+Arguments: none.
+
 You have been invoked with the `/upgrade` command.
+
+## Worker constraints
+
+1. Use the official plugin update mechanism; do not hand-edit installed plugin files.
+2. Report available updates before applying.
+3. **Be concise.** Report version deltas only.
 
 ## Steps
 

--- a/plugins/dev-team/commands/version.md
+++ b/plugins/dev-team/commands/version.md
@@ -12,6 +12,14 @@ Role: worker. This command reports the installed plugin version.
 
 You have been invoked with the `/version` command.
 
+Arguments: none.
+
+## Worker constraints
+
+1. Read only; never write or modify files.
+2. Report the first match found; do not aggregate.
+3. **Be concise.** Output only the version line.
+
 ## Steps
 
 Find the installed plugin version by checking these locations in order:

--- a/plugins/dev-team/hooks/js-fp-review.sh
+++ b/plugins/dev-team/hooks/js-fp-review.sh
@@ -3,7 +3,7 @@
 # Detects common mutation patterns and warns without blocking.
 # Full nuanced analysis is handled by the js-fp-review agent.
 
-set -euo pipefail
+set -uo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)

--- a/plugins/dev-team/hooks/tdd-guard.sh
+++ b/plugins/dev-team/hooks/tdd-guard.sh
@@ -7,7 +7,7 @@
 # the current edit is a test file or implementation file, and warns if
 # implementation is edited without a recent test edit.
 
-set -euo pipefail
+set -uo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)

--- a/plugins/dev-team/hooks/token-efficiency-review.sh
+++ b/plugins/dev-team/hooks/token-efficiency-review.sh
@@ -3,7 +3,7 @@
 # Checks file length, CLAUDE.md length, and function length.
 # Full analysis is handled by the token-efficiency-review agent.
 
-set -euo pipefail
+set -uo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)


### PR DESCRIPTION
## Summary
- Fixed the one FAIL from `/agent-audit`: `spec-compliance-review` now defines a `suggestion` severity level and includes `skip` in its status enum (consistent with its own `## Skip` response).
- Cleared all 21 command WARNs: added role-matched `## <Role> constraints` sections with a "Be concise" directive, missing `Role:` lines, `## Steps` for the three thin delegators (agent-add, review, semantic-scan), and explicit `Arguments` notes.
- Cleared 3 hook WARNs: `js-fp-review.sh`, `tdd-guard.sh`, `token-efficiency-review.sh` switched from `set -euo pipefail` to `set -uo pipefail` so these advisory PostToolUse hooks always exit 0.

## Quality Gate
- [x] Tests: N/A — no JS/Python/Go/Rust suite; CI `plugin-tests.yml` covers the security-assessment plugin only, not these dev-team files
- [x] Type check: N/A (markdown + shell)
- [x] Lint: shellcheck clean on all 3 modified hooks; `bash -n` syntax check clean
- [x] Code review: `/agent-audit` re-run reports **0 WARN, 0 FAIL** across agents, commands, and hooks

## Test Plan
- [ ] Run `/agent-audit` — confirm 0 WARN / 0 FAIL
- [ ] Confirm `spec-compliance-review` skip path still returns `status: "skip"` and validates against the updated enum
- [ ] Confirm the three advisory hooks exit 0 on a normal Write/Edit (no blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)