### PR TITLE
docs(skills): disambiguate /agent-readiness from /harness-audit

### DIFF
--- a/plugins/dev-team/skills/agent-readiness/SKILL.md
+++ b/plugins/dev-team/skills/agent-readiness/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Score how ready the current repository is for AI-assisted development against
   the Agent-Readiness Scorecard. Use when the user asks "how agent-ready is this
   repo", "score this repo for agents", "agent readiness", or wants a tiered
-  readiness report.
+  readiness report. Scores YOUR project repo's readiness — not the dev-team
+  plugin's own review agents and routing (for that, use /harness-audit).
 argument-hint: "[repo-path] [--json <file>] [--markdown <file>]"
 user-invocable: true
 allowed-tools: >-
@@ -16,6 +17,12 @@ allowed-tools: >-
 Role: worker. Scores a **single local repository** against the Agent-Readiness
 Scorecard and reports a tier (Agent-Ready / Assisted / Limited / Hostile) with
 per-criterion evidence.
+
+> **Not `/harness-audit`.** This scores the **subject repository** (your
+> project's build, code quality, docs, and version-control hygiene) from a
+> static checkout. `/harness-audit` audits the **dev-team plugin's own harness**
+> (review-agent effectiveness, model tiers, orchestration) from accumulated
+> runtime metrics. Different subject, different input, different output.
 
 ## Scope (MVP — issue #117)
 

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -4,7 +4,9 @@ description: >-
   Analyze review agent effectiveness, model routing, and orchestration complexity
   against actual usage data. Produces a report of harness components that may be
   candidates for simplification or removal. Use periodically to prevent harness
-  staleness as model capabilities improve.
+  staleness as model capabilities improve. Audits the dev-team plugin's OWN
+  harness from runtime metrics — not your project repo's readiness (for that,
+  use /agent-readiness).
 argument-hint: "[--output <path>]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash(date *), Write
@@ -15,6 +17,14 @@ allowed-tools: Read, Glob, Grep, Bash(date *), Write
 Role: orchestrator. This command analyzes harness effectiveness — it does not modify agents or configuration.
 
 You have been invoked with the `/harness-audit` command.
+
+> **Not `/agent-readiness`.** This audits the **dev-team plugin's own harness**
+> (review-agent effectiveness, model tiers, orchestration) from accumulated
+> runtime metrics in `metrics/`. `/agent-readiness` scores the **subject
+> repository's** readiness for AI-assisted development from a static checkout.
+> Different subject, different input, different output. The inward-facing
+> companion here is `/session-review`, whose `session-digest.jsonl` this command
+> consumes (Step 1).
 
 ## Orchestrator constraints
 


### PR DESCRIPTION
## Summary

Follow-up from a review of standalone skills: `/agent-readiness` and `/harness-audit` read as interchangeable (both "score", both mention "agent"), but they are different tools. Checked whether they should be **consolidated** — verdict: **no**, they have nothing to factor out. Instead, this clarifies each so neither the user nor model routing confuses them.

| | `/agent-readiness` | `/harness-audit` |
|---|---|---|
| Subject | YOUR repository | The dev-team plugin's own harness |
| Input | Static checkout heuristics (`scanner.py`) | Runtime metrics (`metrics/*.jsonl`) |
| Output | Readiness tier + per-criterion evidence | Agent removal / model-tier / orchestration recommendations |

## Changes (docs only)

- One-line clarifier appended to each skill's `description`.
- A "Not the other one" callout in each skill body, stating subject/input/output differences.
- `/harness-audit` body now also names its real inward-facing companion, `/session-review` (whose `session-digest.jsonl` it already consumes in Step 1).

## Testing

- `tests/repo/agent_readiness_tests.bats` passes.
- Both descriptions remain colon-free (the `/agent-audit` frontmatter rule) and parse as valid YAML.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)