### PR TITLE
feat(version): make /version a mechanical, deterministic lookup

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -68,17 +68,20 @@ jobs:
       - name: Run rules-vs-prompts audit
         run: bash scripts/audit-rules-vs-prompts.sh
 
-      # Model-routing conformance: the updatedInput PreToolUse rewrite
-      # contract (ADR-0004) is load-bearing and depends on undocumented
-      # harness behavior. These hook tests are toolchain-free (bash + jq),
-      # unlike the rest of tests/hooks/ which needs stryker/pitest — so they
-      # run here as a CI gate. See issue #104.
-      - name: Run model-routing hook conformance tests (bats)
+      # Toolchain-free hook conformance gates. Most of tests/hooks/ needs
+      # stryker/pitest and is excluded above, but these suites are pure
+      # bash + python3 + jq, so they run here as CI gates:
+      #   - model-routing: the updatedInput PreToolUse rewrite contract
+      #     (ADR-0004) is load-bearing and depends on undocumented harness
+      #     behavior (#104).
+      #   - plugin-version: the mechanical /version resolver.
+      - name: Run toolchain-free hook conformance tests (bats)
         run: |
           bash scripts/run-bats-parallel.sh \
             tests/hooks/updated_input_contract_tests.bats \
             tests/hooks/agent_model_resolve_hook_tests.bats \
-            tests/hooks/model_resolve_tests.bats
+            tests/hooks/model_resolve_tests.bats \
+            tests/hooks/plugin_version_tests.bats
 
   # Cost-regression gate (#140 mechanism, #171 real baseline). Isolated in its
   # own job so the read-only telemetry deploy key is never in scope for the

--- a/plugins/dev-team/hooks/lib/plugin-version.sh
+++ b/plugins/dev-team/hooks/lib/plugin-version.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# plugin-version.sh — mechanically resolve the installed version of a Claude Code
+# plugin, with NO model reasoning involved.
+#
+# Resolution order (matches "current project first, then user settings"):
+#   1. A project-scoped install whose projectPath == the current working dir.
+#   2. A user-scoped (or any other-scoped) install of the same plugin.
+#
+# The single source of truth is ~/.claude/plugins/installed_plugins.json, which
+# Claude Code maintains for every install. The on-disk plugin.json at the
+# recorded installPath is preferred for the version string (it is the actual
+# bytes loaded); the JSON's "version" field is the fallback.
+#
+# Usage:   plugin-version.sh [plugin-name]   (default: dev-team)
+# Output:  one line on stdout, e.g.  dev-team@bfinster v6.7.0 (scope: user)
+# Exit:    0 found, 1 not installed, 2 environment error (no python3 / no file).
+set -euo pipefail
+
+PLUGIN_NAME="${1:-dev-team}"
+INSTALLED_JSON="${UPGRADE_INSTALLED_JSON:-$HOME/.claude/plugins/installed_plugins.json}"
+
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 not found" >&2; exit 2; }
+[ -f "$INSTALLED_JSON" ] || { echo "error: not found: $INSTALLED_JSON" >&2; exit 2; }
+
+PLUGIN_NAME="$PLUGIN_NAME" INSTALLED_JSON="$INSTALLED_JSON" python3 - <<'PY'
+import json, os
+
+name = os.environ["PLUGIN_NAME"]
+path = os.environ["INSTALLED_JSON"]
+cwd = os.path.realpath(os.getcwd())
+
+with open(path) as f:
+    plugins = (json.load(f) or {}).get("plugins", {})
+
+# Collect every install record whose plugin id is "<name>@<marketplace>".
+records = []
+for pid, entries in plugins.items():
+    pname = pid.split("@", 1)[0]
+    market = pid.split("@", 1)[1] if "@" in pid else ""
+    if pname != name:
+        continue
+    for e in (entries if isinstance(entries, list) else [entries]):
+        records.append({
+            "id": pid,
+            "market": market,
+            "scope": e.get("scope", ""),
+            "projectPath": e.get("projectPath", ""),
+            "installPath": e.get("installPath", ""),
+            "version": e.get("version", ""),
+        })
+
+if not records:
+    raise SystemExit(1)
+
+def project_match(r):
+    pp = r.get("projectPath") or ""
+    return r["scope"] == "project" and pp and os.path.realpath(pp) == cwd
+
+# 1. project install for THIS path  2. user scope  3. anything else.
+chosen = (
+    next((r for r in records if project_match(r)), None)
+    or next((r for r in records if r["scope"] == "user"), None)
+    or records[0]
+)
+
+# Prefer the version from the actual on-disk plugin.json at installPath.
+version = chosen["version"]
+manifest = os.path.join(chosen["installPath"], ".claude-plugin", "plugin.json")
+try:
+    with open(manifest) as f:
+        version = (json.load(f) or {}).get("version", version) or version
+except (OSError, json.JSONDecodeError):
+    pass
+
+scope = chosen["scope"] or "unknown"
+where = "scope: project, this project" if project_match(chosen) else f"scope: {scope}"
+print(f'{chosen["id"]} v{version} ({where})')
+PY

