### PR TITLE
feat(evals): trust-gated baseline writes + committed variance/quarantine (#230, #231)

### DIFF
--- a/scripts/eval_grade.py
+++ b/scripts/eval_grade.py
@@ -238,6 +238,9 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--fixtures-dir", default="evals/fixtures")
     ap.add_argument("--actuals")
     ap.add_argument("--baseline")
+    ap.add_argument("--quarantine",
+                    help="quarantine.json (#231): flaky pairs that fail but must "
+                         "not block — informs, does not gate")
     ap.add_argument("--only", default="",
                     help="comma-separated agent/skill names to grade "
                          "(diff-scoped run); empty means all")
@@ -274,6 +277,10 @@ def main(argv: list[str]) -> int:
 
     actuals = _load_json(Path(args.actuals))
     baseline = _load_json(Path(args.baseline)) if args.baseline else None
+    quarantined: set = set()
+    if args.quarantine and Path(args.quarantine).exists():
+        q = _load_json(Path(args.quarantine))
+        quarantined = set(q.get("quarantine", []) if isinstance(q, dict) else q)
 
     only = {s.strip() for s in args.only.split(",") if s.strip()} or None
     results, baseline_pass = run_grading(expected_dir, actuals, baseline, only)
@@ -325,14 +332,26 @@ def main(argv: list[str]) -> int:
         print("## Failures")
         for pair, _, fails in failed:
             regressed = baseline_pass is not None and pair in baseline_pass
-            tag = " [REGRESSION]" if regressed else ""
+            if regressed and pair in quarantined:
+                tag = " [QUARANTINED]"
+            elif regressed:
+                tag = " [REGRESSION]"
+            else:
+                tag = ""
             print(f"  ✗ {pair}{tag}")
             for f in fails:
                 print(f"      - {f}")
 
-    # Determine exit: with a baseline, only baseline-passing regressions block.
+    # Determine exit: with a baseline, only baseline-passing regressions block —
+    # and a quarantined (flaky) pair informs but never blocks (#231).
     if baseline_pass is not None:
-        regressions = [p for p, ok, _ in results if not ok and p in baseline_pass]
+        regressions = [p for p, ok, _ in results
+                       if not ok and p in baseline_pass and p not in quarantined]
+        ignored = [p for p, ok, _ in results
+                   if not ok and p in baseline_pass and p in quarantined]
+        if ignored:
+            print(f"\n{len(ignored)} baseline pair(s) failed but are quarantined "
+                  f"(flaky) — not blocking.")
         if regressions:
             print(f"\n{len(regressions)} regression(s) against baseline.")
             return 1

--- a/scripts/eval_variance.py
+++ b/scripts/eval_variance.py
@@ -49,7 +49,37 @@ def aggregate_trials(expected_dir: Path, trial_actuals: list[dict],
             trials[pair] += 1
             if passed:
                 passes[pair] += 1
+    return _assemble(passes, trials, flap_threshold)
 
+
+def aggregate_per_agent(expected_dir: Path, trials_root: Path, only: set,
+                        flap_threshold: float = 0.0) -> dict:
+    """Aggregate pass@k from a per-agent trial layout: ``<root>/<agent>/trial-*.json``.
+
+    Each agent's trial files contain only that agent's verdicts, so grading is
+    scoped to that agent (``run_grading(only={agent})``) — other agents' pairs are
+    not counted as fails for this agent's trials. This is what the parallel harness
+    produces, so the same K-trial pass@k feeds the trust-gated baseline write."""
+    passes: dict[str, int] = defaultdict(int)
+    trials: dict[str, int] = defaultdict(int)
+    for agent in only:
+        adir = trials_root / agent
+        if not adir.is_dir():
+            continue
+        for tf in sorted(adir.glob("trial-*.json")):
+            try:
+                actuals = json.loads(tf.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            results, _ = run_grading(expected_dir, actuals, None, only={agent})
+            for pair, passed, _fails in results:
+                trials[pair] += 1
+                if passed:
+                    passes[pair] += 1
+    return _assemble(passes, trials, flap_threshold)
+
+
+def _assemble(passes: dict, trials: dict, flap_threshold: float) -> dict:
     by_pair: dict[str, dict] = {}
     flaky: list[str] = []
     for pair in sorted(trials):
@@ -88,6 +118,57 @@ def aggregate_trials(expected_dir: Path, trial_actuals: list[dict],
     }
 
 
+def write_baseline(report: dict, target_path, demote_below: float,
+                   min_trials: int) -> tuple[list, list]:
+    """Trust-gated baseline write (#230). A pair is **added** only when it passed
+    every trial (pass@k == 1.0); **removed** only when it failed consistently
+    (pass@k <= demote_below) over >= min_trials AND is not flaky. A flaky pair is
+    never removed — it is quarantined instead (write_quarantine). So a single
+    noisy trial (trials < min_trials) can add but never delete. Returns
+    (added, removed) relative to the prior baseline."""
+    from datetime import datetime, timezone
+    target = Path(target_path)
+    existing: set = set()
+    if target.exists():
+        try:
+            existing = set(json.loads(target.read_text()).get("passing", []))
+        except (OSError, json.JSONDecodeError):
+            existing = set()
+    by_pair = report["by_pair"]
+    add = {p for p, d in by_pair.items() if d["pass_at_k"] >= 1.0}
+    remove = {p for p, d in by_pair.items()
+              if d["trials"] >= min_trials and d["pass_at_k"] <= demote_below
+              and not d["flap"]}
+    merged = (existing | add) - remove
+    target.write_text(json.dumps({
+        "_comment": "Regression baseline for the agent-eval CI gate (#99). "
+                    "Trust-gated (#230): a pair is removed only when it failed "
+                    "every trial (pass@k <= demote_below) over >= min_trials and "
+                    "is not flaky; a flaky pair is quarantined, not removed; a pair "
+                    "is added only when it passed all trials. Written by "
+                    "eval_variance.py --write-baseline.",
+        "provenance": "measured",
+        "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trials": report.get("trials", 0),
+        "passing": sorted(merged),
+    }, indent=2) + "\n")
+    return sorted(add - existing), sorted(existing & remove)
+
+
+def write_quarantine(report: dict, target_path) -> None:
+    """Persist the flaky-pair set the #99 grader excludes from blocking (#231)."""
+    from datetime import datetime, timezone
+    detail = {p: {"pass_at_k": d["pass_at_k"], "trials": d["trials"]}
+              for p, d in report["by_pair"].items() if d["flap"]}
+    Path(target_path).write_text(json.dumps({
+        "schema": "eval-variance/v1",
+        "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trials": report.get("trials", 0),
+        "quarantine": report.get("quarantine", []),
+        "detail": detail,
+    }, indent=2, sort_keys=True) + "\n")
+
+
 def _load_trials(trials_dir: Path) -> list[dict]:
     out = []
     for f in sorted(trials_dir.glob("*.json")):
@@ -116,28 +197,68 @@ def _slim(report: dict) -> dict:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--trials-dir", required=True,
-                    help="directory of per-trial actuals JSON files")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--trials-dir",
+                     help="directory of per-trial actuals JSON files (each a full "
+                          "cross-agent actuals mapping)")
+    src.add_argument("--trials-root",
+                     help="per-agent layout <root>/<agent>/trial-*.json; needs --only")
+    ap.add_argument("--only", default="",
+                    help="comma-separated agents to read under --trials-root")
     ap.add_argument("--expected-dir", default="evals/expected")
     ap.add_argument("--flap-threshold", type=float, default=0.0,
                     help="minority-outcome fraction above which a pair is flaky")
     ap.add_argument("-o", "--out")
     ap.add_argument("--append", metavar="LOG",
                     help="append one metrics-only trend record")
+    ap.add_argument("--write-baseline", metavar="PATH",
+                    help="write a trust-gated regression baseline (#230)")
+    ap.add_argument("--demote-below", type=float, default=0.0,
+                    help="remove a pair only when pass@k <= this (default 0.0 = "
+                         "failed every trial)")
+    ap.add_argument("--min-trials", type=int, default=2,
+                    help="a removal requires at least this many trials (default 2; "
+                         "guards against deleting on a single noisy sample)")
+    ap.add_argument("--quarantine-out", metavar="PATH",
+                    help="write the flaky-pair quarantine the grader excludes (#231)")
     args = ap.parse_args(argv)
 
-    trials = _load_trials(Path(args.trials_dir))
-    report = aggregate_trials(Path(args.expected_dir), trials, args.flap_threshold)
+    if args.trials_root:
+        only = {s.strip() for s in args.only.split(",") if s.strip()}
+        if not only:
+            print("error: --only is required with --trials-root", file=sys.stderr)
+            return 2
+        report = aggregate_per_agent(Path(args.expected_dir), Path(args.trials_root),
+                                     only, args.flap_threshold)
+    else:
+        trials = _load_trials(Path(args.trials_dir))
+        report = aggregate_trials(Path(args.expected_dir), trials, args.flap_threshold)
+
     out = json.dumps(report, indent=2, sort_keys=True)
     if args.out:
         Path(args.out).write_text(out + "\n")
-    else:
+    elif not (args.write_baseline or args.quarantine_out):
+        # Only dump the full report to stdout when not writing artifacts, so an
+        # artifact-writing run stays quiet enough to read its summary line.
         print(out)
     if args.append:
         log = Path(args.append)
         log.parent.mkdir(parents=True, exist_ok=True)
         with log.open("a") as fh:
             fh.write(json.dumps(_slim(report), sort_keys=True) + "\n")
+    if args.quarantine_out:
+        write_quarantine(report, args.quarantine_out)
+    if args.write_baseline:
+        added, removed = write_baseline(report, args.write_baseline,
+                                        args.demote_below, args.min_trials)
+        print(f"Baseline (trust-gated) → {args.write_baseline}: "
+              f"+{len(added)} / -{len(removed)} "
+              f"(min_trials={args.min_trials}, demote_below={args.demote_below}); "
+              f"{report['flaky_count']} quarantined")
+        if added:
+            print("  added:   " + ", ".join(added))
+        if removed:
+            print("  removed: " + ", ".join(removed))
     return 0
 
 

--- a/scripts/run-full-eval-parallel.sh
+++ b/scripts/run-full-eval-parallel.sh
@@ -29,7 +29,7 @@
 # it. Already-done agents still contribute to the final grade on resume.
 #
 # Usage:  bash scripts/run-full-eval-parallel.sh [TRIALS] [--jobs N] [--fresh]
-#         TRIALS default 1, --jobs default 3.
+#         TRIALS default 3 (multi-trial: the trust gate needs >1 to delete), --jobs default 3.
 # Env:    ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN, plus `claude` + `gh`.
 # Exit:   0 ok, 2 missing prereq/dirty tree, 1 run produced nothing.
 
@@ -37,7 +37,7 @@ set -uo pipefail
 MAIN_ROOT="$(git rev-parse --show-toplevel)" || exit 2
 cd "$MAIN_ROOT" || exit 2
 
-TRIALS=1; JOBS=3; FRESH=0
+TRIALS=3; JOBS=3; FRESH=0   # multi-trial by default (#230): the trust gate needs >1 trial to delete
 while [ $# -gt 0 ]; do
   case "$1" in
     --jobs)  JOBS="${2:-}"; shift 2 ;;
@@ -188,54 +188,49 @@ else
 fi
 
 # ===================== DETERMINISTIC RECONCILE (serial) =====================
-# Collect each agent's FIRST good trial; union them (disjoint agent keys, so
-# jq's recursive `*` merge loses nothing) into one actuals for a single graded
-# baseline write. SUCCEEDED scopes the grade so absent agents keep their pairs.
-SUCCEEDED=(); FIRST_TRIALS=()
+# Grade ALL of each agent's k trials at once (model-free) via eval_variance, which
+# computes pass@k per pair and writes three TRUST-RATED artifacts: a deletion-
+# guarded baseline (a pair is removed only if it failed every trial over >= 2
+# trials and isn't flaky — a single noisy trial can never delete), the full
+# variance report, and the quarantine the #99 grader excludes from blocking.
+# SUCCEEDED scopes the run so agents that produced no trials keep their pairs.
+SUCCEEDED=()
 for a in "${ALL_AGENTS[@]}"; do
-  ft="$(find "$RUN_DIR/$a" -name 'trial-*.json' 2>/dev/null | sort | head -1)"
-  [ -n "$ft" ] || continue
-  SUCCEEDED+=("$a"); FIRST_TRIALS+=("$ft")
+  [ -n "$(find "$RUN_DIR/$a" -name 'trial-*.json' 2>/dev/null | head -1)" ] && SUCCEEDED+=("$a")
 done
 if [ "${#SUCCEEDED[@]}" -eq 0 ]; then
   echo "no actuals produced by any agent — nothing to grade." >&2; exit 1
 fi
 
-COMBINED="$(mktemp)"
-jq -s 'reduce .[] as $x ({}; . * $x)' "${FIRST_TRIALS[@]}" > "$COMBINED"
 ONLY="$(IFS=','; echo "${SUCCEEDED[*]}")"
-echo "== grading ${#SUCCEEDED[@]} agent(s) into evals/baseline.json =="
-python3 scripts/eval_grade.py --actuals "$COMBINED" --only "$ONLY" \
-  --write-baseline evals/baseline.json || { echo "grade failed" >&2; rm -f "$COMBINED"; exit 1; }
-rm -f "$COMBINED"
-
-# Variance trend (local, like the serial sweep): per agent with >1 trial.
-for a in "${SUCCEEDED[@]}"; do
-  tdir="$RUN_DIR/$a"
-  [ "$(find "$tdir" -name 'trial-*.json' | wc -l)" -gt 1 ] || continue
-  ve="$tdir/expected"; mkdir -p "$ve"
-  for ef in evals/expected/*.json; do
-    jq -e --arg a "$a" '.applicableAgents // [] | index($a)' "$ef" >/dev/null 2>&1 && cp "$ef" "$ve/"
-  done
-  python3 scripts/eval_variance.py --trials-dir "$tdir" --expected-dir "$ve" \
-    --append metrics/eval-variance.jsonl -o memory/eval-variance.json >/dev/null 2>&1 || true
-done
+echo "== grading ${#SUCCEEDED[@]} agent(s) (${TRIALS} trial(s) each): trust-gated baseline + variance + quarantine =="
+python3 scripts/eval_variance.py --trials-root "$RUN_DIR" --only "$ONLY" \
+  --expected-dir evals/expected \
+  --write-baseline evals/baseline.json \
+  -o evals/variance-report.json \
+  --quarantine-out evals/quarantine.json \
+  --append metrics/eval-variance.jsonl \
+  || { echo "reconcile (eval_variance) failed" >&2; exit 1; }
 
 # ===================== COMMIT + AUTO-MERGE PR (one PR) ======================
 # Branch already exists (created up front). The trap restores base + drops it
 # if we never commit below.
-if git diff --quiet -- evals/baseline.json; then
-  echo "== baseline unchanged across the harvest — nothing to commit, no PR. =="
+ARTIFACTS=(evals/baseline.json evals/variance-report.json evals/quarantine.json)
+# Stage first: variance-report/quarantine are untracked on the first harvest, and
+# `git diff` (no --cached) can't see untracked files — so check the index.
+git add "${ARTIFACTS[@]}"
+if git diff --cached --quiet -- "${ARTIFACTS[@]}"; then
+  echo "== eval artifacts unchanged across the harvest — nothing to commit, no PR. =="
   echo "   (trials kept in $RUN_DIR; re-run with --fresh for a clean re-harvest.)"
   exit 0
 fi
+git commit -q -m "test(evals): parallel sweep — trust-gated baseline + variance (${STAMP})
 
-git add evals/baseline.json
-git commit -q -m "test(evals): parallel sweep baseline refresh (${STAMP})
-
-Harvested ${#SUCCEEDED[@]} agent(s) across $JOBS worktree-isolated batch(es) via
-run-full-eval-parallel.sh, then graded once (deterministic) into evals/baseline.json
-scoped to the agents that produced actuals. Variance appended to the local trend."
+Harvested ${#SUCCEEDED[@]} agent(s) across $JOBS worktree-isolated batch(es) at
+${TRIALS} trial(s) each, then graded all trials (deterministic) via eval_variance
+into a deletion-guarded evals/baseline.json plus evals/variance-report.json and
+evals/quarantine.json. Scoped to the agents that produced trials, so a failed
+dispatch can't drop an agent's pairs. Local variance trend appended."
 COMMITTED=1
 echo "== committed baseline on $BRANCH; per-agent trials are in $RUN_DIR =="
 
@@ -245,12 +240,13 @@ echo "== committed baseline on $BRANCH; per-agent trials are in $RUN_DIR =="
 # printed `git push` by hand.
 echo "== pushing $BRANCH (pre-push runs the local CI mirror — can take a minute)… =="
 if git push -u origin "$BRANCH"; then
-  PR_URL="$(gh pr create --title "test(evals): parallel sweep baseline refresh (${STAMP})" \
-    --body "Parallel full-corpus harvest via \`run-full-eval-parallel.sh\` — dispatch ran in
-$JOBS git-worktree-isolated batches, reconciled by a single deterministic grade into
-\`evals/baseline.json\` (scoped to the ${#SUCCEEDED[@]} agent(s) that produced actuals, so a
-failed dispatch can't drop an agent's pairs). Review the diff for **regressions** (pairs
-dropped) or **improvements** (pairs newly passing). Variance appended to the local trend." 2>/dev/null)"
+  PR_URL="$(gh pr create --title "test(evals): trust-gated sweep baseline + variance (${STAMP})" \
+    --body "Parallel full-corpus harvest via \`run-full-eval-parallel.sh\` (${TRIALS} trial(s)/agent) —
+dispatch ran in $JOBS git-worktree-isolated batches, then a single deterministic \`eval_variance\`
+pass over all trials wrote a **trust-gated** \`evals/baseline.json\` (a pair is removed only if it
+failed every trial over >= 2 trials and isn't flaky), plus \`evals/variance-report.json\` and
+\`evals/quarantine.json\`. Scoped to the ${#SUCCEEDED[@]} agent(s) that produced trials. Review the
+baseline diff for **regressions**/**improvements** and the quarantine for newly-flaky pairs." 2>/dev/null)"
   echo "opened: $PR_URL"
   gh pr merge "$(echo "$PR_URL" | grep -oE '[0-9]+$')" --auto --squash --delete-branch >/dev/null 2>&1 \
     && echo "auto-merge enabled" || echo "could not enable auto-merge (enable manually)"

--- a/tests/repo/eval_validation_tests.bats
+++ b/tests/repo/eval_validation_tests.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Eval validation gap — Phase 1 (#229/#230/#231). Trust-gated baseline writes and
+# quarantine consumption. Model-free (synthetic per-trial actuals), so it runs in
+# CI like the rest of the grader.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+VAR="$REPO_ROOT/scripts/eval_variance.py"
+GRADE="$REPO_ROOT/scripts/eval_grade.py"
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/expected" "$TMP/trials"
+  # One single-agent fixture per agent so pairs are <stem>::<agent>.
+  for stem in a b c d; do
+    cat > "$TMP/expected/$stem.json" <<EOF
+{"fixture":"$stem.ts","applicableAgents":["ag-$stem"],"agents":{"ag-$stem":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
+EOF
+    mkdir -p "$TMP/trials/ag-$stem"
+  done
+}
+teardown() { rm -rf "$TMP"; }
+
+# Write N trials for agent ag-$stem on fixture $stem with the given status each.
+# usage: trials <stem> <status1> <status2> ...
+trials() {
+  local stem="$1"; shift; local n=0
+  for st in "$@"; do
+    n=$((n + 1))
+    echo "{\"$stem\":{\"agents\":{\"ag-$stem\":{\"status\":\"$st\",\"issues\":[]}}}}" \
+      > "$TMP/trials/ag-$stem/trial-$n.json"
+  done
+}
+
+run_baseline() {  # run_baseline <only-csv> [extra args...]
+  python3 "$VAR" --trials-root "$TMP/trials" --only "$1" --expected-dir "$TMP/expected" \
+    --write-baseline "$TMP/baseline.json" --quarantine-out "$TMP/quarantine.json" "${@:2}"
+}
+
+@test "all-pass pair is added to the baseline" {
+  trials a pass pass pass
+  echo '{"passing":[]}' > "$TMP/baseline.json"
+  run run_baseline "ag-a"
+  [ "$status" -eq 0 ]
+  run jq -r '.passing | join(",")' "$TMP/baseline.json"
+  [ "$output" = "a::ag-a" ]
+}
+
+@test "consistently-failing pair (pass@k 0 over >= min_trials) is removed" {
+  trials b fail fail fail
+  echo '{"passing":["b::ag-b"]}' > "$TMP/baseline.json"
+  run run_baseline "ag-b"
+  [ "$status" -eq 0 ]
+  run jq -r '.passing | length' "$TMP/baseline.json"
+  [ "$output" = "0" ]
+}
+
+@test "single-trial failure does NOT delete (trials < min_trials) — the -9 fix" {
+  trials b fail               # exactly one trial
+  echo '{"passing":["b::ag-b"]}' > "$TMP/baseline.json"
+  run run_baseline "ag-b"
+  [ "$status" -eq 0 ]
+  run jq -r '.passing | join(",")' "$TMP/baseline.json"
+  [ "$output" = "b::ag-b" ]   # survived the noisy single sample
+}
+
+@test "flaky pair is quarantined and NOT removed" {
+  trials c pass pass fail      # 2/3 -> flaky
+  echo '{"passing":["c::ag-c"]}' > "$TMP/baseline.json"
+  run run_baseline "ag-c"
+  [ "$status" -eq 0 ]
+  run jq -r '.passing | join(",")' "$TMP/baseline.json"
+  [ "$output" = "c::ag-c" ]                       # kept
+  run jq -r '.quarantine | join(",")' "$TMP/quarantine.json"
+  [ "$output" = "c::ag-c" ]                       # and quarantined
+}
+
+@test "per-agent scoping leaves an un-run agent's baseline pairs untouched" {
+  trials a pass pass pass                          # only ag-a runs
+  echo '{"passing":["d::ag-d"]}' > "$TMP/baseline.json"
+  run run_baseline "ag-a"
+  [ "$status" -eq 0 ]
+  run jq -r '.passing | sort | join(",")' "$TMP/baseline.json"
+  [ "$output" = "a::ag-a,d::ag-d" ]                # d untouched, a added
+}
+
+@test "grader excludes quarantined pairs from blocking (#231)" {
+  # c is flaky+quarantined and in the baseline; a fresh run where it fails again
+  # must NOT block the gate.
+  echo '{"passing":["c::ag-c"]}' > "$TMP/baseline.json"
+  echo '{"quarantine":["c::ag-c"]}' > "$TMP/quarantine.json"
+  echo '{"c":{"agents":{"ag-c":{"status":"fail","issues":[]}}}}' > "$TMP/run.json"
+  run python3 "$GRADE" --expected-dir "$TMP/expected" --actuals "$TMP/run.json" \
+    --baseline "$TMP/baseline.json" --quarantine "$TMP/quarantine.json" --only ag-c
+  [ "$status" -eq 0 ]
+}
+
+@test "grader still blocks a real (non-quarantined) regression" {
+  echo '{"passing":["c::ag-c"]}' > "$TMP/baseline.json"
+  echo '{"quarantine":[]}' > "$TMP/quarantine.json"
+  echo '{"c":{"agents":{"ag-c":{"status":"fail","issues":[]}}}}' > "$TMP/run.json"
+  run python3 "$GRADE" --expected-dir "$TMP/expected" --actuals "$TMP/run.json" \
+    --baseline "$TMP/baseline.json" --quarantine "$TMP/quarantine.json" --only ag-c
+  [ "$status" -eq 1 ]
+}

--- a/tests/repo/run_full_eval_parallel_tests.bats
+++ b/tests/repo/run_full_eval_parallel_tests.bats
@@ -1,75 +1,59 @@
 #!/usr/bin/env bats
-# run-full-eval-parallel.sh — guards the DETERMINISTIC reconciliation, the only
-# correctness-critical logic the parallel harness adds (dispatch itself needs live
-# models and isn't unit-tested). Two invariants:
-#   1. The jq deep-merge of per-agent FIRST trials is a loss-free union when agents
-#      are disjoint — even when two agents grade the SAME fixture stem.
-#   2. The grade is scoped (--only) to agents that produced actuals, so an agent
-#      that failed to dispatch keeps its existing baseline pairs (no wipe).
+# run-full-eval-parallel.sh — guards the DETERMINISTIC reconciliation the parallel
+# harness performs. Since #230/#231 the reconcile is a single `eval_variance
+# --trials-root` pass over each agent's k trials (the unit rules live in
+# eval_validation_tests.bats); this file asserts the end-to-end harness command
+# produces all three trust-rated artifacts from a synthetic per-agent pool, and
+# that scoping protects un-run agents. Model-free, so it runs in CI.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
-GRADE="$REPO_ROOT/scripts/eval_grade.py"
+VAR="$REPO_ROOT/scripts/eval_variance.py"
 
 setup() {
   TMP="$(mktemp -d)"
-}
-teardown() {
-  rm -rf "$TMP"
-}
-
-# The exact merge the script runs to union per-agent first trials.
-merge_actuals() {
-  jq -s 'reduce .[] as $x ({}; . * $x)' "$@"
-}
-
-@test "disjoint-agent trials union without loss (same stem, different agents)" {
-  # Two batches each produced one agent's actuals for the SAME fixture stem.
-  cat > "$TMP/a.json" <<'EOF'
-{"shared":{"agents":{"agent-a":{"status":"pass","issues":[]}}}}
-EOF
-  cat > "$TMP/b.json" <<'EOF'
-{"shared":{"agents":{"agent-b":{"status":"fail","issues":[]}}}}
-EOF
-  merge_actuals "$TMP/a.json" "$TMP/b.json" > "$TMP/out.json"
-  # Both agents survive under the shared stem — recursive merge, not clobber.
-  run jq -r '.shared.agents | keys | join(",")' "$TMP/out.json"
-  [ "$status" -eq 0 ]
-  [ "$output" = "agent-a,agent-b" ]
-  run jq -r '.shared.agents."agent-a".status' "$TMP/out.json"
-  [ "$output" = "pass" ]
-  run jq -r '.shared.agents."agent-b".status' "$TMP/out.json"
-  [ "$output" = "fail" ]
-}
-
-@test "merge of separate stems keeps every stem" {
-  echo '{"s1":{"agents":{"a":{"status":"pass","issues":[]}}}}' > "$TMP/a.json"
-  echo '{"s2":{"agents":{"b":{"status":"pass","issues":[]}}}}' > "$TMP/b.json"
-  merge_actuals "$TMP/a.json" "$TMP/b.json" > "$TMP/out.json"
-  run jq -r 'keys | join(",")' "$TMP/out.json"
-  [ "$output" = "s1,s2" ]
-}
-
-@test "scoped grade leaves an un-dispatched agent's baseline pairs untouched" {
-  # Corpus: two pairs, one per agent.
-  mkdir -p "$TMP/expected"
+  mkdir -p "$TMP/expected" "$TMP/pool/agent-a" "$TMP/pool/agent-b"
   cat > "$TMP/expected/clean.json" <<'EOF'
 {"fixture":"clean.ts","applicableAgents":["agent-a"],"agents":{"agent-a":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
 EOF
   cat > "$TMP/expected/other.json" <<'EOF'
 {"fixture":"other.ts","applicableAgents":["agent-b"],"agents":{"agent-b":{"expectedStatus":"pass","issueCount":{"min":0,"max":0}}}}
 EOF
-  # Pre-existing baseline says agent-b's pair already passes.
-  cat > "$TMP/baseline.json" <<'EOF'
-{"_comment":"x","provenance":"measured","recorded_at":"2026-01-01T00:00:00Z","passing":["other::agent-b"]}
-EOF
-  # This harvest only produced actuals for agent-a (agent-b failed to dispatch).
-  cat > "$TMP/actuals.json" <<'EOF'
-{"clean":{"agents":{"agent-a":{"status":"pass","issues":[]}}}}
-EOF
-  run python3 "$GRADE" --expected-dir "$TMP/expected" --actuals "$TMP/actuals.json" \
-    --only "agent-a" --write-baseline "$TMP/baseline.json"
+  # agent-a: 3/3 pass on clean; agent-b: 3/3 fail on other (was passing).
+  for n in 1 2 3; do
+    echo '{"clean":{"agents":{"agent-a":{"status":"pass","issues":[]}}}}' > "$TMP/pool/agent-a/trial-$n.json"
+    echo '{"other":{"agents":{"agent-b":{"status":"fail","issues":[]}}}}' > "$TMP/pool/agent-b/trial-$n.json"
+  done
+  echo '{"passing":["other::agent-b"]}' > "$TMP/baseline.json"
+}
+teardown() { rm -rf "$TMP"; }
+
+# The exact reconcile command the harness runs.
+reconcile() {  # reconcile <only-csv>
+  python3 "$VAR" --trials-root "$TMP/pool" --only "$1" --expected-dir "$TMP/expected" \
+    --write-baseline "$TMP/baseline.json" \
+    -o "$TMP/variance-report.json" \
+    --quarantine-out "$TMP/quarantine.json"
+}
+
+@test "reconcile writes all three trust-rated artifacts" {
+  run reconcile "agent-a,agent-b"
   [ "$status" -eq 0 ]
-  # agent-b's pair must SURVIVE (scoped grade never tested it); agent-a's added.
+  [ -f "$TMP/baseline.json" ]
+  [ -f "$TMP/variance-report.json" ]
+  [ -f "$TMP/quarantine.json" ]
+  run jq -r '.schema' "$TMP/variance-report.json"
+  [ "$output" = "eval-variance/v1" ]
+}
+
+@test "reconcile adds a solidly-passing agent and removes a consistently-failing one" {
+  reconcile "agent-a,agent-b"
+  run jq -r '.passing | sort | join(",")' "$TMP/baseline.json"
+  [ "$output" = "clean::agent-a" ]   # agent-a added; other::agent-b removed (0/3)
+}
+
+@test "an un-run agent's baseline pairs survive the reconcile" {
+  # Only agent-a runs; agent-b's prior pair must be left untouched.
+  reconcile "agent-a"
   run jq -r '.passing | sort | join(",")' "$TMP/baseline.json"
   [ "$output" = "clean::agent-a,other::agent-b" ]
 }


### PR DESCRIPTION
Phase 1 of the eval validation gap epic (**#229**). **Closes #230, #231.**

## Problem
The harvest graded a **single** non-deterministic trial and committed it as the regression baseline, so one noisy run could delete previously-passing pairs (the observed **−9**). `eval_variance.py` already computed pass@k + a quarantine list, but it was discarded; the #99 grader had no way to ignore flaky pairs.

## Change
- **`eval_variance.py`** — per-agent trial reader (`--trials-root`/`--only`), a **trust-gated baseline writer** (`--write-baseline`): a pair is **removed** only when it failed *every* trial over `--min-trials` (default 2) and isn't flaky; **added** only when it passed all trials. A single trial can add but **never delete**. Plus a quarantine writer (`--quarantine-out`). Shared aggregation refactored into `_assemble`.
- **`eval_grade.py`** — `--quarantine` excludes flaky pairs from blocking the gate (informs, doesn't gate) while still reporting them.
- **`run-full-eval-parallel.sh`** — defaults to **3 trials**; reconcile is one `eval_variance` pass that writes `evals/baseline.json` (deletion-guarded), `evals/variance-report.json`, and `evals/quarantine.json`, committed together in one PR.

## Verification (all model-free)
- New `tests/repo/eval_validation_tests.bats` (7) — guard rules incl. **"single-trial failure does NOT delete"**, flaky→quarantine, grader honors/ignores quarantine correctly.
- Updated `run_full_eval_parallel_tests.bats` (3) — end-to-end reconcile writes all three artifacts; scoping protects un-run agents.
- **Full `tests/repo/` suite: 211/211 pass.** shellcheck clean. `eval_grade.py --check-corpus` OK.

## Follow-ons (same epic)
- **#232** trial-pool hygiene (stale `trial-*.json`)
- **#233** #99 live gate consumes pass@k thresholds + quarantine

Out of scope / blocked on live model runs: **#213** (operator harvest), **#107** ablation, **#110** persona, **#214** raw-log tier.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_