### PR TITLE
fix(evals): make baseline provenance honest; document opt-in posture

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -7,8 +7,10 @@ deterministic, model-free grader that backs CI.
 
 ## CI gate (issue #99)
 
-`.github/workflows/agent-eval.yml` runs on every PR that touches
-`plugins/dev-team/agents/`, `skills/`, `knowledge/`, or `evals/`:
+`.github/workflows/agent-eval.yml` triggers on every PR that touches
+`plugins/dev-team/agents/`, `skills/`, `knowledge/`, or `evals/`. Triggering
+runs the **structural gate**; the **live gate is opt-in** and does **not**
+enforce on every PR (see below):
 
 1. **Structural gate (always, model-free).** `eval_grade.py --check-corpus`
    asserts every `expected/*.json` is valid, declares an agent/skill target,
@@ -69,12 +71,37 @@ The fixture stem is the `expected/*.json` filename without `.json`
 pass a green live run. The live gate only blocks on **regressions** — a listed
 pair that now fails — so an empty `passing` list never red-lines the gate.
 
-To record/update the baseline:
+To record/update the baseline from a **real** run:
 
 ```bash
-# 1. Run a green live eval to produce actuals.json (Claude Code runner).
-# 2. Grade with no baseline to see the full pass set:
-python3 scripts/eval_grade.py --actuals actuals.json
-# 3. Add the passing "fixture::agent" pairs to baseline.json "passing",
-#    and set "recorded_at" to the run date.
+# 1. Trigger a green live eval to produce actuals.json:
+#    add the `run-eval` label to a PR (post-merge of agent-eval.yml), or
+#    dispatch the workflow with force_live=true. Both require ANTHROPIC_API_KEY.
+# 2. Grade the run and write the baseline in one step — this stamps
+#    provenance="measured" and recorded_at=the run time, and MERGES (passing
+#    pairs added, tested-but-failing removed, untested pairs kept):
+python3 scripts/eval_grade.py --actuals actuals.json --write-baseline evals/baseline.json
 ```
+
+### Provenance (issue #133)
+
+`baseline.json` carries a `provenance` field:
+
+- `hand-authored` — the `passing` set was asserted by hand, **not** measured by
+  a live run. `recorded_at` is then the authoring date, not a run timestamp.
+- `measured` — written by `--write-baseline` from grading a real `actuals.json`.
+  `recorded_at` is the actual run time.
+
+The seed baseline ships as `hand-authored`. Recording a `measured` baseline
+requires the paid `run-eval` path above, so it is done post-merge rather than in
+this repo's hermetic CI.
+
+### Opt-in posture & cost (issues #133, #134)
+
+The live gate is **intentionally opt-in** (the `run-eval` label / `force_live`
+dispatch) to avoid uncontrolled API spend on every PR. This is a deliberate
+cost-control decision, **not** a defect: nothing in shipped prose should claim
+the live gate auto-enforces on every PR. A cost-budgeted default-on run will
+only be reconsidered **after** #134 (runtime cost metering) can produce a
+per-run live-eval cost estimate; until that estimate exists, the gate stays
+opt-in and no default-on change is made.

--- a/evals/baseline.json
+++ b/evals/baseline.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Regression baseline for the agent-eval CI gate (#99). Pairs listed here must not regress. Update with eval_grade.py --actuals <f> --write-baseline (merges into this file: passing pairs added, pairs tested-but-failing removed, untested pairs kept).",
+  "_comment": "Regression baseline for the agent-eval CI gate (#99). Pairs listed here must not regress. `provenance` is 'hand-authored' until a real green live run records it via eval_grade.py --actuals <f> --write-baseline (which stamps provenance='measured' and recorded_at=the run time). `recorded_at` below is the authoring date, NOT a measured-run timestamp (#133).",
+  "provenance": "hand-authored",
   "recorded_at": "2026-06-06T15:12:33Z",
   "passing": [
     "ar-clean-arch::arch-review",

--- a/scripts/eval_grade.py
+++ b/scripts/eval_grade.py
@@ -301,6 +301,9 @@ def main(argv: list[str]) -> int:
                         "eval_grade.py --actuals <f> --write-baseline (merges "
                         "into this file: passing pairs added, pairs tested-but-"
                         "failing removed, untested pairs kept).",
+            # Stamped 'measured' because this baseline came from grading a real
+            # actuals.json run, distinguishing it from a hand-authored seed (#133).
+            "provenance": "measured",
             "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "passing": sorted(merged),
         }, indent=2) + "\n")

--- a/tests/repo/eval_grader_tests.bats
+++ b/tests/repo/eval_grader_tests.bats
@@ -176,6 +176,16 @@ EOF
   [ -f "$CASE/baseline.json" ]
   run jq -r '.passing[0]' "$CASE/baseline.json"
   [ "$output" = "ar-demo::arch-review" ]
+  # a measured run stamps provenance=measured (#133)
+  run jq -r '.provenance' "$CASE/baseline.json"
+  [ "$output" = "measured" ]
+}
+
+@test "baseline: shipped evals/baseline.json declares its provenance (#133)" {
+  # The seed baseline is honestly marked hand-authored, not a measured run.
+  run jq -r '.provenance' "$BATS_TEST_DIRNAME/../../evals/baseline.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hand-authored" ]
 }
 
 @test "grader: --write-baseline MERGES, keeping untested pairs and adding new" {


### PR DESCRIPTION
Closes #133.

## What this resolves

The issue's core is **honesty**: `evals/baseline.json` looked measured (`recorded_at` like a real timestamp) but was hand-authored, and shipped prose implied the live gate auto-enforces on every PR.

- **Provenance made truthful.** `baseline.json` now carries `provenance: "hand-authored"`, with a comment stating `recorded_at` is the authoring date, not a measured-run timestamp. `eval_grade.py --write-baseline` stamps `provenance: "measured"` so a real green run is mechanically distinguished from the seed.
- **Opt-in posture documented & de-contradicted.** `evals/README.md` now states that triggering the workflow runs the *structural* gate while the *live* gate is intentionally opt-in (`run-eval` label / `force_live`) and does **not** auto-enforce on every PR — a deliberate cost-control decision, not a defect.
- **Cost deferral recorded (#134).** A cost-budgeted default-on run will only be reconsidered after #134 can produce a per-run live-eval cost estimate.
- **Refresh procedure** rewritten to the one-step `--write-baseline` merge flow.

## Honest scope note

Recording a *measured* baseline requires the paid `run-eval` path (`ANTHROPIC_API_KEY`), which is not available in this repo's hermetic/automated CI. Rather than fake a measured timestamp, the seed ships explicitly marked `hand-authored`, and the path to a measured baseline is now mechanized (`--write-baseline` stamps `measured`) and documented for the post-merge `run-eval` flow.

## Verification

`bats tests/repo/eval_grader_tests.bats` → all pass (added: `--write-baseline` stamps `measured`; shipped baseline declares `hand-authored`). `bash scripts/ci-local.sh` green.

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_