### PR TITLE
ci: serve only tagged releases via marketplace catalog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,14 @@
   "plugins": [
     {
       "name": "dev-team",
-      "source": "./plugins/dev-team",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/bdfinst/agentic-dev-team.git",
+        "path": "plugins/dev-team",
+        "ref": "dev-team-v6.4.0"
+      },
       "description": "Persona-driven AI development team: orchestrator, team agents, review agents, skills (agent-loaded and user-invocable slash commands), and advisory hooks for Claude Code. Previously published as agentic-dev-team.",
-      "version": "3.3.0",
+      "version": "6.4.0",
       "author": {
         "name": "Bryan Finster"
       },
@@ -21,9 +26,14 @@
     },
     {
       "name": "security-assessment",
-      "source": "./plugins/security-assessment",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/bdfinst/agentic-dev-team.git",
+        "path": "plugins/security-assessment",
+        "ref": "security-assessment-v3.1.1"
+      },
       "description": "Deep security assessment + adversarial ML red-team: SARIF-first tool orchestration, narrowly-scoped LLM agents, FP-reduction with fallback banner, compliance mapping, service-comm diagramming, and a self-owned-target red-team harness. Companion plugin to dev-team. Previously published as agentic-security-assessment.",
-      "version": "1.0.0",
+      "version": "3.1.1",
       "author": {
         "name": "Bryan Finster"
       },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,73 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      dev_team_released: ${{ steps.release.outputs['plugins/dev-team--release_created'] }}
+      dev_team_tag: ${{ steps.release.outputs['plugins/dev-team--tag_name'] }}
+      dev_team_version: ${{ steps.release.outputs['plugins/dev-team--version'] }}
+      security_released: ${{ steps.release.outputs['plugins/security-assessment--release_created'] }}
+      security_tag: ${{ steps.release.outputs['plugins/security-assessment--tag_name'] }}
+      security_version: ${{ steps.release.outputs['plugins/security-assessment--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # After a release is tagged, repoint the marketplace catalog at the new tags so
+  # installers receive the tagged tree instead of whatever is ahead on main.
+  pin-marketplace:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Pin marketplace.json to released tags
+        env:
+          DEV_TEAM_RELEASED: ${{ needs.release-please.outputs.dev_team_released }}
+          DEV_TEAM_TAG: ${{ needs.release-please.outputs.dev_team_tag }}
+          DEV_TEAM_VERSION: ${{ needs.release-please.outputs.dev_team_version }}
+          SECURITY_RELEASED: ${{ needs.release-please.outputs.security_released }}
+          SECURITY_TAG: ${{ needs.release-please.outputs.security_tag }}
+          SECURITY_VERSION: ${{ needs.release-please.outputs.security_version }}
+        run: |
+          set -euo pipefail
+          MP=.claude-plugin/marketplace.json
+
+          pin() {
+            name="$1"; tag="$2"; version="$3"
+            jq --arg name "$name" --arg tag "$tag" --arg version "$version" '
+              (.plugins[] | select(.name == $name))
+                |= (.source.ref = $tag | .version = $version)
+            ' "$MP" > "$MP.tmp"
+            mv "$MP.tmp" "$MP"
+            echo "Pinned $name -> $tag (version $version)"
+          }
+
+          if [ "${DEV_TEAM_RELEASED:-}" = "true" ]; then
+            pin dev-team "$DEV_TEAM_TAG" "$DEV_TEAM_VERSION"
+          fi
+          if [ "${SECURITY_RELEASED:-}" = "true" ]; then
+            pin security-assessment "$SECURITY_TAG" "$SECURITY_VERSION"
+          fi
+
+          # Fail fast if the result is not valid JSON.
+          jq empty "$MP"
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet .claude-plugin/marketplace.json; then
+            echo "marketplace.json already up to date; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json
+          # Use a type outside changelog-sections so this does not pollute changelogs.
+          # Pushes with GITHUB_TOKEN do not re-trigger workflows, so no recursion.
+          git commit -m "ci: pin marketplace catalog to released tags"
+          git push origin main


### PR DESCRIPTION
## Problem

Installers were receiving whatever is on `main`, not the last tagged release. The marketplace entries used **relative-path sources** (`./plugins/dev-team`), which resolve at the marketplace repo's **default-branch HEAD**. The `version` field is purely informational — it does not pin a git ref. So any commits ahead of the last tag leaked to installers.

Two `version` fields were also stale relative to `plugin.json` / the release-please manifest.

## Changes

**`.claude-plugin/marketplace.json`** — switch the two active plugins to tag-pinned `git-subdir` sources (the only source type that supports a subdirectory `path` + `ref` together, which a single-repo marketplace needs):

| Plugin | Before | After |
|---|---|---|
| `dev-team` | relative path, version `3.3.0` | `git-subdir` → `ref: dev-team-v6.4.0`, version `6.4.0` |
| `security-assessment` | relative path, version `1.0.0` | `git-subdir` → `ref: security-assessment-v3.1.1`, version `3.1.1` |

The two deprecated legacy stubs are intentionally left as relative paths — they're frozen, self-removing migration stubs.

**`.github/workflows/release-please.yml`** — add a `pin-marketplace` job that runs after a release is cut. It reads each component's release outputs, rewrites `source.ref` + `version` for **only the components that released** (independent pinning preserved), validates the JSON with `jq empty`, and commits to `main`.

## Why it's safe

- The catalog is always read from `main` HEAD while each entry's `ref` points installs at the tagged subdir — so `main` can race ahead without affecting installers.
- `main` is unprotected, so the bot push works; pushes with the default `GITHUB_TOKEN` **do not re-trigger workflows**, so there's no release loop.
- The commit uses `ci:`, which is outside `changelog-sections`, so it won't pollute future changelogs.

## Post-merge smoke test

```bash
claude plugin marketplace add bdfinst/agentic-dev-team
claude plugin install dev-team@bfinster   # should resolve the v6.4.0 tree
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)