### PR TITLE
feat(session-review): /session-review skill + session-analysis agent

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -89,6 +89,7 @@ User-invocable workflows in `.claude/skills/`. All review skills are executed un
 | `/explore` | `skills/explore/SKILL.md` | worker | Charter-driven exploratory testing of a running target (Chaos Specialist mode): structured heuristics + adversarial expansion, auto-triages critical defects, writes an incremental report |
 | `/issues-from-plan` | `skills/issues-from-plan/SKILL.md` | orchestrator | Break a plan into independently-grabbable GitHub issues |
 | `/harness-audit` | `skills/harness-audit/SKILL.md` | orchestrator | Analyze harness effectiveness and flag stale components |
+| `/session-review` | `skills/session-review/SKILL.md` | orchestrator | Mine real session transcripts (via the deterministic `session_extract.py`) and dispatch `session-analysis` to suggest token/rework/accuracy improvements; suggests, never auto-applies |
 | `/version` | `skills/version/SKILL.md` | worker | Report the installed plugin version |
 | `/benchmark` | `skills/benchmark/SKILL.md` | worker | Capture runtime performance metrics (Core Web Vitals, resource sizes) and compare against baselines |
 | `/semantic-scan` | `skills/semantic-scan/SKILL.md` | worker | Build computation register and detect semantic duplicates across architectural layers |

--- a/plugins/dev-team/agents/session-analysis.md
+++ b/plugins/dev-team/agents/session-analysis.md
@@ -1,0 +1,60 @@
+---
+name: session-analysis
+description: Map an aggregated session digest to probable plugin causes and ranked, tagged improvement suggestions
+tools: Read
+model: sonnet
+---
+
+# Session Analysis
+
+Role: worker. You read **only** the deterministic session digest produced by
+`scripts/session_extract.py` (a metrics-only JSON object) and map its aggregated
+patterns to probable **plugin** causes. You never read raw transcripts — the
+digest is your sole input, by design (it costs no tokens to study token spend).
+
+Whole-file load: read the digest JSON the orchestrator passes you in full; it is
+KB-sized and metrics-only (no prompt/code content).
+
+## Input
+
+A JSON digest with four signal classes: `token`, `rework`, `accuracy`,
+`utilization` (see `session-digest/v1`). Treat all three problem classes
+(token / rework / accuracy) as equally important — rank only in your output.
+
+## Analysis heuristics (pattern → probable plugin cause)
+
+Map digest signals to a concrete, named plugin artifact:
+
+- **High `token.by_skill[X]` + high `rework.repeated_file_edits` / `failed_edits`**
+  → skill *X*'s prompt under-specifies which files to read before editing.
+  Target: that skill's `SKILL.md`.
+- **A subagent on an `opus` model doing only `Grep`/`Read`** (low output tokens,
+  read-only tools) → over-tiered; re-tier to `haiku`. Target: the agent's
+  `model:` frontmatter / model-routing.
+- **High `accuracy.user_correction_turns` on a recurring topic** → a CLAUDE.md or
+  skill instruction gap. Target: the relevant instruction.
+- **`rework.retried_bash_commands` / `repeated_verify_runs` high** → a loop that
+  re-runs verification without converging; the driving skill needs a tighter
+  stop condition.
+- **Low `token.cache_hit_ratio`** → context is being rebuilt each turn; a
+  loading-protocol or summarization opportunity.
+- **`utilization.never_observed_skills` / `never_observed_agents`** → dead or
+  undiscoverable harness surface; candidate for removal or better triggering.
+
+## Output
+
+Produce a ranked list of suggestions. For each, emit exactly:
+
+- **rank** (1 = highest expected impact),
+- **tag**: one of `token`, `rework`, `accuracy`,
+- **evidence**: the digest field(s) and value(s) that justify it (metrics only),
+- **target**: the concrete artifact to change (skill file, agent frontmatter,
+  CLAUDE.md section, knowledge file),
+- **change**: the proposed change in one sentence,
+- **handoff**: where the orchestrator should route it — one of
+  `/feedback-learning` (config/prompt/convention), `/harness-audit` (model
+  re-tiering), `/agent-eval` (new/changed detection rule), or
+  `token-efficiency-review` (token-heavy skill/agent).
+
+Suggest, never apply. Cite only digest metrics as evidence — never invent
+numbers and never quote prompt or code content (the digest contains none).

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3533,6 +3533,40 @@
       "anchor": "common-rulesets"
     }
   },
