### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -49,7 +49,7 @@ jobs:
     name: Structural gate (model-free)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install bats + jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need PR base to diff which agents/skills changed
 
@@ -160,7 +160,7 @@ jobs:
       # for the same branch. A miss here just means a full live dispatch.
       - name: Restore eval replay cache
         if: steps.cred.outputs.run_live == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: evals/.eval-cache.json
           key: eval-cache-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
@@ -342,7 +342,7 @@ jobs:
       # this makes the per-run cache state downloadable.
       - name: Upload eval replay cache artifact
         if: steps.cred.outputs.run_live == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eval-replay-cache-${{ github.run_id }}
           path: evals/.eval-cache.json
@@ -361,7 +361,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -399,7 +399,7 @@ jobs:
       # instead of paying full orchestrator cost.
       - name: Restore eval replay cache
         if: steps.gate.outputs.run_integration == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: evals/.eval-cache.json
           key: eval-cache-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -9,7 +9,7 @@ jobs:
   shell-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install shellcheck + jq
         run: sudo apt-get update && sudo apt-get install -y shellcheck jq
@@ -32,7 +32,7 @@ jobs:
   bats-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
   cost-regression:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install python3 + jq
         run: sudo apt-get update && sudo apt-get install -y jq python3
@@ -102,7 +102,7 @@ jobs:
       # plugins/dev-team/docs/telemetry-ci-access.md.
       - name: Load telemetry deploy key (read-only)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.TELEMETRY_DEPLOY_KEY }}
 
@@ -129,7 +129,7 @@ jobs:
   semgrep-fixtures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install semgrep + pyyaml
         run: pip install --quiet semgrep pyyaml
@@ -148,7 +148,7 @@ jobs:
   harness-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install harness runtime dependency (httpx)
         run: pip install --quiet httpx

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,13 +17,13 @@ jobs:
       # identity (not the default GITHUB_TOKEN) is what lets the release PR's
       # events trigger the pull_request workflows — GITHUB_TOKEN-authored PRs
       # never start new workflow runs (GitHub's recursion guard).
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to their latest available versions across the three workflow files.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6 | **v7** |
| `actions/cache` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `webfactory/ssh-agent` | v0.9.0 | **v0.10.0** |
| `actions/create-github-app-token` | v2 | **v3** |
| `googleapis/release-please-action` | v4 | **v5** |
| `anthropics/claude-code-action` | v1 | v1 (already latest major) |

## Notes

- `release-please-action` v5 and `create-github-app-token` v3 are major bumps that move their runtime to Node 24 — no config changes required.
- `actions/checkout@v7` blocks checking out fork PRs for `pull_request_target`/`workflow_run` triggers; none of these workflows use those triggers, so no impact.
- `claude-code-action@v1` left as-is — v1 is still the latest major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PfvqzHZ3qHRt1CCXDQPQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_014PfvqzHZ3qHRt1CCXDQPQ2)_