### PR TITLE
feat: add Godog BDD entry to Go test stack profile

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/go.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/go.md
@@ -9,5 +9,8 @@ Resolves `test-design-advisor`'s abstract layer (`test-pyramid.md`) to the canon
 | Integration | Testcontainers-go (real DB/broker) | repository/SQL/driver against a real dependency |
 | Contract | Pact-go | consumer↔provider agreement (`microservice-testing.md`) |
 | E2E | `rod` / `chromedp`, or `go test` driving the built binary | critical journeys only |
+| BDD (optional) | Godog — component/service + E2E scenarios | `godog.TestSuite{}.Run(t)` inside `go test`; steps drive the same in-process handlers |
 
 **Notes.** Define narrow interfaces at the consumer and substitute them — idiomatic Go doubling, no mock framework needed (generate with `moq`/`mockgen` only when hand-writing is tedious). Inject a clock (`func() time.Time`) rather than calling `time.Now()` in logic. Use the race detector (`go test -race`) on concurrency-bearing code. Fuzzing is built in (`func FuzzX(f *testing.F)`) — see `testing-techniques/fuzz.md`.
+
+**BDD.** Use Godog when non-technical stakeholders need to read or co-author scenarios (see `references/bdd-value-guide.md` for the decision rubric). Godog wires directly into `go test` via `godog.TestSuite{}.Run(t)` — no separate test binary required. Install steps and the `godog.ErrPending` stub: `bdd-frameworks.md`.

--- a/tests/knowledge/go_profile_godog_tests.bats
+++ b/tests/knowledge/go_profile_godog_tests.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# Contract for the Godog BDD entry in the Go test stack profile
+# (epic #443, issue #437).
+
+PROFILE="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/test-stack-profiles/go.md"
+
+@test "go profile names Godog as a BDD runner" {
+  grep -qi 'Godog' "$PROFILE"
+}
+
+@test "go profile BDD entry references bdd-value-guide.md" {
+  grep -q 'bdd-value-guide.md' "$PROFILE"
+}
+
+@test "go profile cross-references bdd-frameworks.md for install" {
+  grep -q 'bdd-frameworks.md' "$PROFILE"
+}
+
+@test "go profile notes Godog runs inside go test via TestSuite" {
+  grep -Eqi 'godog\.TestSuite|inside .*go test|go test' "$PROFILE"
+}
+
+@test "go profile preserves existing tools" {
+  grep -q 'httptest' "$PROFILE"
+  grep -q 'Testcontainers-go' "$PROFILE"
+  grep -q 'Pact-go' "$PROFILE"
+  grep -q 'testing' "$PROFILE"
+}


### PR DESCRIPTION
## Summary

Epic #443 knowledge-file layer. Gives `/gherkin-derive` a Godog reference to cite when it selects `bdd-runner` mode for a Go project.

## Changes

- **`knowledge/test-stack-profiles/go.md`**
  - New **BDD (optional)** row in the layers table — Godog for component/service + E2E scenarios, run via `godog.TestSuite{}.Run(t)` inside `go test`.
  - **BDD note** pointing to `references/bdd-value-guide.md` (decision rubric) and `bdd-frameworks.md` (install + `godog.ErrPending` stub).
  - Existing tools (`testing`, `httptest`, Testcontainers-go, Pact-go) unchanged.

## Verification

- New `tests/knowledge/go_profile_godog_tests.bats` (5 assertions, incl. an existing-content-preserved check) — RED→GREEN.
- Doc-only `*.md` under a `knowledge/` subdirectory → no index/registry change.

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_