### PR TITLE
feat(build): JS project bootstrap gate — invoke js-project-init when package.json missing

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1530,6 +1530,10 @@
       "summary": "If `--plan` was provided, read that file.",
       "anchor": "1-find-the-plan"
     },
+    "1.5. JS project bootstrap gate": {
+      "summary": "Before any TDD step runs, make sure a JS-flavored plan has a project to build in.",
+      "anchor": "15-js-project-bootstrap-gate"
+    },
     "2. Verify plan status": {
       "summary": "Read the plan file.",
       "anchor": "2-verify-plan-status"

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -37,6 +37,17 @@ Arguments: $ARGUMENTS
 
 If `--plan` was provided, read that file. Otherwise, search `plans/` for `.md` files and find the most recently modified one with `**Status**: approved`. If no approved plan is found, tell the user: "No approved plan found. Run `/plan` first, then approve it."
 
+### 1.5. JS project bootstrap gate
+
+Before any TDD step runs, make sure a JS-flavored plan has a project to build in. A fresh JS project with no `package.json` will fail the first RED step (no test runner, no scripts), so bootstrap it first.
+
+1. **Check for `package.json`** in the working directory. If it exists, **skip this gate silently** and continue to Step 2.
+2. **Check the plan file for JS/TS signals** — any of `.js`, `.mjs`, `.ts`, `.jsx`, `.tsx`, `node`, `npm`, `vitest`, `jest`, `eslint`. If none are present, the plan is non-JS: **skip this gate silently** and continue to Step 2.
+3. **Bootstrap** (only when `package.json` is absent **and** the plan is JS-flavored): print exactly one line — `No package.json found for a JS plan — bootstrapping with js-project-init.` — then invoke the `js-project-init` skill.
+4. **Halt on failure.** If `js-project-init` fails, **stop `/build`** and report the failure — do not proceed to Step 2 or any implementation step.
+
+The user sees no more than one line of output before `js-project-init` runs, and nothing at all when the gate is skipped.
+
 ### 2. Verify plan status
 
 Read the plan file. If the status is not `approved`, ask the user: "This plan has status '<status>'. Approve it before building, or continue anyway?"

--- a/tests/skills/build_js_project_init_gate_tests.bats
+++ b/tests/skills/build_js_project_init_gate_tests.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# #251 — /build must gate on a JS bootstrap step (Step 1.5) that invokes
+# js-project-init when a JS-flavored plan has no package.json, and skips
+# silently otherwise. Documentation gate over the skill prose.
+
+BUILD="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/build/SKILL.md"
+
+@test "Step 1.5 is documented as a heading" {
+  grep -qE '^### 1\.5\. ' "$BUILD"
+}
+
+@test "Step 1.5 sits between 'Find the plan' (Step 1) and 'Verify plan status' (Step 2)" {
+  step1=$(grep -n '^### 1\. ' "$BUILD" | head -1 | cut -d: -f1)
+  step15=$(grep -n '^### 1\.5\. ' "$BUILD" | head -1 | cut -d: -f1)
+  step2=$(grep -n '^### 2\. ' "$BUILD" | head -1 | cut -d: -f1)
+  [ -n "$step1" ] && [ -n "$step15" ] && [ -n "$step2" ]
+  [ "$step1" -lt "$step15" ]
+  [ "$step15" -lt "$step2" ]
+}
+
+@test "gate checks for package.json" {
+  grep -q 'package.json' "$BUILD"
+}
+
+@test "gate enumerates JS/TS signals" {
+  section=$(awk '/^### 1\.5\. /{f=1;next} /^### 2\. /{f=0} f' "$BUILD")
+  for sig in '.js' '.mjs' '.ts' '.jsx' '.tsx' 'node' 'npm' 'vitest' 'jest' 'eslint'; do
+    echo "$section" | grep -qF "$sig"
+  done
+}
+
+@test "gate invokes js-project-init when bootstrapping" {
+  section=$(awk '/^### 1\.5\. /{f=1;next} /^### 2\. /{f=0} f' "$BUILD")
+  echo "$section" | grep -q 'js-project-init'
+}
+
+@test "gate skips silently when package.json exists or plan is non-JS" {
+  section=$(awk '/^### 1\.5\. /{f=1;next} /^### 2\. /{f=0} f' "$BUILD")
+  echo "$section" | grep -qi 'skip this gate silently'
+}
+
+@test "gate emits exactly one notice line before bootstrapping" {
+  section=$(awk '/^### 1\.5\. /{f=1;next} /^### 2\. /{f=0} f' "$BUILD")
+  echo "$section" | grep -qi 'one line'
+}
+
+@test "gate halts /build when js-project-init fails" {
+  section=$(awk '/^### 1\.5\. /{f=1;next} /^### 2\. /{f=0} f' "$BUILD")
+  echo "$section" | grep -qiE 'halt|stop'
+  echo "$section" | grep -qi 'fail'
+}


### PR DESCRIPTION
## Summary

Implements #251. Adds an early gate to `/build` (**Step 1.5**, inserted between "Find the plan" and "Verify plan status") that detects a JS-flavored plan with no `package.json` and invokes `js-project-init` before any TDD step runs. This prevents the first RED step from failing on a fresh JS project that has no test runner or scripts yet.

## Changes (`plugins/dev-team/skills/build/SKILL.md`)

New **Step 1.5 — JS project bootstrap gate**:
- Checks the working directory for `package.json`; if present, skips silently.
- Checks the plan file for JS/TS signals (`.js`, `.mjs`, `.ts`, `.jsx`, `.tsx`, `node`, `npm`, `vitest`, `jest`, `eslint`); if none, skips silently.
- Only when `package.json` is absent **and** the plan is JS-flavored: prints exactly one notice line, then invokes `js-project-init`.
- Halts `/build` if `js-project-init` fails.

Plus `tests/skills/build_js_project_init_gate_tests.bats` — a doc-gate covering the acceptance criteria.

## Acceptance criteria (from #251)

1. ✅ JS plan + no `package.json` → invokes `js-project-init` before any plan step
2. ✅ JS plan + existing `package.json` → gate skipped silently
3. ✅ Non-JS plan + no `package.json` → gate skipped silently
4. ✅ User sees exactly one line of output before `js-project-init` runs
5. ✅ `js-project-init` failure halts `/build` without proceeding
6. ✅ Gate documented as Step 1.5 in SKILL.md

## Verification

```
1..8
ok 1 Step 1.5 is documented as a heading
ok 2 Step 1.5 sits between 'Find the plan' (Step 1) and 'Verify plan status' (Step 2)
ok 3 gate checks for package.json
ok 4 gate enumerates JS/TS signals
ok 5 gate invokes js-project-init when bootstrapping
ok 6 gate skips silently when package.json exists or plan is non-JS
ok 7 gate emits exactly one notice line before bootstrapping
ok 8 gate halts /build when js-project-init fails
```

Existing `build_parallel_doc_tests.bats` still passes (no regression).

Closes #251

https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv)_