### PR TITLE
fix(pr): make /pr own the human gate for code review

### DIFF
--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -173,7 +173,7 @@ If there are zero actionable issues, skip to report generation. Otherwise the or
 - **Fix** → enter the review-fix loop
 - **Report only** → skip to report generation with all findings intact
 
-**Exception — non-interactive mode**: when `/code-review` runs inside `/build` (as an inline checkpoint or final gate), the prompt is skipped and the fix loop runs automatically. The orchestrator's Phase 3 approval already served as the human gate.
+**Exception — non-interactive mode**: when `/code-review` runs inside `/build` or `/pr`, the prompt is skipped and the fix loop runs automatically. The caller already owns the human gate — the orchestrator's Phase 3 approval for `/build`, and the pre-PR confirmation for `/pr`.
 
 ### 6a. Review-fix loop
 
@@ -245,7 +245,7 @@ All three are optional and project-local — they are not part of the plugin.
 - **Inline review checkpoints** (Phase 3 of `/build`) use the same review-fix loop mechanics, but the orchestrator selects a **targeted** subset of agents based on what changed in the unit of work. `/code-review` is the **final gate** before commit and runs the full enabled suite.
 - **[`/review-agent`](../skills/review-agent/SKILL.md)** runs a single agent — used for targeted checks and as the worker for inline checkpoints.
 - **[`/apply-fixes`](../skills/apply-fixes/SKILL.md)** consumes the `corrections/` directory produced here.
-- **[`/pr`](../skills/pr/SKILL.md)** runs `/code-review` as part of its pre-PR quality gate.
+- **[`/pr`](../skills/pr/SKILL.md)** runs `/code-review --json` as part of its pre-PR quality gate. It runs non-interactively (fix loop auto-applies, no "fix or report?" prompt) and `/pr` branches on the returned status — `overall: pass/warn` or `status: skipped` proceeds, `overall: fail` re-engages the user.
 
 ## References
 

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -213,7 +213,7 @@ Otherwise present the Review Findings prompt (template: [`output-format.md`](cod
 - "Fix" / "apply" / "yes" → step 6a
 - "Report" / "no" / "don't fix" → step 7 (no code modified)
 
-**Exception — non-interactive mode**: if running inside `/build`, skip this prompt and proceed to the fix loop. The orchestrator's Phase 3 approval is the human gate.
+**Exception — non-interactive mode**: if running inside `/build` or `/pr`, skip this prompt and proceed to the fix loop. The caller owns the human gate (the orchestrator's Phase 3 approval for `/build`; the pre-PR confirmation for `/pr`).
 
 ### 6a. Review-fix loop
 

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -62,8 +62,10 @@ Run each check sequentially. Stop on first failure:
    - `golangci-lint` available: `golangci-lint run`
 
 4. **Code review** (unless `--skip-review`):
-   - Run `/code-review`
-   - If review returns `fail`, show the results and ask the user whether to proceed or fix
+   - Run `/code-review --json`. `/pr` owns the human gate, so code-review runs non-interactively: it skips its own "fix or report?" prompt and applies its fix loop automatically (up to 5 iterations), then returns an aggregated status.
+   - Read the returned status field. A normal review returns `{"overall": "pass|warn|fail", ...}`; a documentation-only changeset short-circuits with `{"status": "skipped", ...}`:
+     - `overall` of `pass` / `warn`, or `status` of `skipped` → continue to step 3.
+     - `overall` of `fail` → show the remaining findings and ask the user whether to proceed anyway or stop and fix.
 
 Report results as a checklist:
 


### PR DESCRIPTION
/pr invoked /code-review interactively, so code-review ran its own "fix or report?" prompt and fix loop, then /pr re-prompted the user — a double gate with an ambiguous contract.

- Add /pr to code-review's non-interactive exception (alongside /build)
- /pr now runs `/code-review --json` and branches on the returned status (overall pass/warn or status skipped → proceed; overall fail → ask)
- Update docs/code-review-process.md to match the new contract