### PR TITLE
ci(release): author release PRs with a GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,9 +21,20 @@ jobs:
       security_tag: ${{ steps.release.outputs['plugins/security-assessment--tag_name'] }}
       security_version: ${{ steps.release.outputs['plugins/security-assessment--version'] }}
     steps:
+      # Mint a short-lived token from the release bot GitHub App. Using an App
+      # identity (not the default GITHUB_TOKEN) is what lets the release PR's
+      # events trigger the pull_request workflows — GITHUB_TOKEN-authored PRs
+      # never start new workflow runs (GitHub's recursion guard).
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Problem

Checks never ran on release-please PRs (e.g. #121). The workflow invoked `googleapis/release-please-action@v4` with **no `token:` input**, so it fell back to the default `GITHUB_TOKEN`. GitHub's recursion guard means **events triggered by `GITHUB_TOKEN` do not start new workflow runs** — so the release PR's `pull_request` events never fired `plugin-tests.yml` or `agent-eval.yml`, and its required status checks deadlocked it un-mergeable at "Expected — Waiting for status to be reported."

## Fix

Mint a short-lived token from a GitHub App (`actions/create-github-app-token@v2`) and pass it to release-please via `token:`. The release PR then has a real App author identity, which **does** trigger `pull_request` workflows.

`pin-marketplace` is left on `GITHUB_TOKEN` on purpose — its push to `main` is intentionally non-retriggering (see the existing comment in that job).

## Required setup before this works

Two repo secrets, from a GitHub App installed on this repo:

- `RELEASE_BOT_APP_ID` — the App's numeric App ID
- `RELEASE_BOT_PRIVATE_KEY` — the App's private key PEM

App permissions: **Contents: Read & write** + **Pull requests: Read & write**. No webhook needed.

> ⚠️ Don't merge until those secrets exist, or release-please will fail at the token step.

## Note on PR #121

The current release PR was already authored by `github-actions[bot]`, so it won't retroactively gain checks. After this lands + secrets are set, recreate it (push to `main` or re-run Release Please), or push an empty commit to its branch to nudge checks once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)