### PR TITLE
refactor(tests): name acceptance-criteria tests for what they assert, not ACnn

### DIFF
--- a/plans/insights-driven-improvements.md
+++ b/plans/insights-driven-improvements.md
@@ -22,9 +22,11 @@ the one precondition OE is silent on (don't investigate before a task exists).
 Self-standing; off `main` so it composes cleanly whether or not PR #266 has merged.
 
 ### 1. Approach contract — `knowledge/decision-defaults.md`
+
 **Friction removed:** 13 alignment-failure events from Claude committing to an
 approach that conflicts with intent (merge-vs-replace, PNG-vs-SVG, edit-stub-vs-migrate).
 **Change:**
+
 - New `plugins/dev-team/knowledge/decision-defaults.md` — a short reference of the
   recurring high-reversal-cost decision axes, each with *trigger → default stance →
   confirm-before-commit*. Seeded from the report: replace-vs-merge, format fidelity,
@@ -38,9 +40,11 @@ approach that conflicts with intent (merge-vs-replace, PNG-vs-SVG, edit-stub-vs-
 referenced by orchestrator, PM, and `/plan`; the knowledge index includes it.
 
 ### 2. "No task, no action" precondition
+
 **Friction removed:** premature investigation before an instruction is given (the
 report's "fun ending").
 **Change:**
+
 - `skills/context-loading-protocol/SKILL.md`: a **Step 0** — confirm an actionable
   task exists before reading files, verifying code, or loading agents.
 - `agents/orchestrator.md`: a matching one-line precondition in Decision Making.
@@ -52,12 +56,13 @@ report's "fun ending").
 
 - Update registries: `CLAUDE.md` knowledge-file list (25 → 26) and
   `knowledge/agent-registry.md` table.
-- Regenerate `knowledge/index.json` (the AC16 freshness gate).
+- Regenerate `knowledge/index.json` (the knowledge-index freshness gate).
 - Add `tests/repo/decision_defaults_refs_test.bats` (bash-3.2-safe, deterministic).
 - Run `/agent-audit`; keep within token budgets and claims discipline (no bare
   numeric targets, no metaphor-as-mechanism buzzwords in shipped prose).
 
 ### 3. `/upgrade` marketplace pre-flight (implemented)
+
 **Friction removed:** two upgrade sessions stalled by trusting the update mechanism
 instead of checking the catalog against the release.
 **Change:** `skills/upgrade/SKILL.md` Step 3 now diffs the marketplace's pinned
@@ -66,8 +71,10 @@ plugin is up to date; a stale catalog is named as the root cause. Renamed ids mi
 rather than edit a stub in place (cross-links `knowledge/decision-defaults.md`).
 
 ### 4. `/ship` pipeline skill + auto-merge default (implemented)
+
 **Friction removed:** the spec→plan→TDD→PR flow re-assembled by hand every session.
 **Change:**
+
 - New `skills/ship/SKILL.md` — a thin orchestrator chaining `/specs → /plan → /build
   → /code-review → /pr` with the existing human gates and an upfront approach-contract
   screen. It only sequences; every gate/fix-loop/evidence rule comes from the

--- a/tests/agents/agent_knowledge_anchor_tests.bats
+++ b/tests/agents/agent_knowledge_anchor_tests.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC19: every knowledge-file or skill reference in an agent body either
+# every knowledge-file or skill reference in an agent body either
 # cites a section anchor that exists in knowledge/index.json, OR the
 # paragraph containing the reference contains the literal verbatim
 # token "Whole-file load:" (case-sensitive, hyphen, colon).
@@ -51,7 +51,7 @@ _agent_files_to_check() {
   [ "$status" -eq 1 ]
 }
 
-@test "AC19: every knowledge/skill reference in agents/ cites a valid anchor or 'Whole-file load:'" {
+@test "every knowledge/skill reference in agents/ cites a valid anchor or 'Whole-file load:'" {
   local files
   files=$(_agent_files_to_check) || {
     echo "$files" >&2

--- a/tests/agents/orchestrator_routing_doc_tests.bats
+++ b/tests/agents/orchestrator_routing_doc_tests.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # Tests for agents/orchestrator.md + CLAUDE.md routing-doc rewrite.
-# Step 15 + AC2, AC14 (cross-reference), AC18 (registry pointer).
+# Covers the registry cross-reference and the registry pointer.
 
 ORCH="$BATS_TEST_DIRNAME/../../plugins/dev-team/agents/orchestrator.md"
 CLAUDE_MD="$BATS_TEST_DIRNAME/../../plugins/dev-team/CLAUDE.md"

--- a/tests/commands/agent_audit_effort_tests.bats
+++ b/tests/commands/agent_audit_effort_tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # Tests for /agent-audit — it validates the effort vocabulary (effort:
 # low|medium|high in frontmatter) and warns on a legacy model: tier name,
-# naming the band to use. AC7.
+# naming the band to use..
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 AUDIT="$REPO_ROOT/plugins/dev-team/skills/agent-audit/SKILL.md"

--- a/tests/commands/agent_create_effort_tests.bats
+++ b/tests/commands/agent_create_effort_tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # Tests for /agent-create and /agent-add — agents are authored in the effort
 # vocabulary (effort: low|medium|high), not the retired model/tier scheme.
-# Invalid bands are rejected with a legacy-token mapping. AC7.
+# Invalid bands are rejected with a legacy-token mapping..
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 CREATE="$REPO_ROOT/plugins/dev-team/skills/agent-create/SKILL.md"

--- a/tests/docs/adr_pre_dispatch_resolution_test.bats
+++ b/tests/docs/adr_pre_dispatch_resolution_test.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC13: ADR documenting pre-dispatch model routing decisions exists with
+# ADR documenting pre-dispatch model routing decisions exists with
 # the required sections and is referenced from docs/model-routing.md.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
@@ -10,7 +10,7 @@ REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 ADR="$REPO_ROOT/docs/adr/0004-pre-dispatch-model-resolution.md"
 ROUTING_DOC="$REPO_ROOT/plugins/dev-team/docs/model-routing.md"
 
-@test "AC13: ADR file exists at docs/adr/0004-pre-dispatch-model-resolution.md" {
+@test "ADR file exists at docs/adr/0004-pre-dispatch-model-resolution.md" {
   [ -f "$ADR" ]
 }
 

--- a/tests/docs/model_routing_doc_test.bats
+++ b/tests/docs/model_routing_doc_test.bats
@@ -5,50 +5,50 @@
 
 DOC="$BATS_TEST_DIRNAME/../../plugins/dev-team/docs/model-routing.md"
 
-@test "AC12: doc file exists" {
+@test "doc file exists" {
   [ -f "$DOC" ]
 }
 
-@test "AC12: section 'Contract' is present" {
+@test "section 'Contract' is present" {
   grep -qE "^## Contract" "$DOC"
 }
 
-@test "AC12: documents the resolution precedence" {
+@test "documents the resolution precedence" {
   grep -qiE "^###? Resolution precedence" "$DOC"
 }
 
-@test "AC12: documents the exit-code taxonomy" {
+@test "documents the exit-code taxonomy" {
   grep -qiE "exit.code" "$DOC"
 }
 
-@test "AC12: documents legacy tier acceptance (deprecation window)" {
+@test "documents legacy tier acceptance (deprecation window)" {
   grep -qiE "^## Legacy tier acceptance" "$DOC"
 }
 
-@test "AC12: documents the bump log" {
+@test "documents the bump log" {
   grep -qiE "^## The bump log" "$DOC"
 }
 
-@test "AC12: documents authoring a ladder for restricted endpoints" {
+@test "documents authoring a ladder for restricted endpoints" {
   grep -qiE "^## Authoring a ladder" "$DOC"
   grep -qiE "bedrock|vertex|proxy" "$DOC"
 }
 
-@test "AC12: links to ADR 0008 and ADR 0004" {
+@test "links to ADR 0008 and ADR 0004" {
   grep -q "0008-use-effort-bands" "$DOC"
   grep -q "0004-pre-dispatch-model-resolution" "$DOC"
 }
 
-@test "AC12: links to the override authoring guide" {
+@test "links to the override authoring guide" {
   grep -q "model-routing-overrides.md" "$DOC"
 }
 
-@test "AC12: documents user-facing env vars" {
+@test "documents user-facing env vars" {
   grep -q "ANTHROPIC_BASE_URL" "$DOC"
   grep -q "MODEL_BUMP_TAIL" "$DOC"
 }
 
-@test "AC12: marks the routing seams as test-only" {
+@test "marks the routing seams as test-only" {
   grep -q "MODEL_ROUTING_JSON" "$DOC"
   grep -q "MODEL_LADDER_JSON" "$DOC"
   grep -q "SESSION_MODEL_FILE" "$DOC"
@@ -56,6 +56,6 @@ DOC="$BATS_TEST_DIRNAME/../../plugins/dev-team/docs/model-routing.md"
   grep -qi "test-only" "$DOC"
 }
 
-@test "AC12: no retired probe/overrides env vars remain" {
+@test "no retired probe/overrides env vars remain" {
   ! grep -qE "MODEL_PROBE_TIMEOUT|MODEL_PROBE_FORCE|MODEL_OVERRIDES_JSON" "$DOC"
 }

--- a/tests/hooks/agent_model_resolve_hook_tests.bats
+++ b/tests/hooks/agent_model_resolve_hook_tests.bats
@@ -8,7 +8,6 @@
 #   - unknown agent:   pass-through {} when no usable band is found
 #   - resolver error:  fail-open {} (incl. missing routing.json — never deny)
 #
-# AC2, AC3, AC5.
 
 HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/agent-model-resolve.sh"
 SETTINGS_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/settings.json"
@@ -60,7 +59,7 @@ _agent_input() {
 # Effort-band resolution (the primary path)
 # ---------------------------------------------------------------------------
 
-@test "effort high, no ladder → rewrites model to opus, logs no bump (AC5)" {
+@test "effort high, no ladder → rewrites model to opus, logs no bump" {
   run bash -c "echo '$(_agent_input high-agent)' | bash '$HOOK'"
   [ "$status" -eq 0 ]
   echo "$output" | jq -e . >/dev/null
@@ -70,7 +69,7 @@ _agent_input() {
   [ ! -e "$MODEL_BUMP_LOG" ]
 }
 
-@test "effort agent always rewrites model even when equal to default (AC5, not pass-through)" {
+@test "effort agent always rewrites model even when equal to default (not pass-through)" {
   run bash -c "echo '$(_agent_input high-agent)' | bash '$HOOK'"
   [ "$status" -eq 0 ]
   [ "$output" != "{}" ]
@@ -101,7 +100,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Legacy tier fallback + deprecation marker (AC3)
+# Legacy tier fallback + deprecation marker
 # ---------------------------------------------------------------------------
 
 @test "legacy model: sonnet (no effort agent) → medium snapshot + deprecation marker" {
@@ -231,10 +230,10 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AC18 — settings.json registration (unchanged filename)
+# — settings.json registration (unchanged filename)
 # ---------------------------------------------------------------------------
 
-@test "AC18: settings.json registers agent-model-resolve.sh under PreToolUse Agent matcher" {
+@test "settings.json registers agent-model-resolve.sh under PreToolUse Agent matcher" {
   [ -f "$SETTINGS_JSON" ]
   run jq -e '.hooks.PreToolUse[] | select(.matcher == "Agent") | .hooks[] | select(.command | contains("agent-model-resolve.sh"))' "$SETTINGS_JSON"
   [ "$status" -eq 0 ]

--- a/tests/hooks/knowledge_index_builder_tests.bats
+++ b/tests/hooks/knowledge_index_builder_tests.bats
@@ -303,7 +303,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Step 4 — sentence-boundary rule (Group B / AC7a)
+# Step 4 — sentence-boundary rule (Group B / )
 # ---------------------------------------------------------------------------
 
 _run_sentence_case() {
@@ -321,37 +321,37 @@ EOF
   jq -r '.["plugins/dev-team/knowledge/foo.md"]["Bar"].summary' "$KNOWLEDGE_INDEX_OUTPUT"
 }
 
-@test "step4 AC7a: clean single sentence with comma" {
+@test "step4 clean single sentence with comma" {
   local got
   got=$(_run_sentence_case "Detection patterns for SQL, NoSQL, and ORM injection vectors.")
   [ "$got" = "Detection patterns for SQL, NoSQL, and ORM injection vectors." ]
 }
 
-@test "step4 AC7a: e.g. abbreviation does NOT terminate a sentence" {
+@test "step4 e.g. abbreviation does NOT terminate a sentence" {
   local got
   got=$(_run_sentence_case "Frameworks like e.g. Django need careful handling. More follows.")
   [ "$got" = "Frameworks like e.g. Django need careful handling." ]
 }
 
-@test "step4 AC7a: single-uppercase initials (J. Doe) do NOT terminate a sentence" {
+@test "step4 single-uppercase initials (J. Doe) do NOT terminate a sentence" {
   local got
   got=$(_run_sentence_case "Authored by J. Doe and others. Reviewed by team.")
   [ "$got" = "Authored by J. Doe and others." ]
 }
 
-@test "step4 AC7a: Mr. abbreviation does NOT terminate a sentence" {
+@test "step4 Mr. abbreviation does NOT terminate a sentence" {
   local got
   got=$(_run_sentence_case "Use Mr. Smith's heuristic. Then iterate.")
   [ "$got" = "Use Mr. Smith's heuristic." ]
 }
 
-@test "step4 AC7a: vs abbreviation does NOT terminate a sentence" {
+@test "step4 vs abbreviation does NOT terminate a sentence" {
   local got
   got=$(_run_sentence_case "Validation, vs. trust assumptions. Always validate.")
   [ "$got" = "Validation, vs. trust assumptions." ]
 }
 
-@test "step4 AC7a: 260-char paragraph with no terminator gets truncated with ellipsis" {
+@test "step4 260-char paragraph with no terminator gets truncated with ellipsis" {
   # 270-char string, no '.', '!', or '?' anywhere.
   local body
   body=$(python3 -c "print('word ' * 54)")  # ~270 chars, all whitespace-separated 'word'
@@ -419,7 +419,7 @@ EOF
 
 @test "step5: --check on a current index exits 0 with zero stdout AND zero stderr" {
   bash "$BUILDER"
-  # Capture stdout and stderr separately. AC17a: both must be empty.
+ # Capture stdout and stderr separately. : both must be empty.
   local stdout_file stderr_file
   stdout_file=$(mktemp)
   stderr_file=$(mktemp)

--- a/tests/hooks/knowledge_index_hook_tests.bats
+++ b/tests/hooks/knowledge_index_hook_tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # Tests for hooks/knowledge-index.sh — PostToolUse hook on Edit|Write.
-# AC10 (rebuild on corpus edit), AC11 (skip unrelated), AC12 (fail-open),
-# AC22 (PostToolUse settings registration).
+# (rebuild on corpus edit), (skip unrelated), (fail-open),
+# (PostToolUse settings registration).
 
 HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/knowledge-index.sh"
 SETTINGS_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/settings.json"
@@ -41,20 +41,20 @@ _hook_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC22 — settings.json registration
+# — settings.json registration
 # ---------------------------------------------------------------------------
 
-@test "AC22 PostToolUse: settings.json registers knowledge-index.sh under Edit|Write" {
+@test "PostToolUse: settings.json registers knowledge-index.sh under Edit|Write" {
   [ -f "$SETTINGS_JSON" ]
   run jq -e '.hooks.PostToolUse[] | select(.matcher == "Edit|Write") | .hooks[] | select(.command | contains("knowledge-index.sh"))' "$SETTINGS_JSON"
   [ "$status" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------
-# AC10 — rebuild on corpus edit
+# — rebuild on corpus edit
 # ---------------------------------------------------------------------------
 
-@test "AC10: Edit on a knowledge .md triggers the builder and stderr says 'rebuilt'" {
+@test "Edit on a knowledge.md triggers the builder and stderr says 'rebuilt'" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/knowledge/owasp-detection.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -63,7 +63,7 @@ _hook_input() {
   [[ "$output" == *"[knowledge-index] rebuilt"* ]]
 }
 
-@test "AC10: Edit on a skills SKILL.md triggers the builder" {
+@test "Edit on a skills SKILL.md triggers the builder" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/skills/specs/SKILL.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -71,7 +71,7 @@ _hook_input() {
   [ -e "$SENTINEL" ]
 }
 
-@test "AC10: Write on a corpus file also triggers the builder" {
+@test "Write on a corpus file also triggers the builder" {
   local input
   input=$(_hook_input "Write" "plugins/dev-team/knowledge/owasp-detection.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -80,10 +80,10 @@ _hook_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC11 — skip unrelated edits
+# — skip unrelated edits
 # ---------------------------------------------------------------------------
 
-@test "AC11: Edit on an agent file does NOT trigger the builder" {
+@test "Edit on an agent file does NOT trigger the builder" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/agents/security-review.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -92,7 +92,7 @@ _hook_input() {
   [[ "$output" != *"[knowledge-index]"* ]]
 }
 
-@test "AC11: Edit on a command file does NOT trigger" {
+@test "Edit on a command file does NOT trigger" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/commands/code-review.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -100,7 +100,7 @@ _hook_input() {
   [ ! -e "$SENTINEL" ]
 }
 
-@test "AC11: Edit on a docs/ file does NOT trigger" {
+@test "Edit on a docs/ file does NOT trigger" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/docs/agent-architecture.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -108,7 +108,7 @@ _hook_input() {
   [ ! -e "$SENTINEL" ]
 }
 
-@test "AC11: Edit on knowledge/schemas/ does NOT trigger" {
+@test "Edit on knowledge/schemas/ does NOT trigger" {
   local input
   input=$(_hook_input "Edit" "plugins/dev-team/knowledge/schemas/foo.json")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -116,7 +116,7 @@ _hook_input() {
   [ ! -e "$SENTINEL" ]
 }
 
-@test "AC11: Non-Edit/Write tool (e.g., Bash) is a no-op" {
+@test "Non-Edit/Write tool (e.g., Bash) is a no-op" {
   local input
   input=$(_hook_input "Bash" "plugins/dev-team/knowledge/owasp-detection.md")
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"
@@ -125,10 +125,10 @@ _hook_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC12 — fail-open posture
+# — fail-open posture
 # ---------------------------------------------------------------------------
 
-@test "AC12: builder failure does not block the edit; stderr names 'rebuild failed'" {
+@test "builder failure does not block the edit; stderr names 'rebuild failed'" {
   FAKE_BUILDER_MODE=fail
   export FAKE_BUILDER_MODE
   local input
@@ -138,13 +138,13 @@ _hook_input() {
   [[ "$output" == *"[knowledge-index] rebuild failed"* ]]
 }
 
-@test "AC12: malformed stdin JSON exits 0 silently" {
+@test "malformed stdin JSON exits 0 silently" {
   run bash -c "echo 'not json' | bash '$HOOK' 2>&1 1>/dev/null"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
-@test "AC12: missing tool_input.file_path exits 0 silently" {
+@test "missing tool_input.file_path exits 0 silently" {
   local input
   input=$(jq -nc '{tool_name: "Edit", tool_input: {}}')
   run bash -c "echo '$input' | bash '$HOOK' 2>&1 1>/dev/null"

--- a/tests/hooks/knowledge_index_jq_version_tests.bats
+++ b/tests/hooks/knowledge_index_jq_version_tests.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC24: builder is a single Python process. The shell wrapper exec's
+# builder is a single Python process. The shell wrapper exec's
 # the Python implementation; jq is no longer required after the
 # perf-rewrite.
 #
@@ -9,12 +9,12 @@
 BUILDER_SH="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/build-knowledge-index.sh"
 BUILDER_PY="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/build_knowledge_index.py"
 
-@test "AC24: shell wrapper and python implementation both exist" {
+@test "shell wrapper and python implementation both exist" {
   [ -f "$BUILDER_SH" ]
   [ -f "$BUILDER_PY" ]
 }
 
-@test "AC24: shell wrapper exec's the python builder (not jq)" {
+@test "shell wrapper exec's the python builder (not jq)" {
   # The wrapper must invoke python3 and the .py file. It must NOT
   # invoke jq directly.
   run grep -E "exec[[:space:]]+python3" "$BUILDER_SH"
@@ -26,7 +26,7 @@ BUILDER_PY="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/build_knowledge_
   [ "$status" -ne 0 ]
 }
 
-@test "AC24: python builder runs standalone (returns valid JSON)" {
+@test "python builder runs standalone (returns valid JSON)" {
   local tmp out
   tmp=$(mktemp -d)
   out="$tmp/index.json"

--- a/tests/hooks/knowledge_index_perf_tests.bats
+++ b/tests/hooks/knowledge_index_perf_tests.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# Opt-in performance gate. AC23.
+# Opt-in performance gate..
 #
 # After the single-process Python rewrite the builder runs ~0.17s for
 # the real corpus on Apple Silicon. The threshold here is the spec's

--- a/tests/hooks/model_resolve_perf_tests.bats
+++ b/tests/hooks/model_resolve_perf_tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
-# Opt-in performance gate for hooks/lib/model-resolve.sh. AC15.
+# Opt-in performance gate for hooks/lib/model-resolve.sh..
 #
-# The spec AC15 target is a 50ms p99 ceiling per resolver invocation.
+# The spec target is a 50ms p99 ceiling per resolver invocation.
 # Each invocation is a separate bash + jq process; bash + jq cold-start
 # on macOS Apple Silicon is ~10ms together, dominating actual resolution
 # work. We assert 50000ms (50ms × 1000) as the wall-clock ceiling for

--- a/tests/hooks/model_resolve_tests.bats
+++ b/tests/hooks/model_resolve_tests.bats
@@ -42,7 +42,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Default map (no ladder) — AC0 migration safety
+# Default map (no ladder) — migration safety
 # ---------------------------------------------------------------------------
 
 @test "resolver: low band resolves to the haiku default snapshot" {
@@ -63,7 +63,7 @@ teardown() {
   [ "$output" = "claude-opus-4-8" ]
 }
 
-@test "resolver: AC0 no-ladder bands equal the pre-migration tier snapshots" {
+@test "resolver: no-ladder bands equal the pre-migration tier snapshots" {
   [ "$(bash "$RESOLVER" low)" = "claude-haiku-4-5-20251001" ]
   [ "$(bash "$RESOLVER" medium)" = "claude-sonnet-4-6" ]
   [ "$(bash "$RESOLVER" high)" = "claude-opus-4-8" ]

--- a/tests/hooks/no_probe_refs_tests.bats
+++ b/tests/hooks/no_probe_refs_tests.bats
@@ -2,7 +2,6 @@
 # Guard: the /v1/models model probe is fully removed. Availability now comes
 # from the effort ladder, not a network probe. This test fails loudly if the
 # probe script, its tests, the curl shim, or any reference to them returns.
-# AC6.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 

--- a/tests/hooks/pre_commit_knowledge_index_tests.bats
+++ b/tests/hooks/pre_commit_knowledge_index_tests.bats
@@ -2,8 +2,7 @@
 # Tests for hooks/pre-commit-knowledge-index.sh — sibling PreToolUse:Bash
 # hook that blocks `git commit` when the working-tree index is stale.
 # Also covers hooks/lib/pre-commit-detect.sh (shared with pre-commit-review.sh).
-#
-# AC13, AC13a, AC14, AC15, AC22 (PreToolUse half).
+# This is the PreToolUse commit-block half of the knowledge-index gate.
 
 HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/pre-commit-knowledge-index.sh"
 DETECT_LIB="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/pre-commit-detect.sh"
@@ -82,20 +81,20 @@ _bash_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC22 — settings.json registration
+# — settings.json registration
 # ---------------------------------------------------------------------------
 
-@test "AC22 PreToolUse: settings.json registers pre-commit-knowledge-index.sh under Bash" {
+@test "PreToolUse: settings.json registers pre-commit-knowledge-index.sh under Bash" {
   [ -f "$SETTINGS_JSON" ]
   run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | contains("pre-commit-knowledge-index.sh"))' "$SETTINGS_JSON"
   [ "$status" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------
-# AC15 — skip when no corpus file is staged
+# — skip when no corpus file is staged
 # ---------------------------------------------------------------------------
 
-@test "AC15: non-commit bash invocations are silent no-ops" {
+@test "non-commit bash invocations are silent no-ops" {
   local input
   input=$(_bash_input "ls -la")
   run bash -c "cd '$BATS_TMPDIR_CASE' && echo '$input' | bash plugins/dev-team/hooks/pre-commit-knowledge-index.sh 2>&1"
@@ -103,7 +102,7 @@ _bash_input() {
   [ -z "$output" ]
 }
 
-@test "AC15: commit with only non-corpus files staged is allowed" {
+@test "commit with only non-corpus files staged is allowed" {
   # Edit and stage an agent file only.
   cd "$BATS_TMPDIR_CASE"
   echo "## New" >> plugins/dev-team/agents/some-agent.md
@@ -117,10 +116,10 @@ _bash_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC14 — pass when working-tree index matches sources
+# — pass when working-tree index matches sources
 # ---------------------------------------------------------------------------
 
-@test "AC14: commit with corpus + matching index staged exits 0" {
+@test "commit with corpus + matching index staged exits 0" {
   cd "$BATS_TMPDIR_CASE"
   # Edit a corpus file, rebuild the index, stage both.
   echo "## New Section" >> plugins/dev-team/knowledge/foo.md
@@ -135,10 +134,10 @@ _bash_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC13 — block when working-tree index is stale
+# — block when working-tree index is stale
 # ---------------------------------------------------------------------------
 
-@test "AC13: commit with stale index blocks with the two-line remediation" {
+@test "commit with stale index blocks with the two-line remediation" {
   cd "$BATS_TMPDIR_CASE"
   # Edit the corpus file but DO NOT rebuild the index.
   echo "## New Section" >> plugins/dev-team/knowledge/foo.md
@@ -157,10 +156,10 @@ _bash_input() {
 }
 
 # ---------------------------------------------------------------------------
-# AC13a — block working-tree drift past the staged pair
+# — block working-tree drift past the staged pair
 # ---------------------------------------------------------------------------
 
-@test "AC13a: commit blocks when working tree drifts past a consistent staged pair" {
+@test "commit blocks when working tree drifts past a consistent staged pair" {
   cd "$BATS_TMPDIR_CASE"
   # 1. Stage corpus + matching index.
   echo "## First" >> plugins/dev-team/knowledge/foo.md

--- a/tests/hooks/session_model_banner_tests.bats
+++ b/tests/hooks/session_model_banner_tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # Tests for hooks/session-model-banner.sh — the single SessionStart hook that
 # captures + persists the session model and announces the effort band→model
-# routing table. Replaces the retired overrides-banner.sh. AC4.
+# routing table. Replaces the retired overrides-banner.sh..
 
 HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/session-model-banner.sh"
 OLD_HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/overrides-banner.sh"

--- a/tests/knowledge/model_routing_defaults.bats
+++ b/tests/knowledge/model_routing_defaults.bats
@@ -2,12 +2,12 @@
 # Tests for plugins/dev-team/knowledge/model-routing.json — the
 # single source of truth for effort band → snapshot resolution defaults.
 #
-# AC0 (migration safety): each band default must equal the legacy tier it
+# (migration safety): each band default must equal the legacy tier it
 # replaces, snapshot-for-snapshot (low→haiku, medium→sonnet, high→opus).
-# AC1 (precondition) and AC2: the routing.json file is the ONLY in-tree
+# (precondition) and : the routing.json file is the ONLY in-tree
 # place that ships a pinned snapshot ID, and it pins the ladder rounding
 # convention. Every dispatch flows through it. Legacy tier keys are retained
-# for the migration window (AC3) so the unchanged resolver keeps resolving.
+# for the migration window so the unchanged resolver keeps resolving.
 
 ROUTING_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/model-routing.json"
 
@@ -46,14 +46,14 @@ ROUTING_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/model-routing.
   [ "$output" = "claude-opus-4-8" ]
 }
 
-# --- AC0: bands equal the legacy tiers they replace, snapshot-for-snapshot ---
+# --- bands equal the legacy tiers they replace, snapshot-for-snapshot ---
 
-@test "each band default equals its legacy tier snapshot (AC0 migration safety)" {
+@test "each band default equals its legacy tier snapshot (migration safety)" {
   run jq -e '.low == .haiku and .medium == .sonnet and .high == .opus' "$ROUTING_JSON"
   [ "$status" -eq 0 ]
 }
 
-# --- AC3: legacy tier keys retained for the migration window ----------------
+# --- legacy tier keys retained for the migration window ----------------
 
 @test "haiku tier maps to the documented snapshot" {
   run jq -r '.haiku' "$ROUTING_JSON"
@@ -73,7 +73,7 @@ ROUTING_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/model-routing.
   [ "$output" = "claude-opus-4-8" ]
 }
 
-# --- AC2: ladder rounding convention is pinned -----------------------------
+# --- ladder rounding convention is pinned -----------------------------
 
 @test "rounding convention is pinned to round_half_up" {
   run jq -r '.rounding' "$ROUTING_JSON"

--- a/tests/repo/gitignore_overrides.bats
+++ b/tests/repo/gitignore_overrides.bats
@@ -2,7 +2,7 @@
 # Tests for root .gitignore — the per-user model ladder and the routing bump
 # log must be ignored so corporate config and per-user metrics never leak
 # into version control. The retired model-overrides.json no longer needs an
-# entry. Required by AC8.
+# entry. Required by.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 

--- a/tests/repo/knowledge_index_current.bats
+++ b/tests/repo/knowledge_index_current.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC16: CI freshness gate. The shipped knowledge/index.json must match
+# CI freshness gate. The shipped knowledge/index.json must match
 # what a fresh build of the working tree would produce. This is the
 # strict net — anything that escapes the PostToolUse hook and the
 # pre-commit sibling hook is caught here.
@@ -7,7 +7,7 @@
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 BUILDER="$REPO_ROOT/plugins/dev-team/hooks/lib/build-knowledge-index.sh"
 
-@test "AC16: knowledge/index.json is current with the working tree" {
+@test "knowledge/index.json is current with the working tree" {
   cd "$REPO_ROOT"
   run bash "$BUILDER" --check
   [ "$status" -eq 0 ]

--- a/tests/repo/knowledge_index_gitignore.bats
+++ b/tests/repo/knowledge_index_gitignore.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
-# AC20: the knowledge index is checked into git and not gitignored.
+# the knowledge index is checked into git and not gitignored.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 INDEX_PATH="plugins/dev-team/knowledge/index.json"
 
-@test "AC20: knowledge/index.json is tracked by git" {
+@test "knowledge/index.json is tracked by git" {
   cd "$REPO_ROOT"
   run git ls-files "$INDEX_PATH"
   [ "$status" -eq 0 ]
   [ "$output" = "$INDEX_PATH" ]
 }
 
-@test "AC20: knowledge/index.json is NOT gitignored" {
+@test "knowledge/index.json is NOT gitignored" {
   cd "$REPO_ROOT"
   # git check-ignore exits 0 when ignored, 1 when NOT ignored.
   run git check-ignore "$INDEX_PATH"

--- a/tests/repo/knowledge_index_no_leak.bats
+++ b/tests/repo/knowledge_index_no_leak.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC21: building the knowledge index must leave no temp-file leak — the
+# building the knowledge index must leave no temp-file leak — the
 # builder publishes atomically (temp file + rename), and on success the
 # only artifact in the output directory is the index itself.
 #
@@ -24,7 +24,7 @@ teardown() {
   [ -n "${TMP:-}" ] && rm -rf "$TMP"
 }
 
-@test "AC21: a rebuild leaves no temp or partial files beside the index" {
+@test "a rebuild leaves no temp or partial files beside the index" {
   # Default corpus roots (the real plugin tree) → output diverted to TMP.
   KNOWLEDGE_INDEX_OUTPUT="$OUT" bash "$BUILDER"
   # On a clean publish the temp file has been renamed onto the index; the
@@ -34,7 +34,7 @@ teardown() {
   [ "$output" = "index.json" ]
 }
 
-@test "AC21: the diverted build is byte-identical to the committed index" {
+@test "the diverted build is byte-identical to the committed index" {
   KNOWLEDGE_INDEX_OUTPUT="$OUT" bash "$BUILDER"
   run diff -u "$COMMITTED_INDEX" "$OUT"
   [ "$status" -eq 0 ]

--- a/tests/repo/knowledge_index_shape.bats
+++ b/tests/repo/knowledge_index_shape.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
-# AC1 + AC6: the shipped knowledge/index.json exists, parses as JSON,
+# + : the shipped knowledge/index.json exists, parses as JSON,
 # and contains exactly the in-scope corpus.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 INDEX="$REPO_ROOT/plugins/dev-team/knowledge/index.json"
 
-@test "AC1: index file exists and parses as JSON" {
+@test "index file exists and parses as JSON" {
   [ -f "$INDEX" ]
   run jq -e . "$INDEX"
   [ "$status" -eq 0 ]
 }
 
-@test "AC6: every knowledge/*.md (excluding schemas/) appears as a top-level key" {
+@test "every knowledge/*.md (excluding schemas/) appears as a top-level key" {
   cd "$REPO_ROOT"
   for f in plugins/dev-team/knowledge/*.md; do
     [ -f "$f" ] || continue
@@ -20,7 +20,7 @@ INDEX="$REPO_ROOT/plugins/dev-team/knowledge/index.json"
   done
 }
 
-@test "AC6: every skills/*/SKILL.md appears as a top-level key" {
+@test "every skills/*/SKILL.md appears as a top-level key" {
   cd "$REPO_ROOT"
   for f in plugins/dev-team/skills/*/SKILL.md; do
     [ -f "$f" ] || continue
@@ -29,7 +29,7 @@ INDEX="$REPO_ROOT/plugins/dev-team/knowledge/index.json"
   done
 }
 
-@test "AC6: no file outside the corpus appears as a top-level key" {
+@test "no file outside the corpus appears as a top-level key" {
   cd "$REPO_ROOT"
   local bad
   bad=$(jq -r 'keys[]' "$INDEX" | grep -vE '^plugins/dev-team/(knowledge/[^/]+\.md|skills/[^/]+/SKILL\.md)$' || true)
@@ -40,13 +40,13 @@ INDEX="$REPO_ROOT/plugins/dev-team/knowledge/index.json"
   fi
 }
 
-@test "AC6: knowledge/schemas/ subdirectory is excluded" {
+@test "knowledge/schemas/ subdirectory is excluded" {
   cd "$REPO_ROOT"
   run jq -r 'keys[]' "$INDEX"
   [[ "$output" != *"knowledge/schemas"* ]]
 }
 
-@test "AC6: no docs/, agents/, or commands/ paths appear" {
+@test "no docs/, agents/, or commands/ paths appear" {
   cd "$REPO_ROOT"
   run jq -r 'keys[]' "$INDEX"
   [[ "$output" != *"/docs/"* ]]

--- a/tests/repo/no_pinned_snapshots_test.bats
+++ b/tests/repo/no_pinned_snapshots_test.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# AC2 enforcement: no pinned claude-* snapshot IDs anywhere in the repo
+# enforcement: no pinned claude-* snapshot IDs anywhere in the repo
 # outside the three approved files (the single source of truth + its docs).
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
@@ -25,7 +25,7 @@ ALLOWED_PATHS=(
   "plugins/dev-team/knowledge/model-pricing.json"
 )
 
-@test "AC2: no pinned snapshot IDs in plugin source outside approved files" {
+@test "no pinned snapshot IDs in plugin source outside approved files" {
   cd "$REPO_ROOT"
   local raw
   raw=$(git grep -nE 'claude-(haiku|sonnet|opus)-[0-9]' -- \

--- a/tests/repo/routing_stale_refs_tests.bats
+++ b/tests/repo/routing_stale_refs_tests.bats
@@ -9,7 +9,6 @@
 #
 # ADR 0004 and the CHANGELOG are intentionally NOT scanned: they are immutable
 # historical records (ADR 0004 carries an "Amended by 0008" banner).
-# AC8.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 


### PR DESCRIPTION
## Why

Opaque `AC16`/`AC19`/`AC21` test labels are the test-suite equivalent of a tracker ID in a code comment — a number that carries no purpose. They were also **near-orphaned and reused across subsystems** (an `AC15` in the knowledge-index tests vs a *different* `AC15` perf gate in model routing), which made them actively misleading.

This applies the same principle as the comment-hygiene rule shipped in #419: **describe purpose, don't reference an opaque ID.**

## What changed

- Stripped `ACnn` prefixes/tags from every bats `@test` name and comment header across 24 files (~50 tests). Most descriptions were *already* meaningful after the colon — e.g. `AC16: knowledge/index.json is current with the working tree` → `knowledge/index.json is current with the working tree`.
- Handled the varied forms: leading prefixes, trailing `(AC5)` tags, section dividers `# --- AC0: … ---`, and cross-reference lists — with hand-fixes where a comment's only content was the AC number.
- Retired the one safe prose reference: `plans/insights-driven-improvements.md` `AC16 freshness gate` → `knowledge-index freshness gate`.

## Verification

- No duplicate `@test` names introduced (checked).
- No test *behavior* changes — descriptions/comments only.
- Pre-existing macOS-bash-3.2-only failures in `session_learning_trigger_tests.bats` (unbound-array gotcha) are unrelated and reproduce on `main`; CI (bash 4+) is unaffected.

## Deliberately out of scope (flagged, not touched)

- AC refs in **shipped** files (`orchestrator.md`, `task-size-classifier.md`, `model-routing-overrides.md`, `build_knowledge_index.py`).
- The **defining spec** `plans/effort-based-model-routing.md` (declares AC0–AC8).
- The **immutable** `docs/adr/0004` ("AC15 perf gate") — excluded from scanning by convention as a historical record.

These are a separate decision — see PR discussion.