### PR TITLE
feat(security-assessment): build joern C# CPGs for .NET targets

### DIFF
--- a/plugins/security-assessment/docs/user-guide-security-assessment.md
+++ b/plugins/security-assessment/docs/user-guide-security-assessment.md
@@ -66,6 +66,8 @@ Install these if you work with the ecosystems they cover.
 
 **Joern is a special case**: ~400 MB install but enables deterministic call-graph reachability in FP-reduction. Without it, the agent falls back to LLM reasoning and the exec report carries a banner noting the fallback. Install if you run assessments routinely; skip if you try the plugin occasionally.
 
+**.NET / C# targets** need joern ≥ 2.0.0 plus the `dotnetastgen` C# frontend; the reachability wrapper auto-detects C# and passes `joern-parse --language csharp`. `install-macos.sh --all` installs both and `install.sh` verifies the C# path against a committed fixture (`scripts/verify-joern-csharp.sh`); if either is missing, .NET scans degrade to LLM-fallback rather than failing.
+
 ### How to check what's installed
 
 ```bash

--- a/plugins/security-assessment/install-macos.sh
+++ b/plugins/security-assessment/install-macos.sh
@@ -13,6 +13,11 @@
 # Safe to re-run: each step checks presence first and skips when already
 # installed. Homebrew self-update is suppressed (HOMEBREW_NO_AUTO_UPDATE=1).
 #
+# joern (C# reachability for fp-reduction) is optional and large (~400 MB):
+# --all installs joern + the dotnetastgen C# frontend; the default mode only
+# warns when joern is absent. Either way the install never fails on joern.
+# Minimum tested joern version: 2.0.0 (bundles the csharpsrc2cpg frontend).
+#
 # Exit codes:
 #   0  — all requested installs succeeded (or were already present)
 #   1  — missing prerequisite (brew, python3) or one install failed
@@ -191,6 +196,50 @@ if [[ "$MODE" == "all" ]]; then
   section "Red-team / PDF export deps"
   brew_install pandoc
   pip_install weasyprint
+fi
+
+# ── joern — C# / .NET reachability for fp-reduction (optional) ──────────────
+# Minimum tested joern version: 2.0.0 (bundles the csharpsrc2cpg C# frontend,
+# which parses via the external 'dotnetastgen' .NET global tool). joern is
+# optional and never fails the run: --all installs it; default mode warns.
+
+JOERN_DOCS="https://docs.joern.io/installation/"
+JOERN_VERIFY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/verify-joern-csharp.sh"
+
+section "joern — C# / .NET reachability for fp-reduction (optional, ~400 MB)"
+if [[ "$MODE" == "all" ]]; then
+  if command -v joern-parse &>/dev/null; then
+    printf '  [skip] %-16s — already installed\n' joern
+    SKIPPED=$((SKIPPED + 1))
+  elif run brew install --quiet joern; then
+    INSTALLED=$((INSTALLED + 1))
+  else
+    echo "  [warn] could not install joern via brew — .NET targets will use LLM-fallback ($JOERN_DOCS)"
+  fi
+  # joern's C# frontend parses through the external dotnetastgen .NET tool.
+  if command -v dotnet &>/dev/null; then
+    if command -v dotnetastgen &>/dev/null; then
+      printf '  [skip] %-16s — already installed\n' dotnetastgen
+      SKIPPED=$((SKIPPED + 1))
+    elif run dotnet tool install --global dotnetastgen; then
+      INSTALLED=$((INSTALLED + 1))
+    else
+      echo "  [warn] dotnetastgen install failed; C# CPGs may be incomplete ($JOERN_DOCS)"
+    fi
+  else
+    echo "  [warn] .NET SDK not found — joern's C# frontend needs 'dotnetastgen'."
+    echo "         Install the .NET SDK, then: dotnet tool install --global dotnetastgen"
+  fi
+elif command -v joern-parse &>/dev/null; then
+  printf '  [skip] %-16s — already installed\n' joern
+  SKIPPED=$((SKIPPED + 1))
+else
+  echo "  [warn] joern not installed — fp-reduction will use LLM-fallback for .NET/C# targets."
+  echo "         Re-run with --all (or install manually: $JOERN_DOCS) to enable joern-cpg reachability."
+fi
+# Verify the C# path end-to-end against the committed fixture (non-fatal).
+if (( DRY_RUN == 0 )) && command -v joern-parse &>/dev/null && [[ -x "$JOERN_VERIFY" ]]; then
+  "$JOERN_VERIFY" || echo "  (C# verification did not pass — .NET targets use LLM-fallback; see warning above)"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────

--- a/plugins/security-assessment/install.sh
+++ b/plugins/security-assessment/install.sh
@@ -8,6 +8,9 @@
 #   3. Tier-1 tool presence, grouped by capability tier. Required tools are
 #      shown with [REQUIRED] prefix; absence is hard failure. Optional tools
 #      absence emits warnings.
+#   3b. joern C# reachability check (optional). Verifies joern can build a C#
+#      CPG via scripts/verify-joern-csharp.sh. Minimum tested joern version:
+#      2.0.0. Absence/failure is WARN only — it never blocks the install.
 #   4. Prints the exact settings.local.json opt-out snippet for hooks.
 #
 # Exit codes:
@@ -180,6 +183,26 @@ opt weasyprint   "PDF export (fallback)"           "pip install weasyprint"
 # Python packages can't use command -v — check via import.
 printf "  [info] python harness packages checked at /redteam-model invocation time;\n"
 printf "         see plugins/security-assessment/harness/redteam/requirements.txt\n"
+
+# ── 3b. joern C# reachability (optional; powers fp-reduction on .NET) ─────────
+# joern is optional: it enables deterministic call-graph reachability for the
+# .NET/C# FP-reduction path. Absence or a broken C# frontend degrades that
+# single path to LLM-fallback — never a hard install failure. Min tested
+# joern version: 2.0.0 (bundles the csharpsrc2cpg frontend).
+
+section "joern C# reachability (optional — powers fp-reduction on .NET targets)"
+JOERN_VERIFY="$SCRIPT_DIR/scripts/verify-joern-csharp.sh"
+if [ -x "$JOERN_VERIFY" ]; then
+  if "$JOERN_VERIFY"; then
+    PASS=$((PASS + 1))
+  else
+    # verify-joern-csharp.sh already printed an actionable [warn] line.
+    WARN=$((WARN + 1))
+  fi
+else
+  echo "  [warn] verify-joern-csharp.sh not found or not executable; skipping joern check" >&2
+  WARN=$((WARN + 1))
+fi
 
 # ── 4. Hook opt-out snippet ───────────────────────────────────────────────────
 

--- a/plugins/security-assessment/knowledge/fixtures/joern-dotnet/VulnerableController.cs
+++ b/plugins/security-assessment/knowledge/fixtures/joern-dotnet/VulnerableController.cs
@@ -1,0 +1,38 @@
+// Test fixture for the joern C# CPG path (issue #60).
+//
+// Deliberately vulnerable: HTTP query input flows unsanitized through a
+// string concatenation into a SQL command (source -> string-concat -> sink).
+// Consumed by:
+//   - scripts/verify-joern-csharp.sh  (install-time C# frontend verification)
+//   - skills/false-positive-reduction/tools/reachability.sh  (csharp detection)
+// The chain is intentionally simple so a correctly-wired joern C# frontend
+// produces a non-empty CPG with a traceable source->sink path.
+using System.Data.SqlClient;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fixtures.JoernDotnet
+{
+    [ApiController]
+    [Route("api/users")]
+    public class VulnerableController : ControllerBase
+    {
+        private readonly string _connectionString;
+
+        public VulnerableController(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        [HttpGet]
+        public IActionResult GetByName([FromQuery] string name)
+        {
+            // SINK: user-controlled 'name' concatenated straight into SQL text.
+            var query = "SELECT * FROM Users WHERE Name = '" + name + "'";
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(query, connection);
+            connection.Open();
+            using var reader = command.ExecuteReader();
+            return Ok(reader);
+        }
+    }
+}

--- a/plugins/security-assessment/scripts/verify-joern-csharp.sh
+++ b/plugins/security-assessment/scripts/verify-joern-csharp.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# verify-joern-csharp.sh — verify joern can build a C# CPG.
+#
+# Used by install.sh (presence check) and install-macos.sh (post-install
+# check) to confirm the .NET/C# reachability path in fp-reduction actually
+# works. Builds a CPG from the committed C# fixture with
+# `joern-parse --language csharp` and confirms the output CPG is non-empty.
+#
+# Minimum tested joern version: 2.0.0 — the first line that bundles the
+# csharpsrc2cpg C# frontend (older builds reject `--language csharp`). The
+# C# frontend parses via the external 'dotnetastgen' .NET global tool.
+#
+# Usage:
+#   verify-joern-csharp.sh [<fixture-dir>]
+#
+# Exit codes:
+#   0  — joern present and built a non-empty C# CPG (joern-cpg path is live)
+#   1  — joern absent (fp-reduction runs in LLM-fallback mode for .NET)
+#   2  — joern present but the C# CPG build failed or was empty (C# frontend
+#        missing/broken; .NET targets degrade to LLM-fallback)
+
+set -uo pipefail
+
+JOERN_DOCS="https://docs.joern.io/installation/"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="${1:-$SCRIPT_DIR/../knowledge/fixtures/joern-dotnet}"
+
+if ! command -v joern-parse >/dev/null 2>&1; then
+  echo "  [warn] joern not installed — fp-reduction will run in LLM-fallback mode for .NET/C# targets." >&2
+  echo "         Install joern (>= 2.0.0) for deterministic call-graph reachability: $JOERN_DOCS" >&2
+  exit 1
+fi
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+  echo "  [FAIL] C# fixture directory not found: $FIXTURE_DIR" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+TMP_CPG="$WORK/csharp-verify.cpg"
+
+if ! joern-parse "$FIXTURE_DIR" --language csharp --output "$TMP_CPG" >/dev/null 2>&1; then
+  echo "  [warn] 'joern-parse --language csharp' failed on the C# fixture — C# frontend missing/broken." >&2
+  echo "         .NET targets will use LLM-fallback. See $JOERN_DOCS" >&2
+  exit 2
+fi
+
+if [ ! -s "$TMP_CPG" ]; then
+  echo "  [warn] joern produced an empty C# CPG — C# frontend not functional." >&2
+  echo "         .NET targets will use LLM-fallback. See $JOERN_DOCS" >&2
+  exit 2
+fi
+
+echo "  [ok]   joern built a non-empty C# CPG ($(wc -c <"$TMP_CPG" | tr -d ' ') bytes) — .NET reachability via joern-cpg is live."
+exit 0

--- a/plugins/security-assessment/skills/false-positive-reduction/SKILL.md
+++ b/plugins/security-assessment/skills/false-positive-reduction/SKILL.md
@@ -111,7 +111,7 @@ Rationale field is mandatory (min 20 chars per schema). Summarize which factors 
 
 ## Joern integration (when present)
 
-If `joern` is on PATH, invoke via `${CLAUDE_PLUGIN_ROOT}/skills/false-positive-reduction/tools/reachability.sh` (build commands + CPG cache details are in the script). Stage 1 reachability queries the CPG for paths from the finding location back to entry points; cite the entry point path in `reachability.rationale`.
+If `joern` is on PATH, invoke via `${CLAUDE_PLUGIN_ROOT}/skills/false-positive-reduction/tools/reachability.sh` (build commands + CPG cache details are in the script). The wrapper detects the target's primary language (C#/.NET, JS/TS, Python, Java, Go — first match wins) and passes the matching `joern-parse --language`, so non-default frontends like C# build a CPG instead of silently degrading to LLM-fallback; the CPG cache is keyed `<sha>.<language>.cpg`. The C# frontend needs joern ≥ 2.0.0 plus the `dotnetastgen` tool — the install scripts provision and verify it (`scripts/verify-joern-csharp.sh`). Stage 1 reachability queries the CPG for paths from the finding location back to entry points; cite the entry point path in `reachability.rationale`.
 
 ## LLM-fallback mode (joern absent)
 

--- a/plugins/security-assessment/skills/false-positive-reduction/tools/reachability.sh
+++ b/plugins/security-assessment/skills/false-positive-reduction/tools/reachability.sh
@@ -5,8 +5,21 @@
 #   reachability.sh <repo-path> [<cache-dir>]
 #
 # Builds or loads a Code Property Graph for the target repo and exports a CFG
-# JSON that the fp-reduction agent queries. Caches by commit SHA under
-# <cache-dir>/<sha>.cpg so repeat invocations on the same commit are cheap.
+# JSON that the fp-reduction agent queries. Detects the target's primary
+# language and passes the matching `--language` to joern, so non-default
+# frontends (notably C#/.NET) actually build a CPG instead of silently
+# degrading to LLM-fallback when joern's autodetect picks the wrong frontend.
+# Caches by commit SHA + language under <cache-dir>/<sha>.<language>.cpg so
+# repeat invocations on the same commit are cheap and cross-language fixtures
+# don't collide.
+#
+# Language detection (first match wins):
+#   csharp       .cs / .csproj / .sln
+#   javascript   .ts / .tsx / .js / package.json
+#   python       .py / pyproject.toml / requirements.txt
+#   javasrc      .java / pom.xml / build.gradle
+#   gosrc        .go / go.mod
+#   (autodetect) none of the above — joern picks the frontend; cache tag "auto"
 #
 # Exit codes:
 #   0  — CPG built/loaded; path to CFG JSON printed on stdout
@@ -23,6 +36,38 @@ if ! command -v joern-parse >/dev/null 2>&1; then
   exit 1
 fi
 
+# _has_files <repo> <find-predicates...> — true if at least one matching file
+# exists. The find pipeline runs inside a command substitution so pipefail
+# doesn't trip on head closing the pipe early; we test the captured value.
+_has_files() {
+  local repo="$1"
+  shift
+  local found
+  found="$(find "$repo" -type f \( "$@" \) -print 2>/dev/null | head -n1)"
+  [ -n "$found" ]
+}
+
+# detect_language <repo> — prints the joern --language value, or "" (autodetect).
+detect_language() {
+  local repo="$1"
+  if _has_files "$repo" -name '*.cs' -o -name '*.csproj' -o -name '*.sln'; then
+    echo csharp
+  elif _has_files "$repo" -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name 'package.json'; then
+    echo javascript
+  elif _has_files "$repo" -name '*.py' -o -name 'pyproject.toml' -o -name 'requirements.txt'; then
+    echo python
+  elif _has_files "$repo" -name '*.java' -o -name 'pom.xml' -o -name 'build.gradle'; then
+    echo javasrc
+  elif _has_files "$repo" -name '*.go' -o -name 'go.mod'; then
+    echo gosrc
+  else
+    echo ""
+  fi
+}
+
+LANGUAGE="$(detect_language "$REPO")"
+LANG_TAG="${LANGUAGE:-auto}"
+
 mkdir -p "$CACHE_DIR"
 
 # Compute cache key from commit SHA (or "working-tree" if not git)
@@ -32,23 +77,29 @@ else
   SHA="working-tree"
 fi
 
-CPG_PATH="$CACHE_DIR/${SHA}.cpg"
-CFG_JSON="$CACHE_DIR/${SHA}.cfg.json"
+CPG_PATH="$CACHE_DIR/${SHA}.${LANG_TAG}.cpg"
+CFG_JSON="$CACHE_DIR/${SHA}.${LANG_TAG}.cfg.json"
 
 if [ -f "$CFG_JSON" ] && [ "$SHA" != "working-tree" ]; then
   echo "$CFG_JSON"
   exit 0
 fi
 
-# Build CPG
-if ! joern-parse "$REPO" --output "$CPG_PATH" >/dev/null 2>&1; then
-  echo "joern-parse failed on $REPO; caller should use LLM fallback" >&2
+# Build CPG — pass --language when detected; otherwise let joern autodetect.
+build_ok=1
+if [ -n "$LANGUAGE" ]; then
+  joern-parse "$REPO" --language "$LANGUAGE" --output "$CPG_PATH" >/dev/null 2>&1 || build_ok=0
+else
+  joern-parse "$REPO" --output "$CPG_PATH" >/dev/null 2>&1 || build_ok=0
+fi
+if [ "$build_ok" -eq 0 ]; then
+  echo "joern-parse failed on $REPO (language=${LANG_TAG}); caller should use LLM fallback" >&2
   exit 2
 fi
 
 # Export CFG
 if ! joern-export --repr cfg --format json "$CPG_PATH" > "$CFG_JSON" 2>/dev/null; then
-  echo "joern-export failed; caller should use LLM fallback" >&2
+  echo "joern-export failed (language=${LANG_TAG}); caller should use LLM fallback" >&2
   exit 2
 fi
 

--- a/tests/security-assessment/scripts/install-joern-wiring.test.sh
+++ b/tests/security-assessment/scripts/install-joern-wiring.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# install-joern-wiring.test.sh — verify the install scripts wire in the joern
+# C# reachability check (issue #60).
+#
+# install.sh is runnable on Linux/CI (it only checks presence), so we exercise
+# its joern section behaviorally with a stubbed joern-parse. install-macos.sh
+# refuses to run off Darwin, so it is checked structurally.
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN="$THIS_DIR/../../../plugins/security-assessment"
+INSTALL="$PLUGIN/install.sh"
+INSTALL_MACOS="$PLUGIN/install-macos.sh"
+VERIFY="$PLUGIN/scripts/verify-joern-csharp.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+fail() { echo "  FAIL: $*" >&2; FAILED=$((FAILED+1)); }
+ok()   { echo "  PASS: $*"; }
+
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+cat >"$STUB/joern-parse" <<'EOF'
+#!/usr/bin/env bash
+out=""; prev=""; for a in "$@"; do [ "$prev" = "--output" ] && out="$a"; prev="$a"; done
+[ -n "$out" ] && printf 'CPG-BYTES\n' > "$out"
+exit 0
+EOF
+chmod +x "$STUB/joern-parse"
+
+# install.sh accumulates checks and exits 1 when tier-1 tools are missing (as
+# in CI). We ignore its overall exit code and inspect only the joern section.
+
+# --- 1: joern present → install.sh reports the C# CPG path as live --------
+test_install_joern_present() {
+  local out
+  out="$(PATH="$STUB:$PATH" bash "$INSTALL" 2>&1 || true)"
+  grep -qi 'joern' <<<"$out" || { fail "install.sh has no joern section"; return; }
+  grep -qi 'non-empty C# CPG\|joern-cpg' <<<"$out" \
+    || { fail "install.sh did not report the joern C# path as live: $(grep -i joern <<<"$out")"; return; }
+  ok "install.sh + joern present → reports C# joern-cpg path live"
+}
+test_install_joern_present
+
+# --- 2: joern absent → WARN with actionable LLM-fallback note, never FAIL --
+test_install_joern_absent() {
+  if command -v joern-parse >/dev/null 2>&1; then
+    ok "install.sh joern-absent: SKIPPED (joern present in env)"; return
+  fi
+  local out
+  out="$(bash "$INSTALL" 2>&1 || true)"
+  grep -qi 'LLM-fallback' <<<"$out" || { fail "install.sh absent: missing LLM-fallback warning"; return; }
+  grep -q 'docs.joern.io' <<<"$out" || { fail "install.sh absent: missing docs link"; return; }
+  # Absence must be WARN, not a hard failure: no [FAIL] line should mention joern.
+  if grep -i 'joern' <<<"$out" | grep -q '\[FAIL\]'; then
+    fail "install.sh absent: joern absence produced a [FAIL] (should be [warn])"; return
+  fi
+  ok "install.sh + joern absent → [warn] LLM-fallback + docs link, no [FAIL]"
+}
+test_install_joern_absent
+
+# --- 3: install.sh documents the minimum tested joern version -------------
+test_min_version_documented() {
+  grep -q '2\.0\.0' "$INSTALL" || { fail "install.sh header missing min joern version 2.0.0"; return; }
+  grep -q '2\.0\.0' "$VERIFY"  || { fail "verify-joern-csharp.sh missing min joern version 2.0.0"; return; }
+  ok "min tested joern version (2.0.0) documented in install.sh + verify helper"
+}
+test_min_version_documented
+
+# --- 4: install-macos.sh structural wiring --------------------------------
+test_macos_structure() {
+  grep -q 'verify-joern-csharp.sh' "$INSTALL_MACOS" || { fail "install-macos.sh does not call verify-joern-csharp.sh"; return; }
+  grep -qi 'joern' "$INSTALL_MACOS"        || { fail "install-macos.sh has no joern section"; return; }
+  grep -qi 'dotnetastgen' "$INSTALL_MACOS" || { fail "install-macos.sh does not install the C# frontend (dotnetastgen)"; return; }
+  grep -q 'docs.joern.io' "$INSTALL_MACOS" || { fail "install-macos.sh missing joern docs link"; return; }
+  grep -q '2\.0\.0' "$INSTALL_MACOS"       || { fail "install-macos.sh missing min joern version 2.0.0"; return; }
+  grep -qi 'LLM-fallback' "$INSTALL_MACOS" || { fail "install-macos.sh missing LLM-fallback warning"; return; }
+  # joern must not be force-added to the fatal FAILED[] array.
+  if grep -E 'FAILED\+=\(.*joern' "$INSTALL_MACOS" >/dev/null; then
+    fail "install-macos.sh adds joern to the fatal FAILED[] array (must stay optional)"; return
+  fi
+  ok "install-macos.sh wires joern + dotnetastgen + verify + docs (non-fatal)"
+}
+test_macos_structure
+
+# --- 5: verify helper is shipped + executable -----------------------------
+test_verify_shipped() {
+  [ -x "$VERIFY" ] || { fail "verify-joern-csharp.sh missing or not executable"; return; }
+  ok "verify-joern-csharp.sh shipped and executable"
+}
+test_verify_shipped
+
+echo "=== install joern wiring tests ==="
+if [[ $FAILED -gt 0 ]]; then
+  echo "=== FAILED: $FAILED test(s) ==="
+  exit 1
+fi
+echo "=== all install joern wiring tests passed ==="
+exit 0

--- a/tests/security-assessment/scripts/reachability.test.sh
+++ b/tests/security-assessment/scripts/reachability.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# reachability.test.sh — tests for
+# plugins/security-assessment/skills/false-positive-reduction/tools/reachability.sh
+#
+# joern is not installed in CI, so we stub `joern-parse` / `joern-export` on
+# PATH. The stubs record their args and synthesize output files, which lets us
+# assert language detection, the --language flag, language-tagged cache keys,
+# and the exit-code contract deterministically.
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$THIS_DIR/../../../plugins/security-assessment/skills/false-positive-reduction/tools/reachability.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+fail() { echo "  FAIL: $*" >&2; FAILED=$((FAILED+1)); }
+ok()   { echo "  PASS: $*"; }
+
+# --- stub bindirs ---------------------------------------------------------
+# good/ : joern-parse records args + writes a non-empty CPG; joern-export emits JSON.
+# fail/ : joern-parse exits 2 (build failure), joern-export never reached.
+ARGS_FILE="$TMP/joern-args.txt"
+GOOD_BIN="$TMP/good-bin"
+FAIL_BIN="$TMP/fail-bin"
+mkdir -p "$GOOD_BIN" "$FAIL_BIN"
+
+cat >"$GOOD_BIN/joern-parse" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$ARGS_FILE"
+out=""; prev=""
+for a in "\$@"; do [ "\$prev" = "--output" ] && out="\$a"; prev="\$a"; done
+[ -n "\$out" ] && printf 'CPG-BYTES\n' > "\$out"
+exit 0
+EOF
+cat >"$GOOD_BIN/joern-export" <<'EOF'
+#!/usr/bin/env bash
+echo '{"nodes":[]}'
+exit 0
+EOF
+cat >"$FAIL_BIN/joern-parse" <<'EOF'
+#!/usr/bin/env bash
+echo "joern-parse: simulated build failure" >&2
+exit 2
+EOF
+chmod +x "$GOOD_BIN"/* "$FAIL_BIN"/*
+
+# run_reach <extra-PATH-bindir> <repo> -> sets RC, OUT, ERR; resets ARGS_FILE
+run_reach() {
+  : > "$ARGS_FILE"
+  local bindir="$1" repo="$2" cache="$TMP/cache.$RANDOM"
+  CACHE_LAST="$cache"
+  if [ -n "$bindir" ]; then
+    OUT="$(PATH="$bindir:$PATH" bash "$SCRIPT" "$repo" "$cache" 2>"$TMP/err")" && RC=0 || RC=$?
+  else
+    OUT="$(bash "$SCRIPT" "$repo" "$cache" 2>"$TMP/err")" && RC=0 || RC=$?
+  fi
+  ERR="$(cat "$TMP/err")"
+}
+
+# --- fixtures: one dir per ecosystem --------------------------------------
+mk() { mkdir -p "$TMP/$1"; ( cd "$TMP/$1" && shift; for f in "$@"; do mkdir -p "$(dirname "$f")"; : > "$f"; done ); }
+mk csharp     ignore   src/App.csproj  Program.cs
+mk node       ignore   package.json    src/index.ts
+mk python     ignore   pyproject.toml  app.py
+mk java       ignore   pom.xml         src/Main.java
+mk go         ignore   go.mod          main.go
+mk unknown    ignore   README.md       notes.txt
+mk mixed      ignore   App.cs          package.json   # csharp must win (checked first)
+
+# --- 1..5: each ecosystem maps to the right --language --------------------
+assert_lang() {
+  local dir="$1" lang="$2"
+  run_reach "$GOOD_BIN" "$TMP/$dir"
+  [ "$RC" -eq 0 ] || { fail "$dir: expected exit 0, got $RC ($ERR)"; return; }
+  grep -q -- "--language $lang" "$ARGS_FILE" \
+    || { fail "$dir: joern-parse not called with '--language $lang'; args: $(cat "$ARGS_FILE")"; return; }
+  [ -f "$CACHE_LAST/working-tree.$lang.cpg" ] \
+    || { fail "$dir: cache not keyed working-tree.$lang.cpg ($(ls "$CACHE_LAST"))"; return; }
+  [ "$OUT" = "$CACHE_LAST/working-tree.$lang.cfg.json" ] \
+    || { fail "$dir: stdout not the cfg.json path: $OUT"; return; }
+  ok "$dir → --language $lang + cache key working-tree.$lang.cpg"
+}
+assert_lang csharp csharp
+assert_lang node   javascript
+assert_lang python python
+assert_lang java   javasrc
+assert_lang go     gosrc
+
+# --- 6: unknown ecosystem → no --language flag, cache tag "auto" ----------
+test_autodetect() {
+  run_reach "$GOOD_BIN" "$TMP/unknown"
+  [ "$RC" -eq 0 ] || { fail "unknown: expected exit 0, got $RC"; return; }
+  if grep -q -- "--language" "$ARGS_FILE"; then
+    fail "unknown: should NOT pass --language; args: $(cat "$ARGS_FILE")"; return
+  fi
+  [ -f "$CACHE_LAST/working-tree.auto.cpg" ] \
+    || { fail "unknown: cache not keyed working-tree.auto.cpg ($(ls "$CACHE_LAST"))"; return; }
+  ok "unknown ecosystem → autodetect (no --language), cache tag 'auto'"
+}
+test_autodetect
+
+# --- 7: first match wins (csharp before javascript) -----------------------
+test_first_match() {
+  run_reach "$GOOD_BIN" "$TMP/mixed"
+  grep -q -- "--language csharp" "$ARGS_FILE" \
+    || { fail "mixed: expected csharp to win; args: $(cat "$ARGS_FILE")"; return; }
+  if grep -q -- "--language javascript" "$ARGS_FILE"; then
+    fail "mixed: javascript should not be selected"; return
+  fi
+  ok "mixed .cs + package.json → csharp wins (first match)"
+}
+test_first_match
+
+# --- 8: joern absent → exit 1 (LLM fallback) ------------------------------
+test_joern_absent() {
+  run_reach "" "$TMP/csharp"   # no stub bindir; real env has no joern-parse
+  if command -v joern-parse >/dev/null 2>&1; then
+    ok "joern absent: SKIPPED (joern-parse present in env)"; return
+  fi
+  [ "$RC" -eq 1 ] || { fail "joern absent: expected exit 1, got $RC"; return; }
+  grep -qi 'LLM fallback' <<<"$ERR" || { fail "joern absent: stderr missing LLM-fallback note: $ERR"; return; }
+  ok "joern absent → exit 1 + LLM-fallback note"
+}
+test_joern_absent
+
+# --- 9: malformed/failed .NET build → exit 2 + structured reason ----------
+test_build_failure() {
+  run_reach "$FAIL_BIN" "$TMP/csharp"
+  [ "$RC" -eq 2 ] || { fail "build failure: expected exit 2, got $RC"; return; }
+  grep -qi 'joern-parse failed' <<<"$ERR" \
+    || { fail "build failure: stderr missing structured reason: $ERR"; return; }
+  grep -qi 'language=csharp' <<<"$ERR" \
+    || { fail "build failure: stderr should name the detected language: $ERR"; return; }
+  ok "failed C# build → exit 2 + structured reason naming language"
+}
+test_build_failure
+
+echo "=== reachability tests ==="
+if [[ $FAILED -gt 0 ]]; then
+  echo "=== FAILED: $FAILED test(s) ==="
+  exit 1
+fi
+echo "=== all reachability tests passed ==="
+exit 0

--- a/tests/security-assessment/scripts/verify-joern-csharp.test.sh
+++ b/tests/security-assessment/scripts/verify-joern-csharp.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# verify-joern-csharp.test.sh — tests for
+# plugins/security-assessment/scripts/verify-joern-csharp.sh
+#
+# joern is absent in CI, so we stub joern-parse on PATH to exercise the three
+# verification outcomes (built / absent / empty-or-failed) deterministically.
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN="$THIS_DIR/../../../plugins/security-assessment"
+SCRIPT="$PLUGIN/scripts/verify-joern-csharp.sh"
+FIXTURE_DIR="$PLUGIN/knowledge/fixtures/joern-dotnet"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+fail() { echo "  FAIL: $*" >&2; FAILED=$((FAILED+1)); }
+ok()   { echo "  PASS: $*"; }
+
+ARGS_FILE="$TMP/args.txt"
+GOOD="$TMP/good"; EMPTY="$TMP/empty"; FAILBIN="$TMP/failbin"
+mkdir -p "$GOOD" "$EMPTY" "$FAILBIN"
+
+# good: writes a non-empty CPG at --output
+cat >"$GOOD/joern-parse" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$ARGS_FILE"
+out=""; prev=""; for a in "\$@"; do [ "\$prev" = "--output" ] && out="\$a"; prev="\$a"; done
+[ -n "\$out" ] && printf 'CPG-BYTES\n' > "\$out"
+exit 0
+EOF
+# empty: creates an empty CPG at --output
+cat >"$EMPTY/joern-parse" <<'EOF'
+#!/usr/bin/env bash
+out=""; prev=""; for a in "$@"; do [ "$prev" = "--output" ] && out="$a"; prev="$a"; done
+[ -n "$out" ] && : > "$out"
+exit 0
+EOF
+# failbin: joern-parse exits non-zero
+cat >"$FAILBIN/joern-parse" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$GOOD/joern-parse" "$EMPTY/joern-parse" "$FAILBIN/joern-parse"
+
+run() { # run <bindir-or-empty> [args...]
+  : > "$ARGS_FILE"
+  local bindir="$1"; shift
+  if [ -n "$bindir" ]; then
+    OUT="$(PATH="$bindir:$PATH" bash "$SCRIPT" "$@" 2>"$TMP/err")" && RC=0 || RC=$?
+  else
+    OUT="$(bash "$SCRIPT" "$@" 2>"$TMP/err")" && RC=0 || RC=$?
+  fi
+  ERR="$(cat "$TMP/err")"
+}
+
+# --- 1: joern present + non-empty CPG (default fixture) → exit 0 -----------
+test_built() {
+  run "$GOOD"   # no fixture arg → exercises default-fixture resolution
+  [ "$RC" -eq 0 ] || { fail "built: expected exit 0, got $RC ($ERR)"; return; }
+  grep -q -- '--language csharp' "$ARGS_FILE" \
+    || { fail "built: did not invoke joern with --language csharp: $(cat "$ARGS_FILE")"; return; }
+  grep -qi 'ok' <<<"$OUT" || { fail "built: stdout missing [ok] line: $OUT"; return; }
+  ok "joern present + non-empty CPG → exit 0, --language csharp, [ok]"
+}
+test_built
+
+# --- 2: joern absent → exit 1 + actionable LLM-fallback warning -----------
+test_absent() {
+  run ""   # real CI env: no joern-parse
+  if command -v joern-parse >/dev/null 2>&1; then
+    ok "absent: SKIPPED (joern-parse present in env)"; return
+  fi
+  [ "$RC" -eq 1 ] || { fail "absent: expected exit 1, got $RC"; return; }
+  grep -qi 'LLM-fallback' <<<"$ERR" || { fail "absent: missing LLM-fallback warning: $ERR"; return; }
+  grep -q 'docs.joern.io' <<<"$ERR" || { fail "absent: missing joern install docs link: $ERR"; return; }
+  ok "joern absent → exit 1 + LLM-fallback warning + docs link"
+}
+test_absent
+
+# --- 3: joern present but empty CPG → exit 2 ------------------------------
+test_empty() {
+  run "$EMPTY"
+  [ "$RC" -eq 2 ] || { fail "empty: expected exit 2, got $RC"; return; }
+  grep -qi 'empty' <<<"$ERR" || { fail "empty: stderr should explain empty CPG: $ERR"; return; }
+  ok "joern present + empty CPG → exit 2"
+}
+test_empty
+
+# --- 4: joern-parse fails → exit 2 ----------------------------------------
+test_failbuild() {
+  run "$FAILBIN"
+  [ "$RC" -eq 2 ] || { fail "failbuild: expected exit 2, got $RC"; return; }
+  ok "joern-parse non-zero → exit 2"
+}
+test_failbuild
+
+# --- 5: committed fixture is a .cs source→sink chain ----------------------
+test_fixture_present() {
+  local cs
+  cs="$(find "$FIXTURE_DIR" -name '*.cs' -type f 2>/dev/null | head -n1)"
+  [ -n "$cs" ] || { fail "no .cs fixture under $FIXTURE_DIR"; return; }
+  # source: HTTP input; sink: SQL command built by string concatenation.
+  grep -qi 'HttpGet\|FromQuery' "$cs" || { fail "fixture missing HTTP input source"; return; }
+  grep -qi 'SqlCommand\|SELECT .* FROM' "$cs" || { fail "fixture missing SQL sink"; return; }
+  grep -q '+ name' "$cs" || { fail "fixture missing string-concat of user input"; return; }
+  ok "fixture .cs has HTTP-input → string-concat → SQL-command chain"
+}
+test_fixture_present
+
+echo "=== verify-joern-csharp tests ==="
+if [[ $FAILED -gt 0 ]]; then
+  echo "=== FAILED: $FAILED test(s) ==="
+  exit 1
+fi
+echo "=== all verify-joern-csharp tests passed ==="
+exit 0


### PR DESCRIPTION
Closes #60.

The fp-reduction joern path never fired for .NET/C#: the reachability wrapper called `joern-parse` with no `--language`, so C# targets silently degraded to `reachability_tool: llm-fallback` — killing the tool-first half of the value proposition for the most common enterprise ecosystem.

## Runtime — `reachability.sh`
- Detects the target's primary language (`csharp` ← `.cs`/`.csproj`/`.sln`, then `javascript`, `python`, `javasrc`, `gosrc`; **first match wins**) and passes the matching `joern-parse --language`; autodetect otherwise.
- Cache is language-tagged (`<sha>.<language>.cpg`) so cross-language fixtures don't collide.
- Preserves the load-bearing 0/1/2 exit-code contract; build failures emit a structured reason naming the detected language.

## Install-time
- New `scripts/verify-joern-csharp.sh` builds a CPG from the committed C# fixture with `--language csharp` and fails on an empty/non-zero CPG (0 built / 1 absent / 2 broken).
- `install.sh` runs it as a **WARN-only** check — never blocks on joern absence. `install-macos.sh --all` installs joern + the `dotnetastgen` C# frontend; default mode warns with the joern docs link.
- Minimum tested joern version (2.0.0) documented in both install headers.
- `knowledge/fixtures/joern-dotnet/VulnerableController.cs` ships an HTTP-input → string-concat → SQL-command source→sink chain.

## Docs
- `false-positive-reduction` SKILL.md joern section + security-assessment user guide updated for the .NET/C# path.

## Path reconciliation
The spec referenced `plugins/agentic-security-review/`; the live directory is `plugins/security-assessment/`, used throughout.

## Testing
joern can't be installed in CI, so tests stub `joern-parse`/`joern-export`. **19 new tests** — `reachability` (9), `verify-joern-csharp` (5), `install-joern-wiring` (5). Full security-assessment shell suite 9/9; CI bats set 428 passed / 0 failed; shellcheck + `bash -n` clean on every changed script.

Every distilled acceptance criterion is covered except the post-merge smoke test (a real .NET `/security-assessment` run yielding `joern-cpg`), which needs joern + a real .NET repo per the issue's definition of done.

## Out of scope (per issue non-goals)
- The `fp-reduction` agent is unchanged (it already consumes the CFG correctly).
- No shipped-with-plugin joern binary (detect-and-report + install-guidance instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgTB3vezRtHdvLXtEeFG1Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgTB3vezRtHdvLXtEeFG1Z)_