--- a/plugins/dev-team/hooks/lib/plugin-version.sh
+++ b/plugins/dev-team/hooks/lib/plugin-version.sh
@@ -54,11 +54,23 @@ if not records:
 
 def project_match(r):
     pp = r.get("projectPath") or ""
-    return r["scope"] == "project" and pp and os.path.realpath(pp) == cwd
+    if r["scope"] != "project" or not pp:
+        return False
+    pp = os.path.realpath(pp)
+    # A project-scoped plugin applies to the whole project tree, so match
+    # when cwd is the project root OR any directory beneath it (e.g. /version
+    # invoked from a subdirectory).
+    return cwd == pp or cwd.startswith(pp + os.sep)
 
-# 1. project install for THIS path  2. user scope  3. anything else.
+# 1. the project install enclosing cwd — most specific (deepest projectPath)
+#    first, for nested projects;  2. user scope;  3. anything else.
+project_matches = sorted(
+    (r for r in records if project_match(r)),
+    key=lambda r: len(os.path.realpath(r["projectPath"])),
+    reverse=True,
+)
 chosen = (
-    next((r for r in records if project_match(r)), None)
+    (project_matches[0] if project_matches else None)
     or next((r for r in records if r["scope"] == "user"), None)
     or records[0]
 )

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4246,12 +4246,8 @@
     }
   },
   "plugins/dev-team/skills/version/SKILL.md": {
-    "Worker constraints": {
-      "summary": "1.",
-      "anchor": "worker-constraints"
-    },
     "Steps": {
-      "summary": "Find the installed plugin version by checking these locations in order:",
+      "summary": "Run the resolver and report its output verbatim:",
       "anchor": "steps"
     }
   }

--- a/plugins/dev-team/skills/version/SKILL.md
+++ b/plugins/dev-team/skills/version/SKILL.md
@@ -3,31 +3,39 @@ name: version
 description: >-
   Report the installed version of the dev-team plugin.
 user-invocable: true
-allowed-tools: Read, Bash, Glob
+allowed-tools: Bash
 ---
 
 # Version
 
-Role: worker. This command reports the installed plugin version.
+Role: worker. This command reports the installed plugin version. It is a purely
+mechanical lookup — no reasoning, no file-by-file searching.
 
 You have been invoked with the `/version` command.
 
 Arguments: none.
 
-## Worker constraints
-
-1. Read only; never write or modify files.
-2. Report the first match found; do not aggregate.
-3. **Be concise.** Output only the version line.
-
 ## Steps
 
-Find the installed plugin version by checking these locations in order:
+Run the resolver and report its output verbatim:
 
-1. **Project-level install**: Look for a `plugin.json` under the current project's `.claude/plugins/` directory that contains `"name": "dev-team"`. Use `find` or `Glob` to locate it.
-2. **User-level cache**: List directories under `~/.claude/plugins/cache/bfinster/dev-team/` — each subdirectory name is a cached version. Report the highest version found.
-3. **Marketplace source**: Read `~/.claude/plugins/marketplaces/bfinster/plugins/dev-team/.claude-plugin/plugin.json` and extract the `version` field.
+```bash
+"$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin-version.sh"
+```
 
-Report the **first match found** (project > cache > marketplace).
+The script reads `~/.claude/plugins/installed_plugins.json` (Claude Code's
+install record) and resolves the version deterministically: a project-scoped
+install for the current directory wins; otherwise it falls back to the
+user-scoped install. It prints a single line, e.g.:
 
-Output format: `dev-team@bfinster v{version} (source: {project|cache|marketplace})`
+```
+dev-team@bfinster v6.7.0 (scope: user)
+```
+
+- **Exit 0** — print the line as-is.
+- **Exit 1** — the plugin is not recorded as installed; report exactly:
+  `dev-team is not installed (no record in installed_plugins.json).`
+- **Exit 2** — environment error (no `python3`, or the install record is
+  missing); surface the script's stderr message verbatim.
+
+Do not add commentary beyond the single result line.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -89,7 +89,8 @@ chk_model_routing() {
   run_bats \
     tests/hooks/updated_input_contract_tests.bats \
     tests/hooks/agent_model_resolve_hook_tests.bats \
-    tests/hooks/model_resolve_tests.bats
+    tests/hooks/model_resolve_tests.bats \
+    tests/hooks/plugin_version_tests.bats
 }
 chk_cost_regression() { bash scripts/cost-regression-check.sh; }
 chk_eval_corpus()     { python3 scripts/eval_grade.py --check-corpus; }

