### PR TITLE
feat: add Reqnroll BDD entry to .NET test stack profile

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/dotnet.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/dotnet.md
@@ -9,5 +9,8 @@ Resolves `test-design-advisor`'s abstract layer (`test-pyramid.md`) to the canon
 | Integration | Testcontainers-dotnet (real DB/broker) or `EF Core` against a real provider | repository/EF mappings/SQL against a real dependency |
 | Contract | PactNet | consumer↔provider agreement (`microservice-testing.md`) |
 | E2E | Playwright for .NET | critical journeys only |
+| BDD (optional) | Reqnroll — Unit + Component scenarios | `[Binding]` step classes bound to `.feature` files; runs on xUnit/NUnit/MSTest |
 
 **Notes.** Override services in `WebApplicationFactory.WithWebHostBuilder(...ConfigureTestServices)` to double outbound dependencies pre-merge without config. Inject `TimeProvider` (or an `IClock`) for time determinism; never `DateTime.Now` in logic. Avoid the in-memory EF provider for anything relational — it hides SQL bugs; use Testcontainers or SQLite-in-memory deliberately and know its limits.
+
+**BDD.** Use Reqnroll when non-technical stakeholders need to read or co-author scenarios (see `references/bdd-value-guide.md` for the decision rubric) — BDD scenarios typically sit at the Unit and Component boundaries. **Prefer Reqnroll over SpecFlow:** identical API, but SpecFlow requires a commercial license for teams larger than one, while Reqnroll is the MIT-licensed, actively-maintained fork. Install (`dotnet add package Reqnroll.xUnit` / `.NUnit` / `.MsTest`) and the `ScenarioContext.StepIsPending()` stub: `bdd-frameworks.md`.

--- a/tests/knowledge/dotnet_profile_reqnroll_tests.bats
+++ b/tests/knowledge/dotnet_profile_reqnroll_tests.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Contract for the Reqnroll BDD entry in the .NET test stack profile
+# (epic #443, issue #438).
+
+PROFILE="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/test-stack-profiles/dotnet.md"
+
+@test "dotnet profile names Reqnroll as a BDD runner" {
+  grep -qi 'Reqnroll' "$PROFILE"
+}
+
+@test "dotnet profile BDD entry references bdd-value-guide.md" {
+  grep -q 'bdd-value-guide.md' "$PROFILE"
+}
+
+@test "dotnet profile cross-references bdd-frameworks.md" {
+  grep -q 'bdd-frameworks.md' "$PROFILE"
+}
+
+@test "dotnet profile prefers Reqnroll over SpecFlow with a license rationale" {
+  grep -qi 'Reqnroll' "$PROFILE"
+  grep -Eqi 'SpecFlow' "$PROFILE"
+  grep -Eqi 'MIT|license|licen' "$PROFILE"
+}
+
+@test "dotnet profile preserves existing tools" {
+  grep -q 'xUnit' "$PROFILE"
+  grep -q 'WebApplicationFactory' "$PROFILE"
+  grep -q 'Testcontainers-dotnet' "$PROFILE"
+  grep -q 'PactNet' "$PROFILE"
+  grep -q 'Playwright' "$PROFILE"
+}


### PR DESCRIPTION
## Summary

Epic #443 knowledge-file layer. Gives `/gherkin-derive` a Reqnroll reference to cite when it selects `bdd-runner` mode for a C# project.

## Changes

- **`knowledge/test-stack-profiles/dotnet.md`**
  - New **BDD (optional)** row — Reqnroll at the Unit + Component layers, running on xUnit/NUnit/MSTest.
  - **BDD note** pointing to `references/bdd-value-guide.md` (rubric) and `bdd-frameworks.md` (install + stub); **prefers Reqnroll over SpecFlow** (MIT vs. SpecFlow's commercial license for teams > 1).
  - Existing tools (xUnit, WebApplicationFactory, Testcontainers-dotnet, PactNet, Playwright) unchanged.

## Verification

- New `tests/knowledge/dotnet_profile_reqnroll_tests.bats` (5 assertions, incl. existing-content-preserved + SpecFlow-license-rationale) — RED→GREEN.
- Doc-only `*.md` under a `knowledge/` subdirectory → no index/registry change.

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_