### PR TITLE
docs: require branch-and-PR for every change to this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This is the marketplace repository for the dev-team Claude Code plugin.
 
+## Working Rules
+
+- **Always work on a branch.** Never commit directly to `main`. Every change — including documentation-only changes, gitignore tweaks, and one-line fixes — lands via a feature branch and a pull request. If a commit accidentally lands on `main` locally, reset `main` to `origin/main` and move the commit to a branch before pushing. Release commits authored by release-please are the only exception; they arrive as their own PR.
+
 ## Repository Structure
 
 ```
@@ -25,6 +29,7 @@ reports/                           # Review reports (not shipped)
 ```
 
 Two repo-level guides distill the marketplace conventions:
+
 - [`docs/marketplace-builder-plugin-playbook.md`](docs/marketplace-builder-plugin-playbook.md) — how to build a plugin that scaffolds/audits/maintains marketplace monorepos (shipping hygiene, portability, testing, release/catalog sync).
 - [`docs/using-plugin-skills-in-the-web-environment.md`](docs/using-plugin-skills-in-the-web-environment.md) — how to use a plugin's skills from a Claude Code web session.
 


### PR DESCRIPTION
## Summary

Adds a **Working Rules** section to the repo `CLAUDE.md` making the branch-and-PR requirement explicit:

> **Always work on a branch.** Never commit directly to `main`. Every change — including documentation-only changes, gitignore tweaks, and one-line fixes — lands via a feature branch and a pull request. If a commit accidentally lands on `main` locally, reset `main` to `origin/main` and move the commit to a branch before pushing. Release commits authored by release-please are the only exception; they arrive as their own PR.

### Why

Triggered by an accidental local commit to `main` in PR #279's session — recovered by resetting and rebranching before pushing. Encoding the rule in `CLAUDE.md` means future Claude Code sessions in this repo pick it up automatically from the project instructions, not just from a personal memory file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)