### PR TITLE
docs: improve findability and trim verbosity

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -22,7 +22,7 @@ Then, in your project, install tool dependencies and generate config:
 /setup
 ```
 
-- **`/init-dev-team`** installs the tools the plugin depends on — `jq` and `python3` (mutation gate), language-specific mutation testing (Stryker for JS/TS, pitest for Java/Kotlin, Stryker.NET for C#), an optional CodeGraph index for code intelligence, and an opt-in model-availability probe for restricted API endpoints.
+- **`/init-dev-team`** installs the plugin's tool dependencies — `jq`, `python3`, and language-specific mutation tooling (Stryker, pitest, Stryker.NET) — plus an optional CodeGraph index for code intelligence.
 - **`/setup`** detects your stack and generates project-level config and hooks, including the automated pre-commit review gate.
 
 After `/setup`, run `/specs` to start a feature, or ask a question and let the Orchestrator route it.
@@ -36,6 +36,20 @@ claude plugin install security-assessment@bfinster
 ```
 
 For a self-hosted git host, see the [plugin install guide](plugins/dev-team/README.md#install); for a local clone, see [Local development](CONTRIBUTING.md#local-development) in CONTRIBUTING.
+
+Then install the tier-1 static-analysis tools the pipeline depends on:
+
+```bash
+# macOS
+./plugins/security-assessment/install-macos.sh           # tier-1 only
+./plugins/security-assessment/install-macos.sh --all     # tier-1 + optional + PDF deps
+./plugins/security-assessment/install-macos.sh --dry-run # preview without running
+
+# Windows (requires Scoop)
+.\plugins\security-assessment\install-windows.ps1
+```
+
+Verify: `./plugins/security-assessment/install.sh`
 
 ### Install `marketplace-dev` (optional)
 
@@ -62,20 +76,6 @@ claude plugin update --scope <scope> dev-team@bfinster
 claude plugin update --scope <scope> security-assessment@bfinster
 claude plugin update --scope <scope> marketplace-dev@bfinster
 ```
-
-Then install the tier-1 static-analysis tools:
-
-```bash
-# macOS
-./plugins/security-assessment/install-macos.sh           # tier-1 only
-./plugins/security-assessment/install-macos.sh --all     # tier-1 + optional + PDF deps
-./plugins/security-assessment/install-macos.sh --dry-run # preview without running
-
-# Windows (requires Scoop)
-.\plugins\security-assessment\install-windows.ps1
-```
-
-Verify: `./plugins/security-assessment/install.sh`
 
 ## Key Concepts
 
@@ -184,22 +184,15 @@ The commands above support a change in flight. These workflows do the opposite: 
 
 | Workflow | What it reports | Run it when |
 |----------|-----------------|-------------|
-| `/test-health` | Project-wide test-strategy audit: suite shape vs. architecture fit, coverage mapped to the testing quadrants, flaky tests, automation maturity — ending in an ordered improvement plan. **Runs `/test-design` and `/mutation-testing` as part of its rollup**, so it's the broadest starting point. | "How healthy is our test suite?" — start here for whole-suite test work. |
-| `/test-design` | Deep test-design review of the existing suite: a **Farley Score** for all existing tests (quality 1–10 across Dave Farley's 8 properties) plus per-file smells and testability blockers. Also runs standalone. | You want a quantitative quality score and concrete per-test fixes without the full strategy audit. |
-| `/mutation-testing` | Whether your existing tests actually catch bugs — runs a real mutation tool on critical modules and triages surviving mutants. Also feeds `/test-health`. | Coverage looks high but you suspect assertions are weak. |
-| `/code-review --all` | The full review-agent suite (architecture, complexity, naming, security, duplication, docs, …) over the **entire repository**, not just a diff. Add `--background` for a no-gates structural drift review. | Auditing code quality across a whole project or after a long period without review. |
-| `/semantic-scan` | Business logic reimplemented in multiple layers — the same domain calculation duplicated across domain services, adapters, and UI — with canonical-location suggestions. | Hunting for hidden duplication and drift in a layered codebase. |
-| `/threat-modeling` | STRIDE security analysis of attack surfaces, trust boundaries, and mitigations. | Reviewing the security posture of an existing service or data flow. |
-| `/docker-image-audit` | Container and Dockerfile security (CVEs), image bloat, and best-practice violations via hadolint, Trivy, and Grype. | Hardening or slimming an existing image. |
-| `/benchmark <url>` | Runtime performance of a running app (Core Web Vitals, resource sizes), compared against saved baselines. | Establishing or checking a performance baseline. |
-| `/explore --charter '<goal>'` | Charter-driven exploratory testing of a **running** target: structured heuristics + adversarial probing, auto-triaging critical defects into a report. | Finding bugs in a live app that the test suite doesn't cover. |
-
-```text
-/test-health                      Audit the whole test suite and get an improvement plan
-/test-design                      Score every existing test (Farley Score) and surface smells
-/code-review --all                Review the entire repository, not just pending changes
-/semantic-scan                    Find duplicated business logic across layers
-```
+| `/test-health` | Whole-suite test-strategy audit — suite shape, coverage-to-quadrant mapping, flaky tests, maturity — ending in an ordered plan. Rolls up `/test-design` + `/mutation-testing`, so start here. | "How healthy is our test suite?" |
+| `/test-design` | A **Farley Score** (1–10 across Farley's 8 properties) for every test, plus per-file smells and testability blockers. | You want a quality score and per-test fixes without the full audit. |
+| `/mutation-testing` | Whether tests actually catch bugs — mutates critical modules and triages survivors. | Coverage looks high but assertions feel weak. |
+| `/code-review --all` | The full review-agent suite over the **entire repository**, not just a diff (`--background` for a no-gates drift review). | Auditing a whole project, or after a long gap. |
+| `/semantic-scan` | The same business logic reimplemented across layers, with canonical-location suggestions. | Hunting hidden duplication in a layered codebase. |
+| `/threat-modeling` | STRIDE analysis of attack surfaces, trust boundaries, and mitigations. | Reviewing a service's security posture. |
+| `/docker-image-audit` | Container/Dockerfile CVEs, bloat, and best-practice violations (hadolint, Trivy, Grype). | Hardening or slimming an image. |
+| `/benchmark <url>` | Runtime performance of a running app (Core Web Vitals, resource sizes) vs. saved baselines. | Establishing or checking a performance baseline. |
+| `/explore --charter '<goal>'` | Charter-driven exploratory testing of a **running** target, auto-triaging critical defects. | Finding bugs the test suite misses. |
 
 Two harness-level diagnostics review *how the project is set up to work with the team* rather than the product code: `/harness-audit` flags stale or redundant review agents and orchestration, and `/cost-report` reports token spend and cost regressions for a run. Run `/help` for the complete catalog.
 

--- a/README.md
+++ b/README.md
@@ -103,85 +103,19 @@ Developing, testing, or releasing the plugins? See **[CONTRIBUTING.md](CONTRIBUT
 
 ## Documentation
 
-### Start here
+The full documentation — architecture, model routing, eval system, telemetry, ADRs, and experiment reports — lives at **[docs.bryanfinster.com](https://docs.bryanfinster.com/)**, with search and complete navigation.
+
+Start here:
 
 | Doc | Covers |
 | --- | --- |
-| [Getting Started](GETTING-STARTED.md) | User tutorial — the workflow, suggested skills, worked examples |
+| [Getting Started](GETTING-STARTED.md) | Install, the workflow, suggested skills, worked examples |
 | [Contributing](CONTRIBUTING.md) | Local development, testing, adding agents/skills, releasing |
 | [Plugin Development Guide](CLAUDE.md) | Project North Star, repo structure, working rules |
 
-### dev-team — architecture
+Per-plugin docs: **[dev-team](plugins/dev-team/README.md)** · **[security-assessment](plugins/security-assessment/README.md)** · **[marketplace-dev](plugins/marketplace-dev/CLAUDE.md)** — each plugin's README is the entry point to its architecture, commands, and deeper guides.
 
-| Doc | Covers |
-| --- | --- |
-| [Plugin README](plugins/dev-team/README.md) | Install, prerequisites, optional tools, quality gates |
-| [Orchestration Pipeline](plugins/dev-team/CLAUDE.md) | Three-phase workflow, registries, context management |
-| [Architecture](plugins/dev-team/docs/agent-architecture.md) | Context management, quality assurance, governance, model routing |
-| [Team Structure](plugins/dev-team/docs/team-structure.md) | Org chart, team + review-agent dispatch diagrams |
-| [Agents](plugins/dev-team/docs/agent_info.md) | Agent roster, persona template, adding/removing/customizing |
-
-### dev-team — workflows & skills
-
-| Doc | Covers |
-| --- | --- |
-| [Workflows](plugins/dev-team/docs/workflows.md) | `/ship` and `/test-modernize` orchestration with human gates |
-| [Code Review Process](plugins/dev-team/docs/code-review-process.md) | `/code-review` end-to-end flow and the agents it dispatches |
-| [Skills & Commands](plugins/dev-team/docs/skills.md) | Skills catalog and slash-command reference |
-| [Session Review](plugins/dev-team/docs/session-review.md) | Mining session transcripts for improvement suggestions |
-| [Session Review — OSS complements](plugins/dev-team/docs/session-review-oss-complements.md) | OSS tools that complement the session-review loop |
-
-### dev-team — model routing
-
-| Doc | Covers |
-| --- | --- |
-| [Model Routing](plugins/dev-team/docs/model-routing.md) | Environment-aware effort-band → model resolution, defaults, ladder, troubleshooting |
-| [Model Routing — Overrides](plugins/dev-team/docs/model-routing-overrides.md) | Authoring `.claude/model-ladder.json`: schema, precedence, worked ladders, migration guarantee |
-
-### dev-team — evaluation & quality
-
-| Doc | Covers |
-| --- | --- |
-| [Eval System](plugins/dev-team/docs/eval-system.md) | How review-agent accuracy is measured and graded |
-| [Eval Running Guide](plugins/dev-team/docs/eval-running-guide.md) | Running the eval fixtures |
-| [Eval Maintenance](plugins/dev-team/docs/eval-maintenance.md) | Maintaining fixtures, catching regressions, tracking accuracy |
-| [Test Evaluation](plugins/dev-team/docs/test-evaluation.md) | Test-evaluation procedures |
-
-### dev-team — operations & observability
-
-| Doc | Covers |
-| --- | --- |
-| [Concurrent Use](plugins/dev-team/docs/concurrent-use.md) | Worktree isolation and concurrent build strategy |
-| [CodeGraph Nudge](plugins/dev-team/docs/codegraph-nudge.md) | The hook that nudges CodeGraph over multi-file Read/Grep |
-| [Telemetry — CI access](plugins/dev-team/docs/telemetry-ci-access.md) | Giving CI read-only access to the telemetry repo |
-| [Telemetry — repo security](plugins/dev-team/docs/telemetry-repo-security.md) | How machines write digests to the telemetry repo |
-
-### security-assessment plugin
-
-| Doc | Covers |
-| --- | --- |
-| [Plugin README](plugins/security-assessment/README.md) | Design philosophy, install, when to use vs. `/code-review` |
-| [Plugin Architecture](plugins/security-assessment/CLAUDE.md) | Hooks, SARIF orchestration, LLM-safety bounds, red-team targets |
-| [User Guide](plugins/security-assessment/docs/user-guide-security-assessment.md) | Path-A (plugin) vs. Path-B (zero-install) runbook, tool matrix |
-| [Accepted Risks Format](plugins/security-assessment/docs/accepted-risks-format.md) | `ACCEPTED-RISKS.md` schema and format |
-| [Comparative Testing](plugins/security-assessment/docs/comparative-testing.md) | Fixture repo, ground truth, scoring methodology |
-
-### marketplace-dev plugin
-
-| Doc | Covers |
-| --- | --- |
-| [Plugin Guide](plugins/marketplace-dev/CLAUDE.md) | Slash commands, the structural review agent, conventions enforced, eval fixtures |
-| [Agent-type Decision Rules](plugins/marketplace-dev/knowledge/agent-type-decision-rules.md) | The markdown-vs-script decision matrix (rules R1–R10) |
-| [Marketplace Builder Playbook](docs/marketplace-builder-plugin-playbook.md) | The conventions `marketplace-dev` encodes — layout, frontmatter contracts, release/catalog sync |
-
-### Repo-level guides & decision records
-
-| Doc | Covers |
-| --- | --- |
-| [Marketplace Builder Playbook](docs/marketplace-builder-plugin-playbook.md) | Building a plugin that scaffolds/audits marketplace monorepos |
-| [Plugin Skills in the Web Environment](docs/using-plugin-skills-in-the-web-environment.md) | Running a plugin's skills from a Claude Code web session |
-| [Architecture Decision Records](docs/adr/README.md) | Indexed ADRs — model routing, knowledge indexing, eval tiers, integration topology |
-| [Design Specs](docs/specs/python-agent-harness-pattern.md) | In-repo design specs — e.g. the Python agent-harness pattern and CLAUDE.md size reduction |
+Adapting model selection to your environment? See [Model Routing](plugins/dev-team/docs/model-routing.md) and its [override guide](plugins/dev-team/docs/model-routing-overrides.md).
 
 ## CodeGraph
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,24 +60,29 @@ nav:
 
     - dev-team Plugin:
           - Overview: plugins/dev-team/README.md
-          - Team Structure: plugins/dev-team/docs/team-structure.md
-          - Agent Architecture: plugins/dev-team/docs/agent-architecture.md
-          - Agent Info: plugins/dev-team/docs/agent_info.md
-          - Workflows: plugins/dev-team/docs/workflows.md
-          - Skills: plugins/dev-team/docs/skills.md
-          - Code Review Process: plugins/dev-team/docs/code-review-process.md
-          - Model Routing: plugins/dev-team/docs/model-routing.md
-          - Model Routing Overrides: plugins/dev-team/docs/model-routing-overrides.md
-          - Eval System: plugins/dev-team/docs/eval-system.md
-          - Eval Running Guide: plugins/dev-team/docs/eval-running-guide.md
-          - Eval Maintenance: plugins/dev-team/docs/eval-maintenance.md
-          - Test Evaluation: plugins/dev-team/docs/test-evaluation.md
-          - Session Review: plugins/dev-team/docs/session-review.md
-          - Session Review OSS Complements: plugins/dev-team/docs/session-review-oss-complements.md
-          - Concurrent Use: plugins/dev-team/docs/concurrent-use.md
-          - Telemetry CI Access: plugins/dev-team/docs/telemetry-ci-access.md
-          - Telemetry Security: plugins/dev-team/docs/telemetry-repo-security.md
-          - CodeGraph Nudge: plugins/dev-team/docs/codegraph-nudge.md
+          - Architecture:
+                - Team Structure: plugins/dev-team/docs/team-structure.md
+                - Agent Architecture: plugins/dev-team/docs/agent-architecture.md
+                - Agent Info: plugins/dev-team/docs/agent_info.md
+          - Workflows & Skills:
+                - Workflows: plugins/dev-team/docs/workflows.md
+                - Skills: plugins/dev-team/docs/skills.md
+                - Code Review Process: plugins/dev-team/docs/code-review-process.md
+          - Model Routing:
+                - Model Routing: plugins/dev-team/docs/model-routing.md
+                - Model Routing Overrides: plugins/dev-team/docs/model-routing-overrides.md
+          - Evaluation:
+                - Eval System: plugins/dev-team/docs/eval-system.md
+                - Eval Running Guide: plugins/dev-team/docs/eval-running-guide.md
+                - Eval Maintenance: plugins/dev-team/docs/eval-maintenance.md
+                - Test Evaluation: plugins/dev-team/docs/test-evaluation.md
+          - Operations:
+                - Session Review: plugins/dev-team/docs/session-review.md
+                - Session Review OSS Complements: plugins/dev-team/docs/session-review-oss-complements.md
+                - Concurrent Use: plugins/dev-team/docs/concurrent-use.md
+                - Telemetry CI Access: plugins/dev-team/docs/telemetry-ci-access.md
+                - Telemetry Security: plugins/dev-team/docs/telemetry-repo-security.md
+                - CodeGraph Nudge: plugins/dev-team/docs/codegraph-nudge.md
 
     - Guides:
           - Cloud Setup: docs/cloud-setup.md
@@ -97,6 +102,8 @@ nav:
           - "ADR-0008: Effort Bands over Model Names": docs/adr/0008-use-effort-bands-instead-of-model-names-in-agent-frontmatter.md
           - "ADR-0009: Human Consent Gate for Learning": docs/adr/0009-human-consent-gate-for-learning-loop.md
           - "ADR-0010: Per-Session Analysis Granularity": docs/adr/0010-per-session-analysis-granularity.md
+          - "ADR-0011: Enforce Context Ceiling": docs/adr/0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md
+          - "ADR-0012: Auto-Bootstrap CodeGraph Index": docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md
 
     - Experiments:
           - FAQ: docs/experiments/FAQ.md
@@ -105,9 +112,13 @@ nav:
           - 3 Sizes 3 Arms Report: docs/experiments/3sizes-3arms-report.md
           - "02 · When TDD Pays Experiment": docs/experiments/02-experiment-prompt-when-tdd-pays.md
           - When TDD Pays Report: docs/experiments/when-tdd-pays-report.md
+          - When TDD Pays Summary: docs/experiments/when-tdd-pays-summary.md
           - "03 · Ship Arm Manual Run": docs/experiments/03-ship-arm-manual-run-prompt.md
           - "04 · Refactor Granularity Experiment": docs/experiments/04-experiment-prompt-refactor-granularity.md
           - Refactor Granularity Report: docs/experiments/refactor-granularity-report.md
+          - Refactor Granularity Summary: docs/experiments/refactor-granularity-summary.md
+          - Refactor Granularity Progress: docs/experiments/refactor-granularity-progress.md
+          - Refactor Granularity Power Analysis: docs/experiments/refactor-granularity-power-analysis.md
           - "05 · Workflow Matrix Experiment": docs/experiments/05-experiment-prompt-workflow-matrix.md
           - Complexity Refactor Regression: docs/experiments/complexity-refactor-regression.md
 

--- a/plugins/dev-team/README.md
+++ b/plugins/dev-team/README.md
@@ -168,8 +168,8 @@ After starting Claude Code, confirm the system is working:
 
 ## What's included
 
-- **12 team agents** — Orchestrator, Software Engineer, QA Engineer, Architect, Product Manager, etc.
+- **11 team agents** — Orchestrator, Software Engineer, QA Engineer, Architect, Product Manager, etc.
 - **19 review agents** — security-review, domain-review, test-review, naming-review, …
-- **74 skills** — 41 agent-loaded (TDD, design-doc, competitive-analysis, …) + 33 user-invocable slash commands (`/plan`, `/build`, `/pr`, `/code-review`, `/browse`, `/triage`, …)
+- **85 skills** — knowledge modules and procedures the team draws on, 82 of them user-invocable as slash commands (`/plan`, `/build`, `/pr`, `/code-review`, `/browse`, `/triage`, …)
 
 Full catalogs: [Agents](docs/agent_info.md) · [Skills](docs/skills.md)


### PR DESCRIPTION
Acts on a tech-writer review of the documentation set (findability + verbosity). Companion to #501 (link checking).

## Findability
- **Sub-group the flat 22-item "dev-team Plugin" nav** into Architecture / Workflows & Skills / Model Routing / Evaluation / Operations, so the sidebar is scannable instead of a wall.
- **Link orphaned pages** that existed on disk but were unreachable from the nav: ADR-0011, ADR-0012, and four `refactor-granularity` / `when-tdd-pays` experiment files.

## Verbosity
- **GETTING-STARTED**: moved the misplaced tier-1 SAST install block out of "Update an installed plugin" (a non-sequitur left over from the #499 install-section move) into the security-assessment install section; tightened the diagnostic-workflow table to one clause per cell and dropped the code block that just restated four of its rows; shortened the 45-word `/init-dev-team` bullet.
- **README**: collapsed the eight-table "Documentation" section (~80 lines duplicating the whole site nav) to a Start-here trio + per-plugin entry points + a pointer to the docs site. Net −64 lines across the changeset.

## Accuracy (caught while editing)
- Plugin README "What's included" was stale: **team agents 12 → 11** (matches the agent registry and team-structure's "Orchestrator + ten"); **skills 74 (41+33) → 85, 82 of them user-invocable** — verified by counting `SKILL.md` files and `user-invocable: true` frontmatter.

## Verification
- `mkdocs.yml` parses; every nav target exists on disk; no broken relative links in the edited docs.
- Full local gate (`scripts/ci-local.sh`) green, including the `tests/repo` contract that the README links the model-routing override guide (preserved via a concise model-routing pointer).

Touches a shipped plugin README — requires human merge. `mkdocs.yml` edits here are in a different region than #501's `validation:` block, so the two don't conflict.