### PR TITLE
perf: reduce CI wall-clock — --changed-only flag + GHA dependency caching

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -51,6 +51,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Restore the apt download cache so a warm run skips re-fetching the .deb
+      # archives. apt-get update still refreshes the lists. (Issue #467.)
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+
       - name: Install bats + jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
 

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -5,11 +5,31 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel superseded runs on the same PR or ref so rapid pushes don't stack
+# redundant CI (mirrors the concurrency block already in agent-eval.yml).
+concurrency:
+  group: plugin-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shell-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      # Restore the apt download cache so a warm run skips re-fetching the .deb
+      # archives. apt-get update still refreshes the package lists; only the
+      # downloads are served from cache. Keyed on the workflow files + OS so a
+      # workflow edit invalidates it. (Issue #467.)
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
 
       - name: Install shellcheck + jq
         run: sudo apt-get update && sudo apt-get install -y shellcheck jq
@@ -35,6 +55,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
 
       - name: Install bats + jq
         # Across-file parallelism comes from scripts/run-bats-parallel.sh
@@ -92,6 +122,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+
       - name: Install python3 + jq
         run: sudo apt-get update && sudo apt-get install -y jq python3
 
@@ -131,6 +171,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Restore pip's wheel/download cache so a warm run reinstalls semgrep from
+      # cache instead of re-downloading it. Keyed on the workflow files + OS.
+      # (Issue #467.)
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install semgrep + pyyaml
         run: pip install --quiet semgrep pyyaml
 
@@ -149,6 +200,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Install harness runtime dependency (httpx)
         run: pip install --quiet httpx

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -6,11 +6,17 @@
 # agent-eval is NOT here — it is opt-in and lives in scripts/eval-changed.sh.
 #
 # Usage:
-#   bash scripts/ci-local.sh [BASE HEAD]
+#   bash scripts/ci-local.sh [--changed-only] [BASE HEAD]
 #
 # BASE/HEAD (optional) enable the eval-corpus semver-contract check, which needs
 # a commit range (the pre-push hook passes the push range). Without them that one
 # check is skipped; everything else always runs.
+#
+# --changed-only (optional, developer convenience) skips any suite whose watched
+# paths have no changed files in `git diff`, logging each skip. It is NEVER the
+# default and the pre-push hook does not pass it. The changed-file set is the
+# BASE..HEAD range when supplied, otherwise the working tree vs HEAD plus
+# untracked files. If `git diff` fails or the set is empty, all suites run.
 #
 # Parallelism: the independent gates run concurrently in a bounded pool capped at
 # the core count (portable across Linux + macOS, no bash-4 features). Output is
@@ -25,6 +31,20 @@
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)" || exit 2
+
+# --- argument parsing ------------------------------------------------------
+# --changed-only is a position-independent flag; BASE/HEAD are positional and
+# keep their existing meaning so the pre-push hook's `ci-local.sh BASE HEAD`
+# invocation is unaffected.
+CHANGED_ONLY=0
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    --changed-only) CHANGED_ONLY=1 ;;
+    *) positional+=("$arg") ;;
+  esac
+done
+set -- ${positional[@]+"${positional[@]}"}
 
 BASE="${1:-}"
 HEAD="${2:-}"
@@ -75,6 +95,31 @@ case "$JOBS" in ''|*[!0-9]*) JOBS=2 ;; esac
 # bats files are fanned across cores by scripts/run-bats-parallel.sh (xargs -P),
 # which needs no GNU `parallel` package — portable on every macOS + Linux box.
 run_bats() { bash scripts/run-bats-parallel.sh -j "$JOBS" "$@"; }
