### PR TITLE
fix(dev-team): sync /review alias frontmatter with /code-review (#88)

### DIFF
--- a/plugins/dev-team/commands/code-review.md
+++ b/plugins/dev-team/commands/code-review.md
@@ -7,8 +7,9 @@ description: >-
   agents", or has just finished implementing a feature. Use proactively
   before commits and pull requests.
 argument-hint: >-
-  [--agent <name>] [--since <ref>] [--path <dir>] [--all]
-  [--json] [--force]
+  [--agent <name>] [--since <ref>] [--path <dir>] [--all] [--json]
+  [--force --reason "<text>"] [--static-analysis|--no-static-analysis]
+  [--init-risks] [--background]
 user-invocable: true
 allowed-tools: >-
   Read, Edit, Grep, Glob, AskUserQuestion,

--- a/plugins/dev-team/commands/review.md
+++ b/plugins/dev-team/commands/review.md
@@ -6,19 +6,28 @@ description: >-
   code, says "review my code", "check this before I PR", "what's wrong with
   this", "run the agents", or has just finished implementing a feature.
 argument-hint: >-
-  [--agent <name>] [--since <ref>] [--path <dir>] [--all]
-  [--json] [--force]
+  [--agent <name>] [--since <ref>] [--path <dir>] [--all] [--json]
+  [--force --reason "<text>"] [--static-analysis|--no-static-analysis]
+  [--init-risks] [--background]
 user-invocable: true
 allowed-tools: >-
-  Read, Grep, Glob, Bash(git diff *), Bash(npx *), Bash(npm run *),
+  Read, Edit, Grep, Glob, AskUserQuestion,
+  Bash(git diff *), Bash(npx *), Bash(npm run *),
   Bash(pnpm *), Bash(yarn *), Bash(tsc *), Bash(eslint *),
   Bash(git log *), Bash(gh run *), Bash(semgrep *),
-  Skill(review-agent *)
+  Bash(pylint *), Skill(review-agent *)
 ---
 
 # Review (alias)
 
 This is an alias for `/code-review`. Read and follow
 `commands/code-review.md` with all arguments passed through.
+
+> **Keep frontmatter in sync.** This alias delegates the entire `/code-review`
+> flow, so its `allowed-tools` and `argument-hint` MUST mirror
+> `commands/code-review.md`. `allowed-tools` is an allowlist — omitting a tool
+> the canonical command needs (e.g. `Edit` for the fix loop, `AskUserQuestion`
+> for the fix/report prompt, `Bash(pylint *)` for Python lint) silently breaks
+> that capability under `/review`.
 
 Arguments: $ARGUMENTS


### PR DESCRIPTION
## Summary
- Fixes a functional gap in the `/review` alias: `commands/review.md` `allowed-tools` was missing `Edit`, `AskUserQuestion`, and `Bash(pylint *)`. Because `/review` delegates the full `/code-review` flow and `allowed-tools` is an **allowlist**, `/review` could not apply fixes (`Edit`), show the "fix or report?" prompt (`AskUserQuestion`), or run pylint.
- Synced `review.md` `allowed-tools` to match `code-review.md` exactly.
- Completed the `argument-hint` in **both** files — `--reason`, `--static-analysis`/`--no-static-analysis`, `--init-risks`, and `--background` were undocumented.
- Added a "keep frontmatter in sync" note to `review.md` so the allowlist can't silently drift again.

## Quality Gate
- [x] Tests: N/A — no suite covers dev-team command markdown; repo CI (shellcheck + security-assessment) unaffected.
- [x] Type check / Lint: N/A (markdown)
- [x] Structural: `allowed-tools` and `argument-hint` now byte-identical across both files (verified); frontmatter parses; change is purely additive (no sections removed).

## Test Plan
- [ ] Invoke `/review` on a branch with actionable findings → the fix/report prompt appears and fixes apply (previously blocked by the missing `Edit`/`AskUserQuestion`).
- [ ] `/review --reason` shows in the hint; `/review --background` and `/review --init-risks` documented.
- [ ] `/agent-audit` passes.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
