### PR TITLE
feat: auto-bootstrap the CodeGraph index per clone

### DIFF
--- a/docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md
+++ b/docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md
@@ -1,0 +1,47 @@
+# 12. Auto-bootstrap the CodeGraph index per clone
+
+Date: 2026-06-25
+
+## Status
+
+Accepted
+
+Builds on [2. Use sentinel file and argument-shape heuristic for CodeGraph nudge hook](0002-use-sentinel-file-and-argument-shape-heuristic-for-codegraph-nudge-hook.md).
+
+## Context
+
+CodeGraph gives agents code intelligence over an index of the repo. That index is a SQLite database (`.codegraph/codegraph.db`) **derived from source and machine-local** — `.codegraph/.gitignore` excludes `*.db`, so it is never committed. A team that adopts CodeGraph therefore faces a sharing problem: how does every teammate's clone get a working index without each developer remembering to run `codegraph init` by hand?
+
+Two things need to travel with the repo for CodeGraph to "just work" on a fresh clone:
+
+1. **The opt-in signal** — the committed `.codegraph/` directory (its `.gitignore`). This is the same sentinel `codegraph-nudge.sh` already keys off; a repo that never adopted CodeGraph has no `.codegraph/`, so any automation must stay a no-op there and never index a project the maintainer did not bless.
+2. **A way to (re)build the local `.db`** on first use, and to keep it fresh after that.
+
+The freshness half is already handled when an MCP server is registered: `codegraph serve --mcp` runs a file-watcher and does a connect-time catch-up. So the missing piece is the **initial** build on a clone that has the opt-in signal but no local `.db` yet.
+
+Open questions:
+
+- **Where to trigger the initial build.** A `SessionStart` hook can see the cloned repo before any work begins. The alternative — relying on the developer to run `codegraph init` — is exactly the manual step we want to remove.
+- **Blocking vs detached build.** Indexing a large repo takes many seconds; blocking `SessionStart` on it would stall every session start.
+- **Missing binary.** A teammate may not have `codegraph` installed.
+
+## Decision
+
+Add `hooks/codegraph-bootstrap.sh`, a `SessionStart` hook (registered in `settings.json`) that, with CWD = the session's project dir:
+
+- **no `.codegraph/`** → exit 0 (repo has not adopted CodeGraph — never index it);
+- **`.codegraph/` + local `.db` present** → exit 0 (the MCP watcher keeps it current);
+- **`.codegraph/` + `.db` missing + binary present** → build the index in the **background** (`setsid`, falling back to `nohup`) so `SessionStart` never blocks, printing a one-line notice; codegraph's own lock file makes a concurrent `init` fail harmlessly, so no extra spawn guard is needed;
+- **`.codegraph/` + `.db` missing + binary absent** → print a one-line install nudge and exit 0.
+
+Fail-open throughout: malformed input or any error exits 0 — a bootstrap hook must never block a session. Test seams (`CODEGRAPH_BIN`, `CODEGRAPH_DB_FILE`, `CODEGRAPH_BOOTSTRAP_SYNC`) let the bats suite drive the foreground path against a fake binary.
+
+Complementarily, `/init-dev-team` (and `init-dev-team-linux.sh`) — after a successful `codegraph init` — writes a project-root `.mcp.json` registering `codegraph serve --mcp` (deep-merged so existing servers are preserved) and tells the user to commit it alongside `.codegraph/.gitignore`. Committing those two artifacts is what lets every later clone bootstrap automatically. The tools never `git add`/`commit` on the user's behalf.
+
+## Consequences
+
+- Adopting CodeGraph becomes a commit-two-files action (`.codegraph/.gitignore` + `.mcp.json`); every clone then self-bootstraps with no per-developer `codegraph init`.
+- A repo without `.codegraph/` is completely unaffected — the hook is a no-op.
+- The first session on a fresh clone runs with a stale/absent index for a few seconds while the background build completes; the notice tells the user to fall back to Read/Grep/Glob until it finishes.
+- Teammates without the binary get an actionable install nudge rather than a silent failure.
+- Behavior is covered by `tests/hooks/codegraph_bootstrap.bats`, and the settings registration plus the init `.mcp.json` flow by `tests/hooks/codegraph_settings_test.bats` and `tests/commands/init_dev_team_codegraph_test.bats`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@
 * [9. Human Consent Gate for Learning Loop](0009-human-consent-gate-for-learning-loop.md)
 * [10. Per-Session Analysis Granularity](0010-per-session-analysis-granularity.md)
 * [11. Enforce the context ceiling with a transcript-measured PreToolUse hook](0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md)
