### PR TITLE
feat(issues-from-plan): spec parent + DAG-linked slice children (#225)

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2865,7 +2865,7 @@
       "anchor": "1-find-the-plan"
     },
     "2. Analyze the Plan": {
-      "summary": "Read the plan and identify:",
+      "summary": "Read the plan and identify each **slice** (`### Slice <id>:`), its acceptance criteria, and the shared architectural decisions.",
       "anchor": "2-analyze-the-plan"
     },
     "3. Draft Issues": {
@@ -2876,9 +2876,9 @@
       "summary": "Present the issue list as a numbered summary:",
       "anchor": "4-review-with-user"
     },
-    "5. Create Issues": {
-      "summary": "Create each issue using `gh issue create`.",
-      "anchor": "5-create-issues"
+    "5. Create Issues (parent spec, then slice children)": {
+      "summary": "Create the **parent** issue from the spec first, then one **child** issue per slice linked to it, then backfill the sibling `depends on #N` links from the `issue-deps.sh` map:",
+      "anchor": "5-create-issues-parent-spec-then-slice-children"
     },
     "6. Present Results": {
       "summary": "List all created issue URLs with their titles.",

--- a/plugins/dev-team/skills/issues-from-plan/SKILL.md
+++ b/plugins/dev-team/skills/issues-from-plan/SKILL.md
@@ -37,12 +37,15 @@ If no plan is found, ask the user to point you to one.
 
 ### 2. Analyze the Plan
 
-Read the plan and identify:
+Read the plan and identify each **slice** (`### Slice <id>:`), its acceptance criteria, and the shared architectural decisions. Derive the dependency links from the **DAG, not file order** — do not hand-infer them:
 
-- Each discrete unit of work (implementation step, vertical slice, or phase)
-- Dependencies between units (which must complete before others can start)
-- Acceptance criteria for each unit
-- Shared architectural decisions that apply across all issues
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/issue-deps.sh <plan-file>
+```
+
+This returns `{ "<slice>": ["<dep slice>", ...] }` — each slice's direct predecessors. A slice listed earlier in the file carries **no** dependency on a later one unless the DAG says so.
+
+Then locate the plan's **spec** (the linked spec artifact or `docs/specs/<...>.md`); it becomes the **parent** issue. **If the plan has no associated spec, report that and create no parent issue** (and no children) — stop here.
 
 ### 3. Draft Issues
 
@@ -72,9 +75,14 @@ Ask: "Does this breakdown look right? Should any issues be merged or split?"
 
 Wait for approval before creating.
 
-### 5. Create Issues
+### 5. Create Issues (parent spec, then slice children)
 
-Create each issue using `gh issue create`. After creating all issues, update issue bodies to cross-reference actual issue numbers for dependencies.
+Create the **parent** issue from the spec first, then one **child** issue per slice linked to it, then backfill the sibling `depends on #N` links from the `issue-deps.sh` map:
+
+1. **Parent (spec):** `gh issue create` from the spec (intent + acceptance summary); capture its number as `$PARENT`. If step 2 found no spec, skip everything — no parent, no children.
+2. **Children (slices):** for each slice, `gh issue create` with `Part of #$PARENT` in the body. Record the **slice-id → issue-number** mapping as you go.
+3. **DAG links:** for each slice, look up its predecessors from the `issue-deps.sh` map, translate them to the child issue numbers, and set the child's `## Depends On` to `depends on #N` for each (a slice with no predecessors says "none"). Links come from the DAG map, never from file order.
+4. **Partial-failure safety:** if any `gh` call fails partway, do **not** abort silently — report which issues were created (with numbers) and which were not, then let the plan flow continue. Never leave a half-created state unreported.
 
 ```bash
 gh issue create --title "Issue title" --body "$(cat <<'EOF'
@@ -82,9 +90,11 @@ gh issue create --title "Issue title" --body "$(cat <<'EOF'
 
 [Behavior description — what this slice delivers end-to-end]
 
+Part of #<parent>
+
 ## Depends On
 
-- #<number>: [brief reason]
+- #<number>: [brief reason]   <!-- from issue-deps.sh; "none" if no predecessors -->
 
 ## Acceptance Criteria
 

--- a/scripts/issue-deps.sh
+++ b/scripts/issue-deps.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# issue-deps.sh — per-slice sibling dependency sets for issue linking, derived
+# from the plan's DAG (via plan-waves.sh), NOT from plan file order. Read-only:
+# it never edits the plan or plan-waves output.
+#
+# Emits JSON mapping each slice id to its DIRECT predecessor slice ids:
+#   { "A": [], "B": ["A"], "C": ["A"], "D": ["B","C"] }
+#
+# /issues-from-plan maps those slice ids to the child issue numbers it creates
+# and renders "depends on #N" links between siblings.
+#
+# Usage: issue-deps.sh <plan.md>
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FILE="${1:-}"
+{ [ -n "$FILE" ] && [ -f "$FILE" ]; } || { echo "usage: issue-deps.sh <plan.md>" >&2; exit 2; }
+
+# plan-waves.sh validates the DAG (cycle/missing/unknown -> non-zero); propagate.
+"$HERE/plan-waves.sh" "$FILE" | jq '.slices | map_values(.depends_on)'

--- a/tests/commands/issues_from_plan_doc_tests.bats
+++ b/tests/commands/issues_from_plan_doc_tests.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# #225 — /issues-from-plan must create a spec parent + slice children with
+# DAG-derived dependency links, and handle a missing spec and partial failure.
+# Documentation gate.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/issues-from-plan/SKILL.md"
+
+@test "skill exists" {
+  [ -f "$SKILL" ]
+}
+
+@test "derives dependency links from the DAG via issue-deps.sh, not file order" {
+  grep -q 'issue-deps.sh' "$SKILL"
+  grep -qi 'not file order' "$SKILL"
+}
+
+@test "creates a parent issue from the spec" {
+  grep -qi 'parent' "$SKILL"
+  grep -qi 'spec' "$SKILL"
+}
+
+@test "creates slice children linked to the parent" {
+  grep -q 'Part of #' "$SKILL"
+}
+
+@test "reports a missing spec and creates no parent" {
+  grep -qi 'no associated spec' "$SKILL"
+  grep -qi 'create no parent' "$SKILL"
+}
+
+@test "handles partial creation failure without orphaned state" {
+  grep -qi 'partial-failure' "$SKILL"
+  grep -qi 'were created' "$SKILL"
+}

--- a/tests/fixtures/plans/dag-order.md
+++ b/tests/fixtures/plans/dag-order.md
@@ -1,0 +1,6 @@
+### Slice B: Depends on A but listed first
+**Depends-on:** A
+### Slice A: The actual prerequisite, listed second
+**Depends-on:** none
+### Slice C: Independent, listed last
+**Depends-on:** none

--- a/tests/scripts/issue_deps_tests.bats
+++ b/tests/scripts/issue_deps_tests.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# #225 — issue-deps.sh derives per-slice sibling dependency sets from the plan
+# DAG (via plan-waves.sh), not file order. Model-free.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+DEPS="$REPO_ROOT/scripts/issue-deps.sh"
+FIX="$REPO_ROOT/tests/fixtures/plans"
+
+@test "diamond: each slice maps to its direct predecessors" {
+  run "$DEPS" "$FIX/diamond.md"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.A')" = '[]' ]
+  [ "$(echo "$output" | jq -c '.B')" = '["A"]' ]
+  [ "$(echo "$output" | jq -c '.D')" = '["B","C"]' ]
+}
+
+@test "single-slice plan yields one slice with no dependency" {
+  TMP="$(mktemp)"; printf '### Slice 1: only\n**Depends-on:** none\n' > "$TMP"
+  run "$DEPS" "$TMP"
+  rm -f "$TMP"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.["1"]')" = '[]' ]
+  [ "$(echo "$output" | jq -c 'length')" = '1' ]
+}
+
+@test "links follow the DAG, not file order (dep listed after dependent)" {
+  run "$DEPS" "$FIX/dag-order.md"
+  [ "$status" -eq 0 ]
+  # B is listed first but depends on A (listed second)
+  [ "$(echo "$output" | jq -c '.B')" = '["A"]' ]
+  # C is listed last and independent — no dependency on the earlier slices
+  [ "$(echo "$output" | jq -c '.C')" = '[]' ]
+}
+
+@test "an invalid plan (cycle) propagates non-zero" {
+  run "$DEPS" "$FIX/cycle.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing file argument exits non-zero with usage" {
+  run "$DEPS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage:"* ]]
+}


### PR DESCRIPTION
**Closes #225.** Slice 4 (wave 2) of the parallel-build epic **#221** — depends on #222 (merged).

`/issues-from-plan` now creates a **parent issue from the spec** and one **child per slice**, with dependency links derived from the **DAG, not file order**.

## What
- **`scripts/issue-deps.sh`** — per-slice direct-predecessor map from `plan-waves.sh` (`{ "B": ["A"], ... }`). Read-only; propagates plan-waves validation.
- **`skills/issues-from-plan/SKILL.md`** — derive deps via `issue-deps.sh`; spec → parent; each slice → child (`Part of #parent`) with DAG-derived `depends on #N` sibling links; **missing spec** reported with no parent created; **partial failure** reports created-vs-not and continues (no orphaned state).

## AC7 covered — all five scenarios
spec→parent + slice children; single-slice → one child, no dep; links follow the DAG not file order; missing spec → no parent; partial failure → reported, flow continues.

## Verification
- `tests/scripts/issue_deps_tests.bats` (5, incl. dep-listed-after-dependent) + `tests/commands/issues_from_plan_doc_tests.bats` (6) + a `dag-order` fixture. Full content suites **375/375**; shellcheck clean.

Last slice (wave 3): **#226** GitHub-origin post-plan gate.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_