### PR TITLE
feat(evals): persona-vs-context-boundary test (#110)

### DIFF
--- a/scripts/eval_ablation.py
+++ b/scripts/eval_ablation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Knowledge ablation analysis (#107).
+
+Does a knowledge file earn its tokens? Run the eval corpus twice — once with the
+file AVAILABLE, once ABLATED (hidden) — and diff the grades. Pairs that PASSED
+with the knowledge but FAIL without it are the file's measured *retrieval value*.
+
+This module is the deterministic, model-free half: given the two recorded actuals
+(the live with/without runs are driven by run-ablation.sh), it grades both via
+eval_grade and reports the impact. A file whose ablation drops nothing is a
+removal/consolidation candidate.
+
+Inputs
+------
+--expected-dir DIR   Expected specs (default: evals/expected).
+--baseline FILE      Actuals from the run WITH the knowledge available.
+--ablated FILE       Actuals from the run with the knowledge ablated.
+--knowledge NAME     Label for the ablated file (reporting only).
+--only AGENT         Restrict grading to one agent (optional).
+-o FILE              Write the report (default: stdout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from eval_grade import run_grading  # noqa: E402
+
+
+def _passing(expected_dir: Path, actuals: dict, only: set | None) -> set:
+    results, _ = run_grading(expected_dir, actuals, None, only)
+    return {pair for pair, passed, _ in results if passed}
+
+
+def ablation_impact(expected_dir: Path, baseline: dict, ablated: dict,
+                    knowledge: str = "", only: set | None = None) -> dict:
+    """Pairs that pass WITH the knowledge but fail WITHOUT it = retrieval value."""
+    base_pass = _passing(expected_dir, baseline, only)
+    abl_pass = _passing(expected_dir, ablated, only)
+    dropped = sorted(base_pass - abl_pass)   # depended on the knowledge
+    gained = sorted(abl_pass - base_pass)     # noise: passed only without it
+    return {
+        "schema": "knowledge-ablation/v1",
+        "knowledge": knowledge,
+        "retrieval_value": len(dropped),      # how many pairs the file held up
+        "dropped_pairs": dropped,             # the evidence
+        "spurious_gains": gained,             # should be empty; flags noise
+        "verdict": ("earns its place" if dropped else
+                    "no measured impact — removal/consolidation candidate"),
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--expected-dir", default="evals/expected")
+    ap.add_argument("--baseline", required=True)
+    ap.add_argument("--ablated", required=True)
+    ap.add_argument("--knowledge", default="")
+    ap.add_argument("--only")
+    ap.add_argument("-o", "--out")
+    args = ap.parse_args(argv)
+
+    baseline = json.loads(Path(args.baseline).read_text())
+    ablated = json.loads(Path(args.ablated).read_text())
+    only = {args.only} if args.only else None
+    report = ablation_impact(Path(args.expected_dir), baseline, ablated,
+                             args.knowledge, only)
+    out = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_persona.py
+++ b/scripts/eval_persona.py
@@ -1,0 +1,93 @@
+"""Persona-vs-context-boundary analysis (#110).
+
+The repo's sharpest claim is that the value of sub-agents is *context isolation*,
+not *persona specialization*. This tests it empirically: run each agent with its
+persona prose ON vs OFF (same fixtures, same trials) and compare pass@k. A delta
+only counts as REAL when it exceeds the noise band — i.e. neither run flapped on
+that agent's fixtures (variance from #103).
+
+Deterministic, model-free half: given two dirs of trial actuals (persona-on,
+persona-off), it reuses eval_variance.aggregate_trials and reports the per-agent
+delta plus whether it is trustworthy. The live on/off runs (and the check that the
+persona prose was genuinely stripped) are run-persona-eval.sh's job.
+
+Inputs
+------
+--on-trials DIR    trial actuals from the persona-ON runs.
+--off-trials DIR   trial actuals from the persona-OFF runs.
+--expected-dir DIR expected specs (default: evals/expected).
+-o FILE            report (default: stdout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from eval_variance import aggregate_trials, _load_trials  # noqa: E402
+
+
+def persona_delta(expected_dir: Path, on_trials: list[dict],
+                  off_trials: list[dict]) -> dict:
+    on = aggregate_trials(expected_dir, on_trials)["by_agent"]
+    off = aggregate_trials(expected_dir, off_trials)["by_agent"]
+    agents = sorted(set(on) | set(off))
+    rows = {}
+    helps = hurts = noeffect = 0
+    for a in agents:
+        o = on.get(a, {"mean_pass_at_k": 0.0, "flaky_fixtures": 0})
+        f = off.get(a, {"mean_pass_at_k": 0.0, "flaky_fixtures": 0})
+        delta = round(o["mean_pass_at_k"] - f["mean_pass_at_k"], 4)
+        # The delta is trustworthy only if neither run flapped on this agent —
+        # otherwise it's inside the variance band (noise), not signal.
+        flapped = o["flaky_fixtures"] > 0 or f["flaky_fixtures"] > 0
+        real = (delta != 0.0) and not flapped
+        if not real:
+            verdict = "within noise band" if flapped else "no effect"
+            noeffect += 1
+        elif delta > 0:
+            verdict = "persona ADDS detection value"; helps += 1
+        else:
+            verdict = "persona REDUCES detection value"; hurts += 1
+        rows[a] = {
+            "mean_pass_persona_on": o["mean_pass_at_k"],
+            "mean_pass_persona_off": f["mean_pass_at_k"],
+            "delta": delta,
+            "flapped": flapped,
+            "real": real,
+            "verdict": verdict,
+        }
+    return {
+        "schema": "persona-delta/v1",
+        "agents_evaluated": len(agents),
+        "persona_helps": helps,
+        "persona_hurts": hurts,
+        "no_effect_or_noise": noeffect,
+        "by_agent": rows,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--on-trials", required=True)
+    ap.add_argument("--off-trials", required=True)
+    ap.add_argument("--expected-dir", default="evals/expected")
+    ap.add_argument("-o", "--out")
+    args = ap.parse_args(argv)
+    report = persona_delta(Path(args.expected_dir),
+                           _load_trials(Path(args.on_trials)),
+                           _load_trials(Path(args.off_trials)))
+    out = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-ablation.sh
+++ b/scripts/run-ablation.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# run-ablation.sh — measure a knowledge file's retrieval value (#107).
+#
+# Runs the eval corpus WITH a knowledge file, then ABLATED (file hidden + index
+# rebuilt), and diffs the grades via scripts/eval_ablation.py. Pairs that pass
+# with the file but fail without it are its measured value.
+#
+# This costs API tokens (two corpus runs). Opt-in.
+#
+# Usage:  bash scripts/run-ablation.sh <knowledge-file.md> [--agent NAME]
+# Exit:   0 ok, 2 missing prereq/arg.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+KFILE="${1:-}"
+ONLY_AGENT=""
+[ "${2:-}" = "--agent" ] && ONLY_AGENT="${3:-}"
+KPATH="plugins/dev-team/knowledge/${KFILE}"
+[ -n "$KFILE" ] && [ -f "$KPATH" ] || { echo "usage: run-ablation.sh <knowledge-file.md> [--agent NAME]" >&2; exit 2; }
+for t in claude gh jq python3 git; do command -v "$t" >/dev/null 2>&1 || { echo "missing tool: $t" >&2; exit 2; }; done
+[ -n "${ANTHROPIC_API_KEY:-}${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || { echo "no API credentials set." >&2; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+INDEX="plugins/dev-team/hooks/lib/build-knowledge-index.sh"
+
+mkdir -p .claude/evals
+ln -sfn "$PWD/evals/fixtures" .claude/evals/fixtures
+ln -sfn "$PWD/evals/expected" .claude/evals/expected
+
+_dispatch() {  # _dispatch <out-actuals>
+  local out="$1" extra=""
+  [ -n "$ONLY_AGENT" ] && extra="Restrict the run to ONLY the agent '$ONLY_AGENT'."
+  rm -f actuals.json
+  claude -p "Run the review agents against every fixture in .claude/evals/fixtures/
+whose paired .claude/evals/expected/<stem>.json declares applicableAgents, using
+/review-agent. Pass each agent ONLY its fixture — never the expected status or a
+severity example; let it decide every value. Do NOT grade. Write valid JSON only
+to actuals.json keyed by fixture stem:
+  { \"<stem>\": { \"agents\": { \"<agent>\": { \"status\": \"...\", \"issues\": [{ \"severity\": \"...\", \"message\": \"...\" }], \"summary\": \"...\" } } } }
+$extra" \
+    --output-format json --max-turns 200 --model claude-sonnet-4-6 \
+    --allowedTools "Read" "Glob" "Grep" "Write" "Agent" "Skill(review-agent *)" \
+    >/dev/null 2>&1 || true
+  jq -e . actuals.json >/dev/null 2>&1 || { echo "no parseable actuals for $out" >&2; return 1; }
+  mv actuals.json "$out"
+}
+
+echo "== baseline run (knowledge present) =="
+_dispatch "$WORK/with.json" || exit 1
+
+echo "== ablating $KFILE (hiding + rebuilding index) =="
+mv "$KPATH" "$WORK/ablated.md"
+bash "$INDEX" >/dev/null 2>&1 || true
+# restore on any exit from here
+trap 'mv "$WORK/ablated.md" "$KPATH" 2>/dev/null; bash "$INDEX" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
+
+echo "== ablated run (knowledge removed) =="
+_dispatch "$WORK/without.json" || exit 1
+
+echo "== restoring $KFILE =="
+mv "$WORK/ablated.md" "$KPATH"; bash "$INDEX" >/dev/null 2>&1 || true
+trap 'rm -rf "$WORK"' EXIT
+
+echo "== retrieval value =="
+ONLY_ARG=""; [ -n "$ONLY_AGENT" ] && ONLY_ARG="--only $ONLY_AGENT"
+# shellcheck disable=SC2086
+python3 scripts/eval_ablation.py --expected-dir evals/expected \
+  --baseline "$WORK/with.json" --ablated "$WORK/without.json" \
+  --knowledge "$KFILE" $ONLY_ARG

--- a/scripts/run-persona-eval.sh
+++ b/scripts/run-persona-eval.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# run-persona-eval.sh — persona ON vs OFF for one agent (#110).
+#
+# Runs the corpus with an agent's persona prose present, then with it stripped,
+# multi-trial, and diffs pass@k via scripts/eval_persona.py. A delta only counts
+# when it clears the variance band (neither run flapped).
+#
+# GUARD (the experiment's validity hinges on this): the OFF variant MUST differ
+# from the ON definition. If stripping the persona changed nothing, the run is
+# meaningless and this aborts — exactly the failure mode the verification plan
+# warns about.
+#
+# Persona prose is taken to be a leading `## Persona` / `## Identity` / `## Role`
+# section in the agent .md (everything from that header to the next `## `). Agents
+# without such a section can't be toggled automatically — supply an OFF variant.
+#
+# Usage:  bash scripts/run-persona-eval.sh <agent-name> [TRIALS]
+# Exit:   0 ok, 2 missing prereq/arg, 3 toggle did not change the agent.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+AGENT="${1:-}"; TRIALS="${2:-3}"
+APATH="plugins/dev-team/agents/${AGENT}.md"
+[ -n "$AGENT" ] && [ -f "$APATH" ] || { echo "usage: run-persona-eval.sh <agent-name> [TRIALS]" >&2; exit 2; }
+for t in claude gh jq python3 git; do command -v "$t" >/dev/null 2>&1 || { echo "missing tool: $t" >&2; exit 2; }; done
+[ -n "${ANTHROPIC_API_KEY:-}${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || { echo "no API credentials set." >&2; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'mv "$WORK/agent-on.md" "$APATH" 2>/dev/null; rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/on" "$WORK/off"
+cp "$APATH" "$WORK/agent-on.md"
+
+# Build the persona-OFF variant: drop a leading Persona/Identity/Role section.
+python3 - "$APATH" "$WORK/agent-off.md" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+out = re.sub(r"\n##\s+(Persona|Identity|Role)\b.*?(?=\n##\s|\Z)", "\n", src,
+             flags=re.IGNORECASE | re.DOTALL)
+open(sys.argv[2], "w").write(out)
+PY
+
+# GUARD: the toggle must have changed something.
+if diff -q "$WORK/agent-on.md" "$WORK/agent-off.md" >/dev/null; then
+  echo "toggle did NOT change ${AGENT} — no Persona/Identity/Role section to strip." >&2
+  echo "Supply an OFF variant manually; aborting (a no-op toggle measures nothing)." >&2
+  exit 3
+fi
+echo "toggle verified: persona-OFF differs from persona-ON ($(diff "$WORK/agent-on.md" "$WORK/agent-off.md" | grep -c '^<') lines removed)."
+
+mkdir -p .claude/evals
+ln -sfn "$PWD/evals/fixtures" .claude/evals/fixtures
+ln -sfn "$PWD/evals/expected" .claude/evals/expected
+
+_dispatch() {  # _dispatch <out>
+  rm -f actuals.json
+  claude -p "Run the '$AGENT' review agent against every fixture in
+.claude/evals/fixtures/ whose paired expected json targets it, via /review-agent.
+Pass the agent ONLY its fixture — never the expected status or a severity example.
+Do NOT grade. Write valid JSON only to actuals.json keyed by fixture stem:
+  { \"<stem>\": { \"agents\": { \"$AGENT\": { \"status\": \"...\", \"issues\": [{ \"severity\": \"...\", \"message\": \"...\" }], \"summary\": \"...\" } } } }" \
+    --output-format json --max-turns 120 --model claude-sonnet-4-6 \
+    --allowedTools "Read" "Glob" "Grep" "Write" "Agent" "Skill(review-agent *)" \
+    >/dev/null 2>&1 || true
+  jq -e . actuals.json >/dev/null 2>&1 && mv actuals.json "$1"
+}
+
+echo "== persona ON ($TRIALS trials) =="
+cp "$WORK/agent-on.md" "$APATH"
+for n in $(seq 1 "$TRIALS"); do _dispatch "$WORK/on/t$n.json"; done
+
+echo "== persona OFF ($TRIALS trials) =="
+cp "$WORK/agent-off.md" "$APATH"
+for n in $(seq 1 "$TRIALS"); do _dispatch "$WORK/off/t$n.json"; done
+cp "$WORK/agent-on.md" "$APATH"   # restore
+
+echo "== persona delta =="
+python3 scripts/eval_persona.py --on-trials "$WORK/on" --off-trials "$WORK/off" \
+  --expected-dir evals/expected

--- a/tests/repo/eval_ablation_tests.bats
+++ b/tests/repo/eval_ablation_tests.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# #107 — knowledge ablation: pairs that pass WITH a knowledge file but fail
+# WITHOUT it = its retrieval value. Model-free core (synthetic with/without
+# actuals), matching the positive/negative controls in the verification plan.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+ABL="$REPO_ROOT/scripts/eval_ablation.py"
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/expected"
+  cat > "$TMP/expected/dep.json" <<'EOF'
+{"fixture":"dep.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"fail","issueCount":{"min":1,"max":3},"mustMention":["smell"]}}}
+EOF
+  cat > "$TMP/expected/indep.json" <<'EOF'
+{"fixture":"indep.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
+EOF
+  # WITH knowledge: both pairs pass.
+  cat > "$TMP/with.json" <<'EOF'
+{"dep":{"agents":{"a":{"status":"fail","issues":[{"severity":"warning","message":"a smell"}],"summary":"smell found"}}},
+ "indep":{"agents":{"a":{"status":"pass","issues":[],"summary":"clean"}}}}
+EOF
+  # WITHOUT the knowledge: dep::a misses the smell (now passes -> wrong status),
+  # indep::a unchanged.
+  cat > "$TMP/without.json" <<'EOF'
+{"dep":{"agents":{"a":{"status":"pass","issues":[],"summary":"looks fine"}}},
+ "indep":{"agents":{"a":{"status":"pass","issues":[],"summary":"clean"}}}}
+EOF
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "ablation: a load-bearing file's removal drops the dependent pair (positive control)" {
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/without.json" --knowledge test-smells.md
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.retrieval_value')" = "1" ]
+  [ "$(echo "$output" | jq -r '.dropped_pairs[0]')" = "dep::a" ]
+  [[ "$(echo "$output" | jq -r '.verdict')" == *"earns its place"* ]]
+}
+
+@test "ablation: an irrelevant file's removal changes nothing (negative control)" {
+  # ablated == baseline -> no pair drops
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/with.json" --knowledge unrelated.md
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.retrieval_value')" = "0" ]
+  [[ "$(echo "$output" | jq -r '.verdict')" == *"no measured impact"* ]]
+}
+
+@test "ablation: the unrelated pair never drops even when a file is load-bearing" {
+  run python3 "$ABL" --expected-dir "$TMP/expected" \
+    --baseline "$TMP/with.json" --ablated "$TMP/without.json"
+  # indep::a stays passing in both -> not in dropped
+  [ "$(echo "$output" | jq -r '.dropped_pairs | index("indep::a")')" = "null" ]
+}

--- a/tests/repo/eval_persona_tests.bats
+++ b/tests/repo/eval_persona_tests.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# #110 — persona on/off: per-agent pass@k delta, only "real" when it clears the
+# variance band (neither run flapped). Model-free core (synthetic on/off trials).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+PER="$REPO_ROOT/scripts/eval_persona.py"
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/expected" "$TMP/on" "$TMP/off"
+  cat > "$TMP/expected/f1.json" <<'EOF'
+{"fixture":"f1.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"fail","issueCount":{"min":1,"max":3}}}}
+EOF
+  cat > "$TMP/expected/f2.json" <<'EOF'
+{"fixture":"f2.ts","applicableAgents":["a"],"agents":{"a":{"expectedStatus":"fail","issueCount":{"min":1,"max":3}}}}
+EOF
+  _t() { echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"$1\",\"issues\":$3}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"$2\",\"issues\":$4}}}}"; }
+  ISS='[{"severity":"warning","message":"x"}]'
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "persona: a real, non-flapping delta is reported as added value" {
+  ISS='[{"severity":"warning","message":"x"}]'
+  # ON: both fixtures pass (fail status w/ 1 issue) in both trials -> mean 1.0
+  for n in 1 2; do echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}}}" > "$TMP/on/t$n.json"; done
+  # OFF: f1 passes, f2 always wrong status (pass) -> stable fail -> mean 0.5, no flap
+  for n in 1 2; do echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"pass\",\"issues\":[]}}}}" > "$TMP/off/t$n.json"; done
+  run python3 "$PER" --on-trials "$TMP/on" --off-trials "$TMP/off" --expected-dir "$TMP/expected"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.by_agent.a.delta')" = "0.5" ]
+  [ "$(echo "$output" | jq -r '.by_agent.a.real')" = "true" ]
+  [ "$(echo "$output" | jq -r '.persona_helps')" = "1" ]
+}
+
+@test "persona: identical on/off is an honest null (no effect)" {
+  ISS='[{"severity":"warning","message":"x"}]'
+  for d in on off; do for n in 1 2; do echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}}}" > "$TMP/$d/t$n.json"; done; done
+  run python3 "$PER" --on-trials "$TMP/on" --off-trials "$TMP/off" --expected-dir "$TMP/expected"
+  [ "$(echo "$output" | jq -r '.by_agent.a.delta')" = "0.0" ]
+  [ "$(echo "$output" | jq -r '.by_agent.a.real')" = "false" ]
+  [[ "$(echo "$output" | jq -r '.by_agent.a.verdict')" == *"no effect"* ]]
+}
+
+@test "persona: a flapping run marks the delta as within-noise, not real (#110)" {
+  ISS='[{"severity":"warning","message":"x"}]'
+  for n in 1 2; do echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}}}" > "$TMP/on/t$n.json"; done
+  # OFF flaps on f2 (pass then fail) -> flaky -> delta is within noise band
+  echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}}}" > "$TMP/off/t1.json"
+  echo "{\"f1\":{\"agents\":{\"a\":{\"status\":\"fail\",\"issues\":$ISS}}},\"f2\":{\"agents\":{\"a\":{\"status\":\"pass\",\"issues\":[]}}}}" > "$TMP/off/t2.json"
+  run python3 "$PER" --on-trials "$TMP/on" --off-trials "$TMP/off" --expected-dir "$TMP/expected"
+  [ "$(echo "$output" | jq -r '.by_agent.a.flapped')" = "true" ]
+  [ "$(echo "$output" | jq -r '.by_agent.a.real')" = "false" ]
+  [[ "$(echo "$output" | jq -r '.by_agent.a.verdict')" == *"noise"* ]]
+}


### PR DESCRIPTION
Empirically tests *context isolation vs persona specialization*: run each agent with persona prose ON vs OFF, compare pass@k.

- **`eval_persona.py`** (core): per-agent pass@k delta between on/off trial sets; a delta is **real only when it clears the variance band** (neither run flapped), else noise. Reports helps/hurts/no-effect.
- **`run-persona-eval.sh`** (opt-in live): strips a Persona/Identity/Role section for the OFF variant and **guards that the toggle actually changed the agent** (aborts on a no-op — the plan's validity check), runs on/off, diffs.
- **Tests**: real non-flapping delta → added value; identical on/off → honest null; flapping run → within-noise.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)