### PR TITLE
ci: make PR-title check satisfy the required-status-check context

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,8 +8,12 @@ name: PR title lint
 # (PR #350 shipped a feat under a non-conventional title and skipped v7.1.0.)
 
 on:
+  # `synchronize` (a push to the PR) is required: branch protection evaluates the
+  # required check against the PR's head SHA, so the check must re-report on every
+  # new commit — otherwise an updated PR is blocked waiting for a status that never
+  # re-runs (compounded here by strict "require branches up to date").
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 permissions:
   contents: read
@@ -20,6 +24,10 @@ concurrency:
 
 jobs:
   lint-pr-title:
+    # The job name IS the status-check context branch protection matches on.
+    # It must equal the required check configured in the ruleset ("PR title lint"),
+    # not the workflow name — otherwise the requirement is never satisfied.
+    name: PR title lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why PRs are blocked

"PR title lint" was made a **required** status check, but nothing satisfies it:

- **Name mismatch (primary):** branch protection matches the **job** name. The job is `lint-pr-title`, but the ruleset requires `PR title lint` (the *workflow* name). GitHub Actions never reports a context called "PR title lint", so the requirement is perpetually pending → every PR blocks.
- **Missing `synchronize`:** the required check is evaluated against the PR **head SHA**. With the trigger limited to `opened/edited/reopened`, a push (new commits) never re-runs it, so the new SHA has no status. The ruleset is also `strict` (require up-to-date), which makes this worse.

## Fix

1. `name: PR title lint` on the job → the reported context now equals the required context.
2. Add `synchronize` to the triggers → re-reports on every push / branch update.

## ⚠️ This PR is blocked by the very bug it fixes

`main` still reports `lint-pr-title`, so the required `PR title lint` context won't go green here until this merges. To land it, do **one** of:

- **Admin bypass** the requirement on this PR and merge, **or**
- In the `main` ruleset, temporarily remove `PR title lint` from required checks → merge this → re-add it. After merge, real PRs report under "PR title lint" and the requirement is satisfied normally.

## After merge

Re-trigger any already-open PR so it gets the correctly-named check (it never ran on them): edit the PR title (fires `edited`) or push a commit (fires `synchronize`). That includes **#353** (the 7.1.0 release PR).