### PR TITLE
fix(release): sync marketplace catalog via release-please extra-files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,11 +18,11 @@
       "repository": "https://github.com/bdfinst/agentic-dev-team",
       "source": {
         "path": "plugins/dev-team",
-        "ref": "dev-team-v6.4.0",
+        "ref": "dev-team-v6.6.0",
         "source": "git-subdir",
         "url": "https://github.com/bdfinst/agentic-dev-team.git"
       },
-      "version": "6.4.0"
+      "version": "6.6.0"
     },
     {
       "author": {
@@ -35,11 +35,11 @@
       "repository": "https://github.com/bdfinst/agentic-dev-team",
       "source": {
         "path": "plugins/security-assessment",
-        "ref": "security-assessment-v3.1.1",
+        "ref": "security-assessment-v3.2.0",
         "source": "git-subdir",
         "url": "https://github.com/bdfinst/agentic-dev-team.git"
       },
-      "version": "3.1.1"
+      "version": "3.2.0"
     },
     {
       "author": {

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,14 +12,6 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      dev_team_released: ${{ steps.release.outputs['plugins/dev-team--release_created'] }}
-      dev_team_tag: ${{ steps.release.outputs['plugins/dev-team--tag_name'] }}
-      dev_team_version: ${{ steps.release.outputs['plugins/dev-team--version'] }}
-      security_released: ${{ steps.release.outputs['plugins/security-assessment--release_created'] }}
-      security_tag: ${{ steps.release.outputs['plugins/security-assessment--tag_name'] }}
-      security_version: ${{ steps.release.outputs['plugins/security-assessment--version'] }}
     steps:
       # Mint a short-lived token from the release bot GitHub App. Using an App
       # identity (not the default GITHUB_TOKEN) is what lets the release PR's
@@ -37,59 +29,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # After a release is tagged, repoint the marketplace catalog at the new tags so
-  # installers receive the tagged tree instead of whatever is ahead on main.
-  pin-marketplace:
-    needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-      - name: Pin marketplace.json to released tags
-        env:
-          DEV_TEAM_RELEASED: ${{ needs.release-please.outputs.dev_team_released }}
-          DEV_TEAM_TAG: ${{ needs.release-please.outputs.dev_team_tag }}
-          DEV_TEAM_VERSION: ${{ needs.release-please.outputs.dev_team_version }}
-          SECURITY_RELEASED: ${{ needs.release-please.outputs.security_released }}
-          SECURITY_TAG: ${{ needs.release-please.outputs.security_tag }}
-          SECURITY_VERSION: ${{ needs.release-please.outputs.security_version }}
-        run: |
-          set -euo pipefail
-          MP=.claude-plugin/marketplace.json
-
-          pin() {
-            name="$1"; tag="$2"; version="$3"
-            jq --arg name "$name" --arg tag "$tag" --arg version "$version" '
-              (.plugins[] | select(.name == $name))
-                |= (.source.ref = $tag | .version = $version)
-            ' "$MP" > "$MP.tmp"
-            mv "$MP.tmp" "$MP"
-            echo "Pinned $name -> $tag (version $version)"
-          }
-
-          if [ "${DEV_TEAM_RELEASED:-}" = "true" ]; then
-            pin dev-team "$DEV_TEAM_TAG" "$DEV_TEAM_VERSION"
-          fi
-          if [ "${SECURITY_RELEASED:-}" = "true" ]; then
-            pin security-assessment "$SECURITY_TAG" "$SECURITY_VERSION"
-          fi
-
-          # Fail fast if the result is not valid JSON.
-          jq empty "$MP"
-      - name: Commit and push
-        run: |
-          set -euo pipefail
-          if git diff --quiet .claude-plugin/marketplace.json; then
-            echo "marketplace.json already up to date; nothing to commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/marketplace.json
-          # Use a type outside changelog-sections so this does not pollute changelogs.
-          # Pushes with GITHUB_TOKEN do not re-trigger workflows, so no recursion.
-          git commit -m "ci: pin marketplace catalog to released tags"
-          git push origin main
+          # The marketplace catalog (.claude-plugin/marketplace.json) is kept in
+          # sync by release-please's own `json` extra-files updaters (see
+          # release-please-config.json). Those updates land inside the release
+          # PR's verified commits and merge through branch protection normally.
+          # A previous post-merge job that pushed the catalog directly to main
+          # was removed: protected `main` rejects direct pushes (required status
+          # checks + signed-commits rule), so it could never succeed.

--- a/plugins/dev-team/README.md
+++ b/plugins/dev-team/README.md
@@ -119,7 +119,7 @@ claude plugin marketplace add https://gitlab.example.com/team/agentic-dev-team.g
 claude plugin marketplace add git@gitlab.example.com:team/agentic-dev-team.git
 
 # pin a release tag
-claude plugin marketplace add https://gitlab.example.com/team/agentic-dev-team.git#dev-team-v6.4.0
+claude plugin marketplace add https://gitlab.example.com/team/agentic-dev-team.git#dev-team-v6.6.0
 
 # then, for any of the above:
 claude plugin install dev-team@bfinster

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,13 +15,37 @@
       "release-type": "simple",
       "package-name": "dev-team",
       "component": "dev-team",
-      "extra-files": [".claude-plugin/plugin.json"]
+      "extra-files": [
+        ".claude-plugin/plugin.json",
+        {
+          "type": "json",
+          "path": "/.claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[?(@.name=='dev-team')].version"
+        },
+        {
+          "type": "json",
+          "path": "/.claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[?(@.name=='dev-team')].source.ref"
+        }
+      ]
     },
     "plugins/security-assessment": {
       "release-type": "simple",
       "package-name": "security-assessment",
       "component": "security-assessment",
-      "extra-files": [".claude-plugin/plugin.json"]
+      "extra-files": [
+        ".claude-plugin/plugin.json",
+        {
+          "type": "json",
+          "path": "/.claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[?(@.name=='security-assessment')].version"
+        },
+        {
+          "type": "json",
+          "path": "/.claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[?(@.name=='security-assessment')].source.ref"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

The marketplace catalog (`.claude-plugin/marketplace.json`) drifted behind the actual releases: `dev-team` was pinned at `dev-team-v6.4.0` and `security-assessment` at `v3.1.1`, even though `v6.6.0` / `v3.2.0` were already tagged. Because the CLI checks out the pinned `source.ref` and reads the version from the plugin's `plugin.json` at that ref, installs received the stale tagged tree (6.4.0).

### Root cause

The release workflow's `pin-marketplace` job ran **after** the tag was cut and tried to `git push` the catalog update **directly to `main`**. Protected `main` rejects direct pushes — confirmed in the release #175 job log:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 4 of 4 required status checks are expected.
remote: - Commits must have verified signatures.   Found 1 violation: 8c37f68...
```

A post-merge job can never satisfy required status checks, and the bot's plain git commit is unsigned — so the catalog never updated.

## Fix

Let release-please maintain `marketplace.json` itself, via `json` `extra-files` updaters:

- The `json` updater does a `VERSION_REGEX` **substring** replace that preserves surrounding text, so `"dev-team-v6.4.0"` → `"dev-team-v6.6.0"` works for the tag-prefixed `source.ref`, not just the bare `version`.
- It uses `jsonpath-plus`, which supports `[?(@.name=='dev-team')]` filter expressions.
- The repo-root file is referenced with a **leading slash** (`/.claude-plugin/marketplace.json`); `../` traversal is forbidden (release-please PR #1187).
- Two `extra-files` entries on the same path are merged via `CompositeUpdater` (`mergeUpdates`), so both `version` and `source.ref` are updated.

These updates land inside the release PR's **verified** commits and merge through branch protection normally — eliminating the impossible direct-push-to-`main`.

## Changes

- **`release-please-config.json`** — add `json` extra-files for `version` + `source.ref` of both plugins.
- **`.github/workflows/release-please.yml`** — remove the broken post-merge `pin-marketplace` job and its outputs; document why.
- **`.claude-plugin/marketplace.json`** — repair current drift (`dev-team` → `6.6.0`/`v6.6.0`, `security-assessment` → `3.2.0`/`v3.2.0`) so installs are correct immediately.
- **`plugins/dev-team/README.md`** — bump the stale `dev-team-v6.4.0` pinned-tag install example to `v6.6.0`. This touches a plugin path, which drives a release so the new extra-files sync gets exercised.

## Validation

After merge, release-please should open a release PR bumping `dev-team` to `6.6.1`. Watch that PR's diff: `marketplace.json` should show `version` and `source.ref` bumped to `6.6.1` / `dev-team-v6.6.1` in release-please's own verified commits. Merging it cuts the tag with the catalog already correct in the same merge.

https://claude.ai/code/session_01E3CfNhnGgvZxXDrfmTrbA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3CfNhnGgvZxXDrfmTrbA5)_