### PR TITLE
test(evals): add parallel harvest script with deterministic reconcile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ actuals.json
 
 # resumable eval sweep checkpoint
 .eval-sweep-progress.json
+# parallel eval harvest: per-agent trials + resume markers (run-full-eval-parallel.sh)
+.eval-parallel/

--- a/scripts/run-full-eval-parallel.sh
+++ b/scripts/run-full-eval-parallel.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# run-full-eval-parallel.sh — harvest the agent-eval corpus in PARALLEL batches,
+# isolated by git worktrees, then reconcile deterministically into one baseline
+# and open an auto-merge PR.
+#
+# Why worktrees: the serial sweep (run-full-eval.sh) shares ONE working tree, so
+# it cannot be parallelized — every dispatch writes the same `actuals.json` at the
+# repo root, every grade does a read-modify-write of `evals/baseline.json`, and
+# every checkpoint/commit shares one git index. A worktree per batch gives each
+# batch its own cwd, index, and `actuals.json`, so the only *expensive* part (the
+# live `claude -p` dispatch) runs concurrently without collisions.
+#
+# Why the grade is NOT parallelized: `evals/baseline.json` is a flat `passing`
+# pair-list merged as `(existing | passed) - failed`. A batch that never ran agent
+# X still carries X's old passing pairs, so unioning per-batch baselines would
+# RESURRECT pairs another batch correctly removed. The safe design is therefore:
+# parallelize dispatch only; collect each agent's trial actuals into a disjoint
+# per-agent dir; then run ONE deterministic, model-free grade over the union,
+# scoped (`--only`) to the agents that actually produced actuals so a failed
+# dispatch never wipes an agent's baseline.
+#
+# Partition unit is the AGENT: an agent's trials must be graded together (pass@k /
+# variance), so an agent is never split across batches. Round-robin keeps batches
+# balanced. Real speedup is bounded by your account's API rate/token pace, not by
+# --jobs; burns budget faster too. N=2-4 is the sane range (#142 pace guidance).
+#
+# Resumable: per-agent trials live under .eval-parallel/<agent>/ (gitignored) with
+# a `.done` marker. Re-run to pick up only the agents still missing; --fresh wipes
+# it. Already-done agents still contribute to the final grade on resume.
+#
+# Usage:  bash scripts/run-full-eval-parallel.sh [TRIALS] [--jobs N] [--fresh]
+#         TRIALS default 1, --jobs default 3.
+# Env:    ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN, plus `claude` + `gh`.
+# Exit:   0 ok, 2 missing prereq/dirty tree, 1 run produced nothing.
+
+set -uo pipefail
+MAIN_ROOT="$(git rev-parse --show-toplevel)" || exit 2
+cd "$MAIN_ROOT" || exit 2
+
+TRIALS=1; JOBS=3; FRESH=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jobs)  JOBS="${2:-}"; shift 2 ;;
+    --fresh) FRESH=1; shift ;;
+    [0-9]*)  TRIALS="$1"; shift ;;
+    *) echo "usage: run-full-eval-parallel.sh [TRIALS] [--jobs N] [--fresh]" >&2; exit 2 ;;
+  esac
+done
+case "$JOBS" in ''|*[!0-9]*) echo "--jobs must be a positive integer" >&2; exit 2 ;; esac
+[ "$JOBS" -ge 1 ] || { echo "--jobs must be >= 1" >&2; exit 2; }
+
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+RUN_DIR="$MAIN_ROOT/.eval-parallel"          # gitignored: per-agent trials + resume
+WT_BASE="$(mktemp -d)"                        # worktrees live OUTSIDE the repo tree
+
+# --- prerequisites ----------------------------------------------------------
+for t in claude gh jq python3 git; do
+  command -v "$t" >/dev/null 2>&1 || { echo "missing required tool: $t" >&2; exit 2; }
+done
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  echo "no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN — the live eval needs creds." >&2
+  exit 2
+fi
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "working tree is dirty — commit or stash first." >&2; exit 2
+fi
+
+# --- cleanup: always tear down worktrees, even on interrupt -----------------
+cleanup() {
+  local wt
+  for wt in "$WT_BASE"/b*; do
+    if [ -d "$wt" ]; then git worktree remove --force "$wt" >/dev/null 2>&1 || true; fi
+  done
+  git worktree prune >/dev/null 2>&1 || true
+  rm -rf "$WT_BASE"
+}
+trap cleanup EXIT
+
+[ "$FRESH" = 1 ] && rm -rf "$RUN_DIR"
+mkdir -p "$RUN_DIR"
+
+read -r -d '' PROMPT_BASE <<'EOF'
+Run the review agents against the fixtures in .claude/evals/fixtures/ whose paired
+.claude/evals/expected/<stem>.json declares an applicableAgents target, via the
+/review-agent skill.
+
+CRITICAL — do NOT bias the agents: pass each agent ONLY its fixture file. Do not
+tell it the expected status or severity. Let it decide every value itself.
+
+Do NOT grade. Write valid JSON (and nothing else) to actuals.json at the repo
+root, keyed by fixture stem:
+
+  { "<stem>": { "agents": { "<agent>": { "status": "...",
+        "issues": [{ "severity": "...", "message": "..." }], "summary": "..." } } } }
+EOF
+
+# --- the corpus's agents, and which still need dispatching ------------------
+mapfile -t ALL_AGENTS < <(jq -r '.applicableAgents[]?' evals/expected/*.json 2>/dev/null | sort -u)
+[ "${#ALL_AGENTS[@]}" -gt 0 ] || { echo "no applicableAgents in evals/expected — nothing to do." >&2; exit 1; }
+
+TODO=()
+for a in "${ALL_AGENTS[@]}"; do
+  if [ -f "$RUN_DIR/$a/.done" ]; then echo "skip (done): $a"; else TODO+=("$a"); fi
+done
+
+# --- dispatch one batch's agents inside a PRE-CREATED worktree (bg job) ------
+# The worktree is created serially by the caller (git worktree add isn't safe to
+# race), so this function only does live dispatch — no shared-state mutation
+# beyond each agent's own disjoint .eval-parallel/<agent>/ dir.
+# Args: <batch-index> <worktree-path> <agent>...
+run_batch() {
+  local bi="$1" wt="$2"; shift 2
+  (
+    cd "$wt" || exit 1
+    mkdir -p .claude/evals
+    ln -sfn "$wt/evals/fixtures" .claude/evals/fixtures
+    ln -sfn "$wt/evals/expected" .claude/evals/expected
+    local agent out prompt n good
+    for agent in "$@"; do
+      out="$RUN_DIR/$agent"; mkdir -p "$out"
+      prompt="${PROMPT_BASE}"$'\n\n'"IMPORTANT: restrict this run to ONLY the agent '${agent}' and the fixtures that target it; skip every other agent and skill."
+      good=0
+      for n in $(seq 1 "$TRIALS"); do
+        rm -f actuals.json
+        claude -p "$prompt" --output-format json --max-turns 200 --model claude-sonnet-4-6 \
+          --allowedTools "Read" "Glob" "Grep" "Write" "Agent" \
+                         "Skill(review-agent *)" "Skill(test-design-advisor *)" \
+          >/dev/null 2>&1 || true
+        if jq -e . actuals.json >/dev/null 2>&1; then
+          cp actuals.json "$out/trial-${n}.json"; good=$((good + 1))
+        fi
+      done
+      rm -f actuals.json
+      if [ "$good" -gt 0 ]; then
+        touch "$out/.done"; echo "[batch $bi] done: $agent ($good/$TRIALS trial(s))"
+      else
+        echo "[batch $bi] NO actuals: $agent — left un-done for resume" >&2
+      fi
+    done
+  )
+}
+
+# --- partition TODO round-robin into JOBS batches, dispatch in parallel ------
+if [ "${#TODO[@]}" -gt 0 ]; then
+  declare -a BATCH=()
+  for ((i = 0; i < ${#TODO[@]}; i++)); do
+    bi=$(( i % JOBS ))
+    BATCH[bi]="${BATCH[bi]:-} ${TODO[i]}"
+  done
+  echo "== dispatching ${#TODO[@]} agent(s) across up to $JOBS batch(es), $TRIALS trial(s) each =="
+  pids=()
+  for ((bi = 0; bi < JOBS; bi++)); do
+    [ -n "${BATCH[$bi]:-}" ] || continue
+    wt="$WT_BASE/b$bi"
+    if ! git worktree add --detach "$wt" HEAD >/dev/null 2>&1; then   # serial: no race
+      echo "[batch $bi] worktree add failed — skipping batch" >&2; continue
+    fi
+    # shellcheck disable=SC2086
+    run_batch "$bi" "$wt" ${BATCH[$bi]} &
+    pids+=("$!")
+  done
+  fail=0
+  for p in "${pids[@]}"; do wait "$p" || fail=1; done
+  [ "$fail" -eq 0 ] || echo "warning: a batch exited non-zero; reconciling whatever landed." >&2
+else
+  echo "== all agents already harvested in $RUN_DIR — skipping dispatch, reconciling =="
+fi
+
+# ===================== DETERMINISTIC RECONCILE (serial) =====================
+# Collect each agent's FIRST good trial; union them (disjoint agent keys, so
+# jq's recursive `*` merge loses nothing) into one actuals for a single graded
+# baseline write. SUCCEEDED scopes the grade so absent agents keep their pairs.
+SUCCEEDED=(); FIRST_TRIALS=()
+for a in "${ALL_AGENTS[@]}"; do
+  ft="$(find "$RUN_DIR/$a" -name 'trial-*.json' 2>/dev/null | sort | head -1)"
+  [ -n "$ft" ] || continue
+  SUCCEEDED+=("$a"); FIRST_TRIALS+=("$ft")
+done
+if [ "${#SUCCEEDED[@]}" -eq 0 ]; then
+  echo "no actuals produced by any agent — nothing to grade." >&2; exit 1
+fi
+
+COMBINED="$(mktemp)"
+jq -s 'reduce .[] as $x ({}; . * $x)' "${FIRST_TRIALS[@]}" > "$COMBINED"
+ONLY="$(IFS=','; echo "${SUCCEEDED[*]}")"
+echo "== grading ${#SUCCEEDED[@]} agent(s) into evals/baseline.json =="
+python3 scripts/eval_grade.py --actuals "$COMBINED" --only "$ONLY" \
+  --write-baseline evals/baseline.json || { echo "grade failed" >&2; rm -f "$COMBINED"; exit 1; }
+rm -f "$COMBINED"
+
+# Variance trend (local, like the serial sweep): per agent with >1 trial.
+for a in "${SUCCEEDED[@]}"; do
+  tdir="$RUN_DIR/$a"
+  [ "$(find "$tdir" -name 'trial-*.json' | wc -l)" -gt 1 ] || continue
+  ve="$tdir/expected"; mkdir -p "$ve"
+  for ef in evals/expected/*.json; do
+    jq -e --arg a "$a" '.applicableAgents // [] | index($a)' "$ef" >/dev/null 2>&1 && cp "$ef" "$ve/"
+  done
+  python3 scripts/eval_variance.py --trials-dir "$tdir" --expected-dir "$ve" \
+    --append metrics/eval-variance.jsonl -o memory/eval-variance.json >/dev/null 2>&1 || true
+done
+
+# ===================== COMMIT + AUTO-MERGE PR (one PR) ======================
+if git diff --quiet -- evals/baseline.json; then
+  echo "== baseline unchanged across the harvest — no PR. =="
+  echo "   (trials kept in $RUN_DIR; re-run with --fresh for a clean re-harvest.)"
+  exit 0
+fi
+
+BRANCH="eval/sweep-parallel-${STAMP}"
+git checkout -b "$BRANCH" >/dev/null 2>&1 || { echo "branch create failed" >&2; exit 2; }
+git add evals/baseline.json
+git commit -q -m "test(evals): parallel sweep baseline refresh (${STAMP})
+
+Harvested ${#SUCCEEDED[@]} agent(s) across $JOBS worktree-isolated batch(es) via
+run-full-eval-parallel.sh, then graded once (deterministic) into evals/baseline.json
+scoped to the agents that produced actuals. Variance appended to the local trend."
+
+push_ok=0
+for delay in 0 2 4 8 16; do
+  [ "$delay" -gt 0 ] && sleep "$delay"
+  if git push -u origin "$BRANCH" >/dev/null 2>&1; then push_ok=1; break; fi
+done
+[ "$push_ok" -eq 1 ] || { echo "push failed after retries" >&2; exit 2; }
+
+PR_URL="$(gh pr create --title "test(evals): parallel sweep baseline refresh (${STAMP})" \
+  --body "Parallel full-corpus harvest via \`run-full-eval-parallel.sh\` — dispatch ran in
+$JOBS git-worktree-isolated batches, reconciled by a single deterministic grade into
+\`evals/baseline.json\` (scoped to the ${#SUCCEEDED[@]} agent(s) that produced actuals, so a
+failed dispatch can't drop an agent's pairs). Review the diff for **regressions** (pairs
+dropped) or **improvements** (pairs newly passing). Variance appended to the local trend." 2>/dev/null)"
+echo "opened: $PR_URL"
+gh pr merge "$(echo "$PR_URL" | grep -oE '[0-9]+$')" --auto --squash --delete-branch >/dev/null 2>&1 \
+  && echo "auto-merge enabled" || echo "could not enable auto-merge (enable manually)"
+echo "   (trials kept in $RUN_DIR; re-run with --fresh for a clean re-harvest.)"

--- a/tests/repo/run_full_eval_parallel_tests.bats
+++ b/tests/repo/run_full_eval_parallel_tests.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# run-full-eval-parallel.sh — guards the DETERMINISTIC reconciliation, the only
+# correctness-critical logic the parallel harness adds (dispatch itself needs live
+# models and isn't unit-tested). Two invariants:
+#   1. The jq deep-merge of per-agent FIRST trials is a loss-free union when agents
+#      are disjoint — even when two agents grade the SAME fixture stem.
+#   2. The grade is scoped (--only) to agents that produced actuals, so an agent
+#      that failed to dispatch keeps its existing baseline pairs (no wipe).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+GRADE="$REPO_ROOT/scripts/eval_grade.py"
+
+setup() {
+  TMP="$(mktemp -d)"
+}
+teardown() {
+  rm -rf "$TMP"
+}
+
+# The exact merge the script runs to union per-agent first trials.
+merge_actuals() {
+  jq -s 'reduce .[] as $x ({}; . * $x)' "$@"
+}
+
+@test "disjoint-agent trials union without loss (same stem, different agents)" {
+  # Two batches each produced one agent's actuals for the SAME fixture stem.
+  cat > "$TMP/a.json" <<'EOF'
+{"shared":{"agents":{"agent-a":{"status":"pass","issues":[]}}}}
+EOF
+  cat > "$TMP/b.json" <<'EOF'
+{"shared":{"agents":{"agent-b":{"status":"fail","issues":[]}}}}
+EOF
+  merge_actuals "$TMP/a.json" "$TMP/b.json" > "$TMP/out.json"
+  # Both agents survive under the shared stem — recursive merge, not clobber.
+  run jq -r '.shared.agents | keys | join(",")' "$TMP/out.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "agent-a,agent-b" ]
+  run jq -r '.shared.agents."agent-a".status' "$TMP/out.json"
+  [ "$output" = "pass" ]
+  run jq -r '.shared.agents."agent-b".status' "$TMP/out.json"
+  [ "$output" = "fail" ]
+}
+
+@test "merge of separate stems keeps every stem" {
+  echo '{"s1":{"agents":{"a":{"status":"pass","issues":[]}}}}' > "$TMP/a.json"
+  echo '{"s2":{"agents":{"b":{"status":"pass","issues":[]}}}}' > "$TMP/b.json"
+  merge_actuals "$TMP/a.json" "$TMP/b.json" > "$TMP/out.json"
+  run jq -r 'keys | join(",")' "$TMP/out.json"
+  [ "$output" = "s1,s2" ]
+}
+
+@test "scoped grade leaves an un-dispatched agent's baseline pairs untouched" {
+  # Corpus: two pairs, one per agent.
+  mkdir -p "$TMP/expected"
+  cat > "$TMP/expected/clean.json" <<'EOF'
+{"fixture":"clean.ts","applicableAgents":["agent-a"],"agents":{"agent-a":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
+EOF
+  cat > "$TMP/expected/other.json" <<'EOF'
+{"fixture":"other.ts","applicableAgents":["agent-b"],"agents":{"agent-b":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
+EOF
+  # Pre-existing baseline says agent-b's pair already passes.
+  cat > "$TMP/baseline.json" <<'EOF'
+{"_comment":"x","provenance":"measured","recorded_at":"2026-01-01T00:00:00Z","passing":["other::agent-b"]}
+EOF
+  # This harvest only produced actuals for agent-a (agent-b failed to dispatch).
+  cat > "$TMP/actuals.json" <<'EOF'
+{"clean":{"agents":{"agent-a":{"status":"pass","issues":[]}}}}
+EOF
+  run python3 "$GRADE" --expected-dir "$TMP/expected" --actuals "$TMP/actuals.json" \
+    --only "agent-a" --write-baseline "$TMP/baseline.json"
+  [ "$status" -eq 0 ]
+  # agent-b's pair must SURVIVE (scoped grade never tested it); agent-a's added.
+  run jq -r '.passing | sort | join(",")' "$TMP/baseline.json"
+  [ "$output" = "clean::agent-a,other::agent-b" ]
+}


### PR DESCRIPTION
## Summary

Adds `run-full-eval-parallel.sh`, a new evaluation harness that parallelizes agent trial dispatch across git worktrees while maintaining deterministic, loss-free reconciliation into a single baseline. Includes comprehensive unit tests for the reconciliation logic.

## Key Changes

- **New script: `scripts/run-full-eval-parallel.sh`**
  - Parallelizes dispatch across up to N worktree-isolated batches (default 3), each with its own working tree, index, and `actuals.json`
  - Partitions agents round-robin to keep batches balanced; agents are never split across batches
  - Resumable: per-agent trials stored in `.eval-parallel/<agent>/` with `.done` markers; re-run to pick up missing agents only
  - Deterministic reconciliation: collects each agent's first successful trial, unions them via jq recursive merge (loss-free for disjoint agent keys), then runs a single scoped grade
  - Scoped grading (`--only`) ensures agents that failed to dispatch retain their existing baseline pairs
  - Creates auto-merge PR with variance trend appended to local metrics
  - Supports `[TRIALS]`, `--jobs N`, and `--fresh` flags; requires `claude`, `gh`, `jq`, `python3`, `git` and valid API credentials

- **New test suite: `tests/repo/run_full_eval_parallel_tests.bats`**
  - Tests the deterministic merge of per-agent first trials (loss-free union even when agents grade the same fixture stem)
  - Tests that scoped grading preserves baseline pairs for agents that didn't produce actuals
  - Validates the two core correctness invariants of the parallel harness

- **Updated `.gitignore`**
  - Ignores `.eval-parallel/` directory (per-agent trial storage and resume markers)

## Implementation Details

The script's key design decisions:

1. **Worktree isolation**: Each batch runs in its own git worktree (created serially to avoid races), so concurrent dispatch doesn't collide on `actuals.json` or the git index.

2. **Disjoint per-agent directories**: Trial results live under `.eval-parallel/<agent>/`, not merged during dispatch. This prevents one batch's missing agent from resurrecting another batch's correctly-removed pairs.

3. **Single deterministic grade**: After all batches complete, a single `eval_grade.py` run (scoped to agents that produced actuals) reconciles the union of first trials into `evals/baseline.json`. The `--only` flag ensures absent agents keep their pairs.

4. **Resumable**: `.done` markers allow re-runs to skip already-harvested agents while still including them in the final grade.

5. **Variance tracking**: Per-agent variance computed locally (like the serial sweep) for agents with >1 trial, appended to `metrics/eval-variance.jsonl`.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS