### PR TITLE
docs: fix diagram rendering in dark mode and resolve overlaps/clipping

### DIFF
--- a/plugins/dev-team/docs/agent-architecture.md
+++ b/plugins/dev-team/docs/agent-architecture.md
@@ -8,6 +8,12 @@
 
 The Orchestrator receives every request, classifies it by type and complexity, selects agents, assigns models, and coordinates delivery. During Phase 3 (Implement), review agents check coding agent output at each discrete unit-of-work checkpoint. Findings feed back as structured corrections (max 2 cycles before human escalation). After each task, the learning loop captures metrics and evaluates whether configuration updates are needed.
 
+## Three-phase workflow
+
+Feature work flows through three phases — **Research → Plan → Implement** — with a human gate between each. Research turns a request into approved specs (`/specs` → design doc); Plan decomposes them into TDD steps that four critic personas challenge before the human approves; Implement runs the RED-GREEN-REFACTOR build loop with inline review and a `/code-review` gate, then opens the PR and feeds the learning loop.
+
+![Three-phase workflow: Research (/specs → design doc → approve), Plan (/plan with Acceptance, Design, UX, and Strategic critics → approve), and Implement (TDD loop → spec-compliance → quality agents → /code-review with auto-fix → approve), ending in /pr and the learning loop.](diagrams/workflow-three-phase.svg)
+
 ## Model Routing
 
 Each agent declares an effort band (`effort: low|medium|high`) in its frontmatter. Band-to-model resolution is **enforced by a PreToolUse hook** (`hooks/agent-model-resolve.sh`, registered in `settings.json` under `matcher: "Agent"`) backed by the resolver helper `hooks/lib/model-resolve.sh`: it reads the band by `subagent_type` and maps it via the shipped default map in `knowledge/model-routing.json` or, when present, a per-environment ladder `.claude/model-ladder.json` (gitignored, hand-written for restricted endpoints). The session model captured at SessionStart is the fallback for an unmappable model, never a ceiling. See `agents/orchestrator.md` → Resolution Procedure for the full algorithm, `docs/model-routing.md` for the contract and `docs/model-routing-overrides.md` for ladder authoring, and `/model-routing-check` for a read-only diagnostic.

--- a/plugins/dev-team/docs/diagrams/architecture-overview.svg
+++ b/plugins/dev-team/docs/diagrams/architecture-overview.svg
@@ -11,6 +11,9 @@
     </marker>
   </defs>
 
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="600" height="520" fill="#ffffff"/>
+
   <!-- User Request -->
   <g filter="url(#shadow)">
     <rect x="215" y="12" width="170" height="44" rx="22" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
@@ -28,26 +31,26 @@
   </g>
 
   <!-- Branches from Orchestrator -->
-  <line x1="240" y1="134" x2="240" y2="165" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
-  <line x1="360" y1="134" x2="360" y2="165" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="258" y1="134" x2="158" y2="166" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="342" y1="134" x2="358" y2="166" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Model Tier Resolution (PreToolUse hook) -->
   <g filter="url(#shadow)">
-    <rect x="135" y="170" width="210" height="48" rx="12" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <rect x="135" y="170" width="5" height="48" rx="2.5" fill="#8B5CF6"/>
-    <text x="240" y="194" text-anchor="middle" font-size="12" font-weight="600" fill="#1E293B">Model Tier Resolution</text>
-    <text x="240" y="208" text-anchor="middle" font-size="10" font-weight="400" fill="#475569">(PreToolUse hook)</text>
+    <rect x="65" y="170" width="170" height="48" rx="12" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="65" y="170" width="5" height="48" rx="2.5" fill="#8B5CF6"/>
+    <text x="150" y="194" text-anchor="middle" font-size="12" font-weight="600" fill="#1E293B">Model Tier Resolution</text>
+    <text x="150" y="208" text-anchor="middle" font-size="10" font-weight="400" fill="#475569">(PreToolUse hook)</text>
   </g>
 
   <!-- Agent Selection -->
   <g filter="url(#shadow)">
-    <rect x="255" y="170" width="210" height="48" rx="12" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-    <rect x="255" y="170" width="5" height="48" rx="2.5" fill="#3B82F6"/>
+    <rect x="275" y="170" width="170" height="48" rx="12" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+    <rect x="275" y="170" width="5" height="48" rx="2.5" fill="#3B82F6"/>
     <text x="360" y="199" text-anchor="middle" font-size="13" font-weight="600" fill="#1E293B">Agent Selection</text>
   </g>
 
   <!-- Merge arrows down -->
-  <line x1="240" y1="218" x2="300" y2="248" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="150" y1="218" x2="300" y2="248" stroke="#94A3B8" stroke-width="2"/>
   <line x1="360" y1="218" x2="300" y2="248" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Task Execution -->

--- a/plugins/dev-team/docs/diagrams/review-dispatch.svg
+++ b/plugins/dev-team/docs/diagrams/review-dispatch.svg
@@ -14,6 +14,9 @@
     </marker>
   </defs>
 
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="900" height="480" fill="#ffffff"/>
+
   <!-- Orchestrator -->
   <g filter="url(#shadow)">
     <rect x="16" y="190" width="160" height="52" rx="12" fill="#6366F1" stroke="#4F46E5" stroke-width="1"/>

--- a/plugins/dev-team/docs/diagrams/team-agents.svg
+++ b/plugins/dev-team/docs/diagrams/team-agents.svg
@@ -5,6 +5,9 @@
     </filter>
   </defs>
 
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="780" height="420" fill="#ffffff"/>
+
   <!-- Orchestrator (center top) -->
   <g filter="url(#shadow)">
     <rect x="295" y="16" width="190" height="52" rx="12" fill="#6366F1" stroke="#4F46E5" stroke-width="1"/>
@@ -94,11 +97,11 @@
     <text x="660" y="293" text-anchor="middle" font-size="12" font-weight="600" fill="#1E293B">Security Engineer</text>
   </g>
 
-  <!-- DevOps/SRE -->
+  <!-- Platform Engineer -->
   <g filter="url(#shadow)">
     <rect x="560" y="344" width="200" height="48" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
     <rect x="560" y="344" width="5" height="48" rx="2.5" fill="#14B8A6"/>
-    <text x="660" y="373" text-anchor="middle" font-size="12" font-weight="600" fill="#1E293B">DevOps / SRE</text>
+    <text x="660" y="373" text-anchor="middle" font-size="12" font-weight="600" fill="#1E293B">Platform Engineer</text>
   </g>
 
   <!-- Collaboration lines (dashed, between peers) -->
@@ -114,7 +117,7 @@
   <line x1="290" y1="224" x2="220" y2="224" stroke="#CBD5E1" stroke-width="1" stroke-dasharray="4,3"/>
   <!-- PM <-> Tech Writer (short cross) -->
   <line x1="490" y1="156" x2="560" y2="200" stroke="#CBD5E1" stroke-width="1" stroke-dasharray="4,3"/>
-  <!-- SE <-> DevOps (long cross, faded) -->
+  <!-- SE <-> Platform Engineer (long cross, faded) -->
   <line x1="220" y1="128" x2="560" y2="368" stroke="#CBD5E1" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
 
   <!-- Legend -->

--- a/plugins/dev-team/docs/diagrams/test-modernize-flow.svg
+++ b/plugins/dev-team/docs/diagrams/test-modernize-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1180" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1010 1200" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-labelledby="title desc">
   <title id="title">/test-modernize five-phase workflow</title>
   <desc id="desc">Vertical flowchart of the /test-modernize orchestrator. Phase 0 approach contract resolves the tracker CLI (or local files) and the test-binding mode (bdd-runner or xunit-with-annotations). Phase 1 invokes /cd-test-architecture then /issues-from-assessment, but does NOT create Component tests Stories. Phase 2 runs in two passes around the human gate: Pass A authors .feature files; the operator signs off; Pass B creates Component tests Stories bound to specific approved scenarios. Phase 3 disables cannot-fail tests and records baseline coverage. Phase 4 invokes /build then /coverage-delta per Story; /build binds each Component tests Story's tests to the cited scenarios. Phase 5 invokes /build, /mutation-testing, and /quality-targets-converge per Story until the four quality targets are met or waived; new component tests required by Phase 5 must extend approved Gherkin or open a Phase-2 amendment. A human-gate diamond sits between every phase. The dev-team:test-modernization-review agent reviews each phase deliverable and in Phases 2 and 4 verifies Gherkin binding integrity.</desc>
   <defs>
@@ -15,6 +15,9 @@
       <path d="M0,0 L10,4 L0,8 Z" fill="#10B981"/>
     </marker>
   </defs>
+
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="1010" height="1200" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="490" y="28" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">/test-modernize — five-phase workflow</text>
@@ -112,9 +115,9 @@
 
   <!-- Gate 5 -->
   <g filter="url(#shadow)">
