### PR TITLE
feat(dev-team): /explore command, file-based /triage, agent-create reconcile (#56 #57 #58)

### DIFF
--- a/evals/expected/ex-explore-command-missing.json
+++ b/evals/expected/ex-explore-command-missing.json
@@ -1,0 +1,12 @@
+{
+  "fixture": "ex-explore-command-missing",
+  "description": "CLAUDE.md registers /explore but commands/explore.md does not exist — claude-setup-review should flag the broken path",
+  "applicableAgents": ["claude-setup-review"],
+  "agents": {
+    "claude-setup-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 4 },
+      "mustMention": ["explore"]
+    }
+  }
+}

--- a/evals/expected/ex-explore-command-present.json
+++ b/evals/expected/ex-explore-command-present.json
@@ -1,0 +1,12 @@
+{
+  "fixture": "ex-explore-command-present",
+  "description": "CLAUDE.md registers /explore with a path that resolves to an existing commands/explore.md — claude-setup-review should pass",
+  "applicableAgents": ["claude-setup-review"],
+  "agents": {
+    "claude-setup-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 1 },
+      "mustNotMention": ["broken", "does not exist", "missing file"]
+    }
+  }
+}

--- a/evals/fixtures/ex-explore-command-missing/CLAUDE.md
+++ b/evals/fixtures/ex-explore-command-missing/CLAUDE.md
@@ -1,0 +1,34 @@
+# Probe Service
+
+A small HTTP service for managing orders, with a dev-team-style command registry.
+
+## Architecture
+
+- **Runtime**: Node.js + Express
+- **Storage**: PostgreSQL via Prisma
+- **Tests**: Vitest (unit) + Playwright (e2e)
+
+## Directory Structure
+
+- `src/` — service source
+  - `src/routes/` — HTTP route handlers
+  - `src/db/` — Prisma client and queries
+- `commands/` — slash command definitions
+- `tests/` — test suites
+
+## Commands
+
+- `npm run dev` — start the dev server (port 4000)
+- `npm test` — run Vitest unit tests
+- `npm run test:e2e` — run Playwright end-to-end tests
+
+## Slash Commands Registry
+
+| Command | File | What It Does |
+|---------|------|--------------|
+| `/explore` | `commands/explore.md` | Charter-driven exploratory testing of a running endpoint |
+
+<!--
+Note: the registry above points at `commands/explore.md`, but that file does not
+exist in this fixture — a broken path claude-setup-review should flag.
+-->

--- a/evals/fixtures/ex-explore-command-present/CLAUDE.md
+++ b/evals/fixtures/ex-explore-command-present/CLAUDE.md
@@ -1,0 +1,29 @@
+# Probe Service
+
+A small HTTP service for managing orders, with a dev-team-style command registry.
+
+## Architecture
+
+- **Runtime**: Node.js + Express
+- **Storage**: PostgreSQL via Prisma
+- **Tests**: Vitest (unit) + Playwright (e2e)
+
+## Directory Structure
+
+- `src/` — service source
+  - `src/routes/` — HTTP route handlers
+  - `src/db/` — Prisma client and queries
+- `commands/` — slash command definitions
+- `tests/` — test suites
+
+## Commands
+
+- `npm run dev` — start the dev server (port 4000)
+- `npm test` — run Vitest unit tests
+- `npm run test:e2e` — run Playwright end-to-end tests
+
+## Slash Commands Registry
+
+| Command | File | What It Does |
+|---------|------|--------------|
+| `/explore` | `commands/explore.md` | Charter-driven exploratory testing of a running endpoint |

--- a/evals/fixtures/ex-explore-command-present/commands/explore.md
+++ b/evals/fixtures/ex-explore-command-present/commands/explore.md
@@ -1,0 +1,10 @@
+---
+name: explore
+description: Charter-driven exploratory testing of a running endpoint.
+user-invocable: true
+---
+
+# Explore
+
+Probe a running target with structured heuristics and report findings.
+(Stub command file so the registry path in CLAUDE.md resolves.)

--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -43,7 +43,7 @@ Full registry tables with token counts, model tiers, and used-by mappings are in
 
 **Review agents** (20): spec-compliance-review, a11y-review, arch-review, claude-setup-review, complexity-review, concurrency-review, doc-review, domain-review, js-fp-review, naming-review, performance-review, security-review, structure-review, svelte-review, test-review, test-smell-review, token-efficiency-review, refactor-opportunity-review, progress-guardian, data-flow-tracer
 
-**Skills** (37): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Test Design Advisor, CD Test Architecture, Test Health, Browser Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming, Ubiquitous Language
+**Skills** (38): Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Quality Gate Pipeline, Governance & Compliance, Agent & Skill Authoring, Hexagonal Architecture, Domain-Driven Design, Domain Analysis, Specs, Threat Modeling, API Design, Legacy Code, Mutation Testing, Test-Driven Development, Systematic Debugging, Design Doc, Branch Workflow, CI Debugging, Test Design Reviewer, Test Design Advisor, CD Test Architecture, Test Health, Browser Testing, Exploratory Testing, Competitive Analysis, Design Interrogation, Design It Twice, Static Analysis Integration, Feature File Validation, Docker Image Create, Docker Image Audit, Performance Benchmark, ADR Tools, Mermaid Diagramming, Ubiquitous Language
 
 **Subagent prompt templates** (8): `prompts/implementer.md`, `prompts/spec-reviewer.md`, `prompts/quality-reviewer.md`, `prompts/plan-reviewer.md`, `prompts/plan-review-acceptance.md`, `prompts/plan-review-design.md`, `prompts/plan-review-ux.md`, `prompts/plan-review-strategic.md`
 
