### PR TITLE
test(evals): trust-gated sweep baseline + variance (20260607-231840)

### DIFF
--- a/evals/baseline.json
+++ b/evals/baseline.json
@@ -1,14 +1,12 @@
 {
   "_comment": "Regression baseline for the agent-eval CI gate (#99). Trust-gated (#230): a pair is removed only when it failed every trial (pass@k <= demote_below) over >= min_trials and is not flaky; a flaky pair is quarantined, not removed; a pair is added only when it passed all trials. Written by eval_variance.py --write-baseline.",
   "provenance": "measured",
-  "recorded_at": "2026-06-07T22:32:31Z",
-  "trials": 1,
+  "recorded_at": "2026-06-08T00:11:07Z",
+  "trials": 3,
   "passing": [
     "ar-clean-arch::arch-review",
     "ar-layer-violation::arch-review",
-    "cs-broken-paths::claude-setup-review",
     "cs-complete-setup::claude-setup-review",
-    "cx-callback-hell::complexity-review",
     "cx-clean-functions::complexity-review",
     "cx-deep-nesting::complexity-review",
     "cx-god-function::complexity-review",
@@ -17,7 +15,6 @@
     "dm-missing-dtos::domain-review",
     "dm-proper-events::domain-review",
     "dr-accurate-docs::doc-review",
-    "dr-stale-readme::doc-review",
     "ex-explore-command-missing::claude-setup-review",
     "ex-explore-command-present::claude-setup-review",
     "fp-array-mutations::js-fp-review",
@@ -26,12 +23,10 @@
     "fp-safe-sort::js-fp-review",
     "nm-clear-names::naming-review",
     "nm-consistent-conventions::naming-review",
-    "nm-misleading-names::naming-review",
     "sec-env-gitignored::security-review",
     "sec-hardcoded-secrets::security-review",
     "sec-safe-auth::security-review",
     "sec-safe-headers::security-review",
-    "sec-sql-injection::security-review",
     "sec-xss-vulnerable::security-review",
     "st-clean-modules::structure-review",
     "st-god-object::structure-review",
@@ -49,12 +44,9 @@
     "te-duplicate-code::token-efficiency-review",
     "te-efficient-claude::token-efficiency-review",
     "te-long-functions::token-efficiency-review",
-    "te-verbose-claude::token-efficiency-review",
     "test-assertion-roulette.test::test-smell-review",
     "test-clean-doubles.test::test-smell-review",
     "test-mystery-guest.test::test-smell-review",
-    "test-thorough-edge-cases.test::test-review",
-    "test-well-structured.test::test-review",
     "tlg-01-pure-function::test-design-advisor",
     "tlg-02-user-facing-dynamic::test-design-advisor",
     "tlg-03-browser-bug-fix::test-design-advisor",
@@ -63,5 +55,5 @@
     "tlg-09-critical-single-layer::test-design-advisor",
     "tlg-10-multi-gate::test-design-advisor"
   ],
-  "harvest_id": "20260607-223231"
+  "harvest_id": "20260607-231840"
 }

--- a/evals/quarantine.json
+++ b/evals/quarantine.json
@@ -1,8 +1,105 @@
 {
-  "detail": {},
-  "harvest_id": "20260607-223231",
-  "quarantine": [],
-  "recorded_at": "2026-06-07T22:32:31Z",
+  "detail": {
+    "cs-complete-setup::claude-setup-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "cs-missing-sections::claude-setup-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "cx-god-function::complexity-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "dm-leaky-abstraction::domain-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "dr-accurate-docs::doc-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "ex-explore-command-missing::claude-setup-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "fp-array-mutations::js-fp-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "sec-hardcoded-secrets::security-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "sec-safe-headers::security-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "st-god-object::structure-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "st-mixed-concerns::structure-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "sv-closure-state-leak.svelte::svelte-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "sv-effect-pitfalls.svelte::svelte-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "te-duplicate-code::token-efficiency-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "te-long-functions::token-efficiency-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "test-clean-doubles.test::test-smell-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "test-missing-edge-cases.test::test-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    },
+    "test-mystery-guest.test::test-smell-review": {
+      "pass_at_k": 0.6667,
+      "trials": 3
+    },
+    "test-weak-assertions.test::test-review": {
+      "pass_at_k": 0.3333,
+      "trials": 3
+    }
+  },
+  "harvest_id": "20260607-231840",
+  "quarantine": [
+    "cs-complete-setup::claude-setup-review",
+    "cs-missing-sections::claude-setup-review",
+    "cx-god-function::complexity-review",
+    "dm-leaky-abstraction::domain-review",
+    "dr-accurate-docs::doc-review",
+    "ex-explore-command-missing::claude-setup-review",
+    "fp-array-mutations::js-fp-review",
+    "sec-hardcoded-secrets::security-review",
+    "sec-safe-headers::security-review",
+    "st-god-object::structure-review",
+    "st-mixed-concerns::structure-review",
+    "sv-closure-state-leak.svelte::svelte-review",
+    "sv-effect-pitfalls.svelte::svelte-review",
+    "te-duplicate-code::token-efficiency-review",
+    "te-long-functions::token-efficiency-review",
+    "test-clean-doubles.test::test-smell-review",
+    "test-missing-edge-cases.test::test-review",
+    "test-mystery-guest.test::test-smell-review",
+    "test-weak-assertions.test::test-review"
+  ],
+  "recorded_at": "2026-06-08T00:11:07Z",
   "schema": "eval-variance/v1",
-  "trials": 1
+  "trials": 3
 }

