### PR TITLE
ci: dispatch the live agent-eval gate via the bare claude CLI

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -107,14 +107,13 @@ jobs:
     name: Live regression gate (model-dependent)
     runs-on: ubuntu-latest
     needs: structural-gate
-    # anthropics/claude-code-action@v1 authenticates its GitHub operations via
-    # an OIDC token, so id-token: write is required (it is never granted by
-    # default). contents: read to access the repo; pull-requests: write because
-    # the action's post-step buffers inline PR comments.
+    # The live gate dispatches the agents through the bare `claude` CLI (see the
+    # dispatch step below), which authenticates from ANTHROPIC_API_KEY — no OIDC
+    # token and no PR-comment write are needed, so the only permission required
+    # is read access to the repo. (The integration tier already dispatches the
+    # orchestrator via the bare CLI and runs with `contents: read` alone.)
     permissions:
-      id-token: write
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -225,70 +224,86 @@ jobs:
           fi
           echo "::notice title=eval replay cache::${nhits} hit(s) replayed, ${nmiss} miss(es) dispatched"
 
-      # Run the review agents headlessly via the Claude Code GitHub Action and
-      # serialize their RAW outputs to actuals.json in the grader's input shape
-      # (see scripts/eval_grade.py header). Grading stays in the deterministic
-      # grader below — this step only records, it does not judge. The plugin is
-      # installed from the in-repo marketplace so its skills are discoverable.
-      # KNOWN-BROKEN UPSTREAM (do not "fix" with version/native-vs-node pins):
-      # claude-code-action currently crashes at launch in CI with
-      #   "Claude Code process exited with code 1"
-      #   "Internal error: directory mismatch for directory '.../tsconfig.json', fd 4"
-      # before any API call. It is a Bun runtime fd bug in the action, tracked at
-      #   https://github.com/anthropics/claude-code-action/issues/1205
-      #   https://github.com/anthropics/claude-code-action/issues/1295
-      # Reporters confirm it is NOT version-specific (tested multiple versions +
-      # a pinned SHA) and NOT runner-OS-specific. We verified the same: pinning
-      # the CLI version and supplying a custom node-build executable
-      # (path_to_claude_code_executable) both crash identically (PRs #161, #162).
-      # So there is no config knob on our side that fixes it.
+      # Dispatch the review agents headlessly via the bare `claude` CLI — NOT via
+      # anthropics/claude-code-action. The action wraps the CLI in a Bun runtime
+      # that crashes at launch in CI ("directory mismatch for tsconfig.json",
+      # fd 4 / "Claude Code process exited with code 1") before any API call. It
+      # is an upstream bug — anthropics/claude-code-action#1205 (closed
+      # 2026-06-09 but the symptom persists) and #1295 (still open). It is NOT
+      # fixable on our side: the `@v1` pin already resolves to the latest release
+      # and still crashes, and pinning a CLI version / a custom node executable
+      # both crashed identically (PRs #161, #162). The integration tier below
+      # already dispatches the orchestrator through the bare CLI for the same
+      # reason; this mirrors that pattern.
       #
