### PR TITLE
docs: move Getting Started install steps into the docs page

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -2,6 +2,81 @@
 
 This project gives you an AI development team — specialized agents with distinct roles, reusable skills they draw on, and slash commands for skills and workflows. You talk to the team in natural language. The system figures out who should do the work and what knowledge they need.
 
+## Installation
+
+### Install `dev-team`
+
+Start here — most users install only this plugin. Required tools (`jq`, `gh`) are listed in the [Plugins](README.md#plugins) table.
+
+```bash
+claude plugin marketplace add bdfinst/agentic-dev-team
+claude plugin install dev-team@bfinster
+```
+
+The `owner/repo` shorthand and the full `https://github.com/bdfinst/agentic-dev-team` URL are equivalent. For self-hosted or other git hosts, install scopes (`user`/`project`/`local`), and the upgrade/re-point commands, see the [plugin install guide](plugins/dev-team/README.md#install).
+
+Then, in your project, install tool dependencies and generate config:
+
+```text
+/init-dev-team
+/setup
+```
+
+- **`/init-dev-team`** installs the tools the plugin depends on — `jq` and `python3` (mutation gate), language-specific mutation testing (Stryker for JS/TS, pitest for Java/Kotlin, Stryker.NET for C#), an optional CodeGraph index for code intelligence, and an opt-in model-availability probe for restricted API endpoints.
+- **`/setup`** detects your stack and generates project-level config and hooks, including the automated pre-commit review gate.
+
+After `/setup`, run `/specs` to start a feature, or ask a question and let the Orchestrator route it.
+
+### Install `security-assessment` (optional)
+
+Add this plugin only if you want the `/security-assessment` pipeline. Install `dev-team` first.
+
+```bash
+claude plugin install security-assessment@bfinster
+```
+
+For a self-hosted git host, see the [plugin install guide](plugins/dev-team/README.md#install); for a local clone, see [Local development](CONTRIBUTING.md#local-development) in CONTRIBUTING.
+
+### Install `marketplace-dev` (optional)
+
+Add this plugin if you're building or maintaining Claude Code plugins and marketplaces. It is independent of `dev-team` — install it on its own if that's all you need.
+
+```bash
+claude plugin install marketplace-dev@bfinster
+```
+
+Then use `/scaffold-plugin <name>` to create a new plugin, `/scaffold-marketplace <owner>` for a new marketplace, or `/plugin-audit [dir]` to check an existing plugin for structural compliance. See the [marketplace-dev guide](plugins/marketplace-dev/CLAUDE.md) for the full command list.
+
+### Update an installed plugin
+
+Run `/upgrade` from any Claude Code session with `dev-team` installed. It:
+
+1. Reads the current installed scope from `claude plugin list` and passes `--scope <scope>` to `claude plugin update`, so project- and local-scope installs upgrade correctly rather than silently failing against the `user` default.
+2. Asks before enabling marketplace-level auto-update (the same `extraKnownMarketplaces.<marketplace>.autoUpdate` flag the `/plugin` UI toggles); decline to keep manual control.
+3. Reports the previous and new version, and prompts you to restart Claude Code so the new code loads.
+
+Manual fallback when `/upgrade` is unavailable:
+
+```bash
+claude plugin update --scope <scope> dev-team@bfinster
+claude plugin update --scope <scope> security-assessment@bfinster
+claude plugin update --scope <scope> marketplace-dev@bfinster
+```
+
+Then install the tier-1 static-analysis tools:
+
+```bash
+# macOS
+./plugins/security-assessment/install-macos.sh           # tier-1 only
+./plugins/security-assessment/install-macos.sh --all     # tier-1 + optional + PDF deps
+./plugins/security-assessment/install-macos.sh --dry-run # preview without running
+
+# Windows (requires Scoop)
+.\plugins\security-assessment\install-windows.ps1
+```
+
+Verify: `./plugins/security-assessment/install.sh`
+
 ## Key Concepts
 
 **Agents** are roles with personas, responsibilities, and behavioral guidelines. Each agent knows when to escalate, who to collaborate with, and how to make decisions. Think of them as team members with defined specialties.

--- a/README.md
+++ b/README.md
@@ -24,78 +24,16 @@ Plugin names link to each plugin's README (or, for `marketplace-dev`, its `CLAUD
 
 ## Getting Started
 
-### Install `dev-team`
+New here? The **[Getting Started guide](GETTING-STARTED.md)** is the full walkthrough — installing each plugin, configuring a project, the day-to-day workflow, and the diagnostic commands.
 
-Start here — most users install only this plugin. Required tools (`jq`, `gh`) are listed in the [Plugins](#plugins) table above.
+Quick install of the core plugin:
 
 ```bash
 claude plugin marketplace add bdfinst/agentic-dev-team
 claude plugin install dev-team@bfinster
 ```
 
-The `owner/repo` shorthand and the full `https://github.com/bdfinst/agentic-dev-team` URL are equivalent. For self-hosted or other git hosts, install scopes (`user`/`project`/`local`), and the upgrade/re-point commands, see the [plugin install guide](plugins/dev-team/README.md#install).
-
-Then, in your project, install tool dependencies and generate config:
-
-```text
-/init-dev-team
-/setup
-```
-
-- **`/init-dev-team`** installs the tools the plugin depends on — `jq` and `python3` (mutation gate), language-specific mutation testing (Stryker for JS/TS, pitest for Java/Kotlin, Stryker.NET for C#), an optional CodeGraph index for code intelligence, and an opt-in model-availability probe for restricted API endpoints.
-- **`/setup`** detects your stack and generates project-level config and hooks, including the automated pre-commit review gate.
-
-After `/setup`, run `/specs` to start a feature, or ask a question and let the Orchestrator route it.
-
-### Install `security-assessment` (optional)
-
-Add this plugin only if you want the `/security-assessment` pipeline. Install `dev-team` first.
-
-```bash
-claude plugin install security-assessment@bfinster
-```
-
-For a self-hosted git host, see the [plugin install guide](plugins/dev-team/README.md#install); for a local clone, see [Local development](CONTRIBUTING.md#local-development) in CONTRIBUTING.
-
-### Install `marketplace-dev` (optional)
-
-Add this plugin if you're building or maintaining Claude Code plugins and marketplaces. It is independent of `dev-team` — install it on its own if that's all you need.
-
-```bash
-claude plugin install marketplace-dev@bfinster
-```
-
-Then use `/scaffold-plugin <name>` to create a new plugin, `/scaffold-marketplace <owner>` for a new marketplace, or `/plugin-audit [dir]` to check an existing plugin for structural compliance. See the [marketplace-dev guide](plugins/marketplace-dev/CLAUDE.md) for the full command list.
-
-### Update an installed plugin
-
-Run `/upgrade` from any Claude Code session with `dev-team` installed. It:
-
-1. Reads the current installed scope from `claude plugin list` and passes `--scope <scope>` to `claude plugin update`, so project- and local-scope installs upgrade correctly rather than silently failing against the `user` default.
-2. Asks before enabling marketplace-level auto-update (the same `extraKnownMarketplaces.<marketplace>.autoUpdate` flag the `/plugin` UI toggles); decline to keep manual control.
-3. Reports the previous and new version, and prompts you to restart Claude Code so the new code loads.
-
-Manual fallback when `/upgrade` is unavailable:
-
-```bash
-claude plugin update --scope <scope> dev-team@bfinster
-claude plugin update --scope <scope> security-assessment@bfinster
-claude plugin update --scope <scope> marketplace-dev@bfinster
-```
-
-Then install the tier-1 static-analysis tools:
-
-```bash
-# macOS
-./plugins/security-assessment/install-macos.sh           # tier-1 only
-./plugins/security-assessment/install-macos.sh --all     # tier-1 + optional + PDF deps
-./plugins/security-assessment/install-macos.sh --dry-run # preview without running
-
-# Windows (requires Scoop)
-.\plugins\security-assessment\install-windows.ps1
-```
-
-Verify: `./plugins/security-assessment/install.sh`
+Then run `/init-dev-team` and `/setup` in your project. Optional plugins (`security-assessment`, `marketplace-dev`), self-hosted git hosts, install scopes, and the `/upgrade` flow are all covered in the [Getting Started guide](GETTING-STARTED.md).
 
 ## Dev team workflow
 


### PR DESCRIPTION
## What

The README carried the full install / setup / update instructions inline under **Getting Started**. This moves that content into the MkDocs-built `GETTING-STARTED.md` page and leaves the README with a quick-install snippet plus a link to the guide.

## Why

`GETTING-STARTED.md` is already in the docs nav directly after **Home** (the overview), so installation now lives on the page readers reach first — and it's no longer duplicated between the README and the guide.

## Changes

- `GETTING-STARTED.md` — new **Installation** section (dev-team, optional plugins, `/upgrade` flow) moved from the README, with relative links re-pointed (`README.md#plugins`).
- `README.md` — **Getting Started** section trimmed to a quick-install + link to the guide.
- Nav already lists **Getting Started** right after **Home**; no `mkdocs.yml` change needed.

Docs-only change.