### PR TITLE
feat(js-project-init): add lint-staged with pre-commit auto-fix

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2911,7 +2911,7 @@
       "anchor": "step-5-create-starter-files"
     },
     "Step 6: Git hooks": {
-      "summary": "Create the pre-push hook (template in `references/configs.md`):",
+      "summary": "Create both hooks (templates in `references/configs.md`):",
       "anchor": "step-6-git-hooks"
     },
     "Step 7: Verify": {

--- a/plugins/dev-team/skills/js-project-init/SKILL.md
+++ b/plugins/dev-team/skills/js-project-init/SKILL.md
@@ -17,7 +17,7 @@ Defaults:
 - **Editor**: EditorConfig (2-space, UTF-8, LF, trim trailing whitespace, final newline)
 - **Tests**: Vitest
 - **E2E** (frontend only): Playwright
-- **Git hooks**: Husky pre-push (lint + format check + test)
+- **Git hooks**: Husky pre-commit (lint-staged auto-fix of staged files) + pre-push (test)
 - **`.gitignore`**: node_modules, dist, build, coverage, .env, .env.*, OS files
 
 This skill scaffolds the **base tooling layer**. It does not replace framework-specific CLIs (`npx sv create`, `ng new`, `npm create vite@latest`). For a full framework scaffold, run the framework CLI first, then layer on these configs.
@@ -50,16 +50,24 @@ Read the generated `package.json`, then edit to:
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{js,mjs,cjs}": ["prettier --write", "eslint --fix"],
+    "*.{json,md,yaml,yml}": ["prettier --write"]
   }
 }
 ```
+
+`lint-staged` runs Prettier (and ESLint `--fix` on JS) against only the staged
+files on each commit, so formatting/lint drift is corrected automatically before
+it lands — without scanning the whole tree.
 
 Frontend projects also add: `"test:e2e": "playwright test"`.
 
 ### Step 3: Install dependencies
 
 ```bash
-npm install -D eslint prettier vitest @eslint/js eslint-config-prettier husky
+npm install -D eslint prettier vitest @eslint/js eslint-config-prettier husky lint-staged
 ```
 
 `eslint-config-prettier` disables ESLint rules that conflict with Prettier. Do NOT install `eslint-plugin-prettier` — run Prettier as a separate step (`npm run format:check`), not through ESLint.
@@ -98,27 +106,27 @@ git init  # skip if already a git repo
 npx husky init
 ```
 
-Create the pre-push hook (template in `references/configs.md`):
+Create both hooks (templates in `references/configs.md`):
 
 ```bash
-echo 'npm run lint
-npm run format:check
-npm test' > .husky/pre-push
+echo 'npx lint-staged' > .husky/pre-commit
+echo 'npm test' > .husky/pre-push
 ```
 
-Remove Husky's default pre-commit hook (we use pre-push instead):
+`npx husky init` writes a default `pre-commit`; the command above overwrites it.
+
+Frontend projects also run the e2e suite on push:
 
 ```bash
-rm .husky/pre-commit
+echo 'npm test
+npm run test:e2e' > .husky/pre-push
 ```
 
-Frontend projects append e2e:
-
-```bash
-echo 'npm run test:e2e' >> .husky/pre-push
-```
-
-Pre-push gates what goes upstream while keeping the local commit loop fast.
+The pre-commit hook auto-fixes only the staged files (`prettier --write` +
+`eslint --fix`) so the commit loop stays fast and clean; the pre-push hook runs
+the test suite to gate what goes upstream. Because lint-staged formats and lints
+on commit, the redundant `npm run format:check` and `npm run lint` steps are no
+longer needed on pre-push.
 
 ### Step 7: Verify
 
@@ -135,6 +143,7 @@ If any command fails, fix it before reporting success. Show the user the test ou
 After everything passes, give the user:
 - List of files created
 - Available npm scripts
+- Git hooks installed: `pre-commit` (lint-staged auto-fix of staged files) and `pre-push` (test suite; frontend also runs e2e)
 - One-line next-step suggestion (e.g., `npm run test:watch` to develop with live tests)
 
 ## Customization handling

--- a/plugins/dev-team/skills/js-project-init/references/configs.md
+++ b/plugins/dev-team/skills/js-project-init/references/configs.md
@@ -146,12 +146,23 @@ export default defineConfig({
 })
 ```
 
+## .husky/pre-commit
+
+```bash
+npx lint-staged
+```
+
 ## .husky/pre-push
 
 ```bash
-npm run lint
-npm run format:check
 npm test
