### PR TITLE
test(evals): backfill mutation-probe behavior specs (#284–#287)

### DIFF
--- a/evals/skills/README.md
+++ b/evals/skills/README.md
@@ -1,0 +1,36 @@
+# Skill behavior specs (`.feature`)
+
+These Gherkin `.feature` files are the **Given/When/Then behavior specs** for the
+mutation-testing workflow skills shipped in the per-Story mutation probe
+(plan: [`plans/mutation-testing-every-phase.md`](../../plans/mutation-testing-every-phase.md),
+issues #283–#287). They exist for strict acceptance-criteria traceability: each
+slice's AC named a `.feature` spec, and this directory is where they live.
+
+## Why these are specs, not eval-grader fixtures
+
+The deterministic eval grader (`scripts/eval_grade.py` + `scripts/eval_graders/`)
+scores a single agent's or skill's **output** against an expected JSON, using a
+registered grader genre (`verdict`, `skill_gate`, `integration`). The
+mutation/coverage skills here are **workflow/orchestration contract skills**:
+they have no analyzable output to score against a grader genre — their contract
+is the text of the SKILL.md (flags, status enums, halt-prompt wording, atomic
+writes). That contract is enforced executably by **bats** suites under
+`tests/skills/`, which is also exactly what the plan's slice files specify.
+
+Dropping these into `evals/expected/*.json` would either break
+`--check-corpus` (no paired fixture, no applicable grader) or force a new grader
+the plan explicitly deferred. So the spec and its enforcement are split:
+
+| Behavior spec (`.feature`)                                    | Executable enforcement (`tests/skills/*.bats`)              | Issue |
+| ------------------------------------------------------------- | ----------------------------------------------------------- | ----- |
+| `mutation-testing/scoping.feature`                            | `mutation_testing_scoping_tests.bats`                       | #284  |
+| `coverage-delta/mutation-delta.feature`                       | `coverage_delta_mutation_tests.bats`                        | #285  |
+| `test-modernize/phase-4-mutation.feature`                     | `test_modernize_phase_4_mutation_tests.bats`                | #286  |
+| `quality-targets-converge/mutation-reuse.feature`             | `quality_targets_converge_mutation_reuse_tests.bats`        | #287  |
+
+## Keeping them honest
+
+Each `.feature` carries an `# Enforced by:` header naming its bats contract.
+[`tests/repo/feature_spec_refs_test.bats`](../../tests/repo/feature_spec_refs_test.bats)
+asserts that header is present and points at a file that exists, so a spec can't
+silently drift from (or outlive) the suite that enforces it.

--- a/evals/skills/coverage-delta/mutation-delta.feature
+++ b/evals/skills/coverage-delta/mutation-delta.feature
@@ -1,0 +1,69 @@
+# Behavior spec for /coverage-delta's Phase-4 scoped-mutation measurement.
+# Source of record: plans/mutation-testing-every-phase.md (Slice 2) · issue #285
+# Enforced by: tests/skills/coverage_delta_mutation_tests.bats
+#
+# This file is a Given/When/Then spec, not an eval-grader fixture (see
+# evals/skills/README.md). Executable enforcement is the bats contract named
+# above; non-drift is checked by tests/repo/feature_spec_refs_test.bats.
+
+Feature: Phase-4 coverage-delta measures mutation on the Story's files; never gates
+
+  Scenario: first measurement for a file establishes its baseline-of-record
+    Given mutation-history.json has no prior entry for src/order.ts
+    When /coverage-delta is invoked with --story S-1 --story-files src/order.ts
+    Then /mutation-testing runs scoped to src/order.ts (with --workflow-managed-approval)
+    And mutation-history.json gets an entry: {schema_version:1, story:"S-1", file:"src/order.ts", captured_at:<ISO>, survivors_before:null, survivors_after:N, delta:null, status:"first_measurement"}
+    And /coverage-delta's JSON result block on stdout has status:"first_measurement"
+    And exit code is 0
+
+  Scenario: subsequent Story strengthens assertions — survivors drop
+    Given the most recent mutation-history entry for src/order.ts has survivors_after=8
+    When /coverage-delta is invoked with --story S-2 --story-files src/order.ts
+    And /mutation-testing reports 3 surviving mutants on src/order.ts (after filtering status="equivalent")
+    Then mutation-history gets an entry: {story:"S-2", file:"src/order.ts", survivors_before:8, survivors_after:3, delta:-5, status:"ok"}
+    And the result block on stdout has status:"ok"
+    And exit code is 0
+
+  Scenario: Story executes code without asserting — net-new survivors
+    Given the most recent mutation-history entry for src/order.ts has survivors_after=3
+    When /coverage-delta is invoked with --story S-3 --story-files src/order.ts
+    And /mutation-testing reports 5 surviving mutants on src/order.ts (after equivalent filter)
+    Then mutation-history gets an entry with delta:2 and status:"net_new_survivors"
+    And the result block on stdout has status:"net_new_survivors" and lists the new survivors by file:line:operator
+    And exit code is 0 (the worker measures; it does not halt)
+
+  Scenario: --story without --story-files — no mutation run, no history write
+    Given /quality-targets-converge invokes /coverage-delta with --story S-4 and no --story-files
+    When /coverage-delta runs
+    Then no mutation tool is invoked by /coverage-delta itself
+    And mutation-history.json is not appended to
+    And the result block on stdout has mutation:null
+
+  Scenario: --story-files glob matches zero files
+    Given /build's commit diff produces an empty file list
+    When /coverage-delta is invoked with --story S-5 --story-files ""
+    Then no mutation run is triggered
+    And mutation-history gets an entry: {story:"S-5", status:"skipped_empty_scope"}
+
+  Scenario: mutation tool unavailable mid-run
+    Given baseline coverage tooling is fine
+    And no mutation-testing tool is installed for the detected language
+    When /coverage-delta is invoked with --story S-6 --story-files src/order.ts
+    Then /coverage-delta's result block has status:"tool_unavailable" and language:"<detected>"
+    And mutation-history gets an entry: {story:"S-6", file:"src/order.ts", status:"tool_unavailable"}
+    And exit code is 0
+    And the result block names "/init-dev-team" as the installation path
+
+  Scenario: tool present at one Story, absent at a later Story
+    Given mutation-history shows a prior tool:"stryker" entry for src/order.ts
+    And stryker is no longer on PATH
+    When /coverage-delta is invoked with --story S-7 --story-files src/order.ts
+    Then mutation-history records {story:"S-7", file:"src/order.ts", status:"tool_unavailable", prior_tool:"stryker"}
+    And the result block surfaces both the disappearance and the prior tool name
+
+  Scenario: parallel /coverage-delta invocations write atomically
+    Given two [Component tests] Stories close within the same second
+    When /coverage-delta is invoked for each in parallel
+    Then both entries land in mutation-history.json
+    And neither entry is truncated or interleaved
+    And the file is written via temp-file-then-rename

--- a/evals/skills/mutation-testing/scoping.feature
+++ b/evals/skills/mutation-testing/scoping.feature
@@ -1,0 +1,61 @@
+# Behavior spec for /mutation-testing's scoped, workflow-callable mode.
+# Source of record: plans/mutation-testing-every-phase.md (Slice 1) · issue #284
+# Enforced by: tests/skills/mutation_testing_scoping_tests.bats
+#
+# This file is a Given/When/Then spec, not an eval-grader fixture: the
+# mutation/coverage workflow skills are contract skills with no applicable
+# verdict/skill_gate/integration grader genre, so their executable
+# enforcement is the bats contract named above. It is kept here for strict
+# acceptance-criteria traceability and is checked for non-drift by
+# tests/repo/feature_spec_refs_test.bats.
+
+Feature: mutation-testing exposes a scoped, workflow-callable mode
+
+  Scenario: workflow caller scopes the run to a JS/TS file list and receives Stryker JSON
+    Given a JS/TS repo with Stryker installed and a passing test suite
+    And the project's primary language is detected as javascript
+    When /mutation-testing is invoked with --scope src/calculator.ts --emit-json out/mut.json --workflow-managed-approval
+    Then exit code is 0
+    And mut.json.tool equals "stryker"
+    And mut.json.scope equals ["src/calculator.ts"]
+    And mut.json has keys ["schema_version","tool","scope","captured_at","total","killed","survived","equivalent","survivors"]
+    And mut.json.survivors[] entries each have ["file","line","operator","status"] where status is "survived" or "equivalent"
+
+  Scenario: Java caller scopes to a glob and receives pitest JSON
+    Given a Maven repo with pitest configured
+    And the project's primary language is detected as java
+    When /mutation-testing is invoked with --scope "src/main/java/**/*.java" --emit-json out/mut.json --workflow-managed-approval
+    Then exit code is 0
+    And mut.json.tool equals "pitest"
+    And mut.json.scope is the expanded file list
+
+  Scenario: no tool installed — structured error, no partial JSON
+    Given no mutation-testing tool is installed for the detected language
+    When /mutation-testing is invoked with --scope src/foo.ts --emit-json out/mut.json --workflow-managed-approval
+    Then exit code is non-zero
+    And mut.json contains {"schema_version":1,"tool":null,"error":"no_tool_installed","language":"<detected>"}
+    And no partial mutation run output is left in the project
+
+  Scenario: --emit-json target directory unwritable
+    Given /tmp/readonly is a read-only directory
+    When /mutation-testing is invoked with --scope src/foo.ts --emit-json /tmp/readonly/mut.json --workflow-managed-approval
+    Then exit code is non-zero
+    And stderr names the unwritable path
+    And no partial JSON is left on disk
+
+  Scenario: --scope glob matches zero files
+    Given no source file matches the glob "src/does-not-exist/*.ts"
+    When /mutation-testing is invoked with --scope "src/does-not-exist/*.ts" --emit-json out/mut.json --workflow-managed-approval
+    Then exit code is non-zero
+    And mut.json contains {"schema_version":1,"tool":"<tool>","error":"empty_scope","scope_glob":"src/does-not-exist/*.ts"}
+
+  Scenario: interactive mode is unchanged — prompt is observable
+    Given /mutation-testing is invoked without --workflow-managed-approval
+    When the tool's time-estimate exceeds the documented threshold
+    Then stdout contains the literal string "Estimated time:"
+    And the process blocks on stdin until the operator confirms
+
+  Scenario: equivalent mutants are tagged so deltas don't double-count reclassifications
+    When /mutation-testing emits JSON
+    Then each survivor entry has status "survived" or "equivalent"
+    And downstream callers can filter status="equivalent" before computing deltas

--- a/evals/skills/quality-targets-converge/mutation-reuse.feature
+++ b/evals/skills/quality-targets-converge/mutation-reuse.feature
@@ -1,0 +1,49 @@
+# Behavior spec for /quality-targets-converge's mutation-history reuse rule.
+# Source of record: plans/mutation-testing-every-phase.md (Slice 4) · issue #287
+# Enforced by: tests/skills/quality_targets_converge_mutation_reuse_tests.bats
+#
+# This file is a Given/When/Then spec, not an eval-grader fixture (see
+# evals/skills/README.md). Executable enforcement is the bats contract named
+# above; non-drift is checked by tests/repo/feature_spec_refs_test.bats.
+
+Feature: /quality-targets-converge avoids re-measuring files Phase 4 already covered
+
+  Scenario: every file with a recent history entry is reused, not re-measured
+    Given mutation-history.json contains entries for src/order.ts (survivors_after=2) and src/payment.ts (survivors_after=0)
+    And neither file was modified after its history entry's captured_at timestamp
+    When /quality-targets-converge runs its measurement pass
+    Then /mutation-testing is NOT invoked for src/order.ts or src/payment.ts
+    And the surviving-mutant count for those files comes from mutation-history.json (latest entry per file)
+    And the iteration's converge-<n>.json names the reuse explicitly: {reused_from_history:[src/order.ts, src/payment.ts]}
+
+  Scenario: files modified after their last history entry are re-measured
+    Given mutation-history.json has src/order.ts:survivors_after=2 captured at T0
+    And src/order.ts was modified at T1 > T0 (per `git log`)
+    When /quality-targets-converge runs its measurement pass
+    Then /mutation-testing IS invoked scoped to src/order.ts
+    And the result is written to mutation-history.json as a synthetic entry: {story:"converge-<n>", file:"src/order.ts", ...}
+    And subsequent iterations within the same convergence run can reuse it
+
+  Scenario: production-code files never touched in Phase 4 are measured fresh
+    Given mutation-history.json has no entry for src/auth.ts
+    And src/auth.ts is in the in-scope component list
+    When /quality-targets-converge runs its measurement pass
+    Then /mutation-testing is invoked scoped to src/auth.ts (with --workflow-managed-approval)
+    And mutation-history.json gets a synthetic Phase-5 entry for src/auth.ts
+
+  Scenario: status:tool_unavailable from a prior Phase-4 entry — re-attempt allowed
+    Given mutation-history.json's latest entry for src/order.ts has status:"tool_unavailable"
+    When /quality-targets-converge runs its measurement pass
+    Then /mutation-testing IS invoked for src/order.ts (the tool may now be installed)
+    And the new entry overrides the old for reuse purposes
+
+  Scenario: converge-<n>.json reports reuse counts
+    When the iteration completes
+    Then converge-<n>.json has new fields: reused_from_history (count), measured_fresh (count), total_files (count)
+    And the operator's report shows "mutation: reused N, measured M" so the cost saving is visible
+
+  Scenario: existing Phase-5 contract unchanged when mutation-history is absent
+    Given a /test-modernize run from before this change has no mutation-history.json
+    When /quality-targets-converge runs
+    Then it falls back to its current behavior (full /mutation-testing run on the in-scope components)
+    And the SKILL.md documents this fallback explicitly so old runs aren't broken

--- a/evals/skills/test-modernize/phase-4-mutation.feature
+++ b/evals/skills/test-modernize/phase-4-mutation.feature
@@ -1,0 +1,80 @@
+# Behavior spec for /test-modernize Phase 4's mutation halt prompt.
+# Source of record: plans/mutation-testing-every-phase.md (Slice 3) · issue #286
+# Enforced by: tests/skills/test_modernize_phase_4_mutation_tests.bats
+#
+# This file is a Given/When/Then spec, not an eval-grader fixture (see
+# evals/skills/README.md). Executable enforcement is the bats contract named
+# above; non-drift is checked by tests/repo/feature_spec_refs_test.bats.
+
+Feature: /test-modernize Phase 4 surfaces mutation signal to the operator
+
+  Scenario: Phase-4 Story closes with status:ok — workflow advances
+    Given a [Component tests] Story S-1 closed by /build touching src/order.ts
+    When /test-modernize invokes /coverage-delta --story S-1 --story-files src/order.ts
+    And /coverage-delta returns status:"ok"
+    Then the Story is marked closed in phase-4.md
+    And the workflow advances to the next Story without prompting
+
+  Scenario: Phase-4 Story closes with status:first_measurement — workflow advances with note
+    Given a Story whose files have no prior mutation-history entry
+    When /coverage-delta returns status:"first_measurement"
+    Then the operator-visible report names this as the file's first measurement
+    And the survivor count is logged but not gated
+    And the workflow advances
+
+  Scenario: Phase-4 Story close halted on net-new survivors with three documented actions
+    Given /coverage-delta returns status:"net_new_survivors" listing src/order.ts:42 ConditionalBoundary (x>0 → x>=0) and src/order.ts:67 ReturnValue (return result → return null)
+    When /test-modernize processes the result
+    Then it pauses Story close and prints the documented halt prompt:
+      """
+      ⚠ Phase-4 Story <id> close halted — net-new surviving mutants on cited files
+
+      Files this Story claims to test:
+        - src/order.ts:42  ConditionalBoundary   x > 0  →  x >= 0
+        - src/order.ts:67  ReturnValue           return result  →  return null
+
+      Actions:
+        [s] strengthen — add assertions, then re-run /coverage-delta --story <id> --story-files <files>
+        [f] follow-up — open a Phase-5 [Strengthen assertions] Story citing these survivors
+        [w] waive    — record reason; survivors carry into Phase 5
+
+      Choose [s/f/w]:
+      """
+    And the workflow does not advance until the operator chooses
+
+  Scenario: operator chooses 'waive' — reason recorded, workflow advances
+    Given the halt prompt is showing for Story S-3
+    When the operator types "w" and enters a reason
+    Then the reason is appended to memory/test-modernize/<slug>/waivers.json as a Phase-4 waiver tagged with the survivor list
+    And the Story closes
+    And the workflow advances
+
+  Scenario: operator chooses 'follow-up' — Phase-5 Story drafted, workflow advances
+    Given the halt prompt is showing
+    When the operator types "f"
+    Then a draft Phase-5 [Strengthen assertions] Story is appended to phase-5.md citing the file:line:operator triples
+    And the current Story closes
+    And the workflow advances
+
+  Scenario: operator chooses 'strengthen' — workflow waits for re-run
+    Given the halt prompt is showing
+    When the operator types "s"
+    Then the workflow exits the current Story-close gate and waits
+    And /continue (or re-invoking the same /coverage-delta call) re-enters at the same point
+
+  Scenario: status:tool_unavailable — operator chooses install or skip
+    Given /coverage-delta returns status:"tool_unavailable" with language:"javascript"
+    When /test-modernize processes the result
+    Then it prints: "Mutation tool unavailable for javascript. Install via /init-dev-team, or skip mutation gating for this run."
+    And it offers actions [i] install via /init-dev-team, [k] skip — proceed advisory, [q] quit
+    And on [k] the rest of Phase 4 runs without mutation gating and Phase 5 is notified
+
+  Scenario: --story-files derived from /build's commit diff
+    Given /build closed Story S-1 with commits modifying src/order.ts and test/order.test.ts
+    When /test-modernize invokes /coverage-delta for S-1
+    Then --story-files contains "src/order.ts" (production-code files only, tests filtered)
+    And /test-modernize does NOT consult any tracker CLI for the file list
+
+  Scenario: Phase 1, 2, 3 step text unchanged
+    When the SKILL.md is read
+    Then the Phase 1, Phase 2, and Phase 3 sections are unchanged from the prior version (excluding cross-references to mutation-history.json that point readers forward)

--- a/tests/repo/feature_spec_refs_test.bats
+++ b/tests/repo/feature_spec_refs_test.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# Behavior-spec / bats-contract reference sensor.
+#
+# The mutation-probe slice ACs (#284-#287) named Gherkin `.feature` specs under
+# evals/skills/. Those specs are not eval-grader fixtures — their executable
+# enforcement is a bats suite under tests/skills/ (see evals/skills/README.md).
+# This guard keeps the two from drifting apart:
+#
+#   1. every evals/skills/**/*.feature carries an "# Enforced by:" header naming
+#      a tests/skills/<name>.bats file that exists;
+#   2. that referenced bats file is non-empty (i.e. a real suite, not a stub).
+#
+# Model-free and deterministic. If a spec's enforcing suite is renamed or
+# removed, this fails loudly instead of leaving an orphaned spec on disk.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SPEC_DIR="$REPO_ROOT/evals/skills"
+
+@test "every .feature spec names an existing, non-empty bats contract via '# Enforced by:'" {
+  [ -d "$SPEC_DIR" ] || skip "no evals/skills specs present"
+
+  local problems=""
+  local feature
+  while IFS= read -r feature; do
+    [ -n "$feature" ] || continue
+
+    local ref
+    ref="$(grep -oE '# Enforced by: tests/skills/[a-zA-Z0-9_./-]+\.bats' "$feature" | head -n1 | sed 's/^# Enforced by: //')"
+
+    if [ -z "$ref" ]; then
+      problems="${problems}\n  ${feature#$REPO_ROOT/}  (missing '# Enforced by: tests/skills/<name>.bats' header)"
+      continue
+    fi
+    if [ ! -s "$REPO_ROOT/$ref" ]; then
+      problems="${problems}\n  ${feature#$REPO_ROOT/}  ->  $ref  (referenced bats contract missing or empty)"
+    fi
+  done < <(find "$SPEC_DIR" -name '*.feature' | sort)
+
+  if [ -n "$problems" ]; then
+    printf 'Behavior spec(s) not backed by a bats contract:%b\n' "$problems" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## What & why

The per-Story mutation-probe slices (#284–#287) each named a Gherkin `.feature` spec in their acceptance criteria, but the work shipped its executable enforcement as **bats contracts** under `tests/skills/` (matching the plan's slice files) rather than the named `.feature` artifacts. This backfills those specs for strict AC traceability.

Discovered while auditing #283–#314: both initiatives (mutation probe + eval confidence-pyramid) were already implemented and merged; the only literal-AC gap was these four `.feature` files. The integration-tier AC (#304/#313) was already satisfied by the shipped `int-string-calculator` fixture, so it needed no backfill.

## Approach

The mutation/coverage skills are **workflow contract skills** with no applicable eval-grader genre (`verdict`/`skill_gate`/`integration`), so the spec and its enforcement are split:

- Each `.feature` carries an `# Enforced by:` header pointing at the bats suite that actually executes it.
- A new guard, `tests/repo/feature_spec_refs_test.bats`, fails if a spec ever loses its backing contract.
- `evals/skills/README.md` documents the split.

Scenarios are lifted **verbatim** from `plans/mutation-testing-every-phase.md`. **No** `evals/expected/*.json` is added — that would break `--check-corpus` (no paired fixture / no applicable grader) or force a grader the plan explicitly deferred.

| Behavior spec | Enforced by | Issue |
| --- | --- | --- |
| `evals/skills/mutation-testing/scoping.feature` | `tests/skills/mutation_testing_scoping_tests.bats` | #284 |
| `evals/skills/coverage-delta/mutation-delta.feature` | `tests/skills/coverage_delta_mutation_tests.bats` | #285 |
| `evals/skills/test-modernize/phase-4-mutation.feature` | `tests/skills/test_modernize_phase_4_mutation_tests.bats` | #286 |
| `evals/skills/quality-targets-converge/mutation-reuse.feature` | `tests/skills/quality_targets_converge_mutation_reuse_tests.bats` | #287 |

## Verification

- Guard test passes (`1..1 ok`) and was confirmed to **fail** on a spec missing its header (not a false pass).
- `python3 scripts/eval_grade.py --check-corpus` → still **79 fixtures valid** (the new `evals/skills/` tree doesn't touch the grader corpus).
- The guard is auto-discovered by `chk_bats_repo` (`run_bats tests/repo/`), so it runs in the standard local/CI gate.

## Scope

Docs + one guard test only; no shipped plugin code (agents/skills/hooks) changes. Not doc-only, so this needs explicit human merge per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnKZ9dnH1T4jyoj992uGiK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnKZ9dnH1T4jyoj992uGiK)_