--- a/tests/hooks/plugin_version_tests.bats
+++ b/tests/hooks/plugin_version_tests.bats
@@ -35,6 +35,20 @@ EOF
   [[ "$output" == "dev-team@bfinster v9.9.9 (scope: project, this project)" ]]
 }
 
+@test "project-scoped install matches when run from a SUBDIRECTORY of the project root" {
+  proj="$TMP/proj"
+  mkdir -p "$proj/sub/dir"
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"dev-team@bfinster":[
+  {"scope":"user","installPath":"/nonexistent","version":"6.7.0"},
+  {"scope":"project","projectPath":"$proj","installPath":"/nonexistent","version":"9.9.9"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash -c "cd '$proj/sub/dir' && bash '$RESOLVER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "dev-team@bfinster v9.9.9 (scope: project, this project)" ]]
+}
+
 @test "project install for a DIFFERENT path does not match; falls back to user" {
   cat > "$JSON" <<EOF
 {"version":2,"plugins":{"dev-team@bfinster":[

--- a/tests/hooks/plugin_version_tests.bats
+++ b/tests/hooks/plugin_version_tests.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Tests for hooks/lib/plugin-version.sh — the mechanical plugin version resolver.
+
+RESOLVER="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/plugin-version.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  JSON="$TMP/installed_plugins.json"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "reports user-scoped install when no project install matches cwd" {
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"dev-team@bfinster":[
+  {"scope":"user","installPath":"/nonexistent","version":"6.7.0"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "dev-team@bfinster v6.7.0 (scope: user)" ]]
+}
+
+@test "project-scoped install for the current directory wins over user scope" {
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"dev-team@bfinster":[
+  {"scope":"user","installPath":"/nonexistent","version":"6.7.0"},
+  {"scope":"project","projectPath":"$PWD","installPath":"/nonexistent","version":"9.9.9"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "dev-team@bfinster v9.9.9 (scope: project, this project)" ]]
+}
+
+@test "project install for a DIFFERENT path does not match; falls back to user" {
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"dev-team@bfinster":[
+  {"scope":"user","installPath":"/nonexistent","version":"6.7.0"},
+  {"scope":"project","projectPath":"/some/other/project","installPath":"/nonexistent","version":"9.9.9"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "dev-team@bfinster v6.7.0 (scope: user)" ]]
+}
+
+@test "prefers the on-disk plugin.json version at installPath over the record" {
+  install_dir="$TMP/install/.claude-plugin"
+  mkdir -p "$install_dir"
+  echo '{"name":"dev-team","version":"7.0.0"}' > "$install_dir/plugin.json"
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"dev-team@bfinster":[
+  {"scope":"user","installPath":"$TMP/install","version":"6.7.0"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "dev-team@bfinster v7.0.0 (scope: user)" ]]
+}
+
+@test "exits 1 when the plugin is not recorded as installed" {
+  echo '{"version":2,"plugins":{}}' > "$JSON"
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER"
+  [ "$status" -eq 1 ]
+}
+
+@test "exits 2 when the install record file is missing" {
+  run env UPGRADE_INSTALLED_JSON="$TMP/does-not-exist.json" bash "$RESOLVER"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "resolves an alternate plugin name passed as an argument" {
+  cat > "$JSON" <<EOF
+{"version":2,"plugins":{"security-assessment@bfinster":[
+  {"scope":"user","installPath":"/nonexistent","version":"2.1.0"}
+]}}
+EOF
+  run env UPGRADE_INSTALLED_JSON="$JSON" bash "$RESOLVER" security-assessment
+  [ "$status" -eq 0 ]
+  [[ "$output" == "security-assessment@bfinster v2.1.0 (scope: user)" ]]
+}


### PR DESCRIPTION
## What

`/version` previously instructed the model to search several locations in order (project `.claude/plugins/`, user cache, marketplace source) and reason about which match to report. This makes the command a **purely mechanical lookup** — no model reasoning.

New helper `hooks/lib/plugin-version.sh` reads Claude Code's own install record (`~/.claude/plugins/installed_plugins.json`) and resolves the version deterministically:

1. a **project-scoped** install whose `projectPath` == the current working directory, else
2. the **user-scoped** (or any) install

This matches the requested "look in the current path first, then the user's settings" order. The on-disk `plugin.json` at the recorded `installPath` is preferred for the version string; the record's `version` field is the fallback.

The skill is now a thin wrapper: run the script, print the one-line result. Exit codes — `0` found, `1` not installed, `2` environment error (no `python3` / missing record).

## Why

Mechanical version detection shouldn't depend on the model walking a search order. A deterministic script is faster, cheaper, and can't misreport.

## Tests

7 bats tests in `tests/hooks/plugin_version_tests.bats`: project-first preference, user fallback, non-matching project path, on-disk manifest precedence, not-installed (exit 1), missing record file (exit 2), alternate plugin name. shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)