### PR TITLE
docs: rename opaque experiment labels and spec the larger refactoring follow-up

### DIFF
--- a/docs/experiments/experiment-prompt-refactor-cadence-larger.md
+++ b/docs/experiments/experiment-prompt-refactor-cadence-larger.md
@@ -1,0 +1,195 @@
+# Experiment Prompt: Does refactoring pay off on larger code over a longer change horizon?
+
+**Type:** Reusable experiment prompt (hand this whole file to Claude to execute)
+**Harness:** [`scripts/run_refactor_experiment.py`](../../scripts/run_refactor_experiment.py) — **extend it** (see "Extend the harness")
+**Motivation + prior run:** [`refactor-granularity-report.md`](refactor-granularity-report.md)
+(the first run; read its **Limitations** section first — this design exists to remove them)
+
+**Status: specified, NOT run.** This is the follow-up the first run's report recommends.
+
+---
+
+## Why a second run
+
+The first refactoring-cadence run held its methodology cleanly — **0 invariant
+violations in 364 cells**, confirming that "tests never change during refactoring" is
+enforceable — but it could **not** answer whether refactoring pays off, for three
+reasons the report names:
+
+1. **Blast conflated cost with benefit.** Cumulative blast counted the refactoring's
+   own churn, so refactor arms scored "less changeable" *by construction*; the
+   hypothesized payoff (smaller *later* changes) was swamped within a 3-change window.
+2. **Tasks were too small and clear.** Single-module features (MI ≈ 75, coverage
+   saturated at ~100%) left no room for refactoring to improve structure or for the
+   quality sensors to discriminate.
+3. **Four tasks underpowered small effects.** The unit of inference is the task.
+
+This run fixes all three: **larger multi-file tasks, a longer change horizon, a
+held-out no-refactor change that isolates changeability, and far more tasks.**
+
+---
+
+## Prompt
+
+> Run a controlled experiment on whether refactoring cadence and code/test authorship
+> improve changeability and test quality **on larger code over a longer change
+> horizon**, holding the validated invariant that refactoring never changes tests.
+> Extend `scripts/run_refactor_experiment.py` (do not rebuild it). Work on a feature
+> branch; commit the harness extension, the new task corpus, raw data, and the report;
+> do not open a PR unless asked.
+>
+> **Factors (unchanged from the corrected first run):**
+> - **granularity**: none / one-shot (single pass) / continuous (per increment)
+> - **authorship**: single (one agent writes code+tests) / split (independent coder + tester)
+> - plus **`tdd-refactor`** (test-first, continuous, single) as the reference. **7 arms.**
+> - **Invariant (every arm):** a refactor step restructures production code only; any
+>   test-file edit it makes is reverted to the pre-refactor snapshot.
+>
+> **The three fixes:**
+> 1. **Larger tasks** — multi-file packages (3–5 source modules behind a public API),
+>    big enough that structure matters and the quality sensors don't saturate.
+> 2. **Longer change horizon** — an **8-change** chain, each modifying behavior, so a
+>    cleanup can pay back over later changes.
+> 3. **Held-out changeability probe** — after the chain, apply **two identical
+>    "probe" changes to every arm with refactoring disabled**, and measure *their*
+>    blast. This is the clean changeability outcome: how cheaply does each arm's
+>    *accumulated* code absorb a new requirement, with no refactor churn mixed in.
+>
+> **Decompose blast** at every stage into **change-churn** (lines to satisfy the
+> requirement) vs **refactor-churn** (lines the cleanup added), reported separately so
+> the *cost* of refactoring is never confused with its *benefit*.
+>
+> **Scale for power:** **12–16 larger tasks × ~10 trials × 7 arms.** Pre-register N
+> from a power calc on the first run's per-task blast variance.
+
+---
+
+## Pre-registered hypotheses (fix before any data)
+
+- **payoff hypothesis (the one the first run couldn't test):** on larger code over an
+  8-change horizon, refactoring arms (one-shot, continuous) absorb the **held-out probe
+  changes** with lower blast than `none` — i.e. cleanup makes later change cheaper once
+  there is enough code and enough horizon for it to matter. **Null:** probe-change blast
+  is equal across granularity (refactoring buys no measurable changeability even here).
+- **cadence hypothesis:** continuous refactoring yields lower probe-change blast and/or
+  better modularity (radon MI, lizard) than one-shot, holding authorship constant.
+- **break-even hypothesis:** cumulative *refactor-churn* exceeds the *change-churn
+  savings* on early changes but the sign flips by some change index K; estimate K (the
+  horizon at which refactoring starts paying for itself), or report that it never flips.
+- **authorship hypothesis:** an independent tester (split) raises mutation score / EDGE
+  on larger tasks where a single author's blind spots are bigger — or, as in the first
+  run, buys nothing and costs ~3×. (First-run prior: no benefit; re-test at larger scale.)
+
+---
+
+## Design
+
+| factor | levels |
+|---|---|
+| granularity | none / one-shot / continuous |
+| authorship | single / split |
+| reference | `tdd-refactor` (test-first, continuous, single) |
+
+7 arms × 12–16 tasks × ~10 trials. Each cell:
+**build → 8-change chain → 2 held-out probe changes (refactoring disabled, all arms identical).**
+
+Clear specs only (as validated). The invariant and its revert-based enforcement carry
+over unchanged from `run_refactor_experiment.py`.
+
+---
+
+## Tasks — the biggest change (author these first)
+
+Each task is a **multi-file package**, not a single-module kata, large enough that
+refactoring has something to bite and the quality sensors can move:
+
+- **Shape:** a public API module + 3–5 internal modules (e.g. a parser + evaluator +
+  formatter; a rules engine with strategy modules; a small in-memory store with
+  index/query/serialize layers). ~150–400 LOC at build, room to grow over 8 changes.
+- **Build spec:** clear, ≥ 8 CORE behaviors spanning multiple modules.
+- **Change chain (8):** each modifies behavior and is designed so a *monolithic* design
+  pays escalating blast while a *modular* design stays localized — the trap that makes
+  refactoring's payoff visible. Order changes so early ones are cheap and later ones
+  stress cross-module boundaries.
+- **Held-out probes (2):** withheld changes of the same character as the chain, applied
+  with refactoring disabled in **every** arm, used only to measure changeability.
+- **Hidden acceptance:** CORE + per-change + per-probe suites, **validated green against
+  a reference solution before running** (as in the first run's `fare`/`payroll`/etc.).
+- **Quantity:** author **12–16** such tasks (the unit of inference is the task; this is
+  the fix for the first run's power problem). Distinct domains; no overlap with the
+  first run's four.
+
+Suggested domains: mini-spreadsheet (cells+formulas+eval), template engine
+(parse+render+partials), task scheduler (deps+topo+cycles), json-pointer
+(parse+resolve+patch), ledger (accounts+postings+report), url-router
+(patterns+match+reverse), query filter (parse+plan+apply).
+
+---
+
+## Extend the harness
+
+Build on `run_refactor_experiment.py` (the arms, the invariant, the revert
+enforcement, and the radon/lizard/mutation/coverage/smell sensors all carry over). Add:
+
+1. **Multi-file task support** — the corpus loader and `prod_files()` already handle
+   multiple `*.py`; confirm blast/radon/lizard aggregate across modules. Add a manifest
+   schema for multi-module golden packages.
+2. **8-change chain + 2 held-out probes** — extend `changeChain` and add a `probes`
+   list run with refactoring force-disabled for every arm (reuse the `none`-granularity
+   change path regardless of the arm's own granularity).
+3. **Decomposed blast** — record per stage: **change-churn** (numstat of the change
+   dispatch's commits) and **refactor-churn** (numstat of the `refactor:` commits),
+   separately, on production files. Cumulate each across the chain. Probe-change blast
+   is recorded on its own.
+4. **Per-change-index series** — emit blast per change index (not just cumulative) so
+   the break-even index K is estimable.
+5. **Validate with `--skip-dispatch`** before spending, then a 1-task pilot for cost.
+
+---
+
+## Analysis plan (pre-registered)
+
+- **Primary — changeability:** held-out **probe-change blast**, per arm, paired by task
+  (median across trials → compare across the 12–16 tasks). This is the clean outcome the
+  first run lacked. Test granularity (none vs one-shot vs continuous) and the cadence
+  contrast.
+- **Break-even:** plot cumulative (refactor-churn) vs cumulative (change-churn saved
+  relative to `none`) across change index; report K or "never."
+- **Modularity / test quality:** radon MI, lizard, mutation, coverage across granularity
+  — now expected to discriminate on larger code; flag any sensor still saturated.
+- **Authorship:** split vs single on probe-change blast, mutation, EDGE, and cost.
+- **Cost of quality:** every quality figure raw **and** per-dollar; name the efficient
+  frontier.
+- **Power:** size trials from the first run's per-task blast SD; the task count (12–16)
+  is the real lever — pre-register it and the stopping rule.
+
+---
+
+## What each outcome would mean
+
+| result | interpretation |
+|---|---|
+| Probe-change blast: refactor < none | Refactoring **does** pay off once code is large and the horizon is long enough — the first run's null was a tasks/horizon artifact. Recommend refactoring; report the break-even K. |
+| Probe-change blast equal across granularity | Refactoring's changeability payoff is not real even at scale — a strong, surprising result. Choose cadence on cost alone. |
+| Continuous < one-shot on probe blast / MI | Refactor in small steps; cadence matters independently. |
+| Authorship still null | Confirm the first run: independent test authorship not worth ~3× cost. |
+
+## Guardrails (carried from the first run)
+
+1. **Hide acceptance during build/change**; validate every acceptance suite against a
+   reference before running.
+2. **The invariant is enforced by reverting test edits in refactor steps** — keep it;
+   it held at 0 violations in 364 cells.
+3. **Hold the model fixed and report it.**
+4. **Probes must be refactoring-disabled for every arm**, or they stop being a clean
+   changeability probe.
+5. **Pre-register N, the stopping rule, and the analysis** before any dispatch; the task
+   is the unit of inference.
+
+## Expected deliverables
+
+- 12–16 larger multi-file tasks with reference-validated hidden acceptance + 2 probes each.
+- Harness extension: multi-file support, 8-change chain + probes, decomposed
+  change-/refactor-churn, per-index blast series — proven under `--skip-dispatch`.
+- Raw data + one report whose **primary** result is held-out probe-change blast by arm,
+  the break-even K, and the three axes raw + per-dollar.

--- a/docs/experiments/experiment-prompt-refactor-granularity.md
+++ b/docs/experiments/experiment-prompt-refactor-granularity.md
@@ -55,26 +55,26 @@ The three axes and their sensors are defined in [What we measure](#what-we-measu
 
 Carried forward verbatim from the original draft, plus the authorship additions:
 
-- **H-F0 (equivalence, the default):** continuous-refactor and one-shot-refactor are
+- **equivalence hypothesis (the default):** continuous-refactor and one-shot-refactor are
   equivalent on cumulative blast radius within a **±5%** margin (TOST). The n=3 data points
   here; this run is powered to *reject* it if a real effect exists.
-- **H-F1 (granularity):** holding test-protection constant, **continuous** refactoring
+- **granularity hypothesis:** holding test-protection constant, **continuous** refactoring
   yields lower blast radius than **one-shot**. Predicts the gap survives even when tests
   are frozen.
-- **H-F2 (safety net):** **freezing** the suite during the refactor raises EDGE pass rate
+- **safety-net hypothesis:** **freezing** the suite during the refactor raises EDGE pass rate
   (the tests that recorded edge decisions survive) and lowers subsequent blast radius vs a
   free refactor. Predicts **test-suite churn mediates** the blast-radius difference.
-- **H-F3 (authorship):** **split-agent** raises EDGE pass rate and/or mutation score (an
+- **authorship hypothesis:** **split-agent** raises EDGE pass rate and/or mutation score (an
   independent tester writes the behavior the coder didn't think to test) but may raise cost
   and the build-stage failure rate (two agents must converge on one contract). **Null:** a
   single agent testing its own code is as thorough as an independent tester — authorship
   does not move quality or changeability.
-- **H-F4 (interaction):** authorship interacts with protection — the value of an
+- **authorship-interaction hypothesis:** authorship interacts with protection — the value of an
   independent test author is largest when the refactor is **free** to churn the suite,
   because an independent suite is the thing a free refactor erodes (the test-after-refactor EDGE collapse).
   If frozen tests already neutralize churn, split-agent buys little on top.
 
-H-F1, H-F2, H-F3 are not mutually exclusive; the 2×2×2 separates their contributions.
+granularity hypothesis, safety-net hypothesis, authorship hypothesis are not mutually exclusive; the 2×2×2 separates their contributions.
 
 ---
 
@@ -213,7 +213,7 @@ batched-red)` and per-arm prompt strings in `ARM_PROMPTS` / `CHANGE_PROMPTS`. Ad
      label is a violation; flag it.
    - **test-suite churn during refactor:** **test LOC added + deleted** between first-green
      and post-refactor (diff the test files at those two checkpoints). **This is the
-     mediator variable for H-F2** — it is the number the user specifically wants tracked.
+     mediator variable for safety-net hypothesis** — it is the number the user specifically wants tracked.
    - Carry forward the existing CORE/EDGE pass rates, blast radius, cost/stage, mutation,
      and contamination fields.
 4. **Offline graders for the three axes** (post-stage, run on the frozen files — see "What
@@ -266,13 +266,13 @@ row counts / `pgrep`); never kill the session's own `claude` process.
 - **Headline / question 1 (real vs noise):** **TOST** equivalence on cumulative blast
   radius, continuous vs one-shot, ±5% margin. A "confirmed equivalent" verdict is a valid,
   reportable result.
-- **H-F1 (granularity):** two-factor model on blast radius; granularity main effect with
+- **granularity hypothesis:** two-factor model on blast radius; granularity main effect with
   protection held constant.
-- **H-F2 (safety net):** **mediation** — does test-suite churn account for the
+- **safety-net hypothesis:** **mediation** — does test-suite churn account for the
   granularity/protection effect on blast radius? Plus the direct EDGE comparison frozen vs
   free (re-tests the test-after-refactor finding that a free refactor destroys edge coverage under a vague
   spec).
-- **H-F3 / H-F4 (authorship):** authorship main effect on EDGE pass rate, mutation score,
+- **authorship hypothesis / authorship-interaction hypothesis (authorship):** authorship main effect on EDGE pass rate, mutation score,
   cost, and build-stage failure rate; authorship × protection interaction on EDGE and blast
   radius.
 - **Modularity (Axis 1):** per-arm mean modularity findings/solution and per-change file
@@ -307,8 +307,8 @@ and link the new report.
 |---|---|
 | **TOST confirms equivalence** | The refactor-arm tie is real; *refactoring is the mechanism* is the whole story, and **how** you refactor (granularity, ordering) does not move changeability. Choose between the two on cost and edge robustness. |
 | **Granularity effect, no churn mediation** | Continuous refactoring is independently better. Recommend refactoring in small steps regardless of test ordering. |
-| **Churn mediation (H-F2)** | One-shot refactor's cost is collateral test-suite damage. Recommend protecting/regenerating the suite across a refactor; the test-after-refactor EDGE collapse and the changeability residual share one root cause. |
-| **Authorship effect (H-F3)** | An independent test author finds behavior a self-testing agent misses. Recommend splitting code and test authorship — most valuable, per H-F4, when the refactor is free to churn the suite. |
+| **Churn mediation (safety-net hypothesis)** | One-shot refactor's cost is collateral test-suite damage. Recommend protecting/regenerating the suite across a refactor; the test-after-refactor EDGE collapse and the changeability residual share one root cause. |
+| **Authorship effect (authorship hypothesis)** | An independent test author finds behavior a self-testing agent misses. Recommend splitting code and test authorship — most valuable, per authorship-interaction hypothesis, when the refactor is free to churn the suite. |
 | **Authorship null** | A single agent tests its own code as well as an independent one. Drop the split-agent overhead. |
 
 A null on any factor is a publishable result: confirming the refactor workflows are

--- a/docs/experiments/experiment-prompt-when-tdd-pays.md
+++ b/docs/experiments/experiment-prompt-when-tdd-pays.md
@@ -25,10 +25,10 @@ four verdicts. They reframe the research questions for the next run:
 
 | Finding | Implication for next run |
 |---------|--------------------------|
-| **H-A REJECTED (reversed):** test-after 67% EDGE vs tdd-refactor 33% under vague spec | The anchoring effect is real. Add `test-after-refactor` to test whether deferring test commitment AND refactoring combines both advantages |
-| **H-B CONFIRMED:** tdd-refactor lowest blast radius (664 vs 700–770) | Refactoring matters for changeability. The new arm tests whether test-first is necessary to get it |
-| **H-B2 CONFIRMED:** tdd-no-refactor (701) ≈ test-after (700) | **The refactor step is load-bearing, not test ordering.** But the experiment confounds refactoring with its test safety net — `test-after-refactor` isolates this |
-| **H-C NOT CONFIRMED:** TDD's changeability gap is similar across clarity conditions | The advantage is structural (from refactoring), not spec-dependent |
+| **ambiguity hypothesis REJECTED (reversed):** test-after 67% EDGE vs tdd-refactor 33% under vague spec | The anchoring effect is real. Add `test-after-refactor` to test whether deferring test commitment AND refactoring combines both advantages |
+| **changeability hypothesis CONFIRMED:** tdd-refactor lowest blast radius (664 vs 700–770) | Refactoring matters for changeability. The new arm tests whether test-first is necessary to get it |
+| **mechanism-isolation hypothesis CONFIRMED:** tdd-no-refactor (701) ≈ test-after (700) | **The refactor step is load-bearing, not test ordering.** But the experiment confounds refactoring with its test safety net — `test-after-refactor` isolates this |
+| **clarity-interaction hypothesis NOT CONFIRMED:** TDD's changeability gap is similar across clarity conditions | The advantage is structural (from refactoring), not spec-dependent |
 
 **The critical confound the first run could not resolve:** tdd-refactor's changeability
 advantage might come from (a) refactoring itself, (b) having tests before refactoring
@@ -107,13 +107,13 @@ task with an irreducible spec-gap to confirm this floor holds across workflows.
 ## Research questions & hypotheses (pre-register before looking at results)
 
 - **ambiguity-inference / ambiguity.** Does workflow change how well the agent infers *unstated*
-  decisions? **H-A:** under `vague`, `tdd-refactor` passes more **EDGE** assertions
+  decisions? **ambiguity hypothesis:** under `vague`, `tdd-refactor` passes more **EDGE** assertions
   than `test-after`; under `clear` there is no gap (a `workflow × clarity`
   interaction). **Null:** vagueness degrades all arms equally (test-first just
   locks in its own happy-path guess).
 - **changeability / design.** Does workflow change the **changeability** of the design?
-  **H-B:** `tdd-refactor` absorbs the change chain at lower cumulative cost /
-  smaller blast radius than `test-after` and `bduf`. **H-B2 (mechanism):**
+  **changeability hypothesis:** `tdd-refactor` absorbs the change chain at lower cumulative cost /
+  smaller blast radius than `test-after` and `bduf`. **mechanism-isolation hypothesis:**
   `tdd-no-refactor` ≈ `test-after` < `tdd-refactor` ⇒ the benefit comes from
   **refactoring**, not test ordering.
 - **clarity-interaction / the headline interaction.** Is TDD's advantage (on EDGE *and*
@@ -123,16 +123,16 @@ task with an irreducible spec-gap to confirm this floor holds across workflows.
 - **spec-synthesis / spec synthesis vs test-first.** Does `ship`'s explicit acceptance-criteria
   synthesis (the `/specs` phase authors the contract before any code is written)
   resolve ambiguity as well as or better than `tdd-refactor`'s failing-test-as-
-  specification approach? **H-D:** under `vague`, `ship` EDGE pass rate ≥
+  specification approach? **spec-synthesis hypothesis:** under `vague`, `ship` EDGE pass rate ≥
   `tdd-refactor` because the `/specs` phase forces the agent to state every
-  acceptance decision upfront, including those the vague spec omitted. **H-D2
+  acceptance decision upfront, including those the vague spec omitted. **spec-synthesis-changeability hypothesis
   (mechanism):** `ship` changeability ≤ `tdd-refactor` because its inline review
   checkpoints in `/build` catch structural issues that `tdd-refactor`'s refactor
   step misses. **Null:** the `/specs` phase makes the same happy-path assumptions
   as any other arm — synthesising a spec from a vague prompt does not reliably
   surface EDGE decisions.
 - **test-after-refactor / test-after-refactor dominance.** Does deferring test commitment *and*
-  adding a refactor phase dominate all existing arms simultaneously? **H-E:** under
+  adding a refactor phase dominate all existing arms simultaneously? **dominance hypothesis:** under
   `vague`, `test-after-refactor` EDGE pass rate ≥ `test-after` (≈67%) — because
   deferred tests capture the actual emergent contract, including edge cases the
   working implementation surfaced — AND blast radius ≈ `tdd-refactor` (≈664) —
@@ -316,7 +316,7 @@ session's own `claude`.
   EDGE pass rate — this isolates acceptance-criteria synthesis from architecture
   commitment as mechanisms for resolving ambiguity. Report `ship`'s cost premium over
   the cheapest vague arm to frame the "does spec synthesis pay?" trade-off.
-- **test-after-refactor — test-after-refactor dominance:** Three-way test against H-E. (a) EDGE
+- **test-after-refactor — test-after-refactor dominance:** Three-way test against dominance hypothesis. (a) EDGE
   under `vague`: `test-after-refactor` ≥ `test-after`? If yes, deferred tests
   survive a refactor phase without losing their EDGE advantage. If no, the refactor
   changes what the code does, so tests written before refactoring no longer match
@@ -325,7 +325,7 @@ session's own `claude`.
   regardless of when the tests were written. If no, the iterative TDD cycle
   produces a design that a post-implementation refactor cannot replicate. (c) Cost:
   `test-after-refactor` < `tdd-refactor`? This should hold by construction (no
-  red-green iteration during build). All three must confirm to declare H-E supported.
+  red-green iteration during build). All three must confirm to declare dominance hypothesis supported.
   A partial confirm is informative: it identifies which component of `tdd-refactor`'s
   advantage (EDGE, changeability, or both) requires early test commitment.
 - **Secondaries:** radon trajectory; multi-rater code/test/design score (mean ±

--- a/docs/experiments/refactor-granularity-power-analysis.md
+++ b/docs/experiments/refactor-granularity-power-analysis.md
@@ -52,7 +52,7 @@ distribution. Cell-by-cell the refactor arms are not behaving equivalently at al
 | ship / tdd-no-refactor | 25.0% |
 | **test-after-refactor** | **0.0%** |
 
-These are exactly the H-F2 (safety-net erosion) and H-F4 (clarity×protection interaction)
+These are exactly the safety-net hypothesis (safety-net erosion) and authorship-interaction hypothesis (clarity×protection interaction)
 mechanisms the prompt hypothesized — and their effect sizes (7× variance ratio, 0% vs 67%
 EDGE) are far above 5%, so they are detectable at modest N. What is *not* detectable at 4
 tasks is the ±5% blast-radius main effect framed as the headline.
@@ -63,7 +63,7 @@ tasks is the ±5% blast-radius main effect framed as the headline.
    "inconclusive at this scale," and **promote the real effects to primary**: (a) the
    free-vs-frozen *variance/stability* contrast, (b) EDGE collapse under free+vague, (c) the
    test-LOC churn → blast-radius mediation. These are the questions the pilot says are
-   answerable, and they directly settle H-F2/H-F4.
+   answerable, and they directly settle safety-net hypothesis/authorship-interaction hypothesis.
 2. **If the 5% main effect must stay primary, the cost is task count, not trials.** Author
    roughly **20–40 pays-style tasks** (the prompt's "reuse the same 4 tasks" is the binding
    limitation). That is a large authoring effort and a much larger campaign.

--- a/docs/experiments/when-tdd-pays-report.md
+++ b/docs/experiments/when-tdd-pays-report.md
@@ -19,10 +19,10 @@ This experiment crossed **requirement clarity** (clear vs vague spec) with **cod
 
 | Question | Finding |
 |----------|---------|
-| Does TDD produce better edge-case coverage under vague spec? | **No — the opposite.** test-after: 67%, tdd-refactor: 33% (H-A rejected, reversed) |
-| Does TDD produce more changeable code? | **Yes.** tdd-refactor: 664 mean Δlines vs 700–770 for all other arms (H-B confirmed) |
-| Is refactoring the mechanism, or test-first ordering? | **Refactoring.** tdd-no-refactor (701) ≈ test-after (700); removing the refactor step erases the advantage (H-B2 confirmed) |
-| Is TDD's advantage largest under vague spec? | **No.** The gap is consistent across clarity conditions (H-C not confirmed) |
+| Does TDD produce better edge-case coverage under vague spec? | **No — the opposite.** test-after: 67%, tdd-refactor: 33% (ambiguity hypothesis rejected, reversed) |
+| Does TDD produce more changeable code? | **Yes.** tdd-refactor: 664 mean Δlines vs 700–770 for all other arms (changeability hypothesis confirmed) |
+| Is refactoring the mechanism, or test-first ordering? | **Refactoring.** tdd-no-refactor (701) ≈ test-after (700); removing the refactor step erases the advantage (mechanism-isolation hypothesis confirmed) |
+| Is TDD's advantage largest under vague spec? | **No.** The gap is consistent across clarity conditions (clarity-interaction hypothesis not confirmed) |
 | What about vague requirements? | **Fix the spec first.** The notifier task — where the spec omitted per-channel retry semantics — produced 0% on EDGE assertions (behavioural tests for decisions the spec left unstated) for every workflow. No amount of TDD or upfront design recovers information that was never stated. |
 
 ### Workflow decision guide
@@ -58,14 +58,14 @@ This experiment crossed **requirement clarity** (clear vs vague spec) with **cod
 
 **Hypotheses (pre-registered):**
 
-- **H-A (ambiguity):** under `vague`, `tdd-refactor` passes more EDGE (omitted-decision) assertions
+- **ambiguity hypothesis:** under `vague`, `tdd-refactor` passes more EDGE (omitted-decision) assertions
   than `test-after`. Under `clear` there is no gap. Null: vagueness degrades all
   arms equally.
-- **H-B (changeability):** `tdd-refactor` absorbs the 3-change chain at lower
+- **changeability hypothesis:** `tdd-refactor` absorbs the 3-change chain at lower
   cumulative lines-changed than `test-after` and `bduf`.
-- **H-B2 (mechanism):** `tdd-refactor` < `tdd-no-refactor` ≈ `test-after`;
+- **mechanism-isolation hypothesis:** `tdd-refactor` < `tdd-no-refactor` ≈ `test-after`;
   the benefit comes from refactoring, not test ordering.
-- **H-C (interaction):** TDD's advantage is largest in `vague + open-design`
+- **clarity-interaction hypothesis:** TDD's advantage is largest in `vague + open-design`
   — exactly the cell the prior null experiments could not test.
 
 ---
@@ -288,7 +288,7 @@ trap (per-channel retry) shows the largest penalty for naive design.*
 | report-render | 100% (3/3) | 100% (3/3) | 0 |
 | **pooled** | **33%** (4/12) | **67%** (8/12) | **−34 pp** |
 
-**H-A: REJECTED (direction reversed).** Under vague spec, test-after achieves 67%
+**ambiguity hypothesis: REJECTED (direction reversed).** Under vague spec, test-after achieves 67%
 EDGE pass rate vs tdd-refactor's 33% — the opposite of the pre-registered hypothesis.
 
 The null-hypothesis (vagueness degrades all arms equally) is also rejected for pricing
@@ -341,7 +341,7 @@ then write tests that capture its actual behaviour, producing better EDGE covera
 | tdd-no-refactor | 701 | 4 | +37 (+5.6%) |
 | bduf | 770 | 4 | +106 (+16%) |
 
-**H-B: CONFIRMED.** tdd-refactor has the lowest cumulative blast radius across all
+**changeability hypothesis: CONFIRMED.** tdd-refactor has the lowest cumulative blast radius across all
 arms and conditions. The advantage is consistent across all 4 tasks (+1% to +12%)
 and both clarity conditions (clear: −38 lines; vague: −32 lines).
 
@@ -358,7 +358,7 @@ notifier (notifier/bduf/vague mean = 983 lines vs tdd-refactor/clear = 748 lines
 | test-after | 700 | clear + vague |
 | tdd-no-refactor | 701 | vague only |
 
-**H-B2: CONFIRMED.** tdd-no-refactor (701) ≈ test-after (700), both substantially
+**mechanism-isolation hypothesis: CONFIRMED.** tdd-no-refactor (701) ≈ test-after (700), both substantially
 above tdd-refactor (664). Removing the refactoring step from TDD (tdd-no-refactor)
 eliminates the changeability advantage — it performs identically to writing tests
 after the fact.
@@ -387,8 +387,8 @@ The gap is marginally *larger* under clear spec (+39 lines) than vague spec (+32
 There is no interaction: tdd-refactor's changeability advantage is consistent across
 both clarity conditions.
 
-**H-C: NOT CONFIRMED.** The clarity-interaction interaction does not appear for changeability. For
-EDGE pass rate, the interaction is reversed from H-C: under clear spec both arms are
+**clarity-interaction hypothesis: NOT CONFIRMED.** The clarity-interaction interaction does not appear for changeability. For
+EDGE pass rate, the interaction is reversed from clarity-interaction hypothesis: under clear spec both arms are
 equal (100%); under vague spec test-after outperforms tdd-refactor. If anything, the
 clarity × workflow interaction favours test-after, not tdd-refactor.
 
@@ -469,12 +469,12 @@ real decisions unstated, and a multi-stage change chain that punishes rigid desi
 
 | Hypothesis | Direction | Result |
 |------------|-----------|--------|
-| H-A: TDD passes more EDGE under vague | tdd-refactor > test-after | **REJECTED — reversed** (test-after 67% vs tdd-refactor 33%) |
-| H-B: TDD has lower cumulative blast radius | tdd-refactor < all others | **CONFIRMED** (664 vs 700–770) |
-| H-B2: Refactoring is the mechanism | tdd-no-refactor ≈ test-after | **CONFIRMED** (701 vs 700) |
-| H-C: Advantage largest under vague | gap larger at vague | **NOT CONFIRMED** (gap similar, slightly larger at clear) |
+| ambiguity hypothesis: TDD passes more EDGE under vague | tdd-refactor > test-after | **REJECTED — reversed** (test-after 67% vs tdd-refactor 33%) |
+| changeability hypothesis: TDD has lower cumulative blast radius | tdd-refactor < all others | **CONFIRMED** (664 vs 700–770) |
+| mechanism-isolation hypothesis: Refactoring is the mechanism | tdd-no-refactor ≈ test-after | **CONFIRMED** (701 vs 700) |
+| clarity-interaction hypothesis: Advantage largest under vague | gap larger at vague | **NOT CONFIRMED** (gap similar, slightly larger at clear) |
 
-### The H-A reversal: why test-after wins on EDGE under vague spec
+### The ambiguity hypothesis reversal: why test-after wins on EDGE under vague spec
 
 The pre-registered hypothesis assumed that TDD's red-test cycle would force explicit
 edge-case decisions early, producing better contract inference under ambiguity.
@@ -508,11 +508,11 @@ but tdd-no-refactor writes them *before* seeing a working system — and under a
 spec, those early tests do not constrain the design enough to produce a valid
 implementation. The order of seeing-code-then-writing-tests appears protective.
 
-### The H-B/H-B2 result: refactoring is the changeability driver
+### The changeability hypothesis/mechanism-isolation hypothesis result: refactoring is the changeability driver
 
 tdd-no-refactor (701) ≈ test-after (700) > tdd-refactor (664) confirms that the
 green→refactor cycle — not test-first ordering — drives the changeability advantage.
-This replicates the H-B finding from the prior studies while adding the mechanistic
+This replicates the changeability hypothesis finding from the prior studies while adding the mechanistic
 isolation that those studies could not provide.
 
 The practical implication: teams who do test-first without disciplined refactoring get
@@ -671,9 +671,9 @@ The first run could not answer two questions because the relevant arms were miss
 | New primary: test-after-refactor Condition 3 | Cost/stage: test-after-refactor < tdd-refactor |
 | New primary: spec-synthesis | ship EDGE under vague ≥ tdd-refactor EDGE under vague |
 
-**H-D:** under `vague`, `ship` EDGE pass rate ≥ `tdd-refactor` because `/specs` forces the agent to state every acceptance decision before any code is written. Null: `/specs` makes the same happy-path assumptions as any other arm — spec synthesis from a vague prompt does not reliably surface EDGE decisions.
+**spec-synthesis hypothesis:** under `vague`, `ship` EDGE pass rate ≥ `tdd-refactor` because `/specs` forces the agent to state every acceptance decision before any code is written. Null: `/specs` makes the same happy-path assumptions as any other arm — spec synthesis from a vague prompt does not reliably surface EDGE decisions.
 
-**H-E:** `test-after-refactor` dominates every existing arm simultaneously: EDGE ≥ `test-after` (deferred tests capture actual contract), blast radius ≈ `tdd-refactor` (refactoring under tests provides same structural safety net), cost < `tdd-refactor` (no iterative red-green cycles during initial build). All three conditions must hold. Null: the refactor phase changes the implementation enough that post-refactor tests diverge, or the iterative TDD cycle shapes design in ways a post-implementation refactor cannot replicate.
+**dominance hypothesis:** `test-after-refactor` dominates every existing arm simultaneously: EDGE ≥ `test-after` (deferred tests capture actual contract), blast radius ≈ `tdd-refactor` (refactoring under tests provides same structural safety net), cost < `tdd-refactor` (no iterative red-green cycles during initial build). All three conditions must hold. Null: the refactor phase changes the implementation enough that post-refactor tests diverge, or the iterative TDD cycle shapes design in ways a post-implementation refactor cannot replicate.
 
 ### Second-run design matrix
 
@@ -728,7 +728,7 @@ Based on the first-run evidence (see experiment document, "Best path forward" se
 | ship EDGE / vague | ≥ tdd-refactor (33%) — explicit spec synthesis forces unstated decisions |
 | ship changeability | ≤ tdd-refactor (664) — inline review checkpoints in /build catch structural issues |
 
-**H-E falsification criteria:** If test-after-refactor blast radius exceeds tdd-refactor by ≥10%, the iterative TDD cycle shapes design in ways a post-implementation refactor cannot replicate, and tdd-refactor remains the correct choice for open-design tasks despite its higher cost.
+**dominance hypothesis falsification criteria:** If test-after-refactor blast radius exceeds tdd-refactor by ≥10%, the iterative TDD cycle shapes design in ways a post-implementation refactor cannot replicate, and tdd-refactor remains the correct choice for open-design tasks despite its higher cost.
 
 ---
 
@@ -739,7 +739,7 @@ Based on the first-run evidence (see experiment document, "Best path forward" se
 
 ### spec-synthesis: Ship arm vs tdd-refactor
 
-**Hypothesis H-D:** `ship` EDGE pass rate under vague ≥ `tdd-refactor`
+**Hypothesis spec-synthesis hypothesis:** `ship` EDGE pass rate under vague ≥ `tdd-refactor`
 
 > **Execution note (2026-06-24).** The automated harness recorded every `ship` trial
 > as a 900-second CCR dispatch timeout, leaving only synthesized-failure placeholder
@@ -759,7 +759,7 @@ Based on the first-run evidence (see experiment document, "Best path forward" se
 
 **Pooled EDGE: ship 25% (3/12) vs tdd-refactor 33% (4/12)**
 
-**Verdict: H-D REJECTED (null supported).** Run to completion, the `ship` pipeline's
+**Verdict: spec-synthesis hypothesis REJECTED (null supported).** Run to completion, the `ship` pipeline's
 explicit `/specs` acceptance-criteria synthesis did **not** surface omitted edge
 decisions better than `tdd-refactor`'s failing-test-as-specification approach — 25% vs
 33% pooled EDGE, with ship matching or trailing tdd-refactor on every task. The
@@ -826,7 +826,7 @@ is not a substitute for clarifying a vague spec with the stakeholder.
 
 ### test-after-refactor: test-after-refactor dominance
 
-**Hypothesis H-E:** `test-after-refactor` dominates all existing arms simultaneously on EDGE pass rate (≥ test-after), blast radius (within 10% of tdd-refactor), and cost (< tdd-refactor). All three conditions must hold.
+**Hypothesis dominance hypothesis:** `test-after-refactor` dominates all existing arms simultaneously on EDGE pass rate (≥ test-after), blast radius (within 10% of tdd-refactor), and cost (< tdd-refactor). All three conditions must hold.
 
 #### Condition 1: EDGE pass rate under vague (test-after-refactor ≥ test-after, −5 pp tolerance)
 
@@ -869,7 +869,7 @@ TDD vs test-after:
 Both refactor arms (664, 678) sit ~5–6% below both non-refactor arms (700, 701), and
 adding a refactor pass to test-after moved it 700 → 678, into the same band as
 tdd-refactor. Test-first ordering does not separate from test-after *once both refactor*.
-The headline H-B2 finding — the green→refactor cycle, not test ordering, drives
+The headline mechanism-isolation hypothesis finding — the green→refactor cycle, not test ordering, drives
 changeability — holds, and the refactor-arm tie is a second confirmation of it.
 
 The residual 14 lines, *if* it is real rather than noise, has two candidate explanations,
@@ -900,9 +900,9 @@ mechanisms, requires a dedicated higher-power experiment — see
 
 **Condition 3 HOLDS** — test-after-refactor ($0.35/stage) is 20% cheaper than tdd-refactor ($0.44/stage).
 
-#### H-E Overall Verdict
+#### dominance hypothesis Overall Verdict
 
-**H-E NOT SUPPORTED.** Condition 1 fails decisively: under a vague spec, `test-after-refactor` produces 0% EDGE pass rate (pooled across 3 of 4 tasks), worse than both `test-after` (67%) and `tdd-refactor` (33%). The refactoring phase degrades edge-case coverage when the spec is ambiguous — the agent refactors away the tests that document its own decisions.
+**dominance hypothesis NOT SUPPORTED.** Condition 1 fails decisively: under a vague spec, `test-after-refactor` produces 0% EDGE pass rate (pooled across 3 of 4 tasks), worse than both `test-after` (67%) and `tdd-refactor` (33%). The refactoring phase degrades edge-case coverage when the spec is ambiguous — the agent refactors away the tests that document its own decisions.
 
 Conditions 2 and 3 both hold: the blast radius is equivalent to tdd-refactor (+2.1%) and the cost is 20% lower. But the EDGE failure dominates.
 
@@ -936,19 +936,19 @@ changeability at n=3 — the 14-line gap is inside the noise. Two questions rema
 
 ### Hypotheses (to pre-register before any data)
 
-- **H-F0 (equivalence):** continuous-refactor and one-shot-refactor workflows are
+- **equivalence hypothesis:** continuous-refactor and one-shot-refactor workflows are
   equivalent on cumulative blast radius within a ±5% margin (TOST). This is the default
   the second-run data points to; the experiment is powered to *reject* it if a real
   effect exists.
-- **H-F1 (granularity):** holding the test-protection factor constant, **continuous**
+- **granularity hypothesis:** holding the test-protection factor constant, **continuous**
   refactoring yields lower blast radius than **one-shot** refactoring. Predicts the gap
   survives even when tests are protected from churn.
-- **H-F2 (safety net):** **freezing the test suite during the refactor** raises EDGE pass
+- **safety-net hypothesis:** **freezing the test suite during the refactor** raises EDGE pass
   rate (tests that document edge decisions survive) and lowers subsequent blast radius
   relative to a free refactor. Predicts test-suite churn *mediates* the blast-radius
   difference.
 
-H-F1 and H-F2 are not mutually exclusive; the design separates their contributions.
+granularity hypothesis and safety-net hypothesis are not mutually exclusive; the design separates their contributions.
 
 ### Design — a 2×2, adequately powered
 
@@ -974,7 +974,7 @@ pass-rates; add:
 - **refactor granularity (actual):** count of distinct refactor edits between first-green
   and stage-complete — verifies the assigned arm behaved as intended.
 - **test-suite churn during refactor:** test LOC added + deleted between first-green and
-  post-refactor. This is the mediator variable for H-F2.
+  post-refactor. This is the mediator variable for safety-net hypothesis.
 - carry forward CORE/EDGE pass rates and cost/stage.
 
 ### Analysis plan (pre-registered)
@@ -982,9 +982,9 @@ pass-rates; add:
 - **Headline:** TOST equivalence test on cumulative blast radius, continuous vs one-shot,
   ±5% margin → resolves question 1 (real vs noise) directly, including a "confirmed
   equivalent" outcome as a valid result.
-- **H-F1:** two-factor model on blast radius; granularity main effect with test-protection
+- **granularity hypothesis:** two-factor model on blast radius; granularity main effect with test-protection
   held constant.
-- **H-F2:** mediation — does test-suite churn account for the granularity/protection effect
+- **safety-net hypothesis:** mediation — does test-suite churn account for the granularity/protection effect
   on blast radius? Plus the direct EDGE comparison frozen vs free (this also re-tests the
   test-after-refactor Condition 1 finding that free refactor destroys edge coverage under vague spec).
 
@@ -994,7 +994,7 @@ pass-rates; add:
 |---|---|
 | TOST confirms equivalence | The refactor-arm tie is real; "refactoring is the mechanism" is the whole story, and *how* you refactor (granularity, ordering) does not move changeability. Strongest, simplest takeaway. |
 | Granularity effect, no churn mediation | Continuous refactoring is independently better; recommend refactoring in small steps regardless of test ordering. |
-| Churn mediation (H-F2) | The cost of one-shot refactor is collateral test-suite damage; recommend protecting/regenerating the test suite across a refactor, and the test-after-refactor EDGE collapse and the changeability residual share one root cause. |
+| Churn mediation (safety-net hypothesis) | The cost of one-shot refactor is collateral test-suite damage; recommend protecting/regenerating the test suite across a refactor, and the test-after-refactor EDGE collapse and the changeability residual share one root cause. |
 
 A null here is a publishable result: confirming that the two refactor workflows are
 genuinely interchangeable on changeability would let teams choose between them on the axes

--- a/scripts/analyze_tdd_pays.py
+++ b/scripts/analyze_tdd_pays.py
@@ -356,9 +356,9 @@ def rq_d_verdict(rows: list[dict]) -> str:
         avg_tdd = mean(tdd_rates)
         delta = avg_ship - avg_tdd
         verdict = (
-            "ship > tdd-refactor (H-D supported)" if delta > 0.05 else
+            "ship > tdd-refactor (spec-synthesis hypothesis supported)" if delta > 0.05 else
             "ship ≈ tdd-refactor" if abs(delta) <= 0.05 else
-            "ship < tdd-refactor (H-D rejected)"
+            "ship < tdd-refactor (spec-synthesis hypothesis rejected)"
         )
         lines.append(
             f"\n**Pooled EDGE**: ship {fmt_pct(avg_ship)} vs "
@@ -381,7 +381,7 @@ def rq_d_verdict(rows: list[dict]) -> str:
             f"ship blast radius {fmt_f(mean(ship_cum),0)} vs "
             f"tdd-refactor {fmt_f(mean(tdd_cum),0)} "
             f"(Δ={fmt_f(delta_lines,0)} lines, "
-            f"{'H-D2 supported: ship ≤ tdd-refactor' if delta_lines <= 10 else 'ship > tdd-refactor'})"
+            f"{'spec-synthesis-changeability hypothesis supported: ship ≤ tdd-refactor' if delta_lines <= 10 else 'ship > tdd-refactor'})"
         )
         lines.append(f"\n**spec-synthesis2 (changeability)**: {verdict2}")
 
@@ -400,8 +400,8 @@ def rq_e_verdict(rows: list[dict]) -> str:
             continue
         edge_cells[(r["task"], arm)].append(r.get("edge_passed", False))
 
-    lines = ["#### test-after-refactor: test-after-refactor dominance (H-E)\n"]
-    lines.append("All three conditions must hold to declare H-E supported.\n")
+    lines = ["#### test-after-refactor: test-after-refactor dominance (dominance hypothesis)\n"]
+    lines.append("All three conditions must hold to declare dominance hypothesis supported.\n")
 
     lines.append("**Condition 1: EDGE pass rate (stage0, vague)**\n")
     lines.append("| task | test-after-refactor | test-after | tdd-refactor | tar≥ta? |")
@@ -501,11 +501,11 @@ def rq_e_verdict(rows: list[dict]) -> str:
     lines.append("\n**test-after-refactor overall verdict:**")
     if c1 is not None and c2 is not None and c3 is not None:
         if c1 and c2 and c3:
-            lines.append("**H-E SUPPORTED** — test-after-refactor dominates all existing arms simultaneously.")
+            lines.append("**dominance hypothesis SUPPORTED** — test-after-refactor dominates all existing arms simultaneously.")
         else:
             failed = [f"Condition {i+1}" for i, c in enumerate([c1, c2, c3]) if not c]
             lines.append(
-                f"**H-E NOT SUPPORTED** — {', '.join(failed)} fail. "
+                f"**dominance hypothesis NOT SUPPORTED** — {', '.join(failed)} fail. "
                 "test-after-refactor does not dominate all existing arms."
             )
     else:


### PR DESCRIPTION
## What this does

Two follow-ups to the refactoring-cadence experiment (#444):

### 1. Rename every opaque `RQ-*` / `H-*` label to a descriptive name

The lettered research-question and hypothesis labels (`RQ-A`, `H-F2`, …) hid their meaning behind an acronym. Every one is now a descriptive slug across the experiment corpus:

| was | now |
|---|---|
| RQ-A / H-A | `ambiguity-inference` / `ambiguity hypothesis` |
| RQ-B / H-B | `changeability` / `changeability hypothesis` |
| RQ-B2 / H-B2 | `refactoring-vs-ordering` / `mechanism-isolation hypothesis` |
| RQ-C / H-C | `clarity-interaction` |
| RQ-D / H-D | `spec-synthesis` |
| RQ-E / H-E | `test-after-refactor` / `dominance hypothesis` |
| RQ-F / H-F0–F4 | `refactoring-cadence` / equivalence · granularity · safety-net · authorship · authorship-interaction hypotheses |

No `RQ-<letter>` or `H-<letter>` label remains anywhere; the one touched script (`analyze_tdd_pays.py`, output strings only) still parses. (The earlier `RQ-*` pass already landed in #444; this completes the `H-*` set and the prose.)

### 2. Spec the larger follow-up run (specified, not executed)

`docs/experiments/experiment-prompt-refactor-cadence-larger.md` — the follow-up the first run's report recommends, fixing its three limitations:

- **Larger multi-file tasks** (3–5 modules behind a public API) so structure matters and the quality sensors don't saturate.
- **Longer change horizon** (8 changes) so a cleanup can pay back over later changes.
- **Held-out "probe" changes** applied with refactoring *disabled* to every arm — the clean changeability outcome the first run lacked — plus **blast decomposed into change-churn vs refactor-churn**, so refactoring's cost is never confused with its benefit.
- **12–16 tasks** for adequate power (the unit of inference is the task).

It keeps the validated tests-frozen invariant and the granularity × authorship design.

## Notes for review

- Touches 5 `.md` files + label strings in one experiment script — `docs:` (no release-please bump). Auto-merge not armed.
- Branch is based on current `main`, so the prompt-semver gate that bit #444 won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpBfyHM2YC7kByAYWTFJ5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpBfyHM2YC7kByAYWTFJ5s)_