### PR TITLE
feat(evals): backfill cites: on reviewers — activate the citation drift lint

### DIFF
--- a/plugins/dev-team/agents/arch-review.md
+++ b/plugins/dev-team/agents/arch-review.md
@@ -3,6 +3,7 @@ name: arch-review
 description: Architectural alignment — ADR compliance, layer boundary violations, dependency direction, pattern consistency
 tools: Read, Grep, Glob
 model: opus
+cites: [architecture-assessment, adversarial-review-protocol]
 ---
 
 # Architecture Review

--- a/plugins/dev-team/agents/complexity-review.md
+++ b/plugins/dev-team/agents/complexity-review.md
@@ -3,6 +3,7 @@ name: complexity-review
 description: Cyclomatic complexity, nesting depth, function size, parameter count
 tools: Read, Grep, Glob
 model: haiku
+cites: [object-calisthenics]
 ---
 
 # Complexity Review

--- a/plugins/dev-team/agents/domain-review.md
+++ b/plugins/dev-team/agents/domain-review.md
@@ -3,6 +3,7 @@ name: domain-review
 description: Domain boundaries, abstraction leaks, business logic placement
 tools: Read, Grep, Glob, Skill
 model: opus
+cites: [domain-modeling, ubiquitous-language, adversarial-review-protocol]
 ---
 
 # Domain Review

--- a/plugins/dev-team/agents/naming-review.md
+++ b/plugins/dev-team/agents/naming-review.md
@@ -3,6 +3,7 @@ name: naming-review
 description: Naming clarity, conventions, magic values, and consistency
 tools: Read, Grep, Glob
 model: haiku
+cites: [design-smells]
 ---
 
 # Naming Review

--- a/plugins/dev-team/agents/security-review.md
+++ b/plugins/dev-team/agents/security-review.md
@@ -3,6 +3,7 @@ name: security-review
 description: Injection, auth/authz, data exposure, security headers, crypto
 tools: Read, Grep, Glob
 model: opus
+cites: [owasp-detection, accepted-risks-schema, adversarial-review-protocol]
 ---
 
 # Security Review

--- a/plugins/dev-team/agents/structure-review.md
+++ b/plugins/dev-team/agents/structure-review.md
@@ -3,6 +3,7 @@ name: structure-review
 description: SRP violations, DRY, coupling, nesting depth, file organization
 tools: Read, Grep, Glob
 model: sonnet
+cites: [design-smells, object-calisthenics, adversarial-review-protocol]
 ---
 
 # Structure Review

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -3,6 +3,7 @@ name: test-review
 description: Test quality, coverage gaps, assertion quality, and test hygiene
 tools: Read, Grep, Glob, Skill
 model: sonnet
+cites: [testability-patterns, result-verification, test-automation-maturity, adversarial-review-protocol]
 ---
 
 # Test Review

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -3,6 +3,7 @@ name: test-smell-review
 description: xUnit test smells, test double selection, and test-pyramid layer placement
 tools: Read, Grep, Glob, Skill
 model: sonnet
+cites: [test-smells, test-doubles, test-pyramid, fixture-construction, test-organization, test-refactoring, testability-patterns, result-verification, cd-test-architecture, microservice-testing, adversarial-review-protocol]
 ---
 
 # Test Smell Review


### PR DESCRIPTION
## Why

PR #315 introduced the citation drift lint (#312). It is **Phase 1 (advisory only)**, but it can only catch drift on agents that have declared a `cites:` list. Today, **zero reviewers declare one** — so the lint runs but observes nothing.

This PR backfills `cites:` on every reviewer that already references a `knowledge/*.md` or `skills/*/` source in its body, so the lint has something to verify the moment #315 lands.

## What

Mechanical mapping from each reviewer's existing source references to its frontmatter:

| Reviewer | cites |
| --- | --- |
| `arch-review` | `architecture-assessment`, `adversarial-review-protocol` |
| `complexity-review` | `object-calisthenics` |
| `domain-review` | `domain-modeling`, `ubiquitous-language`, `adversarial-review-protocol` |
| `naming-review` | `design-smells` |
| `security-review` | `owasp-detection`, `accepted-risks-schema`, `adversarial-review-protocol` |
| `structure-review` | `design-smells`, `object-calisthenics`, `adversarial-review-protocol` |
| `test-review` | `testability-patterns`, `result-verification`, `test-automation-maturity`, `adversarial-review-protocol` |
| `test-smell-review` | 11 sources (test-smells, test-doubles, test-pyramid, fixture-construction, test-organization, test-refactoring, testability-patterns, result-verification, cd-test-architecture, microservice-testing, adversarial-review-protocol) |

The other reviewers (a11y, claude-setup, concurrency, doc, js-fp, performance, refactor-opportunity, spec-compliance, svelte, test-modernization, token-efficiency) state no numeric thresholds, so the Phase-1 lint has nothing to verify on them — leaving `cites:` unset is correct.

## Merge sequencing

This is **PR 1 of 3** follow-ups to PR #315.

- **Depends on:** #315 (provides the `citation_lint.py` script and the `cites:` schema).
- **Merge order:** merge #315 first, then this PR. Merging this PR before #315 lands is harmless (the `cites:` field is unused frontmatter until the lint exists) but provides no value until #315 is in.
- **Sibling follow-ups (independent of each other, both depend on #315):**
  - PR 2 — citation-lint fixtures (proves the lint itself can't rot)
  - PR 3 — `/agent-eval` and `/agent-create` extensions enforcing `cites:` + cache + integration dispatch

## Scope

Frontmatter-only changes to 8 reviewer agents. No code, hook, fixture, or skill changes. Documentation-only auto-merge does **not** apply (agent files are shipping artifacts, not docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)