### PR TITLE
feat: extend DDD skills with supple design, distillation, and implicit-concept patterns from Evans

### DIFF
--- a/plugins/dev-team/agents/domain-review.md
+++ b/plugins/dev-team/agents/domain-review.md
@@ -78,6 +78,25 @@ Anemic domain model:
 - Entities or aggregates that are pure data holders (only getters/setters, no behavior) while all logic lives in services — suggest moving invariant enforcement and state transitions onto the entity
 - Entities that allow external callers to set internal state directly instead of through intention-revealing methods (e.g., setting a status field directly rather than calling a method like `markPaid()` or `Submit()`)
 
+Implicit concepts (missing specification/policy):
+
+- The same multi-clause business condition duplicated across 2+ places — a named domain rule wearing a disguise; suggest extracting a specification/policy object
+- A rule stated in a comment but enforced ad hoc — the concept lives in language, not in the model
+- Flag only duplication or comment-encoded rules you can cite; a single local condition is not a missing specification
+
+Construction without invariants (missing factory):
+
+- Public constructors / object literals that let callers build an invalid aggregate (required field unset, interdependent fields set independently)
+- The same multi-step aggregate assembly repeated across call sites — creation belongs in one factory
+- Do not flag simple objects that are valid by plain construction
+
+Supple design smells (domain model only — defer general purity/coupling to js-fp-review and structure-review):
+
+- Domain methods named for *how* not *what* (`recalc`, `doProcess`), or boolean flag parameters that switch behavior — not intention-revealing
+- A method on a value object or entity that both mutates and returns (command-query separation); value objects should expose only side-effect-free operations
+- Value-typed concepts (money, range, coordinate) that are mutable (public setters / in-place mutation)
+- Invariants asserted by callers instead of guarded inside the entity/aggregate
+
 ## Skills
 
 Whole-file load: each linked SKILL.md is loaded in full when invoked.
@@ -93,6 +112,9 @@ After producing findings, run the shared challenger loop in `knowledge/adversari
 - Did you check for ubiquitous language drift: same concept with 3+ different names across modules?
 - Are domain objects leaking persistence annotations, HTTP concerns, or infrastructure types?
 - Did you check aggregate boundary enforcement — are child entities accessed directly by external callers?
+- For each "missing specification" finding, did you cite the 2+ locations where the same condition is duplicated (not a single local `if`)?
+- For supple-design smells, did you stay scoped to domain types (entities/value objects/domain services) and not re-report general FP-purity or coupling that js-fp-review / structure-review own?
+- Did you confirm each "mutable value object" is genuinely used as a value (not an entity with identity)?
 
 Append confidence level (High/Medium/Low) to the `summary` field.
 

--- a/plugins/dev-team/knowledge/domain-modeling.md
+++ b/plugins/dev-team/knowledge/domain-modeling.md
@@ -81,6 +81,38 @@ contain all behavior. Signs:
 | Cross-context coupling | Direct imports between bounded contexts instead of events/shared kernel |
 | Aggregate boundary bypass | Reaching into an aggregate's child entities directly |
 
+### Implicit Concepts (missing Specification / Policy)
+
+A named business rule hiding inside scattered conditionals. Surface it as a Specification or Policy object.
+
+| Signal | What it implies |
+|--------|-----------------|
+| The same multi-clause boolean (`if a && b && !c`) duplicated in 2+ places | A domain rule with a name the experts already use — extract to a specification/policy object |
+| A rule expressed as a comment (`// orders over $X to a new address need review`) but enforced ad hoc | The concept exists in language but not in the model |
+| A boolean-returning method on a service that inspects another object's fields | Tell-don't-ask + a candidate specification owned by the domain |
+
+Only flag duplication or comment-encoded rules you can point to. A single, local condition is not a missing specification.
+
+### Construction Without Invariants (missing Factory)
+
+| Signal | What it implies |
+|--------|-----------------|
+| Public constructor / object literal that lets a caller build an invalid aggregate (required field unset, two fields that must agree set independently) | Construction invariant is unenforced — a factory or a guarding constructor should make the object valid-on-creation |
+| The same multi-step assembly of an aggregate repeated across call sites | Creation logic belongs in one factory, not copied into clients |
+
+Do not flag simple objects that are valid by plain construction — a factory there is overhead.
+
+### Supple Design Smells (domain model only)
+
+Scope these to **domain entities, value objects, and domain services** — general purity/coupling elsewhere belongs to `js-fp-review` and `structure-review`, not here.
+
+| Smell | Signal | Fix direction |
+|-------|--------|---------------|
+| Not intention-revealing | A domain method named for *how* not *what* (`recalc`, `doProcess`), or a boolean flag parameter that switches behavior (`price(true)`) | Rename to the domain verb; split the two behaviors |
+| Side effect in a query | A method on a value object or entity that both mutates state and returns a value (violates command-query separation) | Separate the command from the query; value objects expose only side-effect-free operations |
+| Mutable value object | A type used as a value (money, range, coordinate) with public setters or in-place mutation | Make it immutable; return new instances |
+| Unenforced invariant | An entity/aggregate whose invariant is asserted by callers rather than guarded internally | Move the invariant into the type (constructor, factory, or guarded mutator) |
+
 ### Ubiquitous Language Drift
 
 Flag only internal inconsistency observable in code:

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -410,6 +410,18 @@
       "summary": "| Violation | Signal |",
       "anchor": "boundary-violations"
     },
