### PR TITLE
fix(review-gate): bind .review-passed to staged content, not paths (#193)

### DIFF
--- a/plugins/dev-team/hooks/lib/review-gate-hash.sh
+++ b/plugins/dev-team/hooks/lib/review-gate-hash.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# review-gate-hash.sh — the single source of truth for the .review-passed gate
+# hash (#193).
+#
+# The gate binds to the STAGED CONTENT (the cached patch), not just the staged
+# file PATHS. Hashing paths alone let a reviewed file's content change and still
+# commit unreviewed (a TOCTOU gap, reproduced in
+# tests/repo/multiplayer_collision_tests.bats). Hashing `git diff --cached`
+# captures both which files are staged AND their staged content — so any edit
+# after review invalidates the gate and forces a re-review.
+#
+# Both the writer (`/code-review` step 9) and the reader (pre-commit-review.sh)
+# MUST compute the hash identically, so both call this one function. The patch
+# already embeds blob SHAs (the `index <old>..<new>` lines), so the output is
+# deterministic for a given staged state.
+#
+# Usage:
+#   source review-gate-hash.sh && h=$(review_gate_hash)   # from another script
+#   bash review-gate-hash.sh > .review-passed             # run directly to write
+
+review_gate_hash() {
+  git diff --cached --no-color 2>/dev/null \
+    | { shasum -a 256 2>/dev/null || sha256sum 2>/dev/null; } \
+    | cut -d' ' -f1
+}
+
+# When executed directly (not sourced), print the hash.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  review_gate_hash
+fi

--- a/plugins/dev-team/hooks/pre-commit-review.sh
+++ b/plugins/dev-team/hooks/pre-commit-review.sh
@@ -18,6 +18,8 @@ set -uo pipefail
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/pre-commit-detect.sh
 source "${HOOK_DIR}/lib/pre-commit-detect.sh"
+# shellcheck source=lib/review-gate-hash.sh
+source "${HOOK_DIR}/lib/review-gate-hash.sh"
 
 # Read the tool input from stdin
 INPUT=$(cat)
@@ -34,9 +36,9 @@ if [ -z "$STAGED" ]; then
   exit 0
 fi
 
-# Compute hash of staged file paths
-HASH=$(echo "$STAGED" | sort | shasum -a 256 2>/dev/null || echo "$STAGED" | sort | sha256sum 2>/dev/null)
-HASH=$(echo "$HASH" | cut -d' ' -f1)
+# Hash the staged CONTENT (#193), not just paths — so an edit after review
+# invalidates the gate. Identical computation to the /code-review write side.
+HASH=$(review_gate_hash)
 
 # Check for .review-passed gate file
 GATE_FILE=".review-passed"

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1755,7 +1755,7 @@
       "anchor": "8-save-correction-prompts-for-remaining-issues"
     },
     "9. Write pre-commit gate file": {
-      "summary": "If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit:",
+      "summary": "If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit.",
       "anchor": "9-write-pre-commit-gate-file"
     }
   },

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -260,16 +260,12 @@ For issues NOT auto-fixed (confidence: none, auto-fix failed, or suggestions), g
 
 ### 9. Write pre-commit gate file
 
