### PR TITLE
feat: add Cucumber.js BDD entry to Node.js test stack profile

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/node.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/node.md
@@ -9,5 +9,8 @@ Resolves `test-design-advisor`'s abstract layer (`test-pyramid.md`) to the canon
 | Integration | Testcontainers (real DB/broker) or an ephemeral DB | the repository/driver/SQL/serialization actually works |
 | Contract | Pact (JS) or `openapi`-driven checks | consumer↔provider agreement (`microservice-testing.md`) |
 | E2E | Playwright | critical journeys only |
+| BDD (optional) | Cucumber.js — component/service scenarios | `.feature` files with step defs in `features/support/`; drives the public surface via supertest |
 
 **Notes.** `supertest(app)` exercises the full middleware/routing stack in-process — the workhorse component test. Mock outbound HTTP with **MSW** (request-level) rather than stubbing the HTTP client, so serialization is real. Fake timers (`vi.useFakeTimers()` / `jest.useFakeTimers()`) and inject a clock for determinism. Nest: use `Test.createTestingModule(...)` to assemble the component with doubled providers.
+
+**BDD.** Use Cucumber.js when non-technical stakeholders need to read or co-author scenarios (see `references/bdd-value-guide.md` for the decision rubric). Wire Cucumber.js **alongside** your existing Vitest/Jest suite — they are complementary, not alternatives: Cucumber drives the public surface (typically through supertest), xUnit drives internals. Install (`@cucumber/cucumber`) and the `this.pending()` stub: `bdd-frameworks.md`.

--- a/tests/knowledge/node_profile_cucumber_tests.bats
+++ b/tests/knowledge/node_profile_cucumber_tests.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Contract for the Cucumber.js BDD entry in the Node.js test stack profile
+# (epic #443, issue #439).
+
+PROFILE="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/test-stack-profiles/node.md"
+
+@test "node profile names Cucumber.js as a BDD runner" {
+  grep -qi 'Cucumber\.js' "$PROFILE"
+}
+
+@test "node profile BDD entry references bdd-value-guide.md" {
+  grep -q 'bdd-value-guide.md' "$PROFILE"
+}
+
+@test "node profile cross-references bdd-frameworks.md" {
+  grep -q 'bdd-frameworks.md' "$PROFILE"
+}
+
+@test "node profile clarifies Cucumber.js and Vitest/Jest are complementary" {
+  grep -Eqi 'complement|not mutually exclusive|alongside|not.*alternativ' "$PROFILE"
+}
+
+@test "node profile preserves existing tools" {
+  grep -Eq 'Vitest|Jest' "$PROFILE"
+  grep -q 'supertest' "$PROFILE"
+  grep -q 'MSW' "$PROFILE"
+  grep -q 'Pact' "$PROFILE"
+  grep -q 'Playwright' "$PROFILE"
+}


### PR DESCRIPTION
## Summary

Epic #443 knowledge-file layer. Gives `/gherkin-derive` a Cucumber.js reference to cite when it selects `bdd-runner` mode for a Node.js project.

## Changes

- **`knowledge/test-stack-profiles/node.md`**
  - New **BDD (optional)** row — Cucumber.js at the component/service layer, driving the public surface via supertest.
  - **BDD note** pointing to `references/bdd-value-guide.md` (rubric) and `bdd-frameworks.md` (install + stub); clarifies Cucumber.js and Vitest/Jest are **complementary, not alternatives**.
  - Existing tools (Vitest/Jest, supertest, MSW, Pact, Playwright) unchanged.

## Verification

- New `tests/knowledge/node_profile_cucumber_tests.bats` (5 assertions, incl. existing-content-preserved + complementary-not-alternatives) — RED→GREEN.
- Doc-only `*.md` under a `knowledge/` subdirectory → no index/registry change.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_