### PR TITLE
feat(evals): resumable sweep is now the default run mode

### DIFF
--- a/plugins/dev-team/docs/eval-running-guide.md
+++ b/plugins/dev-team/docs/eval-running-guide.md
@@ -22,19 +22,30 @@ JSON schema* with placeholder enums (`"status":"pass or fail"`,
 no example values, "decide every value yourself." The `/agent-eval` skill enforces
 this via its orchestrator constraint #3 ("pass only the fixture file").
 
-## Option 0 — the automated full-run script
+## Option 0 — the automated run script (default: resumable full sweep)
 
 ```bash
-bash scripts/run-full-eval.sh [TRIALS]   # default 1
+bash scripts/run-full-eval.sh [TRIALS]   # default TRIALS=1; default mode = full sweep
+# ...killed / out of tokens? just run it again — it resumes:
+bash scripts/run-full-eval.sh
 ```
 
-Drives the headless `claude -p /agent-eval` dispatch across the **whole** corpus
-(neutral, full-scope), refreshes the tracked `evals/baseline.json` from the result,
-appends the variance trend when `TRIALS>1`, and — if the baseline changed — opens
-an **auto-merge PR** with the diff for review. Needs `claude` + credentials +
-`gh`. A full multi-trial run is expensive; default is a single accuracy pass.
+**By default this runs the resumable full sweep** (see below): every agent, one at
+a time, neutral dispatch, checkpointed. It refreshes the tracked
+`evals/baseline.json`, appends the variance trend when `TRIALS>1`, and opens a
+single **auto-merge PR** at the end. Needs `claude` + credentials + `gh`. Use
+`--agent NAME` to scope to a single agent instead.
 
-### Incremental runs — one agent at a time (not all-or-nothing)
+### Resumable full sweep (the default) — survives a kill or a token cap
+
+A bare `run-full-eval.sh` runs **all** agents incrementally on one branch,
+**committing the baseline after each agent** and tracking progress in a gitignored
+checkpoint (`.eval-sweep-progress.json`). If it's interrupted, the completed agents
+are already committed and recorded — re-running picks up where it left off and
+continues; an interrupted agent is retried. One push, one auto-merge PR at the end.
+(`--sweep` is accepted as an explicit alias for this default.)
+
+### Incremental runs — one agent at a time
 
 ```bash
 bash scripts/run-full-eval.sh 5 --agent security-review   # just this agent, 5 trials
@@ -50,23 +61,6 @@ and the same variance trend, and opens its own small auto-merge PR.
 
 Why it doesn't clobber: the grader merges rather than overwrites, and `--only`
 keeps grading to the scope you ran — so partial coverage is the norm, not a risk.
-
-### Resumable full sweep — survives a kill or a token cap
-
-```bash
-bash scripts/run-full-eval.sh 5 --sweep   # every agent, one at a time, resumable
-# ...killed / ran out of tokens? just run it again:
-bash scripts/run-full-eval.sh --sweep     # picks up where it left off
-```
-
-`--sweep` runs **all** agents incrementally on one branch, **committing the
-baseline after each agent** and tracking progress in a gitignored checkpoint
-(`.eval-sweep-progress.json`). If it's interrupted, the completed agents are
-already committed and recorded — re-running `--sweep` skips them and continues
-with the rest. An interrupted agent (no commit yet) is simply retried. When every
-agent is done it pushes once and opens a single auto-merge PR, then clears the
-checkpoint. This is the way to run the whole corpus without an all-or-nothing
-session.
 
 ### The other incremental mode — only what changed
 

--- a/scripts/run-full-eval.sh
+++ b/scripts/run-full-eval.sh
@@ -3,29 +3,31 @@
 # and open an auto-merge PR. Supports full, single-agent, and a RESUMABLE sweep.
 #
 # Modes:
-#   (default)        one full-corpus run -> baseline refresh -> auto-merge PR.
-#   --agent NAME     INCREMENTAL: just that agent (merges its pairs, others kept).
-#   --sweep          RESUMABLE: every agent, one at a time, checkpointed. If you
-#                    kill it or run out of tokens, re-run `--sweep` and it picks up
+#   (default)        RESUMABLE SWEEP: every agent, one at a time, checkpointed. If
+#                    you kill it or run out of tokens, just re-run and it picks up
 #                    where it left off (per-agent commits + a checkpoint file are
-#                    the progress). One PR at the end.
+#                    the progress). One auto-merge PR at the end.
+#   --agent NAME     just that agent (incremental; merges its pairs, others kept).
 #
 # This costs API tokens. Default TRIALS=1.
 #
-# Usage:  bash scripts/run-full-eval.sh [TRIALS] [--agent NAME | --sweep]
+# Usage:  bash scripts/run-full-eval.sh [TRIALS] [--agent NAME]
+#         (no flag = resumable full sweep; --sweep accepted as the default alias)
 # Env:    ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN, plus `claude` + `gh`.
 # Exit:   0 ok, 2 missing prereq, 1 run produced nothing.
 
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 2
 
-TRIALS=1; ONLY_AGENT=""; SWEEP=0
+# The RESUMABLE SWEEP is the default. --agent NAME scopes to a single agent
+# instead; --sweep is accepted as a (now-default) alias for back-compat.
+TRIALS=1; ONLY_AGENT=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --agent) ONLY_AGENT="${2:-}"; shift 2 ;;
-    --sweep) SWEEP=1; shift ;;
+    --sweep) shift ;;                 # default behavior; kept for back-compat
     [0-9]*)  TRIALS="$1"; shift ;;
-    *) echo "usage: run-full-eval.sh [TRIALS] [--agent NAME | --sweep]" >&2; exit 2 ;;
+    *) echo "usage: run-full-eval.sh [TRIALS] [--agent NAME]   (default: resumable full sweep)" >&2; exit 2 ;;
   esac
 done
 STAMP="$(date -u +%Y%m%d-%H%M%S)"
@@ -96,8 +98,8 @@ _grade_variance() {
   fi
 }
 
-# ============================ RESUMABLE SWEEP ===============================
-if [ "$SWEEP" -eq 1 ]; then
+# ===================== RESUMABLE SWEEP (default mode) ======================
+if [ -z "$ONLY_AGENT" ]; then
   if [ -f "$CKPT" ]; then
     BRANCH="$(jq -r .branch "$CKPT")"; TRIALS="$(jq -r .trials "$CKPT")"
     echo "resuming sweep on '$BRANCH' — $(jq -r '.done | length' "$CKPT") agent(s) already done."
@@ -149,14 +151,10 @@ Merges per-agent results into \`evals/baseline.json\`. Review the diff for **reg
   exit 0
 fi
 
-# ============================ SINGLE RUN ===================================
+# ==================== SINGLE-AGENT RUN (--agent NAME) ======================
 if ! git diff --quiet || ! git diff --cached --quiet; then echo "working tree is dirty — commit or stash first." >&2; exit 2; fi
-if [ -n "$ONLY_AGENT" ]; then
-  SCOPE_LABEL="agent-${ONLY_AGENT}"; SCOPE_DESC="agent '${ONLY_AGENT}' (incremental)"
-  SCOPE_INSTR="IMPORTANT: restrict this run to ONLY the agent '${ONLY_AGENT}' and the fixtures that target it; skip every other agent and skill."
-else
-  SCOPE_LABEL="full"; SCOPE_DESC="full-corpus"; SCOPE_INSTR=""
-fi
+SCOPE_LABEL="agent-${ONLY_AGENT}"; SCOPE_DESC="agent '${ONLY_AGENT}' (incremental)"
+SCOPE_INSTR="IMPORTANT: restrict this run to ONLY the agent '${ONLY_AGENT}' and the fixtures that target it; skip every other agent and skill."
 TRIALS_DIR="$(mktemp -d)"; trap 'rm -rf "$TRIALS_DIR"' EXIT
 echo "== eval (${SCOPE_LABEL}) — ${TRIALS} trial(s), dispatching (costs tokens) =="
 emitted="$(_dispatch "$SCOPE_INSTR" "$TRIALS_DIR")"


### PR DESCRIPTION
Per request: `--sweep` becomes the default.

A bare `run-full-eval.sh` now runs the **resumable full sweep** (every agent, one at a time, checkpointed, resumes after a kill/token cap) instead of a single all-or-nothing full-corpus session.

- Default (no flag) → resumable sweep.
- `--agent NAME` → single-agent incremental run (unchanged).
- `--sweep` → accepted as a back-compat alias for the default.
- Removed the old one-shot full path (the sweep supersedes it).

shellcheck clean; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)