### PR TITLE
fix: improve sidebar visual distinction between section headers and nav items

### DIFF
--- a/docs/stylesheets/sidebar.css
+++ b/docs/stylesheets/sidebar.css
@@ -1,0 +1,18 @@
+/* Sidebar section headers: uppercase, muted, smaller, no hover effect */
+.md-nav--primary .md-nav__item--section > .md-nav__link,
+.md-nav--secondary .md-nav__item--section > .md-nav__link {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--md-default-fg-color--light);
+    cursor: default;
+    pointer-events: none;
+    padding-top: 1rem;
+}
+
+/* Remove the hover highlight on section headers */
+.md-nav--primary .md-nav__item--section > .md-nav__link:hover,
+.md-nav--secondary .md-nav__item--section > .md-nav__link:hover {
+    color: var(--md-default-fg-color--light);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,9 @@ validation:
         anchors: warn
         absolute_links: warn
 
+extra_css:
+    - stylesheets/sidebar.css
+
 theme:
     name: material
     palette:

--- a/scripts/assemble-docs.sh
+++ b/scripts/assemble-docs.sh
@@ -15,7 +15,7 @@ cp "${REPO_ROOT}/GETTING-STARTED.md" "${OUT}/GETTING-STARTED.md"
 cp "${REPO_ROOT}/CONTRIBUTING.md"   "${OUT}/CONTRIBUTING.md"
 cp "${REPO_ROOT}/CHANGELOG.md"      "${OUT}/CHANGELOG.md"
 
-# Repo-level docs tree
+# Repo-level docs tree (includes stylesheets/)
 cp -r "${REPO_ROOT}/docs" "${OUT}/docs"
 
 # dev-team plugin docs


### PR DESCRIPTION
## Summary
Add custom CSS styling for sidebar section headers in the documentation site to make them visually distinct from regular navigation links.

## Changes
- **New file:** `docs/stylesheets/sidebar.css` — styles for `.md-nav__item--section` headers in both primary and secondary navigation:
  - Uppercase text with increased letter-spacing
  - Smaller font size (0.7rem) and bold weight
  - Muted color using `--md-default-fg-color--light`
  - Disabled hover effects (cursor default, pointer-events none)
  - Added top padding for visual separation
- **Updated:** `mkdocs.yml` — register the new stylesheet in `extra_css`
- **Updated:** `scripts/assemble-docs.sh` — clarified comment that the docs tree copy includes stylesheets/

## Implementation Details
Section headers now use `pointer-events: none` and `cursor: default` to prevent interaction, and the hover state explicitly maintains the muted color to avoid any visual feedback on hover. This creates a clear visual hierarchy distinguishing section labels from clickable navigation items.

https://claude.ai/code/session_01XUUQWC13kaXxSfUhB2pJkm