+* [12. Auto-bootstrap the CodeGraph index per clone](0012-auto-bootstrap-codegraph-index-per-clone.md)

--- a/init-dev-team-linux.sh
+++ b/init-dev-team-linux.sh
@@ -105,6 +105,24 @@ elif have codegraph; then
   say "CodeGraph installed but not initialized — running 'codegraph init -i'..."
   if codegraph init -i; then
     say "CodeGraph: initialized ✓"
+    # Share with the team: the .db is machine-local (gitignored), so commit a
+    # project-root .mcp.json registering the MCP server. Every clone then
+    # auto-bootstraps its own index via codegraph-bootstrap.sh. Merge without
+    # clobbering existing servers.
+    MCP_BLOCK='{"mcpServers":{"codegraph":{"type":"stdio","command":"codegraph","args":["serve","--mcp"]}}}'
+    if have jq; then
+      if [ -f .mcp.json ]; then
+        if tmp="$(mktemp)" && jq --argjson add "$MCP_BLOCK" '. * $add' .mcp.json > "$tmp" 2>/dev/null; then
+          mv -f "$tmp" .mcp.json
+        else
+          rm -f "$tmp"
+          warn "CodeGraph: could not merge .mcp.json — leaving it unchanged."
+        fi
+      else
+        printf '%s\n' "$MCP_BLOCK" | jq . > .mcp.json
+      fi
+      say "CodeGraph: wrote .mcp.json — commit it with .codegraph/.gitignore so teammates auto-bootstrap CodeGraph on clone."
+    fi
   else
     say "CodeGraph init failed (exit $?). Continuing without CodeGraph."
   fi

--- a/plugins/dev-team/hooks/codegraph-bootstrap.sh
+++ b/plugins/dev-team/hooks/codegraph-bootstrap.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# codegraph-bootstrap.sh — Claude Code SessionStart hook
+#
+# Rebuilds the per-machine CodeGraph index when a freshly cloned repo has
+# adopted CodeGraph but has no local index yet. This is how a team shares
+# CodeGraph: the SQLite database is derived from source and machine-local
+# (`.codegraph/.gitignore` excludes `*.db`), so it is never committed — instead
+# every clone rebuilds it automatically on the first session. See
+# docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md.
+#
+# Repo opt-in is the committed `.codegraph/` directory (the same sentinel
+# codegraph-nudge.sh keys off). A repo that never adopted CodeGraph has no
+# `.codegraph/`, so this hook is a no-op there — it never indexes a project the
+# maintainer did not bless.
+#
+# Behaviour (CWD = the session's project dir):
+#   * no `.codegraph/`                  -> exit 0 (repo hasn't adopted CodeGraph)
+#   * `.codegraph/` + local db present  -> exit 0 (MCP watcher keeps it fresh)
+#   * `.codegraph/` + db missing + bin  -> build the index in the BACKGROUND
+#   * `.codegraph/` + db missing, no bin-> print a one-line install nudge
+#
+# The index build is detached so SessionStart never blocks on it (indexing a
+# large repo can take many seconds). codegraph's own lock file makes a second
+# concurrent `init` fail harmlessly, so no extra spawn guard is needed; this
+# hook swallows that error (fail-open).
+#
+# Input:  SessionStart JSON on stdin (hook_event_name, cwd, model, ...).
+# Output: Notice/nudge on stderr. Exit 0 always — a buggy bootstrap hook must
+#         never block a session.
+#
+# Env seams (TEST-ONLY):
+#   CODEGRAPH_BIN            codegraph executable (default: codegraph)
+#   CODEGRAPH_DB_FILE        local index path (default: $CWD/.codegraph/codegraph.db)
+#   CODEGRAPH_BOOTSTRAP_SYNC when "1", run the build in the foreground (tests)
+
+set -uo pipefail
+
+# Single-line, grep-friendly, screen-reader-friendly. The `[codegraph-bootstrap]`
+# tag makes the source obvious in session output. Keep these constants in sync
+# with tests/hooks/codegraph_bootstrap.bats.
+BUILD_MSG='[codegraph-bootstrap] This project uses CodeGraph but has no local index yet — building it in the background. Use Read/Grep/Glob until it finishes; CodeGraph keeps it fresh after that.'
+INSTALL_MSG='[codegraph-bootstrap] This project uses CodeGraph but it is not installed on this machine. Install it for code intelligence: https://github.com/colbymchenry/codegraph#installation'
+
+main() {
+  local input
+  input=$(cat 2>/dev/null || true)
+
+  # Fail-open on malformed input — never block a session.
+  echo "$input" | jq -e . >/dev/null 2>&1 || return 0
+
+  local cwd
+  cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+  [ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
+
+  # Repo opt-in: the committed `.codegraph/` directory. Absent → not our concern.
+  [ -d "$cwd/.codegraph" ] || return 0
+
+  local bin db
+  bin="${CODEGRAPH_BIN:-codegraph}"
+  db="${CODEGRAPH_DB_FILE:-$cwd/.codegraph/codegraph.db}"
+
+  # Local index already built — the MCP server's watcher + connect-time
+  # catch-up keep it current from here. Nothing to do.
+  [ -f "$db" ] && return 0
+
+  # Fresh clone / new machine: the repo declares CodeGraph but this machine has
+  # no index. Build it if the binary is here; otherwise nudge to install.
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    printf '%s\n' "$INSTALL_MSG" >&2
+    return 0
+  fi
+
+  printf '%s\n' "$BUILD_MSG" >&2
+
+  if [ "${CODEGRAPH_BOOTSTRAP_SYNC:-0}" = "1" ]; then
+    # Foreground path (tests, or anyone who wants a blocking build).
+    ( cd "$cwd" && "$bin" init ) >/dev/null 2>&1 || true
+  else
+    # Detached so session start is never delayed by indexing. setsid when
+    # available fully decouples the child; nohup is the portable fallback.
+    if command -v setsid >/dev/null 2>&1; then
+      setsid bash -c "cd \"\$1\" && \"\$2\" init >/dev/null 2>&1 || true" _ "$cwd" "$bin" >/dev/null 2>&1 &
+    else
+      nohup bash -c "cd \"\$1\" && \"\$2\" init >/dev/null 2>&1 || true" _ "$cwd" "$bin" >/dev/null 2>&1 &
+    fi
+  fi
+
+  return 0
+}
+
+main

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3492,6 +3492,10 @@
       "summary": "If `.codegraph.init_declined == true`: print",
       "anchor": "init-prompt-branch-installedtrue-initializedfalse"
     },
