### PR TITLE
feat(evals): de-brittle keyword matching in 5 fixtures (#198)

### DIFF
--- a/evals/expected/sec-env-gitignored.json
+++ b/evals/expected/sec-env-gitignored.json
@@ -1,13 +1,22 @@
 {
   "fixture": "sec-env-gitignored",
-  "description": "A .env file with secrets that is properly gitignored — must NOT be flagged as committed secrets (false positive guard)",
-  "applicableAgents": ["security-review"],
+  "description": "A .env file with secrets that is properly gitignored \u2014 must NOT be flagged as committed secrets (false positive guard)",
+  "applicableAgents": [
+    "security-review"
+  ],
   "agents": {
     "security-review": {
       "expectedStatus": "pass",
-      "issueCount": { "min": 0, "max": 1 },
-      "severities": { "error": { "min": 0, "max": 0 } },
-      "mustNotMention": ["committed", "live secrets", "rotate"]
+      "issueCount": {
+        "min": 0,
+        "max": 1
+      },
+      "severities": {
+        "error": {
+          "min": 0,
+          "max": 0
+        }
+      }
     }
   }
 }

--- a/evals/expected/sec-safe-auth.json
+++ b/evals/expected/sec-safe-auth.json
@@ -1,12 +1,16 @@
 {
   "fixture": "sec-safe-auth",
   "description": "Properly implemented authentication with hashed passwords and secure session handling",
-  "applicableAgents": ["security-review"],
+  "applicableAgents": [
+    "security-review"
+  ],
   "agents": {
     "security-review": {
       "expectedStatus": "pass",
-      "issueCount": { "min": 0, "max": 1 },
-      "mustNotMention": ["injection", "hardcoded", "vulnerable"]
+      "issueCount": {
+        "min": 0,
+        "max": 1
+      }
     }
   }
 }

--- a/evals/expected/sec-safe-headers.json
+++ b/evals/expected/sec-safe-headers.json
@@ -1,12 +1,16 @@
 {
   "fixture": "sec-safe-headers",
   "description": "Correctly configured security headers including CSP, HSTS, and X-Frame-Options",
-  "applicableAgents": ["security-review"],
+  "applicableAgents": [
+    "security-review"
+  ],
   "agents": {
     "security-review": {
       "expectedStatus": "pass",
-      "issueCount": { "min": 0, "max": 1 },
-      "mustNotMention": ["missing", "vulnerable"]
+      "issueCount": {
+        "min": 0,
+        "max": 1
+      }
     }
   }
 }

--- a/evals/expected/st-duplicate-code.json
+++ b/evals/expected/st-duplicate-code.json
@@ -1,13 +1,25 @@
 {
   "fixture": "st-duplicate-code",
   "description": "Repeated code blocks that should be extracted into shared functions per DRY",
-  "applicableAgents": ["structure-review"],
+  "applicableAgents": [
+    "structure-review"
+  ],
   "agents": {
     "structure-review": {
       "expectedStatus": "fail",
-      "issueCount": { "min": 3, "max": 6 },
-      "severities": { "warning": { "min": 2, "max": 5 } },
-      "mustMention": ["duplicate", "DRY"]
+      "issueCount": {
+        "min": 3,
+        "max": 6
+      },
+      "severities": {
+        "warning": {
+          "min": 2,
+          "max": 5
+        }
+      },
+      "mustMention": [
+        "duplicat"
+      ]
     }
   }
 }

--- a/evals/expected/st-god-object.json
+++ b/evals/expected/st-god-object.json
@@ -1,13 +1,25 @@
 {
   "fixture": "st-god-object",
   "description": "Object or class handling too many responsibilities violating SRP",
-  "applicableAgents": ["structure-review"],
+  "applicableAgents": [
+    "structure-review"
+  ],
   "agents": {
     "structure-review": {
       "expectedStatus": "fail",
-      "issueCount": { "min": 3, "max": 7 },
-      "severities": { "error": { "min": 1, "max": 3 } },
-      "mustMention": ["responsibility", "SRP"]
+      "issueCount": {
+        "min": 3,
+        "max": 7
+      },
+      "severities": {
+        "error": {
+          "min": 1,
+          "max": 3
+        }
+      },
+      "mustMention": [
+        "responsibilit"
+      ]
     }
   }
 }


### PR DESCRIPTION
The #103 variance run surfaced that the grader's `mustMention`/`mustNotMention` (plain case-insensitive substring) mis-grades correct agent output: *"no hardcoded secrets"* trips `mustNotMention:["hardcoded"]`, and *"responsibilities"* fails `mustMention:["responsibility"]`.

## Fixes (audited the whole corpus, not just the 2 named)
- **Remove negation-blind `mustNotMention`** from 3 clean-PASS fixtures (`sec-safe-auth`, `sec-env-gitignored`, `sec-safe-headers`) — `expectedStatus:pass` + `issueCount` (+ `error 0-0`) already enforce "clean, no false positives".
- **Broaden 2 strict `mustMention` to stems**: `st-god-object` `["responsibility","SRP"]→["responsibilit"]`; `st-duplicate-code` `["duplicate","DRY"]→["duplicat"]`.

## Verification
Re-graded the **real #103 variance actuals** against the fixed fixtures: all four sampled pairs now **pass@3 = 1.0, zero flap** (was 1 flap + 1 stable-fail). `eval_grade --check-corpus` green (76 fixtures).

Commit type is `feat:` because the eval-corpus-semver contract (#101) classifies an expectation edit as a minor bump.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)