### PR TITLE
ci: migrate create-github-app-token to client-id input

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,14 @@ jobs:
       # identity (not the default GITHUB_TOKEN) is what lets the release PR's
       # events trigger the pull_request workflows — GITHUB_TOKEN-authored PRs
       # never start new workflow runs (GitHub's recursion guard).
+      #
+      # `client-id` supersedes the deprecated `app-id` input. The
+      # RELEASE_BOT_APP_ID secret holds the App's Client ID (e.g. Iv23li…),
+      # not the legacy numeric App ID.
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,13 +18,13 @@ jobs:
       # events trigger the pull_request workflows — GITHUB_TOKEN-authored PRs
       # never start new workflow runs (GitHub's recursion guard).
       #
-      # `client-id` supersedes the deprecated `app-id` input. The
-      # RELEASE_BOT_APP_ID secret holds the App's Client ID (e.g. Iv23li…),
+      # `client-id` supersedes the deprecated `app-id` input and takes the
+      # App's Client ID (e.g. Iv23li…) from the RELEASE_BOT_CLIENT_ID secret,
       # not the legacy numeric App ID.
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5


### PR DESCRIPTION
## What

Replace the deprecated `app-id` input on `actions/create-github-app-token@v3` with `client-id` in the Release Please workflow, sourcing the value from a new `RELEASE_BOT_CLIENT_ID` secret.

## Why

Every Release Please run emitted:

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

`client-id` takes the App's Client ID (e.g. `Iv23li…`), which is distinct from the legacy numeric App ID.

## Secret change (already applied)

- New repo secret `RELEASE_BOT_CLIENT_ID` holds the App's Client ID.
- `RELEASE_BOT_PRIVATE_KEY` unchanged.
- Old `RELEASE_BOT_APP_ID` secret is now unused and can be deleted.

## Verify

On the next push to `main`, the `create-github-app-token` step should mint a token without the deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNy5vajkKuJmgu8UW1cp6k)_