### PR TITLE
docs: fix dead spec link in overview page and nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Developing, testing, or releasing the plugins? See **[CONTRIBUTING.md](CONTRIBUT
 | [Marketplace Builder Playbook](docs/marketplace-builder-plugin-playbook.md) | Building a plugin that scaffolds/audits marketplace monorepos |
 | [Plugin Skills in the Web Environment](docs/using-plugin-skills-in-the-web-environment.md) | Running a plugin's skills from a Claude Code web session |
 | [Architecture Decision Records](docs/adr/README.md) | Indexed ADRs — model routing, knowledge indexing, eval tiers, integration topology |
-| [Design Specs](docs/specs/model-complexity-routing.md) | Effort-band model routing design specification |
+| [Design Specs](docs/specs/python-agent-harness-pattern.md) | In-repo design specs — e.g. the Python agent-harness pattern and CLAUDE.md size reduction |
 
 ## CodeGraph
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,7 +112,8 @@ nav:
           - Complexity Refactor Regression: docs/experiments/complexity-refactor-regression.md
 
     - Specs:
-          - Model Complexity Routing: docs/specs/model-complexity-routing.md
+          - Plugin CLAUDE.md Size Reduction: docs/specs/plugin-claude-md-size-reduction.md
+          - Python Agent-Harness Pattern: docs/specs/python-agent-harness-pattern.md
           - Insights Reports Prompt Idea: docs/specs/insights-reports/prompt-idea.md
 
     - Changelog:


### PR DESCRIPTION
While reviewing the overview (README / mkdocs Home) for accuracy, found one dead reference.

## Defect
`docs/specs/model-complexity-routing.md` was deleted when effort-band routing replaced `model:` tiers, but it was still linked from:
- **README.md** — the "Design Specs" row under *Repo-level guides & decision records*.
- **mkdocs.yml** — the *Specs* nav section (a `--strict` mkdocs build fails on a nav entry pointing at a missing file).

The nav was also stale: it omitted the two specs that actually exist (`plugin-claude-md-size-reduction.md`, `python-agent-harness-pattern.md`).

## Fix
- Repoint the README row to a live spec with an accurate description.
- List the three real `docs/specs/` files in the nav.

Everything else on the overview checked out: plugin names/versions, all plugin commands and agent names, install commands, and every other relative link resolve.

Docs/metadata-only change.