### PR TITLE
feat(session-review): cross-project incremental sync extractor (Delta D slice, #178)

### DIFF
--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -32,6 +32,14 @@ Usage:
   session_extract.py [--transcript F ...] [--project-dir D] [--cwd PATH]
                      [--projects-root R] [--pricing P] [--plugin-root PR]
   (default resolves the current project's transcripts under ~/.claude/projects)
+
+  --all-projects                 aggregate across ALL projects, not just the cwd's.
+  --sync-out FILE [--watermark W] [--host H]
+                                 Delta D (#178): cross-project INCREMENTAL sync —
+                                 append one metrics-only record per new/changed
+                                 session to the host digest FILE; the watermark
+                                 dedups by session_id+size so re-runs only emit
+                                 what changed. project is a basename only.
 """
 
 from __future__ import annotations
@@ -330,6 +338,123 @@ def resolve_transcripts(args) -> list[Path]:
     return sorted(matches, key=lambda x: x.name)
 
 
+def resolve_all_transcripts(args) -> list[Path]:
+    """Every transcript across ALL projects under projects-root (Delta D, #178).
+
+    Cross-project: unlike resolve_transcripts (which matches one project's cwd),
+    this returns one file per session across every project on the machine, so the
+    sync can aggregate all of them.
+    """
+    root = Path(args.projects_root or (Path.home() / ".claude" / "projects"))
+    if not root.is_dir():
+        return []
+    return sorted(root.glob("*/*.jsonl"), key=lambda x: x.name)
+
+
+def _project_and_ts(path: Path) -> tuple[str, str]:
+    """Project label (basename of the recorded cwd) and the latest record
+    timestamp, both from transcript DATA — never wall-clock, never a full path.
+    The basename is the only project identifier emitted (privacy boundary)."""
+    project = ""
+    last_ts = ""
+    for rec in _iter_records([path]):
+        if not project:
+            cwd = rec.get("cwd")
+            if isinstance(cwd, str) and cwd:
+                project = os.path.basename(os.path.normpath(cwd))
+        ts = rec.get("timestamp")
+        if isinstance(ts, str) and ts > last_ts:
+            last_ts = ts
+    return project or "unknown", last_ts
+
+
+def sync_record(digest: dict, host: str, project: str,
+                session_id: str, ts: str) -> dict:
+    """One per-session, metrics-only record for cross-machine aggregation (#178).
+
+    Identity (host / project basename / session_id / ts) plus the slim metric
+    blocks. Carries model ids and the main/subagent split (non-sensitive) but no
+    file names, paths, prompts, or code — same privacy boundary as the digest."""
+    base = slim_record(digest)
+    tok = digest.get("token", {})
+    by_model = {m: dict(sorted(v.items()))
+                for m, v in sorted(tok.get("by_model", {}).items())}
+    return {
+        "schema": "session-sync/v1",
+        "host": host,
+        "project": project,
+        "session_id": session_id,
+        "ts": ts,
+        "synced_at": base["recorded_at"],
+        "sessions": digest.get("sessions", 0),
+        "tokens": base["tokens"],
+        "cost_usd": base["cost_usd"],
+        "cache_hit_ratio": base["cache_hit_ratio"],
+        "by_model": by_model,
+        "by_thread": tok.get("by_subagent", {}),
+        "rework": base["rework"],
+        "accuracy": base["accuracy"],
+        "utilization": base["utilization"],
+    }
+
+
+def _load_watermark(path: Path) -> dict:
+    """Read the sync watermark (session_id -> bytes already synced). Missing or
+    malformed -> a fresh empty watermark (fail-open)."""
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text())
+            if isinstance(data, dict) and isinstance(data.get("synced"), dict):
+                return data
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"synced": {}}
+
+
+def cmd_sync(args, pricing: dict, registry: dict, host: str) -> int:
+    """Incremental, cross-project sync (#178): emit one metrics-only record per
+    session that is NEW or has grown since the machine's last sync, into the
+    host digest file. The watermark dedups by session_id + byte size, so re-runs
+    re-emit only changed sessions and skip everything else."""
+    out = Path(args.sync_out)
+    wm_path = Path(args.watermark) if args.watermark else (
+        Path.home() / ".claude" / ".dev-team" / "telemetry-sync.json")
+    wm = _load_watermark(wm_path)
+    synced = wm["synced"]
+
+    if args.transcript:
+        paths = [Path(p) for p in args.transcript]
+    elif args.project_dir:
+        paths = sorted(Path(args.project_dir).glob("*.jsonl"), key=lambda x: x.name)
+    else:
+        paths = resolve_all_transcripts(args)
+
+    emitted = 0
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("a") as fh:
+        for path in paths:
+            session_id = path.stem
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            prev = synced.get(session_id)
+            if isinstance(prev, int) and prev >= size:
+                continue  # already synced and unchanged
+            project, ts = _project_and_ts(path)
+            digest = extract([path], pricing, registry)
+            rec = sync_record(digest, host, project, session_id, ts)
+            fh.write(json.dumps(rec, sort_keys=True) + "\n")
+            synced[session_id] = size
+            emitted += 1
+
+    wm_path.parent.mkdir(parents=True, exist_ok=True)
+    wm_path.write_text(json.dumps(wm, indent=2, sort_keys=True) + "\n")
+    print(f"synced {emitted} new/changed session(s) of {len(paths)} considered "
+          f"-> {out}")
+    return 0
+
+
 def load_registry(plugin_root: Path | None) -> dict:
     """Enumerate shipped skills/agents so we can report never-observed ones."""
     if plugin_root is None:
@@ -358,14 +483,33 @@ def main(argv=None) -> int:
     ap.add_argument("--append", metavar="LOG",
                     help="append one metrics-only summary record to a trend "
                          "stream (append-only JSONL), e.g. metrics/session-digest.jsonl")
+    ap.add_argument("--all-projects", action="store_true",
+                    help="aggregate transcripts across ALL projects, not just the "
+                         "current cwd's project (Delta D, #178)")
+    ap.add_argument("--sync-out", metavar="FILE",
+                    help="cross-project incremental SYNC mode (#178): append one "
+                         "metrics-only record per new/changed session to FILE "
+                         "(the host digest), tracked by --watermark")
+    ap.add_argument("--watermark", metavar="FILE",
+                    help="watermark JSON for incremental sync "
+                         "(default: ~/.claude/.dev-team/telemetry-sync.json)")
+    ap.add_argument("--host", help="host label for sync records (default: hostname)")
     args = ap.parse_args(argv)
 
-    paths = resolve_transcripts(args)
     pricing_path = Path(args.pricing) if args.pricing else (
         Path(__file__).resolve().parent.parent
         / "plugins/dev-team/knowledge/model-pricing.json")
     pricing = _load_pricing(pricing_path)
     registry = load_registry(Path(args.plugin_root) if args.plugin_root else None)
+
+    # Cross-project incremental sync mode (Delta D, #178).
+    if args.sync_out:
+        import socket
+        host = args.host or socket.gethostname()
+        return cmd_sync(args, pricing, registry, host)
+
+    paths = (resolve_all_transcripts(args) if args.all_projects
+             else resolve_transcripts(args))
 
     digest = extract(paths, pricing, registry)
     digest["transcripts"] = len(paths)

--- a/tests/repo/session_extract_sync_tests.bats
+++ b/tests/repo/session_extract_sync_tests.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# Delta D extractor slice (#178): cross-project, incremental, per-session sync.
+# Builds a fake ~/.claude/projects tree with two projects and verifies the
+# --sync-out mode emits one metrics-only record per new/changed session, labels
+# each by project basename, and is incremental via the watermark.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+EXTRACT="$REPO_ROOT/scripts/session_extract.py"
+PLUGIN="$REPO_ROOT/plugins/dev-team"
+
+setup() {
+  ROOT="$(mktemp -d)"
+  PROJECTS="$ROOT/projects"
+  mkdir -p "$PROJECTS/projA" "$PROJECTS/projB"
+  # One transcript per project. Filename stem = session id. cwd basename = project.
+  printf '%s\n' \
+    '{"type":"assistant","cwd":"/home/u/work/alpha","sessionId":"s-a","isSidechain":false,"timestamp":"2026-06-07T10:00:00Z","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":100,"cache_read_input_tokens":400}}}' \
+    > "$PROJECTS/projA/sess-a.jsonl"
+  printf '%s\n' \
+    '{"type":"assistant","cwd":"/srv/code/beta","sessionId":"s-b","isSidechain":true,"timestamp":"2026-06-07T11:00:00Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":2000,"output_tokens":200}}}' \
+    > "$PROJECTS/projB/sess-b.jsonl"
+  OUT="$ROOT/digests/testhost/session-digest.jsonl"
+  WM="$ROOT/watermark.json"
+}
+teardown() { rm -rf "$ROOT"; }
+
+_sync() {
+  python3 "$EXTRACT" --sync-out "$OUT" --watermark "$WM" \
+    --projects-root "$PROJECTS" --host testhost --plugin-root "$PLUGIN"
+}
+
+@test "sync: emits one record per session across projects, labeled by basename" {
+  run _sync
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$OUT")" -eq 2 ]
+  # records carry identity + the sync schema
+  run jq -r 'select(.session_id=="sess-a") | .schema' "$OUT"
+  [ "$output" = "session-sync/v1" ]
+  [ "$(jq -r 'select(.session_id=="sess-a").project' "$OUT")" = "alpha" ]
+  [ "$(jq -r 'select(.session_id=="sess-b").project' "$OUT")" = "beta" ]
+  [ "$(jq -r 'select(.session_id=="sess-a").host' "$OUT")" = "testhost" ]
+  # ts comes from transcript data, not wall-clock
+  [ "$(jq -r 'select(.session_id=="sess-a").ts' "$OUT")" = "2026-06-07T10:00:00Z" ]
+  # main/subagent thread split is preserved
+  [ "$(jq -r 'select(.session_id=="sess-b").by_thread.sidechain' "$OUT")" = "1" ]
+}
+
+@test "sync: incremental — a second run with no changes emits nothing new" {
+  _sync
+  before="$(wc -l < "$OUT")"
+  _sync
+  after="$(wc -l < "$OUT")"
+  [ "$before" -eq 2 ]
+  [ "$after" -eq 2 ]
+  # watermark records both sessions
+  [ "$(jq -r '.synced | keys | length' "$WM")" = "2" ]
+}
+
+@test "sync: a newly added session is the only new emission on re-run" {
+  _sync
+  printf '%s\n' \
+    '{"type":"assistant","cwd":"/home/u/work/alpha","sessionId":"s-c","timestamp":"2026-06-07T12:00:00Z","message":{"model":"claude-opus-4-8","usage":{"input_tokens":500,"output_tokens":50}}}' \
+    > "$PROJECTS/projA/sess-c.jsonl"
+  _sync
+  [ "$(wc -l < "$OUT")" -eq 3 ]
+  # exactly one record for the new session
+  [ "$(jq -rs '[.[] | select(.session_id=="sess-c")] | length' "$OUT")" = "1" ]
+}
+
+@test "sync: a grown session is re-emitted (size watermark)" {
+  _sync
+  # append another usage record to an existing session -> file grows
+  printf '%s\n' \
+    '{"type":"assistant","cwd":"/home/u/work/alpha","sessionId":"s-a","timestamp":"2026-06-07T10:05:00Z","message":{"model":"claude-opus-4-8","usage":{"input_tokens":300,"output_tokens":30}}}' \
+    >> "$PROJECTS/projA/sess-a.jsonl"
+  _sync
+  # sess-a re-emitted (now appears twice in the append-only host digest)
+  [ "$(jq -rs '[.[] | select(.session_id=="sess-a")] | length' "$OUT")" = "2" ]
+}
+
+@test "sync: privacy — basename only, no full paths or prompt/command content" {
+  _sync
+  run cat "$OUT"
+  [[ "$output" != *"/home/u/work/alpha"* ]]   # no full cwd path
+  [[ "$output" != *"/srv/code/beta"* ]]
+  [[ "$output" == *"\"project\": \"alpha\""* || "$output" == *'"project":"alpha"'* ]]
+}
+
+@test "all-projects: non-sync digest aggregates sessions across projects" {
+  run python3 "$EXTRACT" --all-projects --projects-root "$PROJECTS" --plugin-root "$PLUGIN"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.sessions')" = "2" ]
+}


### PR DESCRIPTION
First slice of **Delta D** (#178) — the cross-machine/cross-project aggregation extractor. The git transport and `/session-review` union read are separate follow-up slices, so this **refs, not closes** #178.

## What it adds
- **`--all-projects`** — aggregate transcripts across *every* `~/.claude/projects/*` project, not just the current cwd's.
- **`--sync-out FILE [--watermark W] [--host H]`** — per-session incremental sync. Emits a `session-sync/v1` record per session that is **new or has grown** since the machine's last sync, into the host digest file. The watermark dedups by `session_id` + byte size, so re-runs only emit what changed.
- Each record: `host`, `project` (**basename only**), `session_id`, `ts` (from transcript data), `synced_at`, and the slim metric blocks incl. `by_model` / `by_thread`.

## Privacy
Unchanged boundary: basename only (never a path), counts/ids/model names only, no prompt or command content. New privacy test asserts no full cwd path leaks.

## Verification
- 6 new tests (`session_extract_sync_tests.bats`): per-session emission, basename labeling, incrementality (no-change run emits nothing), new-session and grown-session re-emission, privacy, `--all-projects` aggregation.
- No regression in the existing extractor tests; full repo+docs suites green.
- **Live smoke:** synced **140 real sessions** across all local projects, correctly labeled by basename.

## Remaining for #178
- Git push/pull transport to `agent-telemetry` (the `digests/<host>/` files).
- Union read across hosts in `/session-review` + `/harness-audit`.

Refs #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)