### PR TITLE
docs: simplify language to high school reading level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ evals/                             # Agent eval fixtures (not shipped)
 reports/                           # Review reports (not shipped)
 ```
 
-Two repo-level guides distill the marketplace conventions:
+Two guides explain how the marketplace works:
 
 - [`docs/marketplace-builder-plugin-playbook.md`](docs/marketplace-builder-plugin-playbook.md) — how to build a plugin that scaffolds/audits/maintains marketplace monorepos (shipping hygiene, portability, testing, release/catalog sync).
 - [`docs/using-plugin-skills-in-the-web-environment.md`](docs/using-plugin-skills-in-the-web-environment.md) — how to use a plugin's skills from a Claude Code web session.
@@ -45,7 +45,7 @@ The local gates (`scripts/ci-local.sh`, run by the `pre-push` hook) need these t
 - CLI: `shellcheck`, `bats`, `jq`, `python3` (macOS: `brew install shellcheck bats-core jq python3`)
 - Python modules: install the declared dev dependencies once with `python3 -m pip install -r requirements-dev.txt` (PyYAML is required — several bats suites shell out to Python scripts that import it; semgrep for the security-assessment suites; httpx for the red-team harness smoke test).
 
-**One-shot setup:** `bash scripts/dev-setup.sh` validates this toolchain and installs anything missing (Homebrew on macOS, apt-get on Debian/Ubuntu, then the `requirements-dev.txt` deps). It is idempotent — safe to re-run.
+**One-shot setup:** `bash scripts/dev-setup.sh` validates this toolchain and installs anything missing (Homebrew on macOS, apt-get on Debian/Ubuntu, then the `requirements-dev.txt` deps). Safe to re-run.
 
 `ci-local.sh` checks these up front and exits with an actionable message (pointing at `dev-setup.sh`) if any are missing.
 
@@ -54,7 +54,7 @@ The local gates (`scripts/ci-local.sh`, run by the `pre-push` hook) need these t
 Every shell script — both the dev/CI scripts and the ones shipped inside the plugins — is `bash` and must run on **macOS, Linux, and Windows**. Conventions:
 
 - **macOS** ships bash 3.2, so stay 3.2-safe: no `mapfile`/`readarray`, `declare -A`, `${var,,}`, or `wait -n`; expand possibly-empty arrays with the empty-safe idiom `${arr[@]+"${arr[@]}"}` (bare `"${arr[@]}"` under `set -u` aborts on 3.2).
-- **BSD vs GNU coreutils**: avoid GNU-only flags (`readlink -f`, `sed -i` semantics, `date +%N`, `stat -c`, `find -printf`, `timeout`) or guard them with a fallback (e.g. `recon-inventory.sh`'s `readlink -f || python3`, `_lib.sh`'s `date +%s%3N || python3`, `mutation-adapters/lib.sh`'s `timeout`→`gtimeout`→unbounded).
+- **macOS vs Linux command differences**: avoid Linux-only flags (`readlink -f`, `sed -i` semantics, `date +%N`, `stat -c`, `find -printf`, `timeout`) or guard them with a fallback (e.g. `recon-inventory.sh`'s `readlink -f || python3`, `_lib.sh`'s `date +%s%3N || python3`, `mutation-adapters/lib.sh`'s `timeout`→`gtimeout`→unbounded).
 - **Windows = Git Bash.** Native `cmd.exe`/PowerShell are not targets; the plugin's hooks and helper scripts run under [Git Bash](https://git-scm.com/download/win) (the POSIX shell Claude Code uses for its Bash tool on Windows). Each plugin's `install.sh` detects Windows-without-Git-Bash and tells the user to install it; `scripts/dev-setup.sh` does the same for contributors.
 
 ### Testing locally
@@ -88,7 +88,7 @@ Releases are managed by release-please. Push conventional commits to main:
 
 A release PR is opened automatically. Merging it creates a GitHub Release with a version tag.
 
-**Squash-merge titles must be conventional.** This repo squash-merges PRs, so the **PR title becomes the commit subject** that release-please reads — and `release-type: simple` classifies off the *subject*, not the body. A PR titled `Add X` (no `feat:`/`fix:` prefix) is invisible to release-please and silently skips the version bump, even when its squashed body contains conventional commits. Title every PR conventionally. To recover a release that was missed this way, land a follow-up commit carrying a `Release-As: X.Y.Z` footer.
+**Squash-merge titles must be conventional.** This repo squash-merges PRs, so the **PR title is the only thing release-please reads** for the version bump — not the commit messages in the body. A PR titled `Add X` (no `feat:`/`fix:` prefix) is invisible to release-please and silently skips the version bump, even when its squashed body contains conventional commits. Title every PR conventionally. To recover a release that was missed this way, land a follow-up commit carrying a `Release-As: X.Y.Z` footer.
 
 ## Cloud sessions (claude.ai/code)
 
@@ -98,8 +98,8 @@ cloud **UI** (not a repo file) — see
 [Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web).
 
 **Install the plugin via the Setup script (loads this session).** Claude
-enumerates skills/agents/commands once, at boot, so the plugin must be on disk
-*before* Claude launches. The environment **Setup script** (cloud UI) runs
+loads all skills, agents, and commands once when it starts, so the plugin must
+be on disk *before* Claude launches. The environment **Setup script** (cloud UI) runs
 pre-boot and its filesystem is snapshotted and reused — installing the plugin
 there makes it load in the **same** session. The `claude` CLI **is** available in
 cloud environments. Paste the body of [`.claude/cloud-setup.sh`](.claude/cloud-setup.sh)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Three Claude Code plugins for engineering workflows. Install one or all.
 
 - **`dev-team`** gives Claude Code a full persona-driven development team: an Orchestrator that routes tasks, specialist agents (engineer, QA, architect, reviewers…), skills that encode reusable knowledge, and the four-command feature workflow `/specs → /plan → /build → /pr`.
-- **`security-assessment`** is the security companion. It adds a deterministic-first `/security-assessment` pipeline (SAST + LLM judgment + FP-reduction + exec report), a `/cross-repo-analysis` command for multi-repo attack chains, and an adversarial ML red-team harness (`/redteam-model`) for self-owned model endpoints.
+- **`security-assessment`** is the security companion. It adds a tool-first `/security-assessment` pipeline (SAST + AI judgment + false-positive filtering + executive report), a `/cross-repo-analysis` command for multi-repo attack chains, and an adversarial ML red-team harness (`/redteam-model`) for self-owned model endpoints.
 - **`marketplace-dev`** is the plugin-author's toolkit. It scaffolds new plugins and marketplaces (`/scaffold-plugin`, `/scaffold-marketplace`, `/init-plugin-eval`), audits any plugin for structural compliance (`/plugin-audit`), advises on the markdown-vs-script agent decision (`/agent-type-advisor`), and ships the migrated agent/skill authoring toolkit (`/agent-create`, `/agent-add`, `/agent-remove`).
 
-`dev-team` is the hub: it owns the primitives contract (`codebase-recon`, `ACCEPTED-RISKS.md`, unified finding envelope) that `security-assessment` builds on, so install `dev-team` first and add `security-assessment` when you need it. `marketplace-dev` is independent — it has no hard runtime dependency on `dev-team` and can be installed on its own to build or maintain plugins.
+`dev-team` is the foundation: it owns the shared data contract (`codebase-recon`, `ACCEPTED-RISKS.md`, unified finding format) that `security-assessment` builds on, so install `dev-team` first and add `security-assessment` when you need it. `marketplace-dev` is independent — it has no hard dependency on `dev-team` and can be installed on its own to build or maintain plugins.
 
 ## Plugins
 
@@ -85,7 +85,7 @@ Every `git commit` is automatically gated by `/code-review`. A `PreToolUse` hook
 | **1. Tool-first detection** | semgrep, gitleaks, trivy, hadolint, actionlint, custom rulesets | unified findings stream |
 | **1b. Judgment** | `security-review`, `business-logic-domain-review` agents | appended findings |
 | **1c. Suppression** | `ACCEPTED-RISKS.md` gate (deterministic) | filtered stream + audit log |
-| **2. FP-reduction** | 5-stage rubric (reachability, environment, controls, dedup, severity) | disposition register |
+| **2. False-positive filter** | 5-stage check (reachability, environment, controls, dedup, severity) | decisions log |
 | **2b. Severity floors** | deterministic domain-class calibration | floor-adjusted scores |
 | **3. Narrative + compliance** | `tool-finding-narrative-annotator`, compliance-mapping skill | 4-domain narrative + compliance JSON |
 | **4. Cross-repo** | service-comm parser, shared-cred hash match (multi-target only) | mermaid diagram + SARIF |
@@ -93,7 +93,7 @@ Every `git commit` is automatically gated by `/code-review`. A `PreToolUse` hook
 
 **Zero-install flow**: `scripts/run-assessment-local.sh` runs the same pipeline from the repo checkout without installing the plugin. Auto-detects the `claude` CLI; degrades to deterministic-only when absent. See [the user guide](plugins/security-assessment/docs/user-guide-security-assessment.md) for the full runbook.
 
-**Adversarial ML red-team**: `/redteam-model` probes a self-owned model endpoint (localhost / RFC1918 by default; public targets require a signed `authorization.md`). Eight probes covering recon, evasion, extraction, and report synthesis.
+**Adversarial ML red-team**: `/redteam-model` probes a self-owned model endpoint (localhost / private network by default; public targets require a signed `authorization.md`). Eight probes covering discovery, evasion, data extraction, and report synthesis.
 
 ---
 

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -8,10 +8,9 @@ fallback), see
 
 ## Why declaring the plugin isn't enough
 
-Claude enumerates every skill, agent, and slash command **once, at process
-boot.** A plugin is only visible to a session if its files are on disk *before*
-that boot. So "install the plugin" is really "get the plugin on disk before
-Claude launches."
+Claude loads every skill, agent, and slash command **once, when it starts.**
+A plugin is only visible if its files are on disk *before* that happens.
+So "install the plugin" really means "get the plugin on disk before Claude starts."
 
 That timing is the whole story:
 
@@ -20,20 +19,20 @@ That timing is the whole story:
 | **Setup script** (cloud UI) | **before** Claude boots; filesystem snapshotted & reused | **this** session ✅ |
 | **`SessionStart` hook** (`.claude/install-dev-team.sh`) | **after** Claude boots | **next** session only ⚠️ |
 
-The Setup script is the supported equivalent of a custom image (replacing the
-base image itself is not supported). The `SessionStart` hook can't beat boot
-enumeration, so it only ever lands the plugin for the *next* session — keep it as
-a fallback, not the primary path.
+The Setup script is the supported way to install software before the session
+starts (you cannot replace the underlying machine image). The `SessionStart`
+hook runs too late — the plugin it installs only takes effect in the *next*
+session — so use the Setup script as your primary path and the hook as a fallback.
 
 The `claude` CLI **is** available in cloud environments, so the install commands
 below run fine from the Setup script.
 
 ## The snippet to paste into the Setup script field
 
-claude.ai/code → Environment → **Setup script**. This is self-contained,
-existence-guarded, and always exits 0 (a non-zero Setup script **fails** session
-startup). It prefers a repo-committed bootstrap if one exists, and otherwise
-installs the plugin inline, with a no-CLI guard:
+claude.ai/code → Environment → **Setup script**. The script below checks whether
+the plugin is already installed and always exits without error (a non-zero exit
+**fails** session startup). It uses a repo-committed bootstrap when one exists,
+and otherwise installs the plugin directly:
 
 ```bash
 #!/bin/bash
