### PR TITLE
chore(renovate): ignore eval/test fixture manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,18 @@
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__fixtures__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__tests__/**",
+    "evals/**",
+    "plugins/security-assessment/harness/**"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 4am on monday"]


### PR DESCRIPTION
## Summary

Hardens the Renovate config so it won't churn on the repo's deliberately-vulnerable eval/test fixtures once the Renovate GitHub App is enabled.

## Context

Verifying the Renovate setup turned up that `renovate.json` is present and **passes the official schema validator**, but the **Renovate GitHub App has never run** on this repo (no Dependency Dashboard issue, no onboarding PR, no `app/renovate` PRs, no `renovate/*` branches). Separately, the repo has a critical **Dependabot alert** that traces to a *fixture* — `evals/codebase-recon/fixtures/polyglot/backend/requirements.txt` pinning `fastapi==0.111.0` → `starlette 0.37.2`.

`config:recommended`'s default `ignorePaths` covers `**/tests/**` and `**/node_modules/**` (so `tests/fixtures/**` is already excluded) but **not** `evals/**`. So when Renovate is activated it would start opening update + vulnerability PRs against the deliberately-vulnerable security-assessment corpora. Those fixtures are static scan targets for the security plugin, never installed — bumping them has no security value and would weaken the tests.

## Change

Add an explicit `ignorePaths` to `renovate.json`. Because setting the key **replaces** rather than extends the preset value, this re-states the `config:recommended` defaults and adds:

- `evals/**`
- `plugins/security-assessment/harness/**`

This is also the Renovate-native answer to the open Dependabot alert (no separate `.github/dependabot.yml` needed).

## Verification

```
$ renovate-config-validator renovate.json
 INFO: Config validated successfully
```

## Not in scope (needs a human)

Renovate still has to be **installed/enabled** as a GitHub App on the repo/org (https://github.com/apps/renovate) — that's a repo-admin UI action I can't perform. Until then, nothing manages dependencies regardless of this config. The existing Dependabot alert also still needs a one-click *Dismiss → "used in tests"* in the UI.

https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qDtDpSpXYE6Z52mvrBwv)_