### PR TITLE
refactor: name shipped AC references for what they assert

### DIFF
--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -73,7 +73,7 @@ using `knowledge/task-size-classifier.md`. Whole-file load: all signal definitio
 
 ### Gate procedure
 
-1. **Screen decision axes first (AC5 guardrail).** Read `knowledge/decision-defaults.md`. Whole-file load: all five axis definitions (triggers, defaults, confirm clauses) are needed to check the request against every axis. Check whether the task touches any high-reversal-cost axis (replace-vs-merge, format fidelity, migrate-vs-edit-stub, auto-merge-vs-direct, scope). If any axis is triggered → `decision_axis_triggered = true` → the task **cannot be trivial**, regardless of other signals.
+1. **Screen decision axes first (decision-axis guardrail).** Read `knowledge/decision-defaults.md`. Whole-file load: all five axis definitions (triggers, defaults, confirm clauses) are needed to check the request against every axis. Check whether the task touches any high-reversal-cost axis (replace-vs-merge, format fidelity, migrate-vs-edit-stub, auto-merge-vs-direct, scope). If any axis is triggered → `decision_axis_triggered = true` → the task **cannot be trivial**, regardless of other signals.
 
 2. **Collect objective signals.** Gather `files_changed`, `loc_delta`, `slice_count`,
    `wave_count`, `has_complex_step` per the classifier spec.
@@ -111,7 +111,7 @@ Inputs: files_changed=<N>, loc_delta=<N>, decision_axis_triggered=false.
 Expected saving: ~65% fewer turns vs full pipeline (see docs/experiments/data/3sizes-3arms-summary.json).
 ```
 
-### Demonstration of saving (AC3)
+### Demonstration of saving
 
 From `docs/experiments/data/3sizes-3arms-summary.json` (small-kata tier, haiku-4.5):
 

--- a/plugins/dev-team/docs/model-routing-overrides.md
+++ b/plugins/dev-team/docs/model-routing-overrides.md
@@ -104,7 +104,7 @@ With **no ladder file**, every effort band resolves to the **identical
 snapshot** it did before the effort-band migration
 (`low→claude-haiku-4-5-20251001`, `medium→claude-sonnet-4-6`,
 `high→claude-opus-4-8`) — the shipped default map equals the old tier mapping.
-Doing nothing changes nothing. (Pinned by AC0 in the routing tests.)
+Doing nothing changes nothing. (Pinned by the no-ladder migration-safety test.)
 
 ## Reverting
 

--- a/plugins/dev-team/hooks/lib/build_knowledge_index.py
+++ b/plugins/dev-team/hooks/lib/build_knowledge_index.py
@@ -76,7 +76,7 @@ def slugify(text: str) -> str:
 
 # ---------------------------------------------------------------------------
 # First-sentence extraction — operational boundary rule from the spec.
-# Logic mirrors the previous heredoc Python exactly so AC7a stays green.
+# Logic mirrors the previous heredoc Python exactly so the sentence-boundary rule stays green.
 # ---------------------------------------------------------------------------
 
 

--- a/plugins/dev-team/knowledge/task-size-classifier.md
+++ b/plugins/dev-team/knowledge/task-size-classifier.md
@@ -34,7 +34,7 @@ Apply in order; the first match wins.
 - `slice_count` ≤ 1
 - `wave_count` ≤ 1
 - `has_complex_step` = false
-- `decision_axis_triggered` = false  ← AC5 guardrail: never skips plan for high-reversal-cost work
+- `decision_axis_triggered` = false  ← decision-axis guardrail: never skips plan for high-reversal-cost work
 
 Expected saving vs full pipeline: ~65% fewer turns, ~45% lower cost (small-kata data; see calibration file).
 


### PR DESCRIPTION
## Why

Follow-up to #421 (test-suite rename). That PR was scoped to tests; this one retires the opaque `ACnn` labels that remained in **shipped** plugin files, where an unexplained `AC5` / `AC0` is exactly the kind of number-without-purpose we're eliminating.

## What changed (5 references, 4 files)

| File | Before | After |
|---|---|---|
| `agents/orchestrator.md` | `(AC5 guardrail)` | `(decision-axis guardrail)` |
| `agents/orchestrator.md` | `### Demonstration of saving (AC3)` | `### Demonstration of saving` |
| `knowledge/task-size-classifier.md` | `AC5 guardrail` | `decision-axis guardrail` (kept consistent with orchestrator) |
| `docs/model-routing-overrides.md` | `Pinned by AC0 in the routing tests` | `Pinned by the no-ladder migration-safety test` |
| `hooks/lib/build_knowledge_index.py` | `so AC7a stays green` | `so the sentence-boundary rule stays green` |

## Verification

- No test pins any of these literal strings (grep-checked).
- `knowledge/index.json` is **unchanged** — the `task-size-classifier.md` edit wasn't in an indexed snippet; freshness gate (`--check`) is green.
- Affected bats suites (`tests/agents`, `tests/knowledge`, `tests/docs`, `tests/repo`) pass: 0 failures.

## Left as-is (by design)

- `plans/effort-based-model-routing.md` — the defining spec where AC0–AC8 are authored/tracked.
- `docs/adr/0004` — immutable historical record (excluded from scanning by convention).
- `docs/experiments/…` — references a separate `Epic #362` AC set; not shipped.