### PR TITLE
Add return type annotation to forwardToFraudScoring function

### DIFF
--- a/evals/comparative/fixture-repo/services/auth-gateway/src/server.ts
+++ b/evals/comparative/fixture-repo/services/auth-gateway/src/server.ts
@@ -14,7 +14,7 @@ app.use(express.json());
 app.use("/admin", adminRoutes);
 
 // Outbound call to upstream — no retry / rate limit, hardcoded URL
-async function forwardToFraudScoring(body: unknown) {
+async function forwardToFraudScoring(body: unknown): Promise<unknown> {
   const upstream = process.env.API_UPSTREAM ?? "https://fraud-scoring.internal:8000";
   // SEED: F020 (scan-04 PII flow) — outbound egress with user-controlled body; response echoed back
   const res = await fetch(`${upstream}/predict`, {


### PR DESCRIPTION
## Problem Background
The function `forwardToFraudScoring` in `server.ts` lacks a return type annotation, making its return type ambiguous. This can reduce type safety and code readability in TypeScript, potentially leading to errors during maintenance.

## Changes Made
- Added explicit return type annotation `Promise<unknown>` to the `forwardToFraudScoring` function, aligning with TypeScript best practices and improving code clarity. Since the function is asynchronous, it returns a promise, and the annotation accurately reflects this behavior.

## Verification
- Run the TypeScript compiler (`tsc`) or existing type-checking tools to confirm no type errors are introduced.
- As this is a type annotation addition that does not change runtime functionality, existing tests should pass without modification, ensuring backward compatibility.