### PR TITLE
feat: add craftsmanship-axis review rules (use-the-platform, comment hygiene)

### DIFF
--- a/evals/expected/dr-clean-inline-comments.json
+++ b/evals/expected/dr-clean-inline-comments.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "dr-clean-inline-comments.ts",
+  "description": "Clean counterpart: comments describe purpose, carry no tracker IDs, and each doc comment sits directly above the symbol it documents. Should pass — guards the comment-hygiene and detached-doc-comment rules against over-firing.",
+  "applicableAgents": ["doc-review"],
+  "agents": {
+    "doc-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 1 }
+    }
+  }
+}

--- a/evals/expected/dr-orphaned-doc-comment.json
+++ b/evals/expected/dr-orphaned-doc-comment.json
@@ -1,0 +1,17 @@
+{
+  "fixture": "dr-orphaned-doc-comment.ts",
+  "description": "A rigid-body JSDoc block describing transformPartPolygons sits directly above reflectPolygon, so the comment does not describe the function it annotates. doc-review's inline-comment-drift rule should catch the detached/misplaced doc comment.",
+  "applicableAgents": ["doc-review"],
+  "agents": {
+    "doc-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 3 },
+      "severities": {
+        "warning": { "min": 0, "max": 3 },
+        "suggestion": { "min": 0, "max": 3 }
+      },
+      "mustMention": ["reflectPolygon"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/dr-tracker-ids-in-comments.json
+++ b/evals/expected/dr-tracker-ids-in-comments.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "dr-tracker-ids-in-comments.ts",
+  "description": "Issue/epic/JIRA tracker IDs embedded in shipped code comments (epic #24, #41, #43, JIRA-1187). Should be flagged as comment-hygiene drift — tracker IDs belong in commit messages/PRs, not in code.",
+  "applicableAgents": ["doc-review"],
+  "agents": {
+    "doc-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 5 },
+      "severities": { "suggestion": { "min": 1, "max": 5 } },
+      "mustMention": ["tracker"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/dr-tracker-ids-py.json
+++ b/evals/expected/dr-tracker-ids-py.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "dr-tracker-ids-py.py",
+  "description": "Cross-language proof: Python `#` comments carrying epic/issue/JIRA IDs that the comment-hygiene rule should flag — same principle as the TS fixture, different comment syntax.",
+  "applicableAgents": ["doc-review"],
+  "agents": {
+    "doc-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "suggestion": { "min": 1, "max": 4 } },
+      "mustMention": ["tracker"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/ro-reinvented-builtins-py.json
+++ b/evals/expected/ro-reinvented-builtins-py.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "ro-reinvented-builtins-py.py",
+  "description": "Cross-language proof: Python manual min/max scan and accumulator-loop sum that the reinvent-the-platform rule should flag with min()/max()/sum() suggestions — same principle as the TS fixture, different built-ins.",
+  "applicableAgents": ["refactor-opportunity-review"],
+  "agents": {
+    "refactor-opportunity-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "suggestion": { "min": 1, "max": 4 } },
+      "mustMention": ["max"],
+      "mustNotMention": ["Math.min"]
+    }
+  }
+}

--- a/evals/expected/ro-reinvented-builtins.json
+++ b/evals/expected/ro-reinvented-builtins.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "ro-reinvented-builtins.ts",
+  "description": "Hand-rolled Math.min/Math.max scan, an inline duplicate of an existing helper, and `0 - x` instead of unary minus — should be flagged as reinvent-the-platform refactor opportunities (suggestions, not errors: the manual loop may be an intentional hot-path).",
+  "applicableAgents": ["refactor-opportunity-review"],
+  "agents": {
+    "refactor-opportunity-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 2, "max": 5 },
+      "severities": { "suggestion": { "min": 1, "max": 5 } },
+      "mustMention": ["Math.min"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/ro-repeated-idiom.json
+++ b/evals/expected/ro-repeated-idiom.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "ro-repeated-idiom.ts",
+  "description": "A `Math.abs(x - y) > tol` comparison open-coded four times that should be a named `withinTolerance` predicate, plus repeated inline normalize-to-origin with terse names. The expressiveness/extract-named-predicate refactor opportunity should be flagged.",
+  "applicableAgents": ["refactor-opportunity-review"],
+  "agents": {
+    "refactor-opportunity-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "suggestion": { "min": 1, "max": 4 } },
+      "mustMention": ["tolerance"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/expected/ro-uses-builtins.json
+++ b/evals/expected/ro-uses-builtins.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "ro-uses-builtins.ts",
+  "description": "Clean counterpart: uses Math.min/Math.max and the existing helper, unary minus. Should pass — guards against the reinvent-the-platform rule over-firing on idiomatic code.",
+  "applicableAgents": ["refactor-opportunity-review"],
+  "agents": {
+    "refactor-opportunity-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 1 }
+    }
+  }
+}

--- a/evals/fixtures/dr-clean-inline-comments.ts
+++ b/evals/fixtures/dr-clean-inline-comments.ts
@@ -1,0 +1,29 @@
+// PASS: comments explain intent and behavior without leaking tracker IDs,
+// and each doc comment sits directly above the symbol it describes.
+// Clean counterpart to dr-tracker-ids-in-comments.ts.
+
+export interface NestingConfig {
+  sheet: { width: number; height: number };
+  kerf: number;
+
+  /**
+   * Opt-in NFP-based placement: exact-phase candidate seats and NFP-clearance
+   * collision. Off by default — denser, but ~3–4x slower pending tuning.
+   */
+  useNfpPlacement?: boolean;
+
+  /** Mild fitness pull toward a clustered pack; undefined ⇒ optimizer default. */
+  gravityWeight?: number;
+
+  /** Mild fitness pull toward one large reusable offcut; 0 disables the term. */
+  remnantWeight?: number;
+
+  /**
+   * When true, parts may abut (clearance drops to 0) and the fitness rewards
+   * coincident shared edges so adjacent parts share a single cut line.
+   */
+  commonLineCutting?: boolean;
+}
+
+/** Default spacing between parts, in millimetres. */
+export const DEFAULT_KERF = 1;

--- a/evals/fixtures/dr-orphaned-doc-comment.ts
+++ b/evals/fixtures/dr-orphaned-doc-comment.ts
@@ -1,0 +1,26 @@
+// FAIL: a doc comment is detached from the function it describes.
+// Derived from laser-layout src/lib/geometry/polygon.ts (the rigid-body block
+// that ended up sitting above reflectPolygon instead of transformPartPolygons).
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+type Polygon = Point[];
+
+/**
+ * Transform a part's polygons as a single rigid body: rotate every polygon
+ * around the outer boundary's centroid, then translate the whole group so the
+ * outer boundary's bounding box sits at (x, y). `polygons[0]` is the outer
+ * boundary; the rest are cutouts.
+ */
+// The block above describes transformPartPolygons (below), not reflectPolygon.
+export function reflectPolygon(polygon: Polygon): Polygon {
+  return polygon.map((p) => ({ x: -p.x, y: p.y }));
+}
+
+export function transformPartPolygons(polygons: Polygon[]): Polygon[] {
+  // ... rotates around centroid and translates the group ...
+  return polygons;
+}

--- a/evals/fixtures/dr-tracker-ids-in-comments.ts
+++ b/evals/fixtures/dr-tracker-ids-in-comments.ts
@@ -1,0 +1,22 @@
+// FAIL: issue-tracker / epic IDs bleed into shipped code comments.
+// Derived from laser-layout src/lib/geometry/types.ts (NestingConfig).
+
+export interface NestingConfig {
+  sheet: { width: number; height: number };
+  kerf: number;
+
+  // Opt-in NFP-based placement (epic #24, P3–P5): exact-phase candidate seats.
+  // Off by default — the path is ~3–4x slower and not yet a net bench win.
+  useNfpPlacement?: boolean;
+
+  // Remnant-aware fitness weights (#41): a mild pull toward a clustered pack.
+  gravityWeight?: number;
+  remnantWeight?: number;
+
+  // Common-line cutting (#43): when true, parts are allowed to abut so adjacent
+  // parts share a single cut line.
+  commonLineCutting?: boolean;
+}
+
+// See JIRA-1187 for the rationale behind this default.
+export const DEFAULT_KERF = 1;

--- a/evals/fixtures/dr-tracker-ids-py.py
+++ b/evals/fixtures/dr-tracker-ids-py.py
@@ -1,0 +1,14 @@
+# FAIL: tracker IDs bleed into Python `#` comments.
+# Cross-language proof that the comment-hygiene rule is not TS-specific.
+
+
+class NestingConfig:
+    def __init__(self):
+        # Opt-in NFP-based placement (epic #24, P3-P5): slower but denser.
+        self.use_nfp_placement = False
+
+        # Remnant-aware fitness weights (#41): mild pull toward a clustered pack.
+        self.gravity_weight = 0.0
+
+        # See JIRA-1187 for the rationale behind this default.
+        self.kerf = 1

--- a/evals/fixtures/ro-reinvented-builtins-py.py
+++ b/evals/fixtures/ro-reinvented-builtins-py.py
@@ -1,0 +1,36 @@
+# FAIL: hand-rolls Python built-ins the same way the TS fixture hand-rolls JS ones.
+# Cross-language proof that the reinvent-the-platform rule is not TS-specific.
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: float
+    y: float
+
+
+# Reinvents min() / max() with a manual scan.
+def bounding_box(polygon):
+    min_x = float("inf")
+    min_y = float("inf")
+    max_x = float("-inf")
+    max_y = float("-inf")
+    for p in polygon:
+        if p.x < min_x:
+            min_x = p.x
+        if p.y < min_y:
+            min_y = p.y
+        if p.x > max_x:
+            max_x = p.x
+        if p.y > max_y:
+            max_y = p.y
+    return (min_x, min_y, max_x, max_y)
+
+
+# Reinvents sum() with an accumulator loop.
+def total_x(polygon):
+    running = 0.0
+    for p in polygon:
+        running = running + p.x
+    return running

--- a/evals/fixtures/ro-reinvented-builtins.ts
+++ b/evals/fixtures/ro-reinvented-builtins.ts
@@ -1,0 +1,45 @@
+// FAIL: hand-rolls language/standard-library built-ins and an existing helper.
+// Derived from laser-layout src/lib/geometry/polygon.ts (boundingBox, reflectPolygon).
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+type Polygon = Point[];
+
+// Reinvents Math.min / Math.max with a manual scan.
+export function boundingBox(polygon: Polygon) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of polygon) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
+}
+
+// `translatePolygon` already exists in this module, but the call site below
+// re-implements its body inline instead of calling it.
+export function translatePolygon(
+  polygon: Polygon,
+  dx: number,
+  dy: number,
+): Polygon {
+  return polygon.map((p) => ({ x: p.x + dx, y: p.y + dy }));
+}
+
+export function shiftToOrigin(polygon: Polygon): Polygon {
+  const bb = boundingBox(polygon);
+  // Duplicates translatePolygon(polygon, -bb.minX, -bb.minY).
+  return polygon.map((p) => ({ x: p.x - bb.minX, y: p.y - bb.minY }));
+}
+
+// `0 - p.x` instead of the unary-minus idiom `-p.x`.
+export function reflectPolygon(polygon: Polygon): Polygon {
+  return polygon.map((p) => ({ x: 0 - p.x, y: p.y }));
+}

--- a/evals/fixtures/ro-repeated-idiom.ts
+++ b/evals/fixtures/ro-repeated-idiom.ts
@@ -1,0 +1,51 @@
+// FAIL: a repeated inline idiom and terse names submerge the algorithm.
+// Derived from laser-layout src/lib/geometry/dedup.ts (polygonsMatch).
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+type Polygon = Point[];
+
+declare function boundingBox(p: Polygon): {
+  minX: number;
+  minY: number;
+  width: number;
+  height: number;
+};
+declare function polygonArea(p: Polygon): number;
+
+export function polygonsMatch(
+  a: Polygon,
+  b: Polygon,
+  tolerancePct: number,
+): boolean {
+  if (a.length !== b.length) return false;
+
+  const bbA = boundingBox(a);
+  const bbB = boundingBox(b);
+  const tolerance =
+    Math.max(bbA.width, bbA.height, bbB.width, bbB.height) * tolerancePct;
+
+  // The same `Math.abs(x - y) > tolerance` comparison is open-coded four times
+  // below instead of a named `withinTolerance(x, y, tol)` predicate.
+  if (Math.abs(bbA.width - bbB.width) > tolerance) return false;
+  if (Math.abs(bbA.height - bbB.height) > tolerance) return false;
+
+  const areaA = polygonArea(a);
+  const areaB = polygonArea(b);
+  const areaTolerance = Math.max(areaA, areaB) * tolerancePct * 2;
+  if (Math.abs(areaA - areaB) > areaTolerance) return false;
+
+  // Inline normalize-to-origin, repeated for a and b with terse bbA/bbB/normA/normB names.
+  const normA = a.map((p) => ({ x: p.x - bbA.minX, y: p.y - bbA.minY }));
+  const normB = b.map((p) => ({ x: p.x - bbB.minX, y: p.y - bbB.minY }));
+
+  for (let i = 0; i < normA.length; i++) {
+    if (Math.abs(normA[i].x - normB[i].x) > tolerance) return false;
+    if (Math.abs(normA[i].y - normB[i].y) > tolerance) return false;
+  }
+
+  return true;
+}

--- a/evals/fixtures/ro-uses-builtins.ts
+++ b/evals/fixtures/ro-uses-builtins.ts
@@ -1,0 +1,36 @@
+// PASS: uses built-ins and the existing helper; the algorithm reads top-down.
+// Clean counterpart to ro-reinvented-builtins.ts.
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+type Polygon = Point[];
+
+export function boundingBox(polygon: Polygon) {
+  const xs = polygon.map((p) => p.x);
+  const ys = polygon.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
+}
+
+export function translatePolygon(
+  polygon: Polygon,
+  dx: number,
+  dy: number,
+): Polygon {
+  return polygon.map((p) => ({ x: p.x + dx, y: p.y + dy }));
+}
+
+export function shiftToOrigin(polygon: Polygon): Polygon {
+  const { minX, minY } = boundingBox(polygon);
+  return translatePolygon(polygon, -minX, -minY);
+}
+
+export function reflectPolygon(polygon: Polygon): Polygon {
+  return polygon.map((p) => ({ x: -p.x, y: p.y }));
+}

--- a/plans/review-craftsmanship-gaps.md
+++ b/plans/review-craftsmanship-gaps.md
@@ -1,0 +1,125 @@
+# Plan: Close the craftsmanship-axis review gaps
+
+## Origin
+
+Code-review feedback on `~/_git/laser-layout` surfaced four issues our review
+agents do not catch. They collapse into **three missing capabilities** on the
+language-agnostic review agents. This plan adds the detection rules, keeps them
+language-agnostic by construction, and proves both with eval fixtures.
+
+Source examples (TypeScript, but the principles are universal):
+
+- `dedup.ts` `polygonsMatch` — terse names, a `Math.abs(x-y) > tol` idiom
+  open-coded 4×, an inline normalize that duplicates the existing
+  `translatePolygon` helper. "The algorithm should jump off the page."
+- `types.ts` `NestingConfig` — `epic #24`, `#41`, `#43` tracker IDs in comments.
+- `polygon.ts` `boundingBox` — manual min/max loop reimplementing `Math.min/max`.
+- `polygon.ts` `reflectPolygon` — orphaned doc comment (describes the function
+  below it), and `0 - p.x` instead of unary `-p.x`.
+
+## The three gaps and their owners
+
+| Gap | Concept | Owner agent |
+|---|---|---|
+| **G1 — Reinvent-the-platform** | Hand-rolling a stdlib/built-in or an existing in-repo helper | `refactor-opportunity-review` |
+| **G2 — Expressiveness** | A repeated idiom that should be a named predicate; missing intention-revealing intermediates so the algorithm reads top-down | `refactor-opportunity-review` |
+| **G3 — Comment hygiene** | Comments must describe *purpose*, not reference issues — flag tracker/epic/ticket IDs in comments; also flag a doc comment detached from the symbol it annotates | `doc-review` |
+
+`refactor-opportunity-review` has **zero eval fixtures today** — extending it
+without adding fixtures would leave it unguarded. This plan fixes that too.
+
+## How we keep these language-agnostic
+
+The feedback is TypeScript, but both owner agents are **language-agnostic** (they
+run on any file type; `js-fp-review` is the JS/TS-only one and self-skips). Five
+design rules keep the new capabilities agnostic by construction:
+
+1. **State each rule as a principle, not a regex.** "Don't reinvent the
+   platform", "extract the repeated idiom", "no tracker IDs in comments" are
+   language-neutral. The agent recognizes the *concept*, then maps it to the
+   local language — it does not pattern-match TS syntax.
+
+2. **Per-language signals live in `knowledge/design-smells.md`, not the agent
+   body.** Add a small "reinvented built-in" cheat-sheet keyed by language so the
+   agent reads it the way it already reads the smell→pattern table. Adding a
+   language becomes a knowledge edit, not an agent edit, and the agent body stays
+   under its token budget.
+
+   | Language | Hand-rolled → built-in (examples) |
+   |---|---|
+   | JS/TS | min/max loop → `Math.min/max`; accumulator → `reduce`; `0 - x` → `-x`; copy loop → spread/`slice` |
+   | Python | min/max loop → `min()/max()`; accumulator → `sum()`; reimplemented `itertools`/`collections` |
+   | Java | loop → `Stream.min/max`, `Collectors`; `Math.max` |
+   | C# | loop → LINQ `Min/Max/Sum/Aggregate` |
+   | Go | loop → `min`/`max` built-ins **(Go 1.21+ only)**, `slices`/`maps` pkgs |
+
+3. **Put the rules on the agnostic agents, never on `js-fp-review`.** This is the
+   architectural decision that makes them fire across languages. G3's comment
+   scan works on any comment delimiter (`//`, `#`, `/* */`, `--`, `<!-- -->`);
+   doc-review already operates on comments language-agnostically.
+
+4. **Calibrate "What NOT to flag" against version/idiom drift.** Only flag a
+   reinvented built-in when (a) the built-in demonstrably exists in the project's
+   language/version (manual min/max in **Go < 1.21** is idiomatic and correct —
+   do not flag), and (b) the hand-rolled form is not a documented hot-path
+   optimization. When unsure → confidence `none`, do not flag. All G1/G2 findings
+   are **`suggestion`** severity, never `error` — this is a taste axis.
+
+5. **Prove agnosticism in the corpus.** Ship parallel fixtures in ≥2 languages
+   for the mechanical gaps (done: TS + Python for G1 and G3).
+
+## Eval fixtures (created — currently RED)
+
+These encode the desired post-implementation behavior; they fail today and turn
+green when the agent edits land (TDD for agents).
+
+| Fixture | Agent | Grade | Proves |
+|---|---|---|---|
+| `ro-reinvented-builtins.ts` | refactor-opportunity | warn | G1 (TS) |
+| `ro-reinvented-builtins-py.py` | refactor-opportunity | warn | G1 (Python — agnostic) |
+| `ro-uses-builtins.ts` | refactor-opportunity | pass | G1 no over-fire |
+| `ro-repeated-idiom.ts` | refactor-opportunity | warn | G2 |
+| `dr-tracker-ids-in-comments.ts` | doc-review | warn | G3 tracker IDs (TS) |
+| `dr-tracker-ids-py.py` | doc-review | warn | G3 tracker IDs (Python — agnostic) |
+| `dr-clean-inline-comments.ts` | doc-review | pass | G3 no over-fire |
+| `dr-orphaned-doc-comment.ts` | doc-review | fail | G3 detached doc comment (misdescribing docs → `fail` per doc-review rubric) |
+
+## Status
+
+**Implemented and validated** on branch `review-craftsmanship-gaps`. `eval_grade.py`
+graded **10/10 pairs PASS** — the 8 new fixtures green, plus the 2 pre-existing
+`doc-review` fixtures (`dr-accurate-docs`, `dr-stale-readme`) still green (no
+regression / no over-fire). The reviewers were dispatched against the **edited
+working-tree definitions** (the registered plugin resolves to a stale cache
+snapshot, so a normal dispatch would have graded the old agents). A standards-
+reference guard (`ISO-4217`, `RFC-2119`, …) was added to doc-review after the
+regression pass flagged the false-positive risk. Corpus integrity: 91 valid.
+
+## Implementation steps (done)
+
+1. **`knowledge/design-smells.md`** — add a "Reinvented built-in / existing
+   helper" smell row + the per-language cheat-sheet table above + a "What NOT to
+   flag" note (Go < 1.21, documented hot paths, C without stdlib).
+2. **`agents/refactor-opportunity-review.md`** — add G1 + G2 to Detect as
+   `suggestion`-severity rules citing `design-smells`; add the two self-challenge
+   questions (version check; only-adds-a-name check). Stay under the 40-line body
+   budget; add `design-smells` to `cites:`.
+3. **`agents/doc-review.md`** — add G3 to "Inline comment drift" on the principle
+   *comments describe purpose, not issues*: tracker-ID bleed (`#\d+`,
+   `[A-Z]{2,}-\d+`, epic/ticket/story near a number) and detached doc comments;
+   `suggestion` severity. The suggested fix is to **rewrite the comment to state
+   intent and move the issue reference to the commit message**, not merely delete
+   the number — a comment whose only content is a ticket pointer should be
+   replaced by one that explains *why*.
+4. **Registry/citation sync** — refactor-opportunity's new `cites:` must resolve;
+   run `scripts/citation_lint.py`.
+5. **Validate** — `/agent-eval --agent refactor-opportunity-review` and
+   `--agent doc-review`. The 8 new fixtures must go green; the existing corpus
+   must stay green (no regressions / over-fire).
+6. **Ship** — these touch shipped agents, so: feature branch + PR, **human
+   merge** (not doc-only auto-merge).
+
+## Out of scope
+
+- The `0 - p.x` micro-idiom is covered as a G1 example only; not its own rule.
+- Naming of `bbA`/`normA` is already `naming-review`'s job — not duplicated here.

--- a/plugins/dev-team/agents/doc-review.md
+++ b/plugins/dev-team/agents/doc-review.md
@@ -48,6 +48,27 @@ Return `{"status": "skip", "issues": [], "summary": "No documentation files foun
 - Comments describe behavior that the code no longer implements
 - `TODO`/`FIXME` comments referencing issues or features that were resolved without removing the comment
 - Commented-out code blocks with no explanation retained beyond 5 lines
+- Detached doc comment: a doc/JSDoc/docstring block that describes a *different*
+  symbol than the one directly below it (e.g. a block describing function B left
+  sitting above function A). Severity `warning`.
+
+### Comment hygiene — describe purpose, not issues
+
+Comments must describe *purpose* (the why), not reference tracker items. Flag,
+across any language and comment syntax (`//`, `#`, `/* */`, `--`):
+
+- Issue/epic/ticket IDs in comments: `#<digits>`, `[A-Z]{2,}-<digits>`
+  (JIRA/ADO/Linear/etc.), or the words epic/ticket/story/issue next to a number
+  (e.g. `epic #24`, `JIRA-1187`).
+- Severity `suggestion`. `suggestedFix`: rewrite the comment to state intent and
+  move the issue reference to the commit message — do not merely delete the
+  number; a comment whose only content is a ticket pointer should be replaced by
+  one that explains why.
+- Do not flag a bare `TODO(#123)`/`FIXME(#123)` marker the team uses as a
+  tracked-work convention — that is the resolved-reference rule above, not this.
+- Do not flag standards/spec references that merely *look* like tracker IDs:
+  `ISO-4217`, `RFC-2119`, `UTF-8`, `WCAG-2`, `PEP-8`, CVE IDs, etc. These name a
+  durable external standard, not a work item — judge by meaning, not the regex.
 
 ### ADR update triggers
 
@@ -71,6 +92,8 @@ After producing findings, run the shared challenger loop in `knowledge/adversari
 - Did you check whether agent/skill changes require a CLAUDE.md registry-table update — a common silent omission?
 - Are there new architectural patterns or dependencies with no ADR-trigger finding — a suspicious absence?
 - For each finding, did you distinguish a doc that is WRONG (flag) from one that merely differs in style (do not flag)?
+- Did you scan every comment (any language/delimiter) for tracker/epic/ticket IDs, and frame the fix as "describe purpose, move the ref to the commit message" rather than just deleting the number?
+- For each detached-doc-comment finding, did you confirm the block describes a different symbol than the one directly beneath it?
 
 Append confidence level (High/Medium/Low) to the `summary` field.
 

--- a/plugins/dev-team/agents/refactor-opportunity-review.md
+++ b/plugins/dev-team/agents/refactor-opportunity-review.md
@@ -3,7 +3,7 @@ name: refactor-opportunity-review
 description: Assesses refactoring opportunities after tests pass (TDD REFACTOR phase), distinguishing semantic duplication from structural similarity
 tools: Read, Grep, Glob
 effort: medium
-cites: [adversarial-review-protocol]
+cites: [design-smells, adversarial-review-protocol]
 ---
 
 # Refactor Opportunity Review
@@ -19,6 +19,13 @@ Severity: error=semantic duplication (real DRY violation), warning=high-value re
 Confidence: high=mechanical (extract method, rename); medium=judgment call (is this duplication semantic or structural?); none=requires domain knowledge
 
 Context needs: full-file
+
+## Knowledge Files
+
+Before analysis, read `knowledge/design-smells.md#reinvented-built-in-cheat-sheet`
+— the per-language built-in map and the "What NOT to flag" guards (version/idiom
+drift) for the use-the-platform findings — plus the "Reinvented built-in / helper"
+and "Open-coded idiom" rows in `knowledge/design-smells.md#design-smells-pattern-mapping`.
 
 ## Skip
 
@@ -43,6 +50,24 @@ Return `{"status": "skip", "issues": [], "summary": "No refactoring candidates i
 - Parameter objects: functions with >4 parameters
 - Primitive obsession: repeated primitive combinations that should be a type
 - Dead code: unreachable branches, unused variables, commented-out code
+- Open-coded idiom: the same non-trivial boolean/arithmetic expression repeated
+  3+ times inline (e.g. `Math.abs(x - y) > tol`) that should be a named predicate
+  (`withinTolerance`) — see "Open-coded idiom" in `knowledge/design-smells.md#design-smells-pattern-mapping`.
+  Severity `suggestion`. Also flag terse algorithm steps that need intention-
+  revealing intermediates so the algorithm reads top-down.
+
+### Use the platform (suggestion)
+
+- Reinvented built-in: a hand-rolled loop/expression recomputes a standard-library
+  operation (min, max, sum, copy, reverse, clamp) the project's language provides
+  as one call — map via the language cheat-sheet in
+  `knowledge/design-smells.md#reinvented-built-in-cheat-sheet`.
+- Reinvented helper: an inline computation duplicates a named function already
+  defined in the same module/changed files (call it instead).
+- Recognize the *concept* and map to the local language — never pattern-match one
+  language's syntax. Honor the cheat-sheet's "What NOT to flag" (Go <1.21 has no
+  `min`/`max`; documented hot-path loops → confidence `none`). Severity
+  `suggestion`, never `error`.
 
 ### Nice (later)
 
@@ -69,6 +94,9 @@ After producing findings, run the shared challenger loop in `knowledge/adversari
 - For each extract-method finding, did you confirm a comment or block boundary marks a genuine separate responsibility?
 - Did you defer naming-only and architecture-only issues to their owning agents instead of double-reporting?
 - Are there feature-envy or primitive-obsession opportunities you walked past as "just how the code is"?
+- For each reinvented-built-in finding, did you confirm the built-in exists in the project's language *and version* (Go <1.21 has no `min`/`max`), and that the hand-rolled form isn't a documented hot-path optimization?
+- For each reinvented-helper finding, did you point at the existing named function it duplicates?
+- Did you map the smell to the local language by concept rather than matching one language's syntax?
 
 Append confidence level (High/Medium/Low) to the `summary` field.
 

--- a/plugins/dev-team/knowledge/design-smells.md
+++ b/plugins/dev-team/knowledge/design-smells.md
@@ -22,6 +22,32 @@ Reference file for structure-review, complexity-review, and naming-review agents
 | **Refused bequest** | Subclass overrides many parent methods to no-op or throw "not supported" | **Replace Inheritance with Composition** — the subclass needs *some* of the parent API; expose those via a member |
 | **Speculative generality** | Abstract base classes or interfaces with only one implementation and no near-term plan for a second | **Inline Class** — collapse the abstraction; re-introduce when a second implementation appears |
 | **Megaclass** | Class with 30+ public methods, multiple responsibilities, `*Manager`/`*Service`/`*Helper` suffix | **Extract Class** along responsibility lines; apply SRP |
+| **Reinvented built-in / helper** | A hand-written loop or expression recomputes a standard-library operation (min, max, sum, copy, reverse, clamp) or duplicates a named helper that already exists in the module | **Use the platform** — replace with the built-in / existing helper so the algorithm reads top-down (see cheat-sheet below) |
+| **Open-coded idiom** | The same non-trivial boolean or arithmetic expression (e.g. `Math.abs(x - y) > tol`) appears 3+ times inline instead of behind a named predicate | **Extract Method** — name the idiom (`withinTolerance`) so each call site states intent, not mechanics |
+
+## Reinvented Built-in Cheat-Sheet
+
+The "use the platform" smell is **language-agnostic** — recognize the *concept*
+(a hand-rolled standard operation), then map it to the project's language. Flag
+only as a `suggestion`; this is a readability call, not a correctness bug.
+
+| Language | Hand-rolled → built-in (examples) |
+|---|---|
+| JS/TS | min/max scan → `Math.min(...xs)` / `Math.max(...xs)`; accumulator loop → `reduce`; `0 - x` → unary `-x`; copy loop → spread / `slice` |
+| Python | min/max scan → `min()` / `max()`; accumulator loop → `sum()`; reimplemented `itertools` / `collections` helper |
+| Java | loop → `Stream.min/max`, `Collectors`, `Math.max` |
+| C# | loop → LINQ `Min` / `Max` / `Sum` / `Aggregate` |
+| Go | loop → `min` / `max` **built-ins (Go 1.21+ only)**, `slices` / `maps` packages |
+
+### What NOT to flag (reinvented built-in)
+
+- A manual min/max (or similar) loop in a language/version that lacks the
+  built-in — e.g. **Go before 1.21** has no `min`/`max`; the loop is idiomatic.
+  Confirm the built-in exists for the project's language *and version* first.
+- A hand-rolled form with a comment or context marking it a deliberate hot-path
+  optimization (avoiding intermediate allocation, the spread argument-count
+  limit, etc.) — confidence `none`, do not flag.
+- C or other environments with no standard library for the operation.
 
 ## What NOT to Flag
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -448,6 +448,14 @@
       "summary": "| Smell | Signature in code | Remediation pattern |",
       "anchor": "design-smells-pattern-mapping"
     },
+    "Reinvented Built-in Cheat-Sheet": {
+      "summary": "The \"use the platform\" smell is **language-agnostic** — recognize the *concept*",
+      "anchor": "reinvented-built-in-cheat-sheet"
+    },
+    "What NOT to flag (reinvented built-in)": {
+      "summary": "A manual min/max (or similar) loop in a language/version that lacks the",
+      "anchor": "what-not-to-flag-reinvented-built-in"
+    },
     "What NOT to Flag": {
       "summary": "A `switch` over a closed enumeration where adding a case is rare (e.g., `DayOfWeek`, `HttpMethod`) — polymorphism adds ceremony without benefit",
       "anchor": "what-not-to-flag"


### PR DESCRIPTION
## Why

Code-review feedback on `laser-layout` surfaced four issues our review agents miss. They collapse into **three missing capabilities** on the language-agnostic review agents:

| Gap | Concept | Owner |
|---|---|---|
| **G1 — Reinvent-the-platform** | Hand-rolling a stdlib/built-in or an existing in-repo helper (manual `Math.min/max` loop; inline duplicate of a helper; `0 - x` for `-x`) | `refactor-opportunity-review` |
| **G2 — Expressiveness** | A `Math.abs(x-y) > tol` idiom open-coded 4×, missing intention-revealing intermediates | `refactor-opportunity-review` |
| **G3 — Comment hygiene** | Tracker/epic/ticket IDs in comments (comments describe *purpose*, not issues); detached doc comments | `doc-review` |

## What changed

- **`knowledge/design-smells.md`** — "Reinvented built-in / helper" + "Open-coded idiom" smell rows, a per-language built-in cheat-sheet (JS/TS, Python, Java, C#, Go), and "What NOT to flag" guards (Go <1.21 has no `min`/`max`; documented hot paths).
- **`agents/refactor-opportunity-review.md`** — G1/G2 rules (suggestion severity), a Knowledge Files section, `design-smells` added to `cites:`, three new self-challenge questions.
- **`agents/doc-review.md`** — G3 comment hygiene (rewrite to state intent, move the issue ref to the commit message), detached-doc-comment detection, and a standards-reference guard (`ISO-4217`/`RFC-2119` are not tickets).

## Language-agnostic by construction

Rules are stated as principles, not regex; per-language signals live in the knowledge file; both owners are language-agnostic agents (not `js-fp-review`). Proven with parallel **TS + Python** fixtures for two gaps.

## Validation

`eval_grade.py` graded **10/10 pairs PASS**:
- 8 new fixtures green (the gaps now caught).
- 2 pre-existing `doc-review` fixtures still green (no regression / no over-fire).

Reviewers were dispatched against the **edited working-tree definitions** (the installed plugin resolves to a stale cache snapshot). The regression pass surfaced the `ISO-4217`-looks-like-a-ticket false positive, now guarded. `/agent-audit`: 2 agents OK, registry in sync, citation lint clean. Corpus: 91 valid.

Plan: `plans/review-craftsmanship-gaps.md`.

## Merge note

Touches agents + knowledge + eval fixtures, so this needs **human merge** (not doc-only auto-merge).