-      # This only affects the OPT-IN live path (run-eval label / force_live). The
-      # required structural + semver gates above are unaffected and still run, so
-      # nothing is blocked. Re-enable / re-test once the upstream issues are
-      # fixed; the Grade step below treats a missing actuals.json as a skip.
+      # The CLI authenticates from ANTHROPIC_API_KEY and the model writes its RAW
+      # agent outputs to actuals.json in the grader's input shape (see
+      # scripts/eval_grade.py header). Grading stays in the deterministic grader
+      # below — this step only records. Secret exposure is bounded by the
+      # maintainer-applied 'run-eval' label gate above (same model as the
+      # integration tier); unlike the action there is no self-skip on
+      # workflow-modifying PRs, so the gate can be exercised on its own PR.
+      - name: Install the claude CLI and the dev-team plugin
+        if: steps.cred.outputs.run_live == 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code || true
+          command -v claude >/dev/null \
+            || { echo "::error title=claude CLI missing::npm install of @anthropic-ai/claude-code failed; the live gate cannot dispatch."; exit 1; }
+          # Install the plugin from the in-repo marketplace so its skills/agents
+          # are discoverable to the headless run.
+          claude plugin marketplace add "$PWD"
+          claude plugin install dev-team@bfinster
+
       - name: Run agent-eval (records actuals.json)
         if: steps.cred.outputs.run_live == 'true'
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: ${{ github.workspace }}
-          plugins: "dev-team@bfinster"
-          prompt: |
-            Run the review agents against every fixture in
-            .claude/evals/fixtures/ whose paired .claude/evals/expected/<stem>.json
-            declares an applicableAgents (or applicableSkills) target, using the
-            /review-agent skill for agent fixtures and the test-design-advisor
-            skill for skill fixtures.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Dynamic directives flow in as env so GitHub expression substitution
+          # stays out of the shell body (no quoting hazards in the prompt).
+          SCOPE_INSTRUCTION: ${{ steps.scope.outputs.instruction }}
+          CACHE_SKIP: ${{ steps.cacheplan.outputs.cache_skip }}
+        run: |
+          # Assemble the prompt: static body via a quoted heredoc (no expansion),
+          # then the dynamic scope/cache directives appended from env.
+          cat > eval-prompt.txt <<'PROMPT'
+          Run the review agents against every fixture in
+          .claude/evals/fixtures/ whose paired .claude/evals/expected/<stem>.json
+          declares an applicableAgents (or applicableSkills) target, using the
+          /review-agent skill for agent fixtures and the test-design-advisor
+          skill for skill fixtures.
 
-            Do NOT grade. Record each agent's/skill's raw output and write it to
-            a file named actuals.json at the repository root, in EXACTLY this
-            shape (keyed by fixture stem — the expected filename without .json):
+          Do NOT grade. Record each agent's/skill's raw output and write it to
+          a file named actuals.json at the repository root, in EXACTLY this
+          shape (keyed by fixture stem — the expected filename without .json):
 
