### PR TITLE
feat(telemetry): wire CI cost-regression gate to real cross-machine baseline (#171)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -73,10 +73,42 @@ jobs:
             tests/hooks/agent_model_resolve_hook_tests.bats \
             tests/hooks/model_resolve_tests.bats
 
-      # Cost-regression gate (#140): the cost meter ships a `regression`
-      # subcommand that nothing ran. This self-tests the mechanism (blocking)
-      # and, when a baseline log is committed, runs the real check warn-only —
-      # a non-deterministic meter must not hard-fail an unrelated code PR.
+  # Cost-regression gate (#140 mechanism, #171 real baseline). Isolated in its
+  # own job so the read-only telemetry deploy key is never in scope for the
+  # broader test jobs. The self-test step always runs (blocking); the telemetry
+  # clone + real cross-machine baseline only run where the secret is available.
+  cost-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install python3 + jq
+        run: sudo apt-get update && sudo apt-get install -y jq python3
+
+      # Secrets are NOT exposed to forked-PR runs, so the deploy key (and thus
+      # the real cross-machine baseline) is only available on branches in this
+      # repo and on internal PRs. Fork PRs skip the next two steps and fall back
+      # to the blocking self-test below. Coverage boundary documented in
+      # plugins/dev-team/docs/telemetry-ci-access.md.
+      - name: Load telemetry deploy key (read-only)
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TELEMETRY_DEPLOY_KEY }}
+
+      - name: Clone telemetry (read-only) and build the cross-machine cost baseline
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        run: |
+          git clone --depth 1 git@github.com:bdfinst/agent-telemetry.git /tmp/telemetry
+          python3 scripts/session_extract.py --cost-log /tmp/telemetry/digests \
+            -o /tmp/telemetry-cost-log.jsonl
+          echo "COST_BASELINE_LOG=/tmp/telemetry-cost-log.jsonl" >> "$GITHUB_ENV"
+
+      # Self-tests the mechanism (blocking). When the baseline above was built,
+      # the script ALSO runs the real regression of the latest session against
+      # the cross-machine rolling mean — warn-only, since a non-deterministic
+      # meter must not hard-fail an unrelated code PR. Fork PRs reach here with
+      # no baseline and get the self-test only.
       - name: Run cost-regression check
         run: bash scripts/cost-regression-check.sh
 

--- a/plugins/dev-team/docs/telemetry-ci-access.md
+++ b/plugins/dev-team/docs/telemetry-ci-access.md
@@ -50,31 +50,44 @@ holds both halves where they belong.
 
 ### 4. Consume it in the workflow
 
-The cost-regression job loads the key, clones the data repo read-only, builds the
-rollup, and checks the baseline:
+This wiring is **already in place** — see the `cost-regression` job in
+[`.github/workflows/plugin-tests.yml`](../../../.github/workflows/plugin-tests.yml).
+The job loads the key, clones the data repo read-only, builds a per-session cost
+series from the digests, and runs the regression check against it. The
+credential steps are gated so fork PRs (which have no secret access) skip them
+and fall back to the blocking self-test:
 
 ```yaml
   cost-regression:
     runs-on: ubuntu-latest
-    # Secrets are NOT available to forked-PR runs (see caveat) — gate on that:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     steps:
-      - uses: actions/checkout@v4
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: actions/checkout@v6
+      - name: Install python3 + jq
+        run: sudo apt-get update && sudo apt-get install -y jq python3
+      # Secrets are NOT exposed to forked-PR runs (see caveat) — gate on that:
+      - name: Load telemetry deploy key (read-only)
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.TELEMETRY_DEPLOY_KEY }}
-      - name: Clone telemetry (read-only) and build the baseline rollup
+      - name: Clone telemetry (read-only) and build the cross-machine cost baseline
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: |
           git clone --depth 1 git@github.com:bdfinst/agent-telemetry.git /tmp/telemetry
-          python3 scripts/session_extract.py --rollup /tmp/telemetry/digests \
-            -o /tmp/telemetry-rollup.json
-      - name: Cost-regression check against the real baseline
-        run: bash scripts/cost-regression-check.sh   # (wiring tracked in #171)
+          python3 scripts/session_extract.py --cost-log /tmp/telemetry/digests \
+            -o /tmp/telemetry-cost-log.jsonl
+          echo "COST_BASELINE_LOG=/tmp/telemetry-cost-log.jsonl" >> "$GITHUB_ENV"
+      - name: Run cost-regression check
+        run: bash scripts/cost-regression-check.sh
 ```
 
