### PR TITLE
feat(test-modernize): make Phase-3 disabled-test resolution a Phase-4 contract

### DIFF
--- a/plugins/dev-team/agents/test-modernization-review.md
+++ b/plugins/dev-team/agents/test-modernization-review.md
@@ -96,19 +96,22 @@ Flag as **error** any deleted test, any tool mismatch, any out-of-order timestam
 
 ### Phase 4 — No-refactor adds
 
-Read `memory/test-modernize/<slug>/phase-4.md`, `coverage-history.json`, and `gherkin-bindings.json`.
+Read `memory/test-modernize/<slug>/phase-4.md`, `coverage-history.json`, `gherkin-bindings.json`, `disabled-tests.json`, and `disabled-tests-resolution.json`.
 
 Verify:
 
 - Every Phase-4 Story closed by `/build` has a corresponding entry in `coverage-history.json`.
 - The cumulative line delta is positive (≥ +5 percentage points over the baseline, or the operator flagged this as expected-flat).
-- No production-code diff was introduced by a Phase-4 Story — Phase 4's contract is tests-only.
+- No production-code diff was introduced by a Phase-4 Story — Phase 4's contract is tests-only. `[Repair disabled test]` Stories MUST touch only test files; any production-code change in such a Story is a contract violation (defer-to-Phase-5 was the wrong resolution).
+- **Disabled-test resolution integrity.** Every entry in `disabled-tests.json` has a matching record in `disabled-tests-resolution.json` with `outcome: "repair"` or `outcome: "defer-to-phase-5"` — no entries left in `pending`.
+  - For each `repair` entry, the cited test in source no longer carries a `cannot-fail:` skip tag, has at least one real assertion, AND a `[Repair disabled test]` Story closed against it in this phase.
+  - For each `defer-to-phase-5` entry, a corresponding `[Repair disabled test]` defect Story exists in `memory/test-modernize/<slug>/phase-5.md` citing `file:line:reason` from `disabled-tests.json` and naming the production-code seam the refactor must introduce. The original skip tag is still present in source (deferral preserves the audit trail).
 - **Gherkin binding integrity.** For every `[Component tests]` Story closed in Phase 4, the submitted test code under the Story's PR/commit cites the scenarios from `gherkin-bindings.json`:
   - `bdd-runner` mode → each cited Scenario has a matching `Scenario:` line in a `.feature` file the runner discovers, AND the runner reports it executed and passed.
   - `xunit-with-annotations` mode → each cited Scenario has a corresponding test function whose name mirrors the Scenario name (case-and-punctuation tolerant: snake_case / PascalCase / camelCase variants accepted), AND the function body's leading comment cites the source `.feature` file path.
 - No Scenario from `gherkin-bindings.json` is left without a test (count of unbound scenarios = 0).
 
