### PR TITLE
test(evals): harvest baseline refresh +2 pairs (harvest 20260607-223231)

### DIFF
--- a/evals/baseline.json
+++ b/evals/baseline.json
@@ -1,7 +1,8 @@
 {
-  "_comment": "Regression baseline for the agent-eval CI gate (#99). Pairs listed here must not regress. `provenance` is 'hand-authored' until a real green live run records it via eval_grade.py --actuals <f> --write-baseline (which stamps provenance='measured' and recorded_at=the run time). `recorded_at` below is the authoring date, NOT a measured-run timestamp (#133).",
-  "provenance": "hand-authored",
-  "recorded_at": "2026-06-06T15:12:33Z",
+  "_comment": "Regression baseline for the agent-eval CI gate (#99). Trust-gated (#230): a pair is removed only when it failed every trial (pass@k <= demote_below) over >= min_trials and is not flaky; a flaky pair is quarantined, not removed; a pair is added only when it passed all trials. Written by eval_variance.py --write-baseline.",
+  "provenance": "measured",
+  "recorded_at": "2026-06-07T22:32:31Z",
+  "trials": 1,
   "passing": [
     "ar-clean-arch::arch-review",
     "ar-layer-violation::arch-review",
@@ -26,10 +27,12 @@
     "nm-clear-names::naming-review",
     "nm-consistent-conventions::naming-review",
     "nm-misleading-names::naming-review",
+    "sec-env-gitignored::security-review",
     "sec-hardcoded-secrets::security-review",
     "sec-safe-auth::security-review",
     "sec-safe-headers::security-review",
     "sec-sql-injection::security-review",
+    "sec-xss-vulnerable::security-review",
     "st-clean-modules::structure-review",
     "st-god-object::structure-review",
     "st-mixed-concerns::structure-review",
@@ -59,5 +62,6 @@
     "tlg-08-email-no-reference::test-design-advisor",
     "tlg-09-critical-single-layer::test-design-advisor",
     "tlg-10-multi-gate::test-design-advisor"
-  ]
+  ],
+  "harvest_id": "20260607-223231"
 }

--- a/evals/quarantine.json
+++ b/evals/quarantine.json
@@ -1,0 +1,8 @@
+{
+  "detail": {},
+  "harvest_id": "20260607-223231",
+  "quarantine": [],
+  "recorded_at": "2026-06-07T22:32:31Z",
+  "schema": "eval-variance/v1",
+  "trials": 1
+}