+
+# --- --changed-only resolution ---------------------------------------------
+# Source the suite->path mapping + matcher (pure logic, unit-tested separately),
+# then resolve the changed-file set once. Any failure or an empty set disables
+# the flag so all suites run — the safe direction.
+CHANGED_LIST=""
+if [ "$CHANGED_ONLY" = "1" ]; then
+  # shellcheck source=scripts/lib/ci-changed-only.sh
+  . scripts/lib/ci-changed-only.sh
+  get_changed_files() {
+    if [ -n "$BASE" ] && [ -n "$HEAD" ]; then
+      git diff --name-only "$BASE" "$HEAD"
+    else
+      git diff --name-only HEAD || return 1
+      git ls-files --others --exclude-standard
+    fi
+  }
+  if CHANGED_LIST="$(get_changed_files 2>/dev/null)" && [ -n "$CHANGED_LIST" ]; then
+    : # changed set resolved; honor --changed-only
+  else
+    printf '%s∼ --changed-only: no usable git diff (failed or empty) — running all suites%s\n' \
+      "$yellow" "$reset"
+    CHANGED_ONLY=0
+  fi
+fi
 
 # --- check definitions -----------------------------------------------------
 # Each gate is a function returning its exit code. They are dispatched
@@ -140,6 +185,14 @@ pids=()
 idx=0
 for entry in "${CHECKS[@]}"; do
   fn="${entry##*::}"
+  # --changed-only: skip suites whose watched paths saw no change. Record the
+  # skip as a passing result so the aggregation below logs it in declared order.
+  if [ "$CHANGED_ONLY" = "1" ] && ! ci_suite_has_changes "$fn" "$CHANGED_LIST"; then
+    printf '%s∼ skipped (no relevant changes)%s\n' "$yellow" "$reset" >"$RUNDIR/$idx.out"
+    echo 0 >"$RUNDIR/$idx.rc"
+    idx=$((idx + 1))
+    continue
+  fi
   ( "$fn" >"$RUNDIR/$idx.out" 2>&1; echo $? >"$RUNDIR/$idx.rc" ) &
   pids+=("$!")
   idx=$((idx + 1))

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -104,17 +104,19 @@ CHANGED_LIST=""
 if [ "$CHANGED_ONLY" = "1" ]; then
   # shellcheck source=scripts/lib/ci-changed-only.sh
   . scripts/lib/ci-changed-only.sh
+  # The trailing `--` ends option parsing so a BASE/HEAD value beginning with
+  # `-` can't be misread as a git flag (defense-in-depth; matches the sibling
+  # eval_semver_classify.sh).
   get_changed_files() {
     if [ -n "$BASE" ] && [ -n "$HEAD" ]; then
-      git diff --name-only "$BASE" "$HEAD"
+      git diff --name-only "$BASE" "$HEAD" --
     else
-      git diff --name-only HEAD || return 1
+      git diff --name-only HEAD -- || return 1
       git ls-files --others --exclude-standard
     fi
   }
-  if CHANGED_LIST="$(get_changed_files 2>/dev/null)" && [ -n "$CHANGED_LIST" ]; then
-    : # changed set resolved; honor --changed-only
-  else
+  # Guard: any failure or an empty changeset disables the flag so all suites run.
+  if ! CHANGED_LIST="$(get_changed_files 2>/dev/null)" || [ -z "$CHANGED_LIST" ]; then
     printf '%s∼ --changed-only: no usable git diff (failed or empty) — running all suites%s\n' \
       "$yellow" "$reset"
     CHANGED_ONLY=0

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -28,6 +28,7 @@ ci_watched_paths() {
     chk_citation_lint)      printf '%s' "plugins/dev-team/ evals/ scripts/citation_lint.py" ;;
     chk_eval_semver)        printf '%s' "evals/" ;;
     chk_eslint)             printf '%s' "plugins/dev-team/ *.js *.ts *.json" ;;