@@ -58,9 +57,9 @@ If you also want this repo's test/gate toolchain (`jq`, `shellcheck`, `bats`,
 the Python dev deps, `gh`) in the same step, paste the body of
 [`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) instead — it installs the
 toolchain *and* the plugin, and follows the same exit-0 discipline. It also
-installs Node 24+ and runs `npm ci`, which embeds the husky git hooks
+installs Node 24+ and runs `npm ci`, which sets up the git hooks
 (`pre-commit`, `pre-push`, `commit-msg`) so commits and pushes in the cloud
-session run the same local gates as a workstation. (Skip this only if you don't
+session run the same checks you'd run locally. (Skip this only if you don't
 intend to commit from the session — it adds a minute to setup.)
 
 ## Verify it worked

--- a/docs/using-plugin-skills-in-the-web-environment.md
+++ b/docs/using-plugin-skills-in-the-web-environment.md
@@ -4,7 +4,7 @@ Claude Code **plugins are a local CLI / IDE feature**, but you *can* get a
 plugin's skills, agents, and slash commands working inside a Claude Code **web**
 session (claude.ai/code). The reliable way is to install the plugin from the
 environment's **Setup script**, which runs *before* Claude boots — so the plugin
-is on disk in time to be enumerated and loads in the **same** session. This guide
+is on disk before Claude starts and gets picked up in the **same** session. This guide
 explains why that works, and gives a file-based fallback for restrictive
 environments. It uses this repo's `dev-team` plugin as the worked example.
 
@@ -20,15 +20,15 @@ environments. It uses this repo's `dev-team` plugin as the worked example.
 
 ## 1. Why a plugin must be installed *before* Claude boots
 
-Claude enumerates the skills, agents, and slash commands available to it **once,
-at process boot.** Anything that lands on disk *after* boot is invisible to the
-running session. That single fact drives everything below:
+Claude loads all skills, agents, and slash commands **once, when it starts.**
+Anything that lands on disk *after* that is invisible to the running session.
+That single fact drives everything below:
 
 - The environment **Setup script** (configured in the cloud UI) runs **before**
   Claude launches, and its filesystem is snapshotted and reused by later
-  sessions. A plugin installed there is on disk in time to be enumerated → it
-  loads in the **same** session. This is the supported equivalent of a custom
-  image (replacing the base image itself is *not* supported).
+  sessions. A plugin installed there is on disk before Claude starts, so it
+  loads in the **same** session. This is the supported way to install software
+  before the session starts (you cannot replace the underlying machine image).
 - A **`SessionStart` hook** runs **after** Claude has already launched. A plugin
   it installs is on disk too late for *this* session's enumeration, so it only
   takes effect on the **next** session — the "next-session effect." Useful as a
@@ -46,7 +46,7 @@ policy blocks the install.
 
 ## 2. Option A (recommended) — install via the Setup script
 
-Paste a self-contained, existence-guarded, always-`exit 0` snippet into your
+Paste this script into your
 environment's **Setup script** field (claude.ai/code → Environment → Setup
 script). It installs the repo's toolchain **and** the `dev-team` plugin before
 Claude boots, so the plugin's ~86 skills (including `/ship`) are available in the

--- a/plugins/dev-team/agents/tech-writer.md
+++ b/plugins/dev-team/agents/tech-writer.md
@@ -45,10 +45,20 @@ You are a reader-first communicator who measures success by whether a stranger c
 
 ## Writing Standards
 
+### Reading level
+
+Write for a high school reading level. Docs should be easy to scan and understand without a dictionary.
+
+- **Short sentences.** Break anything over 25 words into two sentences.
+- **Plain words.** Replace jargon with everyday language. Examples: "use" not "utilize", "test cases" not "corpora", "decisions log" not "disposition register", "choices that are hard to undo" not "high-reversal-cost axes".
+- **Define terms on first use.** If a technical term is necessary, add a plain-English explanation in parentheses the first time it appears.
+- **No Latin or academic vocabulary.** Avoid "heuristic", "idempotent", "orthogonal", "ubiquitous", and similar words unless you define them immediately.
+- **Active voice by default.** "The system checks X" not "X is checked by the system."
+
 ### Structure
 
 - Lead with purpose: every document starts with what it is and who it's for
-- Use progressive disclosure: overview first, details later
+- Overview first, details later — don't bury the main point
 - Tables for reference material, prose for concepts, code blocks for examples
 - Keep paragraphs to 3 sentences maximum
 
@@ -63,6 +73,5 @@ You are a reader-first communicator who measures success by whether a stranger c
 
 ### Terminology
 
-- Use the same term for the same concept everywhere (ubiquitous language)
-- Define terms on first use if they might be unfamiliar
+- Use the same term for the same concept everywhere
 - Prefer concrete nouns over abstract ones ("agent file" not "configuration artifact")

--- a/plugins/dev-team/docs/eval-system.md
+++ b/plugins/dev-team/docs/eval-system.md
@@ -9,19 +9,19 @@ use deterministic (code-based) graders for everything they can handle, use
 model-based graders only for what genuinely requires judgment, and calibrate
 both against human review.
 
-## Two eval corpora
+## Two sets of test cases
 
-This document covers the **deterministic detection corpus** (`evals/expected/`):
-does a *review agent* catch a code issue? It is graded model-free by
-`scripts/eval_grade.py` and gated in CI via `--check-corpus`.
+This document covers the **deterministic detection fixtures** (`evals/expected/`):
+does a *review agent* catch a code issue? These are graded automatically by
+`scripts/eval_grade.py` and checked in CI via `--check-corpus`.
 
-A second, complementary corpus grades **behavior, not detection** — the
+A second, complementary set grades **behavior, not detection** — the
 [Ownership Engineering suite](../../../evals/ownership-engineering/) — does a
 *team agent or workflow skill* investigate vs. escalate, decide vs. menu, prove
-vs. assert? Because that is judgment, it is **judge-graded** (LLM-as-judge or
-human), lives outside `evals/expected/` so it never enters the deterministic
-gate, and its currency is tracked by an advisory staleness alert
-(`scripts/oe_scoring_staleness.py`) that flags any subject/fixture whose inputs
+vs. assert? Because that requires judgment, it is **graded by an AI judge or a
+human reviewer**, lives outside `evals/expected/` so it never enters the
+deterministic gate, and its freshness is tracked by a staleness warning
+(`scripts/oe_scoring_staleness.py`) that flags any subject or fixture whose inputs
 changed since they were last scored. See that suite's `README.md` for the run
 procedure.
 


### PR DESCRIPTION
Replace jargon and overly technical phrasing across docs and the tech-writer agent so all documentation reads at a high school level — approachable, concise, and easy to scan.

## Changes

**`plugins/dev-team/agents/tech-writer.md`**
- Added a "Reading level" section to Writing Standards with explicit rules: short sentences, plain words, define terms on first use, no Latin/academic vocabulary, active voice by default
- Includes a word-swap table of common offenders (utilize → use, corpora → test cases, etc.)

**`README.md`**
- "deterministic-first" → "tool-first"
- "FP-reduction" → "false-positive filtering"
- "disposition register" → "decisions log"
- "primitives contract" / "unified finding envelope" → plain descriptions
- "RFC1918" → "private network"
- "recon" → "discovery"

**`CLAUDE.md`**
- "distill the marketplace conventions" → "explain how the marketplace works"
- "idempotent — safe to re-run" → just "safe to re-run"
- "BSD vs GNU coreutils" → "macOS vs Linux command differences"
- "PR title becomes the commit subject that release-please reads" → simpler explanation
- "Claude enumerates skills/agents/commands once, at boot" → "Claude loads all skills, agents, and commands once when it starts"

**`docs/cloud-setup.md`**
- "enumerates every skill…once, at process boot" → "loads every skill…once, when it starts"
- "existence-guarded, always-exits-0 snippet" → plain description
- "embeds the husky git hooks…run the same local gates" → "sets up the git hooks…run the same checks you'd run locally"
- "supported equivalent of a custom image" clarified

**`docs/using-plugin-skills-in-the-web-environment.md`**
- Same boot/enumerate → load fix
- "supported equivalent of a custom image (replacing the base image itself is not supported)" → plain explanation

**`plugins/dev-team/docs/eval-system.md`**
- "Two eval corpora" → "Two sets of test cases"
- "deterministic detection corpus" → "deterministic detection fixtures"
- "judge-graded (LLM-as-judge or human)" → "graded by an AI judge or a human reviewer"
- "advisory staleness alert" → "staleness warning"

---
_Generated by [Claude Code](https://claude.ai/code/session_015jRg74sPXTNAKKih1LhpxE)_