### PR TITLE
feat(evals): trial-pool hygiene — manifest + staleness guard (#232)

### DIFF
--- a/scripts/eval_variance.py
+++ b/scripts/eval_variance.py
@@ -119,7 +119,7 @@ def _assemble(passes: dict, trials: dict, flap_threshold: float) -> dict:
 
 
 def write_baseline(report: dict, target_path, demote_below: float,
-                   min_trials: int) -> tuple[list, list]:
+                   min_trials: int, harvest_id: str | None = None) -> tuple[list, list]:
     """Trust-gated baseline write (#230). A pair is **added** only when it passed
     every trial (pass@k == 1.0); **removed** only when it failed consistently
     (pass@k <= demote_below) over >= min_trials AND is not flaky. A flaky pair is
@@ -140,7 +140,7 @@ def write_baseline(report: dict, target_path, demote_below: float,
               if d["trials"] >= min_trials and d["pass_at_k"] <= demote_below
               and not d["flap"]}
     merged = (existing | add) - remove
-    target.write_text(json.dumps({
+    record = {
         "_comment": "Regression baseline for the agent-eval CI gate (#99). "
                     "Trust-gated (#230): a pair is removed only when it failed "
                     "every trial (pass@k <= demote_below) over >= min_trials and "
@@ -151,22 +151,28 @@ def write_baseline(report: dict, target_path, demote_below: float,
         "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "trials": report.get("trials", 0),
         "passing": sorted(merged),
-    }, indent=2) + "\n")
+    }
+    if harvest_id:
+        record["harvest_id"] = harvest_id  # provenance: which harvest measured this (#232)
+    target.write_text(json.dumps(record, indent=2) + "\n")
     return sorted(add - existing), sorted(existing & remove)
 
 
-def write_quarantine(report: dict, target_path) -> None:
+def write_quarantine(report: dict, target_path, harvest_id: str | None = None) -> None:
     """Persist the flaky-pair set the #99 grader excludes from blocking (#231)."""
     from datetime import datetime, timezone
     detail = {p: {"pass_at_k": d["pass_at_k"], "trials": d["trials"]}
               for p, d in report["by_pair"].items() if d["flap"]}
-    Path(target_path).write_text(json.dumps({
+    record = {
         "schema": "eval-variance/v1",
         "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "trials": report.get("trials", 0),
         "quarantine": report.get("quarantine", []),
         "detail": detail,
-    }, indent=2, sort_keys=True) + "\n")
+    }
+    if harvest_id:
+        record["harvest_id"] = harvest_id
+    Path(target_path).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
 
 
 def _load_trials(trials_dir: Path) -> list[dict]:
@@ -221,6 +227,8 @@ def main(argv=None) -> int:
                          "guards against deleting on a single noisy sample)")
     ap.add_argument("--quarantine-out", metavar="PATH",
                     help="write the flaky-pair quarantine the grader excludes (#231)")
+    ap.add_argument("--harvest-id",
+                    help="stamp this harvest id into the written artifacts (#232 provenance)")
     args = ap.parse_args(argv)
 
     if args.trials_root:
@@ -234,6 +242,8 @@ def main(argv=None) -> int:
         trials = _load_trials(Path(args.trials_dir))
         report = aggregate_trials(Path(args.expected_dir), trials, args.flap_threshold)
 
+    if args.harvest_id:
+        report["harvest_id"] = args.harvest_id
     out = json.dumps(report, indent=2, sort_keys=True)
     if args.out:
         Path(args.out).write_text(out + "\n")
@@ -247,10 +257,11 @@ def main(argv=None) -> int:
         with log.open("a") as fh:
             fh.write(json.dumps(_slim(report), sort_keys=True) + "\n")
     if args.quarantine_out:
