### PR TITLE
feat(plan): slice dependency metadata + wave computation (#222)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -53,7 +53,8 @@ jobs:
             tests/knowledge/ \
             tests/agents/ \
             tests/commands/ \
-            tests/docs/
+            tests/docs/ \
+            tests/scripts/
 
       # Rules-vs-prompts boundary sensor (#118): the security-review-rule-map.yaml
       # policy must stay consistent — no class on two surfaces, every rule-surface

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -86,6 +86,9 @@ Steps are numbered `<slice>.<step>` (1.1, 1.2, 2.1, …).
 
 ### Slice 1: <Slice Name>
 
+**Depends-on:** none
+**Files:** `path/to/file.ts`, `path/to/file.test.ts`
+
 **Behavior:**
 
 ```gherkin
@@ -119,6 +122,9 @@ Feature: <feature name>
 
 ### Slice 2: <Slice Name>
 
+**Depends-on:** 1
+**Files:** `path/to/other.ts`
+
 **Behavior:**
 
 ```gherkin
@@ -130,6 +136,27 @@ Feature: <feature name>
 #### Step 2.1: <Description>
 
 ...
+
+## Parallelization
+
+Each slice declares `Depends-on` (slice ids it must follow, or `none`). The build
+**waves** are derived from those declarations by `scripts/plan-waves.sh` — do not
+hand-maintain them. Independent slices in the same wave can be built concurrently
+(`/build` dispatches them to isolated worktrees).
+
+```mermaid
+graph TD
+  S1[Slice 1] --> S2[Slice 2]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+| 2 | 2 |
+
+If `plan-waves.sh` reports a cycle, a missing `Depends-on`, an unknown reference,
+or a **same-wave file collision** (two slices in one wave declaring the same file),
+fix the plan before the human gate — those break safe concurrent delivery.
 
 ## Complexity Classification
 
@@ -159,11 +186,14 @@ When in doubt, classify up (standard rather than trivial, complex rather than st
 
 This section is the machine-parseable recovery handle. `/build` updates checkboxes here via Edit tool so progress survives a `/clear` or session restart. `/continue` reads this section to determine the resume point.
 
-### Slices
+### Slices (grouped by wave)
 
+#### Wave 1
 - [ ] Slice 1: <title>
   - [ ] Step 1.1: <title>
   - [ ] Step 1.2: <title>
+
+#### Wave 2
 - [ ] Slice 2: <title>
   - [ ] Step 2.1: <title>
 
@@ -177,6 +207,17 @@ This section is the machine-parseable recovery handle. `/build` updates checkbox
 ### 4. Create the plans directory
 
 Create `plans/` if it doesn't exist. When writing the plan file, populate the `## Build Progress` section by copying slice and step titles from `## Slices` and criteria from `## Acceptance Criteria`. These are the checkboxes `/build` will update on disk as each step completes — a slice is checked off once all its steps are.
+
+Then derive the waves — never hand-author them:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/plan-waves.sh <plan-file>
+```
+
+Render the `## Parallelization` Mermaid DAG + wave table and the wave-grouped
+`## Build Progress` from its JSON (`waves`, per-slice `wave`). If it exits non-zero
+(cycle, missing `Depends-on`, or unknown reference) or reports a `collisions` entry,
+fix the plan and re-run before the human gate — those defeat safe concurrent build.
 
 ### 5. Run plan review personas
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -82,7 +82,7 @@ run "security-assessment shell test suite (run-all.sh)" \
 
 # --- plugin-tests.yml :: bats-tests ---------------------------------------
 run "bats — dev-team content suites" \
-  bats tests/repo/ tests/knowledge/ tests/agents/ tests/commands/ tests/docs/
+  bats tests/repo/ tests/knowledge/ tests/agents/ tests/commands/ tests/docs/ tests/scripts/
 
 run "bats — model-routing hook conformance" \
   bats \

--- a/scripts/lib/plan-parse.sh
+++ b/scripts/lib/plan-parse.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# plan-parse.sh — extract per-slice {id, Depends-on, Files} from a plan markdown.
+#
+# Emits one TSV row per slice:  id<TAB>depends<TAB>files
+#   depends: 'none' | a raw list ("1, 2") | '__MISSING__' (no Depends-on line)
+#   files:   a raw list ("a, b") | '' (no slice-level Files line)
+#
+# Only SLICE-LEVEL fields count — the first Depends-on/Files lines under a
+# `### Slice <id>:` heading and BEFORE that slice's first `#### Step` heading, so
+# per-step `**Files**:` lines are not mistaken for the slice's file surface.
+#
+# Sourced by plan-waves.sh (provides plan_parse); also runnable standalone.
+
+plan_parse() {
+  awk '
+  function flush(){ if (id != "") printf "%s\t%s\t%s\n", id, (seen ? deps : "__MISSING__"), files }
+  BEGIN { id=""; deps=""; seen=0; files=""; instep=0 }
+  /^#+[[:space:]]+[Ss]lice[[:space:]]+/ {
+    flush(); line=$0
+    sub(/^#+[[:space:]]+[Ss]lice[[:space:]]+/, "", line); sub(/:.*/, "", line)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+    id=line; deps=""; seen=0; files=""; instep=0; next
+  }
+  /^#{4,}[[:space:]]/ { instep=1 }
+  {
+    if (id == "" || instep) next
+    l = tolower($0)
+    if (!seen && l ~ /depends-on[*]*[[:space:]]*:/) {
+      v=$0; sub(/.*[Dd]epends-[Oo]n[*]*[[:space:]]*:[[:space:]]*/, "", v)
+      gsub(/[*`]/, "", v); gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); deps=v; seen=1
+    } else if (files == "" && l ~ /files[*]*[[:space:]]*:/) {
+      v=$0; sub(/.*[Ff]iles[*]*[[:space:]]*:[[:space:]]*/, "", v)
+      gsub(/[*`]/, "", v); gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); files=v
+    }
+  }
+  END { flush() }
+  ' "$1"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  plan_parse "${1:?usage: plan-parse.sh <plan.md>}"
+fi

--- a/scripts/plan-waves.sh
+++ b/scripts/plan-waves.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# plan-waves.sh — compute parallel build waves from a plan's slice dependency graph.
+#
+# Parses each slice's `Depends-on`, topologically layers the DAG into waves (wave 1
+# = slices with no prerequisites, etc.), detects same-wave file collisions, and
+# emits a stable JSON contract (schema "plan-waves/v1") on stdout:
+#
+#   { "schema", "waves": [[id,...],...], "slices": {id:{depends_on,files,wave}},
+#     "collisions": [{wave, slices:[a,b], file}] }
+#
+# Rejects (exit 2, message on stderr) a dependency cycle, a slice missing its
+# Depends-on declaration (with the `Depends-on: none` remedy), and an unknown
+# dependency reference — naming the offender in each case.
+#
+# Usage: plan-waves.sh <plan.md>
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/plan-parse.sh
+. "$HERE/lib/plan-parse.sh"
+
+FILE="${1:-}"
+{ [ -n "$FILE" ] && [ -f "$FILE" ]; } || { echo "usage: plan-waves.sh <plan.md>" >&2; exit 2; }
+
+# Python core reads the parser's TSV from stdin (script via -c, data via the pipe).
+read -r -d '' PYSRC <<'PY'
+import sys, json, re
+
+slices, order = {}, []
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    parts = line.rstrip("\n").split("\t")
+    sid = parts[0]
+    deps_raw = parts[1] if len(parts) > 1 else "__MISSING__"
+    files_raw = parts[2] if len(parts) > 2 else ""
+    files = [f for f in re.split(r"[,\s]+", files_raw) if f]
+    slices[sid] = {"deps_raw": deps_raw, "files": files}
+    order.append(sid)
+
+def die(msg):
+    sys.stderr.write("plan-waves: " + msg + "\n")
+    sys.exit(2)
+
+if not slices:
+    die("no slices found (expected '### Slice <id>: ...' headings)")
+
+for sid in order:
+    if slices[sid]["deps_raw"] == "__MISSING__":
+        die("slice %r is missing its Depends-on declaration — "
+            "add 'Depends-on: none' if it has no prerequisites." % sid)
+    raw = slices[sid]["deps_raw"].strip()
+    slices[sid]["deps"] = [] if raw.lower() == "none" or raw == "" \
+        else [d for d in re.split(r"[,\s]+", raw) if d]
+
+for sid in order:
+    for d in slices[sid]["deps"]:
+        if d not in slices:
+            die("slice %r depends on unknown slice %r." % (sid, d))
+
+# Kahn layering: each pass takes all slices whose deps are already placed.
+remaining = {s: set(slices[s]["deps"]) for s in order}
+waves, placed = [], set()
+while remaining:
+    ready = sorted(s for s, d in remaining.items() if d <= placed)
+    if not ready:
+        die("dependency cycle among slices: " + ", ".join(sorted(remaining)) + ".")
+    waves.append(ready)
+    for s in ready:
+        placed.add(s)
+        del remaining[s]
+
+wave_of = {s: i for i, w in enumerate(waves, 1) for s in w}
+
+collisions = []
+for i, w in enumerate(waves, 1):
+    for a in range(len(w)):
+        for b in range(a + 1, len(w)):
+            for f in sorted(set(slices[w[a]]["files"]) & set(slices[w[b]]["files"])):
+                collisions.append({"wave": i, "slices": [w[a], w[b]], "file": f})
+
+print(json.dumps({
+    "schema": "plan-waves/v1",
+    "waves": waves,
+    "slices": {s: {"depends_on": slices[s]["deps"], "files": slices[s]["files"],
+                   "wave": wave_of[s]} for s in order},
+    "collisions": collisions,
+}, indent=2, sort_keys=True))
+PY
+
+plan_parse "$FILE" | python3 -c "$PYSRC"

--- a/tests/commands/plan_parallelization_doc_tests.bats
+++ b/tests/commands/plan_parallelization_doc_tests.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# #222 — the /plan skill must render the parallelization structure: per-slice
+# Depends-on, a ## Parallelization section (Mermaid DAG + wave table), and a
+# wave-grouped Build Progress. Documentation gate for slice 1's rendering.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/plan/SKILL.md"
+
+@test "plan skill exists" {
+  [ -f "$SKILL" ]
+}
+
+@test "slice template declares a slice-level Depends-on field" {
+  grep -q '\*\*Depends-on:\*\*' "$SKILL"
+}
+
+@test "slice template declares a slice-level Files surface" {
+  grep -q '\*\*Files:\*\*' "$SKILL"
+}
+
+@test "plan renders a ## Parallelization section" {
+  grep -q '^## Parallelization' "$SKILL"
+}
+
+@test "Parallelization section references the wave computer (plan-waves.sh)" {
+  grep -q 'plan-waves.sh' "$SKILL"
+}
+
+@test "Parallelization section contains a Mermaid DAG and a wave table" {
+  grep -q 'mermaid' "$SKILL"
+  grep -q '| Wave | Slices' "$SKILL"
+}
+
+@test "Build Progress groups slices by wave" {
+  grep -q 'grouped by wave' "$SKILL"
+  grep -q '#### Wave 1' "$SKILL"
+}
+
+@test "plan flow tells the author to fix same-wave collisions before the gate" {
+  grep -qi 'collision' "$SKILL"
+}

--- a/tests/fixtures/plans/collision.md
+++ b/tests/fixtures/plans/collision.md
@@ -1,0 +1,9 @@
+### Slice A: Base
+**Depends-on:** none
+**Files:** `a.ts`
+### Slice B: One
+**Depends-on:** A
+**Files:** `shared.ts`, `b.ts`
+### Slice C: Two
+**Depends-on:** A
+**Files:** `shared.ts`, `c.ts`

--- a/tests/fixtures/plans/cycle.md
+++ b/tests/fixtures/plans/cycle.md
@@ -1,0 +1,4 @@
+### Slice A: X
+**Depends-on:** B
+### Slice B: Y
+**Depends-on:** A

--- a/tests/fixtures/plans/diamond.md
+++ b/tests/fixtures/plans/diamond.md
@@ -1,0 +1,13 @@
+## Slices
+### Slice A: Foundation
+**Depends-on:** none
+**Files:** `a.ts`
+### Slice B: Left
+**Depends-on:** A
+**Files:** `b.ts`
+### Slice C: Right
+**Depends-on:** A
+**Files:** `c.ts`
+### Slice D: Join
+**Depends-on:** B, C
+**Files:** `d.ts`

--- a/tests/fixtures/plans/linear.md
+++ b/tests/fixtures/plans/linear.md
@@ -1,0 +1,8 @@
+### Slice 1: First
+**Depends-on:** none
+**Files:** `one.ts`
+#### Step 1.1: do the thing
+**Files**: `step-level-should-be-ignored.ts`
+### Slice 2: Second
+**Depends-on:** 1
+**Files:** `two.ts`

--- a/tests/fixtures/plans/missing.md
+++ b/tests/fixtures/plans/missing.md
@@ -1,0 +1,4 @@
+### Slice A: Declared
+**Depends-on:** none
+### Slice B: Undeclared
+**Files:** `b.ts`

--- a/tests/fixtures/plans/nodeps.md
+++ b/tests/fixtures/plans/nodeps.md
@@ -1,0 +1,6 @@
+### Slice A: One
+**Depends-on:** none
+### Slice B: Two
+**Depends-on:** none
+### Slice C: Three
+**Depends-on:** none

--- a/tests/fixtures/plans/unknown.md
+++ b/tests/fixtures/plans/unknown.md
@@ -1,0 +1,4 @@
+### Slice A: Base
+**Depends-on:** none
+### Slice B: Bad ref
+**Depends-on:** Z

--- a/tests/scripts/plan_waves_tests.bats
+++ b/tests/scripts/plan_waves_tests.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# plan-waves.sh (#222) — parallel build-wave computation from a plan's slice DAG.
+# Deterministic and model-free; covers the slice-1 Gherkin scenarios.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+WAVES="$REPO_ROOT/scripts/plan-waves.sh"
+FIX="$REPO_ROOT/tests/fixtures/plans"
+
+@test "diamond dependencies layer into waves (A -> {B,C} -> D)" {
+  run "$WAVES" "$FIX/diamond.md"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.waves')" = '[["A"],["B","C"],["D"]]' ]
+}
+
+@test "a plan with no dependencies is one wave" {
+  run "$WAVES" "$FIX/nodeps.md"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.waves')" = '[["A","B","C"]]' ]
+}
+
+@test "linear plan layers in order; step-level Files do not pollute slice Files" {
+  run "$WAVES" "$FIX/linear.md"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.waves')" = '[["1"],["2"]]' ]
+  # slice 1's surface is its slice-level Files only, not the #### step's Files
+  [ "$(echo "$output" | jq -c '.slices."1".files')" = '["one.ts"]' ]
+}
+
+@test "same-wave file collision is surfaced" {
+  run "$WAVES" "$FIX/collision.md"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.collisions[0].file')" = "shared.ts" ]
+  [ "$(echo "$output" | jq -c '.collisions[0].slices')" = '["B","C"]' ]
+}
+
+@test "a dependency cycle is rejected, naming the involved slices" {
+  run "$WAVES" "$FIX/cycle.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cycle"* ]]
+  [[ "$output" == *"A"* && "$output" == *"B"* ]]
+}
+
+@test "a missing Depends-on field is rejected with the 'Depends-on: none' remedy" {
+  run "$WAVES" "$FIX/missing.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing its Depends-on"* ]]
+  [[ "$output" == *"Depends-on: none"* ]]
+}
+
+@test "an unknown dependency reference is rejected" {
+  run "$WAVES" "$FIX/unknown.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown slice"* ]]
+  [[ "$output" == *"Z"* ]]
+}
+
+@test "missing plan file argument exits non-zero with usage" {
+  run "$WAVES"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage:"* ]]
+}