--- a/evals/variance-report.json
+++ b/evals/variance-report.json
@@ -6,62 +6,62 @@
       "pairs": 2
     },
     "claude-setup-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.5,
+      "flaky_fixtures": 3,
+      "mean_pass_at_k": 0.3889,
       "pairs": 6
     },
     "complexity-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 1.0,
+      "flaky_fixtures": 1,
+      "mean_pass_at_k": 0.7333,
       "pairs": 5
     },
     "doc-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.5,
+      "flaky_fixtures": 1,
+      "mean_pass_at_k": 0.3333,
       "pairs": 2
     },
     "domain-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.6,
+      "flaky_fixtures": 1,
+      "mean_pass_at_k": 0.6667,
       "pairs": 5
     },
     "js-fp-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.6667,
+      "flaky_fixtures": 1,
+      "mean_pass_at_k": 0.6111,
       "pairs": 6
     },
     "naming-review": {
       "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.6,
+      "mean_pass_at_k": 0.4,
       "pairs": 5
     },
     "security-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.8333,
+      "flaky_fixtures": 2,
+      "mean_pass_at_k": 0.7222,
       "pairs": 6
     },
     "structure-review": {
-      "flaky_fixtures": 0,
+      "flaky_fixtures": 2,
       "mean_pass_at_k": 0.6,
       "pairs": 5
     },
     "svelte-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 1.0,
+      "flaky_fixtures": 2,
+      "mean_pass_at_k": 0.9167,
       "pairs": 8
     },
     "test-review": {
-      "flaky_fixtures": 0,
-      "mean_pass_at_k": 0.0,
+      "flaky_fixtures": 2,
+      "mean_pass_at_k": 0.1111,
       "pairs": 6
     },
     "test-smell-review": {
-      "flaky_fixtures": 0,
+      "flaky_fixtures": 2,
       "mean_pass_at_k": 0.5,
       "pairs": 4
     },
     "token-efficiency-review": {
-      "flaky_fixtures": 0,
+      "flaky_fixtures": 2,
       "mean_pass_at_k": 0.6,
       "pairs": 5
     }
@@ -70,398 +70,418 @@
     "ar-clean-arch::arch-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "ar-layer-violation::arch-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "cs-broken-paths::claude-setup-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "cs-complete-setup::claude-setup-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "cs-minimal-valid::claude-setup-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "cs-missing-sections::claude-setup-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "cx-callback-hell::complexity-review": {
       "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 3
     },
     "cx-clean-functions::complexity-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "cx-deep-nesting::complexity-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "cx-god-function::complexity-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "cx-simple-logic::complexity-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "dm-clean-boundaries::domain-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "dm-leaky-abstraction::domain-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "dm-logic-in-ui::domain-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "dm-missing-dtos::domain-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "dm-proper-events::domain-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "dr-accurate-docs::doc-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "dr-stale-readme::doc-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "ex-explore-command-missing::claude-setup-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
+      "flap": true,
+      "pass_at_k": 0.3333,
       "passes": 1,
