### PR TITLE
fix: add ambiguity resolution protocol to /specs and wire /ship gate

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4478,6 +4478,10 @@
       "summary": "| Category | Description |",
       "anchor": "critique-categories"
     },
+    "Ambiguity Resolution Protocol": {
+      "summary": "After critiquing the artifacts but before writing the final acceptance criteria, run this protocol on every gap and ambiguity finding.",
+      "anchor": "ambiguity-resolution-protocol"
+    },
     "Scope signals": {
       "summary": "A specification bundles too much when any of these fire:",
       "anchor": "scope-signals"

--- a/plugins/dev-team/skills/ship/SKILL.md
+++ b/plugins/dev-team/skills/ship/SKILL.md
@@ -47,8 +47,17 @@ a genuinely blocking ambiguity remains.
 
 ### 2. Spec (unless `--skip-spec`)
 
-Invoke `/specs` for the feature. Present the Intent, Architecture, and Acceptance
-Criteria for approval. **Human gate** — wait for approval before planning.
+Invoke `/specs` for the feature. `/specs` runs the Ambiguity Resolution Protocol
+before finalizing acceptance criteria — any finding classified `requires-stakeholder-input`
+is surfaced to the human as a required answer, not an optional confirmation.
+
+**These unresolved items ARE the human gate.** Do not auto-approve past them, even in
+non-interactive mode. The only exception is `--skip-spec` (when a reviewed spec already
+exists). A spec that passed its consistency gate with undocumented assumptions is not
+an approved spec.
+
+Present the completed spec (Intent, Architecture, Acceptance Criteria, and Ambiguity
+Log) for human review. **Human gate** — wait for approval before planning.
 
 ### 3. Plan
 

--- a/plugins/dev-team/skills/specs/SKILL.md
+++ b/plugins/dev-team/skills/specs/SKILL.md
@@ -62,6 +62,33 @@ Repeat up to **2 iterations** before escalating.
 | Conflicts | Contradictions between artifacts or with existing system behavior |
 | Scope violations | Spec bundles unrelated features that belong in separate specs |
 
+## Ambiguity Resolution Protocol
+
+After critiquing the artifacts but before writing the final acceptance criteria, run this protocol on every gap and ambiguity finding. This is a hard step — it cannot be skipped.
+
+For each gap or ambiguity:
+
+**Step A — Attempt inference.** Look for a reliable basis: existing codebase behavior, domain conventions, similar precedents in the system, or unambiguous implication from stated requirements.
+
+**Step B — Classify the finding.**
+
+| Class | Meaning | Action |
+|-------|---------|--------|
+| `inferable` | A reasonable developer, given the codebase and domain, would make the same choice | Document the inference and its rationale; proceed |
+| `requires-stakeholder-input` | The decision depends on product or business intent not evident from context; two reasonable developers would choose differently | **Block — ask the human before proceeding** |
+
+**Step C — Resolve `requires-stakeholder-input` items.** Collect all such items and present them as a single batch to the human before writing acceptance criteria:
+
+> "Before writing acceptance criteria, I need clarification on N decisions the spec leaves open: [list]"
+
+Wait for answers. Only then finalize the criteria.
+
+**What "inferable" is NOT:** a convenient default. Naturalness or simplicity does not make a decision inferable — the test is whether a developer working from context alone would reliably land on the same answer. If in doubt, classify as `requires-stakeholder-input`.
+
+**Record every classification** in an `## Ambiguity Log` section of the spec file (see Output below). This log is the audit trail that turns "we asked before building" from an assertion into an artifact.
+
+This protocol exists because the most common failure mode of spec synthesis from a vague prompt is writing decisions that look thorough while encoding the same happy-path assumptions a direct implementation would make silently. The log prevents that by making every assumption visible and every gap either resolved by the human or documented as inferable with explicit rationale.
+
 ## Scope signals
 
 A specification bundles too much when any of these fire:
@@ -89,8 +116,9 @@ Validate all three artifacts as a set:
 - [ ] Architecture specification constrains implementation to what the intent requires, without over-engineering.
 - [ ] Same concepts are named consistently across all three artifacts.
 - [ ] No artifact contradicts another.
+- [ ] Every gap and ambiguity finding is logged — either documented as `inferable` (with explicit rationale) or resolved via explicit stakeholder input. No finding is left as an undocumented assumption.
 
-**Hard stop**: do not proceed to planning until every item passes.
+**Hard stop**: do not proceed to planning until every item passes. The ambiguity log item is the most critical: a passing gate with undocumented assumptions produces false confidence.
 
 ## Output
 
@@ -117,12 +145,21 @@ After the gate passes, write all three artifacts plus the verdict to a markdown 
 ## Acceptance Criteria
 <acceptance criteria artifact>
 
+## Ambiguity Log
+
+All gap and ambiguity findings from the Ambiguity Resolution Protocol, with their classifications and rationale.
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|----------|---------------|-------------|-------------------|
+| <decision text> | `inferable` / `requires-stakeholder-input` | inference / human | <rationale or human's answer> |
+
 ## Consistency Gate
 - [x/  ] Intent is unambiguous
 - [x/  ] Every behavior/goal maps to an acceptance criterion
 - [x/  ] Architecture constrains without over-engineering
 - [x/  ] Terminology consistent across artifacts
 - [x/  ] No contradictions between artifacts
+- [x/  ] Every gap/ambiguity finding is logged — inferable with rationale or resolved by human
 ```
 
 1. **Print** the file path to chat so the user can find it.


### PR DESCRIPTION
## Summary

- **Root cause from experiment:** The `when-tdd-pays` experiment found that `/ship`'s `/specs` phase scores 25% EDGE under vague specs — no better than `tdd-refactor` (33%) and slightly worse. The mechanism: `/specs` surfaces omitted decisions in an "explicit decisions on omitted behaviors" table but self-resolves them to happy-path defaults, then stamps `Consistency Gate: PASS`. It relocates the guess from code to spec without eliminating it — manufacturing false confidence.
- **`/specs`:** Added an **Ambiguity Resolution Protocol** (Steps A/B/C) that runs after critique but before finalizing acceptance criteria. Each gap/ambiguity finding is classified as `inferable` (documented rationale required, proceed) or `requires-stakeholder-input` (block and ask the human in a single batch). The test for "inferable" is whether a developer working from context alone would reliably land on the same answer — not whether a default is natural or convenient.
- **`/specs`:** Added an **Ambiguity Log** to the spec file template and a new consistency gate item requiring every finding to be logged. A gate that passes with undocumented assumptions is explicitly called out as false confidence.
- **`/ship`:** Step 2 (Spec) now makes explicit that `requires-stakeholder-input` items ARE the human gate and cannot be auto-approved past, even in non-interactive mode. Only `--skip-spec` (when a reviewed spec already exists) bypasses this.

## Test plan

- [x] `scripts/ci-local.sh` passes (all bats, shellcheck, eval corpus, eslint, index freshness)
- [x] `knowledge/index.json` rebuilt to include updated `specs` and `ship` content
- [ ] Manual: invoke `/specs` with a vague feature description and confirm the ambiguity classification step runs and blocks on `requires-stakeholder-input` findings before acceptance criteria are written
- [ ] Manual: invoke `/ship` on a vague spec and confirm that unresolved ambiguity items are not auto-approved past

🤖 Generated with [Claude Code](https://claude.com/claude-code)