### PR TITLE
docs: require conventional squash titles; release missed v7.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Releases are managed by release-please. Push conventional commits to main:
 
 A release PR is opened automatically. Merging it creates a GitHub Release with a version tag.
 
+**Squash-merge titles must be conventional.** This repo squash-merges PRs, so the **PR title becomes the commit subject** that release-please reads — and `release-type: simple` classifies off the *subject*, not the body. A PR titled `Add X` (no `feat:`/`fix:` prefix) is invisible to release-please and silently skips the version bump, even when its squashed body contains conventional commits. Title every PR conventionally. To recover a release that was missed this way, land a follow-up commit carrying a `Release-As: X.Y.Z` footer.
+
 ## Cloud sessions (claude.ai/code)
 
 Plugins are a **local CLI / IDE** feature. A Claude Code web session runs in a


### PR DESCRIPTION
## Problem

PR #350 shipped a `feat` (the registry-completeness sensor) but **release-please did not bump the version**. Root cause: this repo squash-merges, so the **PR title becomes the squash commit subject**, and `release-type: simple` classifies off the *subject*. #350's title — *"Eliminate registry drift: effort single-source + registry-completeness sensor"* — has no conventional type prefix, so release-please saw nothing releasable and skipped the bump (no release PR was opened; latest tag is still `dev-team-v7.0.0`).

## Fix

1. **Force the missed release.** This commit carries a `Release-As: 7.1.0` footer — the documented release-please override — so it cuts the minor bump #350 should have produced (`7.0.0 → 7.1.0`, from the `feat(audit):`).
2. **Prevent recurrence.** Document in `CLAUDE.md` that squash-merge / PR titles must be conventional, since release-please reads the subject, not the squashed body.

After this merges, release-please opens the `7.1.0` release PR — merging *that* performs the actual release (the human gate stays intact).

## Follow-up worth considering

Add a CI check that enforces a conventional PR title (e.g. a semantic-PR-title action), so a non-conventional title is caught at PR time rather than silently dropping a release.