### PR TITLE
docs: eval running guide, maintenance guide, feature-verification plan

### DIFF
--- a/plans/eval-feature-verification-plan.md
+++ b/plans/eval-feature-verification-plan.md
@@ -1,0 +1,107 @@
+# Future test plan — verifying #107, #110, #180 work correctly
+
+These three children of [#98](https://github.com/bdfinst/agentic-dev-team/issues/98)
+are **unblocked** (the tooling and the clean-eval methodology now exist) but not
+yet built. This plan defines, for each, what it builds on, how to build it, and —
+the point of this doc — **how to verify it actually works** once built.
+
+Cross-cutting requirement for all three: use the **clean methodology** from
+[`../plugins/dev-team/docs/eval-running-guide.md`](../plugins/dev-team/docs/eval-running-guide.md)
+(neutral dispatch, faithful actuals) and the variance aggregator. A feature that
+"runs" but biases its own measurement is not working.
+
+---
+
+## #107 — Knowledge ablation testing
+
+**Builds on:** the eval harness (`eval_grade.py`), the variance aggregator, and
+the knowledge index. **Mechanism:** for a knowledge file (or anchor), run the eval
+corpus with it **available** vs **ablated** (hidden from the agent) and diff the
+grades → a per-file "retrieval value" score.
+
+**Verification (acceptance):**
+
+1. **Positive control — a load-bearing file shows impact.** Pick a fixture whose
+   correct verdict plausibly depends on a specific knowledge file (e.g. a
+   test-smell fixture and `knowledge/test-smells.md`). Ablating that file must
+   **measurably drop** the agent's grade (pass@k down) vs. with it present.
+2. **Negative control — an irrelevant file shows none.** Ablating a knowledge file
+   unrelated to the fixture must **not** change the grade.
+3. **Report shape.** The output ranks knowledge files by measured grade impact;
+   zero-impact files are listed as removal/consolidation candidates.
+4. **No bias.** Ablation must not change the dispatch prompt (only knowledge
+   availability), and actuals are captured faithfully.
+
+**Pass condition:** the positive control drops, the negative control doesn't, and
+the ranking is reproducible across a re-run (within the variance band from #103).
+
+---
+
+## #110 — Persona-vs-context-boundary test
+
+**Builds on:** the variance harness (#103) and the eval corpus. **Mechanism:** run
+each review agent with its **persona frontmatter ON vs OFF** (same fixtures,
+knowledge, trials) and compare pass@k; the #103 variance band tells you whether a
+delta is real or noise.
+
+**Verification (acceptance):**
+
+1. **The toggle actually toggles.** Confirm the persona-OFF run dispatches an agent
+   whose persona prose is genuinely stripped (diff the two agent definitions used)
+   — otherwise the experiment measures nothing.
+2. **Delta vs. variance band.** For each agent, the persona-on/off pass@k delta is
+   reported **with** the #103 flap/variance, so a delta is only called "real" when
+   it exceeds the noise band.
+3. **Reproducibility.** A re-run reproduces the sign of each agent's delta.
+4. **Honest null.** If personas show no delta beyond noise, the report says so —
+   the test must be capable of returning "no effect."
+
+**Pass condition:** the toggle is verified to change the dispatched agent, and the
+per-agent deltas are reported against the variance band and reproduce on re-run.
+(Acting on the result — dissolving personas — is a separate decision, not part of
+"does the test work.")
+
+---
+
+## #180 — Raw-log tier + methodology lens (Delta A/B)
+
+**Builds on:** the digest/rollup (flags worst sessions), the loop infra (Delta
+C/D). **Mechanism:** for the **top-N worst sessions the digest flags**, dispatch
+one agent **per raw log** to surface *semantic* frictions a metrics digest can't
+(e.g. hallucinated citations), plus a `methodology` lens for operator habits —
+output held to metrics-only/no-quote discipline.
+
+**Verification (acceptance):**
+
+1. **Seeded-friction detection.** Construct a session transcript containing a known
+   semantic friction (e.g. the model citing a skill as a source when that content
+   doesn't exist). The raw-log tier must **surface that friction**.
+2. **No false friction on a clean session.** A clean seeded session yields no
+   fabricated findings.
+3. **Gated by the digest.** The tier runs **only** on digest-flagged worst
+   sessions, never the whole corpus — verify it skips un-flagged sessions.
+4. **Privacy.** The tier's output contains **no** raw prompt/code/path content —
+   only metrics + which-artifact-to-fix. Assert no quoted source leaks.
+5. **Methodology lens.** A session with a planted operator habit (e.g. repeatedly
+   deferring decisions) produces a human-directed observation with no artifact/hook
+   target.
+
+**Pass condition:** seeded friction is detected, clean sessions stay quiet, the
+tier only runs on flagged sessions, and output passes the metrics-only/no-quote
+check.
+
+---
+
+## Regression guard for all three
+
+Add each feature's verification as repeatable tests where possible:
+
+- The **deterministic** parts (report shape, gating logic, privacy assertions,
+  toggle-changes-the-agent) become `bats`/unit tests that run in CI — no model
+  spend.
+- The **model-dependent** parts (does ablation drop the grade, does the tier find
+  the seeded friction) run as **opt-in** live checks under a budget cap, like the
+  #103 variance batches — never in the default CI gate.
+
+This split keeps the "does it work" verification cheap and continuous, with the
+expensive model-truth checks gated behind explicit budget.

--- a/plugins/dev-team/docs/eval-maintenance.md
+++ b/plugins/dev-team/docs/eval-maintenance.md
@@ -1,0 +1,94 @@
+# How eval testing works & keeping it current
+
+The conceptual model behind the agent evals and the discipline for keeping the
+corpus honest over time. For the architecture see [`eval-system.md`](eval-system.md);
+for the operational run procedure see [`eval-running-guide.md`](eval-running-guide.md).
+
+## The pieces
+
+| Piece | Where | Role |
+|---|---|---|
+| Fixtures | `evals/fixtures/` | Input code (deliberately good or bad) the agents review. |
+| Expectations | `evals/expected/*.json` | The **contract**: what a correct verdict looks like per fixture/agent. |
+| Grader | `scripts/eval_grade.py` | Deterministic, model-free: compares recorded actuals to expectations. |
+| Variance | `scripts/eval_variance.py` | Aggregates K trials → pass@k, flap rate, quarantine. |
+| Trend | `metrics/eval-variance.jsonl` | Append-only stability history (metrics only). |
+| Semver contract | `scripts/eval_semver_classify.sh` | The eval corpus IS the version contract (#101). |
+| CI gates | `.github/workflows/agent-eval.yml` | Structural check always; live regression when keyed. |
+
+## How grading works (the rules)
+
+`eval_grade.py grade_agent` checks each expectation field; an empty failure list
+means PASS:
+
+- **`expectedStatus`** — `pass` / `fail`; must match the agent's `status`.
+- **`issueCount: {min, max}`** — number of reported issues must fall in range.
+- **`severities: {error: {min,max}, ...}`** — count per severity in range.
+- **`mustMention: [...]`** — every keyword must appear (case-insensitive
+  **substring**) in the issue messages + summary. **All-of.**
+- **`mustNotMention: [...]`** — none may appear. **All-of.**
+
+Grading is intentionally dumb (no judgment) so it can run as a CI gate and so
+variance is reproducible.
+
+## The calibration trap (learn this — #198)
+
+Because matching is plain substring, expectations drift out of sync with how
+agents actually phrase correct verdicts. Two failure modes, both **fixture bugs,
+not agent bugs**:
+
+1. **`mustNotMention` is negation-blind.** A clean-pass fixture forbidding
+   `"hardcoded"` fails when the agent correctly says *"no hardcoded secrets"*.
+   **Fix:** drop `mustNotMention` on clean-pass fixtures — `expectedStatus:pass` +
+   `issueCount` (+ `error 0-0`) already encode "found clean."
+2. **`mustMention` too strict.** Requiring the exact token `"SRP"` fails when the
+   agent says *"responsibilities"* / *"divergent change"*. **Fix:** use **stems**
+   (`"responsibilit"`) and the vocabulary agents actually emit; avoid all-of lists
+   of rare tokens.
+
+**When a correct agent verdict fails grading, suspect the fixture first.** Verify
+the fix against the agent's *real* output, not a hand-typed approximation.
+
+## Keeping the corpus current
+
+### Adding a fixture
+
+1. Add the input file under `evals/fixtures/`.
+2. Add `evals/expected/<stem>.json` with `fixture`, `applicableAgents`, and the
+   per-agent expectation (prefer `expectedStatus` + `issueCount`; add
+   `mustMention` stems only when a specific concept must be named).
+3. `python3 scripts/eval_grade.py --check-corpus` (every expectation must be
+   schema-valid and pair with a fixture; this runs in CI).
+
+### Changing an expectation = a version bump (#101)
+
+The eval corpus is the semver contract. `eval_semver_classify.sh` (pre-push + CI)
+enforces it:
+
+- GREEN-preserving change → **patch**.
+- Adds expectations → **minor** (`feat:`).
+- **Edits** existing expectations → **minor/major** (`feat:` / `feat!:`) — an
+  edit changes the agents' observable contract.
+A `fix:` commit that edits an expectation will be **rejected**; use the bump the
+classifier names.
+
+### Watching stability over time
+
+- Run per-agent variance batches periodically (see the running guide). The trend
+  in `metrics/eval-variance.jsonl` accumulates pass@k and flap rate.
+- **Flaky pairs** (0 < pass@k < 1) go on the quarantine list — they inform the
+  #99 gate but must not hard-block it. A persistently flaky fixture is either
+  borderline (tighten it) or genuinely non-deterministic for that agent.
+- **Saturated** agents (identical grades for many runs) may have expectations too
+  loose to detect regressions — consider tightening ranges.
+
+## Cardinal rules
+
+1. **Faithful actuals.** The grader sees what you record; abbreviating issue
+   messages drops `mustMention` keywords and fabricates flaps.
+2. **Neutral dispatch.** Never leak `status`/`severity` examples into the agent's
+   prompt (see the running guide).
+3. **Fixtures are the contract.** Keep them honest: a stable-fail on correct
+   output is a corpus bug to fix, not noise to ignore.
+4. **Metrics only.** Digests, the trend, and reports carry counts/ratios/names —
+   never prompt or code content.

--- a/plugins/dev-team/docs/eval-running-guide.md
+++ b/plugins/dev-team/docs/eval-running-guide.md
@@ -1,0 +1,95 @@
+# Running a full eval of everything
+
+How to run a complete, **clean** accuracy + variance eval across all review
+agents. For *how the eval system works and how to keep it current*, see
+[`eval-maintenance.md`](eval-maintenance.md). For the architecture, see
+[`eval-system.md`](eval-system.md).
+
+## The one rule that matters: do not bias the dispatch
+
+An eval is only valid if the agent produces the verdict it would produce in
+production. The fastest way to ruin a run is to leak the answer into the prompt.
+Two real contamination modes (both observed, #103):
+
+- **Pre-filling the verdict.** A prompt template like `{"status":"pass", ...}` on
+  a pass-fixture tells the agent the answer. Never pre-fill `status`.
+- **Leaking an output-format example.** A single `"severity":"warning"` example
+  biases the agent's severity choice, which then fails severity-range grading.
+
+**Clean dispatch** = pass the agent **only the fixture** plus, at most, a *neutral
+JSON schema* with placeholder enums (`"status":"pass or fail"`,
+`"severity":"error, warning, or info"`) — identical for pass and fail fixtures,
+no example values, "decide every value yourself." The `/agent-eval` skill enforces
+this via its orchestrator constraint #3 ("pass only the fixture file").
+
+## Option A — the native skill (preferred)
+
+```
+/agent-eval --trials 5            # all agents × all applicable fixtures, 5 trials
+/agent-eval --agent security-review --trials 5   # one agent (budget-friendly)
+```
+
+The skill dispatches each fixture to its applicable agents via `/review-agent`
+(native invocation, fixture-only context), grades deterministically, computes
+pass@k, and — via `scripts/eval_variance.py` — records flap/quarantine and appends
+the trend. This is the path that cannot leak format examples.
+
+**Path note:** the skill resolves fixtures at `.claude/evals/fixtures/` (an
+*installed* project). In this dev repo the corpus is `evals/` — run it in an
+installed test project, or drive the grader/aggregator directly against `evals/`
+(Option B).
+
+## Option B — manual neutral dispatch (dev repo / explicit control)
+
+Per agent, per fixture, per trial:
+
+1. Dispatch the agent (e.g. `dev-team:security-review`) with the **neutral**
+   prompt above and the fixture path. Capture its JSON verdict.
+2. Assemble one **actuals** file per trial — the shape `eval_grade.py` reads:
+
+   ```json
+   { "<fixture-stem>": { "agents": { "<agent>": {"status":"...","issues":[{"severity":"...","message":"..."}],"summary":"..."} } } }
+   ```
+
+   Record **faithfully** — the issue messages/summary must keep the real wording
+   (the grader checks `mustMention`/`mustNotMention` against them).
+3. Aggregate the trials:
+
+   ```bash
+   python3 scripts/eval_variance.py --trials-dir <dir-of-trial-actuals> \
+     --expected-dir evals/expected --append metrics/eval-variance.jsonl
+   ```
+
+## Batch for budget — per agent, highest-recall first
+
+A full 3–5-trial run of all ~20 agents is hundreds of model dispatches and will
+exceed a small budget. **Run per-agent batches**, recall-critical agents first
+(security, arch, domain), at `--trials 5`. The variance trend accumulates across
+batches, so you don't need one giant run.
+
+Rough sizing: one agent × its fixtures × 5 trials ≈ 25–40 dispatches. Multiply by
+the agent's model tier cost (frontier agents are pricier).
+
+## Reading the results
+
+`eval_variance.py` reports per `fixture::agent`:
+
+- **pass@k = 1.0, no flap** → stable, trustworthy.
+- **0 < pass@k < 1 (flap)** → **quarantine**: the pair is unstable; it should
+  *inform* the #99 CI gate, not hard-block it. Investigate whether the agent is
+  genuinely non-deterministic or the fixture is borderline.
+- **pass@k = 0 (stable fail)** → usually a **miscalibrated fixture** (the agent is
+  right but the expectation is wrong), not an agent bug. Fix the fixture (see the
+  `mustMention`/`mustNotMention` patterns in `eval-maintenance.md`, #198) and
+  re-grade against the real actuals.
+
+## Checklist for a clean full run
+
+- [ ] Neutral dispatch (no pre-filled status, no severity example, identical prompt
+      for pass and fail fixtures).
+- [ ] Faithful actuals (real wording preserved for keyword checks).
+- [ ] Per-agent batches, recall-critical first, `--trials 5`.
+- [ ] Aggregate with `eval_variance.py --append` so the trend accumulates.
+- [ ] Quarantine flaky pairs; fix (don't ignore) stable-fail fixtures.
+- [ ] Record cost; stop when the budget cap is hit (coverage degrades gracefully —
+      the trend keeps what was collected).


### PR DESCRIPTION
Three documents requested for the eval workflow:

1. **`eval-running-guide.md`** — how to run a full **clean** eval of all agents: the no-bias-the-dispatch rule (the #103 contamination lessons), the native `/agent-eval` path vs manual neutral dispatch, per-agent budget batching, and how to read pass@k / flap / quarantine.
2. **`eval-maintenance.md`** — how grading works (the deterministic rules), the **calibration trap** (#198 keyword brittleness), adding/changing fixtures, the eval-corpus-as-semver discipline (#101), and watching stability over time.
3. **`plans/eval-feature-verification-plan.md`** — how to verify **#107 / #110 / #180** actually work once built (positive/negative controls, the variance band, gating, privacy), split into cheap deterministic CI tests vs opt-in budget-gated live checks.

All gates green; prose-honesty sensor passes on the 2 shipped docs; knowledge index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)