+    "Implicit Concepts (missing Specification / Policy)": {
+      "summary": "A named business rule hiding inside scattered conditionals.",
+      "anchor": "implicit-concepts-missing-specification-policy"
+    },
+    "Construction Without Invariants (missing Factory)": {
+      "summary": "| Signal | What it implies |",
+      "anchor": "construction-without-invariants-missing-factory"
+    },
+    "Supple Design Smells (domain model only)": {
+      "summary": "Scope these to **domain entities, value objects, and domain services** — general purity/coupling elsewhere belongs to `js-fp-review` and `structure-review`, not here.",
+      "anchor": "supple-design-smells-domain-model-only"
+    },
     "Ubiquitous Language Drift": {
       "summary": "Flag only internal inconsistency observable in code:",
       "anchor": "ubiquitous-language-drift"
@@ -2530,6 +2542,10 @@
       "summary": "Identify feedback loops and cascading-change risks — the architectural patterns that make every deploy a coordination exercise.",
       "anchor": "5-coupling-trap-detection"
     },
+    "6. Core Domain Distillation": {
+      "summary": "Where is the team's modeling effort actually going, and does that match where the value is?",
+      "anchor": "6-core-domain-distillation"
+    },
     "Steps": {
       "summary": "1.",
       "anchor": "steps"
@@ -2557,6 +2573,10 @@
     "Value Stream": {
       "summary": "State the entrypoint (file and function/command).",
       "anchor": "value-stream"
+    },
+    "Subdomain Classification": {
+      "summary": "Table: context name, class (Core / Supporting / Generic), evidence for the class, confidence tier.",
+      "anchor": "subdomain-classification"
     },
     "Friction Report": {
       "summary": "Each item: category tag, specific files/components involved, confidence tier, and a concrete fix direction.",
@@ -2592,6 +2612,10 @@
       "summary": "Define explicit relationships between bounded contexts:",
       "anchor": "context-mapping"
     },
+    "Distillation — Find the Core Domain": {
+      "summary": "Not all of the model is equally valuable.",
+      "anchor": "distillation-find-the-core-domain"
+    },
     "Tactical Patterns": {
       "summary": "Cluster of entities and value objects with a single **aggregate root**",
       "anchor": "tactical-patterns"
@@ -2620,6 +2644,26 @@
       "summary": "Domain-level abstraction for aggregate persistence",
       "anchor": "repositories"
     },
+    "Factories": {
+      "summary": "Encapsulate complex creation of an aggregate or value object so the result is **valid and whole** the moment it exists",
+      "anchor": "factories"
+    },
+    "Specifications": {
+      "summary": "Encapsulate a business rule as a first-class predicate object (`OverdueInvoiceSpecification`, `EligibleForDiscountSpecification`)",
+      "anchor": "specifications"
+    },
+    "Making Implicit Concepts Explicit": {
+      "summary": "When a constraint, process, or policy is buried in conditionals and scattered across methods, the model is hiding a concept the domain expert already has a word for.",
+      "anchor": "making-implicit-concepts-explicit"
+    },
+    "Supple Design": {
+      "summary": "The craft of refactoring toward deeper insight — design that is safe to change because it reveals intent and contains side effects.",
+      "anchor": "supple-design"
+    },
+    "Knowledge Crunching & Model-Driven Design": {
+      "summary": "The model is not designed up front and frozen — it emerges from **continuous collaboration with domain experts**, distilling messy reality into sharp abstractions.",
+      "anchor": "knowledge-crunching-model-driven-design"
+    },
     "When to Apply": {
       "summary": "| Situation | Approach |",
       "anchor": "when-to-apply"
@@ -2636,13 +2680,17 @@
       "summary": "Map each distinct model to its own context with clear boundaries",
       "anchor": "2-define-bounded-contexts"
     },
-    "3. Select Tactical Patterns": {
-      "summary": "Determine whether the domain complexity warrants aggregates, entities, value objects, and domain events",
-      "anchor": "3-select-tactical-patterns"
+    "3. Distill the Core": {
+      "summary": "Classify each subdomain as Core, Supporting, or Generic; write a one-paragraph Domain Vision Statement for the Core",
+      "anchor": "3-distill-the-core"
     },
-    "4. Validate Model": {
+    "4. Select Tactical Patterns": {
+      "summary": "Determine whether the domain complexity warrants aggregates, entities, value objects, factories, specifications, and domain events",
+      "anchor": "4-select-tactical-patterns"
+    },
+    "5. Validate Model": {
       "summary": "Confirm aggregates enforce consistency boundaries (one transaction = one aggregate)",
-      "anchor": "4-validate-model"
+      "anchor": "5-validate-model"
     },
     "Output": {
       "summary": "Report modeling decisions: bounded contexts identified, aggregate boundaries, context map relationships, and any violations of DDD constraints found in existing code.",

--- a/plugins/dev-team/skills/domain-analysis/SKILL.md
+++ b/plugins/dev-team/skills/domain-analysis/SKILL.md
@@ -16,6 +16,7 @@ This skill is analytical, not prescriptive. It describes what *is*, not what sho
 ## Scope
 
 Before starting, determine scope from the user's request:
+
 - **Single repo**: analyze folder structure, package boundaries, shared models
 - **Multi-repo / microservices**: analyze service boundaries, shared libraries, event contracts, API dependencies
 
@@ -24,6 +25,7 @@ Before starting, determine scope from the user's request:
 Every finding must be grounded in something you actually read. When reporting a God Object, a missing ACL, a coupling trap, or a friction item, cite the specific `file:line` or `file` where the evidence was observed. Do not assert that a pattern exists based on naming conventions alone — open the file and confirm it.
 
 Classify each finding by confidence:
+
 - **observed** — directly visible in a file you read (an import statement, a shared type, a method call)
 - **inferred** — visible at folder or module level without reading implementation (directory name, package dependency in package.json)
 - **suspected** — requires runtime knowledge or cannot be confirmed from static analysis alone
@@ -50,6 +52,7 @@ For each inter-context relationship, classify the integration pattern. This matt
 | **Customer/Supplier** | Downstream negotiates with upstream via contracts or versioned APIs |
 | **Conformist** | Downstream uses upstream's model with no translation |
 | **Open Host Service** | Published protocol (REST, gRPC, event schema) consumed by many |
+| **Separate Ways** | No code path between two contexts that a naive reading would expect to integrate — sometimes deliberate and correct, not always a gap |
 
 Flag missing ACLs: direct dependencies between contexts that pass domain objects across boundaries without translation. These are the highest-risk coupling points — a schema change in one context silently breaks another.
 
@@ -78,6 +81,24 @@ Identify feedback loops and cascading-change risks — the architectural pattern
 - **Coupling traps**: a change to one component's domain model forces breaking changes in others — signals missing abstraction or a misplaced boundary
 - **Shared mutable state**: two contexts writing to the same tables or caches without clear ownership
 
+### 6. Core Domain Distillation
+
+Where is the team's modeling effort actually going, and does that match where the value is? This is the strategic prioritization lens — it tells you where deeper design pays off and where it is waste.
+
+Classify each bounded context:
+
+| Class | Signal | What it means |
+| --- | --- | --- |
+| **Core** | Bespoke, frequently-changed business logic central to why the product exists | Invest the best design here |
+| **Supporting** | Business-specific but not differentiating | Build simply; adequate is fine |
+| **Generic** | Solved problems — auth, notifications, currency, scheduling, file storage | Buy/adopt; custom code here is usually waste |
+
+Flag **effort misallocation** — the friction this lens exists to find:
+
+- **Over-built generic**: an elaborate custom model in a Generic subdomain (a hand-rolled auth/permissions engine, a bespoke job scheduler) — candidates to replace with a library or service
+- **Neglected Core**: the context most central to the business is the most anemic or tangled — the strongest design investment is going to the wrong place
+- Classification is a judgment call; mark it `suspected` unless commit frequency or bespoke complexity makes it `observed`
+
 ## Steps
 
 1. Map bounded contexts from directory structure and naming conventions
@@ -87,7 +108,8 @@ Identify feedback loops and cascading-change risks — the architectural pattern
 5. Run the event storm: list events, emitters, and consumers
 6. Identify the value stream entrypoint in code; trace the happy path step by step
 7. Identify coupling traps and circular dependencies
-8. Write the Friction Report
+8. Classify each context as Core / Supporting / Generic; flag effort misallocation
+9. Write the Friction Report
 
 ## Output
 
@@ -111,6 +133,10 @@ Table: event name, emitting context, consuming contexts, sync/async. If no domai
 
 State the entrypoint (file and function/command). Then list the ordered handoffs with coupling severity (low / medium / high) and confidence tier.
 
+### Subdomain Classification
+
+Table: context name, class (Core / Supporting / Generic), evidence for the class, confidence tier. Add a one-line Domain Vision for the context judged Core. Flag any over-built Generic or neglected Core as a Friction Report item with the `effort-misallocation` category.
+
 ### Friction Report
 
 Each item: category tag, specific files/components involved, confidence tier, and a concrete fix direction. Use this format:
@@ -121,9 +147,10 @@ Description of the coupling or gap.
 Fix: <specific action, e.g., "introduce ACL", "extract context", "replace sync call with domain event">
 ```
 
-Categories: `deployment-coupling` | `data-coupling` | `semantic-coupling` | `event-gap`
+Categories: `deployment-coupling` | `data-coupling` | `semantic-coupling` | `event-gap` | `effort-misallocation`
 
 **Example:**
+
 ```
 [semantic-coupling] output.ts → enricher.ts (confidence: observed, output.ts:3)
 output.ts imports classifyDDD() from enricher.ts — business logic that runs at render time

--- a/plugins/dev-team/skills/domain-driven-design/SKILL.md
+++ b/plugins/dev-team/skills/domain-driven-design/SKILL.md
@@ -8,21 +8,25 @@ user-invocable: true
 # Domain-Driven Design (DDD)
 
 ## Overview
+
 Model software around the business domain. Collaborate with domain experts to build a shared understanding expressed in code through ubiquitous language, bounded contexts, and tactical patterns.
 
 ## Strategic Patterns
 
 ### Ubiquitous Language
+
 - Code, documentation, and communication all use the same domain terminology
 - If the domain expert calls it an "enrollment," the code calls it `Enrollment`, not `Registration`
 - Language inconsistencies signal a modeling problem
 
 ### Bounded Contexts
+
 - Each context owns its own domain model with clear boundaries
 - The same real-world concept may have different representations in different contexts
 - A `Customer` in Billing is not the same model as a `Customer` in Shipping
 
 ### Context Mapping
+
 Define explicit relationships between bounded contexts:
 
 | Pattern | When to Use |
@@ -33,41 +37,102 @@ Define explicit relationships between bounded contexts:
 | **Conformist** | Downstream adopts upstream's model as-is (no negotiation power) |
 | **Open Host Service** | Context exposes a well-defined protocol for many consumers |
 | **Published Language** | Shared interchange format (e.g., industry standard schemas) |
+| **Separate Ways** | No integration at all — the cheaper, more honest choice when the cost of integrating two contexts outweighs the benefit |
+
+### Distillation — Find the Core Domain
+
+Not all of the model is equally valuable. Spend your best modeling effort where it earns the most.
+
+- **Core Domain** — the part that makes the business worth doing; your competitive advantage. Assign your strongest people here; invest in supple design.
+- **Generic Subdomains** — necessary but undifferentiated (auth, notifications, currency conversion). Buy, adopt, or build plainly — do not gold-plate.
+- **Supporting Subdomains** — business-specific but not differentiating. Build simply.
+- **Domain Vision Statement** — a short paragraph naming the Core Domain and why it matters. Write it early; it directs investment and prioritization.
+
+Misallocation is the smell: elaborate custom code in a generic subdomain, or an anemic, neglected Core.
 
 ## Tactical Patterns
 
 ### Aggregates
+
 - Cluster of entities and value objects with a single **aggregate root**
 - All external access goes through the root
 - Enforce consistency boundaries: one transaction = one aggregate
 - Keep aggregates small; reference other aggregates by ID, not by object
 
 ### Entities
+
 - Defined by identity, not attributes
 - Two entities with the same attributes but different IDs are different objects
 - Track lifecycle and state changes
 
 ### Value Objects
+
 - Defined by attributes, not identity
 - Immutable; equality by value comparison
 - Use for: money, addresses, date ranges, measurements
 
 ### Domain Events
+
 - Record that something meaningful happened in the domain
 - Named in past tense: `OrderPlaced`, `PaymentReceived`, `EnrollmentCompleted`
 - Enable cross-context communication and eventual consistency
 - Carry enough data for consumers to act without calling back
 
 ### Domain Services
+
 - Operations that don't naturally belong to a single entity or value object
 - Stateless; coordinate across multiple aggregates
 - Example: `TransferFundsService` operating across two `Account` aggregates
 
 ### Repositories
+
 - Domain-level abstraction for aggregate persistence
 - Interface defined in the domain/application layer (a port)
 - Implementation lives in the infrastructure/adapter layer
 - One repository per aggregate root
+
+### Factories
+
+- Encapsulate complex creation of an aggregate or value object so the result is **valid and whole** the moment it exists
+- Move construction invariants out of clients and out of overloaded constructors
+- A factory belongs to the domain layer; it produces domain objects, it does not persist them
+- Use when a constructor would have to know too much, or when creation enforces a non-trivial invariant
+- Skip for objects that are valid by simple construction — a factory is overhead there
+
+### Specifications
+
+- Encapsulate a business rule as a first-class predicate object (`OverdueInvoiceSpecification`, `EligibleForDiscountSpecification`)
+- Three uses: **validation** (does this object satisfy the rule?), **selection** (query for objects that match), **construction-to-order** (build an object that satisfies the rule)
+- The tool for **making an implicit concept explicit**: when the same multi-clause boolean appears in several places, that duplicated predicate is a named domain rule wearing a disguise — give it a name and a type
+- Compose specifications (and / or / not) rather than copying the condition
+
+## Making Implicit Concepts Explicit
+
+When a constraint, process, or policy is buried in conditionals and scattered across methods, the model is hiding a concept the domain expert already has a word for. Surface it:
+
+| Hidden as | Surface it as |
+| --- | --- |
+| A repeated multi-clause `if` | A **Specification** or **Policy** object |
+| A constraint enforced ad hoc in setters | An invariant the **entity/aggregate** guards |
+| A multi-step business process in a service method | A named **domain process** or sequence of **domain events** |
+| A primitive that always travels with rules (`int balanceCents`) | A **Value Object** (`Money`) that owns those rules |
+
+## Supple Design
+
+The craft of refactoring toward deeper insight — design that is safe to change because it reveals intent and contains side effects. Apply to the Core Domain especially.
+
+- **Intention-Revealing Interfaces** — name classes and methods for *what* they accomplish, not how; a caller should not need to read the implementation. Boolean flag parameters that switch behavior are a smell.
+- **Side-Effect-Free Functions** — push computation into functions that return results without changing state; keep state changes in a small, obvious set of command methods (command-query separation). Value Objects should expose only side-effect-free operations.
+- **Assertions** — state post-conditions and invariants explicitly (in code or tests) so behavior is guaranteed, not inferred from reading the body.
+- **Conceptual Contours** — factor the model along the domain's own seams so that what changes together lives together; a single conceptual change should touch one place.
+- **Standalone Classes** — drive down dependencies so a class can be understood and tested in isolation; low coupling is the goal, not just clean layering.
+- **Closure of Operations** — where it fits, define operations whose argument and result are the same type (`Money.add(Money) → Money`); they compose without dragging in other concepts.
+
+## Knowledge Crunching & Model-Driven Design
+
+- The model is not designed up front and frozen — it emerges from **continuous collaboration with domain experts**, distilling messy reality into sharp abstractions.
+- **Bind the model to the implementation.** If the code drifts from the model the team talks about, the model is fiction. The same terms, the same relationships, in conversation and in code.
+- Expect **breakthroughs**: periodic refactorings where a better abstraction suddenly clarifies a whole area. Leave room for them; they are the payoff of crunching, not a failure of earlier design.
 
 ## When to Apply
 
@@ -81,34 +146,49 @@ Define explicit relationships between bounded contexts:
 ## Steps
 
 ### 1. Establish Ubiquitous Language
+
 - Identify domain terms from requirements and stakeholder input
 - Verify code uses the same terms as domain experts
 - Flag language inconsistencies between code, docs, and conversation
 
 ### 2. Define Bounded Contexts
+
 - Map each distinct model to its own context with clear boundaries
 - Identify context relationships using context mapping patterns (Shared Kernel, ACL, etc.)
 
-### 3. Select Tactical Patterns
-- Determine whether the domain complexity warrants aggregates, entities, value objects, and domain events
+### 3. Distill the Core
+
+- Classify each subdomain as Core, Supporting, or Generic; write a one-paragraph Domain Vision Statement for the Core
+- Direct the strongest modeling effort (and supple design) at the Core; keep Generic subdomains plain
+
+### 4. Select Tactical Patterns
+
+- Determine whether the domain complexity warrants aggregates, entities, value objects, factories, specifications, and domain events
 - For simple CRUD, apply strategic DDD only (contexts + language)
 
-### 4. Validate Model
+### 5. Validate Model
+
 - Confirm aggregates enforce consistency boundaries (one transaction = one aggregate)
 - Confirm cross-context communication uses domain events, not direct references
 - Confirm repositories exist per aggregate root with interfaces in domain/application layer
+- Confirm objects are valid on creation (constructor or factory), and that named business rules are explicit (specifications/policies), not duplicated conditionals
 
 ## Output
+
 Report modeling decisions: bounded contexts identified, aggregate boundaries, context map relationships, and any violations of DDD constraints found in existing code. Be concise — use tables for context maps and violation lists; skip concept narration.
 
 ## Constraints
+
 - Do not share aggregate instances across bounded contexts; reference by ID only
 - Do not leak domain model internals through API boundaries
 - Do not apply full tactical DDD to simple CRUD domains
 
 ## Guidelines
+
 - Start with strategic DDD (contexts, language) before reaching for tactical patterns
 - Not every service needs aggregates; recognize when simpler models suffice
 - Domain events are the primary mechanism for cross-context communication
 - Aggregates define transaction boundaries, not query boundaries (use read models for queries)
 - Validate ubiquitous language continuously; stale language leads to model drift
+- Reserve supple design (intention-revealing interfaces, side-effect-free functions, specifications) for the Core Domain; over-engineering a generic subdomain is its own smell
+- A repeated multi-clause condition is an implicit concept — name it (specification/policy) rather than copying it


### PR DESCRIPTION
## What & why

Improves the plugin's architecture/DDD skills against Eric Evans' *Domain-Driven Design*. The existing skills already cover bounded contexts, context mapping, aggregates, entities, value objects, domain events, services, and repositories well. This fills the four genuine gaps vs. the book — chosen by the maintainer — by **extending existing files** (no new skills/agents, no registry churn).

| Evans gap | Where it landed |
|---|---|
| **Supple Design** (Ch. 10) — intention-revealing interfaces, side-effect-free functions, assertions, conceptual contours, standalone classes, closure of operations | `domain-driven-design` skill section + domain-scoped detection in `domain-modeling.md` + `domain-review` agent |
| **Core Domain Distillation** (Ch. 15) — Core/Supporting/Generic subdomains, Domain Vision Statement | `domain-driven-design` (greenfield) + `domain-analysis` strategic lens with `effort-misallocation` friction |
| **Making Implicit Concepts Explicit + Specification** (Ch. 9) | `domain-driven-design` patterns + `domain-modeling.md` detection + `domain-review` |
| **Factories** (Ch. 6) + minor: **Separate Ways** context-map pattern, **Knowledge Crunching** note | `domain-driven-design` + `domain-analysis` |

Supple-design detection is deliberately **scoped to domain types** (entities/value objects/domain services) so it does not duplicate `js-fp-review` (general FP purity) or `structure-review` (general coupling).

## Verification

- `build-knowledge-index.sh --check` → index fresh ✓
- `check_registry_sync.py` → in sync ✓
- bats: `tests/agents/ tests/knowledge/ tests/commands/ tests/docs/ tests/scripts/ tests/skills/` all pass (exit 0, no failures)
- citation lint: only pre-existing advisory warnings in untouched files

## Merge

Touches shipping components (skills, agent, knowledge) → **requires explicit human merge** (auto-merge intentionally not armed).