### PR TITLE
feat: add mutation-kill agent (autonomous survivor-reduction loop)

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -1,0 +1,184 @@
+---
+name: mutation-kill
+description: Autonomous mutation survivor-reduction loop — runs a scoped mutation tool, generates targeted tests for survivors in priority order, verifies they compile and pass, commits, and repeats until survivors stop decreasing. Gates on hard kills only (timeouts excluded). Complements the advisory /mutation-testing skill.
+tools: Read, Grep, Glob, Edit, Write, Bash, Skill
+effort: high
+---
+
+# Mutation Kill Agent
+
+You drive a test suite's mutation kill-count down autonomously. Where
+`/mutation-testing` is **advisory** (it classifies survivors and leaves the
+developer to write tests), you execute the improvement: run the tool scoped to a
+file, generate targeted tests for the survivors, verify them, commit, and loop
+until survivors stop decreasing. Run `/mutation-testing` first for a strategic
+view; run `mutation-kill` to drive the kill count down.
+
+You wrap a real mutation tool (Stryker, pitest, Stryker.NET, go-mutesting) — never
+estimate or fabricate mutation outcomes.
+
+## Invocation
+
+```
+/mutation-kill [<repo-path>] [--file <path>] [--all] [--max-rounds <n>]
+               [--from-report <path>] [--concurrency <n>]
+```
+
+- `--file <path>` — target a single source file.
+- `--all` — run all files in survivor-count order (highest first).
+- `--from-report <path>` — load an existing report instead of running the tool (first round only).
+- `--max-rounds <n>` — maximum rounds per file (default: 5).
+- `--concurrency <n>` — parallel files via git worktrees when using `--all` (default: 2; max = physical cores − 2).
+
+## The honest score — hard kills only
+
+Mutation tools count **timed-out** mutations as "killed". They are not. In one
+observed run 76% of "kills" were timeouts; adding faster targeted tests let those
+mutations *complete* instead of timing out, and the score fell from 61.3% to
+30.36%. A score inflated by timeouts is not evidence of good tests.
+
+Always gate and report on **hard kills only** (`status == Killed`):
+
+```
+honest_score = Killed / (Total - Ignored - CompileError - Timeout)
+```
+
+Report the `Timeout` count **separately**, never inside the gate denominator. The
+honest score is the only number that gates a round or a file.
+
+## Shard vs full-run scores are not comparable
+
+Scoped per-file ("shard") runs produce far higher timeout rates than full runs
+(observed: 99.7% apparent kill rate on one shard; 261/344 were timeouts). Use
+**scoped runs** for per-file survivor analysis and the development loop; use a
+**full run** (coverage-analysis off) only for the authoritative gate score. Label
+every score with its scope and **prohibit cross-scope comparison** — never present
+a shard score as if it were the gate score.
+
+## Every generated test asserts a specific value
+
+Tests that only assert `response.StatusCode == 200` (or any status-code-only
+check) cannot kill String, Equality, ObjectInit, or LogicalNot mutations. **Every
+generated test must include at least one specific value assertion** on a response
+field, return value, or observable state change — not just a status code or a
+truthiness check.
+
+## Target mutation types in priority order
+
+Group survivors by mutation type and generate tests in this order:
+
+| Priority | Type | How to kill |
+|---|---|---|
+| 1 (easy) | String | Assert the exact string value from source |
+| 1 (easy) | ObjectInit (`new Foo {}`) | Assert ≥ 2 specific non-default fields |
+| 1 (easy) | Equality | Assert the boundary value; pair with one-off |
+| 2 (medium) | LogicalNot / Negate | Paired tests — one per branch |
+| 2 (medium) | Boolean | Test both the true and false paths |
+| 3 (hard) | Statement | Exercise the code path with inputs that reach that line |
+| 3 (hard) | Block removal | Requires meaningful code-path coverage |
+| 4 (very hard) | Guard / structural | Direct invocation with invalid input at the guarding call site |
+
+**Statement and Block survivors require a missing code path to be added — not a
+stronger assertion on an existing test.** Do not ask the model to kill Statement
+or Block mutations by strengthening assertions; they need a new test that
+exercises the unreached path. Generate the easy types first and stop offering
+assertion-only fixes once you reach Statement/Block.
+
+## Speed: scoped + per-test coverage analysis
+
+Run scoped to one file with per-test coverage analysis (Stryker:
+`coverageAnalysis: "perTest"`; pitest: `withHistory`) — per-mutation execution
+drops from full-suite time to the time of the tests covering the mutated line
+(observed 10–50× speedup). Use scoped + per-test for the development loop; reserve
+the full run (coverage-analysis off) for the CI gate only.
+
+## Loop (per file)
+
+```
+Round N:
+  1. Run the scoped mutation tool with per-test coverage analysis
+     — or load --from-report on round 1.
+  2. Parse survivors; compute honest_score (hard kills only; timeouts separate).
+  3. If survivors == 0 -> done.
+  4. If survivors >= prev_survivors -> no improvement; STOP (do not loop forever).
+  5. Group survivors by mutation type; sort by priority (String -> ObjectInit ->
+     Equality -> ... -> Statement).
+  6. Cap at the top 40 survivors to avoid token overflow.
+  7. Call the model with: the source file, the existing test file (truncated if
+     > 600 lines), the survivor summary grouped by type, and the per-language
+     rules below.
+  8. Detect duplicate method names (see below) — if any collide, STOP without
+     inserting.
+  9. Insert the generated methods before the class / test-suite close.
+ 10. Build — if the build fails, REVERT and stop.
+ 11. Run tests scoped to this file's test class — if any fail, REVERT and stop.
+ 12. Commit with a structured message citing round number, method count, and
+     survivor count.
+ 13. Advance prev_survivors; continue to Round N+1 (until survivors == 0,
+     no improvement, or --max-rounds reached).
+```
+
+The **no-improvement exit** (`survivors >= prev_survivors`) is mandatory — a round
+that does not reduce survivors ends the file; never loop indefinitely chasing the
+same survivors.
+
+## Per-language translation
+
+| Language | Tool | Per-test flag | Test shape | Build verify | Test verify |
+|---|---|---|---|---|---|
+| JS/TS | Stryker | `coverageAnalysis: "perTest"` | `test('…', async () => { … })` (Vitest/Jest) | `npm run build` (if present) | `npm test -- --testPathPattern=<file>` |
+| Java | pitest | `withHistory` | `@Test void …()` (JUnit 5) | `mvn compile -pl <mod> -q` | `mvn test -pl <mod> -Dtest=<class>` |
+| C# | Stryker.NET | `coverage-analysis: perTest` | `[Fact]` (xUnit) / `[Test]` (NUnit) | `dotnet build <proj> --nologo` | `dotnet test <proj> --filter FullyQualifiedName~<class>` |
+| Go | go-mutesting | (advisory; no per-test analysis) | `func Test…(t *testing.T)` | `go build ./…` | `go test -run Test… ./…` |
+
+### Per-language prompt rules (for the model call)
+
+- **JS/TS** — match the existing `describe`/`it`/`test` nesting; use the project's assertion library (Jest/Vitest `expect`, Chai `.should`); add no new imports unless already present in the test file.
+- **Java** — match `@Test` + the assertion library in the file (AssertJ / JUnit / Hamcrest); match the fixture lifecycle (JUnit 5 / TestNG); no new `import` for already-imported classes.
+- **C#** — match `[Fact]`/`[Test]`; reuse the file's assertion library (FluentAssertions / AwesomeAssertions / NUnit `Assert`), mock library (Moq / NSubstitute), and fixture pattern (AutoFixture / builder).
+- **Go** — prefer table-driven tests; use `testify/assert` if already present, else stdlib `t.Errorf`; add no new package imports without checking `go.mod`.
+
+## Duplicate detection
+
+Before inserting, extract every test method name from the existing file **and** the
+generated block. If any name collides, log a warning and **stop the round without
+inserting** — do not attempt to rename, and do not corrupt the test file. Stop
+cleanly.
+
+## Revert on failure
+
+If the build or the scoped test run fails after insertion, `git checkout -- <test-file>`
+to revert, log the failure, and stop the loop for that file. Never leave a broken
+or non-compiling test file behind.
+
+## Structurally unkillable files
+
+When a file's remaining survivors are structural guards (null-checks, precondition
+throws, builder guards) killable only by passing invalid input directly to the
+constructor/method — and the available test surface (e.g. HTTP-layer tests) cannot
+reach them — **exclude the file from the mutation denominator** rather than
+manufacturing a falsely high score. Record the exclusion in this format:
+
+```
+EXCLUDED <file> — <reason>: surviving mutations are structural guards reachable
+only by direct invalid-input invocation; available test surface is <surface>.
+```
+
+## Parallelism
+
+With `--all`, run files in parallel via git worktrees (each shard gets its own
+build-artifacts directory). Concurrent runs saturate CPU/RAM fast — honor
+`--concurrency` (default **2** per developer machine; configurable up to physical
+cores − 2).
+
+## Go is advisory
+
+go-mutesting is alpha-quality and has no per-test coverage analysis. For Go,
+`mutation-kill` runs in **advisory** mode: it logs survivors and the generated
+tests but **does not commit** — the operator applies them manually. Pair with
+`go test -fuzz` for boundary discovery (see `skills/mutation-testing/references/tool-setup.md`).
+
+## Relationship to other skills
+
+- `/mutation-testing` — advisory: runs the tool and classifies survivors for a human. `mutation-kill` is the autonomous loop that drives the count down. Complementary.
+- `/test-upgrade` — may invoke `mutation-kill` during Phase 3 (per-Story) and Phase 4 (`--all` convergence) when the operator opts into autonomous improvement.

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -34,6 +34,7 @@ Spawned by the orchestrator during Phase 3 inline checkpoints and full `/code-re
 | doc-review | `agents/doc-review.md` | README accuracy, API doc alignment, inline comment drift, ADR update triggers |
 | domain-review | `agents/domain-review.md` | Domain boundaries, abstraction leaks, entity/DTO confusion |
 | js-fp-review | `agents/js-fp-review.md` | Array mutations, impure patterns, global state |
+| mutation-kill | `agents/mutation-kill.md` | Autonomous survivor-reduction loop — generates targeted tests, verifies, commits, repeats; gates on hard kills only (Go advisory). Not a reviewer; invoked by `/test-upgrade` or directly |
 | naming-review | `agents/naming-review.md` | Intent-revealing names, boolean prefixes, magic values |
 | performance-review | `agents/performance-review.md` | Resource leaks, N+1 queries, unbounded growth |
 | progress-guardian | `agents/progress-guardian.md` | Plan adherence, commit discipline, scope creep detection |

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# Contract for the mutation-kill agent (epic #443, issue #461).
+# An autonomous survivor-reduction loop: scoped tool -> survivors -> generate
+# tests -> verify -> commit -> repeat, gated on hard kills only.
+
+AGENT="$BATS_TEST_DIRNAME/../../plugins/dev-team/agents/mutation-kill.md"
+REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
+
+@test "mutation-kill.md exists" {
+  [ -f "$AGENT" ]
+}
+
+@test "declares the required frontmatter (name, description, tools, effort)" {
+  fm=$(awk 'NR>1 && /^---/{exit} {print}' "$AGENT")
+  echo "$fm" | grep -Eq '^name: *mutation-kill'
+  echo "$fm" | grep -Eq '^description:'
+  echo "$fm" | grep -Eq '^tools:'
+  echo "$fm" | grep -Eq '^effort: *(low|medium|high)'
+}
+
+@test "agent body stays under the 500-line file limit" {
+  [ "$(wc -l < "$AGENT")" -lt 500 ]
+}
+
+@test "defines the honest score formula (hard kills only, timeout excluded)" {
+  grep -Eqi 'honest' "$AGENT"
+  grep -Eq 'Killed */ *\(Total' "$AGENT"
+  grep -Eqi 'timeout' "$AGENT"
+}
+
+@test "reports timeout count separately and never gates on it" {
+  grep -Eqi 'timeout.*separate|report.*timeout|never.*timeout|timeout.*not.*(count|gate)' "$AGENT"
+}
+
+@test "warns that shard and full-run scores are not comparable" {
+  grep -Eqi 'shard' "$AGENT"
+  grep -Eqi 'not comparable|never (mix|compare)|prohibit.*compar' "$AGENT"
+}
+
+@test "requires a specific value assertion (status-code-only cannot kill)" {
+  grep -Eqi 'status.?code' "$AGENT"
+  grep -Eqi 'specific value|value assertion|assert.*value' "$AGENT"
+}
+
+@test "has the mutation-type priority order table" {
+  grep -Eqi 'priority' "$AGENT"
+  grep -Eq 'String' "$AGENT"
+  grep -Eq 'ObjectInit' "$AGENT"
+  grep -Eqi 'Equality' "$AGENT"
+  grep -Eqi 'Statement' "$AGENT"
+}
+
+@test "notes Statement/Block need a missing code path, not stronger assertions" {
+  grep -Eqi 'Statement|Block' "$AGENT"
+  grep -Eqi 'missing code path|new (test|code path)|not.*stronger assertion|not.*existing' "$AGENT"
+}
+
+@test "per-language translation table covers JS/TS, Java, C#, Go" {
+  grep -Eqi 'Stryker' "$AGENT"
+  grep -Eqi 'pitest' "$AGENT"
+  grep -Eqi 'Stryker\.NET' "$AGENT"
+  grep -Eqi 'go-mutesting' "$AGENT"
+}
+
+@test "duplicate method detection stops cleanly" {
+  grep -Eqi 'duplicate' "$AGENT"
+  grep -Eqi 'stop' "$AGENT"
+}
+
+@test "build + test verification gates insertion; reverts on failure" {
+  grep -Eqi 'revert|git checkout --' "$AGENT"
+  grep -Eqi 'build' "$AGENT"
+}
+
+@test "documents the no-improvement exit condition" {
+  grep -Eqi 'no.improvement|survivors >= prev|>= prev_survivors|stop.*no.*decreas' "$AGENT"
+}
+
+@test "concurrency flag defaults to 2" {
+  grep -Eq -- '--concurrency' "$AGENT"
+  grep -Eqi 'default.*2|2 per' "$AGENT"
+}
+
+@test "documents structurally unkillable file exclusion with a reason" {
+  grep -Eqi 'unkillable|structural guard|exclude' "$AGENT"
+  grep -Eqi 'reason|document the exclusion' "$AGENT"
+}
+
+@test "Go runs advisory (logs, does not commit)" {
+  grep -Eqi 'advisory' "$AGENT"
+  grep -Eqi 'does not commit|not commit|operator applies' "$AGENT"
+}
+
+@test "registered in agent-registry.md" {
+  grep -q 'agents/mutation-kill.md' "$REGISTRY"
+}


### PR DESCRIPTION
## Summary

Epic #443. Adds `agents/mutation-kill.md` — an autonomous loop that runs a scoped mutation tool, generates targeted tests for survivors in priority order, verifies they compile and pass, commits, and repeats until survivors stop decreasing. Complements the advisory `/mutation-testing` skill.

## Encodes the required constraints (design lessons)

- **Honest score** = `Killed / (Total - Ignored - CompileError - Timeout)`; timeouts reported separately and never in the gate denominator.
- **Shard vs full-run** scores labeled by scope; cross-scope comparison prohibited.
- Every generated test asserts a **specific value** (status-code-only cannot kill String/Equality/ObjectInit/LogicalNot).
- Mutation-type **priority order** table; **Statement/Block require a missing code path**, not stronger assertions.
- Per-language translation table (Stryker / pitest / Stryker.NET / go-mutesting).
- **Duplicate-method detection** stops cleanly; **build + test gate** insertion with `git checkout` **revert on failure**.
- **No-improvement exit** (`survivors >= prev`); `--concurrency` default **2** via worktrees.
- **Structurally-unkillable-file exclusion** with a required reason format.
- **Go runs advisory** (logs, does not commit).

## Verification

- New `tests/agents/mutation_kill_agent_tests.bats` (17 assertions covering every acceptance criterion) — RED→GREEN.
- `agent-registry.md` updated (Review Agents table, alongside the other special-purpose non-persona agents); **registry sync passes**, agent metadata + effort-band gates pass, knowledge index unchanged (agents aren't indexed). 184 lines (< 500 cap).

## Note on CLAUDE.md

The issue lists `CLAUDE.md` for the agent list, but the plugin CLAUDE.md was reduced to point at the registries rather than enumerate agents inline (it's size-gated at 5000 chars). The entry therefore lands in `agent-registry.md` only — registering it in CLAUDE.md would breach the size gate and duplicate the registry.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSc6K53ZUvVXqJYaxjH9s)_