### PR TITLE
feat(security-scan): offline-harden gitleaks + trivy (#53)

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3704,6 +3704,10 @@
       "summary": "For each Tier 1 tool, run `command -v <tool>`.",
       "anchor": "1-detect-available-tools"
     },
+    "1b. Offline enforcement (gitleaks, trivy)": {
+      "summary": "These tools default to making network calls; in restricted-egress environments those calls hang or fail and take the pre-pass down with them.",
+      "anchor": "1b-offline-enforcement-gitleaks-trivy"
+    },
     "2. Run available tools in parallel": {
       "summary": "Dispatch each available tool's invocation.",
       "anchor": "2-run-available-tools-in-parallel"

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -243,6 +243,20 @@ Display the plan and the review summary. Ask: "Approve this plan to begin implem
 
 Mark the plan status as `approved` once the user confirms. If the user requests changes, update the plan and re-present.
 
+#### Post-approval: offer GitHub issues (GitHub origin only)
+
+After approval, classify the origin remote — **only** offer issue creation on an actual GitHub host:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/git-origin-host.sh
+```
+
+- **`github`** → prompt **once**, showing the count: *"Open 1 parent issue and N linked slice issues from this plan? [y/N]"* (N = number of slices). The default is **No**. Invoke `/issues-from-plan` **only on explicit `y`**; on No (or anything else), create nothing and continue.
+- **`other`** (non-GitHub host, including lookalikes like `notgithub.example.com`) or **`none`** (no origin) → **no prompt**; continue silently.
+- **Non-interactive** (`/plan` run without a usable TTY) → do **not** prompt or block: log *"skipping the GitHub issue prompt (non-interactive)"* and continue.
+
+Never create issues without an explicit `y` on an interactive GitHub-origin prompt.
+
 ## Integration
 
 - The progress-guardian agent tracks step completion against this plan

--- a/plugins/dev-team/skills/static-analysis-integration/SKILL.md
+++ b/plugins/dev-team/skills/static-analysis-integration/SKILL.md
@@ -32,8 +32,8 @@ Maintenance policies for adapters and rulesets live in `maintenance.md` — thos
 | Tool | SARIF invocation | Capability |
 |---|---|---|
 | semgrep | `semgrep scan --sarif --config auto` | SAST |
-| gitleaks | `gitleaks detect --report-format sarif --report-path -` | secrets |
-| trivy | `trivy config --format sarif <path>` + `trivy fs --format sarif <path>` | IaC + supply-chain |
+| gitleaks | `gitleaks detect --report-format sarif --report-path - --no-verify` | secrets |
+| trivy | `trivy config --format sarif --skip-update --offline-scan <path>` + `trivy fs --format sarif --skip-update --offline-scan <path>` | IaC + supply-chain |
 | hadolint | `hadolint --format sarif <Dockerfile>` | IaC (Dockerfile) |
 | actionlint | binary emits JSON; thin adapter maps to SARIF `result` (see `references/tool-configs.md`) | CI/CD |
 
@@ -60,6 +60,22 @@ If no Tier 1 tools are present, return:
 ```json
 { "status": "skip", "tools": [], "findings": [], "summary": "No static analysis tools detected." }
 ```
+
+### 1b. Offline enforcement (gitleaks, trivy)
+
+These tools default to making network calls; in restricted-egress environments those calls hang or fail and take the pre-pass down with them. Both are pinned to local-only operation so the pre-pass never depends on outbound network access.
+
+**gitleaks** runs with `--no-verify`. Verification (confirming a detected secret is a live credential) is the only outbound call gitleaks makes; disabling it keeps detection fully pattern-based and offline. No preflight needed — the flag is always on.
+
+**trivy** runs with `--skip-update --offline-scan` on both `trivy config` and `trivy fs`. Before dispatching trivy, run the **offline DB preflight** against the local cache (`${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/trivy.db`):
+
+| Local DB state | Action | Warning |
+|---|---|---|
+| absent | skip trivy | `trivy local DB missing — run: trivy image --download-db-only` |
+| mtime age ≤ 7 days | run (fresh) | none |
+| mtime age > 7 days | run anyway | `trivy DB is N days old — consider refreshing with: trivy image --download-db-only` |
+
+`N` is the integer day count. The 7-day boundary is inclusive (exactly 7 days = fresh; strictly greater than 7 days = stale). A missing or stale DB is **never a hard pipeline failure** — it degrades to a skip or a warning, consistent with the graceful-degradation constraint.
 
 ### 2. Run available tools in parallel
 

--- a/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
@@ -26,6 +26,7 @@ semgrep scan \
 gitleaks detect \
   --report-format sarif \
   --report-path - \
+  --no-verify \
   --source <path>
 ```
 
@@ -33,6 +34,7 @@ gitleaks detect \
 - **Install hint**: `gitleaks — secrets detection. install: brew install gitleaks`
 - **Detection**: `command -v gitleaks`
 - **Capability tier**: secrets
+- **Offline posture**: `--no-verify` disables gitleaks' active-credential verification, which would otherwise make outbound API calls (e.g. to AWS/GitHub) to confirm a detected secret is live. Detection is purely pattern-based and runs with zero network egress. Always on — this flag carries no detection cost.
 - **Adapter**: none.
 
 ### trivy
@@ -42,6 +44,8 @@ gitleaks detect \
 trivy config \
   --format sarif \
   --output /dev/stdout \
+  --skip-update \
+  --offline-scan \
   <path>
 
 # Filesystem / supply-chain scanning
@@ -49,6 +53,8 @@ trivy fs \
   --format sarif \
   --output /dev/stdout \
   --scanners vuln,config,secret \
+  --skip-update \
+  --offline-scan \
   <path>
 ```
 
@@ -56,6 +62,13 @@ trivy fs \
 - **Install hint**: `trivy — IaC + supply-chain scanning. install: brew install trivy`
 - **Detection**: `command -v trivy`
 - **Capability tier**: IaC + supply-chain
+- **Offline posture**: both `trivy config` and `trivy fs` run with `--skip-update --offline-scan`. `--skip-update` pins trivy to the local vulnerability DB (no DB refresh over the network); `--offline-scan` suppresses the remote metadata lookups trivy otherwise performs for some package ecosystems. Run the **offline DB preflight** below before dispatch.
+- **Offline DB preflight**: locate the local DB at trivy's cache path (`${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/trivy.db`) and check its `mtime`:
+  - **absent** → skip trivy, warn `trivy local DB missing — run: trivy image --download-db-only`
+  - **mtime age ≤ 7 days** → run normally (fresh)
+  - **mtime age > 7 days** → run anyway, warn `trivy DB is N days old — consider refreshing with: trivy image --download-db-only` (substitute `N` with the integer day count)
+
+  The 7-day boundary is inclusive: exactly 7 days old is still fresh; strictly greater than 7 days is stale. A missing or stale DB is never a hard pipeline failure.
 - **Adapter**: none.
 
 ### hadolint

--- a/scripts/git-origin-host.sh
+++ b/scripts/git-origin-host.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# git-origin-host.sh — classify the `origin` remote so /plan only offers GitHub
+# issue creation on an actual GitHub host.
+#
+# Prints exactly one of:
+#   github  — github.com OR an enterprise GHE host (any dot-label equals "github")
+#   other   — a non-GitHub host, including lookalikes like notgithub.example.com
+#   none    — no origin remote, or an unparseable URL (fail-open: never blocks)
+#
+# Reads `git remote get-url origin` unless a URL is given as $1 (for testing).
+# Usage: git-origin-host.sh [remote-url]
+
+set -uo pipefail
+
+url="${1:-}"
+if [ -z "$url" ]; then
+  url="$(git remote get-url origin 2>/dev/null || true)"
+fi
+[ -n "$url" ] || { echo none; exit 0; }
+
+# Extract the host from https://, ssh://, or scp-like (git@host:path) forms.
+host=""
+case "$url" in
+  *://*)   rest="${url#*://}"; rest="${rest#*@}"; host="${rest%%/*}"; host="${host%%:*}" ;;
+  *@*:*)   rest="${url#*@}"; host="${rest%%:*}" ;;
+  *)       host="${url%%:*}" ;;
+esac
+host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
+[ -n "$host" ] || { echo none; exit 0; }
+
+# Match a whole dot-label of "github" (covers github.com and enterprise GHE such
+# as github.example.com). A substring like "notgithub" or "mygithub" does NOT
+# match, because the pattern requires a dot immediately before "github".
+case ".$host." in
+  *.github.*) echo github; exit 0 ;;
+esac
+echo other

--- a/tests/commands/plan_origin_gate_doc_tests.bats
+++ b/tests/commands/plan_origin_gate_doc_tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# #226 — /plan step 6 must gate GitHub issue creation on a GitHub origin:
+# classify via git-origin-host.sh, prompt only on github, show the count, default
+# No, consent-gate /issues-from-plan, and skip non-interactively. Doc gate.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/plan/SKILL.md"
+
+@test "step 6 classifies the origin via git-origin-host.sh" {
+  grep -q 'git-origin-host.sh' "$SKILL"
+}
+
+@test "prompts only on a github origin" {
+  grep -qi 'github.*origin only\|GitHub origin only\|only.*offer issue creation on an actual GitHub host' "$SKILL"
+}
+
+@test "shows the issue count in the prompt" {
+  grep -qi 'parent issue and N linked' "$SKILL"
+}
+
+@test "default is No" {
+  grep -q '\[y/N\]' "$SKILL"
+  grep -qi 'default is \*\*No\*\*\|default is No' "$SKILL"
+}
+
+@test "invokes /issues-from-plan only on explicit consent" {
+  grep -qi 'only on explicit' "$SKILL"
+  grep -q 'issues-from-plan' "$SKILL"
+}
+
+@test "other / none origins do not prompt" {
+  grep -qi 'no prompt' "$SKILL"
+}
+
+@test "non-interactive skips without blocking" {
+  grep -qi 'non-interactive' "$SKILL"
+  grep -qi 'skipping the GitHub issue prompt' "$SKILL"
+}

--- a/tests/scripts/git_origin_host_tests.bats
+++ b/tests/scripts/git_origin_host_tests.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# #226 — git-origin-host.sh classifies the origin remote: github | other | none.
+# github.com + enterprise GHE => github; lookalikes => other; no remote => none.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+HOSTC="$REPO_ROOT/scripts/git-origin-host.sh"
+
+@test "github.com over https is github" {
+  [ "$("$HOSTC" 'https://github.com/o/r')" = "github" ]
+}
+
+@test "github.com over scp-style ssh is github" {
+  [ "$("$HOSTC" 'git@github.com:o/r.git')" = "github" ]
+}
+
+@test "github.com over ssh:// is github" {
+  [ "$("$HOSTC" 'ssh://git@github.com/o/r')" = "github" ]
+}
+
+@test "enterprise GHE host (github.<corp>) is github" {
+  [ "$("$HOSTC" 'https://github.example.com/o/r')" = "github" ]
+  [ "$("$HOSTC" 'git@github.mycorp.com:o/r.git')" = "github" ]
+}
+
+@test "lookalike notgithub.example.com is other" {
+  [ "$("$HOSTC" 'https://notgithub.example.com/o/r')" = "other" ]
+}
+
+@test "lookalike mygithub.com is other" {
+  [ "$("$HOSTC" 'git@mygithub.com:o/r.git')" = "other" ]
+}
+
+@test "a non-github host is other" {
+  [ "$("$HOSTC" 'https://gitlab.com/o/r')" = "other" ]
+}
+
+@test "a repo with no origin remote is none (fail-open)" {
+  TMP="$(mktemp -d)"
+  git -C "$TMP" init -q
+  run bash -c "cd '$TMP' && '$HOSTC'"
+  rm -rf "$TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "none" ]
+}


### PR DESCRIPTION
Summary
Slice A of #38. Pins the two network-calling Tier-1 scanners in the static-analysis-integration skill to local-only operation, so the /code-review static-analysis pre-pass survives restricted-egress environments where trivy's current invocation makes outbound calls and fails. Pure invocation-flag + prose change — no new adapters, no parser changes, no executable code.

Changes
gitleaks — add --no-verify. Verification (confirming a detected secret is a live credential) is gitleaks' only outbound call; disabling it keeps detection fully pattern-based and offline. Always on — no detection cost.
trivy — add --skip-update --offline-scan to both trivy config and trivy fs, plus an offline DB preflight:
DB absent → skip trivy, warn trivy local DB missing — run: trivy image --download-db-only
DB mtime ≤ 7 days → run (fresh)
DB mtime > 7 days → run anyway, warn trivy DB is N days old — consider refreshing with: trivy image --download-db-only
7-day boundary inclusive; a missing/stale DB is never a hard pipeline failure (consistent with the graceful-degradation constraint).