### PR TITLE
fix(skills): reference prompt templates by explicit plugin-root path

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1535,7 +1535,7 @@
       "anchor": "2-verify-plan-status"
     },
     "3. Verify acceptance criteria (gate)": {
-      "summary": "Before implementation begins, dispatch a spec-compliance-review subagent in **criteria verification mode** (see `prompts/spec-reviewer.md` § Pre-build criteria verification mode).",
+      "summary": "Before implementation begins, dispatch a spec-compliance-review subagent in **criteria verification mode** (see `${CLAUDE_PLUGIN_ROOT}/prompts/spec-reviewer.md` § Pre-build criteria verification mode).",
       "anchor": "3-verify-acceptance-criteria-gate"
     },
     "4. Implement each step": {

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -43,7 +43,7 @@ Read the plan file. If the status is not `approved`, ask the user: "This plan ha
 
 ### 3. Verify acceptance criteria (gate)
 
-Before implementation begins, dispatch a spec-compliance-review subagent in **criteria verification mode** (see `prompts/spec-reviewer.md` § Pre-build criteria verification mode). Pass the plan's acceptance criteria and per-step test expectations.
+Before implementation begins, dispatch a spec-compliance-review subagent in **criteria verification mode** (see `${CLAUDE_PLUGIN_ROOT}/prompts/spec-reviewer.md` § Pre-build criteria verification mode). Pass the plan's acceptance criteria and per-step test expectations.
 
 The reviewer evaluates each criterion for:
 
@@ -60,7 +60,7 @@ If any criteria are flagged:
 
 ### 4. Implement each step
 
-Work the plan slice by slice, in order. For each step within a slice, dispatch implementation following the implementer template (`prompts/implementer.md`). Pass the implementer its step **and the slice's Gherkin scenario(s)** — the scenarios are the behavioral contract the step's test must satisfy.
+Work the plan slice by slice, in order. For each step within a slice, dispatch implementation following the implementer template (`${CLAUDE_PLUGIN_ROOT}/prompts/implementer.md`). Pass the implementer its step **and the slice's Gherkin scenario(s)** — the scenarios are the behavioral contract the step's test must satisfy.
 
 1. **RED** — Write the failing test described in the step, covering the slice scenario it traces to. Run the test suite. **Hard gate: the new test must fail.** Paste the failing output. If the test passes without new code, the behavior already exists — pick a different test. Do NOT proceed to GREEN without pasted failing output.
 2. **GREEN** — Write the minimum implementation to make the failing test pass. Do not add behavior beyond what the test requires. Run the test suite. **Hard gate: all tests must pass.** Paste the passing output. Do NOT proceed without pasted passing output.

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -184,10 +184,10 @@ Before presenting to the user, dispatch **four plan review personas in parallel*
 
 | Reviewer | Template | Model | Focus |
 |----------|----------|-------|-------|
-| Acceptance Test Critic | `prompts/plan-review-acceptance.md` | `sonnet` | Per-slice Gherkin quality (determinism, isolation, implementation-independence), scenario gaps, error paths, criteria coverage, TDD traceability |
-| Design & Architecture Critic | `prompts/plan-review-design.md` | `sonnet` | Coupling, abstractions, structural risks, pattern adherence |
-| UX Critic | `prompts/plan-review-ux.md` | `sonnet` | User journey, error UX, cognitive load, accessibility |
-| Strategic Critic | `prompts/plan-review-strategic.md` | `sonnet` | Problem fit, scope, slice boundaries, risk, opportunity cost |
+| Acceptance Test Critic | `${CLAUDE_PLUGIN_ROOT}/prompts/plan-review-acceptance.md` | `sonnet` | Per-slice Gherkin quality (determinism, isolation, implementation-independence), scenario gaps, error paths, criteria coverage, TDD traceability |
+| Design & Architecture Critic | `${CLAUDE_PLUGIN_ROOT}/prompts/plan-review-design.md` | `sonnet` | Coupling, abstractions, structural risks, pattern adherence |
+| UX Critic | `${CLAUDE_PLUGIN_ROOT}/prompts/plan-review-ux.md` | `sonnet` | User journey, error UX, cognitive load, accessibility |
+| Strategic Critic | `${CLAUDE_PLUGIN_ROOT}/prompts/plan-review-strategic.md` | `sonnet` | Problem fit, scope, slice boundaries, risk, opportunity cost |
 
 Pass each reviewer the full plan content. Each returns a structured verdict (`approve` or `needs-revision`) with issues. The Acceptance Test Critic is the gate for the scenarios authored in step 2 — it validates the per-slice Gherkin the same way `feature-file-validation` would, so no separate scenario-review pass is needed before the human gate.
 

--- a/tests/repo/skill_prompt_refs_test.bats
+++ b/tests/repo/skill_prompt_refs_test.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Skill → prompt-template reference sensor (issue #173).
+#
+# Shipped SKILL.md files dispatch sub-agents seeded from prompt templates that
+# live at the PLUGIN ROOT (plugins/dev-team/prompts/). A bare `prompts/X.md`
+# reference is ambiguous — at runtime the model resolved it skill-relative,
+# found nothing, and fell back to inline persona briefs (#173). This sensor
+# keeps every such reference (a) resolvable to a real file and (b) written in
+# the explicit `${CLAUDE_PLUGIN_ROOT}/prompts/...` form so it can't regress.
+#
+# Scope: shipped skills only — plugins/dev-team/skills/**/SKILL.md.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SKILLS_DIR="$REPO_ROOT/plugins/dev-team/skills"
+PROMPTS_DIR="$REPO_ROOT/plugins/dev-team/prompts"
+
+@test "every prompts/<name>.md reference in a SKILL.md resolves to a real template" {
+  local missing=""
+  while IFS= read -r line; do
+    local file="${line%%:*}"
+    local name
+    name="$(printf '%s' "$line" | grep -oE 'prompts/[a-zA-Z0-9_-]+\.md' | head -1 | sed 's#prompts/##')"
+    [ -n "$name" ] || continue
+    if [ ! -f "$PROMPTS_DIR/$name" ]; then
+      missing="${missing}\n  ${file#"$REPO_ROOT"/}: prompts/$name (not found at plugins/dev-team/prompts/)"
+    fi
+  done < <(grep -rn "prompts/[a-zA-Z0-9_-]*\.md" "$SKILLS_DIR" --include='SKILL.md')
+
+  if [ -n "$missing" ]; then
+    echo "Unresolvable prompt-template reference(s):" >&2
+    echo -e "$missing" >&2
+    echo "Move the template under plugins/dev-team/prompts/ or fix the reference." >&2
+    return 1
+  fi
+}
+
+@test "prompt-template references use the explicit \${CLAUDE_PLUGIN_ROOT}/prompts/ form" {
+  # A bare `prompts/X.md` (not preceded by CLAUDE_PLUGIN_ROOT/) is the ambiguous
+  # form that caused #173. Require the plugin-root-explicit prefix.
+  local bare=""
+  while IFS= read -r line; do
+    # Strip the CLAUDE_PLUGIN_ROOT-prefixed occurrences, then see if a bare
+    # `prompts/X.md` still remains on the line.
+    local stripped="${line//\$\{CLAUDE_PLUGIN_ROOT\}\/prompts\//__OK__}"
+    if printf '%s' "$stripped" | grep -qE 'prompts/[a-zA-Z0-9_-]+\.md'; then
+      bare="${bare}\n  ${line}"
+    fi
+  done < <(grep -rn "prompts/[a-zA-Z0-9_-]*\.md" "$SKILLS_DIR" --include='SKILL.md')
+
+  if [ -n "$bare" ]; then
+    echo "Ambiguous bare prompts/ reference(s) — use \${CLAUDE_PLUGIN_ROOT}/prompts/<name>.md:" >&2
+    echo -e "$bare" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## Wave 0 — bug #173

`/plan`'s reviewer step (4 refs) and `/build`'s dispatch (2 refs) referenced their sub-agent templates as bare `prompts/X.md`. The model resolved that skill-relative (`plugins/dev-team/skills/<skill>/prompts/`, which doesn't exist) and silently fell back to inline persona briefs — the templates actually live at the plugin root (`plugins/dev-team/prompts/`).

## Fix
- Made all **six** references explicit: `${CLAUDE_PLUGIN_ROOT}/prompts/X.md` (the established token used elsewhere in skills). Covers `plan/SKILL.md` and `build/SKILL.md` — not just the four in #173, so the convention is consistent.
- Added `tests/repo/skill_prompt_refs_test.bats`: a sensor that fails if any `SKILL.md` prompt reference is (a) unresolvable or (b) written in the ambiguous bare form. Prevents regression.

## Verification
- New sensor: 2/2 pass.
- No bare `prompts/` references remain in any shipped SKILL.md.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)