### PR TITLE
ci(agent-eval): use npm node build of Claude Code, not the crashing native build

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -131,6 +131,21 @@ jobs:
         if: steps.cred.outputs.run_live == 'true'
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      # The action's bundled installer pulls the NATIVE build of Claude Code,
+      # which currently crashes at launch in the runner ("Claude Code process
+      # exited with code 1" / "directory mismatch ... tsconfig.json"). The npm
+      # (node) build does not hit that crash, and the action accepts a custom
+      # executable via path_to_claude_code_executable. Install the node build
+      # here and point the action at it below.
+      - name: Install Claude Code (node build) to dodge the native-build crash
+        id: install-claude
+        if: steps.cred.outputs.run_live == 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          CLAUDE_BIN="$(command -v claude || echo "$(npm prefix -g)/bin/claude")"
+          echo "path=$CLAUDE_BIN" >> "$GITHUB_OUTPUT"
+          "$CLAUDE_BIN" --version
+
       # The agent-eval skill reads fixtures from .claude/evals/{fixtures,
       # expected}/, but this repo stores them at evals/. Symlink them into
       # place so the skill finds the corpus in CI.
@@ -185,6 +200,8 @@ jobs:
           ANTHROPIC_LOG: debug
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the node build installed above, not the action's crashing native build.
+          path_to_claude_code_executable: ${{ steps.install-claude.outputs.path }}
           show_full_output: true
           plugin_marketplaces: ${{ github.workspace }}
           plugins: "dev-team@bfinster"


### PR DESCRIPTION
## Root cause (confirmed via #161's debug flags)

The live agent-eval gate crash is **upstream**, not in our eval code. `anthropics/claude-code-action@v1` installs the **native build of Claude Code `2.1.168`**, the SDK spawns it, and it **exits code 1 at launch** — before any fixture runs, with no stdout even at `ANTHROPIC_LOG=debug`:

```
Installing Claude Code native build 2.1.168...
error: Claude Code process exited with code 1   (sdk.mjs #handleOnExit)
Internal error: directory mismatch for directory ".../tsconfig.json", fd 4
```

Deterministic across two runs. The action effectively hardcodes the CLI version and exposes **no version-pin input** (anthropics/claude-code-action#1135), and native-build installs have broken before (2.1.88 was pulled).

## Fix

The action *does* accept a custom executable (`path_to_claude_code_executable`). So:
- Add a step that installs the **npm (node) build** of `@anthropic-ai/claude-code` — which doesn't hit the native-build `tsconfig` crash — and captures its path.
- Pass that path to the action via `path_to_claude_code_executable`.

`show_full_output: true` / `ANTHROPIC_LOG=debug` (from #161) are kept for **one confirming run**; once the gate is green they should be reverted.

## Validation

This change only takes effect after merge to `main` (claude-code-action self-skips on PRs that modify this workflow). After merge, re-dispatch the live gate (`workflow_dispatch` → `force_live=true`, or the `run-eval` label) to confirm the node build launches and `actuals.json` is produced.

Sources: [claude-code-action#1135](https://github.com/anthropics/claude-code-action/issues/1135), [configuration docs](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md)

https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkh8R6vhx3oYSKJMUqyYeR)_