+    "Share CodeGraph with the team (after a successful init)": {
+      "summary": "The CodeGraph database (`.codegraph/codegraph.db`) is derived from source and",
+      "anchor": "share-codegraph-with-the-team-after-a-successful-init"
+    },
     "Step 3 — Select languages": {
       "summary": "Ask the user which language ecosystems they are working with.",
       "anchor": "step-3-select-languages"

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -22,6 +22,10 @@
           {
             "type": "command",
             "command": "bash hooks/session-model-banner.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash hooks/codegraph-bootstrap.sh"
           }
         ]
       }

--- a/plugins/dev-team/skills/init-dev-team/SKILL.md
+++ b/plugins/dev-team/skills/init-dev-team/SKILL.md
@@ -188,13 +188,46 @@ supersedes the recorded preference.
     1. Print: `Running 'codegraph init -i' in this project...`
     2. Execute `codegraph init -i` with the current working directory as cwd.
        Surface its stdout/stderr to the user.
-    3. On exit 0: print `CodeGraph: initialized ✓` and merge
-       `{"codegraph": {"init_accepted": true}}` into `.claude/init-state.json`.
+    3. On exit 0: print `CodeGraph: initialized ✓`, merge
+       `{"codegraph": {"init_accepted": true}}` into `.claude/init-state.json`,
+       then run the **Share CodeGraph with the team** step below.
     4. On non-zero exit N: print
        `CodeGraph init failed (exit code N). See output above. Continuing without CodeGraph.`
        Do NOT modify `.claude/init-state.json`.
   - On any other response: merge `{"codegraph": {"init_declined": true}}`
     and continue silently.
