### PR TITLE
ci: run dev-team content bats suites in CI

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -29,3 +29,29 @@ jobs:
 
       - name: Run tests/scripts/run-all.sh
         run: bash plugins/security-assessment/tests/scripts/run-all.sh
+
+  bats-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install bats + jq
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+
+      # Content-validation suites: repo invariants, knowledge-index shape,
+      # agent knowledge-anchor citations (AC19), command/doc registry sync.
+      # Pure bash/jq/python3 — no external toolchains.
+      #
+      # tests/hooks/ is intentionally excluded: its mutation-gate end-to-end
+      # tests require stryker/pitest and its overhead tests are timing-based,
+      # neither of which is portable to a clean CI runner.
+      - name: Run dev-team content tests (bats)
+        run: |
+          bats \
+            tests/repo/ \
+            tests/knowledge/ \
+            tests/agents/ \
+            tests/commands/ \
+            tests/docs/

--- a/tests/agents/orchestrator_routing_doc_tests.bats
+++ b/tests/agents/orchestrator_routing_doc_tests.bats
@@ -53,7 +53,7 @@ ROUTING_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/model-routing.
 }
 
 @test "CLAUDE.md: Slash Commands Registry contains a /model-routing-check row" {
-  grep -qE '\| \`/model-routing-check\`' "$CLAUDE_MD"
+  grep -qE '\| `/model-routing-check`' "$CLAUDE_MD"
 }
 
 @test "CLAUDE.md: no pinned claude-(haiku|sonnet|opus)-DIGITS snapshot IDs" {

--- a/tests/commands/security_upgrade_tests.bats
+++ b/tests/commands/security_upgrade_tests.bats
@@ -65,7 +65,7 @@ setup() {
 @test "security-assessment /upgrade is registered in CLAUDE.md dispatch table" {
   local claude_md="$REPO_ROOT/plugins/security-assessment/CLAUDE.md"
   # Must appear in the dispatch registry table.
-  grep -qE '\| \`/upgrade\` \|' "$claude_md"
+  grep -qE '\| `/upgrade` \|' "$claude_md"
   # And in the Commands list (count bumped from 4 to 5).
   grep -qE '\*\*Commands\*\* \(5\)' "$claude_md"
 }
@@ -73,5 +73,5 @@ setup() {
 @test "security-assessment /upgrade is documented in README" {
   local readme="$REPO_ROOT/plugins/security-assessment/README.md"
   grep -qE '^## Update' "$readme"
-  grep -qE '\| \`/upgrade\` \|' "$readme"
+  grep -qE '\| `/upgrade` \|' "$readme"
 }


### PR DESCRIPTION
Adds a `bats-tests` job to `plugin-tests.yml` running the content-validation suites: `tests/{repo,knowledge,agents,commands,docs}` (147 tests).

## Why

The existing `shell-tests` job only runs `plugins/security-assessment/tests` + shellcheck. The root `tests/` bats suites — which validate repo invariants, the knowledge-index shape, **agent knowledge-anchor citations (AC19)**, and command/doc registry sync — were never executed in CI. That's exactly how the AC19 gate silently regressed on `main` (caught and fixed in #94).

## Scope

- **Included:** `tests/repo`, `tests/knowledge`, `tests/agents`, `tests/commands`, `tests/docs` — pure bash/jq/python3, no external toolchains.
- **Excluded:** `tests/hooks/` — its mutation-gate end-to-end tests require stryker/pitest and its overhead tests are timing-based; neither is portable to a clean CI runner. (Documented inline in the workflow.)

Installs `bats` + `jq` via apt; `python3` is preinstalled on `ubuntu-latest`. `fetch-depth: 0` so any history-aware checks behave correctly.

Verified locally: **147 pass, 0 fail**. This PR's own run exercises the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)