### PR TITLE
fix(upgrade): skip legacy-id migration when version >= 6.1.0

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4209,11 +4209,11 @@
       "anchor": "worker-constraints"
     },
     "Steps": {
-      "summary": "The plugins in the `bfinster` marketplace were renamed:",
+      "summary": "**Version gate**: Before running this step, read the current version from",
       "anchor": "steps"
     },
     "0. Detect and migrate legacy plugin ids": {
-      "summary": "The plugins in the `bfinster` marketplace were renamed:",
+      "summary": "**Version gate**: Before running this step, read the current version from",
       "anchor": "0-detect-and-migrate-legacy-plugin-ids"
     },
     "1. Read current version": {

--- a/plugins/dev-team/skills/upgrade/SKILL.md
+++ b/plugins/dev-team/skills/upgrade/SKILL.md
@@ -25,6 +25,10 @@ You have been invoked with the `/upgrade` command.
 
 ### 0. Detect and migrate legacy plugin ids
 
+**Version gate**: Before running this step, read the current version from
+`~/.claude/plugins/cache/*/dev-team/*/.claude-plugin/plugin.json`. If the
+installed version is ≥ 6.1.0, skip this step entirely and proceed to Step 1.
+
 The plugins in the `bfinster` marketplace were renamed:
 
 - `agentic-dev-team` → `dev-team`


### PR DESCRIPTION
## Summary

- Adds a version gate to Step 0 of `/upgrade`: if the installed `dev-team` version is ≥ 6.1.0, the legacy plugin-id migration is skipped entirely
- Prevents unnecessary migration checks on installs that were never on the old `agentic-dev-team` id

## Test plan

- [ ] Run `/upgrade` on a clean install at v6.1.0 or later — Step 0 should be skipped
- [ ] Run `/upgrade` on an install below v6.1.0 — Step 0 should still execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)