+
+### Share CodeGraph with the team (after a successful init)
+
+The CodeGraph database (`.codegraph/codegraph.db`) is derived from source and
+machine-local — `.codegraph/.gitignore` excludes `*.db`, so it is never
+committed. The team shares CodeGraph by **committing two things** so every
+clone bootstraps its own local index automatically (no per-developer
+`codegraph init`):
+
+1. **The committed `.codegraph/` directory** (its `.gitignore`). This is the
+   repo's opt-in signal. On a fresh clone the plugin's `codegraph-bootstrap.sh`
+   SessionStart hook sees `.codegraph/` but no local `*.db` and rebuilds the
+   index automatically.
+2. **A project-root `.mcp.json`** registering the CodeGraph MCP server, so
+   every teammate's Claude Code session auto-starts `codegraph serve --mcp`
+   (its file-watcher + connect-time catch-up keep the index current).
+
+Write/merge `.mcp.json` at the project root without clobbering any existing
+server entries:
+
+```bash
+MCP_BLOCK='{"mcpServers":{"codegraph":{"type":"stdio","command":"codegraph","args":["serve","--mcp"]}}}'
+if [ -f .mcp.json ]; then
+  tmp="$(mktemp)"
+  jq --argjson add "$MCP_BLOCK" '. * $add' .mcp.json > "$tmp" && mv -f "$tmp" .mcp.json
+else
+  printf '%s\n' "$MCP_BLOCK" | jq . > .mcp.json
+fi
+```
+
+Then print: `CodeGraph: wrote .mcp.json — commit it with .codegraph/.gitignore so teammates auto-bootstrap CodeGraph on clone.`
+Do not run `git add`/`git commit` yourself; leave staging to the user.
 
 `.claude/init-state.json` uses a top-level `codegraph` key so future plugins
 can claim sibling keys without collision. Always merge into existing JSON

--- a/tests/commands/init_dev_team_codegraph_test.bats
+++ b/tests/commands/init_dev_team_codegraph_test.bats
@@ -60,6 +60,28 @@ _contains() {
 }
 
 # ---------------------------------------------------------------------------
+# Share-with-the-team step (after a successful init): commit .mcp.json so
+# clones auto-bootstrap. See ADR 0012.
+# ---------------------------------------------------------------------------
+
+@test "share_step_heading_present" {
+  _contains "Share CodeGraph with the team"
+}
+
+@test "share_step_writes_mcp_json" {
+  _contains '"command":"codegraph","args":["serve","--mcp"]'
+}
+
+@test "share_step_merge_preserves_existing_servers" {
+  # Deep-merge so an existing mcpServers entry is not clobbered.
+  _contains '. * $add'
+}
+
+@test "share_step_commit_guidance_present" {
+  _contains "commit it with .codegraph/.gitignore so teammates auto-bootstrap CodeGraph on clone"
+}
+
+# ---------------------------------------------------------------------------
 # Skip-note texts (state-aware re-runs)
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/codegraph_bootstrap.bats
+++ b/tests/hooks/codegraph_bootstrap.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# Tests for hooks/codegraph-bootstrap.sh — the SessionStart hook that rebuilds
+# the machine-local CodeGraph index on a fresh clone of a repo that adopted
+# CodeGraph. See docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md.
+#
+# The hook's real build path is detached (background); tests drive the
+# foreground path via CODEGRAPH_BOOTSTRAP_SYNC=1 and inject a fake `codegraph`
+# binary via CODEGRAPH_BIN so no real indexing runs.
+
+HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/codegraph-bootstrap.sh"
+
+# Keep in sync with the message constants in codegraph-bootstrap.sh.
+BUILD_MSG='[codegraph-bootstrap] This project uses CodeGraph but has no local index yet'
+INSTALL_MSG='[codegraph-bootstrap] This project uses CodeGraph but it is not installed on this machine'
+
+setup() {
+  CASE="$(mktemp -d)"
+  # A fake codegraph that "indexes" by creating the db the real one would.
+  FAKE_BIN_DIR="$CASE/bin"
+  mkdir -p "$FAKE_BIN_DIR"
+  cat > "$FAKE_BIN_DIR/codegraph" <<'EOF'
+#!/usr/bin/env bash
+# init -> create the local index the real codegraph would build.
+[ "${1:-}" = "init" ] && touch "$PWD/.codegraph/codegraph.db"
+exit 0
+EOF
+  chmod +x "$FAKE_BIN_DIR/codegraph"
+}
+
+teardown() {
+  rm -rf "$CASE"
+}
+
+_input() {
+  jq -nc --arg cwd "$1" '{hook_event_name:"SessionStart", cwd:$cwd}'
+}
+
+@test "no .codegraph directory -> silent no-op, exit 0" {
+  run bash -c "echo '$(_input "$CASE")' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "local index already present -> silent no-op, exit 0" {
+  mkdir -p "$CASE/.codegraph"
+  touch "$CASE/.codegraph/codegraph.db"
+  run bash -c "echo '$(_input "$CASE")' | CODEGRAPH_BIN='$FAKE_BIN_DIR/codegraph' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "adopted repo, no index, binary present -> builds the index" {
+  mkdir -p "$CASE/.codegraph"
+  run bash -c "echo '$(_input "$CASE")' | CODEGRAPH_BIN='$FAKE_BIN_DIR/codegraph' CODEGRAPH_BOOTSTRAP_SYNC=1 bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -f "$CASE/.codegraph/codegraph.db" ]
+  [[ "$output" == *"$BUILD_MSG"* ]]
+}
+
+@test "adopted repo, no index, binary missing -> install nudge, no build" {
+  mkdir -p "$CASE/.codegraph"
+  run bash -c "echo '$(_input "$CASE")' | CODEGRAPH_BIN='/nonexistent/codegraph' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -f "$CASE/.codegraph/codegraph.db" ]
+  [[ "$output" == *"$INSTALL_MSG"* ]]
+}
+
+@test "honors CODEGRAPH_DB_FILE override for the index-present check" {
+  mkdir -p "$CASE/.codegraph"
+  local alt="$CASE/.codegraph/custom.db"
+  touch "$alt"
+  run bash -c "echo '$(_input "$CASE")' | CODEGRAPH_DB_FILE='$alt' CODEGRAPH_BIN='$FAKE_BIN_DIR/codegraph' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "malformed stdin fails open (silent, exit 0)" {
+  run bash -c "echo 'not json' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "missing cwd in payload falls back to PWD without error" {
+  # No .codegraph in the fallback dir -> safe no-op.
+  run bash -c "cd '$CASE' && echo '{\"hook_event_name\":\"SessionStart\"}' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/hooks/codegraph_settings_test.bats
+++ b/tests/hooks/codegraph_settings_test.bats
@@ -54,6 +54,15 @@ SETTINGS="$BATS_TEST_DIRNAME/../../plugins/dev-team/settings.json"
   [ "$status" -eq 0 ]
 }
 