-    <polygon points="490,1128 620,1156 490,1184 360,1156" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" transform="translate(0,-22)"/>
-    <text x="490" y="1135" text-anchor="middle" font-size="11" font-weight="600" fill="#92400E">Human gate</text>
-    <text x="490" y="1150" text-anchor="middle" font-size="10" fill="#92400E">targets met (or each waived with reason)</text>
+    <polygon points="490,1128 640,1156 490,1184 340,1156" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="490" y="1153" text-anchor="middle" font-size="11" font-weight="600" fill="#92400E">Human gate</text>
+    <text x="490" y="1168" text-anchor="middle" font-size="10" fill="#92400E">targets met (or each waived with reason)</text>
   </g>
 
   <!-- Arrows main column -->

--- a/plugins/dev-team/docs/diagrams/workflow-linear.svg
+++ b/plugins/dev-team/docs/diagrams/workflow-linear.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 120" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 910 120" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
   <defs>
     <filter id="shadow" x="-4%" y="-4%" width="108%" height="116%">
       <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000" flood-opacity="0.07"/>
@@ -7,6 +7,9 @@
       <path d="M0,0 L10,4 L0,8 Z" fill="#94A3B8"/>
     </marker>
   </defs>
+
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="910" height="120" fill="#ffffff"/>
 
   <!-- Step 1: /specs -->
   <g filter="url(#shadow)">
@@ -17,29 +20,29 @@
   </g>
 
   <!-- Arrow 1 -->
-  <line x1="180" y1="56" x2="210" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="195" y="46" text-anchor="middle" font-size="9" fill="#94A3B8">consistency</text>
-  <text x="195" y="30" text-anchor="middle" font-size="9" fill="#94A3B8">gate</text>
+  <line x1="185" y1="56" x2="245" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="215" y="44" text-anchor="middle" font-size="9" fill="#94A3B8">consistency</text>
+  <text x="215" y="33" text-anchor="middle" font-size="9" fill="#94A3B8">gate</text>
 
   <!-- Step 2: /plan -->
   <g filter="url(#shadow)">
-    <rect x="216" y="20" width="170" height="72" rx="12" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-    <rect x="216" y="20" width="5" height="72" rx="2.5" fill="#3B82F6"/>
-    <text x="301" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/plan</text>
-    <text x="301" y="70" text-anchor="middle" font-size="11" fill="#64748B">TDD steps</text>
+    <rect x="250" y="20" width="170" height="72" rx="12" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+    <rect x="250" y="20" width="5" height="72" rx="2.5" fill="#3B82F6"/>
+    <text x="335" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/plan</text>
+    <text x="335" y="70" text-anchor="middle" font-size="11" fill="#64748B">TDD steps</text>
   </g>
 
   <!-- Arrow 2 -->
-  <line x1="386" y1="56" x2="416" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="401" y="46" text-anchor="middle" font-size="9" fill="#94A3B8">human</text>
-  <text x="401" y="30" text-anchor="middle" font-size="9" fill="#94A3B8">approval</text>
+  <line x1="425" y1="56" x2="485" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="455" y="44" text-anchor="middle" font-size="9" fill="#94A3B8">human</text>
+  <text x="455" y="33" text-anchor="middle" font-size="9" fill="#94A3B8">approval</text>
 
   <!-- Step 3: /build -->
   <g filter="url(#shadow)">
-    <rect x="422" y="20" width="170" height="72" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <rect x="422" y="20" width="5" height="72" rx="2.5" fill="#10B981"/>
-    <text x="507" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/build</text>
-    <text x="507" y="70" text-anchor="middle" font-size="11">
+    <rect x="490" y="20" width="170" height="72" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="490" y="20" width="5" height="72" rx="2.5" fill="#10B981"/>
+    <text x="575" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/build</text>
+    <text x="575" y="70" text-anchor="middle" font-size="11">
       <tspan fill="#EF4444" font-weight="600">RED</tspan>
       <tspan fill="#64748B"> - </tspan>
       <tspan fill="#22C55E" font-weight="600">GREEN</tspan>
@@ -49,15 +52,15 @@
   </g>
 
   <!-- Arrow 3 -->
-  <line x1="592" y1="56" x2="622" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="607" y="46" text-anchor="middle" font-size="9" fill="#94A3B8">code</text>
-  <text x="607" y="30" text-anchor="middle" font-size="9" fill="#94A3B8">review</text>
+  <line x1="665" y1="56" x2="725" y2="56" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="695" y="44" text-anchor="middle" font-size="9" fill="#94A3B8">code</text>
+  <text x="695" y="33" text-anchor="middle" font-size="9" fill="#94A3B8">review</text>
 
   <!-- Step 4: /pr -->
   <g filter="url(#shadow)">
