### PR TITLE
test(cost-pace): make _ts() portable across GNU and BSD date

### DIFF
--- a/tests/repo/cost_pace_tests.bats
+++ b/tests/repo/cost_pace_tests.bats
@@ -8,7 +8,11 @@ setup() { CASE="$(mktemp -d)"; }
 teardown() { rm -rf "$CASE"; }
 
 # A timestamp N days before now, in the meter's ISO format.
-_ts() { date -u -d "$1 days ago" +%Y-%m-%dT%H:%M:%SZ; }
+# Portable across GNU (date -d) and BSD/macOS (date -v).
+_ts() {
+  date -u -d "$1 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-"$1"d +%Y-%m-%dT%H:%M:%SZ
+}
 
 @test "pace: no log -> says nothing to pace" {
   run python3 "$METER" pace --log "$CASE/none.jsonl"


### PR DESCRIPTION
## Summary
- The `cost_pace_tests.bats` helper `_ts()` used GNU-only `date -d`, so the suite failed under the local pre-push CI mirror on macOS/BSD `date` (`illegal option -- d`).
- GitHub Actions (Linux/GNU) was unaffected, so this only bit local pre-push runs on macOS.
- Fall back to BSD `date -v` when `date -d` is unavailable.

## Test Plan
- [x] `scripts/ci-local.sh` passes on macOS (previously 3 failures in the cost-pace suite)
- [ ] Linux CI remains green (GNU `date -d` path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)