### PR TITLE
docs: surface /specs in workflow commands and reorder skill-invocation section

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -29,21 +29,12 @@ As the security engineer, review the authentication flow for the mobile client
 
 Under the hood this dispatches the matching agent persona (the same one the Agent tool addresses as `subagent_type: dev-team:architect`). There is no `/architect` command — the persona is selected by intent, not by a slash.
 
-### Invoke a skill directly
-
-Skills *are* user-invocable as slash commands — use one to apply its procedures to your request:
-
-```text
-/threat-modeling Analyze the new payment API for security risks
-/api-design Define the contract for the notification service
-/specs Specify the user registration feature
-```
-
 ### Use the workflow commands
 
 The structured lifecycle has real slash commands. These are the primary entry points:
 
 ```text
+/specs   Capture intent, architecture, and acceptance criteria (lifecycle entry point)
 /plan    Break a task into an incremental, test-driven plan
 /build   Execute an approved plan with TDD and inline review
 /pr      Run the pre-PR quality gate and open a pull request
@@ -52,6 +43,16 @@ The structured lifecycle has real slash commands. These are the primary entry po
 ```
 
 Run `/help` to see every available command.
+
+### Invoke a skill directly
+
+Beyond the lifecycle commands above, any skill *is* user-invocable as a slash command — use one to apply its procedures to your request:
+
+```text
+/threat-modeling Analyze the new payment API for security risks
+/api-design Define the contract for the notification service
+/specs Specify the user registration feature
+```
 
 ## Common Workflows
 

--- a/tests/docs/getting_started_workflow_commands_tests.bats
+++ b/tests/docs/getting_started_workflow_commands_tests.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# #252 — GETTING-STARTED.md must list /specs as a workflow command and position
+# the primary lifecycle commands ahead of the "Invoke a skill directly" section.
+# Documentation gate.
+
+DOC="$BATS_TEST_DIRNAME/../../GETTING-STARTED.md"
+
+@test "workflow commands block lists /specs as the lifecycle entry point" {
+  # The /specs line must live inside the workflow-commands fenced block, not only
+  # in the skill-invocation examples.
+  run awk '
+    /^### Use the workflow commands/ { in_section=1 }
+    in_section && /^### Invoke a skill directly/ { in_section=0 }
+    in_section && /^\/specs/ { found=1 }
+    END { exit(found ? 0 : 1) }
+  ' "$DOC"
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow commands section appears before 'Invoke a skill directly'" {
+  workflow_line=$(grep -n '^### Use the workflow commands' "$DOC" | head -1 | cut -d: -f1)
+  invoke_line=$(grep -n '^### Invoke a skill directly' "$DOC" | head -1 | cut -d: -f1)
+  [ -n "$workflow_line" ]
+  [ -n "$invoke_line" ]
+  [ "$workflow_line" -lt "$invoke_line" ]
+}
+
+@test "primary lifecycle commands remain documented" {
+  for cmd in '/specs' '/plan' '/build' '/pr' '/code-review' '/triage'; do
+    grep -q -- "$cmd" "$DOC"
+  done
+}


### PR DESCRIPTION
## Summary

Fixes the two issues reported in #252 in `GETTING-STARTED.md`:

1. **`/specs` was missing from the workflow commands block.** The same document declares `/specs` the mandatory first step of the ATDD lifecycle (`## Rules to Know`, `### New Feature`), yet the `### Use the workflow commands` list omitted it. It's now listed first as the lifecycle entry point.
2. **`### Invoke a skill directly` was positioned before the primary lifecycle commands.** This made a secondary usage pattern look like the primary one. The `### Use the workflow commands` section now comes first; the skill-invocation section follows and is reframed as a supplement ("Beyond the lifecycle commands above…").

## Changes

- `GETTING-STARTED.md` — add `/specs` to the workflow commands block; reorder the two `###` subsections.
- `tests/docs/getting_started_workflow_commands_tests.bats` — new doc-gate (matches the repo's existing grep/awk doc-test convention) asserting: `/specs` lives in the workflow block, the workflow section precedes the skill-invocation section, and all primary lifecycle commands remain documented.

## Verification

```
1..3
ok 1 workflow commands block lists /specs as the lifecycle entry point
ok 2 workflow commands section appears before 'Invoke a skill directly'
ok 3 primary lifecycle commands remain documented
```

Docs-only change; no code paths affected.

Closes #252

https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv)_