-        write_quarantine(report, args.quarantine_out)
+        write_quarantine(report, args.quarantine_out, args.harvest_id)
     if args.write_baseline:
         added, removed = write_baseline(report, args.write_baseline,
-                                        args.demote_below, args.min_trials)
+                                        args.demote_below, args.min_trials,
+                                        args.harvest_id)
         print(f"Baseline (trust-gated) → {args.write_baseline}: "
               f"+{len(added)} / -{len(removed)} "
               f"(min_trials={args.min_trials}, demote_below={args.demote_below}); "

--- a/scripts/run-full-eval-parallel.sh
+++ b/scripts/run-full-eval-parallel.sh
@@ -10,23 +10,21 @@
 # batch its own cwd, index, and `actuals.json`, so the only *expensive* part (the
 # live `claude -p` dispatch) runs concurrently without collisions.
 #
-# Why the grade is NOT parallelized: `evals/baseline.json` is a flat `passing`
-# pair-list merged as `(existing | passed) - failed`. A batch that never ran agent
-# X still carries X's old passing pairs, so unioning per-batch baselines would
-# RESURRECT pairs another batch correctly removed. The safe design is therefore:
-# parallelize dispatch only; collect each agent's trial actuals into a disjoint
-# per-agent dir; then run ONE deterministic, model-free grade over the union,
-# scoped (`--only`) to the agents that actually produced actuals so a failed
-# dispatch never wipes an agent's baseline.
+# Why the grade is NOT parallelized: only dispatch is. Each agent's k trials land
+# in a disjoint per-agent dir; then ONE deterministic, model-free `eval_variance`
+# pass over all trials writes the TRUST-GATED baseline + variance-report +
+# quarantine (#230/#231), scoped (`--only`) to the agents that produced a complete
+# trial set, so a failed dispatch never wipes an agent's baseline.
 #
 # Partition unit is the AGENT: an agent's trials must be graded together (pass@k /
 # variance), so an agent is never split across batches. Round-robin keeps batches
 # balanced. Real speedup is bounded by your account's API rate/token pace, not by
 # --jobs; burns budget faster too. N=2-4 is the sane range (#142 pace guidance).
 #
-# Resumable: per-agent trials live under .eval-parallel/<agent>/ (gitignored) with
-# a `.done` marker. Re-run to pick up only the agents still missing; --fresh wipes
-# it. Already-done agents still contribute to the final grade on resume.
+# Resumable + hygienic (#232): per-agent trials live under .eval-parallel/<agent>/
+# (gitignored); `.done` means a COMPLETE k-trial set. A manifest pins {base_sha, k}
+# so a resume onto a different commit or k is refused (mixing corrupts pass@k);
+# re-dispatching an agent clears its stale partial trials first. --fresh wipes all.
 #
 # Usage:  bash scripts/run-full-eval-parallel.sh [TRIALS] [--jobs N] [--fresh]
 #         TRIALS default 3 (multi-trial: the trust gate needs >1 to delete), --jobs default 3.
@@ -93,6 +91,33 @@ trap cleanup EXIT
 [ "$FRESH" = 1 ] && rm -rf "$RUN_DIR"
 mkdir -p "$RUN_DIR"
 
+# --- trial-pool hygiene: manifest + staleness guard (#232) ------------------
+# Every trial feeding one harvest must share the same tree state and k, or pass@k
+# is meaningless. The manifest pins them; resuming onto a different base commit or
+# a different k is refused (abort-and-tell — never silently discard an expensive
+# partial harvest). --fresh already wiped the pool + manifest above.
+BASE_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+MANIFEST="$RUN_DIR/manifest.json"
+if [ -f "$MANIFEST" ]; then
+  m_sha="$(jq -r '.base_sha // ""' "$MANIFEST" 2>/dev/null)"
+  m_k="$(jq -r '.k // ""' "$MANIFEST" 2>/dev/null)"
+  if [ "$m_sha" != "$BASE_SHA" ] || [ "$m_k" != "$TRIALS" ]; then
+    echo "stale trial pool in $RUN_DIR — refusing to mix harvests:" >&2
+    [ "$m_sha" != "$BASE_SHA" ] && echo "  base commit changed: $m_sha -> $BASE_SHA" >&2
+    [ "$m_k" != "$TRIALS" ] && echo "  trial count changed: k=$m_k -> k=$TRIALS" >&2
+    echo "  mixing trials across harvests corrupts pass@k. Re-run with --fresh." >&2
+    exit 2
+  fi
+  HARVEST_ID="$(jq -r '.harvest_id // ""' "$MANIFEST" 2>/dev/null)"
+  echo "== resuming harvest ${HARVEST_ID} (base ${BASE_SHA:0:9}, k=$TRIALS) =="
+else
+  HARVEST_ID="$STAMP"
+  jq -n --arg h "$HARVEST_ID" --arg s "$BASE_SHA" --argjson k "$TRIALS" \
+        --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{harvest_id:$h, base_sha:$s, k:$k, started_at:$t}' > "$MANIFEST"
+  echo "== new harvest ${HARVEST_ID} (base ${BASE_SHA:0:9}, k=$TRIALS) =="
+fi
+
 read -r -d '' PROMPT_BASE <<'EOF'
 Run the review agents against the fixtures in .claude/evals/fixtures/ whose paired
 .claude/evals/expected/<stem>.json declares an applicableAgents target, via the
@@ -135,7 +160,10 @@ run_batch() {
     ln -sfn "$wt/evals/expected" .claude/evals/expected
     local agent out prompt n good
     for agent in "$@"; do
-      out="$RUN_DIR/$agent"; mkdir -p "$out"
+      # Clear-before-(re)dispatch (#232): an agent we're dispatching is not .done,
+      # so any trials present are a stale partial set — wipe them so this agent's
+      # pool is exactly this harvest's trial-1..k.
+      out="$RUN_DIR/$agent"; rm -rf "$out"; mkdir -p "$out"
       prompt="${PROMPT_BASE}"$'\n\n'"IMPORTANT: restrict this run to ONLY the agent '${agent}' and the fixtures that target it; skip every other agent and skill."
       good=0
       for n in $(seq 1 "$TRIALS"); do
@@ -149,10 +177,12 @@ run_batch() {
         fi
       done
       rm -f actuals.json
-      if [ "$good" -gt 0 ]; then
+      # .done means a COMPLETE k-trial set (#232) — a partial set is left un-done
+      # so resume re-dispatches it fresh (cleared above), never half-graded.
+      if [ "$good" -eq "$TRIALS" ]; then
         touch "$out/.done"; echo "[batch $bi] done: $agent ($good/$TRIALS trial(s))"
       else
-        echo "[batch $bi] NO actuals: $agent — left un-done for resume" >&2
+        echo "[batch $bi] partial: $agent ($good/$TRIALS) — left un-done for resume" >&2
       fi
     done
   )
@@ -194,18 +224,21 @@ fi
 # trials and isn't flaky — a single noisy trial can never delete), the full
 # variance report, and the quarantine the #99 grader excludes from blocking.
 # SUCCEEDED scopes the run so agents that produced no trials keep their pairs.
+# Only COMPLETE agents (.done == k trials, #232) are graded — a partial set never
+# reaches the trust gate.
 SUCCEEDED=()
 for a in "${ALL_AGENTS[@]}"; do
-  [ -n "$(find "$RUN_DIR/$a" -name 'trial-*.json' 2>/dev/null | head -1)" ] && SUCCEEDED+=("$a")
+  [ -f "$RUN_DIR/$a/.done" ] && SUCCEEDED+=("$a")
 done
 if [ "${#SUCCEEDED[@]}" -eq 0 ]; then
-  echo "no actuals produced by any agent — nothing to grade." >&2; exit 1
+  echo "no complete agents (.done) — nothing to grade. Re-run to finish partials." >&2; exit 1
 fi
 
 ONLY="$(IFS=','; echo "${SUCCEEDED[*]}")"
 echo "== grading ${#SUCCEEDED[@]} agent(s) (${TRIALS} trial(s) each): trust-gated baseline + variance + quarantine =="
 python3 scripts/eval_variance.py --trials-root "$RUN_DIR" --only "$ONLY" \
   --expected-dir evals/expected \
+  --harvest-id "$HARVEST_ID" \
   --write-baseline evals/baseline.json \
   -o evals/variance-report.json \
   --quarantine-out evals/quarantine.json \

--- a/tests/repo/eval_validation_tests.bats
+++ b/tests/repo/eval_validation_tests.bats
@@ -94,6 +94,18 @@ run_baseline() {  # run_baseline <only-csv> [extra args...]
   [ "$status" -eq 0 ]
 }
 
+@test "harvest-id is stamped into every written artifact (#232 provenance)" {
+  trials a pass pass pass
+  echo '{"passing":[]}' > "$TMP/baseline.json"
+  run python3 "$VAR" --trials-root "$TMP/trials" --only ag-a --expected-dir "$TMP/expected" \
+    --harvest-id "H-123" --write-baseline "$TMP/baseline.json" \
+    -o "$TMP/variance.json" --quarantine-out "$TMP/quarantine.json"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.harvest_id' "$TMP/baseline.json")" = "H-123" ]
+  [ "$(jq -r '.harvest_id' "$TMP/variance.json")" = "H-123" ]
+  [ "$(jq -r '.harvest_id' "$TMP/quarantine.json")" = "H-123" ]
+}
+
 @test "grader still blocks a real (non-quarantined) regression" {
   echo '{"passing":["c::ag-c"]}' > "$TMP/baseline.json"
   echo '{"quarantine":[]}' > "$TMP/quarantine.json"


### PR DESCRIPTION
Part of the eval validation gap epic (**#229**). **Closes #232.**

## Problem
`.eval-parallel/<agent>/trial-*.json` accumulated across resumed runs and was never pruned, so a partial re-run could mix trials from different harvests — or different code/tree states — for the same agent, silently invalidating pass@k. `.done` meant "≥1 trial," so a half-finished agent could be graded.

## Change
- **Pool manifest** (`.eval-parallel/manifest.json`) pins `{harvest_id, base_sha, k}`. Resuming onto a different base commit or a different `k` is **refused** (abort-and-tell — never silently discards an expensive partial harvest; this resolves the epic's open question).
- **Clear-before-(re)dispatch:** an agent being dispatched is not `.done`, so its dir is wiped first — its pool is always exactly this harvest's `trial-1..k`.
- **`.done` = a COMPLETE k-trial set** (was "≥1"); a partial agent is left un-done and re-dispatched fresh on resume, never half-graded. The reconcile grades only `.done` agents.
- **Provenance carry-through:** `harvest_id` is stamped into `evals/baseline.json`, `variance-report.json`, and `quarantine.json` via `eval_variance.py --harvest-id`, so each artifact names the harvest (and `base_sha`) it was measured from.

## Verification
- New provenance test in `eval_validation_tests.bats`; full `tests/repo/` suite **212/212**. shellcheck clean; `--check-corpus` OK.
- The manifest/staleness/clear/`.done` logic is shell-level (it gates the live `claude` dispatch, which can't run here) — validated by shellcheck + `bash -n` + review, and exercised on the next real harvest. The `--harvest-id` provenance and the reconcile it feeds are covered model-free.

## Remaining in the epic
- **#233** #99 live gate consumes pass@k thresholds + quarantine (next).

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_