--- a/evals/variance-report.json
+++ b/evals/variance-report.json
@@ -1,0 +1,467 @@
+{
+  "by_agent": {
+    "arch-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 1.0,
+      "pairs": 2
+    },
+    "claude-setup-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.5,
+      "pairs": 6
+    },
+    "complexity-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 1.0,
+      "pairs": 5
+    },
+    "doc-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.5,
+      "pairs": 2
+    },
+    "domain-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.6,
+      "pairs": 5
+    },
+    "js-fp-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.6667,
+      "pairs": 6
+    },
+    "naming-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.6,
+      "pairs": 5
+    },
+    "security-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.8333,
+      "pairs": 6
+    },
+    "structure-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.6,
+      "pairs": 5
+    },
+    "svelte-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 1.0,
+      "pairs": 8
+    },
+    "test-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.0,
+      "pairs": 6
+    },
+    "test-smell-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.5,
+      "pairs": 4
+    },
+    "token-efficiency-review": {
+      "flaky_fixtures": 0,
+      "mean_pass_at_k": 0.6,
+      "pairs": 5
+    }
+  },
+  "by_pair": {
+    "ar-clean-arch::arch-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "ar-layer-violation::arch-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cs-broken-paths::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "cs-complete-setup::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cs-minimal-valid::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "cs-missing-sections::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "cx-callback-hell::complexity-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cx-clean-functions::complexity-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cx-deep-nesting::complexity-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cx-god-function::complexity-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "cx-simple-logic::complexity-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "dm-clean-boundaries::domain-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "dm-leaky-abstraction::domain-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "dm-logic-in-ui::domain-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "dm-missing-dtos::domain-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "dm-proper-events::domain-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "dr-accurate-docs::doc-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "dr-stale-readme::doc-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "ex-explore-command-missing::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "ex-explore-command-present::claude-setup-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "fp-array-mutations::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "fp-global-state::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "fp-immutable-state::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "fp-object-mutations::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "fp-pure-transforms::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "fp-safe-sort::js-fp-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "nm-clear-names::naming-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "nm-consistent-conventions::naming-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "nm-inconsistent-naming::naming-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "nm-magic-values::naming-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "nm-misleading-names::naming-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sec-env-gitignored::security-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sec-hardcoded-secrets::security-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sec-safe-auth::security-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sec-safe-headers::security-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sec-sql-injection::security-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "sec-xss-vulnerable::security-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "st-clean-modules::structure-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "st-duplicate-code::structure-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "st-god-object::structure-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "st-mixed-concerns::structure-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "st-organized-exports::structure-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-clean-lifecycle.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-closure-state-leak.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-effect-pitfalls.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-lifecycle-issues.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-proper-reactive.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-safe-stores.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-state-proxy-pitfalls.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "sv-store-subscription-leak.svelte::svelte-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "te-clean-code::token-efficiency-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "te-duplicate-code::token-efficiency-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "te-efficient-claude::token-efficiency-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "te-long-functions::token-efficiency-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "te-verbose-claude::token-efficiency-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-assertion-roulette.test::test-smell-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-clean-doubles.test::test-smell-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "test-missing-edge-cases.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-mystery-guest.test::test-smell-review": {
+      "flap": false,
+      "pass_at_k": 1.0,
+      "passes": 1,
+      "trials": 1
+    },
+    "test-no-assertions.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-overspecified-mocks.test::test-smell-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-shared-state.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-thorough-edge-cases.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-weak-assertions.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    },
+    "test-well-structured.test::test-review": {
+      "flap": false,
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 1
+    }
+  },
+  "flaky_count": 0,
+  "harvest_id": "20260607-223231",
+  "pairs_evaluated": 65,
+  "quarantine": [],
+  "schema": "eval-variance/v1",
+  "trials": 1
+}

--- a/metrics/eval-variance.jsonl
+++ b/metrics/eval-variance.jsonl
@@ -1,0 +1,1 @@
+{"flaky_count": 0, "mean_pass_at_k": 0.6462, "pairs_evaluated": 65, "recorded_at": "2026-06-07T22:32:31Z", "schema": "eval-variance/v1", "trials": 1}

--- a/tests/repo/eval_grader_tests.bats
+++ b/tests/repo/eval_grader_tests.bats
@@ -182,10 +182,15 @@ EOF
 }
 
 @test "baseline: shipped evals/baseline.json declares its provenance (#133)" {
-  # The seed baseline is honestly marked hand-authored, not a measured run.
+  # Provenance must be honestly DECLARED — 'hand-authored' for the seed, or
+  # 'measured' once a real harvest (eval_variance --write-baseline) has refreshed
+  # it. The invariant is "honestly labelled", not "forever the seed value".
   run jq -r '.provenance' "$BATS_TEST_DIRNAME/../../evals/baseline.json"
   [ "$status" -eq 0 ]
-  [ "$output" = "hand-authored" ]
+  case "$output" in
+    hand-authored|measured) : ;;
+    *) echo "unexpected provenance: $output" >&2; return 1 ;;
+  esac
 }
 
 @test "grader: --write-baseline MERGES, keeping untested pairs and adding new" {


### PR DESCRIPTION
First operator harvest via `run-full-eval-parallel.sh` (the #213 evidence run), against the trust-gated pipeline from #229.

## What it produced
- `evals/baseline.json`: **+2 pairs (56 → 58)**, `provenance: measured`, `harvest_id: 20260607-223231`.
- `evals/variance-report.json`: new full per-pair report.
- `evals/quarantine.json`: empty.

## Note: this was a single-trial harvest (`trials: 1`)
So it is **add-only** by design — the deletion guard only removes a pair that fails over `min_trials=2`, and flap/quarantine needs ≥2 trials. That means:
- the +2 additions are trustworthy (a pass is safe to claim from one observation),
- but **no deletions and no variance/quarantine signal** were possible from one trial.

To get the fuller trust signal (flap detection, quarantine, and the ability to retire genuinely-regressed pairs), re-run with the default `./scripts/run-full-eval-parallel.sh` (3 trials). This PR is still a valid baseline improvement to land.

Advances **#213**.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_