-If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit:
+If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit. Use the **shared gate-hash helper** so the writer and the pre-commit hook compute the hash identically — it hashes the staged **content** (the cached patch), not just the file paths (#193), so any edit after review invalidates the gate:
 
 ```bash
-git diff --cached --name-only | sort | shasum -a 256 | cut -d' ' -f1 > .review-passed
+bash ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review-gate-hash.sh > .review-passed
 ```
 
-If no files are staged (unstaged changes only), hash the actually-reviewed file list:
-
-```bash
-echo "<reviewed-file-list>" | sort | shasum -a 256 | cut -d' ' -f1 > .review-passed
-```
+Stage the exact changes you reviewed (`git add` them) before writing the gate, so the staged content the hook hashes matches what was reviewed. If `git diff --cached` is empty (you reviewed unstaged changes), stage them first — the gate binds to the staged patch by design.
 
 If overall status is `fail`, do **not** write the gate file — the pre-commit hook will keep blocking until issues are resolved and the review re-run.

--- a/tests/repo/multiplayer_collision_tests.bats
+++ b/tests/repo/multiplayer_collision_tests.bats
@@ -1,11 +1,14 @@
 #!/usr/bin/env bats
-# #109 Phase 1 — reproduce the multiplayer collisions on the .review-passed gate.
-# These are DELIBERATE failing-scenario reproductions (the assertions encode the
-# CURRENT buggy behavior), so the findings in docs/spikes/multiplayer-collisions.md
-# are backed by a runnable demonstration, not just prose.
+# #109 Phase 1 — reproduce the multiplayer collision that REMAINS even after the
+# gate is content-bound (#193): two agents sharing ONE working tree share a
+# single `.review-passed` file and clobber each other's gate. The resolution is
+# operational, not a gate change — one git worktree per agent (see
+# plugins/dev-team/docs/concurrent-use.md). The content-binding behavior itself
+# is covered by review_gate_hash_tests.bats.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 HOOK="$REPO_ROOT/plugins/dev-team/hooks/pre-commit-review.sh"
+GATEHASH="$REPO_ROOT/plugins/dev-team/hooks/lib/review-gate-hash.sh"
 
 setup() {
   WORK="$(mktemp -d)"
@@ -16,44 +19,23 @@ setup() {
 }
 teardown() { cd / || true; rm -rf "$WORK"; }
 
-_commit_hook() {  # run the gate as if `git commit` was invoked
-  echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK"
-}
-_gate_hash() {    # replicate the hook's staged-paths hash
-  git diff --cached --name-only | sort | shasum -a 256 2>/dev/null | cut -d' ' -f1
-}
+_commit_hook() { echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK"; }
+_write_gate()  { bash "$GATEHASH" > .review-passed; }
 
-@test "baseline: a correct gate for the exact staged paths allows the commit" {
+@test "baseline: a gate written for the current staged content allows the commit" {
   echo v1 > a.ts; git add a.ts
-  _gate_hash > .review-passed
+  _write_gate
   run _commit_hook
   [ "$status" -eq 0 ]
 }
 
 @test "collision: a second agent overwriting .review-passed falsely blocks the first (#109)" {
   echo v1 > a.ts; git add a.ts
-  _gate_hash > .review-passed            # agent A passed review for {a.ts}
-  printf 'a-different-set-hash\n' > .review-passed  # agent B (same tree) overwrote it
-  run _commit_hook                       # A commits its still-staged {a.ts}
+  _write_gate                            # agent A passed review for its staged content
+  printf 'a-different-agents-hash\n' > .review-passed  # agent B (same tree) overwrote it
+  run _commit_hook                       # A commits its still-staged change
   [ "$status" -eq 2 ]                     # ...and is blocked despite having passed
   [[ "$output" == *"BLOCKED"* ]]
-}
-
-@test "gap: gate binds staged PATHS not CONTENT — edited content commits unreviewed (#109)" {
-  echo v1 > a.ts; git add a.ts
-  _gate_hash > .review-passed            # "review passed" for a.ts @ v1
-  echo v2-unreviewed > a.ts; git add a.ts # same path, brand-new content
-  run _commit_hook
-  [ "$status" -eq 0 ]                     # allowed — the path hash still matches
-  [ ! -f .review-passed ]                # gate consumed; v2 was never reviewed
-}
-
-@test "collision: shared gate is content-blind to which agent staged what (#109)" {
-  # Two agents stage the SAME path set; whoever writes the gate last lets EITHER
-  # commit — the gate cannot tell A's reviewed change from B's unreviewed one.
-  echo a > a.ts; git add a.ts
-  _gate_hash > .review-passed            # gate for {a.ts}
-  echo "b unreviewed" >> a.ts; git add a.ts
-  run _commit_hook
-  [ "$status" -eq 0 ]                     # B's change rides A's gate
+  # NOT fixed by content-hashing — two agents in one tree share one gate file.
+  # Fix is operational: one worktree per agent (concurrent-use.md).
 }

--- a/tests/repo/review_gate_hash_tests.bats
+++ b/tests/repo/review_gate_hash_tests.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# #193 — the review gate binds staged CONTENT (via review-gate-hash.sh), so
+# editing a reviewed file after the gate is written re-blocks the commit. Both
+# the writer (/code-review step 9) and the reader (pre-commit-review.sh) use the
+# one shared helper, so they cannot diverge.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+HOOK="$REPO_ROOT/plugins/dev-team/hooks/pre-commit-review.sh"
+GATEHASH="$REPO_ROOT/plugins/dev-team/hooks/lib/review-gate-hash.sh"
+
+setup() {
+  WORK="$(mktemp -d)"; cd "$WORK" || return 1
+  git init -q; git config user.email t@t.dev; git config user.name tester
+}
+teardown() { cd / || true; rm -rf "$WORK"; }
+
+_commit_hook() { echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK"; }
+_write_gate()  { bash "$GATEHASH" > .review-passed; }   # the writer side
+
+@test "gate: the exact staged content that was reviewed commits cleanly" {
+  echo v1 > a.ts; git add a.ts
+  _write_gate
+  run _commit_hook
+  [ "$status" -eq 0 ]
+  [ ! -f .review-passed ]            # consumed on success
+}
+
+@test "gate: editing a reviewed file's content re-blocks the commit (#193)" {
+  echo v1 > a.ts; git add a.ts
+  _write_gate                        # reviewed a.ts @ v1
+  echo v2-unreviewed > a.ts; git add a.ts   # same path, new content
+  run _commit_hook
+  [ "$status" -eq 2 ]                # FIXED: blocked (was 0 under path-only hash)
+  [[ "$output" == *"BLOCKED"* ]]
+}
+
+@test "gate: staging an extra unreviewed file re-blocks the commit (#193)" {
+  echo v1 > a.ts; git add a.ts
+  _write_gate
+  echo new > b.ts; git add b.ts
+  run _commit_hook
+  [ "$status" -eq 2 ]
+}
+
+@test "gate: writer and hook compute the SAME content hash (no divergence)" {
+  printf 'line1\nline2\n' > a.ts; git add a.ts
+  # the helper's output (writer) must equal the hash the hook recomputes (reader)
+  _write_gate
+  run _commit_hook
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Fixes the TOCTOU hole #109 Phase 1 surfaced: `.review-passed` hashed staged **paths**, so editing a reviewed file's content and committing passed the gate **unreviewed** — even single-player.

## Fix
A single shared helper `hooks/lib/review-gate-hash.sh` hashes the staged **patch** (`git diff --cached`), used by **both** sides so they can't diverge:
- writer — `/code-review` step 9 calls the helper to write `.review-passed`;
- reader — `pre-commit-review.sh` sources the helper to recompute and compare.

Any post-review content change (or extra staged file) now invalidates the gate and forces re-review.

## Tests
- `review_gate_hash_tests.bats` (new): edit-after-review re-blocks; extra staged file re-blocks; same-content commits cleanly; writer/reader hashes match.
- `multiplayer_collision_tests.bats`: trimmed to the collision content-hashing does **not** fix — two agents sharing one working tree clobber the single gate file (resolved operationally via `concurrent-use.md` / #109). The path-vs-content reproductions moved to the #193 file as fixed-behavior assertions.

## Verification
- CI-relevant suites (`tests/repo|knowledge|agents|commands|docs`) all green; knowledge index regenerated; helper + hook shellcheck clean.
- (Pre-existing, unrelated: 8 mutation-gate tests in `tests/hooks/` fail on clean main due to environment — not in the CI gate, not touched here.)

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)