### PR TITLE
feat(quality-gate,harness-audit): trust review signals over saturating coverage metrics

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2864,21 +2864,25 @@
       "summary": "For each review agent in the registry (`knowledge/agent-registry.md`):",
       "anchor": "2-analyze-review-agent-effectiveness"
     },
-    "3. Analyze model routing": {
+    "3. Analyze review-value fix rates": {
+      "summary": "Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `performance-metrics`).",
+      "anchor": "3-analyze-review-value-fix-rates"
+    },
+    "4. Analyze model routing": {
       "summary": "For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):",
-      "anchor": "3-analyze-model-routing"
+      "anchor": "4-analyze-model-routing"
     },
-    "4. Analyze orchestration complexity": {
+    "5. Analyze orchestration complexity": {
       "summary": "Review the current pipeline for components that may be unnecessary overhead:",
-      "anchor": "4-analyze-orchestration-complexity"
+      "anchor": "5-analyze-orchestration-complexity"
     },
-    "5. Produce report": {
+    "6. Produce report": {
       "summary": "Write the report to the output path using this structure:",
-      "anchor": "5-produce-report"
+      "anchor": "6-produce-report"
     },
-    "6. Present results": {
+    "7. Present results": {
       "summary": "Display a summary of the report and the file path.",
-      "anchor": "6-present-results"
+      "anchor": "7-present-results"
     },
     "Error Handling": {
       "summary": "Missing metrics files: Report what's missing, suggest how to generate data",

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -68,7 +68,41 @@ For each review agent in the registry (`knowledge/agent-registry.md`):
 3. **False positive rate**: If correction data exists (from `/apply-fixes`), check how often findings were dismissed vs. applied. Agents with >50% dismissed findings have a high false positive rate.
 4. **Finding severity distribution**: Is the agent producing mostly minor findings? If >80% of findings are minor severity, consider whether the agent justifies its token cost.
 
-### 3. Analyze model routing
+### 3. Analyze review-value fix rates
+
+Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `performance-metrics`). If the file is absent, note it and continue — this section is skippable.
+
+For each **checkpoint type** (the `checkpoint` field: `step` or `slice`) and each **agent combination** (`agents_run` list, treated as a set-key), compute:
+
+```bash
+[ -f metrics/review-value.jsonl ] && jq -s '
+  group_by(.checkpoint + "|" + (.agents_run | sort | join(",")))
+  | map({
+      checkpoint:    .[0].checkpoint,
+      agents:        (.[0].agents_run | sort | join(", ")),
+      total:         length,
+      no_op:         (map(select(.outcome=="no-op"))    | length),
+      fixed:         (map(select(.outcome=="fixed"))     | length),
+      escalated:     (map(select(.outcome=="escalated")) | length),
+      fix_rate:      ((map(select(.outcome=="fixed")) | length) / length * 100 | round),
+      issues_found:  (map(.issues_found)  | add // 0),
+      issues_fixed:  (map(.issues_fixed)  | add // 0),
+      fix_iterations:(map(.fix_iterations)| add // 0)
+    })' \
+  metrics/review-value.jsonl
+```
+
+Flag **drop candidates**: any checkpoint+agents combination with `fix_rate == 0` across **N ≥ 5** logged runs is a drop candidate — it consistently adds overhead without catching defects.
+
+Flag **high-value checkpoints**: `fix_rate ≥ 50%` — these are earning their cost and should be retained.
+
+**Drop-candidate recommendations** (P2-S3):
+For each drop candidate emit a recommendation in this form:
+> `<checkpoint>/<agents>` fixed 0/<N> runs (fix rate 0%) — candidate to drop. To act: remove this checkpoint type from the relevant `/build` step-complexity tier or exclude these agents from the checkpoint's dispatch list. Do not auto-edit skills; present for human decision.
+
+Do not modify any skill or agent file. The report is the only artifact.
+
+### 4. Analyze model routing
 
 For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):
 
@@ -76,7 +110,7 @@ For each agent listed in `knowledge/agent-registry.md` (with model tier from its
 2. **Under-tiered agents**: Agents on haiku that frequently miss issues caught by human review may need a higher tier.
 3. **Cost distribution**: Which agents consume the most tokens? Are the most expensive agents also the most valuable?
 
-### 4. Analyze orchestration complexity
+### 5. Analyze orchestration complexity
 
 Review the current pipeline for components that may be unnecessary overhead:
 
@@ -84,7 +118,7 @@ Review the current pipeline for components that may be unnecessary overhead:
 2. **Review checkpoint frequency**: Are inline reviews running on every step? If most steps are trivial, the complexity classification (see `skills/plan/SKILL.md` § Complexity Classification) should be catching this.
 3. **Unused skills**: Skills loaded but never applied in logged sessions.
 
-### 5. Produce report
+### 6. Produce report
 
 Write the report to the output path using this structure:
 
@@ -109,6 +143,26 @@ Write the report to the output path using this structure:
 | Agent | Findings | Minor % | Recommendation |
 |-------|----------|---------|----------------|
 
+## Review-Value Fix Rates (inline checkpoint ROI)
+
+> Source: `metrics/review-value.jsonl`. Absent = no `/build` runs logged yet.
+
+### Per-Checkpoint-Type Fix Rates
+| Checkpoint | Agents | Runs | No-op | Fixed | Escalated | Fix rate |
+|------------|--------|------|-------|-------|-----------|----------|
+
+### Drop Candidates (fix rate 0%, N ≥ 5 runs)
+| Checkpoint | Agents | Runs | Recommendation |
+|------------|--------|------|----------------|
+
+> To act on a drop candidate: remove the checkpoint type from the relevant `/build`
+> step-complexity tier or exclude the agents from that checkpoint's dispatch list.
+> Requires human decision — do not auto-edit skills.
+
+### High-Value Checkpoints (fix rate ≥ 50%)
+| Checkpoint | Agents | Runs | Fix rate | Issues fixed |
+|------------|--------|------|----------|--------------|
+
 ## Model Routing Recommendations
 
 | Agent | Current tier | Suggested tier | Rationale |
@@ -123,13 +177,15 @@ Write the report to the output path using this structure:
 - Agents to consider removing: <count>
 - Model tier changes suggested: <count>
 - Orchestration simplifications: <count>
+- Review-value drop candidates: <count>
+- Review-value high-value checkpoints: <count>
 
 ## Next Steps
 
 <Actionable recommendations prioritized by impact>
 ```
 
-### 6. Present results
+### 7. Present results
 
 Display a summary of the report and the file path. Do not repeat the full report in chat — the file is the artifact.
 

--- a/plugins/dev-team/skills/quality-gate-pipeline/SKILL.md
+++ b/plugins/dev-team/skills/quality-gate-pipeline/SKILL.md
@@ -76,6 +76,11 @@ When a signal fires: **Pause** → **Verify** (use tools) → **Correct** → **
 2. **Build succeeds**: If the project has a build step, run it. Paste output.
 3. **Lint clean**: If the project has a linter, run it. Paste output.
 4. **No regressions**: Test count should not decrease.
+5. **Coverage & Mutation (necessary-not-sufficient)**: Coverage thresholds and mutation score gate entry but do not alone gate exit. Saturating at 100% line coverage and 1.0 mutation score on small slices is expected and does not indicate structural quality. They are required to pass but are not the final signal.
+6. **Structural Quality gate**: Before claiming "done", the work must carry a clean-or-triaged `structure-review` + `complexity-review` signal. Options:
+   - **Clean**: Both agents produced no `error`/`warning` findings on the latest diff.
+   - **Triaged**: Every `error`/`warning` finding is logged as a deferred item (with owner + tracking reference) per the Phase 3 exit criteria — and surfaced in the completion summary.
+   - **Waiver**: For hotfixes, documentation-only changes, or work pre-approved by the Orchestrator as out-of-scope for structural review, include a waiver statement: `structural-review-waiver: <reason>` in the completion summary. Waivers are surfaced, not hidden.
 
 **Quality Ownership**: green means the **entire suite**, not just the tests your
 change touched. A failing test is a failing test **regardless of whether this change


### PR DESCRIPTION
## Summary

Implements epic #363 (P2: Trust the right quality signals) across all three planned slices.

- **P2-S1** (#370): Re-weight the quality gate — coverage/mutation are now explicitly *necessary-not-sufficient*. Adds a Structural Quality gate requiring a clean-or-triaged `structure-review` + `complexity-review` pass (or an explicit waiver) before "done". The max-3 review-correction cycle cap is unchanged (AC5).
- **P2-S2** (#371): `/harness-audit` now reads `metrics/review-value.jsonl` and reports per-checkpoint-type fix rates (no-op / fixed / escalated counts + fix rate %). Privacy boundary honored — counts and outcomes only, never code or file content (AC2, AC4).
- **P2-S3** (#372): Report flags always-no-op checkpoints (fix rate 0%, N ≥ 5 runs) as drop candidates with human-actionable recommendations. No auto-editing of skills (AC3).

## Files changed

- `plugins/dev-team/skills/quality-gate-pipeline/SKILL.md` — Phase 2 Required Evidence gains items 5 (coverage/mutation necessary-not-sufficient) and 6 (Structural Quality gate with clean/triaged/waiver paths).
- `plugins/dev-team/skills/harness-audit/SKILL.md` — New Step 3 (review-value fix-rate analysis + drop-candidate recommendations); report template gains a *Review-Value Fix Rates* section with per-checkpoint table, drop-candidates table, and high-value-checkpoints table; Summary adds two new counters.

## Test plan

- [ ] Read `quality-gate-pipeline/SKILL.md` Phase 2 — coverage/mutation items and Structural Quality gate are present with waiver path.
- [ ] Read `harness-audit/SKILL.md` — Step 3 is present with jq command; drop-candidate threshold (fix_rate==0, N≥5) is stated; report template includes Review-Value Fix Rates section with all three sub-tables.
- [ ] Step numbering is sequential (1–7 with no duplicates).
- [ ] No skill or agent files auto-edited by the new analysis step.

Closes #370
Closes #371
Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nh8fpkYqttzHjq9TFeFFV

---
_Generated by [Claude Code](https://claude.ai/code/session_011nh8fpkYqttzHjq9TFeFFV)_