### PR TITLE
Wave 1: observability spine — runtime cost meter + opt-in telemetry beacon (#98)

### DIFF
--- a/plans/external-review-improvements-checklist.md
+++ b/plans/external-review-improvements-checklist.md
@@ -36,12 +36,14 @@ These pay for themselves immediately and create the harness the later waves reus
 
 Nothing downstream can be evidence-based without these two. Build them before the measurement bets.
 
-- [ ] **#102 — Runtime cost/token metering** *(High / Med)*
+- [x] **#102 — Runtime cost/token metering** *(High / Med)*
   - No hard dependency, but do after #100 (it provides the instrument #100 promised for cost claims).
   - Required by #111 (process eval needs a real cost meter to compare pipelines).
-- [ ] **#106 — Opt-in privacy-clean telemetry beacon** *(High / Med)*
+  - Done: `hooks/lib/cost_meter.py` parses the session transcript (token usage isn't in hook payloads), attributes tokens/$ per agent+model via `knowledge/model-pricing.json`, recorded by the `Stop`/`SubagentStop` hook to `metrics/cost-metering.jsonl`; `/cost-report` skill prints spend + rolling-baseline regression. Tests in `tests/repo/cost_meter_tests.bats`.
+- [x] **#106 — Opt-in privacy-clean telemetry beacon** *(High / Med)*
   - No hard dependency. Reuses the append-only event-log convention.
   - Required by #112 (exposure-based gating) and pairs with #113 (auto-learning signals).
+  - Done: `hooks/telemetry.sh` (default-off, local-only) captures command/skill usage (`UserPromptSubmit`) and pre-commit gate fired/bypassed (`PreToolUse` Bash) as minimal events (name + outcome + version, no payloads) to `metrics/telemetry.jsonl`; `/telemetry` skill manages consent and reports usage + bypass rate. Tests in `tests/repo/telemetry_tests.bats`.
 
 **Wave 1 exit:** per-dispatch cost is measurable; gate-bypass/usage telemetry exists (opt-in).
 

--- a/plugins/dev-team/hooks/cost-meter.sh
+++ b/plugins/dev-team/hooks/cost-meter.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# cost-meter.sh — Stop / SubagentStop hook (issue #102).
+#
+# PostToolUse hooks carry no token usage, so this fires when a turn finishes,
+# reads `transcript_path` from the hook payload, and records a per-session cost
+# summary (tokens + dollars, by agent) to metrics/cost-metering.jsonl via
+# hooks/lib/cost_meter.py. Token→cost uses knowledge/model-pricing.json.
+#
+# Posture: record-only and fail-open. Never blocks; any error → exit 0 silently.
+# Opt-out: set DEV_TEAM_COST_METER=off to disable.
+
+set -uo pipefail
+
+input=$(cat)
+
+[ "${DEV_TEAM_COST_METER:-on}" = "off" ] && exit 0
+
+# Need jq + python3; if absent, no-op.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+echo "$input" | jq -e . >/dev/null 2>&1 || exit 0
+
+transcript=$(echo "$input" | jq -r '.transcript_path // empty')
+[ -z "$transcript" ] || [ ! -f "$transcript" ] && exit 0
+
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+[ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log="${cwd}/metrics/cost-metering.jsonl"
+
+python3 "${HOOK_DIR}/lib/cost_meter.py" record \
+  --transcript "$transcript" --log "$log" >/dev/null 2>&1 || true
+
+exit 0

--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Runtime cost/token meter for dispatched work (issue #102).
+
+PostToolUse hooks do NOT carry token usage in Claude Code; the canonical source
+is the session transcript JSONL, where each assistant message records a `usage`
+block (input/output/cache tokens). Every hook payload includes `transcript_path`,
+so a Stop hook can hand this script the transcript to parse. This converts token
+usage to dollars via the named instrument knowledge/model-pricing.json (#102 is
+why that table exists) and writes an append-only metrics log.
+
+Subcommands
+-----------
+report   --transcript T [--json]
+         Parse a transcript and print tokens + cost per agent and per model,
+         plus the session total. This is the acceptance command: "after a run,
+         print actual tokens spent per agent and total."
+
+record   --transcript T --log metrics/cost-metering.jsonl
+         Append one session-summary line to the append-only metrics log
+         (follows the metrics/config-changelog.jsonl convention). Used by the
+         Stop hook. Idempotent on directory creation; never errors out loudly.
+
+regression --log metrics/cost-metering.jsonl [--tolerance 0.5]
+         Compare the most recent session's total cost against the rolling mean
+         of prior sessions; exit 1 if it exceeds mean * (1 + tolerance). The
+         CI/regression hook the acceptance criteria asks for.
+
+The transcript schema is read defensively (usage may sit on the record or under
+`message`; model + agent attribution likewise), so it tolerates schema drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# hooks/lib/cost_meter.py -> plugin root is three parents up.
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_PRICING = _PLUGIN_ROOT / "knowledge/model-pricing.json"
+
+
+def _load_pricing(path: Path) -> dict:
+    data = json.loads(path.read_text())
+    return data
+
+
+def _rate(pricing: dict, model: str) -> dict | None:
+    models = pricing.get("models", {})
+    if model in models:
+        return models[model]
+    alias = pricing.get("aliases", {}).get(model)
+    if alias and alias in models:
+        return models[alias]
+    return None
+
+
+def _dig(rec: dict, *keys: str):
+    """Return the first present key on rec or rec['message']."""
+    for src in (rec, rec.get("message", {}) if isinstance(rec.get("message"), dict) else {}):
+        for k in keys:
+            if k in src and src[k] is not None:
+                return src[k]
+    return None
+
+
+def _cost(usage: dict, rate: dict, pricing: dict) -> float:
+    inp = usage.get("input_tokens", 0) or 0
+    out = usage.get("output_tokens", 0) or 0
+    cw = usage.get("cache_creation_input_tokens", 0) or 0
+    cr = usage.get("cache_read_input_tokens", 0) or 0
+    in_rate = rate["input"]
+    return (
+        inp / 1e6 * in_rate
+        + out / 1e6 * rate["output"]
+        + cw / 1e6 * in_rate * pricing.get("cache_write_multiplier", 1.25)
+        + cr / 1e6 * in_rate * pricing.get("cache_read_multiplier", 0.1)
+    )
+
+
+def parse_transcript(path: Path, pricing: dict) -> dict:
+    """Aggregate usage by agent and by model. Returns a summary dict."""
+    by_agent: dict[str, dict] = {}
+    by_model: dict[str, dict] = {}
+    totals = {"input_tokens": 0, "output_tokens": 0,
+              "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+              "cost_usd": 0.0, "messages": 0}
+    unpriced_models: set[str] = set()
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = _dig(rec, "usage")
+        if not isinstance(usage, dict):
+            continue
+        model = _dig(rec, "model") or "unknown"
+        # Sub-agent attribution: agent_type/agent_id present for subagents,
+        # else the main orchestrator thread.
+        agent = _dig(rec, "agent_type", "subagent_type", "agent_id") or "orchestrator"
+
+        rate = _rate(pricing, model)
+        cost = _cost(usage, rate, pricing) if rate else 0.0
+        if not rate and model != "unknown":
+            unpriced_models.add(model)
+
+        for bucket, key in ((by_agent, agent), (by_model, model)):
+            b = bucket.setdefault(key, {"input_tokens": 0, "output_tokens": 0,
+                                        "cache_creation_input_tokens": 0,
+                                        "cache_read_input_tokens": 0,
+                                        "cost_usd": 0.0, "messages": 0})
+            for f in ("input_tokens", "output_tokens",
+                      "cache_creation_input_tokens", "cache_read_input_tokens"):
+                b[f] += usage.get(f, 0) or 0
+            b["cost_usd"] = round(b["cost_usd"] + cost, 6)
+            b["messages"] += 1
+
+        for f in ("input_tokens", "output_tokens",
+                  "cache_creation_input_tokens", "cache_read_input_tokens"):
+            totals[f] += usage.get(f, 0) or 0
+        totals["cost_usd"] = round(totals["cost_usd"] + cost, 6)
+        totals["messages"] += 1
+
+    return {"by_agent": by_agent, "by_model": by_model, "totals": totals,
+            "unpriced_models": sorted(unpriced_models)}
+
+
+def _print_report(summary: dict) -> None:
+    t = summary["totals"]
+    print(f"# Cost meter — {t['messages']} assistant message(s)\n")
+    print(f"{'AGENT':<28} {'IN':>10} {'OUT':>10} {'COST $':>10}")
+    print("-" * 60)
+    for agent, b in sorted(summary["by_agent"].items(),
+                           key=lambda kv: -kv[1]["cost_usd"]):
+        print(f"{agent:<28} {b['input_tokens']:>10} {b['output_tokens']:>10} "
+              f"{b['cost_usd']:>10.4f}")
+    print("-" * 60)
+    print(f"{'TOTAL':<28} {t['input_tokens']:>10} {t['output_tokens']:>10} "
+          f"{t['cost_usd']:>10.4f}")
+    if summary["unpriced_models"]:
+        print(f"\n⚠ no pricing for: {', '.join(summary['unpriced_models'])} "
+              f"(add to knowledge/model-pricing.json)")
+
+
+def cmd_report(args, pricing) -> int:
+    summary = parse_transcript(Path(args.transcript), pricing)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        _print_report(summary)
+    return 0
+
+
+def cmd_record(args, pricing) -> int:
+    tpath = Path(args.transcript)
+    if not tpath.is_file():
+        return 0  # fail-open: hook must never break the session
+    summary = parse_transcript(tpath, pricing)
+    from datetime import datetime, timezone
+    line = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "transcript": tpath.name,
+        "total": summary["totals"],
+        "by_agent": {a: {"cost_usd": b["cost_usd"],
+                         "input_tokens": b["input_tokens"],
+                         "output_tokens": b["output_tokens"]}
+                     for a, b in summary["by_agent"].items()},
+    }
+    log = Path(args.log)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a") as fh:
+        fh.write(json.dumps(line) + "\n")
+    return 0
+
+
+def cmd_regression(args, pricing) -> int:
+    log = Path(args.log)
+    if not log.is_file():
+        print("no metrics log yet; nothing to compare")
+        return 0
+    entries = []
+    for line in log.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    costs = [e.get("total", {}).get("cost_usd", 0.0) for e in entries]
+    if len(costs) < 2:
+        print(f"only {len(costs)} session(s) logged; need >=2 to compare")
+        return 0
+    latest = costs[-1]
+    prior = costs[:-1]
+    mean = sum(prior) / len(prior)
+    limit = mean * (1 + args.tolerance)
+    print(f"latest=${latest:.4f}  rolling-mean(prior {len(prior)})=${mean:.4f}  "
+          f"limit(+{int(args.tolerance*100)}%)=${limit:.4f}")
+    if mean > 0 and latest > limit:
+        print(f"COST REGRESSION: latest ${latest:.4f} exceeds limit ${limit:.4f}")
+        return 1
+    print("no cost regression")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pricing", default=str(_DEFAULT_PRICING))
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("report"); p.add_argument("--transcript", required=True)
+    p.add_argument("--json", action="store_true")
+    p = sub.add_parser("record"); p.add_argument("--transcript", required=True)
+    p.add_argument("--log", default="metrics/cost-metering.jsonl")
+    p = sub.add_parser("regression"); p.add_argument("--log", default="metrics/cost-metering.jsonl")
+    p.add_argument("--tolerance", type=float, default=0.5)
+
+    args = ap.parse_args(argv)
+    pricing = _load_pricing(Path(args.pricing))
+    return {"report": cmd_report, "record": cmd_record,
+            "regression": cmd_regression}[args.cmd](args, pricing)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/dev-team/hooks/lib/telemetry_report.py
+++ b/plugins/dev-team/hooks/lib/telemetry_report.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Telemetry report (issue #106).
+
+Aggregates the opt-in, privacy-clean event log written by hooks/telemetry.sh
+(metrics/telemetry.jsonl) into: command/skill usage counts, and the pre-commit
+review gate's bypass rate (bypassed / (fired + bypassed)). With telemetry
+disabled the log doesn't exist and this reports that nothing was collected —
+satisfying "with it disabled, nothing leaves the machine."
+
+Usage: telemetry_report.py [--log metrics/telemetry.jsonl] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def aggregate(log: Path) -> dict:
+    commands: Counter = Counter()
+    gates: Counter = Counter()  # outcome -> count, per gate name
+    gate_by_name: dict[str, Counter] = {}
+    total_events = 0
+    for line in log.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            e = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        total_events += 1
+        if e.get("event") == "command":
+            commands[e.get("name", "?")] += 1
+        elif e.get("event") == "gate":
+            name = e.get("name", "?")
+            gate_by_name.setdefault(name, Counter())[e.get("outcome", "?")] += 1
+
+    gate_summary = {}
+    for name, oc in gate_by_name.items():
+        fired = oc.get("fired", 0)
+        bypassed = oc.get("bypassed", 0)
+        denom = fired + bypassed
+        gate_summary[name] = {
+            "fired": fired,
+            "bypassed": bypassed,
+            "bypass_rate": round(bypassed / denom, 4) if denom else 0.0,
+        }
+    return {
+        "total_events": total_events,
+        "command_usage": dict(commands.most_common()),
+        "gates": gate_summary,
+    }
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--log", default="metrics/telemetry.jsonl")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    log = Path(args.log)
+    if not log.is_file():
+        print("Telemetry is off (or no events recorded): "
+              f"{log} does not exist. Nothing has left the machine.")
+        return 0
+
+    summary = aggregate(log)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    print(f"# Telemetry report — {summary['total_events']} event(s)\n")
+    print("## Command / skill usage")
+    if summary["command_usage"]:
+        for name, n in summary["command_usage"].items():
+            print(f"  /{name}: {n}")
+    else:
+        print("  (none)")
+    print("\n## Gate bypass rates")
+    if summary["gates"]:
+        for name, g in summary["gates"].items():
+            print(f"  {name}: {g['bypassed']} bypassed / "
+                  f"{g['fired'] + g['bypassed']} attempts "
+                  f"({g['bypass_rate'] * 100:.1f}% bypassed)")
+    else:
+        print("  (none)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/dev-team/hooks/telemetry.sh
+++ b/plugins/dev-team/hooks/telemetry.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# telemetry.sh — opt-in, privacy-clean telemetry beacon (issue #106).
+#
+# The plugin enforces observability on its targets but has none of its own. This
+# records MINIMAL local events so the author can see which commands/skills get
+# used and how often the pre-commit review gate is bypassed. It is one hook
+# registered on multiple events; it branches on hook_event_name:
+#
+#   UserPromptSubmit  -> a slash command/skill was invoked: record its NAME only
+#   PreToolUse (Bash) -> a `git commit`: record the review gate as fired, or
+#                        BYPASSED when --no-verify is present
+#
+# PRIVACY: records only an event type, a command/gate NAME (matched to the
+# slash-command grammar, never free text), an outcome, and the plugin version.
+# No prompts, no command strings, no file paths, no code, no payloads.
+#
+# CONSENT: OFF by default. Enable with DEV_TEAM_TELEMETRY=on, or a
+# <cwd>/.claude/telemetry.json containing {"enabled": true}. When off, nothing
+# is recorded and nothing leaves the machine.
+#
+# TRANSPORT: local-only. Events append to <cwd>/metrics/telemetry.jsonl. There
+# is no network egress in this implementation by design.
+#
+# Posture: record-only, fail-open. Never blocks; any error -> exit 0.
+
+set -uo pipefail
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+echo "$input" | jq -e . >/dev/null 2>&1 || exit 0
+
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+[ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
+
+# --- consent gate (default OFF) ------------------------------------------------
+enabled="off"
+if [ "${DEV_TEAM_TELEMETRY:-}" = "on" ]; then
+  enabled="on"
+elif [ -f "${cwd}/.claude/telemetry.json" ]; then
+  if jq -e '.enabled == true' "${cwd}/.claude/telemetry.json" >/dev/null 2>&1; then
+    enabled="on"
+  fi
+fi
+[ "$enabled" = "on" ] || exit 0
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+version=$(jq -r '.version // "unknown"' "${HOOK_DIR}/../.claude-plugin/plugin.json" 2>/dev/null || echo unknown)
+log="${cwd}/metrics/telemetry.jsonl"
+
+_emit() {  # _emit <event> <name> <outcome>
+  mkdir -p "$(dirname "$log")" 2>/dev/null || return 0
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg event "$1" --arg name "$2" --arg outcome "$3" --arg v "$version" \
+    '{ts:$ts, event:$event, name:$name, outcome:$outcome, plugin_version:$v}' \
+    >> "$log" 2>/dev/null || true
+}
+
+event_name=$(echo "$input" | jq -r '.hook_event_name // empty')
+
+case "$event_name" in
+  UserPromptSubmit)
+    prompt=$(echo "$input" | jq -r '.prompt // empty')
+    # Only a leading slash-command token (grammar-matched), never free text.
+    if [[ "$prompt" =~ ^/([a-zA-Z][a-zA-Z0-9_-]*) ]]; then
+      _emit "command" "${BASH_REMATCH[1]}" "invoked"
+    fi
+    ;;
+  PreToolUse)
+    tool=$(echo "$input" | jq -r '.tool_name // empty')
+    [ "$tool" = "Bash" ] || exit 0
+    cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
+    if [[ "$cmd" == *"git commit"* ]]; then
+      if [[ "$cmd" == *"--no-verify"* ]] || [[ "$cmd" == *" -n "* ]]; then
+        _emit "gate" "pre-commit-review" "bypassed"
+      else
+        _emit "gate" "pre-commit-review" "fired"
+      fi
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1935,6 +1935,16 @@
       "anchor": "5-load-phase-context"
     }
   },
+  "plugins/dev-team/skills/cost-report/SKILL.md": {
+    "Steps": {
+      "summary": "1.",
+      "anchor": "steps"
+    },
+    "Notes": {
+      "summary": "Disable the meter with `DEV_TEAM_COST_METER=off`.",
+      "anchor": "notes"
+    }
+  },
   "plugins/dev-team/skills/design-doc/SKILL.md": {
     "Overview": {
       "summary": "The Research phase explores what exists.",

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3741,6 +3741,16 @@
       "anchor": "output"
     }
   },
+  "plugins/dev-team/skills/telemetry/SKILL.md": {
+    "Argument: $ARGUMENTS": {
+      "summary": "`status` (default): report whether telemetry is enabled and what's collected.",
+      "anchor": "argument-arguments"
+    },
+    "Steps": {
+      "summary": "1.",
+      "anchor": "steps"
+    }
+  },
   "plugins/dev-team/skills/test-design-advisor/SKILL.md": {
     "Overview": {
       "summary": "An **advisory** skill: it recommends how to test code and how to make untestable code testable.",

--- a/plugins/dev-team/knowledge/model-pricing.json
+++ b/plugins/dev-team/knowledge/model-pricing.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Per-million-token USD pricing for the cost meter (issue #102). Keyed by model snapshot ID (and tier alias). input/output are $ per 1M tokens; cache_write_multiplier (5-min TTL) and cache_read_multiplier are applied to the input rate per Anthropic's prompt-caching pricing (write 1.25x, read 0.1x). Source: Claude API reference, cached 2026-05-26. Update when pricing changes; this is the named instrument for any cost claim.",
+  "source": "platform.claude.com/docs/en/pricing (via claude-api skill cache 2026-05-26)",
+  "cache_write_multiplier": 1.25,
+  "cache_read_multiplier": 0.1,
+  "models": {
+    "claude-opus-4-8":   { "input": 5.0, "output": 25.0 },
+    "claude-opus-4-7":   { "input": 5.0, "output": 25.0 },
+    "claude-opus-4-6":   { "input": 5.0, "output": 25.0 },
+    "claude-sonnet-4-6": { "input": 3.0, "output": 15.0 },
+    "claude-haiku-4-5":  { "input": 1.0, "output": 5.0 },
+    "claude-haiku-4-5-20251001": { "input": 1.0, "output": 5.0 }
+  },
+  "aliases": {
+    "opus": "claude-opus-4-8",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5-20251001"
+  }
+}

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -111,6 +111,22 @@
           { "type": "command", "command": "bash hooks/codegraph-turn-mark.sh" }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": null,
+        "hooks": [
+          { "type": "command", "command": "bash hooks/cost-meter.sh" }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": null,
+        "hooks": [
+          { "type": "command", "command": "bash hooks/cost-meter.sh" }
+        ]
+      }
     ]
   }
 }

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -26,6 +26,13 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash hooks/telemetry.sh" }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit",
@@ -45,7 +52,8 @@
           {
             "type": "command",
             "command": "bash hooks/pre-commit-knowledge-index.sh"
-          }
+          },
+          { "type": "command", "command": "bash hooks/telemetry.sh" }
         ]
       },
       {

--- a/plugins/dev-team/skills/cost-report/SKILL.md
+++ b/plugins/dev-team/skills/cost-report/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: cost-report
+description: >-
+  Report actual token spend and dollar cost of dispatched work — per agent and
+  total — and flag cost regressions. Use when the user asks "how much did that
+  cost", "token spend", "cost of this run", "cost report", or wants to check for
+  a cost regression after /code-review or an orchestration run.
+argument-hint: "[--transcript <path>] [--tolerance <n>]"
+user-invocable: true
+allowed-tools: >-
+  Bash(python3 *, jq *, tail *, cat *, ls *)
+---
+
+# Cost Report (#102)
+
+Role: worker. Reports runtime cost/token spend captured by the cost meter.
+
+Token usage is not available to hooks, so the `Stop`/`SubagentStop` hook
+(`hooks/cost-meter.sh`) records a per-session summary to
+`metrics/cost-metering.jsonl` by parsing the session transcript, converting
+tokens to dollars via `knowledge/model-pricing.json`. This skill reports that
+data.
+
+## Steps
+
+1. **Per-session breakdown.** If the user passes `--transcript <path>` (or you
+   know the current transcript path), run an exact per-agent report:
+
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py report --transcript <path>
+   ```
+
+   Otherwise show the most recently recorded session from the metrics log:
+
+   ```bash
+   tail -n 1 metrics/cost-metering.jsonl | python3 -m json.tool
+   ```
+
+2. **Regression check.** Compare the latest session's total cost against the
+   rolling mean of prior sessions (default tolerance +50%):
+
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py regression \
+     --log metrics/cost-metering.jsonl --tolerance 0.5
+   ```
+
+3. Report the per-agent tokens + cost, the session total, and whether a cost
+   regression was detected. Do not invent numbers — print exactly what the
+   meter emits. If `metrics/cost-metering.jsonl` is absent, tell the user the
+   meter hasn't recorded a session yet (the hook records on turn end).
+
+## Notes
+
+- Disable the meter with `DEV_TEAM_COST_METER=off`.
+- Pricing lives in `knowledge/model-pricing.json` — update it when rates change
+  (it is the named instrument for every cost number this skill prints).

--- a/plugins/dev-team/skills/telemetry/SKILL.md
+++ b/plugins/dev-team/skills/telemetry/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: telemetry
+description: >-
+  Manage and report the opt-in, privacy-clean usage telemetry beacon. Use when
+  the user asks to "enable/disable telemetry", "show telemetry", "usage stats",
+  "which commands do I use", or "how often is the commit gate bypassed".
+argument-hint: "[on|off|status|report]"
+user-invocable: true
+allowed-tools: >-
+  Bash(python3 *, jq *, cat *, mkdir *, ls *), Read, Write
+---
+
+# Telemetry (#106)
+
+Role: worker. Manages consent for and reports the local, opt-in telemetry
+beacon. The beacon (`hooks/telemetry.sh`) records MINIMAL events — a command
+NAME, a gate name + outcome, and the plugin version — to
+`metrics/telemetry.jsonl`. No prompts, paths, code, or payloads are ever
+recorded, and there is **no network egress**: everything stays local.
+
+Telemetry is **OFF by default**. It activates only when
+`.claude/telemetry.json` contains `{"enabled": true}` or the env var
+`DEV_TEAM_TELEMETRY=on` is set.
+
+## Argument: $ARGUMENTS
+
+- `status` (default): report whether telemetry is enabled and what's collected.
+- `on`: enable by writing `.claude/telemetry.json` with `{"enabled": true}`
+  (confirm with the user first — this starts local recording).
+- `off`: disable by writing `{"enabled": false}` (recording stops; the existing
+  log is left in place for the user to inspect or delete).
+- `report`: print the usage summary.
+
+## Steps
+
+1. **status** — check `.claude/telemetry.json` and `DEV_TEAM_TELEMETRY`; state
+   on/off, and list exactly what is and isn't collected (events: command/skill
+   name, gate fired/bypassed, plugin version; never: prompt text, paths, code,
+   network).
+
+2. **on / off** — write `.claude/telemetry.json`:
+   ```json
+   { "enabled": true }
+   ```
+   For `on`, confirm consent first. Note the file is gitignored-by-convention
+   (project-local); recording is local-only.
+
+3. **report** — summarize the event log:
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/telemetry_report.py \
+     --log metrics/telemetry.jsonl
+   ```
+   Shows command/skill usage counts and the pre-commit review gate's bypass
+   rate. If the log doesn't exist, the report says telemetry is off and nothing
+   has left the machine.
+
+Report exactly what the tool emits; do not invent counts.

--- a/tests/repo/cost_meter_tests.bats
+++ b/tests/repo/cost_meter_tests.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Tests for the runtime cost/token meter (issue #102): transcript parsing,
+# per-agent attribution, token->dollar conversion via model-pricing.json, the
+# append-only metrics log, regression detection, and the Stop hook wrapper.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+METER="$REPO_ROOT/plugins/dev-team/hooks/lib/cost_meter.py"
+HOOK="$REPO_ROOT/plugins/dev-team/hooks/cost-meter.sh"
+
+setup() {
+  CASE="$(mktemp -d)"
+  cat > "$CASE/t.jsonl" <<'EOF'
+{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":2000,"cache_read_input_tokens":5000}}}
+{"type":"user","message":{"content":"hi"}}
+{"type":"assistant","agent_type":"security-review","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":8000,"output_tokens":1500,"cache_creation_input_tokens":3000}}}
+EOF
+}
+teardown() { rm -rf "$CASE"; }
+
+@test "meter: report attributes tokens per agent and totals" {
+  run python3 "$METER" report --transcript "$CASE/t.jsonl" --json
+  [ "$status" -eq 0 ]
+  # opus on orchestrator: 10000 in, 2000 out
+  [ "$(echo "$output" | jq -r '.by_agent.orchestrator.input_tokens')" = "10000" ]
+  # subagent attributed to security-review
+  [ "$(echo "$output" | jq -r '.by_agent."security-review".output_tokens')" = "1500" ]
+  [ "$(echo "$output" | jq -r '.totals.input_tokens')" = "18000" ]
+}
+
+@test "meter: dollar cost matches the pricing table" {
+  run python3 "$METER" report --transcript "$CASE/t.jsonl" --json
+  # opus: 10000/1e6*5 + 2000/1e6*25 + 5000/1e6*5*0.1 = 0.05+0.05+0.0025 = 0.1025
+  [ "$(echo "$output" | jq -r '.by_agent.orchestrator.cost_usd')" = "0.1025" ]
+  # sonnet: 8000/1e6*3 + 1500/1e6*15 + 3000/1e6*3*1.25 = 0.024+0.0225+0.01125 = 0.05775
+  [ "$(echo "$output" | jq -r '.by_agent."security-review".cost_usd')" = "0.05775" ]
+}
+
+@test "meter: unknown model is flagged as unpriced (cost 0, not crash)" {
+  echo '{"type":"assistant","message":{"model":"gpt-fake","usage":{"input_tokens":100,"output_tokens":10}}}' > "$CASE/u.jsonl"
+  run python3 "$METER" report --transcript "$CASE/u.jsonl" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.unpriced_models[0]')" = "gpt-fake" ]
+  [ "$(echo "$output" | jq -r '.totals.cost_usd')" = "0.0" ]
+}
+
+@test "meter: record appends a session summary line" {
+  run python3 "$METER" record --transcript "$CASE/t.jsonl" --log "$CASE/log.jsonl"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$CASE/log.jsonl")" -eq 1 ]
+  run jq -r '.total.messages' "$CASE/log.jsonl"
+  [ "$output" = "2" ]
+}
+
+@test "meter: regression flags a cost spike, passes within tolerance" {
+  printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.1}}' > "$CASE/ok.jsonl"
+  run python3 "$METER" regression --log "$CASE/ok.jsonl" --tolerance 0.5
+  [ "$status" -eq 0 ]
+  printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":5.0}}' > "$CASE/bad.jsonl"
+  run python3 "$METER" regression --log "$CASE/bad.jsonl" --tolerance 0.5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"COST REGRESSION"* ]]
+}
+
+@test "hook: Stop payload writes a metrics line under cwd/metrics" {
+  run bash -c "echo '{\"transcript_path\":\"$CASE/t.jsonl\",\"cwd\":\"$CASE\"}' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -f "$CASE/metrics/cost-metering.jsonl" ]
+}
+
+@test "hook: DEV_TEAM_COST_METER=off is a no-op" {
+  run bash -c "DEV_TEAM_COST_METER=off; export DEV_TEAM_COST_METER; echo '{\"transcript_path\":\"$CASE/t.jsonl\",\"cwd\":\"$CASE\"}' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -f "$CASE/metrics/cost-metering.jsonl" ]
+}
+
+@test "hook: missing transcript fails open (exit 0, no write)" {
+  run bash -c "echo '{\"transcript_path\":\"/nope/x.jsonl\",\"cwd\":\"$CASE\"}' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -f "$CASE/metrics/cost-metering.jsonl" ]
+}
+
+@test "settings.json registers cost-meter.sh on Stop and SubagentStop" {
+  run jq -e '.hooks.Stop[].hooks[] | select(.command | contains("cost-meter.sh"))' \
+    "$REPO_ROOT/plugins/dev-team/settings.json"
+  [ "$status" -eq 0 ]
+  run jq -e '.hooks.SubagentStop[].hooks[] | select(.command | contains("cost-meter.sh"))' \
+    "$REPO_ROOT/plugins/dev-team/settings.json"
+  [ "$status" -eq 0 ]
+}

--- a/tests/repo/no_pinned_snapshots_test.bats
+++ b/tests/repo/no_pinned_snapshots_test.bats
@@ -14,10 +14,13 @@ REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 #     values exactly because they describe the migration.
 #   evals/ — semgrep fixtures for OTHER plugins' LLM model strings.
 #   tests/  — bats fixtures that depend on the literal values.
+#   knowledge/model-pricing.json — cost meter's pricing table (#102); must key
+#     by model snapshot because the transcript usage records emit snapshot IDs.
 ALLOWED_PATHS=(
   "plugins/dev-team/knowledge/model-routing.json"
   "plugins/dev-team/docs/model-routing.md"
   "plugins/dev-team/templates/agents/agent-template.md"
+  "plugins/dev-team/knowledge/model-pricing.json"
 )
 
 @test "AC2: no pinned snapshot IDs in plugin source outside approved files" {
@@ -28,6 +31,7 @@ ALLOWED_PATHS=(
     ':!plugins/dev-team/knowledge/model-routing.json' \
     ':!plugins/dev-team/docs/model-routing.md' \
     ':!plugins/dev-team/templates/agents/agent-template.md' \
+    ':!plugins/dev-team/knowledge/model-pricing.json' \
     2>/dev/null || true)
   if [[ -n "$raw" ]]; then
     echo "Pinned snapshot IDs found in non-approved plugin source files:" >&2

--- a/tests/repo/telemetry_tests.bats
+++ b/tests/repo/telemetry_tests.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for the opt-in telemetry beacon (issue #106): default-off consent,
+# command/skill capture, gate fired/bypassed capture, privacy (no payloads),
+# and the report aggregation.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+HOOK="$REPO_ROOT/plugins/dev-team/hooks/telemetry.sh"
+REPORT="$REPO_ROOT/plugins/dev-team/hooks/lib/telemetry_report.py"
+
+setup() { D="$(mktemp -d)"; }
+teardown() { rm -rf "$D"; }
+
+_enable() { mkdir -p "$D/.claude"; echo '{"enabled":true}' > "$D/.claude/telemetry.json"; }
+_send() { echo "$1" | bash "$HOOK"; }
+
+@test "telemetry: OFF by default — nothing is recorded" {
+  _send "{\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"/specs\",\"cwd\":\"$D\"}"
+  [ ! -f "$D/metrics/telemetry.jsonl" ]
+}
+
+@test "telemetry: enabling via .claude/telemetry.json records a command event" {
+  _enable
+  _send "{\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"/code-review --scope x\",\"cwd\":\"$D\"}"
+  [ -f "$D/metrics/telemetry.jsonl" ]
+  run jq -r '.event + " " + .name' "$D/metrics/telemetry.jsonl"
+  [ "$output" = "command code-review" ]
+}
+
+@test "telemetry: env DEV_TEAM_TELEMETRY=on also enables" {
+  run bash -c "DEV_TEAM_TELEMETRY=on; export DEV_TEAM_TELEMETRY; echo '{\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"/build\",\"cwd\":\"$D\"}' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.name' "$D/metrics/telemetry.jsonl")" = "build" ]
+}
+
+@test "telemetry: records gate fired vs bypassed for git commit" {
+  _enable
+  _send "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m hello\"},\"cwd\":\"$D\"}"
+  _send "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit --no-verify -m skip\"},\"cwd\":\"$D\"}"
+  run jq -rs '[.[].outcome] | join(",")' "$D/metrics/telemetry.jsonl"
+  [ "$output" = "fired,bypassed" ]
+}
+
+@test "telemetry: privacy — no prompt text, command string, or paths in the log" {
+  _enable
+  _send "{\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"/specs SECRET_PROMPT_TEXT /home/u/secret\",\"cwd\":\"$D\"}"
+  _send "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m SECRET_MESSAGE\"},\"cwd\":\"$D\"}"
+  run cat "$D/metrics/telemetry.jsonl"
+  [[ "$output" != *"SECRET_PROMPT_TEXT"* ]]
+  [[ "$output" != *"SECRET_MESSAGE"* ]]
+  [[ "$output" != *"/home/u/secret"* ]]
+  # Only the documented keys are present.
+  run jq -rs 'all(.[]; (keys | sort) == ["event","name","outcome","plugin_version","ts"])' "$D/metrics/telemetry.jsonl"
+  [ "$output" = "true" ]
+}
+
+@test "telemetry: non-Bash PreToolUse and non-slash prompts record nothing" {
+  _enable
+  _send "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"x\"},\"cwd\":\"$D\"}"
+  _send "{\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"just a normal question\",\"cwd\":\"$D\"}"
+  [ ! -f "$D/metrics/telemetry.jsonl" ]
+}
+
+@test "report: aggregates usage and bypass rate" {
+  cat > "$D/t.jsonl" <<'EOF'
+{"event":"command","name":"specs","outcome":"invoked","plugin_version":"1"}
+{"event":"command","name":"specs","outcome":"invoked","plugin_version":"1"}
+{"event":"command","name":"build","outcome":"invoked","plugin_version":"1"}
+{"event":"gate","name":"pre-commit-review","outcome":"fired","plugin_version":"1"}
+{"event":"gate","name":"pre-commit-review","outcome":"bypassed","plugin_version":"1"}
+{"event":"gate","name":"pre-commit-review","outcome":"bypassed","plugin_version":"1"}
+EOF
+  run python3 "$REPORT" --log "$D/t.jsonl" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.command_usage.specs')" = "2" ]
+  [ "$(echo "$output" | jq -r '.gates."pre-commit-review".bypass_rate')" = "0.6667" ]
+}
+
+@test "report: disabled (no log) says nothing left the machine" {
+  run python3 "$REPORT" --log "$D/none.jsonl"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing has left the machine"* ]]
+}
+
+@test "settings.json registers telemetry.sh on UserPromptSubmit and PreToolUse Bash" {
+  run jq -e '.hooks.UserPromptSubmit[].hooks[] | select(.command | contains("telemetry.sh"))' \
+    "$REPO_ROOT/plugins/dev-team/settings.json"
+  [ "$status" -eq 0 ]
+  run jq -e '.hooks.PreToolUse[] | select(.matcher=="Bash") | .hooks[] | select(.command | contains("telemetry.sh"))' \
+    "$REPO_ROOT/plugins/dev-team/settings.json"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Implements **Wave 1** of the external-review improvements checklist (the observability spine, part of #98). Nothing downstream can be evidence-based without these two meters.

Closes #102, #106.

## #102 — Runtime cost/token metering

Key finding (confirmed against the Claude Code hooks docs): **PostToolUse hooks carry no token usage** — the canonical source is the session transcript JSONL, and every hook payload includes `transcript_path`.

- `plugins/dev-team/hooks/lib/cost_meter.py` parses the transcript and attributes input/output/cache tokens **per agent and per model**, converting to dollars via `plugins/dev-team/knowledge/model-pricing.json` (pricing verified against the Claude API reference, not guessed).
- `Stop`/`SubagentStop` hook (`hooks/cost-meter.sh`) records a per-session summary to `metrics/cost-metering.jsonl` — fail-open, opt-out via `DEV_TEAM_COST_METER=off`.
- `/cost-report` skill prints per-agent + total spend and runs a **rolling-baseline cost-regression** check (`regression` subcommand).
- Tests: `tests/repo/cost_meter_tests.bats` (9).

## #106 — Opt-in privacy-clean telemetry beacon

- `hooks/telemetry.sh` — **default-OFF, local-only**. Captures command/skill usage (`UserPromptSubmit`) and the pre-commit review gate **fired vs. bypassed** (`PreToolUse` Bash, `--no-verify` detection).
- Records only `{event, name, outcome, plugin_version}` — **no prompts, command strings, paths, code, or payloads, and no network egress**. A test asserts the exact key set so payloads can't leak.
- Consent via `.claude/telemetry.json` or `DEV_TEAM_TELEMETRY=on`; the `/telemetry` skill manages consent and reports command usage + gate-bypass rate (`hooks/lib/telemetry_report.py`).
- Tests: `tests/repo/telemetry_tests.bats` (9).

## Testing

Full content suite green: **213 bats pass, 0 fail** across `tests/{repo,knowledge,agents,commands,docs}/`. Both new shell hooks pass shellcheck; both Python tools compile. Knowledge index rebuilt for the two new skills; the AC2 pinned-snapshot guard updated to allow `model-pricing.json` (it must key by model snapshot, like `model-routing.json`).

## Notes
- Both meters use the established append-only-JSONL convention under `metrics/`.
- These unblock Wave 2: #111 (process eval) needs the cost meter; #112/#113 build on the telemetry signals.

https://claude.ai/code/session_01Vg4LdiQXrvzXu4LNRaWtaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg4LdiQXrvzXu4LNRaWtaf)_