### PR TITLE
ci(cost-meter): wire the cost-regression check into CI

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -72,3 +72,10 @@ jobs:
             tests/hooks/updated_input_contract_tests.bats \
             tests/hooks/agent_model_resolve_hook_tests.bats \
             tests/hooks/model_resolve_tests.bats
+
+      # Cost-regression gate (#140): the cost meter ships a `regression`
+      # subcommand that nothing ran. This self-tests the mechanism (blocking)
+      # and, when a baseline log is committed, runs the real check warn-only —
+      # a non-deterministic meter must not hard-fail an unrelated code PR.
+      - name: Run cost-regression check
+        run: bash scripts/cost-regression-check.sh

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -75,6 +75,10 @@ run "bats — model-routing hook conformance" \
     tests/hooks/agent_model_resolve_hook_tests.bats \
     tests/hooks/model_resolve_tests.bats
 
+# --- plugin-tests.yml :: cost-regression gate (#140) -----------------------
+run "cost-regression check" \
+  bash scripts/cost-regression-check.sh
+
 # --- agent-eval.yml :: structural gate (model-free) ------------------------
 # (eval_grader_tests.bats already ran above as part of tests/repo/.)
 run "eval corpus integrity (eval_grade.py --check-corpus)" \

--- a/scripts/cost-regression-check.sh
+++ b/scripts/cost-regression-check.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# cost-regression-check.sh — CI wiring for the cost-meter regression gate (#140).
+#
+# hooks/lib/cost_meter.py ships a `regression` subcommand, but nothing ran it,
+# so a cost regression could merge unnoticed. This wires it into CI with three
+# honest behaviors given a non-deterministic meter and a transcript-less runner:
+#
+#   1. SELF-TEST (blocking). CI has no session transcripts, so we cannot measure
+#      this PR's cost. We CAN verify the mechanism still works: a synthetic spike
+#      must be flagged (exit 1) and a within-tolerance run must pass (exit 0). If
+#      that breaks, the gate is dishonest and CI fails.
+#
+#   2. COMMITTED BASELINE (warn-only). If a baseline log exists in the repo
+#      (metrics/cost-metering.jsonl), run the real regression check against it.
+#      A non-deterministic meter shouldn't HARD-fail an unrelated code PR, so a
+#      detected regression is surfaced as a warning annotation, not a block.
+#
+#   3. NO BASELINE. If no committed log exists (the current state — the log is
+#      written locally by the Stop hook), say so and pass cleanly.
+#
+# Tolerance and window are configurable via env (COST_TOLERANCE, COST_WINDOW).
+# Exit codes: 0 = ok (incl. warn), 1 = the regression mechanism itself is broken.
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" 2>/dev/null || cd "$(dirname "$0")/.." || exit 1
+
+METER="plugins/dev-team/hooks/lib/cost_meter.py"
+BASELINE="${COST_BASELINE_LOG:-metrics/cost-metering.jsonl}"
+TOLERANCE="${COST_TOLERANCE:-0.5}"
+WINDOW="${COST_WINDOW:-0}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "cost-regression-check: python3 not available; skipping." >&2
+  exit 0
+fi
+
+# --- 1. self-test (blocking) -------------------------------------------------
+echo "== cost-regression self-test =="
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.0}}' \
+  '{"total":{"cost_usd":5.0}}' > "$tmp/spike.jsonl"
+printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.1}}' \
+  > "$tmp/ok.jsonl"
+
+python3 "$METER" regression --log "$tmp/spike.jsonl" --tolerance "$TOLERANCE" >/dev/null 2>&1
+spike_rc=$?
+python3 "$METER" regression --log "$tmp/ok.jsonl" --tolerance "$TOLERANCE" >/dev/null 2>&1
+ok_rc=$?
+
+if [ "$spike_rc" -ne 1 ] || [ "$ok_rc" -ne 0 ]; then
+  echo "FAIL: cost-regression mechanism is broken" >&2
+  echo "  expected spike->exit 1 (got $spike_rc), within-tolerance->exit 0 (got $ok_rc)" >&2
+  exit 1
+fi
+echo "  ok: spike flagged, within-tolerance passes."
+
+# --- 2/3. real baseline (warn-only) or no baseline ---------------------------
+echo "== cost-regression against committed baseline =="
+if [ ! -f "$BASELINE" ]; then
+  echo "  no committed baseline at $BASELINE — the meter records locally via the"
+  echo "  Stop hook. Commit a baseline log to enable PR-time regression warnings."
+  exit 0
+fi
+
+args=(regression --log "$BASELINE" --tolerance "$TOLERANCE")
+[ "$WINDOW" -gt 0 ] && args+=(--window "$WINDOW")
+
+out="$(python3 "$METER" "${args[@]}" 2>&1)"
+rc=$?
+echo "$out"
+if [ "$rc" -ne 0 ]; then
+  # Warn-only: a non-deterministic meter must not block an unrelated PR.
+  echo "::warning title=Cost regression::per-run cost exceeded the rolling baseline (tolerance ${TOLERANCE})"
+fi
+exit 0

