### PR TITLE
feat(dev-team): skip /code-review for documentation-only changesets

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -61,7 +61,7 @@ User-invocable workflows in `.claude/commands/`. All review commands are execute
 
 | Command | File | Role | What It Does |
 |---------|------|------|--------------|
-| `/code-review` | `commands/code-review.md` | orchestrator | Run review agents, auto-fix actionable issues, re-run until clean (up to 5 iterations) |
+| `/code-review` | `commands/code-review.md` | orchestrator | Run review agents, auto-fix actionable issues, re-run until clean (up to 5 iterations). Short-circuits documentation-only changesets (skips review; `--force` overrides) |
 | `/review-agent` | `commands/review-agent.md` | worker | Run a single review agent (used for inline checkpoints) |
 | `/test-design` | `commands/test-design.md` | orchestrator | Deep test-design review: dispatch test-review + test-smell-review, then run test-design-advisor for testability/refactor recommendations (advisory) |
 | `/agent-audit` | `commands/agent-audit.md` | orchestrator | Audit agents/commands/hooks for structural compliance |

--- a/plugins/dev-team/commands/code-review.md
+++ b/plugins/dev-team/commands/code-review.md
@@ -45,7 +45,7 @@ Arguments: $ARGUMENTS
 | `--all` | Force full-repository review even when uncommitted changes exist |
 | `--json` | Output aggregated JSON instead of prose (for CI integration) |
 | `--init-risks` | Scaffold `ACCEPTED-RISKS.md` from `templates/ACCEPTED-RISKS.md.tmpl` if absent. Exits non-zero without overwriting if present. Schema: `knowledge/accepted-risks-schema.md`. |
-| `--force` | Skip pre-flight gates. **Requires `--reason "<text>"`** — logged to `metrics/override-audit.jsonl`. |
+| `--force` | Skip pre-flight gates **and the documentation-only short-circuit** (forces a full review of doc-only changes). **Requires `--reason "<text>"`** — logged to `metrics/override-audit.jsonl`. |
 | `--reason "<text>"` | Override justification (required with `--force`) |
 | `--static-analysis` / `--no-static-analysis` | Force on/off the static analysis pre-pass (Semgrep, ESLint, TypeScript, pylint). Auto-enabled when tools are detected. |
 | `--background` | Drift review mode — review default branch for documentation, naming, and structural drift. Runs doc-review, arch-review, naming-review, structure-review only. Skips pre-flight gates. |
@@ -55,6 +55,7 @@ Arguments: $ARGUMENTS
 
 ```text
 - [ ] Target files determined
+- [ ] Documentation-only check (short-circuit if all docs)
 - [ ] Pre-flight gates passed
 - [ ] Static analysis pre-pass (if enabled)
 - [ ] Agents loaded and filtered
@@ -85,6 +86,23 @@ Priority order:
 | ≤200 | Proceed |
 | 201–500 | Warn: "Reviewing {N} files — consider `--path` to narrow scope." Proceed. |
 | >500 | Warn + confirm: "Reviewing {N} files is expensive. Continue?" Wait. |
+
+**Documentation-only short-circuit.** After the target set is known, classify each file. A file is **documentation** when it matches a doc type or path:
+
+- extension `.md`, `.mdx`, `.markdown`, `.rst`, `.txt`, `.adoc`
+- any path under a `docs/` directory
+- a root doc: `README*`, `CHANGELOG*`, `CONTRIBUTING*`, `LICENSE*`, `NOTICE*`, `AUTHORS*`, `CODE_OF_CONDUCT*`
+
+…**except functional Claude-config markdown, which is never documentation** (it drives agent/skill/command behavior and must be reviewed): any path containing a `.claude/` segment, or under `agents/`, `skills/`, `commands/`, `prompts/`, `knowledge/`, or `templates/agents/`. Treat `CLAUDE.md` and `AGENTS.md` as functional config too, not documentation.
+
+If **every** target file is documentation, short-circuit:
+
+1. Emit: `Documentation-only changeset ({N} files) — skipping code review. Re-run with --force --reason "<text>" to review anyway.`
+2. If the review was auto-scoped to uncommitted changes, write the `.review-passed` gate file (per step 9) so the pre-commit hook allows the commit.
+3. In `--json` mode, emit `{"status": "skipped", "reason": "documentation-only", "files": [<list>]}` instead.
+4. **Stop.** Do not run pre-flight gates, static analysis, or any agent.
+
+**Bypass:** the short-circuit does **not** apply when `--force` (with `--reason`), `--agent <name>`, or `--background` is set — those run as normal. `--background` (drift review) deliberately reviews documentation, so it is never short-circuited.
 
 ### 1b. Check for institutional context
 

--- a/plugins/dev-team/commands/code-review.md
+++ b/plugins/dev-team/commands/code-review.md
@@ -102,7 +102,7 @@ If **every** target file is documentation, short-circuit:
 3. In `--json` mode, emit `{"status": "skipped", "reason": "documentation-only", "files": [<list>]}` instead.
 4. **Stop.** Do not run pre-flight gates, static analysis, or any agent.
 
-**Bypass:** the short-circuit does **not** apply when `--force` (with `--reason`), `--agent <name>`, or `--background` is set — those run as normal. `--background` (drift review) deliberately reviews documentation, so it is never short-circuited.
+**Bypass:** the short-circuit does **not** apply with `--force` (with `--reason`), `--agent <name>`, or `--background` (drift review always inspects docs).
 
 ### 1b. Check for institutional context
 

--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -34,8 +34,10 @@ flowchart TD
     B --> C{Auto-scope}
     C -->|dirty tree| D1[Uncommitted files]
     C -->|clean tree| D2[Full repo]
-    D1 --> E[1b. REVIEW-CONTEXT.md]
-    D2 --> E
+    D1 --> DC{1a. All files docs-only?}
+    D2 --> DC
+    DC -->|yes — no --force/--agent/--background| SC[Short-circuit: notice +<br/>write .review-passed if auto-scoped + stop]
+    DC -->|no| E[1b. REVIEW-CONTEXT.md]
     E --> F[1c. Probe MCP tools]
     F --> G[2. Pre-flight gates]
     G -->|fail| X1[Stop — no agents run]
@@ -69,6 +71,12 @@ Auto-scope (the default) runs `git diff --name-only` plus `git diff --cached --n
 | 201–500 | Warn, proceed |
 | > 500 | Warn and request confirmation |
 
