### PR TITLE
fix(evals): make eval sweep scripts bash 3.2-compatible

### DIFF
--- a/scripts/run-full-eval-parallel.sh
+++ b/scripts/run-full-eval-parallel.sh
@@ -95,7 +95,11 @@ root, keyed by fixture stem:
 EOF
 
 # --- the corpus's agents, and which still need dispatching ------------------
-mapfile -t ALL_AGENTS < <(jq -r '.applicableAgents[]?' evals/expected/*.json 2>/dev/null | sort -u)
+# (read loop, not `mapfile` — the latter is bash 4+, absent on macOS's bash 3.2)
+ALL_AGENTS=()
+while IFS= read -r _agent; do
+  [ -n "$_agent" ] && ALL_AGENTS+=("$_agent")
+done < <(jq -r '.applicableAgents[]?' evals/expected/*.json 2>/dev/null | sort -u)
 [ "${#ALL_AGENTS[@]}" -gt 0 ] || { echo "no applicableAgents in evals/expected — nothing to do." >&2; exit 1; }
 
 TODO=()
@@ -160,7 +164,10 @@ if [ "${#TODO[@]}" -gt 0 ]; then
     pids+=("$!")
   done
   fail=0
-  for p in "${pids[@]}"; do wait "$p" || fail=1; done
+  # Guard the expansion: under `set -u`, bash 3.2 errors on "${empty[@]}".
+  if [ "${#pids[@]}" -gt 0 ]; then
+    for p in "${pids[@]}"; do wait "$p" || fail=1; done
+  fi
   [ "$fail" -eq 0 ] || echo "warning: a batch exited non-zero; reconciling whatever landed." >&2
 else
   echo "== all agents already harvested in $RUN_DIR — skipping dispatch, reconciling =="

--- a/scripts/run-full-eval.sh
+++ b/scripts/run-full-eval.sh
@@ -113,7 +113,12 @@ if [ -z "$ONLY_AGENT" ]; then
     echo "started sweep on '$BRANCH'."
   fi
 
-  mapfile -t ALL_AGENTS < <(jq -r '.applicableAgents[]?' evals/expected/*.json 2>/dev/null | sort -u)
+  # read loop, not `mapfile` — the latter is bash 4+, absent on macOS's bash 3.2
+  ALL_AGENTS=()
+  while IFS= read -r _agent; do
+    [ -n "$_agent" ] && ALL_AGENTS+=("$_agent")
+  done < <(jq -r '.applicableAgents[]?' evals/expected/*.json 2>/dev/null | sort -u)
+  [ "${#ALL_AGENTS[@]}" -gt 0 ] || { echo "no applicableAgents in evals/expected — nothing to do." >&2; exit 1; }
   for agent in "${ALL_AGENTS[@]}"; do
     if jq -e --arg a "$agent" '.done | index($a)' "$CKPT" >/dev/null 2>&1; then
       echo "skip (done): $agent"; continue


### PR DESCRIPTION
## What

Make both agent-eval sweep scripts run on **bash 3.2** (the macOS default `/bin/bash`).

Running `./scripts/run-full-eval-parallel.sh` on macOS aborted with:

```
mapfile: command not found
ALL_AGENTS: unbound variable
```

`mapfile` is bash 4+. Both `run-full-eval.sh` and `run-full-eval-parallel.sh` used it to enumerate agents, then `set -u` turned the empty array into the unbound-variable cascade.

## Changes

- **`run-full-eval.sh`** — replace `mapfile` with a portable `while IFS= read -r` loop; add an empty-corpus guard.
- **`run-full-eval-parallel.sh`** — the same read-loop fix, **plus** guard the `pids` array expansion (`"${empty[@]}"` also errors under `set -u` on bash 3.2).

> Note: the parallel-script fix originally landed on this branch *after* #219 had already auto-merged, so it never reached `main` — this PR re-applies it alongside the serial fix.

No behavior change on bash 4+.

## Verification

- `shellcheck` clean on both scripts (v0.10.0)
- `bash -n` syntax OK on both
- Existing `run_full_eval_parallel_tests.bats` reconciliation suite: 3/3 pass
- Exercised the new read-loop + round-robin partition against the real corpus — 13 agents enumerated and split into balanced batches

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_