### PR TITLE
docs(dev-team): note registry-completeness gate; release v7.1.0

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -43,7 +43,7 @@ See @docs/team-structure.md for the full team org chart (Mermaid diagram).
 
 ## Agent & Skill Registry
 
-Full registry tables with token counts, effort bands, and used-by mappings are in [`knowledge/agent-registry.md`](knowledge/agent-registry.md). The orchestrator reads this file when routing decisions require the full catalog.
+Full registry tables with token counts, effort bands, and used-by mappings are in [`knowledge/agent-registry.md`](knowledge/agent-registry.md). The orchestrator reads this file when routing decisions require the full catalog. A registry-completeness gate (`scripts/check_registry_sync.py`, surfaced as `/agent-audit` step 2e) fails CI when an agent or skill on disk is missing from — or orphaned in — these tables.
 
 ### Quick Reference
 


### PR DESCRIPTION
## Why a second attempt

#351 carried `Release-As: 7.1.0` but only touched **root `CLAUDE.md`**. release-please here is a **path-scoped manifest monorepo** (`Building strategies by path` in the run log): it attributes a commit to a package by the files it changes. A root-only commit belongs to no package, so the override was ignored — no release PR.

This PR touches a file **under `plugins/dev-team/`**, so the `Release-As: 7.1.0` footer attaches to the `dev-team` package and release-please cuts the minor bump that #350's `feat(audit):` should have produced (`7.0.0 → 7.1.0`).

The doc line itself is real and useful: it records the registry-completeness gate added in #350.

## After merge

release-please opens the `7.1.0` release PR; merging that performs the actual release (tag `dev-team-v7.1.0`, GitHub Release, version bumped in `plugin.json` + `marketplace.json`). That merge stays the human gate.