+@test "codegraph-bootstrap.sh is registered in SessionStart" {
+  run jq -e '
+    .hooks.SessionStart[]
+    | .hooks[]
+    | select(.command | contains("codegraph-bootstrap.sh"))
+  ' "$SETTINGS"
+  [ "$status" -eq 0 ]
+}
+
 @test "codegraph-nudge.sh does NOT appear under a regex matcher Read|Grep|Glob" {
   # Per the plan, we chose per-tool entries over a pipe-delimited regex.
   # The negative guard catches ANY pipe-delimited matcher whose first token


### PR DESCRIPTION
## Why

CodeGraph's index (`.codegraph/codegraph.db`) is derived from source and machine-local — `.codegraph/.gitignore` excludes `*.db`, so it can't be shared by committing it. Until now a team adopting CodeGraph had no clean way to share it short of every developer remembering to run `codegraph init`.

## What

**`hooks/codegraph-bootstrap.sh`** — a `SessionStart` hook (registered in `settings.json`) keyed on the committed `.codegraph/` directory (the same opt-in sentinel `codegraph-nudge.sh` uses):

| State | Action |
| --- | --- |
| no `.codegraph/` | no-op (repo never adopted CodeGraph — never index it) |
| `.codegraph/` + local `.db` present | no-op (MCP watcher keeps it fresh) |
| `.codegraph/` + `.db` missing + binary present | build the index in the **background** (`setsid`→`nohup`); never blocks SessionStart |
| `.codegraph/` + `.db` missing + binary absent | one-line install nudge |

Fail-open throughout (malformed input / errors → exit 0). Test seams (`CODEGRAPH_BIN`, `CODEGRAPH_DB_FILE`, `CODEGRAPH_BOOTSTRAP_SYNC`) drive the foreground build against a fake binary.

**Init flow** — `/init-dev-team` and `init-dev-team-linux.sh`, after a successful `codegraph init`, write a project-root `.mcp.json` (deep-merged so existing MCP servers are preserved) registering `codegraph serve --mcp`, and tell the user to commit it with `.codegraph/.gitignore`. Committing those two artifacts is what lets every later clone self-bootstrap.

## Notes for review

- This was uncommitted working-tree work; I picked it up, **renumbered its ADR `0011`→`0012`** (0011 was taken by the just-merged context-ceiling hook — the original references pointed at a nonexistent file), and authored **ADR 0012**.
- Rationale in ADR 0012. Covered by `tests/hooks/codegraph_bootstrap.bats` (7 cases) plus updated `codegraph_settings_test.bats` and `init_dev_team_codegraph_test.bats`.
- `scripts/ci-local.sh` green except the known local-only `eslint` tooling gap (no JS in this diff).

Touches hooks + settings.json + init flow, so it requires explicit human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)