### PR TITLE
docs: adopt North Star + scope self-improvement loop to /session-review deltas

### DIFF
--- a/docs/north-star-task-reevaluation.md
+++ b/docs/north-star-task-reevaluation.md
@@ -1,0 +1,84 @@
+# North Star Re-evaluation of the External-Review Tasks
+
+> Re-scores the 17 children of [#98](https://github.com/bdfinst/agentic-dev-team/issues/98)
+> against the **North Star** (`plugins/dev-team/CLAUDE.md`): *reduce friction — fewer missteps,
+> less rework, lower token cost.* Reputational novelty is explicitly **not** a goal.
+>
+> The original report (`proposed-improvements-from-external-reviews.md`) rated "Impact" on a blend
+> of decision-quality, credibility, **and novelty/first-mover reputation**. Stripping reputation out
+> changes the ranking materially. This doc is the filter applied to that backlog.
+>
+> Verdicts: **KEEP** (serves the North Star as-is) · **MODIFY** (valuable only after reframing toward
+> friction) · **REJECT/DEFER** (reputation- or research-driven; no near-term friction payoff).
+
+## The filter
+
+A task earns priority by how much *observed* friction it removes. Anything justified mainly by "nobody
+has done this / conference talk / first-mover" falls — that is the exact justification the North Star
+rejects.
+
+> **Correction (the feedback loop already exists).** An earlier pass treated the feedback loop as
+> unbuilt and proposed a new `/telemetry-insights` skill. That was wrong: the plugin already ships
+> **`/session-review`** (#127/#131), which mines transcripts via a deterministic, zero-token extractor
+> (`scripts/session_extract.py`) for `token | rework | accuracy | utilization`, then suggests
+> improvements and hands them to governed machinery (`/feedback-learning`, `/agent-eval`,
+> `/harness-audit`, `token-efficiency-review`). The rework signals an earlier draft called "missing"
+> are already extracted. So the loop is the **spine**, and the only genuine deltas are captured in
+> [`docs/specs/session-review-enhancements.md`](specs/session-review-enhancements.md): cross-machine
+> aggregation, a frequency→lever escalation rule, and an optional raw-log tier (adding a `methodology`
+> lens). The verdicts below are updated accordingly.
+
+## Verdicts
+
+| # | Task | Original impact basis | Verdict | Rationale under the North Star |
+|---|------|----------------------|---------|--------------------------------|
+| 99 | Agent-eval regression gate in CI | self-testing | **KEEP** | Protects agent quality → fewer missed findings = less rework. Already landed; finish the live-gate so the non-deterministic part actually runs, not just the structural check. |
+| 104 | `updatedInput` conformance test | self-testing | **KEEP** | A silent routing break is pure friction (wrong model, wrong cost). Cheap insurance. Landed. |
+| 102 | Runtime cost/token metering | observability | **CLOSED w/ verified gaps** | Meter + per-agent/model/command + **per-phase** attribution work on real data. But two closed-COMPLETED pieces are functionally inert (verified, not assumed): **#139's per-fix-loop-iteration** breakdown reads a `fixLoopIteration` marker that **no runtime stamps** (it exists only in test fixtures) → real sessions bucket all spend as `unattributed`; **#140's CI gate** is a blocking *mechanism self-test* only — the real cost-regression check is warn-only and dormant (no committed baseline; the log is gitignored/local), so it cannot fail a PR for a real regression. Green tests, but neither delivers its titled outcome. **Re-open / file follow-ups if real cost-gating is wanted.** |
+| 106 | Opt-in telemetry beacon | observability | **KEEP — narrow** | Local-only was the *right* call. But its events (command/skill/gate) are a thin subset of what `/session-review`'s digest already extracts from transcripts. Keep it as the cheap always-on counter; do **not** grow it into the loop. Cross-machine aggregation belongs to the session-digest (Delta D), not the beacon. |
+| 139 | Fix-loop / per-phase cost granularity | refines #102 | **CLOSED — half inert (→ #170)** | Per-phase works (static command→phase map). Per-fix-loop-iteration is inert: no runtime stamps the `fixLoopIteration` marker (fixtures only) → real spend is all `unattributed`. Fix tracked in **#170**. Separately, rework *itself* is already extracted by `session_extract.py`, so the loop isn't blocked on this. |
+| 140 | Wire cost-regression into CI | refines #102 | **CLOSED — self-test only (→ #171)** | Wired, but the blocking part only self-tests the mechanism on synthetic data; the real check is warn-only and dormant (no committed baseline). It does not gate real cost regressions. Real gate needs a committed/aggregated baseline — overlaps the session-digest cross-machine aggregation (Delta D). Tracked in **#171**. |
+| 113 | Automatic post-session learning loop | learning | **CLOSE — already shipped** | This is `/session-review` (#127/#131): it mines sessions and routes suggestions to `/feedback-learning`'s audited writes. The automatic-learning loop exists. Close #113 as delivered; track only the deltas in `session-review-enhancements.md`. |
+| 107 | Knowledge ablation testing | self-testing | **KEEP** | Directly lowers token cost: identifies knowledge files that never change a verdict = dead weight on every dispatch. Concrete, recurring friction payoff. |
+| 109 | Concurrency / multiplayer collisions | correctness | **KEEP — pull forward** | Literal friction (clobbered progress files, stale gate). Phase 1 (reproduce) is an afternoon. Mis-filed in Wave 3; do Phase 1 early. |
+| 110 | Persona-vs-context-boundary test | architecture | **MODIFY** | Keep *only* as a maintenance/token-cost question: does the persona layer cost tokens without improving detection? If yes, dissolving it reduces friction. Drop the "deepest structural assumption / strong story" framing — that is reputation. |
+| 101 | Eval-corpus-as-semver | self-testing | **MODIFY → minimal** | Strip the "first to formalize it" goal. Retain only the thin value: flag a commit whose type contradicts its eval-diff (catches a mis-typed release). Do not invest beyond that. Landed; do not expand. |
+| 100 | Prose/Targets slop cleanup | credibility | **KEEP** | Honest docs reduce user missteps (no chasing promised-but-absent features). Landed, with a sensor. |
+| 108 | Mutation testing for prose/prompts | self-testing (novel) | **DEFER** | Justification is explicitly "standout moonshot / conference talk." Output is an *ambiguous* coverage map (dead weight vs. missing fixture — undecidable without per-rule human judgment) at real per-ablation model cost. No direct friction payoff. Revisit only if a cheap, unambiguous variant appears. |
+| 111 | Process eval (A/B the ceremony) | self-testing (novel) | **MODIFY → narrow** | The general "is the ceremony worth it" study is expensive and biased by weak ground truth. Replace with the *specific* question `/session-review`'s trend stream can already answer from real sessions: *which* phases/gates correlate with high rework or bypass? Let the digest answer it, not a synthetic A/B. |
+| 112 | Per-increment trunk integration topology | CD alignment | **DEFER (ADR only)** | Intellectually the deepest reframe, but it is a *redesign*, not friction reduction for current users, and it assumes flag/rollback infra the plugin does not own. Keep as an ADR/spike; do not implement until the loop shows current gates actually cause friction. |
+| 105 | Resolve Multi-LLM/Gemini vestigiality | scope honesty | **KEEP — just delete** | A doc promising an absent capability is a misstep generator. Delete the table (Low path). Trivial. |
+| 114 | Component extraction / publication | distribution | **REJECT** | Explicitly reputational ("talk, blog, standalone repo"). The North Star rules this out as a goal. Park indefinitely; it removes no user friction. |
+| 115 | Reconcile `agent-ast.md` orphan spec | hygiene | **KEEP — trivial** | An orphan spec is minor misdirection. Archive or issue-track it. Quick win. |
+| 103 | Eval variance & saturation data | self-testing | **KEEP** | Tells you which agents/fixtures to trust in the #99 gate → fewer false blocks (friction). Supports the loop. |
+
+## Net effect on the roadmap
+
+**The loop already exists — extend, don't rebuild:** the spine is `/session-review` (#127/#131), so
+
+# 113 **closes as shipped**. The only loop work left is the three deltas in
+
+[`session-review-enhancements.md`](specs/session-review-enhancements.md): cross-machine aggregation of
+the session-digest, a frequency→lever escalation rule, and an optional raw-log/`methodology` tier.
+
+# 139 **demotes** (rework is already extracted) and #106 **narrows** to a cheap counter
+
+**Teeth still worth finishing:** #102 + #140 (a cost meter that enforces nothing is documentation),
+
+# 99 (finish the live eval gate)
+
+**Stays (independent friction reducers):** #104, #107, #109 (pull Phase 1 forward), #103, #100,
+
+# 105 (delete), #115
+
+**Falls (reputation/research, no near-term friction payoff):** #114 **rejected**; #108 and #112
+**deferred** to ADR/curiosity scope; #110 and #111 **narrowed** to their friction-relevant core;
+
+# 101 frozen at minimal
+
+## Decision rule going forward
+
+For any *new* proposed task (including the deferred ones if revisited): it ships only if it can name
+the friction it removes and the metric that would show the reduction. If the honest answer is "it
+would be novel / a good talk / first-mover," that is a **REJECT** under the North Star — file it
+elsewhere, not in this backlog.

--- a/docs/proposed-improvements-from-external-reviews.md
+++ b/docs/proposed-improvements-from-external-reviews.md
@@ -293,3 +293,56 @@ Worth recording so improvements don't undo strengths:
 - **The agent-readiness scorecard** — a tiered, client-facing "how well can an agent work this repo" rubric (a latent product/consulting angle).
 
 The throughline: the parts touched by a deterministic gate are excellent. Every improvement above is, at bottom, *extend that same discipline to the parts no gate currently reaches — especially the agents, the workflow, and the claims.*
+
+---
+
+## Status & revised plan (updated 2026-06-07)
+
+This section supersedes the original Summary matrix above for *prioritization*. Two things changed since the report was written:
+
+1. **A North Star was adopted** (`plugins/dev-team/CLAUDE.md`): *every change must reduce friction — fewer missteps, less rework, lower token cost; reputational novelty is explicitly not a goal.* This strips "first-mover / conference talk" out of the Impact rating and re-sorts the backlog. Full re-scoring: [`north-star-task-reevaluation.md`](north-star-task-reevaluation.md).
+2. **The self-improvement loop already exists.** `/session-review` (#127, #129, #131 — all closed) mines real Claude Code transcripts (`~/.claude/projects/<slug>/*.jsonl`) via a deterministic, zero-token extractor for `token | rework | accuracy | utilization`, then suggests improvements and hands them to governed machinery (`/feedback-learning`, `/agent-eval`, `/harness-audit`, `token-efficiency-review`). The "automatic learning loop" and "rework metering" the reviews asked for are **shipped**. The only remaining loop work is three deltas: [`specs/session-review-enhancements.md`](specs/session-review-enhancements.md).
+
+### Landed (closed)
+
+Fully landed: **#99** (agent-eval CI gate), **#100** (prose/Targets cleanup + sensor), **#101** (eval-corpus-as-semver), **#102** (cost/token metering — meter + per-agent/model/command/**phase** attribution), **#104** (`updatedInput` conformance), **#141** (eslint-ignore fixtures), **#142** (pace guidance), **#106**'s core beacon, and the loop itself: **#127 / #129 / #131** and **#135**.
+
+**Closed COMPLETED but functionally inert (verified by inspecting the artifacts, not the issue state — flag for re-open):**
+
+- **#139 — per-fix-loop-iteration granularity is inert.** `cost_meter.py` buckets by a `fixLoopIteration` marker that **no runtime stamps** (it exists only in test fixtures), so real sessions attribute all fix-loop spend to `unattributed`. Per-*phase* works (static command→phase map); per-*iteration* does not. Fix needs a runtime that stamps the marker during the review→fix cycle. **Follow-up: #170.**
+- **#140 — cost-regression CI gate self-tests only.** The blocking step verifies the mechanism on synthetic data; the real check is warn-only and dormant because no baseline log is committed (it's gitignored/local). It cannot fail a PR for a real cost regression. A real gate needs a committed/aggregated baseline — which overlaps the session-digest cross-machine aggregation (Delta D below). **Follow-up: #171.**
+
+Lesson worth recording: green tests + closed issue ≠ functional outcome. Both reproduce the reviews' own "a gate that doesn't run is documentation" pattern one layer down.
+
+### Remaining open issues — disposition under the North Star
+
+| Issue | Disposition | Plan |
+|---|---|---|
+| **#113** Automatic post-session learning loop | **CLOSE — already shipped** | Delivered by `/session-review`. Close as done; track only the deltas below. |
+| **#106** Opt-in telemetry beacon | **NARROW** | Keep as the cheap always-on command/skill/gate counter. Do **not** grow it into the loop. Cross-machine aggregation belongs to the session-digest, not the beacon. |
+| **#107** Knowledge ablation testing | **KEEP** | Directly lowers token cost (finds knowledge files that never change a verdict). Reuses the eval harness. |
+| **#109** Concurrency / multiplayer collisions | **KEEP — pull forward** | "Designed for teams" is unfalsified. Phase 1 (reproduce collisions on `memory/*-progress-*.md`, `.review-passed`) is an afternoon; do it early. |
+| **#103** Eval variance & saturation | **KEEP** | Tells you which fixtures to trust/quarantine in the #99 gate → fewer false blocks. |
+| **#105** Multi-LLM/Gemini vestigiality | **KEEP — just delete** | Doc promises an absent capability = misstep generator. Delete the table. Trivial. |
+| **#115** `agent-ast.md` orphan spec | **KEEP — trivial** | Archive or issue-track it. Quick hygiene win. |
+| **#110** Persona-vs-context-boundary | **NARROW** | Keep only as a maintenance/token-cost question (does the persona layer cost tokens without improving detection?). Drop the "deepest structural assumption" framing. |
+| **#111** Process eval (A/B the ceremony) | **NARROW** | Don't build a synthetic A/B. Let `/session-review`'s trend stream answer the friction-relevant version: *which* phases/gates correlate with high rework or bypass? |
+| **#108** Prose/prompt mutation testing | **DEFER (ADR/curiosity)** | Justification is reputational; output is an ambiguous coverage map at real per-ablation cost. Revisit only if a cheap, unambiguous variant appears. |
+| **#112** Per-increment trunk integration topology | **DEFER (ADR only)** | The deepest reframe, but a redesign assuming flag/rollback infra the plugin doesn't own. Write the ADR/spike; don't implement until the loop shows current gates cause friction. |
+| **#114** Component extraction / publication | **REJECT** | Explicitly reputational. Out of scope under the North Star; park indefinitely. |
+
+### The only remaining loop work — `/session-review` deltas
+
+Tracked in [`specs/session-review-enhancements.md`](specs/session-review-enhancements.md); build in this order:
+
+1. **Cross-machine aggregation** of `metrics/session-digest.jsonl` — per-host files pushed to a **separate private repo** (the raw `~/.claude/projects` logs never leave the machine; only the metrics digest aggregates). Matches the original multi-machine need. *May re-scope #106's aggregation intent or get its own issue.*
+2. **Frequency → lever escalation** — make recurrence drive response strength (rare → hint; frequent + deterministically-matchable → promote to a hook, validated via `/agent-eval`).
+3. **Optional raw-log tier + `methodology` lens** — for the top-N worst sessions the digest flags, one agent per raw log catches semantic frictions a metrics digest can't (hallucinated citations, operator habits). Most token-spending; gate it behind the digest; do last.
+
+### Sequencing
+
+`#105 + #115` (trivial hygiene) → `#113` (close as shipped) → **loop deltas 1→2→3** + `#109` Phase 1 (cheap, high-value) → `#107` / `#103` (eval-harness reuse) → `#110` / `#111` (narrowed measurement) → `#108` / `#112` (ADR/spike only). **#114 rejected.** Security epics (#38 family, #60/#62/#63) are tracked separately and out of scope for this document.
+
+### Governing rule
+
+Per the North Star: any remaining or new item ships only if it can name the friction it removes and the metric that would show the reduction. "Would be novel / a good talk / first-mover" is a **REJECT**.

--- a/docs/specs/session-review-enhancements.md
+++ b/docs/specs/session-review-enhancements.md
@@ -1,0 +1,123 @@
+# Design — `/session-review` Enhancements
+
+> **Status:** Design (not yet implemented). Tracks the North Star (`plugins/dev-team/CLAUDE.md`).
+> **Supersedes:** the earlier `telemetry-feedback-loop.md` draft, which reinvented capability the
+> plugin already ships and wrongly claimed rework signals were missing. They are **not** missing —
+> `scripts/session_extract.py` already extracts `token | rework | accuracy | utilization` from
+> transcripts, and `/session-review` (#127/#131) already mines them, suggests improvements, and
+> hands off to governed machinery (`/feedback-learning`, `/agent-eval`, `/harness-audit`,
+> `token-efficiency-review`). This spec covers only the **three deltas** that loop is genuinely missing.
+
+## 0. Why this is a delta spec, not a new loop
+
+The feedback loop already exists and is well-engineered:
+
+- **Deterministic, zero-token extraction** — `session_extract.py` crushes MBs of JSONL into a
+  KB-sized metrics digest with no model calls ("never spend tokens to study token spend").
+- **Privacy by construction** — metrics only: counts, ratios, names, basenames; correction
+  keywords counted, never quoted.
+- **Governed apply path** — `/session-review` *suggests, never applies*; suggestions route to
+  `/feedback-learning`'s audited writes, `/agent-eval` validation, etc.
+
+Do not rebuild any of that. The gaps below were surfaced by comparing against a peer transcript-mining
+skill (Alexandre Poitevin's "session-analysis") and against the original stated need (multi-machine).
+
+## 1. Delta A — a raw-log (semantic) tier over digest-flagged sessions
+
+**Gap.** The metrics digest is deliberately quantitative, so it discards frictions that have **no
+count-signature**:
+
+- *the AI cited a skill as its source when that content didn't exist* — a hallucinated-citation
+  pattern invisible to ratios;
+- *the operator keeps deferring decisions to "later" with no owner* — a methodology habit (see Delta B).
+
+The digest approximates user-corrections with a keyword scan (`"no"`, `"actually"`, `"revert"`), which
+is a crude proxy for what an agent reading the actual exchange would catch.
+
+**Design.** Add an **optional second tier**, gated by the first:
+
+1. Tier 1 (unchanged): the deterministic digest ranks/triages sessions cheaply.
+2. Tier 2 (new): for the **top-N worst sessions the digest flags**, dispatch one agent **per raw log**
+   (one ~1MB transcript = one agent = one context boundary; fan out in parallel). Each agent reads its
+   single raw log and returns semantic frictions the digest can't see.
+
+Cost is bounded *because* Tier 1 decides where Tier 2 is worth spending — you never read every raw log,
+only the few already proven expensive/thrashy. Execution maps cleanly to a Workflow: `pipeline(flagged
+logs, analyze-raw, ...) → consolidate`.
+
+**Privacy note.** Tier 2 reads raw content, so its *output* must be held to the same metrics-only/
+no-quote discipline as the digest: it may report *that* a hallucinated citation occurred and *which*
+artifact to fix, not paste the prompt/code. The raw log itself never leaves the machine.
+
+## 2. Delta B — a fifth lens: operator methodology ("just me")
+
+**Gap.** The four extracted classes (`token | rework | accuracy | utilization`) are all about the AI
+and harness. None mines the **operator's own habits**, yet the highest-value findings in the peer skill
+were exactly that ("you keep deferring business decisions with no owner/deadline"). No gate fixes a
+human habit — but surfacing it is valuable, and it is structurally invisible to a metrics digest.
+
+**Design.** Add a `methodology` lens, produced **only** by the Tier-1-flagged Tier-2 raw pass (Delta A).
+Its suggestions have no target artifact and no hook — the hand-off is "to the human, as an observation,"
+a category the report must support alongside the existing artifact-targeted kinds.
+
+## 3. Delta C — explicit frequency → lever-strength escalation
+
+**Gap.** `/session-review` has the trend stream (`metrics/session-digest.jsonl`, #129) but no stated
+rule turning *recurrence* into *response strength*. The peer skill states it crisply: a friction *"caught
+13 times across sessions"* earned promotion from advice to an enforced **hook**.
+
+**Design.** Make escalation an explicit ranking rule in the analysis step, driven by the trend stream:
+
+| Recurrence (across sessions) | Determinism of the pattern | Recommended lever |
+|---|---|---|
+| Rare / one-off | any | hint / observation only |
+| Recurring | judgment-shaped (no reliable matcher) | instruction-file rule → `/feedback-learning` |
+| Frequent | deterministically matchable | **promote to a hook** (validate via `/agent-eval` first) |
+
+This reuses the existing rules-vs-prompts ≤10% FP policy as the "deterministically matchable" test.
+
+## 4. Delta D — cross-machine aggregation (the original stated need)
+
+**Gap.** `/session-review` mines `~/.claude/projects/<current-project>/*.jsonl` — **single machine**. The
+stated goal is to learn across *the multiple machines the author uses*.
+
+**Design.** Aggregate the **trend stream** (`metrics/session-digest.jsonl`), not the telemetry beacon and
+not raw logs:
+
+- Each machine appends host-suffixed digest records / writes `metrics/session-digest-<host>.jsonl`.
+- A sync step pushes/pulls those files to a **separate private repo** named by env var
+  (e.g. `DEV_TEAM_TELEMETRY_REMOTE`). `metrics/*.jsonl` stays gitignored in *this* repo — the gitignore
+  is untouched; aggregation targets the private repo only.
+- Per-host filenames make the merge **conflict-free by construction** (add-files, never line-merge).
+- `/session-review` (and `/harness-audit`, which already consumes the trend stream) reads the union of
+  host files so recurrence in Delta C is counted **across machines**, not just one.
+- Absent the env var, everything stays local and the loop still runs on one machine's data.
+
+**Why git over a synced folder/hosted store:** versioned history (recurrence analysis needs time),
+no new secret beyond an SSH key, conflict-free with per-host files, and it reuses the append-only-log
+convention already in the repo.
+
+## 5. Acceptance criteria
+
+- [ ] Tier 2: for digest-flagged worst sessions only, a per-log agent pass runs and returns semantic
+      frictions (e.g. hallucinated citations) the digest cannot; every raw log is one agent's sole input;
+      Tier 2 output is metrics-only/no-quote.
+- [ ] A `methodology` lens produces human-directed observations with no artifact/hook target.
+- [ ] The analysis step applies the recurrence→lever table, using the cross-machine trend stream for counts.
+- [ ] Each machine writes host-suffixed digest files; a sync command pushes/pulls them to a private repo
+      named by env var; absent the env var, nothing leaves the machine and the loop still runs locally.
+- [ ] No raw prompt/code/path content is ever written to any report or to the aggregation repo.
+
+## 6. Build order
+
+1. **Delta D (cross-machine aggregation)** — smallest, matches the literal stated need, and makes Delta C
+   meaningful (recurrence across machines). Transport + host-suffixed files + union read.
+2. **Delta C (escalation rule)** — pure analysis-step logic over the now-aggregated trend stream.
+3. **Delta A + B (raw-log tier + methodology lens)** — the largest and most token-spending; gate it
+   behind the digest so cost stays bounded. Do last.
+
+## 7. What NOT to do
+
+- Do not rebuild extraction, privacy handling, or the suggest-never-apply governance — they exist.
+- Do not aggregate the telemetry beacon or raw logs across machines — aggregate the **digest** only.
+- Do not let Tier 2 read every session — only the few Tier 1 already flagged as worst.

--- a/plans/external-review-improvements-checklist.md
+++ b/plans/external-review-improvements-checklist.md
@@ -6,6 +6,16 @@ Source report: [`docs/proposed-improvements-from-external-reviews.md`](../docs/p
 Ordering principle: **cheap self-tests first → observability spine → measurement-dependent bets → paradigm work.**
 Each wave is gated on the prior wave's infrastructure, not just preference.
 
+> **Re-prioritized under the North Star (2026-06-07).** The wave ordering below predates the
+> North Star (`plugins/dev-team/CLAUDE.md`: *reduce friction, not reputation*). For the current
+> KEEP / MODIFY / REJECT verdict on each item — which strips reputational/novelty justification out
+> of the "Impact" rating — see [`docs/north-star-task-reevaluation.md`](../docs/north-star-task-reevaluation.md).
+> The feedback loop those items feed **already exists** as `/session-review` (#127/#131); the only
+> remaining loop work is the deltas in
+> [`docs/specs/session-review-enhancements.md`](../docs/specs/session-review-enhancements.md).
+> Headlines: #113 closes as shipped; #139 demotes (rework already extracted) and #106 narrows; #114
+> rejected; #108/#112 deferred to ADR scope; #110/#111 narrowed; #140 (+#102) and #99 are the teeth to finish.
+
 ---
 
 ## Wave 0 — Cheap, high-leverage, unblock everything else

--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -4,6 +4,14 @@
 
 This project implements a fully automated development team using persona-driven AI agents orchestrated through an intelligent coordination pipeline. The Orchestrator agent acts as the central dispatcher, routing tasks to specialized agents based on task classification, complexity, and required expertise.
 
+## North Star
+
+Every change must reduce friction for someone trying to get work done with this plugin: **fewer missteps, less rework, lower token cost.** We measure friction, we do not assume it — telemetry and cost metering exist to close a loop where observed friction becomes a concrete improvement: a hint to the user, a new skill, an agent-config change, or a hook that constrains a bad path.
+
+Not goals: reputational novelty, feature breadth, or ceremony for its own sake. A change that cannot name the friction it removes — and the metric that would show the reduction — does not ship. (This applies the same claims-discipline rule as quantitative prose: every claim must name the instrument that measures it.)
+
+When prioritizing or rejecting work, this is the tie-breaker: the option that removes more real, observed friction wins.
+
 ## Architecture
 
 This project uses a layered loading strategy to minimize token usage:

--- a/tests/docs/prose_honesty_test.bats
+++ b/tests/docs/prose_honesty_test.bats
@@ -77,3 +77,13 @@ BANNED_PHRASES=(
   run grep -iq "must name the instrument" "$CLAUDE_MD"
   [ "$status" -eq 0 ]
 }
+
+@test "CLAUDE.md states the North Star (reduce friction; a change must name the friction it removes)" {
+  # The North Star is doctrine for every change. This sensor keeps it from
+  # being silently deleted: it must declare the friction goal and the
+  # name-the-friction-or-it-does-not-ship rule.
+  run grep -iq "## North Star" "$CLAUDE_MD"
+  [ "$status" -eq 0 ]
+  run grep -iq "does not ship" "$CLAUDE_MD"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Establishes a **North Star** for the plugin and re-grounds the open external-review backlog (#98) against it, correcting two factual errors discovered along the way.

### North Star (doctrine)
- Adds a `## North Star` section to `plugins/dev-team/CLAUDE.md`: *every change must reduce friction — fewer missteps, less rework, lower token cost; reputational novelty is explicitly not a goal.*
- Makes it enforceable via the existing prose-honesty sensor (`tests/docs/prose_honesty_test.bats`) so the doctrine can't be silently deleted.

### The self-improvement loop already exists
The earlier `telemetry-feedback-loop.md` draft reinvented capability the plugin already ships as **`/session-review`** (#127/#129/#131) and wrongly claimed rework signals were "missing" (they're extracted by `scripts/session_extract.py`). Replaced with **`docs/specs/session-review-enhancements.md`**, scoping the three genuine deltas:
1. cross-machine aggregation of the session-digest (per-host files → private repo) — the original multi-machine need;
2. frequency → lever escalation (rare → hint; frequent + deterministic → hook);
3. optional raw-log tier + `methodology` lens (catches semantic frictions a metrics digest can't).

### Verified, not assumed: two closed issues are functionally inert
- **#139** per-fix-loop-iteration granularity: reads a `fixLoopIteration` marker **no runtime stamps** (fixtures only) → real sessions bucket all fix-loop spend as `unattributed`. Per-*phase* works. Follow-up **#170**.
- **#140** cost-regression CI gate: only self-tests the mechanism on synthetic data; the real check is warn-only and dormant (no committed baseline). Cannot fail a PR for a real cost regression. Follow-up **#171**.

### Backlog re-evaluation
`docs/north-star-task-reevaluation.md` re-scores all #98 children with reputation stripped out of "Impact", plus a plan summary appended to `docs/proposed-improvements-from-external-reviews.md`.

## Files
- `plugins/dev-team/CLAUDE.md` — North Star section
- `tests/docs/prose_honesty_test.bats` — sensor for the doctrine
- `docs/specs/session-review-enhancements.md` — the three real loop deltas (replaces the telemetry-feedback-loop draft)
- `docs/north-star-task-reevaluation.md` — KEEP/MODIFY/REJECT verdicts
- `docs/proposed-improvements-from-external-reviews.md` — status & revised plan
- `plans/external-review-improvements-checklist.md` — cross-links

## Notes
- Docs-only + one bats assertion. No runtime behavior change.
- Follow-ups #170 and #171 track the verified cost-meter gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)