-    <rect x="628" y="20" width="170" height="72" rx="12" fill="#FFF7ED" stroke="#F97316" stroke-width="1.5"/>
-    <rect x="628" y="20" width="5" height="72" rx="2.5" fill="#F97316"/>
-    <text x="713" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/pr</text>
-    <text x="713" y="70" text-anchor="middle" font-size="11" fill="#64748B">quality gates</text>
+    <rect x="730" y="20" width="170" height="72" rx="12" fill="#FFF7ED" stroke="#F97316" stroke-width="1.5"/>
+    <rect x="730" y="20" width="5" height="72" rx="2.5" fill="#F97316"/>
+    <text x="815" y="50" text-anchor="middle" font-size="14" font-weight="600" fill="#1E293B">/pr</text>
+    <text x="815" y="70" text-anchor="middle" font-size="11" fill="#64748B">quality gates</text>
   </g>
 </svg>

--- a/plugins/dev-team/docs/diagrams/workflow-three-phase.svg
+++ b/plugins/dev-team/docs/diagrams/workflow-three-phase.svg
@@ -14,6 +14,9 @@
     </marker>
   </defs>
 
+  <!-- Light background so the diagram stays readable in dark-mode docs -->
+  <rect width="900" height="510" fill="#ffffff"/>
+
   <!-- User Request + Orchestrator -->
   <g filter="url(#shadow)">
     <rect x="370" y="6" width="160" height="32" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>

--- a/plugins/dev-team/docs/team-structure.md
+++ b/plugins/dev-team/docs/team-structure.md
@@ -4,9 +4,9 @@ This document is a visual index of the agent team. For behavioral details of eac
 
 ## Team Agents
 
-![Org chart showing the Orchestrator at the top, dispatching to eleven team agents: Software Engineer, QA Engineer, UI/UX Designer, Architect, Product Manager, Technical Writer, Security Engineer, Platform Engineer, ADR Author, and Codebase Recon.](diagrams/team-agents.svg)
+![Org chart showing the Orchestrator at the top, dispatching to ten team agents: Software Engineer, QA Engineer, UI/UX Designer, Architect, Product Manager, Technical Writer, Security Engineer, Platform Engineer, ADR Author, and Codebase Recon.](diagrams/team-agents.svg)
 
-The Orchestrator sits at the root and routes every request to one or more of the eleven team agents based on task classification. Only the Orchestrator spans phases; the other agents are loaded on demand when their phase begins and unloaded via summarization before the next phase starts. Full roster: [Agents → Team Agents](agent_info.md#team-agents).
+The Orchestrator sits at the root and routes every request to one or more of the ten team agents based on task classification. Only the Orchestrator spans phases; the other agents are loaded on demand when their phase begins and unloaded via summarization before the next phase starts. Full roster: [Agents → Team Agents](agent_info.md#team-agents).
 
 ## Review Agent Dispatch (Phase 3 Inline Checkpoints)
 


### PR DESCRIPTION
## Problem

The six documentation diagrams in `plugins/dev-team/docs/diagrams/` are transparent SVGs with dark text. In the docs **dark mode** (and GitHub's dark README view), their titles, edge labels, and arrows were invisible. Two also had geometry bugs.

## Rendering fix (all 6)
Added a light background rect to each SVG so diagrams render correctly in both light and dark themes.

## Geometry fixes
- **architecture-overview** — 'Model Tier Resolution' and 'Agent Selection' boxes overlapped by 90px with clipped text; separated them and re-routed the branch/merge arrows (verified clear of the loop-back curve).
- **test-modernize-flow** — right-rail 'Gherkin binding' label overflowed the viewBox; final gate used a `translate` hack that clipped it. Widened the viewBox (980×1180 → 1010×1200) and normalized the gate.
- **workflow-linear** — edge labels bled onto box corners; widened inter-box gaps (viewBox 820 → 910).

## Content
- Wired the previously-orphaned **workflow-three-phase.svg** into `agent-architecture.md` (new 'Three-phase workflow' section).
- Aligned `team-structure.md` + `team-agents.svg`: **ten** agents (was 'eleven', only ten listed/shown) and **Platform Engineer** (box said 'DevOps / SRE', mismatching the agent name).

## Verification
All six re-rendered on dark and light backgrounds and visually confirmed; XML well-formedness checked; `scripts/check_md_references.py` passes; `scripts/assemble-docs.sh` still assembles.