-Flag as **error** any production-code change attributed to a Phase-4 Story, any unbound approved Scenario, any test method that names itself after a Scenario that does not exist in the approved Gherkin (drift in the other direction — code claiming to test a scenario that isn't real).
+Flag as **error** any production-code change attributed to a Phase-4 Story (including a `[Repair disabled test]` Story), any unbound approved Scenario, any test method that names itself after a Scenario that does not exist in the approved Gherkin (drift in the other direction — code claiming to test a scenario that isn't real), any `disabled-tests.json` entry left in `pending`, any `repair` entry whose source still carries a `cannot-fail:` tag, or any `defer-to-phase-5` entry without a corresponding Phase-5 Story.
 
 Flag as **warning** a negative or near-zero coverage delta (a Story made coverage worse, or didn't move it — surface for operator decision).
 
@@ -120,10 +123,11 @@ Verify:
 
 - For every `[Refactor-for-testability]` Story closed by `/build`, the matching `[Baseline]` Story was closed and green BEFORE it.
 - The refactor was behavior-preserving (the baseline still passes after the refactor).
+- For every `[Repair disabled test]` Story deferred from Phase 4, the Story closed in Phase 5 with: (a) the production-code refactor that introduced the seam, (b) the previously-disabled test unskipped with a real assertion against that seam, and (c) the `cannot-fail:` tag removed from source.
 - The four quality targets are either met or explicitly waived with reason.
 - Mutation-testing was run after every Phase-5 Story closed.
 
-Flag as **error** any refactor without a green baseline, any behavior change paired with a structural change in the same Story, any silent (un-recorded) waiver.
+Flag as **error** any refactor without a green baseline, any behavior change paired with a structural change in the same Story, any silent (un-recorded) waiver, any deferred `[Repair disabled test]` Story closed without removing the `cannot-fail:` tag, or any deferred entry from `disabled-tests-resolution.json` with no closed Phase-5 Story.
 
 ## Output format
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4457,7 +4457,7 @@
       "anchor": "3a-review-the-phase-loop-phase-4-phase-5-use-this-identically"
     },
     "4. Fix disabled tests + add no-refactor tests — `/build` + `/coverage-delta` + mutation gate": {
-      "summary": "For each Phase-4 child issue in dependency order (from `memory/test-modernize/<slug>/phase-1.md` and `phase-2.md`):",
+      "summary": "**Pre-flight — resolve Phase-3 disabled tests.** Before any Phase-4 child issue runs, read `memory/test-modernize/<slug>/disabled-tests.json` and walk it entry-by-entry.",
       "anchor": "4-fix-disabled-tests-add-no-refactor-tests-build-coverage-delta-mutation-gate"
     },
     "5. Refactor-for-testability + converge — `/build` + `/mutation-testing` + `/quality-targets-converge`": {

--- a/plugins/dev-team/skills/test-modernize/SKILL.md
+++ b/plugins/dev-team/skills/test-modernize/SKILL.md
@@ -153,11 +153,19 @@ The phase's human gate reads this file before firing — without it (escape hatc
 
 ### 4. Fix disabled tests + add no-refactor tests — `/build` + `/coverage-delta` + mutation gate
 
-For each Phase-4 child issue in dependency order (from `memory/test-modernize/<slug>/phase-1.md` and `phase-2.md`):
+**Pre-flight — resolve Phase-3 disabled tests.** Before any Phase-4 child issue runs, read `memory/test-modernize/<slug>/disabled-tests.json` and walk it entry-by-entry. For each disabled test, the orchestrator must choose one outcome and record it in `memory/test-modernize/<slug>/disabled-tests-resolution.json`:
+
+- **`repair`** — the test can be made meaningful **without changing production code** (e.g. add a real assertion, replace `expect(true).toBeTruthy()` with the actual observable behavior, remove the swallowed-exception catch). Dispatch `/build` against a `[Repair disabled test] <file>::<test>` work item that unskips the test, lands the assertion, and proves it can fail (kill the production line under test or mutate it and confirm the test goes red). The `cannot-fail:` skip tag is removed.
+- **`defer-to-phase-5`** — repairing the test requires a production-code refactor (no seam to assert against, hidden collaborator, untestable side effect). Do NOT touch the test in Phase 4. Draft a Phase-5 `[Repair disabled test] <file>::<test>` defect Story into `memory/test-modernize/<slug>/phase-5.md` that cites `file:line:reason` from `disabled-tests.json` and names the production-code seam the refactor must introduce. Leave the `cannot-fail:` skip tag in place so the source-of-truth audit trail stays intact.
+
+The Phase-4 gate refuses to fire while any entry in `disabled-tests.json` is still in the default `pending` state — every entry must resolve to `repair` (done + unskipped) or `defer-to-phase-5` (Story drafted) before the gate is evaluated.
+
+Then, for each Phase-4 child issue in dependency order (from `memory/test-modernize/<slug>/phase-1.md` and `phase-2.md`):
 
 1. Invoke `/build <issue-id-or-path>` — drives RED-GREEN-REFACTOR with inline `/code-review`.
    - For `[Component tests]` Stories created in Phase 2, `/build` is told to bind each test to the specific `<feature-file>::<scenario-name>` pairs cited in the Story's Acceptance Criteria using the binding mode recorded in `phase-0.md` (`bdd-runner` or `xunit-with-annotations`). The Acceptance Criteria checkboxes (one per scenario) must all turn green before the Story closes.
    - For `[Baseline]` Stories (created in Phase 1), tests lock in current behavior at existing seams — no Gherkin binding required.
+   - For `[Repair disabled test]` Stories drafted in the pre-flight, `/build` removes the skip tag, lands a real assertion against the cited public-interface behavior, and proves the new assertion can fail.
 2. After every Story closes, **extract the Story's production-code file list from `/build`'s commit diff** (`git diff --name-only <story-base-sha>..<story-head-sha>` filtered to production code — test files dropped). The orchestrator MUST NOT consult a tracker CLI for this list; the commit diff is the only source of truth so a tracker JSON-shape change can never silently break the gate.
 3. Invoke `/coverage-delta <repo-path> --parent <url-or-empty> --repo-slug <slug> --story <id> --story-files <files-from-step-2>`. The worker measures and reports; it never halts. Read its stdout result block and act on the `status` field:
 
@@ -204,7 +212,7 @@ For each Phase-4 child issue in dependency order (from `memory/test-modernize/<s
    - On findings, dispatch `/apply-fixes corrections/`; re-run `/code-review`; loop body capped at **max 2 iterations** before the operator escalation prompt fires.
    - Write the resulting evidence to `memory/test-modernize/<slug>/phase-4-review.json` per the schema in 3a.
 
-**Human gate** — Δ-coverage AND Phase-4 mutation results AND `phase-4-review.json` (any waivers explicit) accepted before any production-code refactor.
+**Human gate** — Δ-coverage AND Phase-4 mutation results AND `phase-4-review.json` (any waivers explicit) AND `disabled-tests-resolution.json` (every Phase-3-disabled test resolved to `repair` or `defer-to-phase-5`) accepted before any production-code refactor.
 
 ### 5. Refactor-for-testability + converge — `/build` + `/mutation-testing` + `/quality-targets-converge`
 


### PR DESCRIPTION
## Why

In Phase 3, `/test-audit-disable` skip-and-tags every cannot-fail test with `cannot-fail: <reason> — repair in Phase 4`. The orchestrator never made the corollary rule explicit, so a Phase-4 run could close without touching the disabled list, and the operator had no defined escape hatch when repair required a production-code refactor.

## What

* **Phase 4 pre-flight** (`plugins/dev-team/skills/test-modernize/SKILL.md`) walks `disabled-tests.json` and records each entry's outcome in a new `disabled-tests-resolution.json`:
  * `repair` — meaningful assertion possible without production-code change. `[Repair disabled test] <file>::<test>` Story unskips, asserts, proves can-fail.
  * `defer-to-phase-5` — repair needs a production-code refactor. Defect Story drafted into `phase-5.md` citing `file:line:reason` and the seam the refactor must introduce. Skip tag stays in source.
* Phase-4 human gate refuses to fire while any entry is still `pending`.
* `test-modernization-review` Phase-4 checks (`plugins/dev-team/agents/test-modernization-review.md`):
  * Every entry resolved (no `pending`).
  * Every `repair` test unskipped + asserting.
  * Every `defer-to-phase-5` paired with a real Phase-5 Story; skip tag still present.
  * Production code in any Phase-4 `[Repair disabled test]` Story = contract violation.
* Phase-5 acceptance recognises the `[Repair disabled test]` Story type and requires (a) the refactor that introduces the seam, (b) the test unskipped with a real assertion, (c) the `cannot-fail:` tag removed from source.

## Scope

Documentation-only changes to two skill/agent specs and the auto-regenerated `knowledge/index.json` summary. No code, hook, or fixture changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)