### PR TITLE
feat(dev-team): automate test-layer-gates fixture as an agent-eval (#85)

### DIFF
--- a/evals/expected/tlg-01-pure-function.json
+++ b/evals/expected/tlg-01-pure-function.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-01-pure-function",
+  "description": "Pure function (format currency) — no behavior pre-gate should fire; Step 2 unit pick stands",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": [],
+      "expectedLayers": ["unit"],
+      "mustMention": ["unit"],
+      "mustNotMention": ["↑", "REQUIRED"]
+    }
+  }
+}

--- a/evals/expected/tlg-02-user-facing-dynamic.json
+++ b/evals/expected/tlg-02-user-facing-dynamic.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-02-user-facing-dynamic",
+  "description": "Gate A — user-facing dynamic; E2E recommended alongside lower layers with cost + amortization; E2E architecture deferred",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["A"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["E2E", "journey", "cd-test-architecture"],
+      "mustNotMention": ["REQUIRED"]
+    }
+  }
+}

--- a/evals/expected/tlg-03-browser-bug-fix.json
+++ b/evals/expected/tlg-03-browser-bug-fix.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-03-browser-bug-fix",
+  "description": "Gate B — bug found in the browser; regression anchored at the E2E discovery layer",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["B"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["E2E", "regression"],
+      "mustNotMention": ["REQUIRED"]
+    }
+  }
+}

--- a/evals/expected/tlg-04-unit-bug-fix.json
+++ b/evals/expected/tlg-04-unit-bug-fix.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-04-unit-bug-fix",
+  "description": "Gate B negative — bug found at the unit level; regression stays at unit, no escalation above the discovery layer",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["B"],
+      "expectedLayers": ["unit"],
+      "mustMention": ["unit", "regression"],
+      "mustNotMention": ["↑"]
+    }
+  }
+}

