### PR TITLE
feat(cost-meter): attribute spend per command and per fix-loop iteration

### DIFF
--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Runtime cost/token meter for dispatched work (issue #102).
+"""Runtime cost/token meter for dispatched work (issues #102, #134).
 
 PostToolUse hooks do NOT carry token usage in Claude Code; the canonical source
 is the session transcript JSONL, where each assistant message records a `usage`
@@ -8,22 +8,42 @@ so a Stop hook can hand this script the transcript to parse. This converts token
 usage to dollars via the named instrument knowledge/model-pricing.json (#102 is
 why that table exists) and writes an append-only metrics log.
 
+Attribution dimensions (#134)
+------------------------------
+Beyond per-agent and per-model, spend is attributed to:
+  * the invoking COMMAND/skill, read from the transcript's `attributionSkill`
+    field (falls back to "untagged" when a record carries no skill tag), and
+  * the fix-loop ITERATION, read from a `fixLoopIteration` / `reviewIteration`
+    / `iteration` marker on the record. The transcript has no native iteration
+    boundary, so the review->fix cycle is expected to stamp this marker on its
+    dispatches; absent the marker, usage degrades to the "unattributed" bucket
+    rather than being silently lost.
+
+Privacy boundary (#134, req 6)
+------------------------------
+This meter persists ONLY token counts, dollar amounts, model identifiers, agent
+identifiers, the skill/command tag, and the iteration index. It never reads or
+records prompt text, code, file paths, or tool payloads from the transcript —
+only the `usage`/`model`/attribution fields. The append-only metrics log is a
+metrics-only artifact by construction.
+
 Subcommands
 -----------
 report   --transcript T [--json]
-         Parse a transcript and print tokens + cost per agent and per model,
-         plus the session total. This is the acceptance command: "after a run,
-         print actual tokens spent per agent and total."
+         Parse a transcript and print tokens + cost per agent, per model, per
+         command, and per fix-loop iteration, plus the session total. The
+         acceptance command: "after a run, print actual tokens spent."
 
 record   --transcript T --log metrics/cost-metering.jsonl
          Append one session-summary line to the append-only metrics log
          (follows the metrics/config-changelog.jsonl convention). Used by the
          Stop hook. Idempotent on directory creation; never errors out loudly.
 
-regression --log metrics/cost-metering.jsonl [--tolerance 0.5]
+regression --log metrics/cost-metering.jsonl [--tolerance 0.5] [--window N]
          Compare the most recent session's total cost against the rolling mean
-         of prior sessions; exit 1 if it exceeds mean * (1 + tolerance). The
-         CI/regression hook the acceptance criteria asks for.
+         of prior sessions; exit 1 if it exceeds mean * (1 + tolerance). With
+         --window N the baseline is the mean of only the N most recent prior
+         sessions (a windowed rolling baseline) instead of all-time mean.
 
 The transcript schema is read defensively (usage may sit on the record or under
 `message`; model + agent attribution likewise), so it tolerates schema drift.
@@ -79,13 +99,21 @@ def _cost(usage: dict, rate: dict, pricing: dict) -> float:
     )
 
 
+_TOKEN_FIELDS = ("input_tokens", "output_tokens",
+                 "cache_creation_input_tokens", "cache_read_input_tokens")
+
+
+def _new_bucket() -> dict:
+    return {f: 0 for f in _TOKEN_FIELDS} | {"cost_usd": 0.0, "messages": 0}
+
+
 def parse_transcript(path: Path, pricing: dict) -> dict:
-    """Aggregate usage by agent and by model. Returns a summary dict."""
+    """Aggregate usage by agent, model, command, and fix-loop iteration."""
     by_agent: dict[str, dict] = {}
     by_model: dict[str, dict] = {}
-    totals = {"input_tokens": 0, "output_tokens": 0,
-              "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
-              "cost_usd": 0.0, "messages": 0}
+    by_command: dict[str, dict] = {}
+    by_iteration: dict[str, dict] = {}
+    totals = _new_bucket()
     unpriced_models: set[str] = set()
 
     for line in path.read_text().splitlines():
@@ -103,42 +131,53 @@ def parse_transcript(path: Path, pricing: dict) -> dict:
         # Sub-agent attribution: agent_type/agent_id present for subagents,
         # else the main orchestrator thread.
         agent = _dig(rec, "agent_type", "subagent_type", "agent_id") or "orchestrator"
+        # Invoking command/skill (#134): the transcript's attributionSkill tag.
+        command = _dig(rec, "attributionSkill", "attribution_skill") or "untagged"
+        # Fix-loop iteration marker (#134): stamped by the review->fix cycle;
+        # absent markers degrade to "unattributed" rather than being lost.
+        iteration = _dig(rec, "fixLoopIteration", "reviewIteration", "iteration")
+        iteration = str(iteration) if iteration is not None else "unattributed"
 
         rate = _rate(pricing, model)
         cost = _cost(usage, rate, pricing) if rate else 0.0
         if not rate and model != "unknown":
             unpriced_models.add(model)
 
-        for bucket, key in ((by_agent, agent), (by_model, model)):
-            b = bucket.setdefault(key, {"input_tokens": 0, "output_tokens": 0,
-                                        "cache_creation_input_tokens": 0,
-                                        "cache_read_input_tokens": 0,
-                                        "cost_usd": 0.0, "messages": 0})
-            for f in ("input_tokens", "output_tokens",
-                      "cache_creation_input_tokens", "cache_read_input_tokens"):
+        for bucket, key in ((by_agent, agent), (by_model, model),
+                            (by_command, command), (by_iteration, iteration)):
+            b = bucket.setdefault(key, _new_bucket())
+            for f in _TOKEN_FIELDS:
                 b[f] += usage.get(f, 0) or 0
             b["cost_usd"] = round(b["cost_usd"] + cost, 6)
             b["messages"] += 1
 
-        for f in ("input_tokens", "output_tokens",
-                  "cache_creation_input_tokens", "cache_read_input_tokens"):
+        for f in _TOKEN_FIELDS:
             totals[f] += usage.get(f, 0) or 0
         totals["cost_usd"] = round(totals["cost_usd"] + cost, 6)
         totals["messages"] += 1
 
-    return {"by_agent": by_agent, "by_model": by_model, "totals": totals,
-            "unpriced_models": sorted(unpriced_models)}
+    return {"by_agent": by_agent, "by_model": by_model,
+            "by_command": by_command, "by_iteration": by_iteration,
+            "totals": totals, "unpriced_models": sorted(unpriced_models)}
+
+
+def _print_dimension(title: str, bucket: dict) -> None:
+    if not bucket:
+        return
+    print(f"\n{title:<28} {'IN':>10} {'OUT':>10} {'COST $':>10}")
+    print("-" * 60)
+    for key, b in sorted(bucket.items(), key=lambda kv: -kv[1]["cost_usd"]):
+        print(f"{key:<28} {b['input_tokens']:>10} {b['output_tokens']:>10} "
+              f"{b['cost_usd']:>10.4f}")
 
 
 def _print_report(summary: dict) -> None:
     t = summary["totals"]
-    print(f"# Cost meter — {t['messages']} assistant message(s)\n")
-    print(f"{'AGENT':<28} {'IN':>10} {'OUT':>10} {'COST $':>10}")
-    print("-" * 60)
-    for agent, b in sorted(summary["by_agent"].items(),
-                           key=lambda kv: -kv[1]["cost_usd"]):
-        print(f"{agent:<28} {b['input_tokens']:>10} {b['output_tokens']:>10} "
-              f"{b['cost_usd']:>10.4f}")
+    print(f"# Cost meter — {t['messages']} assistant message(s)")
+    _print_dimension("AGENT", summary["by_agent"])
+    _print_dimension("COMMAND", summary.get("by_command", {}))
+    # Iteration ordered numerically where possible (1, 2, ... then unattributed).
+    _print_dimension("FIX-LOOP ITERATION", summary.get("by_iteration", {}))
     print("-" * 60)
     print(f"{'TOTAL':<28} {t['input_tokens']:>10} {t['output_tokens']:>10} "
           f"{t['cost_usd']:>10.4f}")
@@ -162,14 +201,19 @@ def cmd_record(args, pricing) -> int:
         return 0  # fail-open: hook must never break the session
     summary = parse_transcript(tpath, pricing)
     from datetime import datetime, timezone
+    def _slim(bucket: dict) -> dict:
+        return {k: {"cost_usd": b["cost_usd"],
+                    "input_tokens": b["input_tokens"],
+                    "output_tokens": b["output_tokens"]}
+                for k, b in bucket.items()}
+
     line = {
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "transcript": tpath.name,
         "total": summary["totals"],
-        "by_agent": {a: {"cost_usd": b["cost_usd"],
-                         "input_tokens": b["input_tokens"],
-                         "output_tokens": b["output_tokens"]}
-                     for a, b in summary["by_agent"].items()},
+        "by_agent": _slim(summary["by_agent"]),
+        "by_command": _slim(summary["by_command"]),
+        "by_iteration": _slim(summary["by_iteration"]),
     }
     log = Path(args.log)
     log.parent.mkdir(parents=True, exist_ok=True)
@@ -198,9 +242,14 @@ def cmd_regression(args, pricing) -> int:
         return 0
     latest = costs[-1]
     prior = costs[:-1]
+    # Windowed rolling baseline (#134): mean of only the N most recent priors.
+    window = getattr(args, "window", 0) or 0
+    if window > 0:
+        prior = prior[-window:]
     mean = sum(prior) / len(prior)
     limit = mean * (1 + args.tolerance)
-    print(f"latest=${latest:.4f}  rolling-mean(prior {len(prior)})=${mean:.4f}  "
+    win_label = f"window {len(prior)}" if window > 0 else f"prior {len(prior)}"
+    print(f"latest=${latest:.4f}  rolling-mean({win_label})=${mean:.4f}  "
           f"limit(+{int(args.tolerance*100)}%)=${limit:.4f}")
     if mean > 0 and latest > limit:
         print(f"COST REGRESSION: latest ${latest:.4f} exceeds limit ${limit:.4f}")
@@ -220,6 +269,9 @@ def main(argv: list[str]) -> int:
     p.add_argument("--log", default="metrics/cost-metering.jsonl")
     p = sub.add_parser("regression"); p.add_argument("--log", default="metrics/cost-metering.jsonl")
     p.add_argument("--tolerance", type=float, default=0.5)
+    p.add_argument("--window", type=int, default=0,
+                   help="baseline = mean of the N most recent prior sessions "
+                        "(0 = all-time mean)")
 
     args = ap.parse_args(argv)
     pricing = _load_pricing(Path(args.pricing))

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1940,6 +1940,14 @@
       "summary": "1.",
       "anchor": "steps"
     },
+    "Attribution dimensions (#134)": {
+      "summary": "`report` breaks spend down by **agent**, **command** (the transcript's",
+      "anchor": "attribution-dimensions-134"
+    },
+    "Privacy boundary (#134)": {
+      "summary": "The meter persists **only** token counts, dollar amounts, model/agent",
+      "anchor": "privacy-boundary-134"
+    },
     "Notes": {
       "summary": "Disable the meter with `DEV_TEAM_COST_METER=off`.",
       "anchor": "notes"

--- a/plugins/dev-team/skills/cost-report/SKILL.md
+++ b/plugins/dev-team/skills/cost-report/SKILL.md
@@ -44,10 +44,33 @@ data.
      --log metrics/cost-metering.jsonl --tolerance 0.5
    ```
 
-3. Report the per-agent tokens + cost, the session total, and whether a cost
-   regression was detected. Do not invent numbers — print exactly what the
-   meter emits. If `metrics/cost-metering.jsonl` is absent, tell the user the
-   meter hasn't recorded a session yet (the hook records on turn end).
+3. Report the per-agent, per-command, and per-fix-loop-iteration tokens + cost,
+   the session total, and whether a cost regression was detected. Do not invent
+   numbers — print exactly what the meter emits. If `metrics/cost-metering.jsonl`
+   is absent, tell the user the meter hasn't recorded a session yet (the hook
+   records on turn end).
+
+   For a windowed cost-regression baseline (mean of only the N most recent prior
+   sessions instead of all-time), pass `--window N`:
+
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py regression \
+     --log metrics/cost-metering.jsonl --tolerance 0.5 --window 10
+   ```
+
+## Attribution dimensions (#134)
+
+`report` breaks spend down by **agent**, **command** (the transcript's
+`attributionSkill` tag, so you can separate `/code-review` spend from `/build`),
+and **fix-loop iteration** (read from a `fixLoopIteration` marker — records
+without the marker fall into an `unattributed` bucket rather than being lost).
+
+## Privacy boundary (#134)
+
+The meter persists **only** token counts, dollar amounts, model/agent
+identifiers, the command tag, and the iteration index — never prompt text, code,
+file paths, or tool payloads. `metrics/cost-metering.jsonl` is a metrics-only
+artifact by construction.
 
 ## Notes
 

--- a/tests/repo/cost_meter_tests.bats
+++ b/tests/repo/cost_meter_tests.bats
@@ -79,6 +79,58 @@ teardown() { rm -rf "$CASE"; }
   [ ! -f "$CASE/metrics/cost-metering.jsonl" ]
 }
 
+@test "meter: attributes spend per command via attributionSkill (#134)" {
+  cat > "$CASE/cmd.jsonl" <<'EOF'
+{"type":"assistant","attributionSkill":"code-review","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":2000}}}
+{"type":"assistant","attributionSkill":"build","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":4000,"output_tokens":500}}}
+{"type":"assistant","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":100,"output_tokens":10}}}
+EOF
+  run python3 "$METER" report --transcript "$CASE/cmd.jsonl" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.by_command."code-review".input_tokens')" = "10000" ]
+  [ "$(echo "$output" | jq -r '.by_command.build.output_tokens')" = "500" ]
+  # records with no skill tag fall into "untagged", not lost
+  [ "$(echo "$output" | jq -r '.by_command.untagged.input_tokens')" = "100" ]
+}
+
+@test "meter: attributes spend per fix-loop iteration (#134)" {
+  cat > "$CASE/iter.jsonl" <<'EOF'
+{"type":"assistant","attributionSkill":"code-review","fixLoopIteration":1,"message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":2000}}}
+{"type":"assistant","attributionSkill":"code-review","fixLoopIteration":2,"message":{"model":"claude-opus-4-8","usage":{"input_tokens":6000,"output_tokens":1000}}}
+{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":500,"output_tokens":50}}}
+EOF
+  run python3 "$METER" report --transcript "$CASE/iter.jsonl" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.by_iteration."1".input_tokens')" = "10000" ]
+  [ "$(echo "$output" | jq -r '.by_iteration."2".input_tokens')" = "6000" ]
+  # un-marked records degrade to "unattributed"
+  [ "$(echo "$output" | jq -r '.by_iteration.unattributed.input_tokens')" = "500" ]
+}
+
+@test "meter: record persists by_command and by_iteration (#134)" {
+  cat > "$CASE/iter.jsonl" <<'EOF'
+{"type":"assistant","attributionSkill":"code-review","fixLoopIteration":1,"message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":2000}}}
+EOF
+  run python3 "$METER" record --transcript "$CASE/iter.jsonl" --log "$CASE/log.jsonl"
+  [ "$status" -eq 0 ]
+  run jq -r '.by_command."code-review".input_tokens' "$CASE/log.jsonl"
+  [ "$output" = "10000" ]
+  run jq -r '.by_iteration."1".output_tokens' "$CASE/log.jsonl"
+  [ "$output" = "2000" ]
+}
+
+@test "meter: regression --window uses only recent priors (#134)" {
+  # priors: 1,1,1, then a high 9; latest 5. All-time mean(1,1,1,9)=3 -> limit 4.5
+  # -> 5 regresses. Windowed mean of last 1 prior (9) -> limit 13.5 -> 5 passes.
+  printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.0}}' \
+    '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":9.0}}' \
+    '{"total":{"cost_usd":5.0}}' > "$CASE/w.jsonl"
+  run python3 "$METER" regression --log "$CASE/w.jsonl" --tolerance 0.5
+  [ "$status" -eq 1 ]
+  run python3 "$METER" regression --log "$CASE/w.jsonl" --tolerance 0.5 --window 1
+  [ "$status" -eq 0 ]
+}
+
 @test "settings.json registers cost-meter.sh on Stop and SubagentStop" {
   run jq -e '.hooks.Stop[].hooks[] | select(.command | contains("cost-meter.sh"))' \
     "$REPO_ROOT/plugins/dev-team/settings.json"


### PR DESCRIPTION
Closes #134.

## Gaps addressed

- **Gap 1 — no per-fix-loop-iteration attribution.** `parse_transcript` now buckets usage by **fix-loop iteration**, read from a `fixLoopIteration`/`reviewIteration`/`iteration` marker on the record. The transcript has no native iteration boundary, so the review→fix cycle is expected to stamp the marker; absent it, usage degrades to an `unattributed` bucket rather than being lost. `/cost-report` surfaces the breakdown.
- **Gap 2 — no per-command breakdown.** Added a **command** dimension keyed on the transcript's `attributionSkill` tag (fallback `untagged`), so `/code-review` spend separates from `/build` spend.
- **Privacy boundary (req 6).** Documented explicitly in the module docstring and the `/cost-report` skill: the meter persists only token counts, dollars, model/agent IDs, the command tag, and the iteration index — never prompts, code, paths, or payloads.
- **Windowed baseline.** `regression --window N` now bases the rolling mean on the N most recent prior sessions instead of all-time.

## Verification

`bats tests/repo/cost_meter_tests.bats` → 13/13 (added: per-command attribution incl. untagged fallback, per-iteration attribution incl. unattributed degradation, record persists both dimensions, windowed-baseline regression). `bash scripts/ci-local.sh` green; knowledge index rebuilt.

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_