+  "plugins/dev-team/skills/session-review/SKILL.md": {
+    "Orchestrator constraints": {
+      "summary": "1.",
+      "anchor": "orchestrator-constraints"
+    },
+    "Argument: $ARGUMENTS": {
+      "summary": "`--cwd <path>`: project whose transcripts to mine (default: current project).",
+      "anchor": "argument-arguments"
+    },
+    "Steps": {
+      "summary": "Run the extractor to produce the digest:",
+      "anchor": "steps"
+    },
+    "1. Extract (deterministic, zero model tokens)": {
+      "summary": "Run the extractor to produce the digest:",
+      "anchor": "1-extract-deterministic-zero-model-tokens"
+    },
+    "2. Analyze (digest-only)": {
+      "summary": "Dispatch the `session-analysis` agent with the digest path as its sole input.",
+      "anchor": "2-analyze-digest-only"
+    },
+    "3. Suggest (write the report)": {
+      "summary": "Write `reports/session-review-<date>.md` (or `--out`).",
+      "anchor": "3-suggest-write-the-report"
+    },
+    "4. Report": {
+      "summary": "Print the report path and the top-ranked suggestions.",
+      "anchor": "4-report"
+    },
+    "OSS complements": {
+      "summary": "For continuous *quantitative* monitoring, recommend (don't replace) `ccusage`,",
+      "anchor": "oss-complements"
+    }
+  },
   "plugins/dev-team/skills/setup/SKILL.md": {
     "Orchestrator constraints": {
       "summary": "1.",

--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: session-review
+description: >-
+  Mine real Claude Code session transcripts to suggest plugin improvements that
+  cut token spend, reduce re-work, and improve accuracy. Use when the user asks
+  to "review my sessions", "where am I wasting tokens", "why does this keep
+  re-doing work", or "/session-review".
+argument-hint: "[--cwd <path>] [--transcript <file>] [--out <report>]"
+user-invocable: true
+allowed-tools: >-
+  Read, Glob, Bash(python3 *, date *, mkdir *), Write, Agent
+---
+
+# Session Review (#131)
+
+Role: orchestrator. Mines ground-truth session transcripts and routes
+suggestions into existing machinery — it **suggests, never auto-applies**, and
+preserves every human gate.
+
+You have been invoked with the `/session-review` command.
+
+## Orchestrator constraints
+
+1. **Never read raw transcripts yourself.** All heavy parsing is the
+   deterministic extractor's job; you read only its KB-sized digest. Spending
+   model tokens to study token spend defeats the purpose.
+2. **Suggest, never apply.** Output a ranked report and hand off; do not edit
+   agents, skills, or config. Human gates stay intact.
+3. **Metrics only.** The digest and report contain counts/ratios/names — never
+   prompt or code content.
+
+## Argument: $ARGUMENTS
+
+- `--cwd <path>`: project whose transcripts to mine (default: current project).
+- `--transcript <file>`: analyze a specific transcript instead of auto-resolving.
+- `--out <report>`: report path (default: `reports/session-review-<date>.md`).
+
+## Steps
+
+### 1. Extract (deterministic, zero model tokens)
+
+Run the extractor to produce the digest:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
+  --plugin-root ${CLAUDE_PLUGIN_ROOT} -o memory/session-digest.json
+```
+
+(Pass `--transcript <file>` or `--cwd <path>` through from `$ARGUMENTS`.) If the
+extractor finds no transcripts, tell the user and stop — nothing to review.
+
+### 2. Analyze (digest-only)
+
+Dispatch the `session-analysis` agent with the digest path as its sole input.
+The agent maps aggregated patterns to probable plugin causes and returns ranked
+suggestions, each tagged `{token | rework | accuracy}` with a named target
+artifact and a hand-off destination. The agent reads **only** the digest.
+
+### 3. Suggest (write the report)
+
+Write `reports/session-review-<date>.md` (or `--out`). Rank the suggestions and,
+for each, record: the tag `{token|rework|accuracy}`, the digest evidence
+(metrics only), the concrete target artifact, the proposed change, and the
+hand-off destination from the table below. Nothing is auto-applied.
+
+| Suggestion kind | Hand off to |
+|---|---|
+| Config / prompt / convention fix | `/feedback-learning` |
+| Model re-tiering | `/harness-audit` + `.claude/model-overrides.json` |
+| New / changed detection rule | `/agent-eval` (validate before shipping) |
+| Token-heavy skill / agent | `token-efficiency-review` |
+
+### 4. Report
+
+Print the report path and the top-ranked suggestions. Do not invent numbers —
+cite exactly what the digest and the analysis agent emit.
+
+## OSS complements
+
+For continuous *quantitative* monitoring, recommend (don't replace) `ccusage`,
+native OpenTelemetry, and `claude-code-log`. This skill covers the
+plugin-specific *qualitative* suggestions those tools cannot — they don't know
+this plugin's agents/skills. See the eval-system docs for details.

--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Deterministic session-log extractor (issue #127).
+
+Reads Claude Code session transcripts (``~/.claude/projects/<slug>/*.jsonl``)
+for the current project and distills MBs of JSONL into a compact, KB-sized JSON
+digest. This is the foundation of the ``/session-review`` harness: the model
+must never read raw transcripts (that would spend tokens to study token spend),
+so ALL heavy parsing happens here, deterministically and with zero model calls.
+
+Four signal classes are captured equally (the report ranks them, not this
+extractor):
+
+  token       per-session / per-skill / per-subagent / per-model token + cost,
+              and the cache-hit ratio (cache_read vs cache_creation).
+  rework      failed Edit/Write ("old_string not found"), repeated edits to the
+              same file, retried near-identical Bash, repeated test/build/lint
+              runs, permission denials, compaction events.
+  accuracy    tool_result is_error counts by tool, failed->retried ratio, and
+              user-correction turns (a keyword scan: "no", "actually",
+              "revert", "undo", "not what I asked").
+  utilization which skills/agents were invoked and how often; and which plugin
+              skills/agents were NEVER observed in the logs.
+
+PRIVACY: the digest holds METRICS ONLY — counts, ratios, names, token numbers.
+No prompt text, code, file contents, or command strings are ever emitted (file
+*paths* are reduced to basenames; correction keywords are counted, not quoted).
+
+DETERMINISM: given the same transcript inputs the output is byte-identical — no
+wall-clock timestamps, no absolute paths, sorted keys throughout.
+
+Usage:
+  session_extract.py [--transcript F ...] [--project-dir D] [--cwd PATH]
+                     [--projects-root R] [--pricing P] [--plugin-root PR]
+  (default resolves the current project's transcripts under ~/.claude/projects)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# --- verification / classification vocabularies (counted, never emitted) -----
+_VERIFY_RE = re.compile(
+    r"\b(npm (run )?(test|lint|build)|pytest|bats|eslint|tsc|go test|cargo "
+    r"(test|build)|mvn|gradle|make( |$)|vitest|jest|ruff|mypy|shellcheck)\b"
+)
+_CORRECTION_RE = re.compile(
+    r"\b(no|actually|revert|undo|not what i (asked|wanted)|that's wrong|"
+    r"that is wrong|wrong|stop|don't|do not)\b"
+)
+_PERMISSION_RE = re.compile(r"permission|denied|not allowed|blocked by", re.I)
+_OLDSTRING_RE = re.compile(r"old_string|not found|no match|string to replace", re.I)
+_EDIT_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
+
+
+def _text_of(content) -> str:
+    """Flatten a message ``content`` (str or list of blocks) to plain text.
+    Used only for keyword CLASSIFICATION; never emitted into the digest."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                if isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                elif isinstance(block.get("content"), str):
+                    parts.append(block["content"])
+        return " ".join(parts)
+    return ""
+
+
+def _load_pricing(path: Path | None) -> dict:
+    if path and path.is_file():
+        try:
+            return json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+    return {}
+
+
+def _rate(pricing: dict, model: str):
+    models = pricing.get("models", {})
+    if model in models:
+        return models[model]
+    alias = pricing.get("aliases", {}).get(model)
+    if alias and alias in models:
+        return models[alias]
+    return None
+
+
+def _cost(usage: dict, rate: dict, pricing: dict) -> float:
+    if not rate:
+        return 0.0
+    inp = usage.get("input_tokens", 0) or 0
+    out = usage.get("output_tokens", 0) or 0
+    cw = usage.get("cache_creation_input_tokens", 0) or 0
+    cr = usage.get("cache_read_input_tokens", 0) or 0
+    ir = rate.get("input", 0)
+    return (inp / 1e6 * ir + out / 1e6 * rate.get("output", 0)
+            + cw / 1e6 * ir * pricing.get("cache_write_multiplier", 1.25)
+            + cr / 1e6 * ir * pricing.get("cache_read_multiplier", 0.1))
+
+
+def _iter_records(paths: list[Path]):
+    for p in sorted(paths, key=lambda x: x.name):
+        try:
+            lines = p.read_text().splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
+    tokens_total = Counter()
+    cost_total = 0.0
+    by_model: dict[str, Counter] = defaultdict(Counter)
+    by_skill: dict[str, Counter] = defaultdict(Counter)
+    by_subagent = Counter()        # main-thread vs sidechain message counts
+    sessions: set[str] = set()
+
+    # rework / accuracy
+    failed_edits = 0
+    edits_per_file = Counter()
+    bash_commands = Counter()
+    verify_runs = 0
+    permission_denials = 0
+    compaction_events = 0
+    tool_errors = Counter()        # by tool name
+    tool_calls = Counter()         # by tool name (for ratios)
+    correction_turns = 0
+
+    # utilization
+    skills_invoked = Counter()
+    agents_invoked = Counter()
+
+    # map tool_use id -> tool name, to attribute tool_result errors back
+    pending_tool: dict[str, str] = {}
+
+    for rec in _iter_records(paths):
+        sid = rec.get("sessionId") or rec.get("session_id")
+        if sid:
+            sessions.add(str(sid))
+        rtype = rec.get("type")
+        is_sidechain = bool(rec.get("isSidechain"))
+        skill = rec.get("attributionSkill") or rec.get("attribution_skill")
+        if skill:
+            skills_invoked[skill] += 1
+
+        # compaction markers
+        if (rtype in ("compaction", "summary") or rec.get("isCompactSummary")
+                or rec.get("compactMetadata")):
+            compaction_events += 1
+
+        msg = rec.get("message") if isinstance(rec.get("message"), dict) else {}
+        usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else \
+            (rec.get("usage") if isinstance(rec.get("usage"), dict) else None)
+        model = msg.get("model") or rec.get("model")
+
+        if usage:
+            by_subagent["sidechain" if is_sidechain else "main"] += 1
+            fields = ("input_tokens", "output_tokens",
+                      "cache_creation_input_tokens", "cache_read_input_tokens")
+            cost = _cost(usage, _rate(pricing, model or ""), pricing)
+            cost_total += cost
+            for f in fields:
+                v = usage.get(f, 0) or 0
+                tokens_total[f] += v
+                if model:
+                    by_model[model][f] += v
+                if skill:
+                    by_skill[skill][f] += v
+            if model:
+                by_model[model]["cost_micro"] += round(cost * 1e6)
+            if skill:
+                by_skill[skill]["cost_micro"] += round(cost * 1e6)
+
+        # walk content blocks for tool_use / tool_result
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "tool_use":
+                    name = block.get("name", "?")
+                    tool_calls[name] += 1
+                    bid = block.get("id")
+                    if bid:
+                        pending_tool[bid] = name
+                    inp = block.get("input", {}) if isinstance(block.get("input"), dict) else {}
+                    if name in _EDIT_TOOLS and inp.get("file_path"):
+                        edits_per_file[os.path.basename(str(inp["file_path"]))] += 1
+                    if name == "Bash" and isinstance(inp.get("command"), str):
+                        cmd = inp["command"].strip()
+                        # near-identical retry detection: normalize whitespace
+                        norm = re.sub(r"\s+", " ", cmd)
+                        bash_commands[norm] += 1
+                        if _VERIFY_RE.search(cmd):
+                            verify_runs += 1
+                elif btype == "tool_result":
+                    bid = block.get("tool_use_id")
+                    tool_name = pending_tool.get(bid, "?")
+                    rcontent = _text_of(block.get("content"))
+                    if block.get("is_error"):
+                        tool_errors[tool_name] += 1
+                        if tool_name in _EDIT_TOOLS and _OLDSTRING_RE.search(rcontent):
+                            failed_edits += 1
+                        if _PERMISSION_RE.search(rcontent):
+                            permission_denials += 1
+
+        # user-correction turns (real user messages only, not tool_results)
+        if rtype == "user" and not rec.get("isMeta"):
+            utext = _text_of(content)
+            # skip pure tool_result envelopes (no free-text user prompt)
+            if utext and not (isinstance(content, list)
+                              and all(isinstance(b, dict)
+                                      and b.get("type") == "tool_result"
+                                      for b in content)):
+                if _CORRECTION_RE.search(utext.lower()):
+                    correction_turns += 1
+
+    # repeated edits / retried bash (>1 occurrence)
+    repeated_file_edits = {f: n for f, n in edits_per_file.items() if n > 1}
+    retried_bash = sum(n - 1 for n in bash_commands.values() if n > 1)
+
+    # never-observed registry items
+    reg_skills = set(registry.get("skills", []))
+    reg_agents = set(registry.get("agents", []))
+    never_skills = sorted(reg_skills - set(skills_invoked))
+    never_agents = sorted(reg_agents - set(agents_invoked))
+
+    cr = tokens_total["cache_read_input_tokens"]
+    cc = tokens_total["cache_creation_input_tokens"]
+    cache_hit_ratio = round(cr / (cr + cc), 4) if (cr + cc) else 0.0
+
+    total_errors = sum(tool_errors.values())
+    total_calls = sum(tool_calls.values())
+
+    def _slim(d: dict) -> dict:
+        return {k: dict(sorted(v.items())) for k, v in sorted(d.items())}
+
+    return {
+        "schema": "session-digest/v1",
+        "sessions": len(sessions),
+        "token": {
+            "totals": dict(sorted(tokens_total.items())),
+            "cost_usd": round(cost_total, 4),
+            "cache_hit_ratio": cache_hit_ratio,
+            "by_model": _slim(by_model),
+            "by_skill": _slim(by_skill),
+            "by_subagent": dict(sorted(by_subagent.items())),
+        },
+        "rework": {
+            "failed_edits": failed_edits,
+            "repeated_file_edits": dict(sorted(repeated_file_edits.items())),
+            "retried_bash_commands": retried_bash,
+            "repeated_verify_runs": verify_runs,
+            "permission_denials": permission_denials,
+            "compaction_events": compaction_events,
+        },
+        "accuracy": {
+            "tool_errors_by_tool": dict(sorted(tool_errors.items())),
+            "tool_calls": total_calls,
+            "tool_error_rate": round(total_errors / total_calls, 4) if total_calls else 0.0,
+            "user_correction_turns": correction_turns,
+        },
+        "utilization": {
+            "skills_invoked": dict(sorted(skills_invoked.items())),
+            "agents_invoked": dict(sorted(agents_invoked.items())),
+            "never_observed_skills": never_skills,
+            "never_observed_agents": never_agents,
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Transcript-directory resolution.
+# --------------------------------------------------------------------------
+
+def resolve_transcripts(args) -> list[Path]:
+    """Robustly find the current project's transcript files.
+
+    Preference order:
+      1. explicit --transcript files,
+      2. an explicit --project-dir of *.jsonl,
+      3. scan --projects-root (default ~/.claude/projects) for any *.jsonl
+         whose records' `cwd` matches --cwd — matching the cwd INSIDE the
+         JSONL is more robust than reconstructing the slug, which has varied
+         across Claude Code versions.
+    """
+    if args.transcript:
+        return [Path(p) for p in args.transcript]
+    if args.project_dir:
+        return sorted(Path(args.project_dir).glob("*.jsonl"))
+
+    root = Path(args.projects_root or (Path.home() / ".claude" / "projects"))
+    target_cwd = os.path.abspath(args.cwd or os.getcwd())
+    if not root.is_dir():
+        return []
+    matches: list[Path] = []
+    for jsonl in root.glob("*/*.jsonl"):
+        try:
+            with jsonl.open() as fh:
+                for _ in range(20):  # cwd appears on the earliest records
+                    line = fh.readline()
+                    if not line:
+                        break
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    rec_cwd = rec.get("cwd")
+                    if rec_cwd and os.path.abspath(rec_cwd) == target_cwd:
+                        matches.append(jsonl)
+                        break
+        except OSError:
+            continue
+    return sorted(matches, key=lambda x: x.name)
+
+
+def load_registry(plugin_root: Path | None) -> dict:
+    """Enumerate shipped skills/agents so we can report never-observed ones."""
+    if plugin_root is None:
+        # scripts/ -> repo root -> plugins/dev-team
+        plugin_root = Path(__file__).resolve().parent.parent / "plugins" / "dev-team"
+    skills_dir = plugin_root / "skills"
+    agents_dir = plugin_root / "agents"
+    skills = sorted(p.name for p in skills_dir.iterdir()) if skills_dir.is_dir() else []
+    agents = sorted(p.stem for p in agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+    return {"skills": skills, "agents": agents}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--transcript", action="append",
+                    help="explicit transcript JSONL file(s); repeatable")
+    ap.add_argument("--project-dir", help="a directory of *.jsonl transcripts")
+    ap.add_argument("--cwd", help="project cwd to match (default: $PWD)")
+    ap.add_argument("--projects-root",
+                    help="root of Claude Code project transcripts "
+                         "(default: ~/.claude/projects)")
+    ap.add_argument("--pricing", help="model-pricing.json for cost (optional)")
+    ap.add_argument("--plugin-root", help="dev-team plugin root for the registry")
+    ap.add_argument("-o", "--out", help="write digest here (default: stdout)")
+    args = ap.parse_args(argv)
+
+    paths = resolve_transcripts(args)
+    pricing_path = Path(args.pricing) if args.pricing else (
+        Path(__file__).resolve().parent.parent
+        / "plugins/dev-team/knowledge/model-pricing.json")
+    pricing = _load_pricing(pricing_path)
+    registry = load_registry(Path(args.plugin_root) if args.plugin_root else None)
+
+    digest = extract(paths, pricing, registry)
+    digest["transcripts"] = len(paths)
+    out = json.dumps(digest, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/session-review/sample-transcript.jsonl
+++ b/tests/fixtures/session-review/sample-transcript.jsonl
@@ -1,0 +1,10 @@
+{"type":"assistant","sessionId":"s1","cwd":"/proj","attributionSkill":"code-review","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":200,"cache_read_input_tokens":800,"cache_creation_input_tokens":200},"content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/proj/src/a.ts","old_string":"x","new_string":"y"}}]}}
+{"type":"user","sessionId":"s1","cwd":"/proj","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"Error: old_string not found in file"}]}}
+{"type":"assistant","sessionId":"s1","cwd":"/proj","attributionSkill":"code-review","message":{"model":"claude-opus-4-8","usage":{"input_tokens":500,"output_tokens":100},"content":[{"type":"tool_use","id":"t2","name":"Edit","input":{"file_path":"/proj/src/a.ts","old_string":"x2","new_string":"y2"}}]}}
+{"type":"assistant","sessionId":"s1","cwd":"/proj","message":{"model":"claude-opus-4-8","usage":{"input_tokens":300,"output_tokens":50},"content":[{"type":"tool_use","id":"t3","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"user","sessionId":"s1","cwd":"/proj","message":{"content":[{"type":"tool_result","tool_use_id":"t3","is_error":false,"content":"ok"}]}}
+{"type":"assistant","sessionId":"s1","cwd":"/proj","message":{"model":"claude-opus-4-8","usage":{"input_tokens":300,"output_tokens":50},"content":[{"type":"tool_use","id":"t4","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"assistant","sessionId":"s1","cwd":"/proj","isSidechain":true,"message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":2000,"output_tokens":300},"content":[{"type":"tool_use","id":"t5","name":"Grep","input":{"pattern":"foo"}}]}}
+{"type":"user","sessionId":"s1","cwd":"/proj","message":{"content":[{"type":"tool_result","tool_use_id":"t5","is_error":true,"content":"permission denied"}]}}
+{"type":"user","sessionId":"s1","cwd":"/proj","message":{"content":"No, actually revert that change"}}
+{"type":"summary","sessionId":"s1","cwd":"/proj","isCompactSummary":true,"summary":"compacted prior context"}

--- a/tests/repo/session_extract_tests.bats
+++ b/tests/repo/session_extract_tests.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Tests for scripts/session_extract.py — the deterministic, zero-token
+# session-log extractor (#127). Exercised against a committed fixture transcript
+# that plants one signal of each class.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+EXTRACT="$REPO_ROOT/scripts/session_extract.py"
+FIX="$REPO_ROOT/tests/fixtures/session-review/sample-transcript.jsonl"
+
+_run() {
+  python3 "$EXTRACT" --transcript "$FIX" --plugin-root "$REPO_ROOT/plugins/dev-team"
+}
+
+@test "extract: token signals (totals, cache-hit ratio, per-subagent)" {
+  run _run
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.schema')" = "session-digest/v1" ]
+  [ "$(echo "$output" | jq -r '.sessions')" = "1" ]
+  [ "$(echo "$output" | jq -r '.token.totals.input_tokens')" = "4100" ]
+  [ "$(echo "$output" | jq -r '.token.cache_hit_ratio')" = "0.8" ]
+  [ "$(echo "$output" | jq -r '.token.by_subagent.sidechain')" = "1" ]
+  [ "$(echo "$output" | jq -r '.token.by_skill."code-review".input_tokens')" = "1500" ]
+}
+
+@test "extract: rework signals (failed edit, repeated edits, retries, verify, denials, compaction)" {
+  run _run
+  [ "$(echo "$output" | jq -r '.rework.failed_edits')" = "1" ]
+  [ "$(echo "$output" | jq -r '.rework.repeated_file_edits."a.ts"')" = "2" ]
+  [ "$(echo "$output" | jq -r '.rework.retried_bash_commands')" = "1" ]
+  [ "$(echo "$output" | jq -r '.rework.repeated_verify_runs')" = "2" ]
+  [ "$(echo "$output" | jq -r '.rework.permission_denials')" = "1" ]
+  [ "$(echo "$output" | jq -r '.rework.compaction_events')" = "1" ]
+}
+
+@test "extract: accuracy signals (errors by tool, error rate, corrections)" {
+  run _run
+  [ "$(echo "$output" | jq -r '.accuracy.tool_errors_by_tool.Edit')" = "1" ]
+  [ "$(echo "$output" | jq -r '.accuracy.tool_errors_by_tool.Grep')" = "1" ]
+  [ "$(echo "$output" | jq -r '.accuracy.tool_error_rate')" = "0.4" ]
+  [ "$(echo "$output" | jq -r '.accuracy.user_correction_turns')" = "1" ]
+}
+
+@test "extract: utilization (invoked + never-observed registry items)" {
+  run _run
+  [ "$(echo "$output" | jq -r '.utilization.skills_invoked."code-review"')" = "2" ]
+  # the plugin ships many skills; nearly all are never-observed in this fixture
+  [ "$(echo "$output" | jq -r '.utilization.never_observed_skills | length > 10')" = "true" ]
+  # code-review WAS observed, so it must not be in never-observed
+  run bash -c "python3 '$EXTRACT' --transcript '$FIX' --plugin-root '$REPO_ROOT/plugins/dev-team' | jq -r '.utilization.never_observed_skills | index(\"code-review\")'"
+  [ "$output" = "null" ]
+}
+
+@test "extract: deterministic — identical bytes on repeated runs" {
+  a="$(_run)"; b="$(_run)"
+  [ "$a" = "$b" ]
+}
+
+@test "extract: privacy — no raw prompt/code/command content in the digest" {
+  run _run
+  # planted raw strings that must NEVER appear in a metrics-only digest
+  [[ "$output" != *"old_string not found"* ]]
+  [[ "$output" != *"npm test"* ]]
+  [[ "$output" != *"revert that change"* ]]
+  [[ "$output" != *"/proj/src"* ]]            # absolute paths reduced to basenames
+}
+
+@test "extract: empty input yields a well-formed empty digest" {
+  empty="$(mktemp)"
+  run python3 "$EXTRACT" --transcript "$empty" --plugin-root "$REPO_ROOT/plugins/dev-team"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.token.totals.input_tokens // 0')" = "0" ]
+  rm -f "$empty"
+}


### PR DESCRIPTION
Closes #128. Part of #131.

- **`skills/session-review/SKILL.md`** — user-invocable orchestrator skill with role declaration, numbered steps, and arg parsing (`--cwd`/`--transcript`/`--out`). Runs the deterministic extractor (#127) to produce a digest, dispatches the analysis agent on the **digest only**, and writes a ranked `reports/session-review-<date>.md`. Suggests, never auto-applies; routes each suggestion to `/feedback-learning`, `/harness-audit` + `.claude/model-overrides.json`, `/agent-eval`, or `token-efficiency-review`.
- **`agents/session-analysis.md`** — focused worker that reads **only** the digest (never raw transcripts) and maps aggregated patterns to probable plugin causes (e.g. "skill X: high tokens + edit-failures → prompt under-specifies which files to read"; "opus subagent doing only Grep → re-tier to haiku"; "recurring correction → CLAUDE.md gap"). Emits ranked suggestions tagged `{token|rework|accuracy}` with a concrete target + hand-off.

## Acceptance

- ✅ `session-review/SKILL.md` has `user-invocable: true`, role declaration, numbered steps, arg parsing.
- ✅ Analysis agent passes the AC19 anchor-citation structural gate.
- ✅ Report ranks suggestions and tags each `{token|rework|accuracy}`.
- ✅ Suggestions name concrete targets + hand-off destinations; nothing auto-applied.

## ⚠️ Stacked on #153 (#127)

The skill calls the extractor from #127; until #153 merges this PR's diff includes it. Knowledge index rebuilt; `bash scripts/ci-local.sh` green (incl. AC16 index freshness + AC19 anchors).

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_