@@ -85,7 +85,8 @@ User-invocable workflows in `.claude/commands/`. All review commands are execute
 | `/unfreeze` | `commands/unfreeze.md` | worker | Lift the scope lock set by `/freeze` |
 | `/guard` | `commands/guard.md` | worker | Combined `/careful` + `/freeze` for production-critical sessions |
 | `/upgrade` | `commands/upgrade.md` | worker | Check for and apply plugin updates from within a session |
-| `/triage` | `commands/triage.md` | worker | Investigate a bug and file a GitHub issue with TDD fix plan |
+| `/triage` | `commands/triage.md` | worker | Investigate a bug and write a triage record to `.triage/<slug>.md` with a TDD fix plan |
+| `/explore` | `commands/explore.md` | worker | Charter-driven exploratory testing of a running target (Chaos Specialist mode): structured heuristics + adversarial expansion, auto-triages critical defects, writes an incremental report |
 | `/issues-from-plan` | `commands/issues-from-plan.md` | orchestrator | Break a plan into independently-grabbable GitHub issues |
 | `/harness-audit` | `commands/harness-audit.md` | orchestrator | Analyze harness effectiveness and flag stale components |
 | `/version` | `commands/version.md` | worker | Report the installed plugin version |
@@ -118,7 +119,7 @@ For trivial tasks (typo fix, simple query), the Orchestrator routes directly to 
 | **Plan** | Specs, API Design, Hexagonal Architecture, Legacy Code | Define what to build, specify interfaces and test strategy |
 | **Plan → Team** | `/issues-from-plan` | Break plan into GitHub issues for team distribution |
 | **Implement** | Test-Driven Development, Systematic Debugging, Mutation Testing, Browser Testing, Performance Benchmark, CI Debugging | Build with TDD, debug issues, validate quality, measure performance |
-| **Bug Triage** | `/triage` (Systematic Debugging + GitHub issue creation) | Investigate bugs and file actionable issues |
+| **Bug Triage** | `/triage` (Systematic Debugging + file-based triage record in `.triage/`) | Investigate bugs and write actionable triage records |
 | **Review** | Quality Gate Pipeline, Test Design Reviewer | Validate output before delivery |
 | **Cross-phase** | Context Loading Protocol, Context Summarization, Feedback & Learning, Human Oversight Protocol, Performance Metrics, Governance & Compliance, Branch Workflow, Agent & Skill Authoring | Orchestration, context management, learning |
 

