### PR TITLE
fix(mutation-gate): _timeout fallback must not pollute stdout (macOS)

### DIFF
--- a/plugins/dev-team/hooks/mutation-adapters/lib.sh
+++ b/plugins/dev-team/hooks/mutation-adapters/lib.sh
@@ -22,8 +22,11 @@ _timeout() {
   elif command -v gtimeout &>/dev/null; then
     gtimeout "$@"
   else
-    # No timeout command — run unbounded; emit advisory to stdout
-    emit_advisory "MUTATION GATE ADVISORY: timeout command unavailable; mutation run has no time limit"
+    # No timeout command — run unbounded. The diagnostic goes to STDERR: stdout
+    # is the hook's JSON decision channel and must carry exactly one object, so
+    # emitting an advisory here (emit_advisory writes JSON to stdout) corrupts
+    # the protocol with a second object — observed on macOS without coreutils.
+    echo "mutation-gate: timeout unavailable (install coreutils for gtimeout); run is unbounded" >&2
     shift
     "$@"
   fi

--- a/tests/hooks/lib.bats
+++ b/tests/hooks/lib.bats
@@ -69,8 +69,10 @@ EOF
   " 2>&1
   [ "$status" -eq 0 ]
   [[ "$output" == *"hello_unbounded"* ]]
-  # Also emits advisory on stderr (merged into output via 2>&1)
-  [[ "$output" == *"MUTATION GATE ADVISORY"* ]]
+  # Diagnostic goes to STDERR (merged via 2>&1) — NOT stdout, which is the hook's
+  # single-JSON decision channel. Emitting JSON here corrupted the protocol on
+  # macOS without coreutils.
+  [[ "$output" == *"timeout unavailable"* ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
On a machine without `timeout` **or** `gtimeout` (macOS without coreutils), `_timeout()`'s fallback called `emit_advisory` — which writes a JSON object to **stdout** — then ran the command, so the mutation-gate hook emitted **two** JSON objects on stdout. stdout is the PostToolUse decision channel and must carry exactly one object; the second corrupts it (`json.load` → "Extra data line 7"). This silently broke the gate for macOS users without coreutils and made the `tests/hooks/` end-to-end suite fail locally (the 8 failures).

## Fix
The "no timeout command" diagnostic goes to **stderr**, leaving stdout clean. Updated the `_timeout` unbounded test to assert the stderr diagnostic.

## Verification
- `tests/hooks/` now **fully green (222 passing)** locally; CI-relevant suites still green; shellcheck clean.
- Root-caused by faithful repro (the hook was emitting the unbounded advisory *and* the real `decision:block` JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)