### PR TITLE
feat(session-review): raw-log tier + methodology lens (#180, Delta A/B)

### DIFF
--- a/scripts/eval_rawlog.py
+++ b/scripts/eval_rawlog.py
@@ -1,0 +1,119 @@
+"""Raw-log tier — worst-session flagging + privacy guard (#180, Delta A/B).
+
+The metrics digest is cheap but blind to *semantic* frictions (a hallucinated
+citation, an operator habit). The raw-log tier reads the few WORST sessions in
+full to surface those — but only the worst (cost is bounded), and its output must
+stay metrics-only (no quoted prompt/code/paths).
+
+This module is the deterministic half:
+  * `worst_sessions` ranks sessions by a friction score and returns the top-N —
+    the GATE that keeps the expensive raw pass off everything else.
+  * `validate_finding` enforces the privacy boundary on a tier finding: only
+    metrics/ids/enums, never a quote, snippet, path, or free-text payload.
+
+The live per-log agent pass and the methodology lens are run-rawlog-tier.sh's job;
+every finding it produces must pass `validate_finding` before it is kept.
+
+Inputs (CLI)
+------------
+--flag DIR [--top N]   rank sessions in DIR's digests, print the worst N.
+--validate FILE        check a JSON findings list against the privacy boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from session_extract import _iter_records, _REWORK_KEYS  # noqa: E402
+
+# A tier finding may carry ONLY these keys — all metrics/ids/enums.
+_ALLOWED_FINDING_KEYS = {
+    "session_id", "project", "host", "friction_type", "lens",
+    "target_artifact", "confidence", "count",
+}
+_ALLOWED_LENSES = {"methodology", "harness", "devex", "accuracy"}
+# A value that looks like a path or code payload leaks raw content.
+_LEAKY_VALUE_RE = re.compile(r"[/\\]|```|def |class |function |SELECT |<script")
+
+
+def _friction_score(rec: dict) -> float:
+    rw = rec.get("rework", {}) if isinstance(rec.get("rework"), dict) else {}
+    acc = rec.get("accuracy", {}) if isinstance(rec.get("accuracy"), dict) else {}
+    gate = rec.get("gate", {}) if isinstance(rec.get("gate"), dict) else {}
+    score = sum(float(rw.get(k, 0) or 0) for k in _REWORK_KEYS)
+    score += float(acc.get("user_correction_turns", 0) or 0)
+    score += float(acc.get("tool_error_rate", 0.0) or 0.0) * float(acc.get("tool_calls", 0) or 0)
+    score += 2.0 * float(gate.get("commit_bypasses", 0) or 0)   # bypass weighted
+    return round(score, 4)
+
+
+def worst_sessions(digests_root: Path, top: int = 5) -> list[dict]:
+    by_id: dict[str, dict] = {}
+    for f in sorted(digests_root.glob("*/session-digest.jsonl")):
+        for rec in _iter_records([f]):
+            if rec.get("schema") == "session-sync/v1" and rec.get("session_id"):
+                by_id[str(rec["session_id"])] = rec
+    ranked = sorted(
+        ({"session_id": sid, "project": r.get("project", "?"),
+          "host": r.get("host", "?"), "friction_score": _friction_score(r)}
+         for sid, r in by_id.items()),
+        key=lambda d: (-d["friction_score"], d["session_id"]),
+    )
+    return ranked[:max(top, 0)]
+
+
+def validate_finding(finding: dict) -> list[str]:
+    """Return privacy violations for one tier finding; empty == clean."""
+    violations = []
+    if not isinstance(finding, dict):
+        return ["finding is not an object"]
+    extra = set(finding) - _ALLOWED_FINDING_KEYS
+    if extra:
+        violations.append(f"disallowed keys (possible payload leak): {sorted(extra)}")
+    lens = finding.get("lens")
+    if lens is not None and lens not in _ALLOWED_LENSES:
+        violations.append(f"unknown lens {lens!r}")
+    for k, v in finding.items():
+        if isinstance(v, str) and _LEAKY_VALUE_RE.search(v):
+            violations.append(f"field {k!r} looks like a path/code payload")
+    return violations
+
+
+def validate_findings(findings: list) -> dict:
+    rows = [{"index": i, "violations": validate_finding(f)} for i, f in enumerate(findings)]
+    bad = [r for r in rows if r["violations"]]
+    return {"schema": "rawlog-validation/v1", "findings": len(findings),
+            "clean": len(findings) - len(bad), "violations": bad,
+            "ok": not bad}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--flag", metavar="DIR", help="rank sessions, print worst N")
+    ap.add_argument("--top", type=int, default=5)
+    ap.add_argument("--validate", metavar="FILE", help="check a findings JSON list")
+    ap.add_argument("-o", "--out")
+    args = ap.parse_args(argv)
+
+    if args.flag:
+        result = {"schema": "rawlog-flagged/v1", "top": args.top,
+                  "worst_sessions": worst_sessions(Path(args.flag), args.top)}
+    elif args.validate:
+        findings = json.loads(Path(args.validate).read_text())
+        result = validate_findings(findings if isinstance(findings, list) else [])
+    else:
+        ap.error("one of --flag or --validate is required")
+        return 2
+    out = json.dumps(result, indent=2, sort_keys=True)
+    Path(args.out).write_text(out + "\n") if args.out else print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-rawlog-tier.sh
+++ b/scripts/run-rawlog-tier.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# run-rawlog-tier.sh — raw-log semantic tier over the worst sessions (#180).
+#
+# 1. Flag the top-N worst sessions from the digests (scripts/eval_rawlog.py).
+# 2. For each, dispatch ONE agent to read that raw transcript and report semantic
+#    frictions (e.g. hallucinated citations) plus a `methodology` lens — output
+#    held to metrics-only/no-quote.
+# 3. Validate every finding through the privacy guard; drop any that leak.
+#
+# Only the worst sessions get the (expensive) raw pass — the rest are never read.
+# Costs API tokens. Opt-in.
+#
+# Usage:  bash scripts/run-rawlog-tier.sh [DIGESTS_DIR] [--top N]
+# Exit:   0 ok, 2 missing prereq.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+DIGESTS="${1:-${DEV_TEAM_TELEMETRY_CLONE:-$HOME/.claude/.dev-team/agent-telemetry}/digests}"
+TOP=5
+[ "${2:-}" = "--top" ] && TOP="${3:-5}"
+PROJECTS="$HOME/.claude/projects"
+for t in claude jq python3 git; do command -v "$t" >/dev/null 2>&1 || { echo "missing tool: $t" >&2; exit 2; }; done
+[ -n "${ANTHROPIC_API_KEY:-}${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || { echo "no API credentials set." >&2; exit 2; }
+[ -d "$DIGESTS" ] || { echo "no digests dir at $DIGESTS" >&2; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+echo "== flagging worst $TOP sessions =="
+python3 scripts/eval_rawlog.py --flag "$DIGESTS" --top "$TOP" -o "$WORK/flagged.json"
+mapfile -t SIDS < <(jq -r '.worst_sessions[].session_id' "$WORK/flagged.json")
+[ "${#SIDS[@]}" -gt 0 ] || { echo "no sessions to review."; exit 0; }
+
+echo "[]" > "$WORK/findings.json"
+for sid in "${SIDS[@]}"; do
+  tx="$(find "$PROJECTS" -name "${sid}.jsonl" 2>/dev/null | head -1)"
+  [ -n "$tx" ] || { echo "  $sid: transcript not found, skipping" >&2; continue; }
+  echo "== raw-log review: $sid =="
+  rm -f rawlog-out.json
+  claude -p "Read the Claude Code session transcript at '$tx' and identify SEMANTIC
+frictions a metrics digest cannot see: hallucinated citations (the model citing a
+skill/file as a source when that content does not exist), the AI repeating a
+mistake that slipped a guardrail, and OPERATOR methodology habits (e.g. deferring
+decisions with no owner). Also note dev-environment papercuts.
+
+OUTPUT DISCIPLINE — this is mandatory: write a JSON array to rawlog-out.json. Each
+finding may contain ONLY these keys: session_id, project, host, friction_type,
+lens (one of: methodology, harness, devex, accuracy), target_artifact, confidence,
+count. NEVER include a quote, snippet, code, file path, or any prompt/output text.
+Report THAT a friction occurred and WHICH artifact to fix — never the content.
+session_id is '$sid'. Write valid JSON only." \
+    --output-format json --max-turns 30 --model claude-sonnet-4-6 \
+    --allowedTools "Read" "Write" >/dev/null 2>&1 || true
+  if jq -e 'type=="array"' rawlog-out.json >/dev/null 2>&1; then
+    jq -s '.[0] + .[1]' "$WORK/findings.json" rawlog-out.json > "$WORK/m.json" && mv "$WORK/m.json" "$WORK/findings.json"
+  fi
+  rm -f rawlog-out.json
+done
+
+echo "== privacy validation (drop any leaking finding) =="
+python3 scripts/eval_rawlog.py --validate "$WORK/findings.json" -o "$WORK/validation.json"
+if [ "$(jq -r '.ok' "$WORK/validation.json")" != "true" ]; then
+  echo "WARNING: some findings violated the metrics-only boundary and are reported below; do NOT ship them:" >&2
+  jq '.violations' "$WORK/validation.json" >&2
+fi
+echo "== clean findings =="
+jq --slurpfile v "$WORK/validation.json" \
+   'to_entries | map(select((($v[0].violations // []) | map(.index) | index(.key)) | not) | .value)' \
+   "$WORK/findings.json"

--- a/tests/repo/eval_rawlog_tests.bats
+++ b/tests/repo/eval_rawlog_tests.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# #180 — raw-log tier: the deterministic gate (flag only the worst sessions) and
+# the privacy guard (a tier finding must stay metrics-only, no quoted payloads).
+# Model-free; the live per-log pass is opt-in (run-rawlog-tier.sh).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+RL="$REPO_ROOT/scripts/eval_rawlog.py"
+
+setup() {
+  TMP="$(mktemp -d)"; mkdir -p "$TMP/digests/box"
+  cat > "$TMP/digests/box/session-digest.jsonl" <<'EOF'
+{"schema":"session-sync/v1","host":"box","project":"p","session_id":"calm","rework":{"failed_edits":0},"accuracy":{"tool_calls":2,"tool_error_rate":0,"user_correction_turns":0},"gate":{"commit_bypasses":0}}
+{"schema":"session-sync/v1","host":"box","project":"p","session_id":"messy","rework":{"failed_edits":8,"retried_bash_commands":4},"accuracy":{"tool_calls":10,"tool_error_rate":0.3,"user_correction_turns":2},"gate":{"commit_bypasses":1}}
+{"schema":"session-sync/v1","host":"box","project":"p","session_id":"mid","rework":{"failed_edits":2},"accuracy":{"tool_calls":5,"tool_error_rate":0.1,"user_correction_turns":0},"gate":{"commit_bypasses":0}}
+EOF
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "flag: the worst session ranks first; the gate bounds to top-N (#180)" {
+  run python3 "$RL" --flag "$TMP/digests" --top 2
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.worst_sessions | length')" = "2" ]
+  [ "$(echo "$output" | jq -r '.worst_sessions[0].session_id')" = "messy" ]
+  # 'calm' (lowest friction) is gated out of the top-2 — never gets the raw pass
+  [ "$(echo "$output" | jq -r '[.worst_sessions[].session_id] | index("calm")')" = "null" ]
+}
+
+@test "validate: a metrics-only finding passes the privacy guard (#180)" {
+  echo '[{"session_id":"messy","project":"p","friction_type":"hallucinated_citation","lens":"harness","target_artifact":"session-review","confidence":"high","count":1}]' > "$TMP/f.json"
+  run python3 "$RL" --validate "$TMP/f.json"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.ok')" = "true" ]
+  [ "$(echo "$output" | jq -r '.clean')" = "1" ]
+}
+
+@test "validate: a finding carrying a quote/payload field is rejected (#180)" {
+  echo '[{"session_id":"messy","quote":"the secret is hunter2","lens":"harness"}]' > "$TMP/f.json"
+  run python3 "$RL" --validate "$TMP/f.json"
+  [ "$(echo "$output" | jq -r '.ok')" = "false" ]
+  [[ "$(echo "$output" | jq -r '.violations[0].violations[0]')" == *"disallowed keys"* ]]
+}
+
+@test "validate: a path/code-looking value is rejected (#180)" {
+  echo '[{"session_id":"messy","target_artifact":"/Users/x/secret.ts","lens":"harness"}]' > "$TMP/f.json"
+  run python3 "$RL" --validate "$TMP/f.json"
+  [ "$(echo "$output" | jq -r '.ok')" = "false" ]
+  [[ "$(echo "$output" | jq -r '.violations[0].violations | join(" ")')" == *"path/code payload"* ]]
+}
+
+@test "validate: an unknown lens is rejected (#180)" {
+  echo '[{"session_id":"messy","lens":"freeform"}]' > "$TMP/f.json"
+  run python3 "$RL" --validate "$TMP/f.json"
+  [ "$(echo "$output" | jq -r '.ok')" = "false" ]
+}


### PR DESCRIPTION
The metrics digest can't see *semantic* frictions (hallucinated citations, operator habits). The raw-log tier reads the few **worst** sessions in full to catch them — bounded by the gate, output **metrics-only**.

- **`eval_rawlog.py`** (core): `worst_sessions` ranks by friction score → top-N (the **gate**; the expensive raw pass never touches the rest). `validate_finding` enforces the privacy boundary — a finding may carry only metrics/ids/enums, never a quote, path, or code payload.
- **`run-rawlog-tier.sh`** (opt-in live): flags worst-N, dispatches one agent per raw transcript with strict no-quote instructions, validates every finding and drops leakers.
- **Tests**: gate bounds to top-N (worst first, clean session excluded); privacy guard accepts metrics-only, rejects quote/payload fields, path/code values, and unknown lenses.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)