--- a/plugins/dev-team/README.md
+++ b/plugins/dev-team/README.md
@@ -14,7 +14,7 @@ For the workflow overview, team philosophy, and three-phase (Research → Plan �
 - `jq` — used by hooks for JSON parsing
   - macOS: `brew install jq`
   - Linux: `apt install jq` or `yum install jq`
-- `gh` — [GitHub CLI](https://cli.github.com/), used by `/pr` and `/triage` for creating PRs and issues
+- `gh` — [GitHub CLI](https://cli.github.com/), used by `/pr` and `/issues-from-plan` for creating PRs and issues
   - macOS: `brew install gh`
   - Linux: see [GitHub CLI install docs](https://github.com/cli/cli#installation)
   - Then authenticate: `gh auth login`

--- a/plugins/dev-team/agents/qa-engineer.md
+++ b/plugins/dev-team/agents/qa-engineer.md
@@ -41,6 +41,7 @@ model: sonnet
 - [Agent Eval](../commands/agent-eval.md) - invoke to validate review agent accuracy when adding or modifying test fixtures in `.claude/evals/`
 - [Browser Testing](../skills/browser-testing/SKILL.md) - invoke when e2e visual verification is needed; uses Playwright for navigation, form interaction, and screenshot capture via `/browse`
 - [Test Health](../skills/test-health/SKILL.md) - invoke via `/test-health` for a periodic project-wide test-strategy audit (shape vs. architecture, quadrant coverage, coverage/mutation ROI, automation maturity); delegates pipeline assessment to cd-test-architecture
+- [Exploratory Testing](../skills/exploratory-testing/SKILL.md) - invoke via `/explore` for charter-driven Chaos Specialist probing of a running feature/endpoint; structured heuristics + adversarial expansion, auto-triages critical defects to `/triage`
 
 ## Behavioral Guidelines
 

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -24,9 +24,9 @@ Context needs: full-file
 
 Read `knowledge/testability-patterns.md` before analysis. Whole-file load: the agent uses the decision flow, the anti-patterns table, and all four patterns as one connected reference when flagging untestable code (missing interfaces, static factories, concrete class coupling). Never recommend a test workaround (reflection, InternalsVisibleTo, mocking concrete classes).
 
-For maintainability findings (duplicated selectors/literals, UI-based setup), consult `knowledge/test-automation-maturity.md` — apply its single-point-of-change check and graduated-disclosure thresholds (don't recommend abstraction below the count threshold).
+For maintainability findings (duplicated selectors/literals, UI-based setup), consult `knowledge/test-automation-maturity.md`. Whole-file load: apply its single-point-of-change check and graduated-disclosure thresholds (don't recommend abstraction below the count threshold).
 
-For assertion-quality findings, consult `knowledge/result-verification.md` — name the specific verification pattern (Expected Object, Custom Assertion, Guard Assertion, Delta Assertion) that fixes a weak/cluttered/misleading assertion, and enforce one logical condition per test.
+For assertion-quality findings, consult `knowledge/result-verification.md`. Whole-file load: name the specific verification pattern (Expected Object, Custom Assertion, Guard Assertion, Delta Assertion) that fixes a weak/cluttered/misleading assertion, and enforce one logical condition per test.
 
 ## Skills
 
@@ -91,7 +91,7 @@ Test code quality:
 - Copy-pasted assertion blocks that should be extracted into a helper
 - Magic literal values in assertions with no explanation of their significance
 - Dead test utilities or helpers that are defined but never called
-- Low automation maturity (`knowledge/test-automation-maturity.md`): a volatile detail (selector, endpoint, field name) duplicated raw across many test files (single-point-of-change failure); UI driven to establish preconditions instead of back-door setup — flag only when suite size makes the cost real (graduated thresholds)
+- Low automation maturity (`test-automation-maturity.md`): a volatile detail (selector, endpoint, field name) duplicated raw across many test files (single-point-of-change failure); UI driven to establish preconditions instead of back-door setup — flag only when suite size makes the cost real (graduated thresholds)
 
 Testability blockers:
 

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -28,7 +28,7 @@ The design-level companion to test-review. This agent names xUnit test smells, j
 
 Load on demand by finding type — do not load all four unless the target needs them:
 
-- `knowledge/test-smells.md` — the canonical xUnit smell taxonomy (code/behavior/project smells). Primary reference; load for every run.
+- `knowledge/test-smells.md` — the canonical xUnit smell taxonomy (code/behavior/project smells). Primary reference; load for every run. Whole-file load: scan the full taxonomy to name each finding.
 - `knowledge/test-doubles.md` — dummy/stub/spy/mock/fake selection and state-vs-behavior verification. Load when the target uses mocking.
 - `knowledge/test-pyramid.md` — layer responsibilities and shape anti-patterns. Load when judging test level.
 - `knowledge/microservice-testing.md` — contract/CDC testing. Load only when the target spans independently-deployable services.
@@ -51,7 +51,7 @@ Test file indicators by language:
 
 ## Detect
 
-Always read `knowledge/test-smells.md` first; report each finding by its named smell. Detect across the three levels:
+Always read `test-smells.md` first; report each finding by its named smell. Detect across the three levels:
 
 Code smells (single test):
 
@@ -60,7 +60,7 @@ Code smells (single test):
 - **Conditional Test Logic** — `if`/`switch`/loops/try-catch around assertions; the test verifies different things on different runs
 - **Hard-Coded / Magic Values** in assertions with no stated meaning. *Remedy:* name/derive the expected value; Expected Object (`result-verification.md`)
 - **Test Code Duplication** — copy-pasted arrange/assert blocks that should be a builder or custom assertion (not two genuinely different boundary cases). *Remedy:* Test Data Builder / Extract Creation Method (`fixture-construction.md`), Custom Assertion (`result-verification.md`), or Test Utility Method (`test-organization.md`)
-- **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code (distinct from a *test* using Back Door Manipulation to reach SUT-owned state — see `knowledge/test-strategy.md`; only the production-code form is a smell)
+- **Test Logic in Production** — `if (testMode)`, test-only back doors in shipped code (distinct from a *test* using Back Door Manipulation to reach SUT-owned state — see `test-strategy.md`; only the production-code form is a smell)
 
 Behavior smells (only visible on run):
 
@@ -72,11 +72,11 @@ Project smells (suite-wide):
 
 - **Buggy Tests** (pass when code is broken — recommend mutation testing), **Manual Intervention** (human step needed to run), **High Test Maintenance Cost** (*remedy:* Test Utility Method / Parameterized Test / Testcase Class per Fixture — `test-organization.md`), **Production Bugs** slipping a green suite
 
-Test double misuse (load `knowledge/test-doubles.md`):
+Test double misuse (load `test-doubles.md`):
 
 - Mock where a Stub + state assertion would do; mocking value objects/pure functions; mocking the type under test; asserting call order/count that doesn't matter; mocking concrete classes instead of ports
 
-Pyramid placement (load `knowledge/test-pyramid.md`):
+Pyramid placement (load `test-pyramid.md`):
 
 - Unit test doing real I/O (mis-layered → Slow Tests); E2E asserting a single edge case (belongs at unit); suite-level ice-cream-cone / hourglass / cupcake shape
 

--- a/plugins/dev-team/commands/explore.md
+++ b/plugins/dev-team/commands/explore.md
@@ -1,0 +1,51 @@
+---
+name: explore
+description: >-
+  Charter-driven exploratory testing of a running feature or endpoint. Dispatches
+  the QA Engineer in "Chaos Specialist" mode to probe with structured heuristics
+  (Goldilocks, Happy-Path Divergence, Telemetry Deepening, Invariant Probing,
+  CRUD Sweep), run adversarial expansion, and auto-triage critical defects into an
+  incremental report. Use when the user says "explore this endpoint", "poke at
+  this feature", or wants hands-off exploratory testing of a live target.
+argument-hint: "--charter '<goal>' [target] [--probe-budget <n>] [--invariants '<expr,...>'] [--no-adversarial] [--force]"
+user-invocable: true
+allowed-tools: Read, Grep, Glob, Bash, Write, Skill, Agent
+---
+
+# Explore
+
+Role: worker. This command is a thin entry point: it parses arguments, runs the
+charter-quality + reachability pre-flight, then runs the
+[`exploratory-testing`](../skills/exploratory-testing/SKILL.md) skill as the
+probe loop. It does not probe directly — the skill owns the protocol.
+
+## Worker constraints
+
+1. Probe a **running** target; do not fix anything. Critical defects go to `/triage`.
+2. Stop at or before the probe budget; always leave a usable (possibly partial) report.
+3. **Be concise.** Stream one line per probe to chat; detail lives in the report.
+
+## Parse Arguments
+
+Arguments: $ARGUMENTS
+
+- `--charter '<goal>'` — **required**. `Explore [target] with [approach] to discover [concern]`.
+- `target` — URL/endpoint/command under test (may be implied by the charter).
+- `--probe-budget <n>` — default `15`.
+- `--invariants '<expr,...>'` — per-probe invariants; a violation is Critical-immediate.
+- `--no-adversarial` — skip adversarial expansion (on by default).
+- `--force` — proceed past a charter-quality warning.
+
+If `--charter` is absent, do not probe and do not write a report — emit exactly:
+
+```
+What should I investigate? Provide a charter: --charter '<goal>'
+```
+
+## Steps
+
+1. **Charter quality** — evaluate the charter against the field-guide anti-patterns. On a match, emit a one-line warning and prompt to refine or re-run with `--force`; do not probe until acceptable or forced.
+2. **Reachability** — baseline-request the target. If unreachable, report the URL + error and stop (no report).
+3. **Run the skill** — invoke `exploratory-testing` with the parsed charter, budget, invariants, and flags. It runs the probe loop, adversarial expansion, defect classification, auto-triage, and writes `reports/explore-<YYYYMMDDThhmmss>.md` incrementally — ending with a "Next Exploration" section of 2–3 follow-up charters.
+
+Surface the report path and any triaged defects in chat. On `/stop`, the skill finalizes a partial report.

--- a/plugins/dev-team/commands/triage.md
+++ b/plugins/dev-team/commands/triage.md
@@ -1,10 +1,10 @@
 ---
 name: triage
 description: >-
-  Investigate a bug, find its root cause, and file a GitHub issue with a TDD
-  fix plan. Use when the user reports a bug and wants it triaged, says "triage
-  this", "investigate and file an issue", or wants a hands-off bug investigation
-  that produces an actionable issue.
+  Investigate a bug, find its root cause, and write a portable triage record to
+  .triage/<slug>.md with a TDD fix plan. Use when the user reports a bug and
+  wants it triaged, says "triage this", "investigate and write it up", or wants
+  a hands-off bug investigation that produces an actionable record.
 argument-hint: "<bug description or error message>"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write, Agent
@@ -14,19 +14,23 @@ allowed-tools: Read, Glob, Grep, Bash, Write, Agent
 
 Role: worker.
 
-Investigate a bug hands-off, find root cause, and file a GitHub issue with a TDD fix plan.
+Investigate a bug hands-off, find root cause, and write a TDD fix plan to a
+portable triage record at `.triage/<slug>.md` — no issue-tracker dependency.
 
 ## Worker constraints
 
-1. Investigate and file an issue; do not fix the bug.
-2. Find root cause before filing; do not file on symptoms alone.
-3. **Be concise.** Issue body is structured; chat is a one-line summary + URL.
+1. Investigate and record; do not fix the bug.
+2. Find root cause before recording; do not record on symptoms alone.
+3. **Be concise.** The record is structured; chat is the `triage-record:` line
+   plus a one-line root-cause summary — not the full body.
 
 ## Process
 
 ### 1. Capture the Problem
 
-Get the bug description from the arguments or conversation. If unclear, ask ONE question: "What's the problem you're seeing?" Then start investigating immediately — minimize questions.
+Get the bug description from the arguments or conversation. If no description is
+given, ask EXACTLY one question: `What's the problem you're seeing?` and stop.
+If a description is given, ask nothing — start investigating immediately.
 
 Arguments: $ARGUMENTS
 
@@ -38,13 +42,10 @@ Apply the systematic debugging protocol from `skills/systematic-debugging/SKILL.
 2. **Investigate**: Trace data flow, check recent changes, find working reference code
 3. **Root cause**: Form and test a hypothesis
 
-Use the Agent tool with `subagent_type: "Explore"` to deeply investigate the codebase. Look at:
-
-- Related source files and their dependencies
-- Existing tests (what's tested, what's missing)
-- Recent changes to affected files (`git log`)
-- Error handling in the code path
-- Similar patterns elsewhere that work correctly
+Use the Agent tool with `subagent_type: "Explore"` to deeply investigate the codebase:
+related source files and dependencies, existing tests (covered vs missing),
+recent changes to affected files (`git log`), error handling in the code path,
+and similar patterns elsewhere that work correctly.
 
 ### 3. Design TDD Fix Plan
 
@@ -53,14 +54,47 @@ Create an ordered list of RED-GREEN cycles, each a vertical slice:
 - **RED**: A specific test capturing broken/missing behavior
 - **GREEN**: The minimal code change to make that test pass
 
-Tests should verify behavior through public interfaces, not implementation details.
+Tests verify behavior at the public interface, not implementation details.
 
-### 4. Create GitHub Issue
+### 4. Write the Triage Record
 
-Create the issue using `gh issue create`:
+**Resolve the slug** from the bug title/description with this 8-step algorithm:
+
+1. Lowercase.
+2. Strip non-ASCII characters.
+3. Replace spaces and underscores with hyphens.
+4. Strip every character that is not `[a-z0-9-]`.
+5. Collapse consecutive hyphens to one.
+6. If longer than 60 characters, truncate to 60, then cut back to the last
+   hyphen (so no word is split).
+7. Strip leading/trailing hyphens.
+8. If the result is empty, fall back to `triage-YYYYMMDD` (today's UTC date).
+
+**Resolve collisions:** if `.triage/<slug>.md` exists, append `-2`, `-3`, … up
+to `-99` until a free name is found. **Never overwrite** an existing record.
+
+**Write the file:**
 
 ```bash
-gh issue create --title "<concise bug title>" --body "$(cat <<'EOF'
+mkdir -p .triage/
+```
+
+If `.triage/` cannot be created or written (permission/read-only): report
+`Cannot write .triage/<slug>.md: <error>`, write the same content to a temp file
+(`tmp/triage-<slug>.md` or `$TMPDIR`), and print the full record content to chat
+so nothing is lost.
+
+The record is YAML frontmatter followed by four sections:
+
+```markdown
+---
+id: <resolved-slug>
+created: <YYYY-MM-DDThh:mm:ssZ>
+status: open
+---
+
+# <concise bug title>
+
 ## Problem
 
 - **Actual behavior**: [what happens]
@@ -69,9 +103,8 @@ gh issue create --title "<concise bug title>" --body "$(cat <<'EOF'
 
 ## Root Cause Analysis
 
-[What code path is involved, why it fails, contributing factors.
-Describe modules and behaviors, not file paths — the issue should
-remain useful after refactors.]
+[What code path is involved, why it fails, contributing factors. Describe
+modules and behaviors, not file paths — the record should survive refactors.]
 
 ## TDD Fix Plan
 
@@ -89,10 +122,20 @@ remain useful after refactors.]
 - [ ] All new tests pass
 - [ ] Existing tests still pass
 - [ ] No regressions introduced
-EOF
-)"
+```
+
+At least one RED/GREEN cycle is required. **If no root cause was determined,**
+the entire `## TDD Fix Plan` body is exactly:
+
+```
+Root cause not determined — manual investigation required
 ```
 
 ### 5. Present Results
 
-Print the issue URL and a one-line root cause summary. Do not repeat the full issue body in chat.
+Print exactly two lines:
+
+1. `triage-record: .triage/<resolved-slug>.md` (the actual resolved path)
+2. A root-cause summary of at most 120 characters.
+
+Do not repeat the full record body in chat.

--- a/plugins/dev-team/docs/skills.md
+++ b/plugins/dev-team/docs/skills.md
@@ -134,7 +134,7 @@ Slash commands are invoked by the user (e.g., `/code-review`) and executed under
 | `/init-dev-team` | [`init-dev-team.md`](../commands/init-dev-team.md) | Install plugin prerequisites (jq, python3, mutation tools), offer CodeGraph, and optionally probe Anthropic model availability for restricted endpoints |
 | `/continue` | [`continue.md`](../commands/continue.md) | Resume work from a prior session using phase progress files |
 | `/browse` | [`browse.md`](../commands/browse.md) | Browser-based QA via Playwright: navigate, screenshot, click, fill forms |
-| `/triage` | [`triage.md`](../commands/triage.md) | Investigate a bug, find root cause, file a GitHub issue with TDD fix plan |
+| `/triage` | [`triage.md`](../commands/triage.md) | Investigate a bug, find root cause, write a triage record to `.triage/<slug>.md` with a TDD fix plan |
 | `/issues-from-plan` | [`issues-from-plan.md`](../commands/issues-from-plan.md) | Break a plan into independently-grabbable GitHub issues |
 | `/benchmark` | [`benchmark.md`](../commands/benchmark.md) | Capture runtime performance metrics (Core Web Vitals, resource sizes) and compare against baselines |
 

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -78,6 +78,7 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | CD Test Architecture | `skills/cd-test-architecture/SKILL.md` | ~900 | QA Engineer, Architect, Platform Engineer, Software Engineer |
 | Test Health | `skills/test-health/SKILL.md` | ~900 | QA Engineer, `/test-health` command |
 | Browser Testing | `skills/browser-testing/SKILL.md` | 700 | QA Engineer |
+| Exploratory Testing | `skills/exploratory-testing/SKILL.md` | ~900 | QA Engineer, `/explore` command |
 | Competitive Analysis | `skills/competitive-analysis/SKILL.md` | 600 | Orchestrator, Product Manager |
 | Design Interrogation | `skills/design-interrogation/SKILL.md` | 500 | Architect, Product Manager, Orchestrator |
 | Design It Twice | `skills/design-it-twice/SKILL.md` | 550 | Architect, Software Engineer |

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -971,7 +971,7 @@
       "anchor": "line-budget-gate"
     },
     "Step 11 — Run /agent-audit Validation Gate": {
-      "summary": "**If `--dry` was passed**: display the complete generated file content to the user and stop.",
+      "summary": "`/agent-audit` (structural compliance of the generated agent file) is the",
       "anchor": "step-11-run-agent-audit-validation-gate"
     },
     "Step 12 — Present Draft and Confirm Write": {
@@ -983,7 +983,7 @@
       "anchor": "step-13-update-agent-registry"
     },
     "Step 14 — Update CLAUDE.md": {
-      "summary": "Locate the table in `plugins/dev-team/CLAUDE.md` whose heading",
+      "summary": "CLAUDE.md carries a **prose Quick Reference list**, not a table — the",
       "anchor": "step-14-update-claudemd"
     },
     "Completion Report": {
@@ -1777,6 +1777,60 @@
     "Guidelines": {
       "summary": "Start with strategic DDD (contexts, language) before reaching for tactical patterns",
       "anchor": "guidelines"
+    }
+  },
+  "plugins/dev-team/skills/exploratory-testing/SKILL.md": {
+    "Overview": {
+      "summary": "The QA Engineer in charter-driven **\"Chaos Specialist\"** mode.",
+      "anchor": "overview"
+    },
+    "Constraints": {
+      "summary": "**Probe a running target.** This skill exercises live behavior — it does not read code to reason about bugs (that is `/triage`'s job once a defect is found).",
+      "anchor": "constraints"
+    },
+    "Parse Arguments": {
+      "summary": "`--charter '<goal>'` — **required.** Charter format: `Explore [target] with [approach] to discover [concern]`.",
+      "anchor": "parse-arguments"
+    },
+    "Steps": {
+      "summary": "Check the charter against the anti-patterns in the field guide (§1): too specific (a test case), too broad (infinite scope), missing `with` (no approach), missing `to discover` (no risk hypothesis).",
+      "anchor": "steps"
+    },
+    "1. Evaluate charter quality (before any probe)": {
+      "summary": "Check the charter against the anti-patterns in the field guide (§1): too specific (a test case), too broad (infinite scope), missing `with` (no approach), missing `to discover` (no risk hypothesis).",
+      "anchor": "1-evaluate-charter-quality-before-any-probe"
+    },
+    "2. Reachability pre-flight": {
+      "summary": "Confirm the target responds (a baseline request).",
+      "anchor": "2-reachability-pre-flight"
+    },
+    "3. Plan the probe set (variable identification)": {
+      "summary": "From the field guide (§2), identify what can vary for this target (parameters, values, types, sizes, character sets, combinations).",
+      "anchor": "3-plan-the-probe-set-variable-identification"
+    },
+    "4. Probe loop (until budget or `/stop`)": {
+      "summary": "Run heuristics, decrementing the budget per probe.",
+      "anchor": "4-probe-loop-until-budget-or-stop"
+    },
+    "5. Adversarial expansion (default on; `--no-adversarial` skips)": {
+      "summary": "After the heuristic probes, expand along **3 implicit-expectation lenses** (field guide §5) — pick the 3 most relevant of: authorization bypass, data integrity, timing/ordering, performance-at-scale, crash-resistance — generating **up to 6 angles** total (budget permitting).",
+      "anchor": "5-adversarial-expansion-default-on-no-adversarial-skips"
+    },
+    "6. Classify defects + auto-triage": {
+      "summary": "Classify each finding by severity.",
+      "anchor": "6-classify-defects-auto-triage"
+    },
+    "7. Session debrief": {
+      "summary": "When the budget is exhausted or `/stop` is received, stop and state the termination reason (budget reached / charter exhausted / stopped).",
+      "anchor": "7-session-debrief"
+    },
+    "Output": {
+      "summary": "Write incrementally to `reports/explore-<YYYYMMDDThhmmss>.md`:",
+      "anchor": "output"
+    },
+    "Integration": {
+      "summary": "Invoked by the `/explore` command; runs as the QA Engineer's Chaos Specialist mode.",
+      "anchor": "integration"
     }
   },
   "plugins/dev-team/skills/feature-file-validation/SKILL.md": {

--- a/plugins/dev-team/skills/agent-create/SKILL.md
+++ b/plugins/dev-team/skills/agent-create/SKILL.md
@@ -55,6 +55,7 @@ If `--tier` was provided, map to model: `small` → `haiku`, `mid` → `sonnet`,
 The name must match `^[a-z][a-z0-9-]*$` exactly.
 
 If it does not:
+
 1. Emit: `Name must match ^[a-z][a-z0-9-]*$ — use lowercase letters, digits, and hyphens only`
 2. Compute a kebab-case correction:
    - Lowercase all characters
@@ -112,6 +113,7 @@ Only apply a default when the value was not specified by the user.
 Glob `plugins/dev-team/agents/<name>.md`.
 
 If the file exists:
+
 1. Read its `description` frontmatter field
 2. Emit: `plugins/dev-team/agents/<name>.md already exists (description: <existing-description>)`
 3. Ask: `Overwrite? (yes/no)`
@@ -203,16 +205,19 @@ Context needs: <diff-only|full-file|project-structure>
 ## Skip
 
 Return `{"status": "skip", ...}` when:
+
 - <inapplicability condition>
 
 ## Detect
 
 <Category>:
+
 - <specific pattern to flag>
 
 ## Ignore
 
 <what other agents handle> (handled by other agents)
+
 ```
 
 ### Team Agent Body Structure (required order)
@@ -235,7 +240,7 @@ Return `{"status": "skip", ...}` when:
 
 Apply these rules when generating the body:
 
-1. **No opener**: no line may match `^You are an? ` (case-insensitive)
+1. **No opener**: no line may match `^You are an?` (case-insensitive)
 2. **No description restatement**: title must not contain the `description` field value verbatim (whitespace-normalized)
 3. **No placeholder text**: body must not contain `your-agent-name`, `One-sentence description`, or `# Agent Name`
 4. **Bullet length**: no single bullet point may span more than two lines
@@ -249,8 +254,9 @@ Apply these rules when generating the body:
 After generating the body, count all lines (including blank lines).
 
 **Review agents**: if line count > 40:
+
 1. Emit: `Body is N lines — X lines over the 40-line budget for review agents`
-2. List each removed/collapsed item, each prefixed with `- ` (dash space)
+2. List each removed/collapsed item, each prefixed with `-` (dash space)
 3. Emit: `Approve this trim? (yes/no)`
 4. On `yes`: apply trim and continue
 5. On `no`: emit `Options: (a) reduce spec scope and regenerate, (b) accept N lines and proceed without trimming` and wait
@@ -258,11 +264,13 @@ After generating the body, count all lines (including blank lines).
 **Team agents**: same gate with budget of 75 and label `team agents`.
 
 **Trimmable content** (in priority order):
+
 - Blank separator lines between sections (but not between bullets)
 - Multi-line bullets collapsed to one line
 - Wordy bullet text shortened to the essential action
 
 **Protected content** (never trim):
+
 - Output JSON block
 - Section headings (`## Skip`, `## Detect`, `## Ignore`, `## Responsibilities`)
 - The closing `---` of any required section
@@ -271,12 +279,19 @@ After generating the body, count all lines (including blank lines).
 
 ## Step 11 — Run /agent-audit Validation Gate
 
+`/agent-audit` (structural compliance of the generated agent file) is the
+validation gate of record — it is the tool that audits agent files. The gate is
+**blocking**: an unresolved audit failure aborts creation (the cancel path
+below), it never silently continues. (`claude-setup-review` audits project-level
+CLAUDE.md setup, not a single new agent file, so it is not the gate here.)
+
 **If `--dry` was passed**: display the complete generated file content to the user and stop. Do not write any file, do not run validation, do not update the registry or CLAUDE.md.
 
 Otherwise: write the generated content to disk, then invoke the agent-audit skill:
 `Skill(agent-audit plugins/dev-team/agents/<name>.md)`
 
 **If the audit returns errors:**
+
 1. Emit the raw `/agent-audit` output verbatim
 2. Emit: `All your inputs are preserved.`
 3. Emit: `(a) auto-correct and re-validate  (b) cancel`
@@ -319,15 +334,23 @@ Append a row to the correct table:
 
 ## Step 14 — Update CLAUDE.md
 
-Locate the table in `plugins/dev-team/CLAUDE.md` whose heading
-contains `Review Agents` (review type) or `Team Agents` (team type).
+CLAUDE.md carries a **prose Quick Reference list**, not a table — the
+authoritative agent tables live in `knowledge/agent-registry.md` (updated in
+Step 13). Update the matching Quick Reference line under `### Quick Reference`:
 
-If the heading is not found: emit
-`Cannot update CLAUDE.md: heading containing '<type> Agents' not found. Update manually.`
-and stop without modifying the file.
+- Review type → the line beginning `**Review agents** (<N>):`
+- Team type → the line beginning `**Team agents** (<N>):`
 
-Append a row to the correct table. Confirm both updates in the completion
-report.
+Edit that line in place: **increment the parenthesised count** `(<N>)` → `(<N+1>)`
+and **append `, <name>`** to the comma-separated list (before any trailing
+token-count note, e.g. `(~4,510 tokens total)`).
+
+If the line is not found: emit
+`Cannot update CLAUDE.md: '<type> agents' Quick Reference line not found. Update manually.`
+and stop without modifying the file. (This is a real-failure branch, not the
+normal path — the line exists in the shipped CLAUDE.md.)
+
+Confirm both updates in the completion report.
 
 ---
 
@@ -340,5 +363,5 @@ Model: <model> (<tier-label>)
 Body: <N> lines
 Validation: PASS (/agent-audit)
 Registry updated: knowledge/agent-registry.md (<type> Agents table)
-CLAUDE.md updated: <type> Agents table
+CLAUDE.md updated: <type> agents Quick Reference list (count <N>→<N+1>)
 ```

--- a/plugins/dev-team/skills/exploratory-testing/SKILL.md
+++ b/plugins/dev-team/skills/exploratory-testing/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: exploratory-testing
+description: Charter-driven exploratory testing — probe a running feature/endpoint with structured heuristics, evaluate charter quality, run adversarial expansion, classify defects, and auto-triage critical findings into an incremental report. Use when the user runs /explore, says "explore this endpoint", "poke at this feature", "find bugs in the running app", or wants hands-off exploratory testing of a live target.
+role: worker
+user-invocable: true
+---
+
+# Exploratory Testing
+
+## Overview
+
+The QA Engineer in charter-driven **"Chaos Specialist"** mode. Given a charter and a running target (endpoint, CLI, feature), it probes with structured heuristics, captures telemetry on every probe, classifies defects, auto-triages critical findings, and writes an incremental report ending with runnable follow-up charters. It is bounded by a **probe budget** so a session always terminates.
+
+Frameworks (charter quality, variable identification, state model, implicit-expectation lenses) live in `knowledge/exploratory-testing-field-guide.md`; this file is the protocol.
+
+## Constraints
+
+- **Probe a running target.** This skill exercises live behavior — it does not read code to reason about bugs (that is `/triage`'s job once a defect is found).
+- **Bounded.** Stop at or before the probe budget (default 15) with a stated reason. Every probe counts.
+- **Incremental.** Append each probe result to the report as it runs — a `/stop` or budget exhaustion must still leave a usable partial report.
+- **Auto-triage critical defects only**, and never fix them — hand off to `/triage`.
+- **Be concise.** Stream one line per probe to chat; the detail lives in the report.
+
+## Parse Arguments
+
+- `--charter '<goal>'` — **required.** Charter format: `Explore [target] with [approach] to discover [concern]`.
+- `--probe-budget <n>` — max probes (default **15**).
+- `--invariants '<expr,...>'` — per-probe invariants to validate; a violation is Critical-immediate.
+- `--no-adversarial` — skip adversarial expansion (on by default).
+- `--force` — proceed past a charter-quality warning without refining.
+- target — the URL/endpoint/command under test (from the charter or an explicit arg).
+
+If `--charter` is absent, do not probe: emit exactly `What should I investigate? Provide a charter: --charter '<goal>'` and stop with no report.
+
+## Steps
+
+### 1. Evaluate charter quality (before any probe)
+
+Check the charter against the anti-patterns in the field guide (§1): too specific (a test case), too broad (infinite scope), missing `with` (no approach), missing `to discover` (no risk hypothesis). On a match, emit a **one-line warning** naming the anti-pattern and prompt: refine the charter, or re-run with `--force`. Do not probe until the charter is acceptable or `--force` is given.
+
+### 2. Reachability pre-flight
+
+Confirm the target responds (a baseline request). If unreachable, write no report and report the target URL plus the connection error. A reachable baseline (the happy path) is **probe 1** and anchors Happy-Path Divergence.
+
+### 3. Plan the probe set (variable identification)
+
+From the field guide (§2), identify what can vary for this target (parameters, values, types, sizes, character sets, combinations). If the charter names an **entity noun** (order, user, account…), include a **CRUD Sweep** (create/read/update/delete + read-after-delete). For permission/role/multi-select fields, include **Goldilocks set-dimension variants** (none / one / some / all / invalid member).
+
+### 4. Probe loop (until budget or `/stop`)
+
+Run heuristics, decrementing the budget per probe. Capture telemetry on **every** probe: probe type, exact input, HTTP status (or exit code), response time, response size, and any captured stderr.
+
+The five heuristics:
+
+| Heuristic | What it does |
+|-----------|--------------|
+| **Goldilocks** | too-small / just-right / too-big for each variable; plus set-dimension variants (none/one/some/all/invalid) for set-valued fields |
+| **Happy-Path Divergence** | start from the confirmed happy path (probe 1), then change one thing at a time and watch for divergence |
+| **Telemetry Deepening** | when a probe is slow / large / noisy, follow it with sharper probes around that variable (perf cliffs, O(n²), truncation) |
+| **Invariant Probing** | if `--invariants` given, assert each after every probe (e.g. balance never negative, count conserved) |
+| **CRUD Sweep** | for entity charters: create → read → update → delete → read-after-delete; watch for orphans, stale reads, double-delete |
+
+**Follow surprises:** when a probe produces an unexpected result, spend the next probes varying that input (field guide §4). **Off-charter temptations** are recorded as follow-up charters (Step 7), not chased now.
+
+### 5. Adversarial expansion (default on; `--no-adversarial` skips)
+
+After the heuristic probes, expand along **3 implicit-expectation lenses** (field guide §5) — pick the 3 most relevant of: authorization bypass, data integrity, timing/ordering, performance-at-scale, crash-resistance — generating **up to 6 angles** total (budget permitting). Label every adversarial probe `adversarial-<lens>` in the report.
+
+### 6. Classify defects + auto-triage
+
+Classify each finding by severity. A **Critical** defect (data corruption, auth bypass, crash, invariant violation) triggers auto-triage:
+
+- Retry the probe **once** to rule out a transient — **except invariant violations**, which are **Critical-immediate** (no retry).
+- If it reproduces (or is invariant-immediate), invoke **`/triage`** with the reproduction. On success, record the returned `triage-record: .triage/<slug>.md` path in the report. On triage failure, preserve the reproduction at `tmp/explore-trace-<timestamp>.md` and record that path instead.
+- **No defect → no triage.** Non-critical findings are recorded in the report only.
+
+### 7. Session debrief
+
+When the budget is exhausted or `/stop` is received, stop and state the termination reason (budget reached / charter exhausted / stopped). Finalize the report, ending with a **"Next Exploration"** section: 2–3 runnable follow-up charter strings (off-charter temptations and unfollowed surprises become these).
+
+## Output
+
+Write incrementally to `reports/explore-<YYYYMMDDThhmmss>.md`:
+
+```markdown
+## Exploration — <charter>
+
+**Target**: <url>   **Budget**: <used>/<n>   **Status**: <complete|partial|stopped — reason>
+
+### Probes
+| # | Heuristic | Input | Status | Time | Size | stderr | Finding |
+
+### Defects
+| Severity | Probe # | Summary | Triage |
+(Triage = `.triage/<slug>.md` path, or `tmp/explore-trace-<ts>.md` on triage failure)
+
+### Next Exploration
+- `--charter 'Explore … with … to discover …'`
+- `--charter '…'`
+```
+
+The report must contain **≥1 Goldilocks and ≥1 Happy-Path Divergence** entry unless the charter explicitly restricts scope. Write it incrementally so a partial report survives `/stop`.
+
+## Integration
+
+- Invoked by the `/explore` command; runs as the QA Engineer's Chaos Specialist mode.
+- Hands critical defects to `/triage` (which writes `.triage/<slug>.md`).
+- Frameworks: `knowledge/exploratory-testing-field-guide.md`. For *test design* (which layer, which double) use `test-design-advisor`; this skill probes running behavior, it does not design a suite.


### PR DESCRIPTION
Implements three issues. **#57 lands first as a dependency of #56** (auto-triage now writes a portable record instead of a GitHub issue).

## #57 — `/triage` writes `.triage/<slug>.md`
- `commands/triage.md` rewritten: 8-step slug algorithm, `mkdir -p .triage/`, collision handling (`-2`…`-99`, never overwrite), unwritable-dir fallback (report + temp write + full-content echo), YAML frontmatter (`id`/`created`/`status: open`) + four sections (Problem, Root Cause Analysis, TDD Fix Plan with ≥1 RED/GREEN, Acceptance Criteria), exact no-root-cause sentence, `triage-record:` output line.
- Registry/docs updated: CLAUDE.md Slash Commands + Skills-by-Phase, `docs/skills.md`, README `gh` note. `grep "gh "/"GitHub"` in `triage.md` → empty.

## #56 — `/explore` exploratory-testing command
- New `skills/exploratory-testing/SKILL.md` (QA "Chaos Specialist"): five heuristics (Goldilocks + set-dimension variants, Happy-Path Divergence, Telemetry Deepening, Invariant Probing, CRUD Sweep), charter-quality gate, adversarial expansion (3 lenses / up to 6 angles), telemetry capture, defect classification, auto-triage to `.triage/` (retry-once except invariant violations; `tmp/explore-trace-*` on triage failure), probe budget (default 15), incremental report ending in "Next Exploration".
- New `commands/explore.md` (thin; missing `--charter` → exact prompt).
- Registered in `qa-engineer`, `agent-registry.md` (**resolves the dangling `skills/exploratory-testing/SKILL.md` reference**), CLAUDE.md registry, skills count 37→38.
- Eval fixtures `ex-explore-command-present` / `ex-explore-command-missing` (+ expected) for `claude-setup-review`.

## #58 — reconcile `agent-create`
- **Step 14** rewritten to update CLAUDE.md's **prose Quick Reference list** (increment count + append name) — the mechanism that actually exists; eliminates the silent "table heading not found → Update manually" skip.
- **Step 11** documents `/agent-audit` as the blocking validation gate of record (the removed spec's `claude-setup-review` audits CLAUDE.md *setup*, not a new agent file — so `/agent-audit` is the correct tool; the gate already aborts on unresolved failure).

## Incidental fix — latent AC19 (not in CI)
`tests/agents/agent_knowledge_anchor_tests.bats` (every agent knowledge ref must cite a valid anchor or carry `Whole-file load:`) was **already red on `main`** — my #79 PR introduced a bare `test-automation-maturity.md` ref in `test-review.md`, and `test-smell-review.md` had pre-existing bare refs; `tests/agents/` isn't in the `shell-tests` CI job, so it slipped. Fixed both files: inline refs are now bare filenames, Knowledge-Files blocks carry the token.

## Verification
- `tests/repo` + `tests/knowledge` + `tests/agents` + `tests/commands`: **130 pass, 0 fail** (AC19 now green).
- `build_knowledge_index.py --check` clean; new skill indexed.
- Per-issue AC greps pass (slug/output lines, exact prompts, registry rows, dangling-ref resolved).

Closes #56, #57, #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)