--- a/evals/expected/tlg-05-htmx-swap-mutation.json
+++ b/evals/expected/tlg-05-htmx-swap-mutation.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-05-htmx-swap-mutation",
+  "description": "Gate C — HTMX swap over a server state mutation; browser test REQUIRED, integration complementary, E2E architecture deferred",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["C"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["REQUIRED", "browser", "cd-test-architecture"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-06-alpine-toggle.json
+++ b/evals/expected/tlg-06-alpine-toggle.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-06-alpine-toggle",
+  "description": "Gate C structural — client-side Alpine swap, no server call; browser test REQUIRED for the structural seam",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["C"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["REQUIRED", "browser", "seam"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-07-pdf-with-reference.json
+++ b/evals/expected/tlg-07-pdf-with-reference.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-07-pdf-with-reference",
+  "description": "Gate D — visual artifact with a reference; approval (text) and/or screenshot (layout) with maintenance cost surfaced",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["D"],
+      "expectedLayers": ["unit"],
+      "mustMention": ["approval", "screenshot"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-08-email-no-reference.json
+++ b/evals/expected/tlg-08-email-no-reference.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-08-email-no-reference",
+  "description": "Gate D no-reference — visual artifact with no reference; falls back to manual review and suggests creating a reference",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["D"],
+      "expectedLayers": ["unit"],
+      "mustMention": ["manual", "reference"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-09-critical-single-layer.json
+++ b/evals/expected/tlg-09-critical-single-layer.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-09-critical-single-layer",
+  "description": "Redundancy check — business-critical behavior at one layer; flags single-layer coverage and names a second, different-failure-mode layer",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["redundancy"],
+      "expectedLayers": ["unit"],
+      "mustMention": ["failure mode", "second"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-10-multi-gate.json
+++ b/evals/expected/tlg-10-multi-gate.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-10-multi-gate",
+  "description": "Multi-gate A + B — user-facing dynamic AND browser-found bug fix; required layers unioned (E2E, no duplicate), each gate's cost listed once",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["A", "B"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["E2E", "regression"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/tlg-11-ambiguous.json
+++ b/evals/expected/tlg-11-ambiguous.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "tlg-11-ambiguous",
+  "description": "Ambiguity — dynamic-ness unclear; advisor states its assumption and asks once, never escalates silently",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["ambiguity"],
+      "expectedLayers": [],
+      "mustMention": ["assum", "ambiguous"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/fixtures/test-layer-gates.md
+++ b/evals/fixtures/test-layer-gates.md
@@ -3,7 +3,15 @@
 Verification fixture for the behavior pre-gates added to the `test-design-advisor` skill (issue #80).
 Each row is a behavior the advisor may be asked to design tests for, the gate(s) expected to fire, and the
 expected resulting layer(s). The Step 3 walk-through runs the advisor against each row and records
-actual == expected. This is the reviewer-rerunnable spec the gates are written to satisfy.
+actual == expected. This is the human-readable spec the gates are written to satisfy.
+
+> **Automated (issue #85).** This manual walk-through is now reproducible as an
+> agent-eval: the 11 rows are encoded as the `tlg-*` corpus
+> (`evals/fixtures/tlg-*.md` + `evals/expected/tlg-*.json`). Re-run with
+> `/agent-eval --skill test-design-advisor` instead of walking the table by hand.
+> A deterministic structural guard lives at `tests/repo/eval_tlg_fixtures.bats`.
+> This file remains the canonical row-by-row source of truth; the `tlg-*` corpus
+> mirrors it one-to-one (row N → `tlg-0N-*`).
 
 Layer vocabulary matches `knowledge/test-pyramid.md`: unit / integration / component / contract / E2E.
 Gate-column sentinels: `—` (no gate), `↑<layer>` (escalated), `→ cd-test-architecture` (E2E architecture deferred).

--- a/evals/fixtures/tlg-01-pure-function.md
+++ b/evals/fixtures/tlg-01-pure-function.md
@@ -1,0 +1,7 @@
+# Behavior to design tests for
+
+Format a currency amount from an integer number of cents into a display string —
+e.g. `1050` → `"$10.50"`, `0` → `"$0.00"`, negative values → `"-$1.00"`.
+
+This is a pure function: no I/O, no user interface, no persistence, no network.
+It takes a number and returns a string.

--- a/evals/fixtures/tlg-02-user-facing-dynamic.md
+++ b/evals/fixtures/tlg-02-user-facing-dynamic.md
@@ -1,0 +1,8 @@
+# Behavior to design tests for
+
+When the user clicks "Add to cart" on a product, the cart badge in the page
+header updates to show the new item count without a full page reload.
+
+The user performs an action and must *see* the correctly rendered result (the
+updated badge) in the browser. The flow runs through the front end, an API call,
+and a re-render of the header.

--- a/evals/fixtures/tlg-03-browser-bug-fix.md
+++ b/evals/fixtures/tlg-03-browser-bug-fix.md
@@ -1,0 +1,8 @@
+# Behavior to design tests for
+
+Bug fix. A logged-in user reported, **while using the app in the browser**, that
+the order discount shown at checkout is wrong: a 10%-off coupon applied to a $200
+order displays a $10 discount instead of $20.
+
+Reproduce the defect and add a regression test so it cannot recur. The bug was
+discovered in the browser at the checkout page.

--- a/evals/fixtures/tlg-04-unit-bug-fix.md
+++ b/evals/fixtures/tlg-04-unit-bug-fix.md
@@ -1,0 +1,8 @@
+# Behavior to design tests for
+
+Bug fix. An off-by-one error in the CSV row parser drops the last row of every
+file. The defect was **discovered while running the parser's unit tests** — a
+unit test exercising a 3-row file returned only 2 rows.
+
+Add a regression test that pins the corrected behavior. The bug was found at the
+unit level, in pure parsing logic with no UI and no I/O.

--- a/evals/fixtures/tlg-05-htmx-swap-mutation.md
+++ b/evals/fixtures/tlg-05-htmx-swap-mutation.md
@@ -1,0 +1,9 @@
+# Behavior to design tests for
+
+On the cart page, changing an item's quantity fires an **HTMX** `POST /cart/item`.
+The server writes the new quantity to the database, then returns an HTML fragment
+that HTMX swaps into the order-total element (`hx-target="#order-total"`,
+`hx-swap="outerHTML"`).
+
+The behavior spans a server-side state mutation **and** a client-side swap of the
+returned fragment into the DOM.

--- a/evals/fixtures/tlg-06-alpine-toggle.md
+++ b/evals/fixtures/tlg-06-alpine-toggle.md
@@ -1,0 +1,8 @@
+# Behavior to design tests for
+
+A product card has a "Show details" control wired with **Alpine.js**
+(`x-data="{ open: false }"`, `@click="open = !open"`, `x-show="open"`). Clicking
+it toggles a details panel's visibility entirely on the client.
+
+There is **no server call** — the behavior is a purely client-side dynamic swap
+of what the user sees.

--- a/evals/fixtures/tlg-07-pdf-with-reference.md
+++ b/evals/fixtures/tlg-07-pdf-with-reference.md
@@ -1,0 +1,7 @@
+# Behavior to design tests for
+
+Generate a printable **invoice PDF** from an order: line items, totals, tax,
+and a company header laid out to match a designer's spec.
+
+A **reference mockup** of the expected invoice layout exists (a signed-off design
+file). Correctness includes both the textual content and the visual layout.

--- a/evals/fixtures/tlg-08-email-no-reference.md
+++ b/evals/fixtures/tlg-08-email-no-reference.md
@@ -1,0 +1,7 @@
+# Behavior to design tests for
+
+Render a transactional **HTML email** template (order confirmation) from order
+data: greeting, item list, total, and a support footer.
+
+There is **no reference or mockup** for the expected output — nothing to compare
+the rendered email against. Correctness is currently a matter of visual judgment.

--- a/evals/fixtures/tlg-09-critical-single-layer.md
+++ b/evals/fixtures/tlg-09-critical-single-layer.md
@@ -1,0 +1,8 @@
+# Behavior to design tests for
+
+The **funds-transfer amount calculation** — debiting one account and crediting
+another, including fee and overdraft handling. This is **business-critical**:
+an error moves real money incorrectly.
+
+It is currently covered by **only a single unit test** of the calculation. The
+persistence and transaction boundary around it have no coverage.

--- a/evals/fixtures/tlg-10-multi-gate.md
+++ b/evals/fixtures/tlg-10-multi-gate.md
@@ -1,0 +1,9 @@
+# Behavior to design tests for
+
+Bug fix that is **also** user-facing dynamic behavior. A user reported, **in the
+browser**, that after applying a coupon code the displayed order total does not
+update — they must reload the page to see the discounted total. The total is
+meant to update live when the coupon is applied.
+
+Two signals are present at once: it is a **browser-discovered bug fix** and a
+**user-facing dynamic** behavior (the user acts and must see the total re-render).

--- a/evals/fixtures/tlg-11-ambiguous.md
+++ b/evals/fixtures/tlg-11-ambiguous.md
@@ -1,0 +1,9 @@
+# Behavior to design tests for
+
+The "Apply filter" control on the product listing updates the results to match
+the selected filters.
+
+The description does **not** say whether applying a filter is a client-side
+dynamic update (re-rendering results in place without a reload) or a full
+server-side round-trip that reloads the page. Whether a browser-level dynamic
+gate applies is genuinely unclear from this description alone.

--- a/plugins/dev-team/commands/agent-eval.md
+++ b/plugins/dev-team/commands/agent-eval.md
@@ -5,11 +5,11 @@ description: >-
   adding or modifying a review agent, to validate detection accuracy, or
   when the user says "run the evals", "test the agents", "check for
   regressions", or "how accurate is the agent".
-argument-hint: "[--agent <name>] [--fixture <name>] [--trials <n>] [--verbose]"
+argument-hint: "[--agent <name>] [--skill <name>] [--fixture <name>] [--trials <n>] [--verbose]"
 user-invocable: true
 allowed-tools: >-
   Read, Grep, Glob, Bash(readlink *, ls *, date *, mkdir *),
-  Skill(review-agent *)
+  Skill(review-agent *), Skill(test-design-advisor *)
 ---
 
 # Agent Eval
@@ -22,8 +22,9 @@ against eval fixtures and grade the results.
 
 ## Orchestrator constraints
 
-1. **Do not review code yourself.** Delegate all reviews to
-   `/review-agent`. Your job is dispatching and grading.
+1. **Do not review or design yourself.** Delegate reviews to
+   `/review-agent` and advisory analysis to the skill under eval (e.g.
+   `test-design-advisor`). Your job is dispatching and grading.
 2. **Grade deterministically.** Compare agent JSON output against
    expected JSON using exact criteria (status match, count ranges,
    keyword checks). Do not apply judgment.
@@ -39,8 +40,10 @@ against eval fixtures and grade the results.
 
 Arguments: $ARGUMENTS
 
-- `--agent <name>`: Run only the named agent
+- `--agent <name>`: Run only the named review agent
   (e.g., `js-fp-review`)
+- `--skill <name>`: Run only the named advisory skill
+  (e.g., `test-design-advisor`) against its skill fixtures
 - `--fixture <name>`: Run only the named fixture
   (e.g., `fp-array-mutations.ts`)
 - `--trials <n>`: Run each fixture N times (default: 1). Enables
@@ -65,15 +68,21 @@ For each fixture:
 - Match the fixture stem (filename without extension) to its
   expected JSON
 - For directory fixtures (cs-*), the directory name is the stem
-- Parse `applicableAgents` to know which agents to run
+- Parse `applicableAgents` (review-agent fixtures) and/or
+  `applicableSkills` (advisory-skill fixtures, e.g. the `tlg-*`
+  test-layer-gates corpus) to know what to dispatch. A fixture is an
+  **agent fixture**, a **skill fixture**, or both, depending on which
+  keys its expected JSON declares.
 
 If `--agent` is specified, filter to fixtures where that agent is in
 `applicableAgents`.
+If `--skill` is specified, filter to fixtures where that skill is in
+`applicableSkills`.
 If `--fixture` is specified, filter to that fixture only.
 
 ### 3. Run agents against fixtures
 
-For each fixture/agent pair:
+For each fixture/agent pair (agent fixtures):
 
 1. Invoke `/review-agent <agent-name>` with the fixture
    file/directory as the target
@@ -81,6 +90,17 @@ For each fixture/agent pair:
    `summary`
 3. If running multiple trials (`--trials`), repeat and collect all
    results
+
+For each fixture/skill pair (skill fixtures, e.g. `tlg-*`):
+
+1. Invoke the skill (e.g. `test-design-advisor`) with the fixture file
+   as the target — the fixture is a behavior description the advisor
+   designs tests for. Pass **only** the fixture file, never the
+   expected JSON.
+2. Capture the advisor's report text — specifically the *Pyramid
+   placement* table (the `Gate` column and recommended `Layer`(s)) and
+   the surrounding rationale.
+3. Repeat per `--trials` as above.
 
 ### 4. Grade each result
 
@@ -112,6 +132,25 @@ Compare agent output against expected JSON:
 - For each keyword in `mustNotMention`: no issue message contains
   keyword → PASS
 - Violation → FAIL
+
+**Skill fixtures (gate-firing grade):** for a fixture graded against a
+skill, compare the advisor's report (Step 3) to the `skills.<name>`
+block:
+
+- **Gate firing** — every gate in `expectedGates` is reflected in the
+  report's Gate column / rationale; when `expectedGates` is `[]`, the
+  report shows no escalation (Gate cell `—`, no `↑`). Match → PASS.
+- **Layer(s)** — every layer in `expectedLayers` appears in the
+  *Pyramid placement* recommendation; escalations only raise the layer,
+  never lower it. Match → PASS. (`expectedLayers: []` — e.g. the
+  ambiguity row — skips this check.)
+- **Keyword checks** — `mustMention` / `mustNotMention` are applied to
+  the **full advisor report text** (not `issues[]`, which skills don't
+  emit), case-insensitive substring, same PASS/FAIL rule as above.
+
+Grade deterministically: the `↑`, `REQUIRED`, `→ cd-test-architecture`,
+`approval`/`screenshot`, and `—` sentinels are literal — match them as
+written, do not paraphrase.
 
 Each check produces PASS/FAIL. Overall fixture grade: PASS only if
 all checks pass.

--- a/plugins/dev-team/docs/eval-system.md
+++ b/plugins/dev-team/docs/eval-system.md
@@ -170,7 +170,8 @@ evals/
 │   ├── dm-*.ts         # domain-review (5 files)
 │   ├── te-*.md/.ts     # token-efficiency-review (5 files)
 │   ├── sv-*.svelte.ts  # svelte-review (8 files)
-│   └── cs-*/           # claude-setup-review (4 directories)
+│   ├── cs-*/           # claude-setup-review (4 directories)
+│   └── tlg-*.md        # test-design-advisor behavior pre-gates (11 files)
 ├── expected/           # Reference solutions (checked in)
 │   └── <fixture-stem>.json
 ├── transcripts/        # Auto-created by runner (gitignored)
@@ -199,13 +200,45 @@ severity ranges, and keyword checks.
 }
 ```
 
+### Advisory-skill fixtures (gate firing)
+
+Most fixtures grade a **review agent** by its `status/issues[]` JSON. Advisory
+skills (e.g. `test-design-advisor`) don't emit that shape — they emit a report
+with a *Pyramid placement* table. The `tlg-*` corpus grades the skill's
+**behavior pre-gates** (issue #80) by declaring `applicableSkills` and a `skills`
+block instead of `applicableAgents`/`agents`:
+
+```json
+{
+  "fixture": "tlg-05-htmx-swap-mutation",
+  "description": "Gate C — HTMX swap over a server state mutation",
+  "applicableSkills": ["test-design-advisor"],
+  "skills": {
+    "test-design-advisor": {
+      "expectedGates": ["C"],
+      "expectedLayers": ["E2E"],
+      "mustMention": ["REQUIRED", "browser", "cd-test-architecture"],
+      "mustNotMention": []
+    }
+  }
+}
+```
+
+`/agent-eval` drives the skill against each fixture and grades the Gate column +
+recommended layers + keyword checks (see the command's Step 4). This replaces the
+manual walk-through that `evals/fixtures/test-layer-gates.md` recorded for #80 —
+re-run it with `/agent-eval --skill test-design-advisor`. `expectedGates` uses the
+gate vocabulary `A`/`B`/`C`/`D`/`redundancy`/`ambiguity` (or `[]` for "no gate
+fires"); `expectedLayers` uses the `test-pyramid.md` vocabulary.
+
 ### `/agent-eval` command
 
-Run agents against fixtures and grade results:
+Run agents and skills against fixtures and grade results:
 
 ```bash
-/agent-eval                                  # run all agents against all fixtures
-/agent-eval --agent js-fp-review             # run one agent
+/agent-eval                                  # run everything against all fixtures
+/agent-eval --agent js-fp-review             # run one review agent
+/agent-eval --skill test-design-advisor      # run the gate-firing (tlg-*) corpus
 /agent-eval --fixture fp-array-mutations.ts  # run one fixture
 /agent-eval --trials 3                       # multi-trial with pass@k scoring
 ```

--- a/tests/repo/eval_tlg_fixtures.bats
+++ b/tests/repo/eval_tlg_fixtures.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# #85: the test-layer-gates eval corpus (tlg-*) is structurally well-formed —
+# 1:1 fixture<->expected pairing, valid skill schema, valid gate/layer vocab.
+# Deterministic structural guard; behavioral gate-firing is graded by
+# /agent-eval --skill test-design-advisor (model-judged).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+FIXTURES="$REPO_ROOT/evals/fixtures"
+EXPECTED="$REPO_ROOT/evals/expected"
+
+@test "tlg: there are 11 fixtures (one per #80 gate row)" {
+  run bash -c "ls \"$FIXTURES\"/tlg-*.md | wc -l | tr -d ' '"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 11 ]
+}
+
+@test "tlg: every fixture has a matching expected JSON" {
+  for f in "$FIXTURES"/tlg-*.md; do
+    stem=$(basename "$f" .md)
+    [ -f "$EXPECTED/$stem.json" ] || { echo "missing expected: $stem.json" >&2; return 1; }
+  done
+}
+
+@test "tlg: every expected JSON has a matching fixture" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    stem=$(basename "$e" .json)
+    [ -f "$FIXTURES/$stem.md" ] || { echo "missing fixture: $stem.md" >&2; return 1; }
+  done
+}
+
+@test "tlg: every expected JSON parses and declares the advisor skill" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    run jq -e '.applicableSkills | index("test-design-advisor")' "$e"
+    [ "$status" -eq 0 ] || { echo "not a test-design-advisor skill fixture: $e" >&2; return 1; }
+  done
+}
+
+@test "tlg: fixture field matches the file stem" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    stem=$(basename "$e" .json)
+    run jq -re '.fixture' "$e"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$stem" ] || { echo "fixture field mismatch in $e: $output != $stem" >&2; return 1; }
+  done
+}
+
+@test "tlg: skills block has the required array fields" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    run jq -e '
+      .skills["test-design-advisor"] as $s
+      | ($s.expectedGates | type == "array")
+        and ($s.expectedLayers | type == "array")
+        and ($s.mustMention | type == "array")
+        and ($s.mustNotMention | type == "array")
+    ' "$e"
+    [ "$status" -eq 0 ] || { echo "bad skills block: $e" >&2; return 1; }
+  done
+}
+
+@test "tlg: expectedGates use the gate vocabulary" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    run jq -e '
+      .skills["test-design-advisor"].expectedGates
+      | all(. as $g | ["A","B","C","D","redundancy","ambiguity"] | index($g))
+    ' "$e"
+    [ "$status" -eq 0 ] || { echo "invalid gate value in $e" >&2; return 1; }
+  done
+}
+
+@test "tlg: expectedLayers use the test-pyramid vocabulary" {
+  for e in "$EXPECTED"/tlg-*.json; do
+    run jq -e '
+      .skills["test-design-advisor"].expectedLayers
+      | all(. as $l | ["unit","integration","component","contract","E2E"] | index($l))
+    ' "$e"
+    [ "$status" -eq 0 ] || { echo "invalid layer value in $e" >&2; return 1; }
+  done
+}
+
+@test "tlg: all four behavior gates (A,B,C,D) plus redundancy and ambiguity are represented" {
+  run bash -c "cat \"$EXPECTED\"/tlg-*.json | jq -r '.skills[\"test-design-advisor\"].expectedGates[]' | sort -u | tr '\n' ' '"
+  [ "$status" -eq 0 ]
+  for g in A B C D redundancy ambiguity; do
+    [[ "$output" == *"$g"* ]] || { echo "gate not represented in corpus: $g" >&2; return 1; }
+  done
+}


### PR DESCRIPTION
Closes #85. Follow-on to #80 — automates the manual gate-firing walk-through so regressions are caught without hand re-runs.

## What changed

- **`tlg-*` eval corpus** — the 11 rows of `evals/fixtures/test-layer-gates.md` are now `evals/fixtures/tlg-*.md` (behavior descriptions) + `evals/expected/tlg-*.json`. Negatives are covered: pure-fn silence (no gate), unit-found-bug non-escalation (Gate B negative), multi-gate A+B union, and ambiguity → ask.
- **New `applicableSkills` schema** for advisory-skill fixtures (skills emit a Gate-column report, not `status/issues[]`):
  ```json
  "applicableSkills": ["test-design-advisor"],
  "skills": { "test-design-advisor": {
    "expectedGates": ["C"], "expectedLayers": ["E2E"],
    "mustMention": ["REQUIRED","browser","cd-test-architecture"], "mustNotMention": []
  }}
  ```
- **`/agent-eval` skill-eval track** — `--skill` filter, dispatches `test-design-advisor` against each fixture, grades the Gate column + recommended layers + keyword checks. Re-run the whole #80 walk-through with `/agent-eval --skill test-design-advisor`.
- **Deterministic guard** — `tests/repo/eval_tlg_fixtures.bats` (9 tests): 1:1 fixture↔expected pairing, schema fields, valid gate/layer vocab, all gates (A/B/C/D/redundancy/ambiguity) represented.
- **Docs** — `eval-system.md` documents the advisory-skill track; the #80 fixture now points at the automated corpus (kept as the canonical row-by-row spec).

## Two-layer verification (per the eval-system design)

- **Structural / deterministic** — `tests/repo/eval_tlg_fixtures.bats`, runs in the repo bats suite. ✅ 9/9 pass locally (full `tests/repo` suite: 44/44).
- **Behavioral / model-judged** — `/agent-eval --skill test-design-advisor` drives the advisor and grades gate firings (Layer 2 of the eval system). Gate-firing of an LLM skill can't be graded without running the LLM, so this is the right layer for it.

Relates to #80, epic #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)