### PR TITLE
ci: lint PR titles against commitlint so squash subjects stay conventional

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,36 @@
+name: PR title lint
+
+# release-please derives the version bump from the commit subject on main.
+# Because this repo squash-merges, that subject is the PR *title* — which the
+# .husky/commit-msg commitlint hook never sees (it only lints local commit
+# messages). Lint the PR title here with the SAME commitlint ruleset so a
+# non-conventional title fails at PR time instead of silently dropping a release.
+# (PR #350 shipped a feat under a non-conventional title and skipped v7.1.0.)
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+        env:
+          HUSKY: 0
+      - name: Lint PR title against commitlint.config.js
+        env:
+          # Pass via env, never interpolate untrusted PR input into the shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s' "$PR_TITLE" | npx commitlint --verbose


### PR DESCRIPTION
## Why

This repo squash-merges, so the **PR title becomes the commit subject** that release-please reads. The `.husky/commit-msg` commitlint hook only lints **local commit messages** — it never sees the PR title. That's the exact gap that let **#350** ship a `feat` under a non-conventional title and silently skip the **v7.1.0** bump (recovered manually via `Release-As` in #352).

## What

A `pull_request` workflow (open/edit/reopen) that runs the repo's **own** commitlint ruleset (`commitlint.config.js`) against the PR title. A non-conventional title fails the check before merge.

- **Single source of truth**: reuses `commitlint.config.js`, so the PR title is held to the exact same rules as commits — no second type list to drift (vs. `amannn/action-semantic-pull-request`, which would duplicate the type config).
- **Safe**: PR title passed via env var, never interpolated into the shell. `pull_request` (not `pull_request_target`), `contents: read` only.

Verified locally: #350's title fails (`type may not be empty`), conventional titles pass, and GitHub's `(#NNN)` squash suffix passes.

## To make it enforce

Mark **PR title lint** as a required status check in branch protection for `main` — otherwise it reports but doesn't block.

> Note: a newly-added workflow may not run on its own PR; it takes effect for subsequent PRs after this merges.