### PR TITLE
chore: upgrade actions/setup-node to v6

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Single source of truth for the Node version — read from .nvmrc.
           node-version-file: .nvmrc


### PR DESCRIPTION
## Summary
Updates the `actions/setup-node` GitHub Action from v4 to v6 in the PR title linting workflow.

## Changes
- Bumped `actions/setup-node` from v4 to v6 in `.github/workflows/pr-title-lint.yml`
- The workflow continues to read the Node version from `.nvmrc` as the single source of truth

## Notes
This is a documentation-only/workflow infrastructure change with no impact on shipped code, agents, skills, or hooks. The PR title linting workflow will benefit from improvements and bug fixes in the newer action version.

https://claude.ai/code/session_014jjhmTeBYB2GMZMnQoiEYb