### PR TITLE
feat: add Cucumber-JVM BDD entry to Spring Boot test stack profile

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/spring-boot.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/spring-boot.md
@@ -9,5 +9,8 @@ Resolves `test-design-advisor`'s abstract layer (`test-pyramid.md`) to the canon
 | Integration | Testcontainers (real DB/broker) + `@DataJpaTest` / `@SpringBootTest` | assert the adapter/SQL/serialization against a real dependency |
 | Contract | Spring Cloud Contract or Pact | verify consumer↔provider agreement (`microservice-testing.md`), not E2E |
 | E2E | Playwright / Selenium against the deployed app | critical journeys only |
+| BDD (optional) | Cucumber-JVM — component/service scenarios | `.feature` files run inside JUnit 5 via `cucumber-junit-platform-engine` |
 
 **Notes.** Prefer slice annotations (`@WebMvcTest`, `@DataJpaTest`) over full `@SpringBootTest` — faster context, sharper scope. Inject a fixed `Clock` bean for time determinism. Wrap third-party clients in an owned adapter and double the adapter (`cd-test-architecture.md`), never the SDK. Kotlin: same tools; MockK is an idiomatic alternative to Mockito.
+
+**BDD.** Use Cucumber-JVM when non-technical stakeholders need to read or co-author scenarios (see `references/bdd-value-guide.md` for the decision rubric). Wire it via `cucumber-junit-platform-engine` so Cucumber runs inside JUnit 5 — Maven Surefire and the Gradle `test` task pick it up automatically (the Maven and Gradle dependency sets differ slightly). Full wiring for both build tools and the `PendingException` stub: `bdd-frameworks.md`.

--- a/tests/knowledge/spring_boot_profile_cucumber_tests.bats
+++ b/tests/knowledge/spring_boot_profile_cucumber_tests.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Contract for the Cucumber-JVM BDD entry in the Spring Boot test stack profile
+# (epic #443, issue #440).
+
+PROFILE="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/test-stack-profiles/spring-boot.md"
+
+@test "spring profile names Cucumber-JVM as a BDD runner" {
+  grep -qi 'Cucumber-JVM' "$PROFILE"
+}
+
+@test "spring profile BDD entry references bdd-value-guide.md" {
+  grep -q 'bdd-value-guide.md' "$PROFILE"
+}
+
+@test "spring profile cross-references bdd-frameworks.md" {
+  grep -q 'bdd-frameworks.md' "$PROFILE"
+}
+
+@test "spring profile names both Maven and Gradle wiring" {
+  grep -qi 'Maven' "$PROFILE"
+  grep -qi 'Gradle' "$PROFILE"
+}
+
+@test "spring profile notes the cucumber-junit-platform-engine wiring" {
+  grep -q 'cucumber-junit-platform-engine' "$PROFILE"
+}
+
+@test "spring profile preserves existing tools" {
+  grep -q 'JUnit 5' "$PROFILE"
+  grep -q 'SpringBootTest' "$PROFILE"
+  grep -q 'Testcontainers' "$PROFILE"
+  grep -Eq 'Pact|Spring Cloud Contract' "$PROFILE"
+}


### PR DESCRIPTION
## Summary

Epic #443 knowledge-file layer (final slice of this layer). Gives `/gherkin-derive` a Cucumber-JVM reference to cite when it selects `bdd-runner` mode for a Java/Spring Boot project.

## Changes

- **`knowledge/test-stack-profiles/spring-boot.md`**
  - New **BDD (optional)** row — Cucumber-JVM at the component/service layer, run inside JUnit 5 via `cucumber-junit-platform-engine`.
  - **BDD note** pointing to `references/bdd-value-guide.md` (rubric) and `bdd-frameworks.md` (full wiring + stub); notes **both Maven and Gradle** paths (dependency sets differ slightly).
  - Existing tools (JUnit 5, `@SpringBootTest`, Testcontainers, Spring Cloud Contract / Pact, Playwright) unchanged.

## Verification

- New `tests/knowledge/spring_boot_profile_cucumber_tests.bats` (6 assertions, incl. existing-content-preserved + Maven/Gradle both named) — RED→GREEN.
- Doc-only `*.md` under a `knowledge/` subdirectory → no index/registry change.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_