+    chk_oe_staleness)       printf '%s' "" ;;  # advisory; intentionally always-run (no stable watched path)
     *)                      printf '%s' "" ;;
   esac
 }

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ci-changed-only.sh — suite -> watched-path mapping and change-matching helpers
+# for ci-local.sh's --changed-only flag. SOURCED, not executed.
+#
+# The git interaction (resolving the changed-file set) stays in ci-local.sh; this
+# file holds only the pure mapping + matching logic so it is unit-testable
+# (tests/scripts/ci_changed_only_tests.bats) without a contrived git history.
+#
+# bash 3.2 safe: the mapping is a case statement, not an associative array.
+
+# ci_watched_paths <check-fn-name>
+# Echoes the space-separated paths a check watches. Entry shapes:
+#   - trailing slash ("tests/repo/")  -> directory prefix
+#   - contains '*'   ("*.js")          -> glob (matched against the full path)
+#   - anything else  ("scripts/x.sh")  -> exact file path
+# An unmapped check echoes nothing; callers treat empty as "always run", so a
+# new check is never silently skipped just because no mapping was added for it.
+ci_watched_paths() {
+  case "$1" in
+    chk_shellcheck_helpers) printf '%s' "plugins/security-assessment/scripts/" ;;
+    chk_shellcheck_tests)   printf '%s' "tests/security-assessment/scripts/" ;;
+    chk_sa_shell_suite)     printf '%s' "plugins/security-assessment/ tests/security-assessment/" ;;
+    chk_bats_repo)          printf '%s' "tests/repo/ plugins/dev-team/" ;;
+    chk_bats_content_rest)  printf '%s' "tests/knowledge/ tests/agents/ tests/commands/ tests/docs/ tests/scripts/ plugins/dev-team/" ;;
+    chk_model_routing)      printf '%s' "tests/hooks/ plugins/dev-team/hooks/" ;;
+    chk_cost_regression)    printf '%s' "scripts/cost-regression-check.sh scripts/session_extract.py" ;;
+    chk_eval_corpus)        printf '%s' "evals/ scripts/eval_grade.py scripts/eval_graders/" ;;
+    chk_citation_lint)      printf '%s' "plugins/dev-team/ evals/ scripts/citation_lint.py" ;;
+    chk_eval_semver)        printf '%s' "evals/" ;;
+    chk_eslint)             printf '%s' "plugins/dev-team/ *.js *.ts *.json" ;;
+    *)                      printf '%s' "" ;;
+  esac
+}
+
+# ci_suite_has_changes <check-fn-name> <changed-files>
+# <changed-files> is a whitespace-separated list of changed paths.
+# Returns 0 (run the suite) when the suite is unmapped, or when any watched path
+# matches a changed file. Returns 1 (skippable) otherwise.
+ci_suite_has_changes() {
+  local fn="$1"
+  local changed="$2"
+  local paths
+  paths="$(ci_watched_paths "$fn")"
+  [ -z "$paths" ] && return 0
+
+  # Disable pathname expansion while splitting watched paths: a glob entry like
+  # '*.js' must be matched against the changed-file list (the case below), never
+  # expanded against the working directory. set -f does not affect case-pattern
+  # matching, so the glob still matches there. Restore the prior state on exit.
+  local had_noglob=0
+  case "$-" in *f*) had_noglob=1 ;; *) set -f ;; esac
+
+  local rc=1 p f
+  for p in $paths; do
+    for f in $changed; do
+      # $p is intentionally used as a glob pattern in the inner case below.
+      # shellcheck disable=SC2254
+      case "$p" in
+        */)    case "$f" in "$p"*) rc=0 ;; esac ;;
+        *'*'*) case "$f" in $p) rc=0 ;; esac ;;
+        *)     [ "$f" = "$p" ] && rc=0 ;;
+      esac
+      [ "$rc" -eq 0 ] && break 2
+    done
+  done
+
+  [ "$had_noglob" -eq 1 ] || set +f
+  return "$rc"
+}

