### PR TITLE
feat(evals): #99 live gate honors the quarantine (#233)

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -248,7 +248,12 @@ jobs:
               "wrote no file. The live gate will exercise the agents after merge."
             exit 0
           fi
+          # Honor the quarantine (#233): flaky pairs recorded by a multi-trial
+          # harvest (eval_variance) inform but must NOT block the gate. The grader
+          # treats a missing quarantine.json as an empty set, so this is safe
+          # before the first harvest commits one.
           python3 scripts/eval_grade.py \
             --actuals actuals.json \
             --baseline evals/baseline.json \
+            --quarantine evals/quarantine.json \
             --only "${{ steps.scope.outputs.only }}"


### PR DESCRIPTION
Part of the eval validation gap epic (**#229**). **Closes #233.** Final deterministic piece of the epic.

## Change
The #99 live agent-eval gate graded actuals against `evals/baseline.json` but had no way to ignore flaky pairs. This passes `--quarantine evals/quarantine.json` to `eval_grade.py`, so a pair a multi-trial harvest recorded as flaky (via `eval_variance`) **informs but does not block** the gate — matching the local harvest's "quarantine, don't block" rule. The grader treats a missing `quarantine.json` as an empty set, so it's safe before the first harvest commits one.

## Scope note
The optional **multi-trial quorum** in CI is deferred: the live `claude-code-action` path is **KNOWN-BROKEN upstream** (documented in the workflow itself) and untestable here. Quarantine consumption is the safe, substantive deliverable; the shared "don't block on flaky" definition is what keeps CI and the local harvest consistent.

## Verification
- YAML parses; `eval_grade.py --quarantine <absent>` exits 0 (the pre-harvest CI case).
- No change to the required structural/semver gates or the opt-in behavior.

## Epic #229 — deterministic portion complete
- #230, #231 ✅ (#234) · #232 ✅ (#235) · **#233 ✅ (this)**

Remaining are live-model runs only: **#213** (operator harvest — now fully enabled), **#107** ablation, **#110** persona, **#214** raw-log tier.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_