### PR TITLE
feat: create bdd-frameworks.md knowledge reference for per-language BDD wire-in

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/bdd-frameworks.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/bdd-frameworks.md
@@ -1,0 +1,164 @@
+# BDD Frameworks — per-language wire-in
+
+The minimal steps to wire a BDD runner into a project, one section per supported
+language. Use this **after** `references/bdd-value-guide.md` recommends
+`bdd-runner` mode — this file is the mechanics, not the decision.
+
+Every runner here outputs JUnit-XML (or an equivalent the CI already understands),
+so the BDD suite plugs into the existing pipeline without new reporting.
+
+---
+
+## JS/TS — Cucumber.js
+
+- **Framework:** [@cucumber/cucumber](https://github.com/cucumber/cucumber-js) (v11+).
+- **Install:** `npm install --save-dev @cucumber/cucumber`
+- **Directory layout:**
+  - `features/` — `.feature` files.
+  - `features/support/` — step definitions and world/hooks.
+- **Runner config** — `cucumber.yaml` (or `cucumber.js`) at repo root:
+  ```yaml
+  default:
+    require:
+      - features/support/**/*.js
+    format:
+      - "junit:reports/cucumber-junit.xml"
+  ```
+- **Step stub (pending):**
+  ```js
+  import { Given } from "@cucumber/cucumber";
+  Given("a precondition", function () {
+    return this.pending(); // marks the step (and scenario) pending
+  });
+  ```
+- **Run:** `npx cucumber-js`
+- **CI note:** the `junit` formatter writes `reports/cucumber-junit.xml`; point the existing JUnit reporter at it. Cucumber.js runs alongside Vitest/Jest — they are complementary, not alternatives.
+
+---
+
+## Java / Maven — Cucumber-JVM
+
+- **Framework:** [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm) on the JUnit 5 platform.
+- **Install** — add to `pom.xml`:
+  ```xml
+  <dependency>
+    <groupId>io.cucumber</groupId>
+    <artifactId>cucumber-java</artifactId>
+    <version>7.18.1</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.cucumber</groupId>
+    <artifactId>cucumber-junit-platform-engine</artifactId>
+    <version>7.18.1</version>
+    <scope>test</scope>
+  </dependency>
+  ```
+- **Directory layout:**
+  - `src/test/resources/features/` — `.feature` files.
+  - `src/test/java/.../steps/` — step-definition classes.
+- **Runner config** — a suite entry point:
+  ```java
+  import org.junit.platform.suite.api.*;
+
+  @Suite
+  @IncludeEngines("cucumber")
+  @SelectClasspathResource("features")
+  public class RunCucumberTest {}
+  ```
+  (add `import static io.cucumber.junit.platform.engine.Constants.*;` only if you also set `@ConfigurationParameter` options such as the `pretty` plugin.)
+- **Step stub (pending):**
+  ```java
+  import io.cucumber.java.en.Given;
+  import io.cucumber.java.PendingException;
+
+  public class Steps {
+    @Given("a precondition")
+    public void a_precondition() { throw new io.cucumber.java.PendingException(); }
+  }
+  ```
+- **Run:** `mvn test` (Surefire discovers the JUnit 5 suite automatically).
+- **CI note:** Surefire emits JUnit XML under `target/surefire-reports/` — no extra config.
+
+---
+
+## Java / Gradle — Cucumber-JVM
+
+Same engine as Maven; only the wiring differs.
+
+- **Install** — add to `build.gradle`:
+  ```groovy
+  testImplementation 'io.cucumber:cucumber-java:7.18.1'
+  testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.18.1'
+  testImplementation 'org.junit.platform:junit-platform-suite:1.10.2'
+  ```
+- **Runner config** — ensure the `test` task uses the JUnit Platform and sees the feature resources:
+  ```groovy
+  test {
+    useJUnitPlatform()
+    systemProperty 'cucumber.junit-platform.naming-strategy', 'long'
+  }
+  ```
+  Keep `.feature` files under `src/test/resources/features/` (same suite class as Maven).
+- **Step stub:** identical to Maven (`io.cucumber.java.PendingException`).
+- **Run:** `./gradlew test`
+- **CI note:** Gradle writes JUnit XML under `build/test-results/test/`.
+
+---
+
+## C# — Reqnroll
+
+- **Framework:** [Reqnroll](https://reqnroll.net/) — the actively-maintained, MIT-licensed successor to SpecFlow. **Prefer Reqnroll over SpecFlow:** identical API, but SpecFlow requires a commercial license for teams larger than one, while Reqnroll is free.
+- **Install:** `dotnet add package Reqnroll.xUnit` (or `Reqnroll.NUnit` / `Reqnroll.MsTest` to match the project's test runner).
+- **Directory layout:**
+  - `Features/` — `.feature` files (set as `AdditionalFiles` / Reqnroll items).
+  - `StepDefinitions/` — `[Binding]` step classes.
+- **Runner config** — `reqnroll.json` at the project root:
+  ```json
+  { "language": { "feature": "en" } }
+  ```
+- **Step stub (pending):** inject `ScenarioContext` via the constructor and call `StepIsPending()` on the instance (it is not a static method):
+  ```csharp
+  using Reqnroll;
+
+  [Binding]
+  public class Steps {
+    private readonly ScenarioContext _scenarioContext;
+    public Steps(ScenarioContext scenarioContext) => _scenarioContext = scenarioContext;
+
+    [Given("a precondition")]
+    public void GivenAPrecondition() => _scenarioContext.StepIsPending();
+  }
+  ```
+- **Run:** `dotnet test`
+- **CI note:** `dotnet test --logger "junit;LogFilePath=reports/reqnroll-junit.xml"` (via the JUnit test logger) produces JUnit XML for the pipeline.
+
+---
+
+## Go — Godog
+
+- **Framework:** [Godog](https://github.com/cucumber/godog) — the official Cucumber implementation for Go.
+- **Install:** `go get github.com/cucumber/godog/cmd/godog@latest` (the library is pulled in transitively; the CLI is optional).
+- **Directory layout:**
+  - `features/` — `.feature` files.
+  - step definitions live in a `*_test.go` file beside the suite entry point.
+- **Runner config** — a suite entry point in `*_test.go` so Godog runs inside `go test` (no separate binary):
+  ```go
+  func TestFeatures(t *testing.T) {
+    suite := godog.TestSuite{
+      ScenarioInitializer: InitializeScenario,
+      Options: &godog.Options{Format: "junit", Paths: []string{"features"}, TestingT: t},
+    }
+    if suite.Run() != 0 { t.Fatal("non-zero status returned, failed to run feature tests") }
+  }
+  ```
+- **Step stub (pending):**
+  ```go
+  func aPrecondition() error { return godog.ErrPending }
+
+  func InitializeScenario(sc *godog.ScenarioContext) {
+    sc.Step(`^a precondition$`, aPrecondition)
+  }
+  ```
+- **Run:** `go test ./...` (the suite runs as an ordinary Go test).
+- **CI note:** with the `TestingT` option set (above), scenario failures surface as normal `go test` results, so the existing pipeline already sees them. For a separate JUnit-XML artifact, point `Options.Output` at a file writer (e.g. `f, _ := os.Create("reports/godog-junit.xml"); opts.Output = f`) with `Format: "junit"`.

--- a/tests/knowledge/bdd_frameworks_tests.bats
+++ b/tests/knowledge/bdd_frameworks_tests.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Content contract for the per-language BDD wire-in reference
+# (epic #443, issue #436). One section per language with the minimal steps to
+# install and run a BDD runner.
+
+REF="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/test-stack-profiles/bdd-frameworks.md"
+
+@test "bdd-frameworks.md exists" {
+  [ -f "$REF" ]
+}
+
+@test "covers all four languages / five sections (JS, Java Maven, Java Gradle, C#, Go)" {
+  grep -Eqi 'Cucumber\.js' "$REF"          # JS/TS
+  grep -Eqi 'Cucumber-JVM' "$REF"          # Java
+  grep -Eqi '\bMaven\b' "$REF"
+  grep -Eqi '\bGradle\b' "$REF"
+  grep -Eqi 'Reqnroll' "$REF"              # C#
+  grep -Eqi 'Godog' "$REF"                 # Go
+}
+
+@test "C# uses Reqnroll, not SpecFlow" {
+  grep -qi 'Reqnroll' "$REF"
+  # SpecFlow may be named only to say 'use Reqnroll instead'; must not be the recommendation.
+  ! grep -Eqi 'use SpecFlow|recommend SpecFlow|SpecFlow\.xUnit' "$REF"
+}
+
+@test "each language documents an install command" {
+  grep -Eq 'npm install .*@cucumber/cucumber' "$REF"
+  grep -Eq 'cucumber-junit-platform-engine' "$REF"
+  grep -Eq 'dotnet add package Reqnroll' "$REF"
+  grep -Eq 'go get .*godog' "$REF"
+}
+
+@test "documents directory layout (features/ and step-defs)" {
+  grep -Eq 'features/' "$REF"
+  grep -Eqi 'step.def|step_definitions|support/|src/test/resources/features' "$REF"
+}
+
+@test "documents the per-language pending step stub shape" {
+  grep -Eq 'this\.pending\(\)' "$REF"        # Cucumber.js
+  grep -Eq 'PendingException' "$REF"         # Cucumber-JVM
+  grep -Eq 'StepIsPending\(\)' "$REF"        # Reqnroll
+  grep -Eq 'godog\.ErrPending' "$REF"        # Godog
+}
+
+@test "documents how to run and a CI/JUnit-XML note" {
+  grep -Eqi 'run' "$REF"
+  grep -Eqi 'JUnit XML|junit|CI' "$REF"
+}


### PR DESCRIPTION
## Summary

Epic #443 knowledge-file layer. Documents the minimal steps to wire a BDD runner into a project per language — used after `bdd-value-guide.md` (#435) recommends `bdd-runner` mode.

## Changes

- **`knowledge/test-stack-profiles/bdd-frameworks.md`** (new) — one section per language: **JS/TS (Cucumber.js)**, **Java/Maven** + **Java/Gradle (Cucumber-JVM)**, **C# (Reqnroll)**, **Go (Godog)**. Each documents framework + version, install command, directory layout, runner config, pending step stub, run command, and a JUnit-XML/CI note.
  - C# uses **Reqnroll** (MIT) with a note preferring it over SpecFlow (commercial license for teams > 1).
  - Go documents the `godog.ErrPending` stub and the `godog.TestSuite{}` + `TestingT` pattern that runs inside `go test`.

## Verification

- New `tests/knowledge/bdd_frameworks_tests.bats` (7 assertions) — RED→GREEN.
- Doc-only `*.md` under a `knowledge/` subdirectory → no index/registry change.
- Local `doc-review` caught and I fixed three real issues: the Reqnroll `StepIsPending()` was shown as a static call (corrected to an injected `ScenarioContext` instance, [per Reqnroll docs](https://docs.reqnroll.net/latest/execution/mark-steps-as-not-implemented.html)); an unused Cucumber-JVM `Constants` import; and an imprecise Godog JUnit-XML note.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_