-> The `cost-regression-check.sh` step that *reads* this baseline is intentionally
-> **deferred** until this access exists (per #171). Once you've completed steps
-> 1–3, say so and the wiring will be added.
+> Why `--cost-log` and not `--rollup`? The regression meter
+> (`cost_meter.py regression`) compares the **latest** session against the
+> rolling mean of priors, so it needs a *time-ordered per-session series*, not a
+> single aggregate. `session_extract.py --cost-log <digests>` emits exactly that
+> (`{"total":{"cost_usd":..}}` records, oldest→newest, deduped on `session_id`).
+> The real cross-machine check is **warn-only** — a non-deterministic meter must
+> not hard-fail an unrelated code PR.
 
 ## Alternative: a fine-grained PAT (read-only)
 

--- a/plugins/dev-team/docs/telemetry-ci-access.md
+++ b/plugins/dev-team/docs/telemetry-ci-access.md
@@ -1,0 +1,108 @@
+# Giving CI read access to the telemetry repo
+
+To make the cost-regression gate (#171) — and any future rollup-based gate —
+enforce against **real** data, CI needs to **read** the private `agent-telemetry`
+repo and build the cross-machine rollup. This doc sets that up with least
+privilege: **read-only, single-repo, revocable**, and with no write access to
+your data.
+
+Companion docs: [`telemetry-repo-security.md`](telemetry-repo-security.md) (how
+machines *write* digests) and the watermark/sync flow in `/session-review`.
+
+## Principle
+
+- CI only ever **reads** the digest database — it never writes telemetry.
+- The credential is scoped to the **one** `agent-telemetry` repo, **read-only**,
+  and can be revoked without touching anything else.
+- The raw `~/.claude/projects` transcripts are never involved; CI consumes the
+  already-sanitized, metrics-only digest.
+
+## Recommended: a read-only deploy key
+
+A deploy key authorizes an SSH key for a **single repository**. Make it
+**read-only** so CI can clone but never push.
+
+### 1. Generate a dedicated keypair (locally)
+
+```bash
+ssh-keygen -t ed25519 -f ./telemetry-ci -N "" -C "agentic-dev-team CI read-only"
+# produces:  telemetry-ci  (private)   telemetry-ci.pub  (public)
+```
+
+### 2. Add the PUBLIC key to `agent-telemetry` as a read-only deploy key
+
+GitHub → `agent-telemetry` → Settings → Deploy keys → **Add deploy key**:
+
+- Title: `agentic-dev-team CI (read-only)`
+- Key: contents of `telemetry-ci.pub`
+- **Leave "Allow write access" UNCHECKED** ← this is what keeps CI read-only.
+
+### 3. Add the PRIVATE key to `agentic-dev-team` as an Actions secret
+
+GitHub → `agentic-dev-team` → Settings → Secrets and variables → Actions →
+**New repository secret**:
+
+- Name: `TELEMETRY_DEPLOY_KEY`
+- Value: contents of `telemetry-ci` (the private key)
+
+Then delete the local key files (`rm telemetry-ci telemetry-ci.pub`) — GitHub now
+holds both halves where they belong.
+
+### 4. Consume it in the workflow
+
+The cost-regression job loads the key, clones the data repo read-only, builds the
+rollup, and checks the baseline:
+
+```yaml
+  cost-regression:
+    runs-on: ubuntu-latest
+    # Secrets are NOT available to forked-PR runs (see caveat) — gate on that:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TELEMETRY_DEPLOY_KEY }}
+      - name: Clone telemetry (read-only) and build the baseline rollup
+        run: |
+          git clone --depth 1 git@github.com:bdfinst/agent-telemetry.git /tmp/telemetry
+          python3 scripts/session_extract.py --rollup /tmp/telemetry/digests \
+            -o /tmp/telemetry-rollup.json
+      - name: Cost-regression check against the real baseline
+        run: bash scripts/cost-regression-check.sh   # (wiring tracked in #171)
+```
+
+> The `cost-regression-check.sh` step that *reads* this baseline is intentionally
+> **deferred** until this access exists (per #171). Once you've completed steps
+> 1–3, say so and the wiring will be added.
+
+## Alternative: a fine-grained PAT (read-only)
+
+If you prefer HTTPS: create a **fine-grained** PAT scoped to **only**
+`agent-telemetry` with **Contents: Read-only**, store it as the
+`TELEMETRY_DEPLOY_KEY` (or `TELEMETRY_TOKEN`) secret, and clone via
+`https://x-access-token:${TOKEN}@github.com/bdfinst/agent-telemetry.git`. Prefer
+the deploy key — it is the tightest scope (one repo, read-only) and needs no
+account-level token.
+
+## Security notes and caveats
+
+- **Read-only, by construction.** The deploy key has no write access, so a leak
+  exposes *read* of one private metrics repo — never write, never your account.
+- **Fork-PR caveat (important).** GitHub does not expose secrets to workflows
+  triggered by pull requests from forks. So the cost gate runs on branches in
+  this repo and on internal PRs, but **not** on fork PRs — those fall back to the
+  mechanism self-test. For a solo/private setup this is a non-issue; documented so
+  the coverage boundary is honest.
+- **Rotation.** To rotate: generate a new key, add it, update the secret, delete
+  the old deploy key. To revoke entirely: delete the deploy key on
+  `agent-telemetry` — CI loses read access immediately, nothing else affected.
+- **Never echo the key** in workflow logs; `ssh-agent` keeps it out of the
+  environment dump.
+
+## What this unblocks
+
+- **#171** — the cost-regression gate compares each run against the real
+  cross-machine baseline instead of only self-testing the mechanism.
+- Any future gate that wants cross-machine rollup data in CI (the same clone +
+  `--rollup` pattern).

--- a/scripts/cost-regression-check.sh
+++ b/scripts/cost-regression-check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# cost-regression-check.sh — CI wiring for the cost-meter regression gate (#140).
+# cost-regression-check.sh — CI wiring for the cost-meter regression gate
+# (#140 mechanism, #171 real cross-machine baseline).
 #
 # hooks/lib/cost_meter.py ships a `regression` subcommand, but nothing ran it,
 # so a cost regression could merge unnoticed. This wires it into CI with three
@@ -10,13 +11,15 @@
 #      must be flagged (exit 1) and a within-tolerance run must pass (exit 0). If
 #      that breaks, the gate is dishonest and CI fails.
 #
-#   2. COMMITTED BASELINE (warn-only). If a baseline log exists in the repo
-#      (metrics/cost-metering.jsonl), run the real regression check against it.
-#      A non-deterministic meter shouldn't HARD-fail an unrelated code PR, so a
-#      detected regression is surfaced as a warning annotation, not a block.
+#   2. REAL BASELINE (warn-only). If COST_BASELINE_LOG points at a cost series,
+#      run the real regression check against it. In CI that series is built from
+#      the private telemetry repo (the cross-machine per-session costs; #171); a
+#      committed metrics/cost-metering.jsonl works too. A non-deterministic meter
+#      shouldn't HARD-fail an unrelated code PR, so a detected regression is
+#      surfaced as a warning annotation, not a block.
 #
-#   3. NO BASELINE. If no committed log exists (the current state — the log is
-#      written locally by the Stop hook), say so and pass cleanly.
+#   3. NO BASELINE. If no baseline log is available (e.g. a fork PR with no access
+#      to the telemetry repo, or no committed log), say so and pass cleanly.
 #
 # Tolerance and window are configurable via env (COST_TOLERANCE, COST_WINDOW).
 # Exit codes: 0 = ok (incl. warn), 1 = the regression mechanism itself is broken.
@@ -58,10 +61,10 @@ fi
 echo "  ok: spike flagged, within-tolerance passes."
 
 # --- 2/3. real baseline (warn-only) or no baseline ---------------------------
-echo "== cost-regression against committed baseline =="
+echo "== cost-regression against baseline =="
 if [ ! -f "$BASELINE" ]; then
-  echo "  no committed baseline at $BASELINE — the meter records locally via the"
-  echo "  Stop hook. Commit a baseline log to enable PR-time regression warnings."
+  echo "  no baseline log at $BASELINE — point COST_BASELINE_LOG at a cost series"
+  echo "  (CI builds one from the telemetry repo, #171) or commit a local log."
   exit 0
 fi
 

--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -597,6 +597,42 @@ def cmd_rollup(args, registry: dict) -> int:
     return 0
 
 
+def cost_log(digests_root: Path) -> list[dict]:
+    """Per-session cost SERIES for the cost-meter regression gate (#171).
+
+    `rollup()` returns one aggregate; the regression check in `cost_meter.py`
+    instead needs a time-ordered list of per-session costs so it can compare the
+    most recent session against the cross-machine rolling baseline. This reads
+    the same `digests/<host>/session-digest.jsonl` union, dedups on session_id
+    (last write wins), orders oldest->newest by `ts`, and emits cost-meter
+    records: `{"ts": ..., "total": {"cost_usd": ...}}` (extra `ts` is ignored by
+    `regression` and used by `pace`)."""
+    by_id: dict[str, dict] = {}
+    for f in sorted(digests_root.glob("*/session-digest.jsonl")):
+        for rec in _iter_records([f]):
+            if rec.get("schema") != "session-sync/v1":
+                continue
+            sid = rec.get("session_id")
+            if sid:
+                by_id[str(sid)] = rec  # last write wins -> dedup on session_id
+    recs = sorted(by_id.values(),
+                  key=lambda r: (r.get("ts") or "", str(r.get("session_id"))))
+    return [{"ts": r.get("ts"),
+             "total": {"cost_usd": r.get("cost_usd", 0.0) or 0.0}}
+            for r in recs]
+
+
+def cmd_cost_log(args) -> int:
+    root = Path(args.cost_log)
+    lines = ("\n".join(json.dumps(rec, sort_keys=True) for rec in cost_log(root))
+             if root.is_dir() else "")
+    if args.out:
+        Path(args.out).write_text(lines + ("\n" if lines else ""))
+    elif lines:
+        print(lines)
+    return 0
+
+
 # --------------------------------------------------------------------------
 # Delta C (#179): frequency -> lever-strength escalation.
 #
@@ -716,6 +752,10 @@ def main(argv=None) -> int:
     ap.add_argument("--rollup", metavar="DIR",
                     help="union read (#178): aggregate all hosts' "
                          "DIR/<host>/session-digest.jsonl into one cross-machine view")
+    ap.add_argument("--cost-log", metavar="DIR",
+                    help="cost-meter baseline (#171): from DIR/<host>/session-digest.jsonl "
+                         "emit a time-ordered per-session cost series "
+                         "({\"total\":{\"cost_usd\":..}}) for `cost_meter.py regression`")
     ap.add_argument("--escalate", metavar="DIR",
                     help="Delta C (#179): rank friction signals from DIR's rollup "
                          "and recommend a lever (hint / instruction-rule / hook)")
@@ -735,6 +775,10 @@ def main(argv=None) -> int:
     # Cross-machine union read (Delta D, #178).
     if args.rollup:
         return cmd_rollup(args, registry)
+
+    # Cross-machine cost baseline for the regression gate (#171).
+    if args.cost_log:
+        return cmd_cost_log(args)
 
     # Frequency -> lever escalation (Delta C, #179).
     if args.escalate:

--- a/tests/repo/cost_regression_ci_tests.bats
+++ b/tests/repo/cost_regression_ci_tests.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
 # Tests for scripts/cost-regression-check.sh — the CI wiring for the cost-meter
-# regression gate (#140): self-test (blocking), committed baseline (warn-only),
-# and no-baseline (clean pass).
+# regression gate (#140 mechanism, #171 real cross-machine baseline): self-test
+# (blocking), real baseline (warn-only), and no-baseline (clean pass).
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 CHECK="$REPO_ROOT/scripts/cost-regression-check.sh"
+EXTRACT="$REPO_ROOT/scripts/session_extract.py"
 
 setup() { WORK="$(mktemp -d)"; }
 teardown() { rm -rf "$WORK"; }
@@ -13,7 +14,7 @@ teardown() { rm -rf "$WORK"; }
   run env COST_BASELINE_LOG="$WORK/none.jsonl" bash "$CHECK"
   [ "$status" -eq 0 ]
   [[ "$output" == *"spike flagged, within-tolerance passes"* ]]
-  [[ "$output" == *"no committed baseline"* ]]
+  [[ "$output" == *"no baseline log"* ]]
 }
 
 @test "ci-cost: a committed baseline with a spike warns but does NOT block" {
@@ -32,6 +33,22 @@ teardown() { rm -rf "$WORK"; }
   [ "$status" -eq 0 ]
   [[ "$output" == *"no cost regression"* ]]
   [[ "$output" != *"::warning"* ]]
+}
+
+@test "ci-cost: #171 end-to-end — telemetry digests -> cost-log baseline -> warn" {
+  # Simulate the CI flow: a cloned telemetry repo's digests become the baseline.
+  mkdir -p "$WORK/digests/boxA"
+  cat > "$WORK/digests/boxA/session-digest.jsonl" <<'EOF'
+{"schema":"session-sync/v1","host":"boxA","session_id":"s1","ts":"2026-06-01T00:00:00Z","cost_usd":1.0}
+{"schema":"session-sync/v1","host":"boxA","session_id":"s2","ts":"2026-06-02T00:00:00Z","cost_usd":1.0}
+{"schema":"session-sync/v1","host":"boxA","session_id":"s3","ts":"2026-06-03T00:00:00Z","cost_usd":9.0}
+EOF
+  python3 "$EXTRACT" --cost-log "$WORK/digests" -o "$WORK/cost-log.jsonl"
+  # newest session (ts 06-03) is the spike; priors mean to 1.0
+  run env COST_BASELINE_LOG="$WORK/cost-log.jsonl" COST_TOLERANCE=0.5 bash "$CHECK"
+  [ "$status" -eq 0 ]                       # warn-only: never blocks
+  [[ "$output" == *"COST REGRESSION"* ]]
+  [[ "$output" == *"::warning"* ]]
 }
 
 @test "ci-cost: registered as a step in plugin-tests.yml" {

--- a/tests/repo/session_extract_rollup_tests.bats
+++ b/tests/repo/session_extract_rollup_tests.bats
@@ -88,3 +88,42 @@ EOF
   [ "$status" -eq 0 ]
   [ "$(echo "$output" | jq -r '.sessions')" = "0" ]
 }
+
+# ---- #171: --cost-log per-session cost series for the regression gate ----
+_seed_cost_digests() {
+  mkdir -p "$TMP/digests/boxA" "$TMP/digests/boxB"
+  # ts deliberately out of file order; cost-log must sort oldest->newest by ts.
+  cat > "$TMP/digests/boxA/session-digest.jsonl" <<'EOF'
+{"schema":"session-sync/v1","host":"boxA","session_id":"s2","ts":"2026-06-02T00:00:00Z","cost_usd":2.0}
+{"schema":"session-sync/v1","host":"boxA","session_id":"s1","ts":"2026-06-01T00:00:00Z","cost_usd":1.0}
+EOF
+  cat > "$TMP/digests/boxB/session-digest.jsonl" <<'EOF'
+{"schema":"session-sync/v1","host":"boxB","session_id":"s3","ts":"2026-06-03T00:00:00Z","cost_usd":3.0}
+EOF
+}
+
+@test "cost-log: emits a ts-ordered per-session cost series across hosts (#171)" {
+  _seed_cost_digests
+  run python3 "$EXTRACT" --cost-log "$TMP/digests" --plugin-root "$PLUGIN"
+  [ "$status" -eq 0 ]
+  # three records, oldest first, in cost-meter shape
+  [ "$(echo "$output" | wc -l | tr -d ' ')" = "3" ]
+  [ "$(echo "$output" | jq -s 'map(.total.cost_usd) == [1,2,3]')" = "true" ]
+  [ "$(echo "$output" | head -1 | jq -r '.ts')" = "2026-06-01T00:00:00Z" ]
+}
+
+@test "cost-log: dedups a session_id seen twice, last write wins (#171)" {
+  _seed_cost_digests
+  # re-emit s1 with a higher cost -> one record, newest value
+  echo '{"schema":"session-sync/v1","host":"boxB","session_id":"s1","ts":"2026-06-01T00:00:00Z","cost_usd":5.0}' \
+    >> "$TMP/digests/boxB/session-digest.jsonl"
+  run python3 "$EXTRACT" --cost-log "$TMP/digests" --plugin-root "$PLUGIN"
+  [ "$(echo "$output" | wc -l | tr -d ' ')" = "3" ]
+  [ "$(echo "$output" | jq -s 'map(.total.cost_usd) == [5,2,3]')" = "true" ]
+}
+
+@test "cost-log: empty/missing dir yields no records, clean exit (#171)" {
+  run python3 "$EXTRACT" --cost-log "$TMP/nope" --plugin-root "$PLUGIN"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
## What

Gives CI **read-only** access to the private `agent-telemetry` repo and feeds the cost-regression gate a **real cross-machine baseline** instead of only self-testing the mechanism (#171).

## Credential setup (already live, outside this PR)

- Read-only deploy key `153772205` on `agent-telemetry` (write access **unchecked**).
- `TELEMETRY_DEPLOY_KEY` secret on `agentic-dev-team` (private half).
- Least privilege: one repo, read-only, revocable by deleting the deploy key.

## Code in this PR

- **`session_extract.py --cost-log <digests>`** — emits a ts-ordered, `session_id`-deduped per-session cost series (`{"total":{"cost_usd":..}}`) that `cost_meter.py regression` consumes. The rollup is an aggregate; the regression meter needs a *series* (latest vs rolling mean of priors), so this is a new mode rather than misusing `--rollup` with a fake baseline.
- **`plugin-tests.yml`** — dedicated `cost-regression` **job** (isolates the deploy key). Loads the key, clones telemetry read-only, builds the baseline, runs the check. Credential steps are gated to non-fork events; fork PRs fall back to the **blocking self-test**.
- **`cost-regression-check.sh`** — reworded for the real baseline; real cross-machine check stays **warn-only** (a non-deterministic meter must not hard-fail an unrelated PR). No logic change — it was already parameterized by `COST_BASELINE_LOG`.
- **`docs/telemetry-ci-access.md`** — step 4 now reflects the shipped wiring.

## Tests

- +3 `--cost-log` tests (ordering across hosts, dedup last-write-wins, empty dir).
- +1 end-to-end #171 test (digests → cost-log → warn-only regression).
- `bats tests/repo/ tests/docs/`: **196 passing, 0 failures**. shellcheck + YAML parse clean. Pre-push local CI gate passed.

## Coverage boundary

Fork PRs have no secret access → telemetry steps skip, blocking self-test still runs. Solo/private setup: non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)