### PR TITLE
feat(plan): GitHub-origin post-plan issue gate (#226)

### DIFF
--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -243,6 +243,20 @@ Display the plan and the review summary. Ask: "Approve this plan to begin implem
 
 Mark the plan status as `approved` once the user confirms. If the user requests changes, update the plan and re-present.
 
+#### Post-approval: offer GitHub issues (GitHub origin only)
+
+After approval, classify the origin remote — **only** offer issue creation on an actual GitHub host:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/git-origin-host.sh
+```
+
+- **`github`** → prompt **once**, showing the count: *"Open 1 parent issue and N linked slice issues from this plan? [y/N]"* (N = number of slices). The default is **No**. Invoke `/issues-from-plan` **only on explicit `y`**; on No (or anything else), create nothing and continue.
+- **`other`** (non-GitHub host, including lookalikes like `notgithub.example.com`) or **`none`** (no origin) → **no prompt**; continue silently.
+- **Non-interactive** (`/plan` run without a usable TTY) → do **not** prompt or block: log *"skipping the GitHub issue prompt (non-interactive)"* and continue.
+
+Never create issues without an explicit `y` on an interactive GitHub-origin prompt.
+
 ## Integration
 
 - The progress-guardian agent tracks step completion against this plan

--- a/scripts/git-origin-host.sh
+++ b/scripts/git-origin-host.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# git-origin-host.sh — classify the `origin` remote so /plan only offers GitHub
+# issue creation on an actual GitHub host.
+#
+# Prints exactly one of:
+#   github  — github.com OR an enterprise GHE host (any dot-label equals "github")
+#   other   — a non-GitHub host, including lookalikes like notgithub.example.com
+#   none    — no origin remote, or an unparseable URL (fail-open: never blocks)
+#
+# Reads `git remote get-url origin` unless a URL is given as $1 (for testing).
+# Usage: git-origin-host.sh [remote-url]
+
+set -uo pipefail
+
+url="${1:-}"
+if [ -z "$url" ]; then
+  url="$(git remote get-url origin 2>/dev/null || true)"
+fi
+[ -n "$url" ] || { echo none; exit 0; }
+
+# Extract the host from https://, ssh://, or scp-like (git@host:path) forms.
+host=""
+case "$url" in
+  *://*)   rest="${url#*://}"; rest="${rest#*@}"; host="${rest%%/*}"; host="${host%%:*}" ;;
+  *@*:*)   rest="${url#*@}"; host="${rest%%:*}" ;;
+  *)       host="${url%%:*}" ;;
+esac
+host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
+[ -n "$host" ] || { echo none; exit 0; }
+
+# Match a whole dot-label of "github" (covers github.com and enterprise GHE such
+# as github.example.com). A substring like "notgithub" or "mygithub" does NOT
+# match, because the pattern requires a dot immediately before "github".
+case ".$host." in
+  *.github.*) echo github; exit 0 ;;
+esac
+echo other

--- a/tests/commands/plan_origin_gate_doc_tests.bats
+++ b/tests/commands/plan_origin_gate_doc_tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# #226 — /plan step 6 must gate GitHub issue creation on a GitHub origin:
+# classify via git-origin-host.sh, prompt only on github, show the count, default
+# No, consent-gate /issues-from-plan, and skip non-interactively. Doc gate.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/plan/SKILL.md"
+
+@test "step 6 classifies the origin via git-origin-host.sh" {
+  grep -q 'git-origin-host.sh' "$SKILL"
+}
+
+@test "prompts only on a github origin" {
+  grep -qi 'github.*origin only\|GitHub origin only\|only.*offer issue creation on an actual GitHub host' "$SKILL"
+}
+
+@test "shows the issue count in the prompt" {
+  grep -qi 'parent issue and N linked' "$SKILL"
+}
+
+@test "default is No" {
+  grep -q '\[y/N\]' "$SKILL"
+  grep -qi 'default is \*\*No\*\*\|default is No' "$SKILL"
+}
+
+@test "invokes /issues-from-plan only on explicit consent" {
+  grep -qi 'only on explicit' "$SKILL"
+  grep -q 'issues-from-plan' "$SKILL"
+}
+
+@test "other / none origins do not prompt" {
+  grep -qi 'no prompt' "$SKILL"
+}
+
+@test "non-interactive skips without blocking" {
+  grep -qi 'non-interactive' "$SKILL"
+  grep -qi 'skipping the GitHub issue prompt' "$SKILL"
+}

--- a/tests/scripts/git_origin_host_tests.bats
+++ b/tests/scripts/git_origin_host_tests.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# #226 — git-origin-host.sh classifies the origin remote: github | other | none.
+# github.com + enterprise GHE => github; lookalikes => other; no remote => none.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+HOSTC="$REPO_ROOT/scripts/git-origin-host.sh"
+
+@test "github.com over https is github" {
+  [ "$("$HOSTC" 'https://github.com/o/r')" = "github" ]
+}
+
+@test "github.com over scp-style ssh is github" {
+  [ "$("$HOSTC" 'git@github.com:o/r.git')" = "github" ]
+}
+
+@test "github.com over ssh:// is github" {
+  [ "$("$HOSTC" 'ssh://git@github.com/o/r')" = "github" ]
+}
+
+@test "enterprise GHE host (github.<corp>) is github" {
+  [ "$("$HOSTC" 'https://github.example.com/o/r')" = "github" ]
+  [ "$("$HOSTC" 'git@github.mycorp.com:o/r.git')" = "github" ]
+}
+
+@test "lookalike notgithub.example.com is other" {
+  [ "$("$HOSTC" 'https://notgithub.example.com/o/r')" = "other" ]
+}
+
+@test "lookalike mygithub.com is other" {
+  [ "$("$HOSTC" 'git@mygithub.com:o/r.git')" = "other" ]
+}
+
+@test "a non-github host is other" {
+  [ "$("$HOSTC" 'https://gitlab.com/o/r')" = "other" ]
+}
+
+@test "a repo with no origin remote is none (fail-open)" {
+  TMP="$(mktemp -d)"
+  git -C "$TMP" init -q
+  run bash -c "cd '$TMP' && '$HOSTC'"
+  rm -rf "$TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "none" ]
+}


### PR DESCRIPTION
**Closes #226.** Slice 5 (wave 3) of the parallel-build epic **#221** — depends on #225 (merged). **Final slice — completes the epic.**

`/plan` offers GitHub issue creation only on a real GitHub origin: count-shown, default-No, consent-gated, non-interactive-safe.

## What
- **`scripts/git-origin-host.sh`** — classify origin as `github | other | none`. Matches a whole `github` dot-label (github.com **and** enterprise GHE like `github.example.com`); lookalikes (`notgithub.example.com`, `mygithub.com`) → `other`; no remote / unparseable → `none` (fail-open). Handles https, `ssh://`, and scp-style `git@host:path`.
- **`skills/plan/SKILL.md` step 6** — post-approval gate: classify origin; prompt **only** on `github` with the issue count and a **No** default; invoke `/issues-from-plan` only on explicit consent; `other`/`none` never prompt; non-interactive logs a skip and continues without blocking.

## AC8 covered — all six scenarios
github prompts (count, default No, consent-only); enterprise GHE prompts; lookalike doesn't; no remote doesn't; decline creates nothing; non-interactive skips without hanging.

## Verification
- `tests/scripts/git_origin_host_tests.bats` (8) + `tests/commands/plan_origin_gate_doc_tests.bats` (7). Full content suites **390/390**; shellcheck clean.

---
With this, **epic #221 is fully delivered**: #222 wave computation · #223 parallelization persona · #224 wave-aware concurrent build · #225 issues-from-plan DAG · #226 this. I'll close the epic once this merges.

https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqhigqmik2fQjJb6D9MmS)_