### PR TITLE
feat(session-review): frequency→lever escalation (Delta C, #179)

### DIFF
--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -94,6 +94,21 @@ token/cost, summed rework/accuracy, and skills/agents **never invoked on any
 machine**. Hand the analysis agent the rollup when present, the local digest
 otherwise.
 
+Then compute the **frequency → lever escalation** (Delta C, #179) — recurrence
+decides how strong a response each friction earns:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
+  --plugin-root ${CLAUDE_PLUGIN_ROOT} --escalate "$CLONE/digests" \
+  -o memory/telemetry-escalation.json
+```
+
+Each recommendation carries a `lever`: **hint** (rare — surface only),
+**instruction-rule** (recurring; hand to `/feedback-learning`), or **hook**
+(frequent *and* deterministically matchable; validate via `/agent-eval` before
+shipping). "Matchable" is the deterministic side of the rules-vs-prompts ≤10% FP
+policy. Use the escalation `lever` to set the hand-off in Step 3.
+
 ### 2. Analyze (digest-only)
 
 Dispatch the `session-analysis` agent with the digest path as its sole input.

--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -597,6 +597,83 @@ def cmd_rollup(args, registry: dict) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------
+# Delta C (#179): frequency -> lever-strength escalation.
+#
+# Each known friction signal is tagged with whether a deterministic guard could
+# match it (the "hook-matchable" property). Combined with how often the friction
+# recurs (per-session rate across the rollup), this yields the recommended lever:
+#   rare                       -> hint (surface only)
+#   recurring, not matchable   -> instruction-file rule (/feedback-learning)
+#   frequent AND matchable     -> promote to a hook (validate via /agent-eval)
+# "matchable" is the deterministic side of the rules-vs-prompts <=10% FP policy.
+# --------------------------------------------------------------------------
+
+# signal -> (rollup section, key, hook-matchable?, human label)
+_FRICTION_SIGNALS = [
+    ("rework", "permission_denials", True, "permission denials"),
+    ("rework", "retried_bash_commands", True, "retried bash commands"),
+    ("rework", "repeated_verify_runs", True, "repeated verify runs"),
+    ("rework", "failed_edits", False, "failed edits (old_string not found)"),
+    ("rework", "compaction_events", False, "context compaction events"),
+    ("accuracy", "user_correction_turns", False, "user-correction turns"),
+]
+
+
+def _lever_for(rate: float, matchable: bool,
+               rare_rate: float, frequent_rate: float) -> tuple[str, str]:
+    if rate < rare_rate:
+        return "hint", "rare — surface as a hint only"
+    if matchable and rate >= frequent_rate:
+        return "hook", "frequent and deterministically matchable — promote to a hook (validate via /agent-eval)"
+    if matchable:
+        return "instruction-rule", "recurring and matchable but below the hook threshold — an instruction-file rule for now (/feedback-learning)"
+    return "instruction-rule", "recurring but judgment-shaped (no reliable matcher) — an instruction-file rule (/feedback-learning)"
+
+
+def escalate(roll: dict, rare_rate: float = 0.25,
+             frequent_rate: float = 1.0) -> dict:
+    """Turn rollup recurrence into ranked lever recommendations (#179)."""
+    sessions = max(int(roll.get("sessions", 0)), 0)
+    recs = []
+    for section, key, matchable, label in _FRICTION_SIGNALS:
+        count = roll.get(section, {}).get(key, 0) or 0
+        if not count:
+            continue
+        rate = round(count / sessions, 4) if sessions else 0.0
+        lever, rationale = _lever_for(rate, matchable, rare_rate, frequent_rate)
+        recs.append({
+            "signal": key,
+            "label": label,
+            "count": count,
+            "per_session_rate": rate,
+            "matchable": matchable,
+            "lever": lever,
+            "rationale": rationale,
+        })
+    # rank by per-session rate (worst first), then count
+    recs.sort(key=lambda r: (-r["per_session_rate"], -r["count"]))
+    return {
+        "schema": "telemetry-escalation/v1",
+        "sessions": sessions,
+        "thresholds": {"rare_rate": rare_rate, "frequent_rate": frequent_rate},
+        "recommendations": recs,
+    }
+
+
+def cmd_escalate(args, registry: dict) -> int:
+    root = Path(args.escalate)
+    roll = rollup(root, registry) if root.is_dir() else {"sessions": 0}
+    out = json.dumps(
+        escalate(roll, rare_rate=args.rare_rate, frequent_rate=args.frequent_rate),
+        indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
 def load_registry(plugin_root: Path | None) -> dict:
     """Enumerate shipped skills/agents so we can report never-observed ones."""
     if plugin_root is None:
@@ -639,6 +716,14 @@ def main(argv=None) -> int:
     ap.add_argument("--rollup", metavar="DIR",
                     help="union read (#178): aggregate all hosts' "
                          "DIR/<host>/session-digest.jsonl into one cross-machine view")
+    ap.add_argument("--escalate", metavar="DIR",
+                    help="Delta C (#179): rank friction signals from DIR's rollup "
+                         "and recommend a lever (hint / instruction-rule / hook)")
+    ap.add_argument("--rare-rate", type=float, default=0.25,
+                    help="per-session rate below which a friction is a hint (default 0.25)")
+    ap.add_argument("--frequent-rate", type=float, default=1.0,
+                    help="per-session rate at/above which a matchable friction "
+                         "becomes a hook (default 1.0)")
     args = ap.parse_args(argv)
 
     pricing_path = Path(args.pricing) if args.pricing else (
@@ -650,6 +735,10 @@ def main(argv=None) -> int:
     # Cross-machine union read (Delta D, #178).
     if args.rollup:
         return cmd_rollup(args, registry)
+
+    # Frequency -> lever escalation (Delta C, #179).
+    if args.escalate:
+        return cmd_escalate(args, registry)
 
     # Cross-project incremental sync mode (Delta D, #178).
     if args.sync_out:

--- a/tests/repo/session_extract_escalate_tests.bats
+++ b/tests/repo/session_extract_escalate_tests.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Delta C (#179): frequency -> lever escalation over the cross-machine rollup.
+# rare -> hint; recurring+judgment -> instruction-rule; frequent+matchable -> hook.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+EXTRACT="$REPO_ROOT/scripts/session_extract.py"
+PLUGIN="$REPO_ROOT/plugins/dev-team"
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/digests/box"
+  # 2 sessions. permission_denials total 4 (rate 2.0, matchable -> hook).
+  # failed_edits total 1 (rate 0.5, not matchable -> instruction-rule).
+  # compaction_events total 0 across... add a rare matchable: retried_bash 1
+  #   over 2 sessions = rate 0.4 (>=rare, <frequent), matchable -> instruction-rule.
+  # user_correction_turns total 0 -> omitted (no count).
+  cat > "$TMP/digests/box/session-digest.jsonl" <<'EOF'
+{"schema":"session-sync/v1","host":"box","project":"p","session_id":"s1","tokens":{"input_tokens":1},"cost_usd":0,"rework":{"permission_denials":3,"failed_edits":1,"retried_bash_commands":1},"accuracy":{"tool_calls":1,"tool_error_rate":0,"user_correction_turns":0},"utilization":{"skills_invoked":{},"agents_invoked":{}}}
+{"schema":"session-sync/v1","host":"box","project":"p","session_id":"s2","tokens":{"input_tokens":1},"cost_usd":0,"rework":{"permission_denials":1,"failed_edits":0,"retried_bash_commands":0},"accuracy":{"tool_calls":1,"tool_error_rate":0,"user_correction_turns":0},"utilization":{"skills_invoked":{},"agents_invoked":{}}}
+EOF
+}
+teardown() { rm -rf "$TMP"; }
+
+_esc() { python3 "$EXTRACT" --escalate "$TMP/digests" --plugin-root "$PLUGIN"; }
+
+@test "escalate: frequent + matchable friction -> hook" {
+  run _esc
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.schema')" = "telemetry-escalation/v1" ]
+  [ "$(echo "$output" | jq -r '.sessions')" = "2" ]
+  # permission_denials: 4 / 2 = 2.0 rate, matchable -> hook
+  [ "$(echo "$output" | jq -r '.recommendations[] | select(.signal=="permission_denials").lever')" = "hook" ]
+  [ "$(echo "$output" | jq -r '.recommendations[] | select(.signal=="permission_denials").per_session_rate')" = "2.0" ]
+}
+
+@test "escalate: recurring judgment-shaped friction -> instruction-rule" {
+  run _esc
+  # failed_edits: 1/2 = 0.5, not matchable -> instruction-rule
+  [ "$(echo "$output" | jq -r '.recommendations[] | select(.signal=="failed_edits").lever')" = "instruction-rule" ]
+}
+
+@test "escalate: matchable but below hook threshold -> instruction-rule" {
+  run _esc
+  # retried_bash_commands: 1/2 = 0.5 (>=rare 0.25, <frequent 1.0), matchable
+  [ "$(echo "$output" | jq -r '.recommendations[] | select(.signal=="retried_bash_commands").lever')" = "instruction-rule" ]
+}
+
+@test "escalate: rare friction -> hint (threshold override)" {
+  # raise rare-rate so 0.5 counts as rare
+  run python3 "$EXTRACT" --escalate "$TMP/digests" --rare-rate 0.6 --plugin-root "$PLUGIN"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.recommendations[] | select(.signal=="failed_edits").lever')" = "hint" ]
+}
+
+@test "escalate: recommendations ranked worst-first by rate" {
+  run _esc
+  # permission_denials (2.0) must rank above failed_edits (0.5)
+  [ "$(echo "$output" | jq -r '.recommendations[0].signal')" = "permission_denials" ]
+}
+
+@test "escalate: zero-count signals are omitted" {
+  run _esc
+  # user_correction_turns total 0 -> not in recommendations
+  [ "$(echo "$output" | jq -r '[.recommendations[] | select(.signal=="user_correction_turns")] | length')" = "0" ]
+}


### PR DESCRIPTION
Completes the "suggest" half of the loop: turns the cross-machine rollup's recurrence into an explicit response-strength rule.

## The rule
| Recurrence | Determinism | Lever |
|---|---|---|
| Rare | any | **hint** (surface only) |
| Recurring | judgment-shaped | **instruction-rule** → `/feedback-learning` |
| Frequent | deterministically matchable | **hook** (validate via `/agent-eval`) |

## What it adds
- **`--escalate DIR`** — reads the rollup, ranks friction signals by per-session rate, tags each with hook-matchability, recommends a lever. Thresholds (`--rare-rate`, `--frequent-rate`) are the named instrument.
- Each known friction (permission denials, retried bash, repeated verify runs, failed edits, compaction, user corrections) is tagged matchable vs judgment — the deterministic side of the rules-vs-prompts ≤10% FP policy.
- Wired into `/session-review`: the escalation `lever` drives the Step 3 hand-off.

## Verification
- 6 tests (`session_extract_escalate_tests.bats`): hook / instruction-rule / hint assignment, threshold override, worst-first ranking, zero-count omission.
- Full repo+docs suites green; knowledge index regenerated.
- **Live over 141 sessions:** `repeated_verify_runs` 1.62/session → **hook**; corrections + retried bash → instruction-rule; rare signals → hint.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)