### PR TITLE
feat: eval fixtures for uncovered review agents; plugin-audit skill fixes

### DIFF
--- a/evals/expected/a11y-missing-labels.json
+++ b/evals/expected/a11y-missing-labels.json
@@ -1,0 +1,22 @@
+{
+  "fixture": "a11y-missing-labels",
+  "description": "UI markup with clickable divs lacking keyboard handlers, an icon control with no accessible name, an image without alt text, an unlabeled input, skipped heading levels, and outline:none with no focus replacement",
+  "applicableAgents": [
+    "a11y-review"
+  ],
+  "agents": {
+    "a11y-review": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 3,
+        "max": 9
+      },
+      "severities": {
+        "error": {
+          "min": 1,
+          "max": 7
+        }
+      }
+    }
+  }
+}

--- a/evals/expected/cc-check-then-act.json
+++ b/evals/expected/cc-check-then-act.json
@@ -1,0 +1,22 @@
+{
+  "fixture": "cc-check-then-act",
+  "description": "Async code with a check-then-act race on shared Map state across a suspension point, a non-idempotent charge handler, and an unhandled fire-and-forget rejection",
+  "applicableAgents": [
+    "concurrency-review"
+  ],
+  "agents": {
+    "concurrency-review": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 2,
+        "max": 6
+      },
+      "severities": {
+        "error": {
+          "min": 1,
+          "max": 4
+        }
+      }
+    }
+  }
+}

--- a/evals/expected/perf-nplus1-loop.json
+++ b/evals/expected/perf-nplus1-loop.json
@@ -1,0 +1,22 @@
+{
+  "fixture": "perf-nplus1-loop",
+  "description": "Runtime code with an N+1 query inside a loop, an unbounded Map cache, a leaked connection plus an uncleared setInterval, and a network call with no timeout",
+  "applicableAgents": [
+    "performance-review"
+  ],
+  "agents": {
+    "performance-review": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 2,
+        "max": 7
+      },
+      "severities": {
+        "error": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    }
+  }
+}

--- a/evals/expected/sess-token-rework.json
+++ b/evals/expected/sess-token-rework.json
@@ -1,0 +1,16 @@
+{
+  "fixture": "sess-token-rework",
+  "description": "A session-digest/v1 with high code-review token spend alongside repeated file edits and failed edits, a low cache-hit ratio, recurring user corrections, and never-observed harness surface — mapping to concrete plugin-level fixes",
+  "applicableAgents": [
+    "session-analysis"
+  ],
+  "agents": {
+    "session-analysis": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 2,
+        "max": 8
+      }
+    }
+  }
+}

--- a/evals/expected/spec-unmet-criterion.json
+++ b/evals/expected/spec-unmet-criterion.json
@@ -1,0 +1,16 @@
+{
+  "fixture": "spec-unmet-criterion",
+  "description": "A spec with three acceptance criteria and a Gherkin scenario, paired with an implementation that omits the expiry criterion, violates the no-enumeration criterion, adds an out-of-scope export feature, and tests only one criterion",
+  "applicableAgents": [
+    "spec-compliance-review"
+  ],
+  "agents": {
+    "spec-compliance-review": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 2,
+        "max": 7
+      }
+    }
+  }
+}

