### PR TITLE
chore: Wave 1 hygiene (#105, #115, #106)

### DIFF
--- a/docs/spikes/agent-ast-universal-harvester.md
+++ b/docs/spikes/agent-ast-universal-harvester.md
@@ -1,3 +1,17 @@
+# Spike: Universal AST Harvester
+
+> **Status: unscheduled spike (not on the roadmap).** Relocated from the repo
+> root (`agent-ast.md`) to reconcile it with the repo's issue discipline (#115).
+> This is an idea capture, not committed work — it has no tracking issue and no
+> slices. If it is ever picked up, promote it to an epic first.
+>
+> **Why it might matter:** a deterministic, cross-repo structural index optimised
+> for LLM consumption is a potential backend for LLM-optimised code views — the
+> kind of supply-side input the review agents and `/session-review` consume.
+> Captured here rather than left floating at the root.
+
+---
+
 Build a Universal AST Harvester system under an `ast-harvester/` directory.
 
 The system crawls a list of repositories, parses source code into Abstract Syntax Trees using tree-sitter, and exports a Domain-Enriched Structural Index in JSON and Markdown formats optimised for LLM consumption.
@@ -9,15 +23,18 @@ Accept a YAML or JSON config file listing repositories as Git URLs or local path
 
 **Parser engine**
 Use tree-sitter with language grammars for TypeScript, JavaScript, Python, and Go. Extract:
+
 - Definitions: classes, interfaces, structs, enums
 - Behaviors: function and method signatures with decorators/annotations
 - Relationships: import/export graphs
 
 **Contextual enrichment**
+
 - Domain Triggers: flag methods whose names contain keywords like `publish`, `emit`, `send`, `handle`, `dispatch`, `notify`
 - State Managers: flag classes whose names match patterns like `Repository`, `Cache`, `Store`, `Registry`, `Singleton`
 
 **Output**
+
 - Context Map (per repo): full structural index with definitions, functions, imports, exports, domain triggers, and state managers — no raw implementation bodies
 - LLM Manifest (cross-repo): flattened API surface, DDD classification (aggregates, repositories, services, domain events, value objects), and external dependencies
 
@@ -25,10 +42,12 @@ Use tree-sitter with language grammars for TypeScript, JavaScript, Python, and G
 Track each repo's HEAD commit SHA. Skip re-parsing repos whose SHA has not changed since the last run.
 
 **CLI**
+
 - `harvest` — clone/pull repos and write context maps and manifest
 - `manifest` — rebuild the manifest from existing context maps without re-parsing
 
 ## Tech stack
+
 - TypeScript (CommonJS, ts-node)
 - tree-sitter + tree-sitter-typescript, tree-sitter-javascript, tree-sitter-python, tree-sitter-go
 - simple-git for repository operations

--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -167,15 +167,6 @@ When a task requires multiple agents:
 
 Each agent declares a tier alias (`haiku`, `sonnet`, `opus`) in its `model:` frontmatter. Tier-to-snapshot resolution is enforced by the PreToolUse hook `hooks/agent-model-resolve.sh` (registered in `settings.json` under `matcher: "Agent"`), backed by the resolver helper `hooks/lib/model-resolve.sh`. Defaults ship in `knowledge/model-routing.json`; per-user overrides live in the gitignored `.claude/model-overrides.json`. See `agents/orchestrator.md` → Resolution Procedure for the full algorithm, `docs/model-routing.md` for the contract and troubleshooting, and run `/model-routing-check` for a read-only diagnostic.
 
-## Multi-LLM Routing
-
-| Criteria | Claude | Gemini |
-|----------|--------|--------|
-| Task complexity | Complex tasks | Simple, high-volume |
-| Cost sensitivity | Premium | Cost-optimized |
-| Context requirements | Large context needs | Standard context |
-| Precision requirements | Critical components | Standard components |
-
 ## Context Management
 
 Context management is the Orchestrator's responsibility, governed by two operational skills:

--- a/plugins/dev-team/docs/agent-architecture.md
+++ b/plugins/dev-team/docs/agent-architecture.md
@@ -168,17 +168,6 @@ Agents append to `memory/decisions.md` when making non-obvious decisions during 
 3. The Orchestrator monitors for recurring patterns (3+ occurrences)
 4. System-initiated changes are proposed to the user with rationale
 
-## Multi-LLM Routing
-
-Tasks can be routed to different LLMs based on complexity and cost:
-
-| Criteria | Claude | Gemini |
-| --- | --- | --- |
-| Task complexity | Complex tasks | Simple, high-volume |
-| Cost sensitivity | Premium | Cost-optimized |
-| Context requirements | Large context | Standard context |
-| Precision requirements | Critical components | Standard components |
-
 ## Performance Targets
 
 Two metrics are instrumented today: token budgets (measured by `scripts/measure-tokens.sh`) and per-agent detection accuracy (measured by `/agent-eval` against `evals/expected/*.json`). Other goals — efficiency gains, hallucination rate, extraction accuracy, first-pass acceptance — are aspirational and have **no sensor in this repo**, so no numeric target is published until an instrument exists. See the *Claims discipline* section of [`CLAUDE.md`](../CLAUDE.md) for the full instrumented-vs-aspirational breakdown.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3784,6 +3784,10 @@
     }
   },
   "plugins/dev-team/skills/telemetry/SKILL.md": {
+    "Scope — keep this small (#106)": {
+      "summary": "This beacon is intentionally a **cheap, always-on local counter**: which",
+      "anchor": "scope-keep-this-small-106"
+    },
     "Argument: $ARGUMENTS": {
       "summary": "`status` (default): report whether telemetry is enabled and what's collected.",
       "anchor": "argument-arguments"

--- a/plugins/dev-team/skills/telemetry/SKILL.md
+++ b/plugins/dev-team/skills/telemetry/SKILL.md
@@ -23,6 +23,17 @@ Telemetry is **OFF by default**. It activates only when
 `.claude/telemetry.json` contains `{"enabled": true}` or the env var
 `DEV_TEAM_TELEMETRY=on` is set.
 
+## Scope — keep this small (#106)
+
+This beacon is intentionally a **cheap, always-on local counter**: which
+commands/skills run, how often the commit gate is bypassed. It is **not** the
+self-improvement loop and must not grow into one. The loop is `/session-review`,
+whose digest already extracts a superset of these signals (token, rework,
+accuracy, utilization) from transcripts and routes suggestions to governed
+machinery. Cross-machine aggregation also belongs to the **session-digest**
+(Delta D / #178), not this beacon. If you find yourself adding analysis or
+network egress here, that work belongs in `/session-review` instead.
+
 ## Argument: $ARGUMENTS
 
 - `status` (default): report whether telemetry is enabled and what's collected.
@@ -40,17 +51,21 @@ Telemetry is **OFF by default**. It activates only when
    network).
 
 2. **on / off** — write `.claude/telemetry.json`:
+
    ```json
    { "enabled": true }
    ```
+
    For `on`, confirm consent first. Recording is local-only; the event log
    `metrics/telemetry.jsonl` is gitignored so it can never be committed.
 
 3. **report** — summarize the event log:
+
    ```bash
    python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/telemetry_report.py \
      --log metrics/telemetry.jsonl
    ```
+
    Shows command usage, skill usage (including agent-/auto-invoked skills,
    counted distinctly from user-typed commands), and the pre-commit review
    gate's bypass rate. If the log doesn't exist, the report says telemetry is

--- a/tests/docs/prose_honesty_test.bats
+++ b/tests/docs/prose_honesty_test.bats
@@ -19,6 +19,10 @@ BANNED_PHRASES=(
   "federated learning"
   "LSTM-inspired"
   "LSTM inspired"
+  # #105: the Multi-LLM/Gemini routing table promised a capability no code
+  # implements (the stack is Claude-Code-locked). Removed; keep it gone.
+  "Multi-LLM Routing"
+  "Gemini"
 )
 
 @test "no metaphor-as-mechanism buzzwords in shipped plugin prose" {


### PR DESCRIPTION
Clears the three Wave 1 quick wins from [the plan](plans/north-star-implementation-plan.md). All independent, North-Star hygiene.

### #105 — scope honesty
Removed the vestigial **Multi-LLM/Gemini routing table** from `CLAUDE.md` *and* `docs/agent-architecture.md` (it promised a capability no code implements — the stack is Claude-Code-locked). Extended the prose-honesty sensor to ban `Multi-LLM Routing`/`Gemini` so it can't return. Regenerated `knowledge/index.json`.

### #115 — orphan spec
Relocated `agent-ast.md` from the repo root to `docs/spikes/agent-ast-universal-harvester.md` with an explicit **"unscheduled spike, no tracking issue"** header — reconciles it with the repo's issue discipline (no more spec floating at root).

### #106 — narrow the beacon
Documented the telemetry beacon's **scope boundary** in its SKILL: it stays a cheap local counter, *not* the self-improvement loop (that's `/session-review`); cross-machine aggregation belongs to the session-digest (Delta D / #178). No behavior change — a deliberate "keep this small" guardrail.

### Verification
- Full content/docs suites green; `knowledge/index.json` current; prose-honesty sensor passes with the new bans.
- No `Gemini`/`Multi-LLM` left in shipped prose.

Closes #105
Closes #115
Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)