--- a/tests/repo/cost_regression_ci_tests.bats
+++ b/tests/repo/cost_regression_ci_tests.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Tests for scripts/cost-regression-check.sh — the CI wiring for the cost-meter
+# regression gate (#140): self-test (blocking), committed baseline (warn-only),
+# and no-baseline (clean pass).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+CHECK="$REPO_ROOT/scripts/cost-regression-check.sh"
+
+setup() { WORK="$(mktemp -d)"; }
+teardown() { rm -rf "$WORK"; }
+
+@test "ci-cost: self-test passes and no baseline -> clean exit 0" {
+  run env COST_BASELINE_LOG="$WORK/none.jsonl" bash "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"spike flagged, within-tolerance passes"* ]]
+  [[ "$output" == *"no committed baseline"* ]]
+}
+
+@test "ci-cost: a committed baseline with a spike warns but does NOT block" {
+  printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.0}}' \
+    '{"total":{"cost_usd":9.0}}' > "$WORK/base.jsonl"
+  run env COST_BASELINE_LOG="$WORK/base.jsonl" COST_TOLERANCE=0.5 bash "$CHECK"
+  [ "$status" -eq 0 ]                       # warn-only: never blocks
+  [[ "$output" == *"COST REGRESSION"* ]]
+  [[ "$output" == *"::warning"* ]]
+}
+
+@test "ci-cost: a within-tolerance baseline passes without a warning" {
+  printf '%s\n' '{"total":{"cost_usd":1.0}}' '{"total":{"cost_usd":1.1}}' \
+    > "$WORK/base.jsonl"
+  run env COST_BASELINE_LOG="$WORK/base.jsonl" COST_TOLERANCE=0.5 bash "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no cost regression"* ]]
+  [[ "$output" != *"::warning"* ]]
+}
+
+@test "ci-cost: registered as a step in plugin-tests.yml" {
+  grep -q "cost-regression-check.sh" "$REPO_ROOT/.github/workflows/plugin-tests.yml"
+}


### PR DESCRIPTION
Closes #140.

## Gap

`cost_meter.py` ships a `regression` subcommand whose own docstring calls it "the CI/regression hook the acceptance criteria asks for" — but nothing ran it. A cost regression could merge unnoticed.

## Approach (honest about a non-deterministic, transcript-less runner)

New `scripts/cost-regression-check.sh` with three behaviors:

1. **Self-test (blocking).** CI has no session transcripts, so we can't measure this PR's cost — but we verify the *mechanism*: a synthetic spike must be flagged (exit 1) and a within-tolerance run must pass (exit 0). If that breaks, CI fails.
2. **Committed baseline (warn-only).** If `metrics/cost-metering.jsonl` exists, run the real regression check and surface a `::warning` annotation instead of hard-failing an unrelated code PR (the meter is non-deterministic).
3. **No baseline.** Explains the log is written locally by the Stop hook, and passes cleanly (the current state).

Baseline source, tolerance, and window are configurable via `COST_BASELINE_LOG` / `COST_TOLERANCE` / `COST_WINDOW`. Wired into `plugin-tests.yml` and the `ci-local.sh` mirror.

## Verification

`bats tests/repo/cost_regression_ci_tests.bats` → 4/4 (self-test+no-baseline, spike warns-not-blocks, within-tolerance no-warn, registered in workflow). `shellcheck` clean; YAML validates; `bash scripts/ci-local.sh` green.

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_