-              {
-                "<stem>": {
-                  "agents": {
-                    "<agent>": { "status": "...",
-                                 "issues": [{ "severity": "...", "message": "..." }],
-                                 "summary": "..." }
-                  },
-                  "skills": {
-                    "<skill>": { "report": "full advisor report text",
-                                 "gates": ["A"], "layers": ["unit"] }
-                  }
+            {
+              "<stem>": {
+                "agents": {
+                  "<agent>": { "status": "...",
+                               "issues": [{ "severity": "...", "message": "..." }],
+                               "summary": "..." }
+                },
+                "skills": {
+                  "<skill>": { "report": "full advisor report text",
+                               "gates": ["A"], "layers": ["unit"] }
                 }
               }
+            }
 
-            Include only the block(s) (agents/skills) that the fixture targets.
-            Write valid JSON and nothing else to actuals.json.
+          Include only the block(s) (agents/skills) that the fixture targets.
+          Write valid JSON and nothing else to actuals.json.
+          PROMPT
+          printf '\n%s\n%s\n' "$SCOPE_INSTRUCTION" "$CACHE_SKIP" >> eval-prompt.txt
 
-            ${{ steps.scope.outputs.instruction }}
-            ${{ steps.cacheplan.outputs.cache_skip }}
-          claude_args: |
-            --output-format json
-            --max-turns 60
-            --model claude-sonnet-4-6
-            --allowedTools "Read" "Glob" "Grep" "Write" "Agent" "Skill(review-agent *)" "Skill(test-design-advisor *)"
+          # Bare-CLI headless dispatch. A non-zero exit must NOT hard-fail the
+          # job — the grade step below treats a missing/empty actuals.json as a
+          # skip, keeping the opt-in gate non-blocking on dispatch trouble.
+          claude -p "$(cat eval-prompt.txt)" \
+            --output-format json \
+            --max-turns 60 \
+            --model claude-sonnet-4-6 \
+            --allowedTools "Read" "Glob" "Grep" "Write" "Agent" "Skill(review-agent *)" "Skill(test-design-advisor *)" \
+            || echo "::warning title=live dispatch exited non-zero::The claude CLI returned an error; grading treats a missing actuals.json as a skip."
 
       # Merge the cache-replayed pairs (replay.json, #311) into whatever the
       # dispatch recorded, so the grader sees the full pair set — replayed
@@ -307,24 +322,21 @@ jobs:
           echo "merged actuals (replay ∪ dispatched):"
           jq -r 'keys[]' actuals.json | sed 's/^/  · /' || true
 
-      - name: Grade against baseline (or skip if the action did not run)
+      - name: Grade against baseline (or skip if dispatch produced nothing)
         if: steps.cred.outputs.run_live == 'true'
         run: |
-          # anthropics/claude-code-action self-skips (exit 0, no model run) on
-          # any PR that adds/modifies this workflow file — GitHub workflow
-          # validation requires the file to match the default branch. In that
-          # case no actuals.json is produced; treat it as a skip, not a
-          # failure, so it does not red-line PRs. The gate exercises the agents
-          # once this workflow is merged to the default branch. With the replay
-          # cache (#311), an all-hits run still produces a populated actuals.json
-          # from replay.json, so grading proceeds with zero dispatch.
+          # If the bare-CLI dispatch produced no parseable actuals.json (it
+          # exited non-zero, wrote nothing, or every pair replayed from an empty
+          # cache), treat it as a skip — not a failure — so dispatch trouble does
+          # not red-line PRs on the opt-in gate. With the replay cache (#311), an
+          # all-hits run still produces a populated actuals.json from replay.json,
+          # so grading proceeds with zero dispatch.
           if [ ! -s actuals.json ] || ! jq -e 'keys|length>0' actuals.json >/dev/null 2>&1; then
             echo "::warning title=live eval did not run::No parseable" \
-              "actuals.json was produced and the replay cache was empty. This is" \
-              "expected on a PR that adds or modifies this workflow" \
-              "(claude-code-action only runs once the workflow is unchanged on" \
-              "the default branch), or if the runner wrote no file. The live gate" \
-              "will exercise the agents after merge."
+              "actuals.json was produced and the replay cache was empty — the" \
+              "claude CLI dispatch wrote no file or exited early. Skipping the" \
+              "grade rather than failing the opt-in gate; check the dispatch" \
+              "step log above."
             exit 0
           fi
           # Honor the quarantine (#233): flaky pairs recorded by a multi-trial

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,15 +16,23 @@ enforce on every PR (see below):
    asserts every `expected/*.json` is valid, declares an agent/skill target,
    and pairs with a fixture; `tests/repo/eval_grader_tests.bats` exercises the
    grader. No tokens, no flakes.
-2. **Live gate (paid, label-gated).** Dispatches the review agents via the
-   Claude Code GitHub Action (`anthropics/claude-code-action@v1`), records
-   their raw outputs to `actuals.json`, and grades against `baseline.json` —
-   failing the PR on any **regression** with a readable diff. It costs tokens,
-   so it runs **only when the PR carries the `run-eval` label** (or via a
-   manual `workflow_dispatch` with `force_live=true`), and only when
-   `ANTHROPIC_API_KEY` is set. Otherwise it is **skipped, not failed** (a
-   GitHub notice is emitted); the structural gate still runs. A `concurrency`
-   group cancels superseded runs so rapid pushes don't stack paid runs.
+2. **Live gate (paid, label-gated).** Dispatches the review agents via the bare
+   `claude` CLI (`@anthropic-ai/claude-code`), records their raw outputs to
+   `actuals.json`, and grades against `baseline.json` — failing the PR on any
+   **regression** with a readable diff. It costs tokens, so it runs **only when
+   the PR carries the `run-eval` label** (or via a manual `workflow_dispatch`
+   with `force_live=true`), and only when `ANTHROPIC_API_KEY` is set. Otherwise
+   it is **skipped, not failed** (a GitHub notice is emitted); the structural
+   gate still runs. A `concurrency` group cancels superseded runs so rapid
+   pushes don't stack paid runs.
+
+   > **Why the bare CLI, not `anthropics/claude-code-action`?** The action wraps
+   > the CLI in a Bun runtime that crashes at launch in CI ("directory mismatch
+   > for tsconfig.json", fd 4) before any API call — upstream
+   > [#1205](https://github.com/anthropics/claude-code-action/issues/1205) /
+   > [#1295](https://github.com/anthropics/claude-code-action/issues/1295), not
+   > fixable by version/SHA pinning. The live gate dispatches the agents
+   > directly with `claude -p`, mirroring the integration tier.
 
    **Diff-scoped runs.** The live gate runs only the agents/skills the PR
    changed (derived from the diff and threaded into both the runner prompt and
@@ -32,17 +40,13 @@ enforce on every PR (see below):
    grader, or the workflow — falls back to a full run, since one knowledge file
    can feed many agents. This is the main per-run cost lever.
 
-   **Note on workflow validation:** `claude-code-action` will *self-skip* (no
-   model run) on any PR that adds or modifies this workflow file, because
-   GitHub requires the workflow to match the default branch. The live gate
-   therefore only exercises the agents once `agent-eval.yml` is merged to the
-   default branch.
-
-   The runner is wired (it stages the corpus into `.claude/evals/`, installs
-   the `dev-team@bfinster` plugin, and prompts the model to write
-   `actuals.json` in the shape below). To record the baseline: add the
-   `run-eval` label to a PR (post-merge of this workflow), confirm it produces
-   a well-formed `actuals.json`, then capture its passing pairs below.
+   The runner is wired (it stages the corpus into `.claude/evals/`, installs the
+   `claude` CLI and the `dev-team@bfinster` plugin, and prompts the model to
+   write `actuals.json` in the shape below). Unlike the GitHub Action, the bare
+   CLI has no self-skip on PRs that modify this workflow, so the gate can be
+   exercised on the labeling PR itself. To record the baseline: add the
+   `run-eval` label to a PR, confirm it produces a well-formed `actuals.json`,
+   then capture its passing pairs below.
 
 ### Grader input shape (`actuals.json`)
 


### PR DESCRIPTION
## Problem

The live regression gate (`live-gate` job in `agent-eval.yml`) dispatched the review agents through **`anthropics/claude-code-action@v1`**, which crashes at launch in CI before any API call:

```
Claude Code process exited with code 1
Internal error: directory mismatch for directory '.../tsconfig.json', fd 4
```

This is an upstream Bun-runtime bug — [claude-code-action#1205](https://github.com/anthropics/claude-code-action/issues/1205) (closed 2026-06-09 but the symptom persists) and [#1295](https://github.com/anthropics/claude-code-action/issues/1295) (still open). It is **not fixable by version pinning**: `@v1` already resolves to the latest release (`v1.0.159`, same commit), which still crashes — confirmed twice on a recent `run-eval` run, and consistent with this repo's prior findings in PRs #161/#162.

## Change

Replace the action with a **direct `claude -p` dispatch**, mirroring the **integration tier**, which already runs the orchestrator via the bare CLI for the same reason.

- New step installs `@anthropic-ai/claude-code` and the `dev-team@bfinster` plugin from the in-repo marketplace.
- Dispatch runs the **same prompt and `--model`/`--max-turns`/`--allowedTools`** the action used; the dynamic scope/cache directives flow in via env to avoid quoting hazards.
- The **deterministic grader downstream is unchanged** — the `actuals.json` contract is identical.
- Drops the now-unneeded `id-token: write` / `pull-requests: write` permissions (CLI authenticates from `ANTHROPIC_API_KEY`; only `contents: read` remains).
- A non-zero CLI exit no longer hard-fails the job — the grade step still treats a missing `actuals.json` as a skip, keeping the opt-in gate non-blocking on dispatch trouble.
- `evals/README.md` updated to describe the CLI dispatch and drop the stale action self-skip note.

Validated with `actionlint` (only pre-existing SC2129 style nits in an untouched step remain).

## ⚠️ Self-test caveat

This PR modifies `agent-eval.yml`. A labeled run on **this** PR still executes the **old, action-based** workflow from the merge base (GitHub runs the base-branch workflow for the change). So the CLI path can only be verified by adding the `run-eval` label to a PR **after this merges to `main`**. The change is structural and `actionlint`-clean, but the bare-CLI dispatch is unverified in CI until then — it's a best-effort fix for a path that is currently 100% broken.

## Verification plan (post-merge)
1. Merge to `main`.
2. Open/relabel a small PR with `run-eval`.
3. Confirm the `Run agent-eval` step gets past SDK init (the old failure was ~30s in) and writes `actuals.json`.
4. Capture passing pairs into `evals/baseline.json` (incl. the 5 fixtures from #485).