### PR TITLE
docs(concurrent-use): resolve #109 Phase 2 — one worktree per agent

### DIFF
--- a/docs/spikes/multiplayer-collisions.md
+++ b/docs/spikes/multiplayer-collisions.md
@@ -1,8 +1,13 @@
 # Spike: multiplayer / concurrent-use collisions (#109 Phase 1)
 
-> **Phase 1 (reproduce + characterize) — done.** Phase 2 (decide enforce-vs-document
-> and implement) is a separate step and needs a human decision (see the end).
-> Reproductions: `tests/repo/multiplayer_collision_tests.bats`.
+> **Phase 1 (reproduce + characterize) — done.** Reproductions:
+> `tests/repo/multiplayer_collision_tests.bats`.
+>
+> **Phase 2 — resolved (document, don't enforce).** The plugin documents the
+> safe pattern — one git worktree per agent — in
+> [`../../plugins/dev-team/docs/concurrent-use.md`](../../plugins/dev-team/docs/concurrent-use.md),
+> rather than adding locks. The independent single-player gate bug (paths-not-
+> content) is spun off to **#193**.
 
 ## Scope
 

--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -247,9 +247,17 @@ All three are optional and project-local — they are not part of the plugin.
 - **[`/apply-fixes`](../skills/apply-fixes/SKILL.md)** consumes the `corrections/` directory produced here.
 - **[`/pr`](../skills/pr/SKILL.md)** runs `/code-review --json` as part of its pre-PR quality gate. It runs non-interactively (fix loop auto-applies, no "fix or report?" prompt) and `/pr` branches on the returned status — `overall: pass/warn` or `status: skipped` proceeds, `overall: fail` re-engages the user.
 
+## Concurrent use
+
+The `.review-passed` gate is a single, gitignored file per working tree. Two
+agents sharing **one** checkout will overwrite each other's gate. Run each
+concurrent agent in its own [git worktree](concurrent-use.md) — separate
+checkouts (the normal team workflow) are unaffected.
+
 ## References
 
 - [Skill spec](../skills/code-review/SKILL.md) — operational detail for the orchestrator
+- [Concurrent use](concurrent-use.md) — one worktree per agent; why the gate is per-checkout
 - [Output format](../skills/code-review/output-format.md) — per-agent JSON, aggregated JSON, correction prompts
 - [Report template](../knowledge/review-template.md) — prose report structure
 - [Scoring rubric](../knowledge/review-rubric.md) — health scoring and severity mapping

--- a/plugins/dev-team/docs/concurrent-use.md
+++ b/plugins/dev-team/docs/concurrent-use.md
@@ -1,0 +1,63 @@
+# Concurrent use — multiple agents or people on one repo
+
+Short version: **the normal team workflow is safe; for two *agents* on one
+machine, give each its own git worktree.**
+
+This resolves the concurrency question (#109): the plugin **documents** a safe
+pattern rather than enforcing locks, because git worktrees already solve the
+problem cleanly.
+
+## Why the normal case is already safe
+
+The plugin's local coordination state is per-checkout, not shared:
+
+| State | Where | Shared across checkouts? |
+|---|---|---|
+| Review gate `.review-passed` | repo root, **gitignored** | No — local to each working tree |
+| `.claude/model-overrides.json` | **gitignored** | No — local to each working tree |
+| Plan / build progress | `plans/<name>.md` (**tracked**) | Merges through normal git |
+
+So two developers, each with their **own clone**, never collide on these — and
+plan files reconcile the way any tracked file does. "Designed for teams" holds
+for the standard one-checkout-per-person workflow.
+
+## The unsafe case: two agents sharing ONE working tree
+
+Two background agents, two terminals in the same directory, or a human and an
+agent in the same checkout share **one** `.git/index` and **one** set of local
+state files. That is where collisions occur (reproduced in
+[`../../../docs/spikes/multiplayer-collisions.md`](../../../docs/spikes/multiplayer-collisions.md)):
+the shared `.review-passed` gets overwritten (false blocks), the staged set
+interleaves, and `model-overrides.json` writes race.
+
+## The rule: one worktree per agent
+
+Use a separate [git worktree](https://git-scm.com/docs/git-worktree) for each
+concurrent agent. Each worktree has its own working directory, its own index,
+and its own gitignored local state — so the agents never share a gate or a
+staging area, while still sharing one clone's history and branches.
+
+```bash
+# From your main checkout, create an isolated worktree per task/agent:
+git worktree add ../myrepo-feature-a feature-a
+git worktree add ../myrepo-feature-b feature-b
+
+# Run each agent in its own worktree directory. When done:
+git worktree remove ../myrepo-feature-a
+```
+
+Guidance:
+
+- **One agent (or session) per worktree.** Don't point two agents at the same
+  directory.
+- Worktrees are cheap (they share the object store) — make one per parallel task.
+- The review gate, model overrides, and staged set are now per-worktree, so the
+  collisions above cannot occur.
+
+## Known limitation (separate from concurrency)
+
+The review gate currently binds to staged **paths**, not **content**, so editing
+a file's content after review can commit it unreviewed even for a single user.
+That is an independent correctness bug tracked in **#193** — fixing it (hash the
+staged patch) also hardens the shared-tree case, but the worktree rule above is
+the recommended isolation regardless.


### PR DESCRIPTION
**Phase 2 of #109**, resolved toward **document, don't enforce**.

## Finding → guidance
- **Separate clones (normal team workflow) are already safe** — the review gate and model overrides are gitignored per-tree; plan files merge via git.
- **Two agents on one machine** should use **one git worktree each** — separate index, gate, and overrides, no collisions.

New shipped doc `plugins/dev-team/docs/concurrent-use.md` (worktree pattern + why), referenced from `code-review-process.md`; the spike doc's Phase 2 is marked resolved. Enforcement via locks is unnecessary given worktrees already isolate cleanly.

The independent single-player gate bug (`.review-passed` binds paths not content) is spun off to **#193**.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)