--- a/tests/scripts/ci_changed_only_tests.bats
+++ b/tests/scripts/ci_changed_only_tests.bats
@@ -60,9 +60,31 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "glob path: a non-matching extension under no watched dir is skipped" {
+@test "glob path: a file outside every watched path is skipped" {
   run ci_suite_has_changes chk_eslint "README.md"
   [ "$status" -eq 1 ]
+}
+
+@test "glob path: the eslint dir-prefix arm matches a non-JS file under it" {
+  run ci_suite_has_changes chk_eslint "plugins/dev-team/skills/foo/SKILL.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "glob path: the *.json arm matches a manifest change" {
+  run ci_suite_has_changes chk_eslint "plugins/dev-team/.claude-plugin/plugin.json"
+  [ "$status" -eq 0 ]
+}
+
+# Proves the set -f (noglob) guard is load-bearing: with real *.js files present
+# in the working directory, an unquoted '*.js' watched entry would otherwise
+# expand against the filesystem and stop matching the changed path. The matcher
+# must still match 'app.js' (which does NOT exist on disk) via the glob.
+@test "glob match is filesystem-independent (noglob guard)" {
+  local d; d="$(mktemp -d)"
+  : > "$d/decoy.js"
+  run bash -c 'cd "$1" && . "$2" && ci_suite_has_changes chk_eslint "app.js"' _ "$d" "$LIB"
+  rm -rf "$d"
+  [ "$status" -eq 0 ]
 }
 
 # --- unmapped suites always run (conservative fallback) -------------------
@@ -70,6 +92,20 @@ setup() {
 @test "unmapped suite always runs (never silently skipped)" {
   run ci_suite_has_changes chk_oe_staleness "anything.txt"
   [ "$status" -eq 0 ]
+}
+
+@test "unmapped suite runs even with an empty changeset" {
+  run ci_suite_has_changes chk_oe_staleness ""
+  [ "$status" -eq 0 ]
+}
+
+# Pin the mapping table itself, independent of the matcher, so a misspelled or
+# dropped suite key is caught directly (not just as a silent always-run).
+@test "ci_watched_paths pins representative suite mappings" {
+  [[ "$(ci_watched_paths chk_bats_repo)" == *"tests/repo/"* ]]
+  [[ "$(ci_watched_paths chk_cost_regression)" == *"scripts/cost-regression-check.sh"* ]]
+  [[ "$(ci_watched_paths chk_eslint)" == *"*.js"* ]]
+  [ -z "$(ci_watched_paths chk_oe_staleness)" ]
 }
 
 # --- multi-file changesets -------------------------------------------------

--- a/tests/scripts/ci_changed_only_tests.bats
+++ b/tests/scripts/ci_changed_only_tests.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# ci-changed-only.sh — the suite->watched-path mapping and change-matching logic
+# behind ci-local.sh's --changed-only flag. The git interaction stays in
+# ci-local.sh; the pure matching logic lives here so it is unit-testable without
+# a contrived git history. These tests pin the match contract: directory
+# prefixes, exact files, globs, unmapped (always-run) suites, and multi-file
+# changesets.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+LIB="$REPO_ROOT/scripts/lib/ci-changed-only.sh"
+
+setup() {
+  # shellcheck source=/dev/null
+  source "$LIB"
+}
+
+@test "lib sources cleanly and exposes the matcher" {
+  type ci_suite_has_changes
+  type ci_watched_paths
+}
+
+# --- directory-prefix watched paths ---------------------------------------
+
+@test "dir-prefix path: a change under the directory runs the suite" {
+  run ci_suite_has_changes chk_bats_repo "tests/repo/foo_tests.bats"
+  [ "$status" -eq 0 ]
+}
+
+@test "dir-prefix path: a change outside every watched dir is skipped" {
+  run ci_suite_has_changes chk_bats_repo "scripts/eval_grade.py"
+  [ "$status" -eq 1 ]
+}
+
+@test "dir-prefix path: any one of several watched dirs matching runs it" {
+  run ci_suite_has_changes chk_bats_content_rest "tests/docs/some_doc_test.bats"
+  [ "$status" -eq 0 ]
+}
+
+# --- exact-file watched paths ---------------------------------------------
+
+@test "exact-file path: the named file matches" {
+  run ci_suite_has_changes chk_cost_regression "scripts/cost-regression-check.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "exact-file path: a different file in the same dir does not match" {
+  run ci_suite_has_changes chk_cost_regression "scripts/other-script.sh"
+  [ "$status" -eq 1 ]
+}
+
+# --- glob watched paths ----------------------------------------------------
+
+@test "glob path: a .js file anywhere matches the eslint suite" {
+  run ci_suite_has_changes chk_eslint "some/nested/dir/app.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "glob path: a .ts file matches the eslint suite" {
+  run ci_suite_has_changes chk_eslint "pkg/index.ts"
+  [ "$status" -eq 0 ]
+}
+
+@test "glob path: a non-matching extension under no watched dir is skipped" {
+  run ci_suite_has_changes chk_eslint "README.md"
+  [ "$status" -eq 1 ]
+}
+
+# --- unmapped suites always run (conservative fallback) -------------------
+
+@test "unmapped suite always runs (never silently skipped)" {
+  run ci_suite_has_changes chk_oe_staleness "anything.txt"
+  [ "$status" -eq 0 ]
+}
+
+# --- multi-file changesets -------------------------------------------------
+
+@test "multi-file changeset: one matching file is enough to run" {
+  run ci_suite_has_changes chk_model_routing "README.md plugins/dev-team/hooks/agent-model-resolve.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "multi-file changeset: no matching file skips" {
+  run ci_suite_has_changes chk_model_routing "README.md docs/notes.md"
+  [ "$status" -eq 1 ]
+}
+
+# --- empty changeset -------------------------------------------------------
+
+@test "empty changeset skips a mapped suite" {
+  run ci_suite_has_changes chk_bats_repo ""
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Closes #467.

Reduces feedback time for local pre-push CI and GitHub Actions PR runs without weakening any check or renaming any required status check.

## What changed

### Slice 1 — `concurrency:` on `plugin-tests.yml`
Cancels superseded runs on the same PR/ref so rapid pushes don't stack redundant CI (mirrors the block already in `agent-eval.yml`).

### Slice 2 — `--changed-only` flag for `scripts/ci-local.sh`
Opt-in, developer-convenience flag that skips any suite whose watched paths have no changed files in `git diff`, logging each skip (`∼ skipped (no relevant changes)`). **Never the default**; the pre-push hook's `[BASE HEAD]` invocation is unaffected. Falls back to running all suites when `git diff` fails or the changeset is empty.

The suite→watched-path mapping and pure match logic live in a sourced helper (`scripts/lib/ci-changed-only.sh`) so they're unit-testable without a contrived git history. `bash` 3.2 safe (no associative arrays / `mapfile` / `wait -n`).

### Slices 3 & 4 — dependency caching
- **apt** download cache (`/var/cache/apt/archives` + `/var/lib/apt/lists`) on `shell-tests`, `bats-tests`, `cost-regression` (plugin-tests.yml) and `structural-gate` (agent-eval.yml). `apt-get update` still refreshes lists; only downloads are served from cache.
- **pip** cache (`~/.cache/pip`) on `semgrep-fixtures` and `harness-smoke`.

> **Spec reconciliation:** the issue's slice-3 list mentions pip caching for `structural-gate`, but that job installs via apt (`bats`/`jq`), not pip — so it gets the **apt** cache (consistent with the issue's apt-caching design note, which lists `structural-gate`). No job uses both.

## Acceptance criteria
**Local CI** — `--changed-only` runs clean; mapped suites with no relevant changes skip and log; matching suites run; without the flag all suites run as today; empty/failed `git diff` → run all; `[BASE HEAD]` unaffected; shellcheck clean; bats green. ✅
**GitHub Actions** — `concurrency:` added; pip restore on `semgrep-fixtures`/`harness-smoke`; apt restore on `shell-tests`/`bats-tests` (+`cost-regression`,`structural-gate`); all five required `plugin-tests` job names unchanged; no test removed. ✅
**Observable improvement** — warm-cache runs reuse downloads; a single-suite `--changed-only` run skips the rest (verified below). ✅

## Verification evidence
- `bats tests/scripts/ci_changed_only_tests.bats` → **18 passing** (dir-prefix, exact-file, glob, unmapped always-run, multi-file, empty changeset, a test proving the `set -f` noglob guard is load-bearing, direct mapping assertions).
- `shellcheck -x --severity=warning scripts/ci-local.sh scripts/lib/ci-changed-only.sh` → clean.
- `tests/scripts/` (140 ok) and repo shipped-script-ref invariants → green (no regressions).
- Integration run of `ci-local.sh --changed-only <docs-only range>` → 11 mapped suites skipped, advisory always-run suite ran, exit 0.
- Both workflow YAMLs parse; job-name set unchanged.

## Review
Ran security / structure / test-quality review agents over the diff; applied the actionable findings (git `--` end-of-options separator, guard-clause flattening, explicit unmapped-suite sentinel, and the noglob-proving + coverage-gap tests). Suggestions that contradicted the approved spec (the `*.json` eslint glob, the `**/*.yml` cache key) were left as-specified.

## Merge
Touches CI workflows + a shell script (not docs-only), so per the repo rule this requires **explicit human merge** — auto-merge intentionally **not** armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqvbdFUistPpEtiMDEZ5XV)_