--- a/evals/fixtures/a11y-missing-labels.html
+++ b/evals/fixtures/a11y-missing-labels.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Account settings</title>
+    <style>
+      /* Removes the focus ring with no visible replacement. */
+      button,
+      a,
+      input {
+        outline: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Clickable div acting as a button: not focusable, no keyboard handler, no accessible name. -->
+    <div class="btn" onclick="saveProfile()">Save</div>
+
+    <!-- Icon-only control with no accessible name. -->
+    <span class="icon-trash" onclick="deleteAccount()">🗑</span>
+
+    <!-- Image conveying meaning without alt text. -->
+    <img src="/avatar.png" />
+
+    <!-- Text input with no associated label. -->
+    <input type="text" name="displayName" placeholder="Display name" />
+
+    <!-- Heading levels skip from h1 to h3. -->
+    <h1>Settings</h1>
+    <h3>Notifications</h3>
+
+    <!-- Dynamic status region with no aria-live, so updates are not announced. -->
+    <div id="status"></div>
+
+    <script>
+      function saveProfile() {}
+      function deleteAccount() {}
+    </script>
+  </body>
+</html>

--- a/evals/fixtures/cc-check-then-act.ts
+++ b/evals/fixtures/cc-check-then-act.ts
@@ -1,0 +1,31 @@
+// Shared mutable state mutated from multiple concurrent async paths.
+const balances = new Map<string, number>();
+
+// Read-then-write without atomicity: two concurrent withdrawals can both pass
+// the check before either decrements, overdrawing the account (lost update).
+export async function withdraw(accountId: string, amount: number): Promise<void> {
+  const current = balances.get(accountId) ?? 0;
+  if (current < amount) {
+    throw new Error("insufficient funds");
+  }
+  await persist(accountId, current); // suspension point widens the race window
+  balances.set(accountId, current - amount);
+}
+
+// Non-idempotent handler: a retried request charges the card twice because there
+// is no idempotency key or deduplication.
+export async function handleCharge(req: { cardId: string; cents: number }): Promise<void> {
+  await chargeCard(req.cardId, req.cents);
+  await sendReceipt(req.cardId);
+}
+
+// Fire-and-forget promise: the rejection is unhandled, so a failed flush is
+// silently swallowed.
+export function scheduleFlush(): void {
+  flushQueue();
+}
+
+async function persist(_id: string, _v: number): Promise<void> {}
+async function chargeCard(_id: string, _cents: number): Promise<void> {}
+async function sendReceipt(_id: string): Promise<void> {}
+async function flushQueue(): Promise<void> {}

--- a/evals/fixtures/perf-nplus1-loop.ts
+++ b/evals/fixtures/perf-nplus1-loop.ts
@@ -1,0 +1,41 @@
+interface Order {
+  id: string;
+  customerId: string;
+}
+
+// Unbounded cache: grows forever with no size limit or eviction policy.
+const customerCache = new Map<string, unknown>();
+
+// N+1 query: one query per order inside the loop instead of a single batched
+// fetch keyed by the collected customer ids.
+export async function enrichOrders(orders: Order[], db: Db): Promise<unknown[]> {
+  const results: unknown[] = [];
+  for (const order of orders) {
+    const customer = await db.query(
+      "SELECT * FROM customers WHERE id = ?",
+      order.customerId,
+    );
+    customerCache.set(order.customerId, customer);
+    results.push({ order, customer });
+  }
+  return results;
+}
+
+// Resource leak: opens a connection but never closes it on the error path
+// (no try/finally), and polls on an interval that is never cleared.
+export function startPoller(db: Db): void {
+  const conn = db.connect();
+  setInterval(() => {
+    conn.ping();
+  }, 1000);
+}
+
+// Network call with no timeout: a hung upstream blocks this caller forever.
+export async function fetchProfile(url: string): Promise<Response> {
+  return fetch(url);
+}
+
+interface Db {
+  query(sql: string, ...args: unknown[]): Promise<unknown>;
+  connect(): { ping(): void };
+}

--- a/evals/fixtures/sess-token-rework.json
+++ b/evals/fixtures/sess-token-rework.json
@@ -1,0 +1,49 @@
+{
+  "schema": "session-digest/v1",
+  "sessions": 4,
+  "token": {
+    "totals": { "input": 4200000, "output": 180000 },
+    "cost_usd": 14.21,
+    "cache_hit_ratio": 0.11,
+    "by_model": {
+      "opus": { "input": 3100000, "output": 120000 },
+      "haiku": { "input": 1100000, "output": 60000 }
+    },
+    "by_skill": {
+      "code-review": { "input": 2600000, "output": 90000, "cost_micro": 9800000 },
+      "build": { "input": 600000, "output": 40000, "cost_micro": 2100000 }
+    },
+    "by_subagent": {
+      "doc-review": 410000,
+      "naming-review": 380000
+    }
+  },
+  "rework": {
+    "failed_edits": 9,
+    "repeated_file_edits": {
+      "src/payments/charge.ts": 6,
+      "src/payments/refund.ts": 4
+    },
+    "retried_bash_commands": 7,
+    "repeated_verify_runs": 5,
+    "permission_denials": 1,
+    "compaction_events": 3
+  },
+  "accuracy": {
+    "tool_errors_by_tool": { "Edit": 6, "Bash": 3 },
+    "tool_calls": 220,
+    "tool_error_rate": 0.0409,
+    "user_correction_turns": 5
+  },
+  "gate": {
+    "commit_attempts": 4,
+    "commit_bypasses": 2,
+    "bypass_rate": 0.5
+  },
+  "utilization": {
+    "skills_invoked": { "code-review": 4, "build": 3 },
+    "agents_invoked": { "doc-review": 4, "naming-review": 3 },
+    "never_observed_skills": ["mutation-testing", "farley-score"],
+    "never_observed_agents": ["svelte-review", "a11y-review"]
+  }
+}

--- a/evals/fixtures/spec-unmet-criterion/docs/specs/password-reset.md
+++ b/evals/fixtures/spec-unmet-criterion/docs/specs/password-reset.md
@@ -1,0 +1,22 @@
+# Spec: Password reset
+
+## Acceptance criteria
+
+1. A user can request a reset link by submitting their email.
+2. The reset link expires 30 minutes after it is issued.
+3. Submitting an unknown email returns the same generic response as a known
+   email (no account enumeration).
+
+## Scenarios
+
+```gherkin
+Scenario: Expired reset link is rejected
+  Given a reset link issued 31 minutes ago
+  When the user opens the link
+  Then the reset is refused and a new link is offered
+```
+
+## Plan — files to change
+
+- `src/reset.ts` — implement request + expiry.
+- `tests/reset.test.ts` — cover all three criteria and the expiry scenario.

--- a/evals/fixtures/spec-unmet-criterion/src/reset.ts
+++ b/evals/fixtures/spec-unmet-criterion/src/reset.ts
@@ -1,0 +1,29 @@
+interface Store {
+  findUserByEmail(email: string): Promise<{ id: string } | null>;
+  saveToken(userId: string, token: string, issuedAt: number): Promise<void>;
+}
+
+// Criterion 1 (request a link) is implemented.
+// Criterion 2 (30-minute expiry) is NOT implemented — no expiry is recorded or
+// enforced anywhere, and there is no validateToken function.
+// Criterion 3 (no account enumeration) is VIOLATED — the unknown-email branch
+// returns a different response than the known-email branch.
+export async function requestReset(email: string, store: Store): Promise<string> {
+  const user = await store.findUserByEmail(email);
+  if (!user) {
+    return "no account found for that email";
+  }
+  const token = cryptoRandom();
+  await store.saveToken(user.id, token, Date.now());
+  return "reset link sent";
+}
+
+// Scope violation: an unrequested feature not traceable to any acceptance
+// criterion in the spec.
+export async function exportAllUsers(store: Store): Promise<unknown> {
+  return (store as unknown as { dump(): unknown }).dump();
+}
+
+function cryptoRandom(): string {
+  return Math.random().toString(36).slice(2);
+}

--- a/evals/fixtures/spec-unmet-criterion/tests/reset.test.ts
+++ b/evals/fixtures/spec-unmet-criterion/tests/reset.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { requestReset } from "../src/reset";
+
+// Only criterion 1 has a test. Criterion 2 (expiry), criterion 3 (no
+// enumeration), and the "Expired reset link is rejected" scenario have no
+// coverage.
+describe("password reset", () => {
+  it("sends a reset link for a known email", async () => {
+    const store = {
+      findUserByEmail: async () => ({ id: "u1" }),
+      saveToken: async () => {},
+    };
+    expect(await requestReset("a@b.com", store)).toBe("reset link sent");
+  });
+});

--- a/plugins/dev-team/skills/adr-tools/SKILL.md
+++ b/plugins/dev-team/skills/adr-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-tools
-description: Create and manage Architecture Decision Records using the adr-tools CLI (https://github.com/npryce/adr-tools). Use when the user asks to "add an ADR", "record this decision", "create an ADR", "supersede ADR N", "link ADRs", "generate the ADR table of contents", or any request involving the `adr` command. Pairs with the adr-author agent: this skill is the mechanics (commands, files, links); adr-author is the decision framework (when an ADR is warranted) and the prose authoring.
+description: Create and manage Architecture Decision Records using the npryce adr-tools CLI. Use when the user asks to "add an ADR", "record this decision", "create an ADR", "supersede ADR N", "link ADRs", "generate the ADR table of contents", or any request involving the `adr` command. Pairs with the adr-author agent — this skill is the mechanics (commands, files, links); adr-author is the decision framework (when an ADR is warranted) and the prose authoring.
 role: worker
 user-invocable: true
 ---

--- a/plugins/dev-team/skills/docker-image-audit/SKILL.md
+++ b/plugins/dev-team/skills/docker-image-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docker-image-audit
 description: Audit Docker images and Dockerfiles for security vulnerabilities, bloat, and best-practice violations using hadolint, Trivy, and Grype. Produces a structured severity report with actionable fixes. Use this skill whenever the user wants to check a Docker image for security issues, scan a container for vulnerabilities, audit a Dockerfile, harden a Docker image, reduce image size, minimize attack surface, check for CVEs in a container, or says things like "is this Dockerfile secure?", "scan my image", "check my container for vulnerabilities", "how can I make this image smaller?", "audit my Docker setup", or "harden this container". Also trigger when the user has just created or modified a Dockerfile and wants validation before shipping it.
+role: worker
 user-invocable: true
 ---
 

--- a/plugins/dev-team/skills/docker-image-create/SKILL.md
+++ b/plugins/dev-team/skills/docker-image-create/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docker-image-create
 description: Generate production-ready Dockerfiles from project source code. Detects language/framework automatically and produces multi-stage builds with minimal, distroless, or slim base images. Use this skill whenever the user wants to containerize an application, create a Dockerfile, dockerize a project, build a Docker image, or says things like "make this run in Docker", "create a container for this app", "I need a Dockerfile", "package this for deployment", or "containerize this service". Also trigger when the user has an existing Dockerfile and wants it rewritten for production use, or when they ask about Docker best practices for their project.
+role: worker
 user-invocable: true
 ---
 

--- a/plugins/dev-team/skills/js-project-init/SKILL.md
+++ b/plugins/dev-team/skills/js-project-init/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: js-project-init
 description: Initialize a new JavaScript project with ES modules, functional style, prettier, eslint, editorconfig, vitest, and gitignore. Use this skill whenever the user wants to start a new JS project, scaffold a Node.js app, create a new package, bootstrap a JavaScript repo, or says things like "init a new project", "set up a JS project", "create a new node app", "start a new frontend project", or "bootstrap a new package". Also trigger when the user asks to add standard JS tooling (linting, formatting, testing) to an empty or near-empty directory.
+role: worker
 user-invocable: true
 ---
 


### PR DESCRIPTION
Resolves the actionable findings from `/marketplace-dev:plugin-audit plugins/dev-team --fix`.

## Skill frontmatter
- **adr-tools** — removed colons from the `description` (the audit's no-colon rule). The `https://` URL was dropped from the trigger text (it remains in the body); the clause `:` became an em dash.
- **docker-image-audit, docker-image-create, js-project-init** — added the required `role: worker` frontmatter.

## Eval coverage (new fixtures)
Authored a fixture + `expected/*.json` for the five review agents that had **no corpus coverage**:

| Fixture | Agent | Exercises |
| --- | --- | --- |
| `a11y-missing-labels.html` | a11y-review | clickable divs, missing alt/labels, skipped headings, `outline:none` |
| `cc-check-then-act.ts` | concurrency-review | check-then-act race across `await`, non-idempotent handler, unhandled rejection |
| `perf-nplus1-loop.ts` | performance-review | N+1 in loop, unbounded cache, leaked connection + interval, no timeout |
| `spec-unmet-criterion/` | spec-compliance-review | missing criterion, no-enumeration violation, scope creep, uncovered scenario |
| `sess-token-rework.json` | session-analysis | high skill spend + repeated edits, low cache-hit, corrections, dead surface |

Corpus 91 → 96; `python3 scripts/eval_grade.py --check-corpus` passes.

## Not addressed (by design)
- **Body budgets** — 27 agents exceed the generic 40/75-line budget. Not trimmed: that budget is from the marketplace scaffold; the plugin's native `agent-audit` sets no line budget and trimming would delete detection rules.

## Follow-up
The new fixtures pass the **structural** gate but are **not** in `baseline.json` yet — that needs a label-gated **live** eval run (`run-eval` label / `force_live=true`) to confirm the agents produce the expected verdicts.