### PR TITLE
ci(agent-eval): surface the real error from the live-gate action crash

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -175,8 +175,17 @@ jobs:
       - name: Run agent-eval (records actuals.json)
         if: steps.cred.outputs.run_live == 'true'
         uses: anthropics/claude-code-action@v1
+        # Debugging a launch-time crash of the action's bundled Claude Code
+        # process ("Claude Code process exited with code 1"): by default the
+        # action hides the SDK's output ("full output hidden for security"), so
+        # the real error is invisible. show_full_output surfaces it and
+        # ANTHROPIC_LOG=debug makes the SDK verbose. Revert both once the
+        # underlying failure is identified.
+        env:
+          ANTHROPIC_LOG: debug
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
           plugin_marketplaces: ${{ github.workspace }}
           plugins: "dev-team@bfinster"
           prompt: |


### PR DESCRIPTION
## Why

The live agent-eval gate (`live-gate` job) crashed at launch with `Claude Code process exited with code 1`, inside `anthropics/claude-code-action@v1` — before any fixture was graded (no `actuals.json` produced). The action **hides the SDK output by default** (`full output hidden for security`), so the actual failure is invisible; the only visible line is a benign internal warning (`directory mismatch … tsconfig.json` — *"You don't need to do anything"*).

## What

On the **Run agent-eval** step only:
- `show_full_output: true` — so the action prints the SDK's real stdout/stderr instead of suppressing it.
- `env: ANTHROPIC_LOG: debug` — so the bundled Claude Code SDK logs verbosely.

Temporary debugging aid — revert both once the underlying cause is identified.

## ⚠️ Note on when this takes effect

`claude-code-action` self-skips on any PR that modifies this workflow (GitHub requires the workflow to match the default branch), so the change only exercises **after merge to `main`**. Once merged, re-dispatch the live gate (`workflow_dispatch` with `force_live=true`, or the `run-eval` label) to capture the real error.

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_