### PR TITLE
feat(cloud): cloud-only dev-team install hook + cloud session docs

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Cloud-session setup for agentic-dev-team.
+#
+# HOW TO USE: this is NOT auto-run. Claude Code on the web takes its setup script
+# from the cloud environment UI, not from a repo file. So: open your environment's
+# settings (claude.ai/code → Environment → Setup script) and PASTE the body of
+# this file into the "Setup script" field. It runs as root on a fresh Ubuntu VM
+# before Claude launches, and installs the tooling this repo's tests/gates need.
+#
+# IT DOES NOT INSTALL THE dev-team PLUGIN. The `claude` CLI is not available in
+# cloud environments, so `claude plugin marketplace add` / `claude plugin install`
+# cannot run there. See CLAUDE.md → "Cloud sessions" for how to use the plugin's
+# workflow in a cloud session (read its skill files directly).
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y jq shellcheck bats
+
+# Python dev deps — several bats suites shell out to Python that imports these.
+python3 -m pip install --quiet -r requirements-dev.txt \
+  || pip3 install --quiet -r requirements-dev.txt
+
+# gh CLI (PR operations), if the image doesn't already ship it.
+command -v gh >/dev/null 2>&1 || apt-get install -y gh || true
+
+echo "agentic-dev-team cloud setup complete: jq shellcheck bats python-deps gh"

--- a/.claude/install-dev-team.sh
+++ b/.claude/install-dev-team.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SessionStart hook (registered in .claude/settings.json): make the dev-team
+# plugin available in CLOUD sessions only.
+#
+# CLOUD-ONLY GATE: this is a no-op unless DEV_TEAM_CLOUD_INSTALL=1 is set. Set
+# that variable in your Claude Code web environment (Environment settings ->
+# Environment variables). Do NOT set it locally — so local sessions, where the
+# plugin is already installed, are never touched by this hook.
+#
+# In a gated (cloud) session it tries to install the plugin if the `claude` CLI
+# is present; if the CLI is absent (cloud VMs may not ship it), it emits guidance
+# to run the plugin's workflows from its skill files instead. Fail-open — never
+# blocks session start.
+set -uo pipefail
+
+# Local (or any session without the cloud flag): do nothing.
+[ "${DEV_TEAM_CLOUD_INSTALL:-}" = "1" ] || exit 0
+
+# Cloud, but no CLI to install with: guide to the skill-file route.
+if ! command -v claude >/dev/null 2>&1; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"The dev-team plugin could not be installed in this cloud session (no `claude` CLI here). Run its workflows manually by reading the skill source and following it: plugins/dev-team/skills/<name>/SKILL.md (e.g. plan, code-review, build); agents at plugins/dev-team/agents/<name>.md. See CLAUDE.md -> Cloud sessions."}}
+JSON
+  exit 0
+fi
+
+# Already installed? quiet no-op.
+if claude plugin list 2>/dev/null | grep -qi 'dev-team'; then
+  exit 0
+fi
+
+# Install idempotently, time-boxed so it can never hang session start.
+# (A plugin installed at SessionStart takes effect on the NEXT session.)
+_tmo() {
+  if command -v timeout >/dev/null 2>&1; then timeout 120 "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout 120 "$@"
+  else "$@"; fi
+}
+_tmo claude plugin marketplace add bdfinst/agentic-dev-team >/dev/null 2>&1 || true
+_tmo claude plugin install dev-team@bfinster >/dev/null 2>&1 || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,17 @@
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/install-dev-team.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,4 +68,34 @@ Releases are managed by release-please. Push conventional commits to main:
 
 A release PR is opened automatically. Merging it creates a GitHub Release with a version tag.
 
+## Cloud sessions (claude.ai/code)
+
+Plugins are a **local CLI / IDE** feature. A Claude Code web session runs in a
+fresh managed VM that clones this repo; setup scripts and env vars are set in the
+cloud **UI** (not a repo file) — see
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web).
+
+**Cloud-only auto-install hook.** `.claude/settings.json` registers a
+`SessionStart` hook (`.claude/install-dev-team.sh`) that installs the dev-team
+plugin — but **only when `DEV_TEAM_CLOUD_INSTALL=1`**. Set that variable in your
+cloud environment's *Environment variables* field; leave it unset locally, so the
+hook is a no-op on your machine (where the plugin is already installed). Caveats:
+the hook can only install if the cloud VM ships the `claude` CLI; if it doesn't,
+it falls back to guidance (below). A plugin installed at `SessionStart` takes
+effect on the **next** session, not the current one.
+
+**If the plugin can't load (no CLI), use its files directly.** The skills and
+agents are plain files in this repo; run any workflow manually:
+
+- a skill → `plugins/dev-team/skills/<name>/SKILL.md` (e.g. `/plan` →
+  read `plugins/dev-team/skills/plan/SKILL.md` and follow its steps);
+- a review agent → `plugins/dev-team/agents/<name>.md`;
+- the catalog → `plugins/dev-team/knowledge/agent-registry.md`.
+
+**Test tooling in cloud.** To run this repo's gates in a cloud session, paste the
+body of [`.claude/cloud-setup.sh`](.claude/cloud-setup.sh) into the environment's
+*Setup script* field (installs `jq`, `shellcheck`, `bats`, the Python dev deps,
+and `gh`). There is no dedicated secrets store yet — treat env vars as visible to
+anyone who can edit the environment.
+
 See `plugins/dev-team/CLAUDE.md` for the full orchestration pipeline configuration.


### PR DESCRIPTION
Makes the dev-team plugin usable in Claude Code **web/cloud** sessions, without affecting local sessions.

## `SessionStart` hook — cloud-only, by design
`.claude/settings.json` registers a SessionStart hook (`.claude/install-dev-team.sh`) that installs the plugin, **gated on `DEV_TEAM_CLOUD_INSTALL=1`**:
- Set that env var in your **cloud environment** (web UI → Environment variables) → the hook runs there.
- Leave it unset **locally** → the hook is a silent no-op (no reinstalling on every local session).

It's fail-open and time-boxed. If the cloud VM has no `claude` CLI (which the docs don't confirm is present), it can't install and instead **injects guidance** to run the plugin's workflows from its skill files. A SessionStart install takes effect on the **next** session.

## Also included
- **`.claude/cloud-setup.sh`** — paste its body into the cloud environment's *Setup script* field (installs jq/shellcheck/bats/python-deps/gh). Setup scripts are UI-only, not auto-run from a repo file.
- **CLAUDE.md "Cloud sessions"** — documents the gate var, the skill-file fallback (the reliable route when no plugin), and the honest cloud constraints.

Verified: local = silent no-op; gate-on + no-CLI = valid guidance JSON; settings.json valid; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)