### PR DESCRIPTION
**Closes #222.** Slice 1 (wave 1) of the parallel-build epic **#221**.

Makes the plan parallelism-aware: each slice declares `Depends-on` + a `Files` surface, and build **waves** are derived from the DAG — never hand-maintained.

## What
- **`scripts/lib/plan-parse.sh`** — extract per-slice `{id, Depends-on, Files}` from a plan (slice-level fields only; step-level `**Files**` ignored).
- **`scripts/plan-waves.sh`** — topological wave layering + same-wave file-collision detection → stable JSON (`plan-waves/v1`). Rejects (exit 2, named offender): cycle, missing `Depends-on` (with the `Depends-on: none` remedy), unknown reference.
- **`skills/plan/SKILL.md`** — per-slice `Depends-on`/`Files`, a `## Parallelization` section (Mermaid DAG + wave table) derived via `plan-waves.sh`, wave-grouped Build Progress.
- **CI wiring** — `tests/scripts/` added to **both** `ci-local.sh` and `plugin-tests.yml` so the gate runs in CI.

## AC1 — all seven slice-1 Gherkin scenarios covered
diamond → waves; no-deps → one wave; cycle / missing / unknown rejected; same-wave collision surfaced; step-level Files don't pollute the slice surface; plan renders the Parallelization section.

## Verification
- `tests/scripts/plan_waves_tests.bats` (8) + `tests/commands/plan_parallelization_doc_tests.bats` (8) + 7 fixtures. Model-free.
- Full content suites **335/335**; shellcheck clean; workflow YAML valid.

Next in the epic (wave 2): #223 parallelization-review persona · #224 wave-aware concurrent build · #225 issues-from-plan DAG — all depend on this.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_