+### 1a. Documentation-only short-circuit
+
+After the target set is known, if **every** file is documentation, `/code-review` short-circuits: it emits `Documentation-only changeset — skipping code review`, writes the `.review-passed` gate file when auto-scoped to uncommitted changes (so the commit isn't blocked), and stops before any gate or agent runs. In `--json` mode it emits `{"status": "skipped", "reason": "documentation-only"}`.
+
+Documentation = `.md`/`.mdx`/`.rst`/`.txt`/`.adoc`, `docs/**`, and root docs (`README*`, `CHANGELOG*`, `LICENSE*`, …) — **except functional Claude-config markdown** (`.claude/**`, `agents/`, `skills/`, `commands/`, `prompts/`, `knowledge/`, `templates/agents/`, `CLAUDE.md`, `AGENTS.md`), which is always reviewed. `--force --reason`, `--agent`, and `--background` bypass the short-circuit.
+
 ### 1b. Institutional context
 
 If `REVIEW-CONTEXT.md` exists at the repo root, its contents are read and passed to every agent as "Institutional context provided for this review". This is where a team records domain knowledge, related services, known quirks, or architectural history that agents cannot discover from code alone. The file is optional.
@@ -89,7 +97,7 @@ Deterministic checks run before any AI agent is invoked. Cheaper checks block ex
 | 4 | Semgrep SAST | `semgrep scan --config auto` | ERROR-severity findings |
 | 5 | Pipeline-red check | `gh run list` on current branch | failing CI (warn only) |
 
-Missing tools are skipped silently. Gate failures stop the pipeline — no agents run. `--force --reason "<text>"` skips all gates and logs an entry to `metrics/override-audit.jsonl`. `--background` skips gates entirely.
+Missing tools are skipped silently. Gate failures stop the pipeline — no agents run. `--force --reason "<text>"` skips all gates (and the step-1a documentation-only short-circuit) and logs an entry to `metrics/override-audit.jsonl`. `--background` skips gates entirely.
 
 ### 2b. Static analysis pre-pass
 


### PR DESCRIPTION
## Summary
- `/code-review` now **short-circuits documentation-only changesets** — emits a notice, writes the `.review-passed` gate (so the commit isn't blocked), and skips pre-flight gates, static analysis, and all agents.
- "Documentation" = `.md`/`.mdx`/`.rst`/`.txt`/`.adoc`, `docs/**`, and root docs (README/CHANGELOG/LICENSE/…), **except functional Claude-config markdown** (`.claude/**`, `agents/`, `skills/`, `commands/`, `prompts/`, `knowledge/`, `templates/agents/`, `CLAUDE.md`, `AGENTS.md`), which is always reviewed — so agent/skill/command edits in plugin repos still get reviewed.
- Bypass: `--force --reason`, `--agent`, and `--background` run as normal.

## Quality Gate
- [x] Tests: N/A — no suite covers dev-team markdown; the repo's CI (`plugin-tests.yml`: shellcheck + security-assessment shell tests) is unaffected by this change.
- [x] Type check: N/A
- [x] Lint: N/A (markdown; no markdownlint gate configured)
- [x] Code review: ran `claude-setup-review`, `doc-review`, `token-efficiency-review`. One actionable finding — the pipeline doc (`code-review-process.md`) was stale — **fixed** (Mermaid step 1a + prose + `--force` note). Token-efficiency tightening applied. Pre-existing `commands/review.md` alias drift (argument-hint, allowed-tools) left **out of scope** — not introduced here.

## Test Plan
- [ ] Run `/code-review` on a branch whose diff is only `README.md` / `docs/**` → expect "Documentation-only changeset — skipping code review" and a written `.review-passed`.
- [ ] Run `/code-review` on a diff touching `skills/**` or `CLAUDE.md` → expect a normal full review (not short-circuited).
- [ ] Run `/code-review --force --reason "audit"` on a doc-only diff → expect a full review.
- [ ] Mixed diff (one `.md` doc + one `.py`) → expect a normal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
