### PR TITLE
feat(session-review): telemetry sync transport + config validation + security docs (#178)

### DIFF
--- a/plugins/dev-team/docs/telemetry-repo-security.md
+++ b/plugins/dev-team/docs/telemetry-repo-security.md
@@ -1,0 +1,120 @@
+# Telemetry repository — security & setup
+
+The cross-machine telemetry repo (Delta D, #178) is a **private append-only
+database**, not a code repo. This doc explains how to wire it up so machines can
+write to it directly — **no pull-request toil for data** — while keeping access
+least-privilege and revocable.
+
+## The model: treat the repo like a database
+
+- **One writer-owned file per machine:** `digests/<host>/session-digest.jsonl`.
+  Because no two machines touch the same file, concurrent writes never conflict —
+  the same property a per-shard append log gives a database.
+- **Direct writes to the default branch.** Each machine does
+  `extract → commit → pull --rebase → push`. There is **no PR**, because review
+  adds toil with no security value over append-only, non-executable metric rows.
+- **Producer-enforced privacy.** The extractor emits metrics only — counts,
+  ratios, token numbers, model ids, and a project **basename** (never a path,
+  prompt, command, or code). The repo is a sink for already-sanitized data.
+
+## Repository settings
+
+Configure the data repo (e.g. `agent-telemetry`) like this:
+
+| Setting | Value | Why |
+|---|---|---|
+| Visibility | **Private** | It holds your usage metrics; never make it public. |
+| Branch protection on default branch | **Off** (no "Require a pull request before merging", no required reviews, no required status checks) | Machines push data directly; a PR gate would block every sync. |
+| Push access | **Only you / your machines** (see deploy keys below) | Least privilege. |
+| Contents | **Metrics JSONL only** | No code runs from here; keep it that way. |
+
+There is intentionally **no CI and no merge queue** on this repo — it is data, so
+the dev-team quality gates (which guard *code*) do not apply.
+
+## Authentication — least privilege, per machine
+
+Do **not** point this at your account-wide SSH key or a classic personal access
+token with `repo` scope: either would grant every machine access to *all* your
+repositories. Use one of these, scoped to **this repo only**:
+
+### Option A — per-host deploy key (recommended)
+
+A deploy key is an SSH key authorized for a **single repository**, so a machine
+that can write telemetry cannot touch anything else.
+
+```bash
+# On each machine:
+ssh-keygen -t ed25519 -f ~/.ssh/agent-telemetry -N "" -C "telemetry-$(hostname -s)"
+cat ~/.ssh/agent-telemetry.pub
+# GitHub → agent-telemetry repo → Settings → Deploy keys → Add deploy key
+#   - paste the public key
+#   - CHECK "Allow write access"
+```
+
+Point git at that key for this repo (so it isn't used for anything else):
+
+```bash
+# ~/.ssh/config
+Host agent-telemetry.github.com
+  HostName github.com
+  IdentityFile ~/.ssh/agent-telemetry
+  IdentitiesOnly yes
+```
+
+…and set the remote to that host alias:
+`git@agent-telemetry.github.com:<owner>/agent-telemetry.git`.
+
+**Revocation:** lose a laptop → delete that one deploy key. Other machines are
+unaffected, and nothing else of yours was ever exposed.
+
+### Option B — fine-grained personal access token
+
+If you prefer HTTPS: create a **fine-grained** PAT scoped to **only** the
+`agent-telemetry` repository with **Repository permissions → Contents: Read and
+write** and nothing else. Store it in a credential helper (macOS Keychain, git
+credential manager) — never in plaintext or in the repo. Prefer one token per
+machine so tokens are individually revocable.
+
+> Avoid classic PATs and broad SSH keys. The whole point is that a compromised
+> telemetry credential leaks *metrics for one repo*, not your code or account.
+
+## Configure dev-team to use it
+
+Tell the plugin where the repo is (the `/session-review` skill will prompt and
+write this for you on first run):
+
+```bash
+# Env var (highest precedence):
+export DEV_TEAM_TELEMETRY_REMOTE="git@agent-telemetry.github.com:<owner>/agent-telemetry.git"
+
+# …or the config file ~/.claude/.dev-team/telemetry.json:
+{ "remote": "git@agent-telemetry.github.com:<owner>/agent-telemetry.git" }
+```
+
+Optional keys / env vars: `clone` / `DEV_TEAM_TELEMETRY_CLONE` (local working
+clone, default `~/.claude/.dev-team/agent-telemetry`) and `host` /
+`DEV_TEAM_TELEMETRY_HOST` (label, default `hostname -s`).
+
+Then sync:
+
+```bash
+scripts/telemetry-sync.sh --check   # validate config (no network)
+scripts/telemetry-sync.sh           # extract -> commit -> pull --rebase -> push
+```
+
+## What is and isn't protected
+
+- **Protected by design:** access is per-repo and per-machine (revocable); writes
+  are conflict-free; the repo is private; only sanitized metrics ever leave a
+  machine; raw `~/.claude/projects/**` transcripts never leave.
+- **Your responsibility:** keep the repo private, keep deploy keys/tokens scoped
+  and rotated, and don't add collaborators who shouldn't see your usage metrics.
+
+## Why no PR gate is the right call here
+
+PRs exist to review *changes to code that will execute*. This repo stores
+append-only, non-executable metric rows in per-host files. A PR per sync would be
+pure toil — it cannot catch a "bug" (there is no logic), and the privacy boundary
+is enforced upstream by the extractor, not by a reviewer. So: gate the **code**
+that produces the data (the dev-team repo's CI does), and let the **data** flow
+directly into its database.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3551,8 +3551,12 @@
       "anchor": "argument-arguments"
     },
     "Steps": {
-      "summary": "Run the extractor to produce the digest:",
+      "summary": "Before analysing, check whether a **telemetry repository** (the cross-machine",
       "anchor": "steps"
+    },
+    "0. Cross-machine telemetry — validate config, then sync (#178)": {
+      "summary": "Before analysing, check whether a **telemetry repository** (the cross-machine",
+      "anchor": "0-cross-machine-telemetry-validate-config-then-sync-178"
     },
     "1. Extract (deterministic, zero model tokens)": {
       "summary": "Run the extractor to produce the digest:",

--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -37,6 +37,35 @@ You have been invoked with the `/session-review` command.
 
 ## Steps
 
+### 0. Cross-machine telemetry — validate config, then sync (#178)
+
+Before analysing, check whether a **telemetry repository** (the cross-machine
+"database", Delta D) is configured, so the digest reflects every machine, not
+just this one:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh --check
+```
+
+- **Exit 0** → a repo is configured. Run the sync to push this machine's digest
+  and pull the others, then continue:
+
+  ```bash
+  bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh
+  ```
+
+- **Exit 3** → no repo configured. **Ask the user** for the telemetry repo
+  location (a git URL), e.g. *"Where should cross-machine telemetry be stored?
+  Paste a private git repo URL, or say 'skip' to review this machine only."*
+  - If they give a URL, write it to `~/.claude/.dev-team/telemetry.json` as
+    `{ "remote": "<url>" }` (create the dir if needed), confirm, then run the
+    sync command above. Point them at
+    [`telemetry-repo-security.md`](../../docs/telemetry-repo-security.md) for the
+    one-time deploy-key/token setup.
+  - If they say skip, proceed local-only — do **not** block the review.
+
+Never invent a URL or enable anything without the user's explicit location.
+
 ### 1. Extract (deterministic, zero model tokens)
 
 Run the extractor to produce the digest:

--- a/scripts/telemetry-sync.sh
+++ b/scripts/telemetry-sync.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# telemetry-sync.sh — push this machine's session digest to the telemetry
+# "database" repo and pull everyone else's (Delta D, #178).
+#
+# The repo is treated like a DATABASE, not code: each machine owns one
+# append-only file (digests/<host>/session-digest.jsonl), writes are direct to
+# the default branch (no PR), and per-host filenames make merges conflict-free.
+# See docs/telemetry-repo-security.md for the access model.
+#
+# Config resolution (first match wins):
+#   1. $DEV_TEAM_TELEMETRY_REMOTE                      (a git URL)
+#   2. ~/.claude/.dev-team/telemetry.json  ->  .remote
+# Optional:
+#   $DEV_TEAM_TELEMETRY_CLONE  local working clone  (default ~/.claude/.dev-team/agent-telemetry)
+#   $DEV_TEAM_TELEMETRY_HOST   host label           (default: hostname -s)
+#   .clone / .host in the config file are honored too.
+#
+# Usage:
+#   telemetry-sync.sh --check    validate config only; exit 3 if not configured
+#   telemetry-sync.sh            extract -> commit -> pull --rebase -> push
+#
+# Exit codes: 0 ok, 2 missing tool, 3 not configured, 4 transport/git error.
+
+set -uo pipefail
+
+CONFIG="${DEV_TEAM_TELEMETRY_CONFIG:-$HOME/.claude/.dev-team/telemetry.json}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_cfg() {  # _cfg <key> — read a key from the JSON config, empty if absent
+  [ -f "$CONFIG" ] && command -v jq >/dev/null 2>&1 || return 0
+  jq -r --arg k "$1" '.[$k] // empty' "$CONFIG" 2>/dev/null
+}
+
+# --- resolve config --------------------------------------------------------
+REMOTE="${DEV_TEAM_TELEMETRY_REMOTE:-$(_cfg remote)}"
+if [ -z "$REMOTE" ]; then
+  echo "No telemetry repository configured." >&2
+  echo "Configure it one of two ways:" >&2
+  echo "  - export DEV_TEAM_TELEMETRY_REMOTE=git@github.com:<owner>/<repo>.git" >&2
+  echo "  - or write {\"remote\": \"git@github.com:<owner>/<repo>.git\"} to $CONFIG" >&2
+  echo "(The /session-review skill will prompt you and write this for you.)" >&2
+  echo "Setup + security: plugins/dev-team/docs/telemetry-repo-security.md" >&2
+  exit 3
+fi
+
+CLONE="${DEV_TEAM_TELEMETRY_CLONE:-$(_cfg clone)}"
+CLONE="${CLONE:-$HOME/.claude/.dev-team/agent-telemetry}"
+HOST="${DEV_TEAM_TELEMETRY_HOST:-$(_cfg host)}"
+HOST="${HOST:-$(hostname -s 2>/dev/null || echo unknown-host)}"
+
+if [ "${1:-}" = "--check" ]; then
+  echo "telemetry remote: $REMOTE"
+  echo "local clone:      $CLONE"
+  echo "host label:       $HOST"
+  exit 0
+fi
+
+for t in git python3; do
+  command -v "$t" >/dev/null 2>&1 || { echo "missing required tool: $t" >&2; exit 2; }
+done
+
+# --- ensure a local clone of the data repo ---------------------------------
+if [ ! -d "$CLONE/.git" ]; then
+  mkdir -p "$(dirname "$CLONE")"
+  git clone --quiet "$REMOTE" "$CLONE" || { echo "clone failed: $REMOTE" >&2; exit 4; }
+fi
+git -C "$CLONE" pull --rebase --quiet || { echo "pull --rebase failed" >&2; exit 4; }
+
+# --- extract new/changed sessions into this host's append-only file --------
+DIGEST_DIR="$CLONE/digests/$HOST"
+mkdir -p "$DIGEST_DIR"
+WM="$HOME/.claude/.dev-team/telemetry-sync.json"
+mkdir -p "$(dirname "$WM")"
+python3 "$SCRIPT_DIR/session_extract.py" \
+  --sync-out "$DIGEST_DIR/session-digest.jsonl" \
+  --watermark "$WM" --host "$HOST" \
+  --plugin-root "$SCRIPT_DIR/../plugins/dev-team" \
+  || { echo "extract failed" >&2; exit 4; }
+
+# --- commit + push (direct to default branch; it's a database) -------------
+if [ -z "$(git -C "$CLONE" status --porcelain)" ]; then
+  echo "no new sessions to sync for $HOST"
+  exit 0
+fi
+git -C "$CLONE" add -A
+git -C "$CLONE" -c user.name="dev-team telemetry" \
+  -c user.email="telemetry@dev-team.local" \
+  commit --quiet -m "telemetry: $HOST $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  || { echo "commit failed" >&2; exit 4; }
+git -C "$CLONE" pull --rebase --quiet || { echo "rebase before push failed" >&2; exit 4; }
+git -C "$CLONE" push --quiet || { echo "push failed" >&2; exit 4; }
+echo "synced digest for $HOST -> $REMOTE"

--- a/tests/repo/telemetry_sync_tests.bats
+++ b/tests/repo/telemetry_sync_tests.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# telemetry-sync.sh config validation (#178). Network/git paths aren't exercised
+# in CI; these cover the deterministic config-resolution + --check contract that
+# /session-review relies on to decide whether to prompt for a repo location.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SYNC="$REPO_ROOT/scripts/telemetry-sync.sh"
+
+setup() { TMP="$(mktemp -d)"; }
+teardown() { rm -rf "$TMP"; }
+
+@test "sync --check: unconfigured exits 3 with guidance" {
+  run env -u DEV_TEAM_TELEMETRY_REMOTE \
+    DEV_TEAM_TELEMETRY_CONFIG="$TMP/none.json" bash "$SYNC" --check
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"No telemetry repository configured"* ]]
+  [[ "$output" == *"telemetry-repo-security.md"* ]]
+}
+
+@test "sync --check: env var configures the remote (exit 0)" {
+  run env DEV_TEAM_TELEMETRY_REMOTE="git@github.com:o/r.git" \
+    DEV_TEAM_TELEMETRY_CONFIG="$TMP/none.json" bash "$SYNC" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git@github.com:o/r.git"* ]]
+}
+
+@test "sync --check: config file configures the remote (exit 0)" {
+  printf '%s\n' '{"remote":"git@github.com:o/r.git","host":"box1"}' > "$TMP/cfg.json"
+  run env -u DEV_TEAM_TELEMETRY_REMOTE \
+    DEV_TEAM_TELEMETRY_CONFIG="$TMP/cfg.json" bash "$SYNC" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git@github.com:o/r.git"* ]]
+  [[ "$output" == *"box1"* ]]
+}
+
+@test "sync --check: env var overrides the config file" {
+  printf '%s\n' '{"remote":"git@github.com:from/config.git"}' > "$TMP/cfg.json"
+  run env DEV_TEAM_TELEMETRY_REMOTE="git@github.com:from/env.git" \
+    DEV_TEAM_TELEMETRY_CONFIG="$TMP/cfg.json" bash "$SYNC" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"from/env.git"* ]]
+  [[ "$output" != *"from/config.git"* ]]
+}


### PR DESCRIPTION
**Delta D slice 2** (#178) — wires the cross-project extractor (slice 1, #186) into a real sync, makes `/session-review` validate the telemetry repo is configured, and documents the secure "database" setup. **Refs, not closes** #178 (the union read across hosts is the remaining slice).

## Config validation (the ask)
`/session-review` **Step 0** now runs `telemetry-sync.sh --check`:
- configured → push this machine's digest + pull the others, then analyze cross-machine data;
- **not configured → ask the user for the repo location**, write `~/.claude/.dev-team/telemetry.json`, point them at the security doc; if they skip, proceed local-only. Never invents a URL, never blocks the review.

## Transport — treat the repo like a database
`scripts/telemetry-sync.sh`: resolve remote (env or config) → ensure local clone → `session_extract.py --sync-out digests/<host>/…` → commit → `pull --rebase` → **push directly to the default branch**. Per-host files = conflict-free; no PR.

## Security docs — `docs/telemetry-repo-security.md`
- Private repo; **branch protection OFF** (no PR toil for data); push access limited to your machines.
- **Least-privilege auth:** per-host **deploy key** (write, single-repo, revocable per machine) — recommended — or a **fine-grained PAT** scoped to only that repo's Contents. Explicitly warns off account-wide SSH keys / classic PATs.
- Why no PR gate is correct: append-only, non-executable metric rows; privacy is enforced upstream by the extractor (basename-only, metrics-only); gate the *code*, let the *data* flow.

## Verification
- `telemetry-sync.sh --check`: 4 tests (unconfigured→exit 3, env, config file, env-overrides-config); shellcheck clean.
- Prose-honesty sensor passes on the new shipped doc; knowledge index regenerated; full repo+docs suites green.

Refs #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)