+```
+
+Frontend projects append the e2e suite:
+
+```bash
+npm test
+npm run test:e2e
 ```
 
 ## src/index.js (starter file)

--- a/tests/skills/js_project_init_lint_staged_tests.bats
+++ b/tests/skills/js_project_init_lint_staged_tests.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# #250 — js-project-init must scaffold lint-staged with a pre-commit auto-fix hook
+# and simplify the pre-push hook to the test suite only. Documentation gate over
+# the skill prose and its config templates.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/js-project-init/SKILL.md"
+CFG="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/js-project-init/references/configs.md"
+
+@test "package.json template declares a lint-staged block with per-extension fix commands" {
+  grep -q '"lint-staged"' "$SKILL"
+  grep -q '"\*.{js,mjs,cjs}": \["prettier --write", "eslint --fix"\]' "$SKILL"
+  grep -q '"\*.{json,md,yaml,yml}": \["prettier --write"\]' "$SKILL"
+}
+
+@test "lint-staged is added to the dev dependency install" {
+  grep -q 'npm install -D .*lint-staged' "$SKILL"
+}
+
+@test "pre-commit hook runs lint-staged" {
+  grep -q "echo 'npx lint-staged' > .husky/pre-commit" "$SKILL"
+}
+
+@test "pre-push hook runs npm test" {
+  grep -q "echo 'npm test' > .husky/pre-push" "$SKILL"
+}
+
+@test "frontend pre-push retains the e2e suite" {
+  grep -q 'npm run test:e2e' "$SKILL"
+}
+
+@test "step 8 summary lists both git hooks" {
+  grep -qi 'pre-commit.*lint-staged' "$SKILL"
+  grep -qi 'pre-push.*test' "$SKILL"
+}
+
+@test "configs.md pre-commit template contains npx lint-staged" {
+  grep -q 'npx lint-staged' "$CFG"
+}
+
+@test "configs.md pre-push template contains npm test and no lint/format:check" {
+  # Extract the '## .husky/pre-push' section up to the next level-2 heading.
+  section=$(awk '/^## \.husky\/pre-push/{f=1;next} /^## /{f=0} f' "$CFG")
+  echo "$section" | grep -q 'npm test'
+  ! echo "$section" | grep -q 'format:check'
+  ! echo "$section" | grep -qw 'npm run lint'
+}


### PR DESCRIPTION
## Summary

Implements #250. Adds `lint-staged` to the `js-project-init` scaffold so that only **staged** files are auto-fixed (`prettier --write` + `eslint --fix`) on pre-commit, and simplifies the pre-push hook to `npm test` only. The previous pre-push `format:check` + `lint` steps were whole-tree and redundant now that lint-staged fixes formatting/lint drift on each commit.

## Changes (`plugins/dev-team/skills/js-project-init/`)

- **SKILL.md Step 2** — add a `"lint-staged"` block to `package.json` with per-extension fix commands.
- **SKILL.md Step 3** — add `lint-staged` to `npm install -D`.
- **SKILL.md Step 6** — write a `pre-commit` hook (`npx lint-staged`) and a `pre-push` hook (`npm test`; frontend also runs `test:e2e`); drop the old `rm .husky/pre-commit` and the `lint`/`format:check` pre-push steps.
- **SKILL.md Step 8** — summary now lists both hooks.
- **SKILL.md Defaults** — describe the two-hook setup.
- **references/configs.md** — add the `pre-commit` template, simplify the `pre-push` template (with the frontend e2e variant).
- **tests/skills/js_project_init_lint_staged_tests.bats** — new doc-gate covering the acceptance criteria.

## Acceptance criteria (from #250)

1. ✅ `package.json` contains `"lint-staged"` with per-extension fix commands
2. ✅ `.husky/pre-commit` contains `npx lint-staged`
3. ✅ `.husky/pre-push` contains `npm test`, no `format:check`/`lint`
4. ✅ `lint-staged` in `devDependencies`
5. ✅ Step 7 verify sequence unchanged (the `lint`/`format:check`/`test` npm scripts still exist, so it still passes)
6. ✅ Frontend retains `test:e2e` in pre-push
7. ✅ Step 8 summary lists both hooks

## Verification

```
1..8
ok 1 package.json template declares a lint-staged block with per-extension fix commands
ok 2 lint-staged is added to the dev dependency install
ok 3 pre-commit hook runs lint-staged
ok 4 pre-push hook runs npm test
ok 5 frontend pre-push retains the e2e suite
ok 6 step 8 summary lists both git hooks
ok 7 configs.md pre-commit template contains npx lint-staged
ok 8 configs.md pre-push template contains npm test and no lint/format:check
```

Closes #250

https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv)_