-      "trials": 1
+      "trials": 3
     },
     "ex-explore-command-present::claude-setup-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "fp-array-mutations::js-fp-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "fp-global-state::js-fp-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "fp-immutable-state::js-fp-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "fp-object-mutations::js-fp-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "fp-pure-transforms::js-fp-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "fp-safe-sort::js-fp-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "nm-clear-names::naming-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "nm-consistent-conventions::naming-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "nm-inconsistent-naming::naming-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "nm-magic-values::naming-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "nm-misleading-names::naming-review": {
       "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "pass_at_k": 0.0,
+      "passes": 0,
+      "trials": 3
     },
     "sec-env-gitignored::security-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sec-hardcoded-secrets::security-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "sec-safe-auth::security-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sec-safe-headers::security-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "sec-sql-injection::security-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "sec-xss-vulnerable::security-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "st-clean-modules::structure-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "st-duplicate-code::structure-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "st-god-object::structure-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "st-mixed-concerns::structure-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "st-organized-exports::structure-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-clean-lifecycle.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-closure-state-leak.svelte::svelte-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "sv-effect-pitfalls.svelte::svelte-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "sv-lifecycle-issues.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-proper-reactive.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-safe-stores.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-state-proxy-pitfalls.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "sv-store-subscription-leak.svelte::svelte-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "te-clean-code::token-efficiency-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "te-duplicate-code::token-efficiency-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "te-efficient-claude::token-efficiency-review": {
       "flap": false,
       "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "passes": 3,
+      "trials": 3
     },
     "te-long-functions::token-efficiency-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "te-verbose-claude::token-efficiency-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "test-assertion-roulette.test::test-smell-review": {
       "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "pass_at_k": 1.0,
+      "passes": 3,
+      "trials": 3
     },
     "test-clean-doubles.test::test-smell-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
+      "flap": true,
+      "pass_at_k": 0.3333,
       "passes": 1,
-      "trials": 1
+      "trials": 3
     },
     "test-missing-edge-cases.test::test-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "test-mystery-guest.test::test-smell-review": {
-      "flap": false,
-      "pass_at_k": 1.0,
-      "passes": 1,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.6667,
+      "passes": 2,
+      "trials": 3
     },
     "test-no-assertions.test::test-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "test-overspecified-mocks.test::test-smell-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "test-shared-state.test::test-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "test-thorough-edge-cases.test::test-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     },
     "test-weak-assertions.test::test-review": {
-      "flap": false,
-      "pass_at_k": 0.0,
-      "passes": 0,
-      "trials": 1
+      "flap": true,
+      "pass_at_k": 0.3333,
+      "passes": 1,
+      "trials": 3
     },
     "test-well-structured.test::test-review": {
       "flap": false,
       "pass_at_k": 0.0,
       "passes": 0,
-      "trials": 1
+      "trials": 3
     }
   },
-  "flaky_count": 0,
-  "harvest_id": "20260607-223231",
+  "flaky_count": 19,
+  "harvest_id": "20260607-231840",
   "pairs_evaluated": 65,
-  "quarantine": [],
+  "quarantine": [
+    "cs-complete-setup::claude-setup-review",
+    "cs-missing-sections::claude-setup-review",
+    "cx-god-function::complexity-review",
+    "dm-leaky-abstraction::domain-review",
+    "dr-accurate-docs::doc-review",
+    "ex-explore-command-missing::claude-setup-review",
+    "fp-array-mutations::js-fp-review",
+    "sec-hardcoded-secrets::security-review",
+    "sec-safe-headers::security-review",
+    "st-god-object::structure-review",
+    "st-mixed-concerns::structure-review",
+    "sv-closure-state-leak.svelte::svelte-review",
+    "sv-effect-pitfalls.svelte::svelte-review",
+    "te-duplicate-code::token-efficiency-review",
+    "te-long-functions::token-efficiency-review",
+    "test-clean-doubles.test::test-smell-review",
+    "test-missing-edge-cases.test::test-review",
+    "test-mystery-guest.test::test-smell-review",
+    "test-weak-assertions.test::test-review"
+  ],
   "schema": "eval-variance/v1",
-  "trials": 1
+  "trials": 3
 }


### PR DESCRIPTION
Parallel full-corpus harvest via `run-full-eval-parallel.sh` (3 trials/agent) — dispatch ran in git-worktree-isolated batches, then a single deterministic `eval_variance` pass over all trials wrote a **trust-gated** `evals/baseline.json` (a pair is removed only if it failed every trial over >= 2 trials and isn't flaky), plus `evals/variance-report.json` and `evals/quarantine.json`.

Review the baseline diff for **regressions**/**improvements** and the quarantine for newly-flaky pairs.