### PR TITLE
feat(evals): knowledge ablation testing (#107)

### DIFF
--- a/scripts/eval_ablation.py
+++ b/scripts/eval_ablation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Knowledge ablation analysis (#107).
+
+Does a knowledge file earn its tokens? Run the eval corpus twice — once with the
+file AVAILABLE, once ABLATED (hidden) — and diff the grades. Pairs that PASSED
+with the knowledge but FAIL without it are the file's measured *retrieval value*.
+
+This module is the deterministic, model-free half: given the two recorded actuals
+(the live with/without runs are driven by run-ablation.sh), it grades both via
+eval_grade and reports the impact. A file whose ablation drops nothing is a
+removal/consolidation candidate.
+
+Inputs
+------
+--expected-dir DIR   Expected specs (default: evals/expected).
+--baseline FILE      Actuals from the run WITH the knowledge available.
+--ablated FILE       Actuals from the run with the knowledge ablated.
+--knowledge NAME     Label for the ablated file (reporting only).
+--only AGENT         Restrict grading to one agent (optional).
+-o FILE              Write the report (default: stdout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from eval_grade import run_grading  # noqa: E402
+
+
+def _passing(expected_dir: Path, actuals: dict, only: set | None) -> set:
+    results, _ = run_grading(expected_dir, actuals, None, only)
+    return {pair for pair, passed, _ in results if passed}
+
+
+def ablation_impact(expected_dir: Path, baseline: dict, ablated: dict,
+                    knowledge: str = "", only: set | None = None) -> dict:
+    """Pairs that pass WITH the knowledge but fail WITHOUT it = retrieval value."""
+    base_pass = _passing(expected_dir, baseline, only)
+    abl_pass = _passing(expected_dir, ablated, only)
+    dropped = sorted(base_pass - abl_pass)   # depended on the knowledge
+    gained = sorted(abl_pass - base_pass)     # noise: passed only without it
+    return {
+        "schema": "knowledge-ablation/v1",
+        "knowledge": knowledge,
+        "retrieval_value": len(dropped),      # how many pairs the file held up
+        "dropped_pairs": dropped,             # the evidence
+        "spurious_gains": gained,             # should be empty; flags noise
+        "verdict": ("earns its place" if dropped else
+                    "no measured impact — removal/consolidation candidate"),
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--expected-dir", default="evals/expected")
+    ap.add_argument("--baseline", required=True)
+    ap.add_argument("--ablated", required=True)
+    ap.add_argument("--knowledge", default="")
+    ap.add_argument("--only")
+    ap.add_argument("-o", "--out")
+    args = ap.parse_args(argv)
+
+    baseline = json.loads(Path(args.baseline).read_text())
+    ablated = json.loads(Path(args.ablated).read_text())
+    only = {args.only} if args.only else None
+    report = ablation_impact(Path(args.expected_dir), baseline, ablated,
+                             args.knowledge, only)
+    out = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-ablation.sh
+++ b/scripts/run-ablation.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# run-ablation.sh — measure a knowledge file's retrieval value (#107).
+#
+# Runs the eval corpus WITH a knowledge file, then ABLATED (file hidden + index
+# rebuilt), and diffs the grades via scripts/eval_ablation.py. Pairs that pass
+# with the file but fail without it are its measured value.
+#
+# This costs API tokens (two corpus runs). Opt-in.
+#
+# Usage:  bash scripts/run-ablation.sh <knowledge-file.md> [--agent NAME]
+# Exit:   0 ok, 2 missing prereq/arg.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+KFILE="${1:-}"
+ONLY_AGENT=""
+[ "${2:-}" = "--agent" ] && ONLY_AGENT="${3:-}"
+KPATH="plugins/dev-team/knowledge/${KFILE}"
+[ -n "$KFILE" ] && [ -f "$KPATH" ] || { echo "usage: run-ablation.sh <knowledge-file.md> [--agent NAME]" >&2; exit 2; }
+for t in claude gh jq python3 git; do command -v "$t" >/dev/null 2>&1 || { echo "missing tool: $t" >&2; exit 2; }; done
+[ -n "${ANTHROPIC_API_KEY:-}${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || { echo "no API credentials set." >&2; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+INDEX="plugins/dev-team/hooks/lib/build-knowledge-index.sh"
+
+mkdir -p .claude/evals
+ln -sfn "$PWD/evals/fixtures" .claude/evals/fixtures
+ln -sfn "$PWD/evals/expected" .claude/evals/expected
+
+_dispatch() {  # _dispatch <out-actuals>
+  local out="$1" extra=""
+  [ -n "$ONLY_AGENT" ] && extra="Restrict the run to ONLY the agent '$ONLY_AGENT'."
+  rm -f actuals.json
+  claude -p "Run the review agents against every fixture in .claude/evals/fixtures/
+whose paired .claude/evals/expected/<stem>.json declares applicableAgents, using
+/review-agent. Pass each agent ONLY its fixture — never the expected status or a
+severity example; let it decide every value. Do NOT grade. Write valid JSON only
+to actuals.json keyed by fixture stem:
+  { \"<stem>\": { \"agents\": { \"<agent>\": { \"status\": \"...\", \"issues\": [{ \"severity\": \"...\", \"message\": \"...\" }], \"summary\": \"...\" } } } }
+$extra" \
+    --output-format json --max-turns 200 --model claude-sonnet-4-6 \
+    --allowedTools "Read" "Glob" "Grep" "Write" "Agent" "Skill(review-agent *)" \
+    >/dev/null 2>&1 || true
+  jq -e . actuals.json >/dev/null 2>&1 || { echo "no parseable actuals for $out" >&2; return 1; }
+  mv actuals.json "$out"
+}
+
+echo "== baseline run (knowledge present) =="
+_dispatch "$WORK/with.json" || exit 1
+
+echo "== ablating $KFILE (hiding + rebuilding index) =="
+mv "$KPATH" "$WORK/ablated.md"
+bash "$INDEX" >/dev/null 2>&1 || true
+# restore on any exit from here
+trap 'mv "$WORK/ablated.md" "$KPATH" 2>/dev/null; bash "$INDEX" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
+
+echo "== ablated run (knowledge removed) =="
+_dispatch "$WORK/without.json" || exit 1
+
+echo "== restoring $KFILE =="
+mv "$WORK/ablated.md" "$KPATH"; bash "$INDEX" >/dev/null 2>&1 || true
+trap 'rm -rf "$WORK"' EXIT
+
+echo "== retrieval value =="
+ONLY_ARG=""; [ -n "$ONLY_AGENT" ] && ONLY_ARG="--only $ONLY_AGENT"
+# shellcheck disable=SC2086
+python3 scripts/eval_ablation.py --expected-dir evals/expected \
+  --baseline "$WORK/with.json" --ablated "$WORK/without.json" \
+  --knowledge "$KFILE" $ONLY_ARG

--- a/tests/repo/eval_ablation_tests.bats
+++ b/tests/repo/eval_ablation_tests.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# #107 — knowledge ablation: pairs that pass WITH a knowledge file but fail
+# WITHOUT it = its retrieval value. Model-free core (synthetic with/without
+# actuals), matching the positive/negative controls in the verification plan.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+ABL="$REPO_ROOT/scripts/eval_ablation.py"
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/expected"
+  cat > "$TMP/expected/dep.json" <<'EOF'
+{"fixture":"dep.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"fail","issueCount":{"min":1,"max":3},"mustMention":["smell"]}}}
+EOF
+  cat > "$TMP/expected/indep.json" <<'EOF'
+{"fixture":"indep.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
+EOF
+  # WITH knowledge: both pairs pass.
+  cat > "$TMP/with.json" <<'EOF'
+{"dep":{"agents":{"a":{"status":"fail","issues":[{"severity":"warning","message":"a smell"}],"summary":"smell found"}}},
+ "indep":{"agents":{"a":{"status":"pass","issues":[],"summary":"clean"}}}}
+EOF
+  # WITHOUT the knowledge: dep::a misses the smell (now passes -> wrong status),
+  # indep::a unchanged.
+  cat > "$TMP/without.json" <<'EOF'
+{"dep":{"agents":{"a":{"status":"pass","issues":[],"summary":"looks fine"}}},
+ "indep":{"agents":{"a":{"status":"pass","issues":[],"summary":"clean"}}}}
+EOF
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "ablation: a load-bearing file's removal drops the dependent pair (positive control)" {
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/without.json" --knowledge test-smells.md
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.retrieval_value')" = "1" ]
+  [ "$(echo "$output" | jq -r '.dropped_pairs[0]')" = "dep::a" ]
+  [[ "$(echo "$output" | jq -r '.verdict')" == *"earns its place"* ]]
+}
+
+@test "ablation: an irrelevant file's removal changes nothing (negative control)" {
+  # ablated == baseline -> no pair drops
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/with.json" --knowledge unrelated.md
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.retrieval_value')" = "0" ]
+  [[ "$(echo "$output" | jq -r '.verdict')" == *"no measured impact"* ]]
+}
+
+@test "ablation: the unrelated pair never drops even when a file is load-bearing" {
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/without.json"
+  # indep::a stays passing in both -> not in dropped
+  [ "$(echo "$output" | jq -r '.dropped_pairs | index("indep::a")')" = "null" ]
+}


### PR DESCRIPTION
Measures a knowledge file's **retrieval value**: run the corpus WITH it vs ABLATED; pairs that pass with it but fail without it are its value.

- **`eval_ablation.py`** (deterministic core): diffs baseline vs ablated grades → `retrieval_value`, `dropped_pairs`, verdict. Zero-impact files are removal/consolidation candidates.
- **`run-ablation.sh`** (opt-in live): baseline run → hide file + rebuild index → ablated run → restore → diff. Costs tokens.
- **Tests**: positive control (load-bearing removal drops the dependent pair) + negative control (irrelevant removal changes nothing), model-free per the verification plan.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)