### PR TITLE
fix: publish CNAME so docs custom domain binds on gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
       - "**.md"
       - mkdocs.yml
       - requirements-docs.txt
+      - scripts/assemble-docs.sh
+      - .github/workflows/docs.yml
   workflow_dispatch:
 
 permissions:

--- a/scripts/assemble-docs.sh
+++ b/scripts/assemble-docs.sh
@@ -22,3 +22,7 @@ cp -r "${REPO_ROOT}/docs" "${OUT}/docs"
 cp "${REPO_ROOT}/plugins/dev-team/README.md"    "${OUT}/plugins/dev-team/README.md"
 cp "${REPO_ROOT}/plugins/dev-team/CHANGELOG.md" "${OUT}/plugins/dev-team/CHANGELOG.md"
 cp -r "${REPO_ROOT}/plugins/dev-team/docs"      "${OUT}/plugins/dev-team/docs"
+
+# GitHub Pages custom domain — published to the gh-pages root so GitHub binds it.
+# Must match the host in mkdocs.yml site_url.
+printf 'docs.bryanfinster.com\n' > "${OUT}/CNAME"


### PR DESCRIPTION
## Problem

The custom domain `docs.bryanfinster.com` (declared as `site_url` in mkdocs.yml) never resolved:
- No `CNAME` file was deployed to `gh-pages`
- GitHub Pages had no custom domain configured
- The `docs` DNS record had been added in an inert Google Domains editor while the zone is authoritative on Netlify DNS

## Fix
- `scripts/assemble-docs.sh` now writes a `CNAME` so `mkdocs gh-deploy` republishes it to `gh-pages` on every deploy (otherwise the next `--force` deploy wipes the domain binding).
- `docs.yml` path filter now includes `scripts/assemble-docs.sh` and the workflow itself, so build-logic changes (including the CNAME) actually trigger a deploy.

## Status (already done outside this PR)
- ✅ Netlify DNS: `docs.bryanfinster.com CNAME bdfinst.github.io` — resolves to GitHub Pages IPs
- ✅ GitHub Pages custom domain bound (`cname: docs.bryanfinster.com`), serving 200 over HTTP
- ⏳ HTTPS cert provisioning (automatic)

This PR makes the binding **durable** across future docs deploys. Safe to merge.