### PR TITLE
feat(dev-team): xUnit testing knowledge build-out (#73 #74 #75 #76)

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -47,7 +47,7 @@ Full registry tables with token counts, model tiers, and used-by mappings are in
 
 **Subagent prompt templates** (8): `prompts/implementer.md`, `prompts/spec-reviewer.md`, `prompts/quality-reviewer.md`, `prompts/plan-reviewer.md`, `prompts/plan-review-acceptance.md`, `prompts/plan-review-design.md`, `prompts/plan-review-ux.md`, `prompts/plan-review-strategic.md`
 
-**Knowledge files** (21 + 3 collections): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns, test-smells, test-doubles, test-pyramid, test-strategy, microservice-testing, cd-test-architecture, component-test-patterns, test-layer-gates, testing-quadrants, test-automation-maturity; collections: `test-matrix-examples/`, `testing-techniques/`, `test-stack-profiles/`
+**Knowledge files** (25 + 3 collections): agent-registry, review-template, review-rubric, owasp-detection, domain-modeling, architecture-assessment, exploratory-testing-field-guide, adversarial-review-protocol, design-smells, object-calisthenics, testability-patterns, test-smells, test-doubles, test-pyramid, test-strategy, fixture-construction, result-verification, test-organization, test-refactoring, microservice-testing, cd-test-architecture, component-test-patterns, test-layer-gates, testing-quadrants, test-automation-maturity; collections: `test-matrix-examples/`, `testing-techniques/`, `test-stack-profiles/`
 
 **Agent templates** (9): ts-enforcer, esm-enforcer, react-testing, front-end-testing, twelve-factor-audit, python-quality, go-quality, csharp-quality, angular-testing (in `templates/agents/`, scaffolded by `/setup`)
 

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -26,6 +26,8 @@ Read `knowledge/testability-patterns.md` before analysis. Whole-file load: the a
 
 For maintainability findings (duplicated selectors/literals, UI-based setup), consult `knowledge/test-automation-maturity.md` — apply its single-point-of-change check and graduated-disclosure thresholds (don't recommend abstraction below the count threshold).
 
+For assertion-quality findings, consult `knowledge/result-verification.md` — name the specific verification pattern (Expected Object, Custom Assertion, Guard Assertion, Delta Assertion) that fixes a weak/cluttered/misleading assertion, and enforce one logical condition per test.
+
 ## Skills
 
 Whole-file load: each linked SKILL.md is loaded in full when invoked.

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -33,6 +33,10 @@ Load on demand by finding type — do not load all four unless the target needs 
 - `knowledge/test-pyramid.md` — layer responsibilities and shape anti-patterns. Load when judging test level.
 - `knowledge/microservice-testing.md` — contract/CDC testing. Load only when the target spans independently-deployable services.
 - `knowledge/testability-patterns.md` — load when a smell's root cause is untestable production code (recommend the production-code change, never a test workaround).
+- `knowledge/fixture-construction.md` — the named remedy for fixture smells (Mystery Guest, General Fixture, Irrelevant Information, setup duplication): Creation Method / Test Data Builder / Object Mother, Automated Teardown.
+- `knowledge/result-verification.md` — the named remedy for assertion smells (Assertion Roulette, Hard-Coded Values, fragile/overspecified asserts): Expected Object, Custom Assertion, Guard Assertion, Delta Assertion.
+- `knowledge/test-organization.md` — the named remedy for structure smells (Obscure Test, Test Code Duplication, High Test Maintenance Cost): Four-Phase Test, Testcase Class per Fixture, Test Utility Method, Parameterized Test.
+- `knowledge/test-refactoring.md` — the goals/principles a smell violates and the behavior-preserving move toward the target pattern. Cite a **named refactoring**, not prose, for each remedy.
 
 ## Skip
 
@@ -51,11 +55,11 @@ Always read `knowledge/test-smells.md` first; report each finding by its named s
 
 Code smells (single test):
 
-- **Obscure Test** — behavior under test not statable from the test alone; sub-types: **Eager Test** (many behaviors/asserts in one method), **Mystery Guest** (depends on external data the test doesn't create), **General Fixture** (shared setup builds more than the test needs), **Irrelevant Information** (setup exposes values that don't affect the assertion)
-- **Assertion Roulette** — multiple bare assertions, no messages, failure can't be localized
+- **Obscure Test** — behavior under test not statable from the test alone; sub-types: **Eager Test** (many behaviors/asserts in one method), **Mystery Guest** (depends on external data the test doesn't create), **General Fixture** (shared setup builds more than the test needs), **Irrelevant Information** (setup exposes values that don't affect the assertion). *Remedy:* Four-Phase structure (`test-organization.md`); Mystery Guest/General Fixture/Irrelevant Information → a Creation Method / Minimal Fixture (`fixture-construction.md`); Eager Test → Split Test (`test-refactoring.md`)
+- **Assertion Roulette** — multiple bare assertions, no messages, failure can't be localized. *Remedy:* Expected Object / Custom Assertion (`result-verification.md`)
 - **Conditional Test Logic** — `if`/`switch`/loops/try-catch around assertions; the test verifies different things on different runs
-- **Hard-Coded / Magic Values** in assertions with no stated meaning
-- **Test Code Duplication** — copy-pasted arrange/assert blocks that should be a builder or custom assertion (not two genuinely different boundary cases)
+- **Hard-Coded / Magic Values** in assertions with no stated meaning. *Remedy:* name/derive the expected value; Expected Object (`result-verification.md`)
+- **Test Code Duplication** — copy-pasted arrange/assert blocks that should be a builder or custom assertion (not two genuinely different boundary cases). *Remedy:* Test Data Builder / Extract Creation Method (`fixture-construction.md`), Custom Assertion (`result-verification.md`), or Test Utility Method (`test-organization.md`)
 - **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code (distinct from a *test* using Back Door Manipulation to reach SUT-owned state — see `knowledge/test-strategy.md`; only the production-code form is a smell)
 
 Behavior smells (only visible on run):
@@ -66,7 +70,7 @@ Behavior smells (only visible on run):
 
 Project smells (suite-wide):
 
-- **Buggy Tests** (pass when code is broken — recommend mutation testing), **Manual Intervention** (human step needed to run), **High Test Maintenance Cost**, **Production Bugs** slipping a green suite
+- **Buggy Tests** (pass when code is broken — recommend mutation testing), **Manual Intervention** (human step needed to run), **High Test Maintenance Cost** (*remedy:* Test Utility Method / Parameterized Test / Testcase Class per Fixture — `test-organization.md`), **Production Bugs** slipping a green suite
 
 Test double misuse (load `knowledge/test-doubles.md`):
 

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -128,6 +128,10 @@ Knowledge files in `knowledge/` provide progressive disclosure — agents read t
 | Test Doubles | `knowledge/test-doubles.md` | ~700 | test-smell-review, test-design-advisor |
 | Test Pyramid | `knowledge/test-pyramid.md` | ~800 | test-smell-review, test-review, test-design-advisor, test-health |
 | Test Strategy | `knowledge/test-strategy.md` | ~900 | test-design-advisor, test-smell-review, test-review |
+| Fixture Construction | `knowledge/fixture-construction.md` | ~750 | test-design-advisor, test-smell-review, test-review |
+| Result Verification | `knowledge/result-verification.md` | ~700 | test-design-advisor, test-review, test-smell-review |
+| Test Organization | `knowledge/test-organization.md` | ~750 | test-design-advisor, test-smell-review |
+| Test Refactoring | `knowledge/test-refactoring.md` | ~750 | test-design-advisor, test-smell-review |
 | Microservice Testing | `knowledge/microservice-testing.md` | ~700 | test-smell-review, test-design-advisor |
 | CD Test Architecture | `knowledge/cd-test-architecture.md` | ~1,100 | cd-test-architecture, test-design-advisor |
 | Component Test Patterns | `knowledge/component-test-patterns.md` | ~1,600 | cd-test-architecture |

--- a/plugins/dev-team/knowledge/fixture-construction.md
+++ b/plugins/dev-team/knowledge/fixture-construction.md
@@ -1,0 +1,56 @@
+# Fixture Construction
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. Where `test-strategy.md` decides *which* fixture (lifecycle Fresh/Shared, design Minimal/Standard), this file covers *how* the fixture is built and disposed — the construction mechanics that realize that strategy and fix fixture smells at the root.
+
+Source: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com) — Fixture Setup + Fixture Teardown pattern families. Language- and framework-agnostic — described by role, not any library's API.
+
+Core principle: **build only what this test needs, through intent-revealing construction, and release everything the test created.** Hide irrelevant detail; surface what matters to the behavior under test.
+
+---
+
+## 1. Construction patterns (how the fixture object is built)
+
+| Pattern | What it is | Use when | Cost / risk |
+|---|---|---|---|
+| **Creation Method** | An intent-revealing factory that builds *and returns* the fixture (`anOverdueAccount()`), hiding irrelevant constructor detail | **Default.** Removes Irrelevant Information and Test Code Duplication | — (the safe first move) |
+| **Test Data Builder** | A fluent builder with sensible defaults; each test overrides only the attribute that matters (`anAccount().overdrawn().build()`) | Objects with many attributes, where tests vary one or two | Slightly more code than a Creation Method; worth it past a few variations |
+| **Object Mother** | A library of *named canonical* fixtures shared across tests (`Customers.goldTier()`) | A small set of genuinely shared, well-understood standard cases | Tends to grow into a **General Fixture** — each test gets more than it needs; keep it minimal |
+
+**Decision:** Creation Method by default → Test Data Builder when attributes vary per test → Object Mother only for a few genuinely canonical cases. Prefer building through the SUT's public API; if the fixture cannot be constructed that way, that is a **production-code** problem — introduce a seam per `testability-patterns.md`, never reflection or `InternalsVisibleTo`.
+
+---
+
+## 2. Setup location (where construction runs)
+
+| Location | What it is | Trade-off vs Fresh Fixture isolation |
+|---|---|---|
+| **In-line Setup** | Each test builds its own fixture in the test body | Maximum clarity & isolation; duplication if many tests share shape → extract a Creation Method |
+| **Delegated Setup** | Tests call shared Creation Methods, but from the test body | Removes duplication while keeping each test's setup explicit — usually the sweet spot |
+| **Implicit Setup** | A per-test hook (`setUp`/`beforeEach`) builds the fixture for every test in the class | Concise, but can drift into **General Fixture**/**Mystery Guest** if it builds more than some tests use |
+| **Lazy Setup** | The fixture is created on first use and memoized | Useful for an expensive read-only fixture; risks shared mutable state if not truly read-only |
+| **SuiteFixture Setup** | One fixture built once per *suite* of classes | Last resort for very expensive setup; couples tests across classes — pairs with an Immutable Shared Fixture only |
+
+Keep setup **Fresh + Minimal** by default (`test-strategy.md`); each step toward Implicit/Lazy/SuiteFixture trades isolation for speed and must be justified.
+
+---
+
+## 3. Teardown (releasing what the test created)
+
+| Pattern | What it is | Use when |
+|---|---|---|
+| **In-line Teardown** | The test releases its own resources at the end | Few resources, simple lifetimes |
+| **Implicit Teardown** | A per-test hook (`tearDown`/`afterEach`) releases the fixture | Several tests share the same cleanup shape |
+| **Automated Teardown** | The fixture layer *registers* everything created and releases it automatically after each test | **Persistent fixtures** (DB rows, files, queues) — prevents resource leakage / **Erratic Test** without per-test cleanup code |
+
+For any fixture that touches persistent state, recommend **Automated Teardown** (or equivalent) so a failing test can't leak state into the next — the root fix for the resource-leakage form of the Erratic Test smell.
+
+---
+
+## How this connects to the rest of the toolkit
+
+- **`test-strategy.md`** — *which* fixture (lifecycle/design); this file is *how* it's constructed.
+- **`test-smells.md`** — the smells these fix: Mystery Guest & General Fixture & Irrelevant Information & Test Code Duplication (construction), resource-leakage Erratic Test (teardown).
+- **`testability-patterns.md`** — the production seams (DI, interface extraction) that let a built fixture be injected without back doors.
+- **`test-doubles.md`** — a Fake (in-memory repo/DB) is itself a constructed fixture; choose the double there.
+- **`test-organization.md`** — Setup and Teardown are the first and last of the Four-Phase Test.
+- **`test-refactoring.md`** — the behavior-preserving moves (Extract Creation Method, Introduce Test Data Builder, Replace General Fixture with Minimal Fixture) that get an existing test here.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -371,6 +371,24 @@
       "anchor": "5-implicit-expectations"
     }
   },
+  "plugins/dev-team/knowledge/fixture-construction.md": {
+    "1. Construction patterns (how the fixture object is built)": {
+      "summary": "| Pattern | What it is | Use when | Cost / risk |",
+      "anchor": "1-construction-patterns-how-the-fixture-object-is-built"
+    },
+    "2. Setup location (where construction runs)": {
+      "summary": "| Location | What it is | Trade-off vs Fresh Fixture isolation |",
+      "anchor": "2-setup-location-where-construction-runs"
+    },
+    "3. Teardown (releasing what the test created)": {
+      "summary": "| Pattern | What it is | Use when |",
+      "anchor": "3-teardown-releasing-what-the-test-created"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "**`test-strategy.md`** — *which* fixture (lifecycle/design); this file is *how* it's constructed.",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
+    }
+  },
   "plugins/dev-team/knowledge/microservice-testing.md": {
     "The Layers (per service)": {
       "summary": "| Layer | Scope | What it verifies | Doubles |",
@@ -479,6 +497,24 @@
     "A10: SSRF": {
       "summary": "| Pattern | Language | Grep Signal |",
       "anchor": "a10-ssrf"
+    }
+  },
+  "plugins/dev-team/knowledge/result-verification.md": {
+    "Verification style: state vs behavior": {
+      "summary": "| Style | What it checks | Use when |",
+      "anchor": "verification-style-state-vs-behavior"
+    },
+    "Assertion patterns": {
+      "summary": "| Pattern | What it is | Use when | Fixes |",
+      "anchor": "assertion-patterns"
+    },
+    "Rules": {
+      "summary": "**One logical condition per test.** Several unrelated assertions in one method is an Eager Test — split it (`test-organization.md` / `test-refactoring.md`).",
+      "anchor": "rules"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "**`test-smells.md`** — the smells these fix: Assertion Roulette, Obscure Test, Fragile/Overspecified Test, Hard-Coded Values.",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
     }
   },
   "plugins/dev-team/knowledge/review-rubric.md": {
@@ -661,6 +697,32 @@
       "anchor": "redundancy-check-business-critical-only-after-placement"
     }
   },
+  "plugins/dev-team/knowledge/test-organization.md": {
+    "The Four-Phase Test (the anchor)": {
+      "summary": "Every test follows four phases, visibly separated:",
+      "anchor": "the-four-phase-test-the-anchor"
+    },
+    "Testcase Class grouping": {
+      "summary": "| Grouping | One class per… | Use when | Trade-off |",
+      "anchor": "testcase-class-grouping"
+    },
+    "Sharing logic: composition over inheritance": {
+      "summary": "| Mechanism | What it is | Use when |",
+      "anchor": "sharing-logic-composition-over-inheritance"
+    },
+    "Parameterized Test": {
+      "summary": "When several test methods differ only by input/expected **data**, collapse them into a **Parameterized Test** — one test logic over many data rows.",
+      "anchor": "parameterized-test"
+    },
+    "Test Discovery / Enumeration / Selection + naming": {
+      "summary": "The runner finds tests by **Test Discovery** (convention/annotation), builds a **Test Enumeration**, and runs a selected subset.",
+      "anchor": "test-discovery-enumeration-selection-naming"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "**`fixture-construction.md`** — the Setup/Teardown phases.",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
+    }
+  },
   "plugins/dev-team/knowledge/test-pyramid.md": {
     "The Layers": {
       "summary": "| Layer | Scope | Speed | Doubles | What it proves |",
@@ -689,6 +751,24 @@
     "Boundaries": {
       "summary": "The pyramid is a heuristic, not a quota.",
       "anchor": "boundaries"
+    }
+  },
+  "plugins/dev-team/knowledge/test-refactoring.md": {
+    "1. Goals & Principles (the criteria a refactoring moves toward)": {
+      "summary": "**Goals — a good automated test is:**",
+      "anchor": "1-goals-principles-the-criteria-a-refactoring-moves-toward"
+    },
+    "2. Test Refactoring catalog (the behavior-preserving moves)": {
+      "summary": "Each move removes a named smell (`test-smells.md`) and targets a pattern in a sibling file:",
+      "anchor": "2-test-refactoring-catalog-the-behavior-preserving-moves"
+    },
+    "Decision flow": {
+      "summary": "1.",
+      "anchor": "decision-flow"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "**`test-smells.md`** — the smells each refactoring removes.",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
     }
   },
   "plugins/dev-team/knowledge/test-smells.md": {
@@ -2600,9 +2680,13 @@
       "summary": "Using `knowledge/test-strategy.md`, recommend per test group: fixture design + lifecycle (default Minimal + Fresh; escalate to Immutable Shared → Shared only under measured speed pressure), how the test is driven (scripted default; data-driven when variation is purely data), and SUT interaction (front-door by default; Layer Test for layered code; Back Door Manipulation only when the front door obscures intent).",
       "anchor": "3b-recommend-fixture-and-interaction-strategy"
     },
-    "4. Propose a behavior-preserving refactor sequence (only if blockers exist)": {
-      "summary": "If Step 1 found blockers, produce an ordered sequence that makes the code testable without changing behavior:",
-      "anchor": "4-propose-a-behavior-preserving-refactor-sequence-only-if-blockers-exist"
+    "3c. Recommend verification and test structure": {
+      "summary": "Using `knowledge/result-verification.md`, recommend the assertion pattern that fixes verification smells: **Expected Object** for field-by-field clutter, **Custom Assertion / Verification Method** for repeated complex comparisons or poor failure messages, **Guard Assertion** before a precondition-dependent assertion, **Delta Assertion** against a baseline for shared/persistent fixtures — and verify one logical condition per test.",
+      "anchor": "3c-recommend-verification-and-test-structure"
+    },
+    "4. Propose a behavior-preserving refactor sequence (only if blockers or test smells exist)": {
+      "summary": "If Step 1 found blockers in **production** code, produce an ordered sequence that makes it testable without changing behavior:",
+      "anchor": "4-propose-a-behavior-preserving-refactor-sequence-only-if-blockers-or-test-smells-exist"
     },
     "5. Report": {
       "summary": "Write the recommendation (see Output).",

--- a/plugins/dev-team/knowledge/result-verification.md
+++ b/plugins/dev-team/knowledge/result-verification.md
@@ -1,0 +1,51 @@
+# Result Verification
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. This file covers the **Verify** phase — how a test asserts the outcome — and the patterns that make a failure point straight at its cause. Where `test-doubles.md` chooses the collaborator stand-in, this file chooses the *assertion*.
+
+Source: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com) — Result Verification chapter. Language- and framework-agnostic — described by role, not any assertion library's API.
+
+Core principle: **verify one logical condition per test, and make every assertion say what it expected and why** — so a red test localizes the defect instead of hiding it.
+
+---
+
+## Verification style: state vs behavior
+
+| Style | What it checks | Use when |
+|---|---|---|
+| **State verification** | The SUT's resulting state / return value after exercise | **Default.** The outcome is observable as a value or state |
+| **Behavior verification** | That the SUT *called* a collaborator a certain way | Only at a true side-effect boundary with no observable state (e.g. a message was published) |
+
+Prefer state verification; reach for behavior verification only when there is no state to assert. The *double* that enables behavior verification (spy/mock) is chosen in `test-doubles.md`; here, decide *whether* behavior verification is even the right approach.
+
+---
+
+## Assertion patterns
+
+| Pattern | What it is | Use when | Fixes |
+|---|---|---|---|
+| **Assertion Method** | A single primitive assert on one value, with a message | A single expected value | baseline |
+| **Expected Object** | Build the whole expected object and assert equality in **one** comparison | Asserting many fields of one result | **Assertion Roulette**, field-by-field clutter |
+| **Custom Assertion** | A domain-named assertion encapsulating a comparison **and** an intent-revealing failure message (`assertIsOverdue(account)`) | The same non-trivial comparison recurs, or the default failure message is opaque | duplication + poor diagnostics |
+| **Verification Method** | A named sequence of assertions reused across tests | A multi-assertion check repeats with the same meaning | Test Code Duplication in the Verify phase |
+| **Guard Assertion** | Assert a precondition **before** the main assertion, so a missing precondition fails clearly | The main assertion would otherwise throw a cryptic null/empty error | misleading failures |
+| **Delta Assertion** | Assert the *change* relative to a captured baseline, not an absolute value | Working against a Shared/persistent fixture whose absolute state you don't control | brittle absolute assertions on shared fixtures |
+
+---
+
+## Rules
+
+- **One logical condition per test.** Several unrelated assertions in one method is an Eager Test — split it (`test-organization.md` / `test-refactoring.md`).
+- **Locatable intent.** Every assertion carries a message or is self-describing, so a failure names the expectation.
+- **No magic values.** Don't assert against unexplained literals; name the expected value or derive it visibly (avoid hard-coded values whose meaning is lost).
+
+**Decision flow:** single value → Assertion Method with a message → multi-field object → **Expected Object** → repeated/complex domain comparison → **Custom Assertion** / **Verification Method** → precondition that would fail cryptically → **Guard Assertion** → outcome relative to a shared fixture → **Delta Assertion**.
+
+---
+
+## How this connects to the rest of the toolkit
+
+- **`test-smells.md`** — the smells these fix: Assertion Roulette, Obscure Test, Fragile/Overspecified Test, Hard-Coded Values.
+- **`test-doubles.md`** — behavior verification with mocks/spies; choose the double there, decide the verification approach here.
+- **`test-strategy.md`** — Delta Assertion is the verification counterpart of a Shared/persistent Fixture.
+- **`test-organization.md`** — Verify is the third of the Four-Phase Test.
+- **`test-refactoring.md`** — the moves that get an existing test here: Introduce Expected Object, Extract Custom Assertion / Verification Method, Add Guard Assertion, Split Test.

--- a/plugins/dev-team/knowledge/test-organization.md
+++ b/plugins/dev-team/knowledge/test-organization.md
@@ -1,0 +1,70 @@
+# Test Organization
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. This file covers how a single test and a whole suite are *structured* — the Four-Phase Test that every test follows, how test classes are grouped, how shared logic is reused, and how the runner finds tests.
+
+Source: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com) — Test Organization patterns + XUnit Basics. Language- and framework-agnostic — described by role, not any runner's API.
+
+Core principle: **make the structure of every test obvious** — its four phases, its place in a cohesive class, and its name — so the suite reads as documentation.
+
+---
+
+## The Four-Phase Test (the anchor)
+
+Every test follows four phases, visibly separated:
+
+1. **Setup** — establish the fixture (→ `fixture-construction.md`).
+2. **Exercise** — invoke the SUT.
+3. **Verify** — assert the outcome (→ `result-verification.md`).
+4. **Teardown** — release what Setup created (→ `fixture-construction.md`).
+
+When setup, exercise, and assertions are interleaved with no visible phases, that is the **Obscure Test** smell — restructure into four phases first.
+
+---
+
+## Testcase Class grouping
+
+| Grouping | One class per… | Use when | Trade-off |
+|---|---|---|---|
+| **Testcase Class per Class** | production class | default, simple SUTs | can bloat as the SUT grows behaviors |
+| **Testcase Class per Feature** | feature/behavior across classes | a feature spans several production classes | needs a clear feature boundary |
+| **Testcase Class per Fixture** | shared setup | one class's methods need *different* setups | more classes, but each has one cohesive fixture (kills General Fixture) |
+
+Split into **Testcase Class per Fixture** when a single class's methods diverge in what they set up.
+
+---
+
+## Sharing logic: composition over inheritance
+
+| Mechanism | What it is | Use when |
+|---|---|---|
+| **Test Utility Method / Test Helper** | Shared arrange/assert logic as called methods (composition) | **Default** for any shared logic — explicit, low-coupling |
+| **Testcase Superclass** | A base test class supplying shared setup/utilities via inheritance | Only for genuinely *universal* setup across many classes; couples every subclass to it |
+
+Prefer a Test Utility Method / Helper; escalate to a Testcase Superclass only for truly universal setup, and note its coupling cost.
+
+---
+
+## Parameterized Test
+
+When several test methods differ only by input/expected **data**, collapse them into a **Parameterized Test** — one test logic over many data rows. This is the in-code counterpart of the **Data-Driven Test** automation strategy in `test-strategy.md`; use it when the variation is purely data, not when cases differ in logic.
+
+---
+
+## Test Discovery / Enumeration / Selection + naming
+
+The runner finds tests by **Test Discovery** (convention/annotation), builds a **Test Enumeration**, and runs a selected subset. Two consequences for design:
+
+- Give each test an **intent-revealing name** stating the scenario and expected outcome — the name is the first line of documentation a failure shows.
+- Keep tests selectable (tags/categories) so fast and slow suites can be run separately.
+
+**Decision flow:** make the four phases visible → group classes per fixture when setups diverge → share via a Test Utility Method, escalating to a Testcase Superclass only for universal setup → collapse data-only duplication into a Parameterized Test → name every test for its scenario.
+
+---
+
+## How this connects to the rest of the toolkit
+
+- **`fixture-construction.md`** — the Setup/Teardown phases.
+- **`result-verification.md`** — the Verify phase.
+- **`test-strategy.md`** — Parameterized Test ↔ Data-Driven Test.
+- **`test-smells.md`** — the smells these fix: Obscure Test, Test Code Duplication, High Test Maintenance Cost.
+- **`test-refactoring.md`** — the moves that get an existing suite here: Extract Testcase Class per Fixture, Extract Test Utility Method, Introduce Parameterized Test, Split Test.

--- a/plugins/dev-team/knowledge/test-refactoring.md
+++ b/plugins/dev-team/knowledge/test-refactoring.md
@@ -1,0 +1,67 @@
+# Test Refactoring & Automation Principles
+
+Reference file for `test-review`, `test-smell-review`, and the `test-design-advisor` skill. The capstone of the testing-knowledge set: the **goals & principles** define what a good automated test *is* (the criteria); the **refactoring catalog** lists the behavior-preserving moves that get an existing test there. Together they connect a named smell (`test-smells.md`) to the target pattern in the sibling files and back.
+
+Source: Gerard Meszaros, *xUnit Test Patterns* (xunitpatterns.com) — Goals of Test Automation, Principles of Test Automation, and the Test Refactorings catalog. Language- and framework-agnostic — described by role, not any library's API.
+
+---
+
+## 1. Goals & Principles (the criteria a refactoring moves toward)
+
+**Goals — a good automated test is:**
+
+- **Documentation / specification** — reads as an example of how the SUT is meant to behave.
+- **Self-checking** — passes or fails on its own; no human reads output to judge it.
+- **Repeatable** — same result every run, any order, any machine.
+- **Robust** — breaks only when the behavior it checks changes (not on unrelated edits).
+- **Isolated / independent** — does not depend on other tests or leak state to them.
+- **Economical** — fast, and cheap to write and maintain.
+
+**Principles — how to get there:**
+
+- Write tests first (drive the design); design for testability.
+- Communicate intent (intent-revealing names, Custom Assertions).
+- Verify **one condition per test**; minimize test overlap.
+- Keep tests **independent**; keep **no logic in tests** (no conditionals/loops around assertions).
+
+A test that violates a goal has a smell; the refactoring below moves it back toward the goal.
+
+---
+
+## 2. Test Refactoring catalog (the behavior-preserving moves)
+
+Each move removes a named smell (`test-smells.md`) and targets a pattern in a sibling file:
+
+| Refactoring | Removes smell | Toward (target file) |
+|---|---|---|
+| **Inline Mystery Guest** → build data locally via a Creation Method / Fresh Fixture | Mystery Guest | `fixture-construction.md` |
+| **Replace General Fixture with Minimal Fixture** | General Fixture, Irrelevant Information | `fixture-construction.md` |
+| **Extract Creation Method / Introduce Test Data Builder** | Test Code Duplication (setup) | `fixture-construction.md` |
+| **Replace Inline Setup with Implicit / Delegated Setup** | Test Code Duplication (setup) | `fixture-construction.md` |
+| **Introduce Expected Object** | Assertion Roulette | `result-verification.md` |
+| **Extract Custom Assertion / Verification Method** | Test Code Duplication (verify), poor diagnostics | `result-verification.md` |
+| **Add Guard Assertion** | misleading/cryptic failure | `result-verification.md` |
+| **Split Test** (one logical condition per test) | Eager Test | `test-organization.md` |
+| **Extract Testcase Class per Fixture** | General Fixture, Obscure Test | `test-organization.md` |
+| **Extract Test Utility Method / Testcase Superclass** | Test Code Duplication, High Test Maintenance Cost | `test-organization.md` |
+| **Introduce Parameterized Test** | data-only duplication | `test-organization.md` |
+
+---
+
+## Decision flow
+
+1. Identify the smell (`test-smells.md`).
+2. Name the violated goal/principle (self-checking? isolated? one condition? intent-revealing?).
+3. Pick the refactoring above that moves the test toward it.
+4. Apply **under green** — and **characterization-first**: if the test (or the code it covers) lacks coverage of current behavior, pin that behavior before any move (`testability-patterns.md`, `legacy-code`).
+
+These are **test-side** refactorings. When the blocker is *production* code that can't be tested at all, use the production seams in `testability-patterns.md` instead — never a test workaround (reflection, `InternalsVisibleTo`, mocking concretes).
+
+---
+
+## How this connects to the rest of the toolkit
+
+- **`test-smells.md`** — the smells each refactoring removes.
+- **`fixture-construction.md`** / **`result-verification.md`** / **`test-organization.md`** — the target patterns the moves head toward.
+- **`test-strategy.md`** — the lifecycle/automation choices the refactored test should land on.
+- **`testability-patterns.md`** / **`legacy-code`** — production seams + characterization-first when the target is untested.

--- a/plugins/dev-team/skills/test-design-advisor/SKILL.md
+++ b/plugins/dev-team/skills/test-design-advisor/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 
 An **advisory** skill: it recommends how to test code and how to make untestable code testable. It does not write tests or refactor code — it produces a design the human (or `/build`) then implements. Use it before writing a test suite for an untested or hard-to-test module, or when a test is hard to write and you suspect the design is the cause.
 
-Grounded in these knowledge references: `knowledge/test-smells.md`, `knowledge/test-doubles.md`, `knowledge/test-pyramid.md` (layers + shapes), `knowledge/test-layer-gates.md` for behavior pre-gates, `knowledge/microservice-testing.md`, `knowledge/testability-patterns.md` for production-code seams, and `knowledge/test-strategy.md` for fixture and SUT-interaction strategy. On match it overlays `knowledge/testing-techniques/` (specialized techniques), resolves tools from `knowledge/test-stack-profiles/<stack>.md`, and may adapt a worked template from `knowledge/test-matrix-examples/`.
+Grounded in these knowledge references: `knowledge/test-smells.md`, `knowledge/test-doubles.md`, `knowledge/test-pyramid.md` (layers + shapes), `knowledge/test-layer-gates.md` for behavior pre-gates, `knowledge/microservice-testing.md`, `knowledge/testability-patterns.md` for production-code seams, and `knowledge/test-strategy.md` for fixture and SUT-interaction strategy. For the xUnit pattern families it grounds in `knowledge/fixture-construction.md` (how the fixture is built/disposed), `knowledge/result-verification.md` (assertion patterns), `knowledge/test-organization.md` (Four-Phase + suite structure), and `knowledge/test-refactoring.md` (goals/principles + the test-side refactoring catalog). On match it overlays `knowledge/testing-techniques/` (specialized techniques), resolves tools from `knowledge/test-stack-profiles/<stack>.md`, and may adapt a worked template from `knowledge/test-matrix-examples/`.
 
 ## Constraints
 
@@ -79,16 +79,26 @@ For each collaborator at each test, recommend the simplest double using the deci
 
 Using `knowledge/test-strategy.md`, recommend per test group: fixture design + lifecycle (default Minimal + Fresh; escalate to Immutable Shared → Shared only under measured speed pressure), how the test is driven (scripted default; data-driven when variation is purely data), and SUT interaction (front-door by default; Layer Test for layered code; Back Door Manipulation only when the front door obscures intent). Flag any reliance on a mutable Shared Fixture as an Interacting-Tests risk.
 
-### 4. Propose a behavior-preserving refactor sequence (only if blockers exist)
+For the construction **mechanics** that realize that strategy, recommend a specific pattern from `knowledge/fixture-construction.md` — Creation Method / Test Data Builder / Object Mother for building, the right setup location, and **Automated Teardown** for persistent fixtures — to fix fixture smells (Mystery Guest, General Fixture, Irrelevant Information, Test Code Duplication) at the root rather than only naming them.
 
-If Step 1 found blockers, produce an ordered sequence that makes the code testable without changing behavior:
+### 3c. Recommend verification and test structure
+
+Using `knowledge/result-verification.md`, recommend the assertion pattern that fixes verification smells: **Expected Object** for field-by-field clutter, **Custom Assertion / Verification Method** for repeated complex comparisons or poor failure messages, **Guard Assertion** before a precondition-dependent assertion, **Delta Assertion** against a baseline for shared/persistent fixtures — and verify one logical condition per test.
+
+Using `knowledge/test-organization.md`, recommend test/suite structure: make the **Four-Phase Test** (Setup → Exercise → Verify → Teardown) visible, group **Testcase Class per Class / Feature / Fixture** when setups diverge, share via a **Test Utility Method / Helper** (composition) over a **Testcase Superclass** (inheritance), and collapse data-only duplication into a **Parameterized Test**.
+
+### 4. Propose a behavior-preserving refactor sequence (only if blockers or test smells exist)
+
+If Step 1 found blockers in **production** code, produce an ordered sequence that makes it testable without changing behavior:
 
 1. Add characterization tests around current behavior (if untested) — pin existing behavior first.
 2. Introduce the seam (the specific pattern from `testability-patterns.md`).
 3. Write the now-possible tests at the layer from Step 2.
 4. Refactor under green.
 
-Each step names the pattern and the exact production change required.
+When the smell is in the **test** itself (not production code), name the specific behavior-preserving move from `knowledge/test-refactoring.md` that removes the smell and shifts the test toward the violated goal/principle — e.g. *Inline Mystery Guest* → Fresh Fixture via Creation Method, *Replace General Fixture with Minimal Fixture*, *Introduce Expected Object*, *Extract Custom Assertion*, *Split Test*. Test refactorings are behavior-preserving and **characterization-first** when the target is untested.
+
+Each step names the pattern and the exact change required.
 
 ### 5. Report
 


### PR DESCRIPTION
Completes the four sub-issues under umbrella **#77** (testing-knowledge build-out from xUnit Test Patterns). Foundation #72 (`test-strategy.md`) already shipped; these four map onto the **Four-Phase Test** plus a capstone.

## New knowledge files (language-agnostic, house style)

| Sub-issue | File | Covers |
|-----------|------|--------|
| **#73** | `fixture-construction.md` | Creation Method, Test Data Builder, Object Mother; In-line/Delegated/Implicit/Lazy/SuiteFixture setup; In-line/Implicit/**Automated** teardown |
| **#74** | `result-verification.md` | Assertion Method, Expected Object, Custom Assertion, Verification Method, Guard Assertion, Delta Assertion; state-vs-behavior; one-condition-per-test |
| **#75** | `test-organization.md` | Four-Phase Test; Testcase Class per Class/Feature/Fixture; Testcase Superclass vs Test Utility Method; Parameterized Test; Test Discovery |
| **#76** | `test-refactoring.md` | Capstone — Goals & Principles + a refactoring catalog mapping each smell → behavior-preserving move → target file |

## Wiring (one cohesive slice)

- **`test-design-advisor`** grounds in all four; Step 3b gains fixture-construction mechanics, new Step 3c covers verification + organization, Step 4 covers test-side refactorings (not only production seams).
- **`test-smell-review`** smell entries now cite a *named remedy* (e.g. Mystery Guest → Creation Method, Assertion Roulette → Expected Object, High Test Maintenance Cost → Test Utility Method) instead of prose.
- **`test-review`** references `result-verification.md` for the assertion-quality gate.
- **`agent-registry.md`** (+4 rows), **`CLAUDE.md`** (knowledge count 21→25 + names), **`index.json`** regenerated.

## Coordination with #79

Landed **second** per the epic note — registry/CLAUDE.md/advisor lists were appended **by union**, not re-added. The #79 forward-reference from `test-automation-maturity.md` to `test-refactoring.md` now resolves.

## Verification

- All four files: every required pattern name present (per-sub-issue AC greps). ✅
- Advisor grounds in all four; test-smell-review cross-refs all four; test-review refs result-verification; registry + CLAUDE.md updated. ✅
- `build_knowledge_index.py --check` exits 0 (index regenerated, fresh). ✅
- `tests/repo` 44/44, `tests/knowledge` + `tests/agents` green (knowledge-index shape + agent-knowledge-anchor validations pass). ✅

Closes #73, #74, #75, #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)