### PR TITLE
feat(evals): real-corpus regression guard for the citation drift lint

### DIFF
--- a/tests/repo/citation_lint_corpus_tests.bats
+++ b/tests/repo/citation_lint_corpus_tests.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Citation-lint regression guard against the *real* plugin corpus.
+#
+# The bats suite in `citation_lint_tests.bats` (shipped with PR #315) exercises
+# the lint against a synthetic plugin tree — it pins the parser's behaviour but
+# tells us nothing about whether the actual corpus passes. This suite runs the
+# lint over `plugins/dev-team/agents/` so a future change cannot:
+#
+#   (a) break a reviewer's `cites:` resolution by renaming a knowledge file,
+#   (b) silently regress an agent that used to declare `cites:` to none, or
+#   (c) introduce a new threshold-bearing reviewer that ships with no cites:
+#       and no operator awareness.
+#
+# All assertions are advisory (Phase 1 lint exits 0 by design); the bats suite
+# fails when the *observed warnings* drift from the expected fingerprint.
+
+LINT="$BATS_TEST_DIRNAME/../../scripts/citation_lint.py"
+PLUGIN_ROOT="$BATS_TEST_DIRNAME/../../plugins/dev-team"
+
+require_lint() {
+  if [ ! -x "$LINT" ] && [ ! -f "$LINT" ]; then
+    skip "citation_lint.py not present yet (PR #315 not merged)"
+  fi
+}
+
+@test "lint exits 0 on the real plugin corpus (Phase 1 advisory contract)" {
+  require_lint
+  run python3 "$LINT" --plugin-root "$PLUGIN_ROOT" "$PLUGIN_ROOT/agents"/*.md
+  [ "$status" -eq 0 ]
+}
+
+@test "every reviewer with declared cites: resolves to real sources" {
+  require_lint
+  # Any 'unknown source' warning means a cites: entry points at a file that
+  # does not exist — i.e. a knowledge file was renamed without updating the
+  # citing agent. Hard fail (advisory exit code, but the warning text is
+  # specific and unambiguous).
+  run python3 "$LINT" --plugin-root "$PLUGIN_ROOT" "$PLUGIN_ROOT/agents"/*.md
+  [ "$status" -eq 0 ]
+  if echo "$output" | grep -qiE "unknown source|unresolved"; then
+    echo "$output"
+    false
+  fi
+}
+
+@test "no drift on backfilled reviewers (warnings limited to the expected set)" {
+  require_lint
+  # Reviewers that have a cites: list AND zero threshold drift today. If any of
+  # these later appear in the warning stream, a backfilled agent silently
+  # regressed.
+  CITED_CLEAN=(arch-review complexity-review domain-review naming-review \
+               security-review structure-review test-review test-smell-review)
+  run python3 "$LINT" --plugin-root "$PLUGIN_ROOT" "$PLUGIN_ROOT/agents"/*.md
+  [ "$status" -eq 0 ]
+  for name in "${CITED_CLEAN[@]}"; do
+    # An emitted line starting with "<name>:" is a drift / advisory warning for
+    # that agent. Skip if cites: was added but a threshold still drifts — the
+    # backfill PR will surface that case explicitly.
+    if echo "$output" | grep -qE "^${name}:"; then
+      echo "$output"
+      echo "Regression: ${name} now produces a citation warning; check whether"
+      echo "a knowledge file changed or a new threshold was added."
+      false
+    fi
+  done
+}


### PR DESCRIPTION
## Why

PR #315 ships `scripts/citation_lint.py` with a bats suite (`tests/repo/citation_lint_tests.bats`) that exercises the parser against a **synthetic** plugin tree. That pins the lint's mechanics but doesn't catch the failure modes that matter most in practice:

1. A knowledge file gets renamed → a reviewer's `cites:` entry no longer resolves → the lint silently flags it as `unknown source` instead of catching the rename in CI.
2. A reviewer that used to be clean (via PR #319's backfill) silently gains a new inlined threshold → drift reappears without anyone noticing.

The synthetic tests can't detect either, because they never look at the real corpus.

## What

`tests/repo/citation_lint_corpus_tests.bats` — three guards that run the lint against the real `plugins/dev-team/agents/` directory:

1. **Phase 1 advisory contract** — the lint exits 0 on the real corpus today.
2. **`cites:` resolution integrity** — no `unknown source` / `unresolved` warning in the output (catches renamed knowledge files).
3. **Backfill stability** — reviewers known to be clean today (the 8 from PR #319) produce zero warnings going forward.

The suite **skips when `scripts/citation_lint.py` is absent**, so it can land on `main` before PR #315 merges without red-lining the gate; it activates automatically once the script is present.

## Merge sequencing

This is **PR 2 of 3** follow-ups to PR #315.

- **Depends on:** #315 (provides the lint script). #319 (`cites:` backfill) is **strongly recommended** before this — guard #3 lists those reviewers as the known-clean set.
- **Merge order:**
  1. #315 (parent)
  2. #319 (`cites:` backfill) — populates the clean set this guard expects
  3. **this PR** (locks the clean state in)
- Merging this PR before #315: harmless. Bats skips the suite cleanly.
- Merging this PR after #315 but **before** #319: the third guard fails because none of the backfilled reviewers are clean yet. Rebase the PR onto #319's branch or wait for #319 to merge.

## Sibling follow-ups

- PR 3 — `/agent-eval` + `/agent-create` extensions that enforce `cites:` + cache + integration dispatch (independent of this PR; depends only on #315).

## Scope

One new bats file under `tests/repo/`. No agent, skill, hook, or fixture changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)