### PR TITLE
chore: require pyyaml as a declared dev dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ reports/                           # Review reports (not shipped)
 
 Edit files directly in `plugins/dev-team/`. All plugin components (agents, skills, hooks) live there.
 
+### Prerequisites
+
+The local gates (`scripts/ci-local.sh`, run by the `pre-push` hook) need these tools on every dev machine:
+
+- CLI: `shellcheck`, `bats`, `jq`, `python3` (macOS: `brew install shellcheck bats-core jq python3`)
+- Python modules: install the declared dev dependencies once with `python3 -m pip install -r requirements-dev.txt` (PyYAML is required — several bats suites shell out to Python scripts that import it; semgrep for the security-assessment suites).
+
+`ci-local.sh` checks these up front and exits with an actionable message if any are missing.
+
 ### Testing locally
 
 Register the local checkout as a marketplace, then install from it into a test project:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+# Python dependencies required to develop and run the local test/CI gates.
+#
+# Install with:  python3 -m pip install -r requirements-dev.txt
+#
+# These mirror what GitHub CI installs (.github/workflows/plugin-tests.yml:
+# "Install semgrep + pyyaml"). The local pre-push gate (scripts/ci-local.sh)
+# runs the same suites, so the same deps are required on every dev machine.
+
+# Required: parsed by the agent-readiness scanner, the static-analysis adapter,
+# the accepted-risks applier, the eval comparative scorer, and the
+# security-assessment fixture audit. Without it, bats suites fail mid-run with
+# "ModuleNotFoundError: No module named 'yaml'".
+PyYAML>=6.0
+
+# Required for the security-assessment suites (SAST). CI installs it alongside
+# pyyaml; install locally if you run or modify the security-assessment plugin.
+semgrep

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -55,6 +55,21 @@ if [ "${#missing[@]}" -gt 0 ]; then
   exit 2
 fi
 
+# --- python module prerequisites (declared in requirements-dev.txt) ---------
+# Binaries alone aren't enough: several bats suites shell out to Python scripts
+# that import third-party modules. Check them up front so a missing dep fails
+# loudly here instead of as a cryptic ModuleNotFoundError mid-suite.
+py_missing=()
+# shellcheck disable=SC2043  # single entry today; kept as a list for new modules
+for m in yaml; do
+  python3 -c "import $m" >/dev/null 2>&1 || py_missing+=("$m")
+done
+if [ "${#py_missing[@]}" -gt 0 ]; then
+  printf '%s%sMissing required Python modules: %s%s\n' "$bold" "$red" "${py_missing[*]}" "$reset" >&2
+  printf 'Install the dev dependencies: python3 -m pip install -r requirements-dev.txt\n' >&2
+  exit 2
+fi
+
 # --- plugin-tests.yml :: shell-tests --------------------------------------
 run "shellcheck — security-assessment helper scripts" \
   shellcheck -x plugins/security-assessment/scripts/*.sh


### PR DESCRIPTION
## Summary

A fresh dev machine failed the `pre-push` gate with a cryptic mid-suite `ModuleNotFoundError: No module named 'yaml'`. The agent-readiness scanner and several other Python helpers shelled out to by the bats suites import pyyaml. CI already installs it (`plugin-tests.yml` → "Install semgrep + pyyaml"), but nothing **declared** or **checked** it locally — so the requirement was invisible until a suite crashed.

## Changes

- **`requirements-dev.txt`** (new) — declares the Python dev deps in one place: `PyYAML` (required) and `semgrep` (security-assessment suites). Mirrors what CI installs. Install with `python3 -m pip install -r requirements-dev.txt`.
- **`scripts/ci-local.sh`** — the existing tool-prereq preflight only checked *binaries*. Extended it to also verify the Python `yaml` *module* and fail fast with an actionable `pip install -r requirements-dev.txt` message (exit 2) instead of a cryptic traceback mid-suite.
- **`CLAUDE.md`** — added a Prerequisites note to the dev guide.

## Verification

- `shellcheck scripts/ci-local.sh` — clean.
- Full `bash scripts/ci-local.sh` — all local CI checks pass.
- Simulated missing module → fails fast: `Missing required Python modules: yaml` + install hint, exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)