### PR TITLE
ci: unify critical validations on ci-local.sh (single source of truth)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -39,28 +39,10 @@ jobs:
       - name: Build site
         run: mkdocs build --site-dir /tmp/site
 
+      # Same nav-integrity assertion the local gate runs (scripts/ci-local.sh's
+      # chk_nav_integrity), kept in one script so CI and pre-push can't drift.
       - name: Assert every nav entry resolves to a file
-        run: |
-          python3 - <<'PY'
-          import os, sys, yaml
-          nav = yaml.safe_load(open("mkdocs.yml"))["nav"]
-          out = "_mkdocs_src"
-          missing = []
-          def walk(node):
-              if isinstance(node, list):
-                  for item in node: walk(item)
-              elif isinstance(node, dict):
-                  for value in node.values(): walk(value)
-              elif isinstance(node, str):
-                  if not os.path.exists(os.path.join(out, node)):
-                      missing.append(node)
-          walk(nav)
-          if missing:
-              print("nav entries with no matching file under %s/:" % out)
-              for m in missing: print("  -", m)
-              sys.exit(1)
-          print("OK: every nav entry resolves to an assembled file.")
-          PY
+        run: python3 scripts/check_nav_integrity.py
 
   # Validates relative links and anchors inside the documentation bodies. Offline:
   # only local file links are resolved, so external link rot never flakes the gate.

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -34,20 +34,11 @@ jobs:
       - name: Install shellcheck + jq
         run: sudo apt-get update && sudo apt-get install -y shellcheck jq
 
-      - name: Shellcheck security-assessment helper scripts
-        run: |
-          shellcheck -x plugins/security-assessment/scripts/*.sh
-
-      - name: Shellcheck test files
-        run: |
-          shellcheck tests/security-assessment/scripts/*.sh
-
-      - name: Shellcheck repo audit scripts
-        run: |
-          shellcheck scripts/audit-rules-vs-prompts.sh
-
-      - name: Run tests/security-assessment/scripts/run-all.sh
-        run: bash tests/security-assessment/scripts/run-all.sh
+      # Shellcheck (helpers, test scripts, the repo audit script) + the
+      # security-assessment shell suite — defined once in scripts/ci-local.sh so
+      # CI and the local pre-push gate run identical checks.
+      - name: Shell checks (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_shellcheck_helpers,chk_shellcheck_tests,chk_sa_shell_suite
 
   bats-tests:
     runs-on: ubuntu-latest
@@ -87,47 +78,15 @@ jobs:
       # exact references listed — the class that broke /ship's decision-defaults
       # screen. Runs before the bats suite (which also asserts it) so a failure
       # prints the offenders and fails fast.
-      - name: Run markdown reference integrity check
-        run: python3 scripts/check_md_references.py
-
-      - name: Run dev-team content tests (bats)
-        # Fans the suite's files across the runner's vCPUs via xargs -P.
-        run: |
-          bash scripts/run-bats-parallel.sh \
-            tests/repo/ \
-            tests/knowledge/ \
-            tests/agents/ \
-            tests/commands/ \
-            tests/docs/ \
-            tests/scripts/
-
-      # Skills-catalog freshness: docs/skills.md is generated from each SKILL.md's
-      # frontmatter. This fails (with a diff) if a skill was added/removed/renamed
-      # or a description edited without regenerating — the bats suite above also
-      # asserts it; this prints the drift.
-      - name: Run skills-catalog freshness check
-        run: bash plugins/dev-team/hooks/lib/build-skills-index.sh --check
-
-      # Rules-vs-prompts boundary sensor (#118): the security-review-rule-map.yaml
-      # policy must stay consistent — no class on two surfaces, every rule-surface
-      # class has fixtures + a measured fp_rate <= 10%.
-      - name: Run rules-vs-prompts audit
-        run: bash scripts/audit-rules-vs-prompts.sh
-
-      # Toolchain-free hook conformance gates. Most of tests/hooks/ needs
-      # stryker/pitest and is excluded above, but these suites are pure
-      # bash + python3 + jq, so they run here as CI gates:
-      #   - model-routing: the updatedInput PreToolUse rewrite contract
-      #     (ADR-0004) is load-bearing and depends on undocumented harness
-      #     behavior (#104).
-      #   - plugin-version: the mechanical /version resolver.
-      - name: Run toolchain-free hook conformance tests (bats)
-        run: |
-          bash scripts/run-bats-parallel.sh \
-            tests/hooks/updated_input_contract_tests.bats \
-            tests/hooks/agent_model_resolve_hook_tests.bats \
-            tests/hooks/model_resolve_tests.bats \
-            tests/hooks/plugin_version_tests.bats
+      # Markdown reference integrity, the dev-team content bats suites
+      # (tests/repo + knowledge/agents/commands/docs/scripts), skills-catalog
+      # freshness, the rules-vs-prompts boundary sensor (#118), and the
+      # toolchain-free hook-conformance bats (model-routing #104, /version) —
+      # all defined once in scripts/ci-local.sh so CI and the local pre-push
+      # gate can't drift. Tests/hooks mutation-gate suites are still excluded
+      # (they need stryker/pitest); only the pure bash+python+jq ones run.
+      - name: Content + hook-conformance checks (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_md_references,chk_bats_repo,chk_bats_content_rest,chk_skills_index,chk_rules_vs_prompts,chk_model_routing
 
   # Cost-regression gate (#140 mechanism, #171 real baseline). Isolated in its
   # own job so the read-only telemetry deploy key is never in scope for the
@@ -175,8 +134,8 @@ jobs:
       # the cross-machine rolling mean — warn-only, since a non-deterministic
       # meter must not hard-fail an unrelated code PR. Fork PRs reach here with
       # no baseline and get the self-test only.
-      - name: Run cost-regression check
-        run: bash scripts/cost-regression-check.sh
+      - name: Run cost-regression check (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_cost_regression
 
   # Per-rule semgrep fixture measurement (#124): runs semgrep over the
   # positive/negative fixtures of the 36 custom rules to MEASURE real behaviour
@@ -204,8 +163,8 @@ jobs:
       # Fails if a rule is missing a fixture, a working rule's negative fires
       # (measured fp_rate > 0.10 — the demotion trigger), a non-known-broken
       # rule's positive fires on nothing, or a known-broken entry now works.
-      - name: Measure custom semgrep rule fixtures
-        run: python3 scripts/audit-semgrep-fixtures.py
+      - name: Measure custom semgrep rule fixtures (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_semgrep_fixtures
 
   # Lightweight smoke test for the red-team harness: guards the orchestrator
   # self-bootstrap + probe-loader wiring (relative imports must resolve so the
@@ -228,5 +187,5 @@ jobs:
       - name: Install harness runtime dependency (httpx)
         run: pip install --quiet httpx
 
-      - name: Red-team harness smoke test
-        run: python3 tests/security-assessment/harness/smoke_test.py
+      - name: Red-team harness smoke test (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_harness_smoke

--- a/scripts/check_nav_integrity.py
+++ b/scripts/check_nav_integrity.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Assert every mkdocs nav entry resolves to an assembled file.
+
+Catches the breakage a deleted or renamed doc leaves behind: a nav entry in
+mkdocs.yml that points at a file no longer present in the assembled docs tree.
+Run after scripts/assemble-docs.sh. Shared by the link-check workflow's
+nav-integrity job and scripts/ci-local.sh so the rule has a single definition.
+
+Exit 0 when every nav entry resolves; exit 1 (listing the offenders) otherwise.
+"""
+import os
+import sys
+
+import yaml
+
+OUT = "_mkdocs_src"
+CONFIG = "mkdocs.yml"
+
+
+def collect_missing(node, missing):
+    if isinstance(node, list):
+        for item in node:
+            collect_missing(item, missing)
+    elif isinstance(node, dict):
+        for value in node.values():
+            collect_missing(value, missing)
+    elif isinstance(node, str):
+        if not os.path.exists(os.path.join(OUT, node)):
+            missing.append(node)
+
+
+def main():
+    with open(CONFIG) as handle:
+        nav = yaml.safe_load(handle).get("nav")
+    if not nav:
+        print("no nav defined in %s — nothing to check" % CONFIG)
+        return 0
+    missing = []
+    collect_missing(nav, missing)
+    if missing:
+        print("nav entries with no matching file under %s/:" % OUT)
+        for entry in missing:
+            print("  -", entry)
+        print("\nAssemble first (scripts/assemble-docs.sh); a missing entry means "
+              "a deleted/renamed doc or a stale nav reference.")
+        return 1
+    print("OK: every nav entry resolves to an assembled file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -37,10 +37,16 @@ cd "$(git rev-parse --show-toplevel)" || exit 2
 # keep their existing meaning so the pre-push hook's `ci-local.sh BASE HEAD`
 # invocation is unaffected.
 CHANGED_ONLY=0
+# --only=fn[,fn...] runs just the named checks. CI calls it so each gate job
+# invokes the same definitions this script owns (single source of truth),
+# keeping the required-status-check job names stable. The per-job tool installs
+# live in the workflow, so the global prereq gate below is skipped under --only.
+ONLY=""
 positional=()
 for arg in "$@"; do
   case "$arg" in
     --changed-only) CHANGED_ONLY=1 ;;
+    --only=*) ONLY="${arg#--only=}" ;;
     *) positional+=("$arg") ;;
   esac
 done
@@ -59,31 +65,34 @@ reset=$(tput sgr0 2>/dev/null || true)
 section() { printf '\n%s== %s ==%s\n' "$bold" "$1" "$reset"; }
 
 # --- tool prerequisites (CI installs these; require them locally too) -------
-missing=()
-for t in shellcheck bats jq python3; do
-  command -v "$t" >/dev/null 2>&1 || missing+=("$t")
-done
-if [ "${#missing[@]}" -gt 0 ]; then
-  printf '%s%sMissing required tools: %s%s\n' "$bold" "$red" "${missing[*]}" "$reset" >&2
-  printf 'Install everything the dev gates need: bash scripts/dev-setup.sh\n' >&2
-  printf '  (or, macOS only: brew install %s)\n' "${missing[*]}" >&2
-  exit 2
-fi
+# Skipped under --only: CI invokes a subset and installs exactly that subset's
+# tools per job, so a full-toolchain gate here would false-fail those jobs.
+if [ -z "$ONLY" ]; then
+  missing=()
+  for t in shellcheck bats jq python3 semgrep; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    printf '%s%sMissing required tools: %s%s\n' "$bold" "$red" "${missing[*]}" "$reset" >&2
+    printf 'Install everything the dev gates need: bash scripts/dev-setup.sh\n' >&2
+    printf '  (or, macOS only: brew install %s)\n' "${missing[*]}" >&2
+    exit 2
+  fi
 
-# --- python module prerequisites (declared in requirements-dev.txt) ---------
-# Binaries alone aren't enough: several bats suites shell out to Python scripts
-# that import third-party modules. Check them up front so a missing dep fails
-# loudly here instead of as a cryptic ModuleNotFoundError mid-suite.
-py_missing=()
-# shellcheck disable=SC2043  # single entry today; kept as a list for new modules
-for m in yaml; do
-  python3 -c "import $m" >/dev/null 2>&1 || py_missing+=("$m")
-done
-if [ "${#py_missing[@]}" -gt 0 ]; then
-  printf '%s%sMissing required Python modules: %s%s\n' "$bold" "$red" "${py_missing[*]}" "$reset" >&2
-  printf 'Install the dev dependencies: python3 -m pip install -r requirements-dev.txt\n' >&2
-  printf '  (or run the one-shot setup: bash scripts/dev-setup.sh)\n' >&2
-  exit 2
+  # --- python module prerequisites (declared in requirements-dev.txt) -------
+  # Binaries alone aren't enough: several gates shell out to Python scripts that
+  # import third-party modules. Check them up front so a missing dep fails
+  # loudly here instead of as a cryptic ModuleNotFoundError mid-suite.
+  py_missing=()
+  for m in yaml httpx; do
+    python3 -c "import $m" >/dev/null 2>&1 || py_missing+=("$m")
+  done
+  if [ "${#py_missing[@]}" -gt 0 ]; then
+    printf '%s%sMissing required Python modules: %s%s\n' "$bold" "$red" "${py_missing[*]}" "$reset" >&2
+    printf 'Install the dev dependencies: python3 -m pip install -r requirements-dev.txt\n' >&2
+    printf '  (or run the one-shot setup: bash scripts/dev-setup.sh)\n' >&2
+    exit 2
+  fi
 fi
 
 # --- concurrency setup -----------------------------------------------------
@@ -130,7 +139,7 @@ fi
 # instead of running after them.
 
 chk_shellcheck_helpers() { shellcheck -x plugins/security-assessment/scripts/*.sh; }
-chk_shellcheck_tests()   { shellcheck tests/security-assessment/scripts/*.sh; }
+chk_shellcheck_tests()   { shellcheck tests/security-assessment/scripts/*.sh scripts/audit-rules-vs-prompts.sh; }
 chk_sa_shell_suite()     { bash tests/security-assessment/scripts/run-all.sh; }
 chk_bats_repo()          { run_bats tests/repo/; }
 chk_bats_content_rest()  { run_bats tests/knowledge/ tests/agents/ tests/commands/ tests/docs/ tests/scripts/; }
@@ -147,6 +156,17 @@ chk_oe_staleness()    { python3 scripts/oe_scoring_staleness.py --warn-only; }
 chk_citation_lint()   { python3 scripts/citation_lint.py --all; }  # advisory (#312)
 chk_md_references()   { python3 scripts/check_md_references.py; }
 chk_skills_index()    { bash plugins/dev-team/hooks/lib/build-skills-index.sh --check; }
+chk_rules_vs_prompts() { bash scripts/audit-rules-vs-prompts.sh; }
+chk_semgrep_fixtures() { python3 scripts/audit-semgrep-fixtures.py; }
+chk_harness_smoke()    { python3 tests/security-assessment/harness/smoke_test.py; }
+# Lightweight nav gate: assemble the docs tree, then assert every mkdocs nav
+# entry resolves to a file (the breakage a deleted/renamed doc leaves behind).
+# The full mkdocs build + lychee body-link scan stay CI-only (link-check.yml) so
+# mkdocs/lychee never become local prereqs.
+chk_nav_integrity() {
+  bash scripts/assemble-docs.sh >/dev/null 2>&1 || return 1
+  python3 scripts/check_nav_integrity.py
+}
 chk_eval_semver() {
   if [ -n "$BASE" ] && [ -n "$HEAD" ]; then
     bash scripts/eval_semver_classify.sh "$BASE" "$HEAD"
@@ -172,14 +192,32 @@ CHECKS=(
   "bats — dev-team content (knowledge/agents/commands/docs/scripts)::chk_bats_content_rest"
   "bats — model-routing hook conformance::chk_model_routing"
   "cost-regression check::chk_cost_regression"
+  "semgrep rule fixtures (audit-semgrep-fixtures.py)::chk_semgrep_fixtures"
+  "red-team harness smoke (smoke_test.py)::chk_harness_smoke"
+  "rules-vs-prompts audit (audit-rules-vs-prompts.sh)::chk_rules_vs_prompts"
   "eval corpus integrity (eval_grade.py --check-corpus)::chk_eval_corpus"
   "OE scoring staleness (advisory; oe_scoring_staleness.py)::chk_oe_staleness"
   "citation drift lint (citation_lint.py, advisory)::chk_citation_lint"
   "markdown reference integrity (check_md_references.py)::chk_md_references"
   "skills catalog freshness (docs/skills.md)::chk_skills_index"
+  "nav integrity (mkdocs nav → assembled file)::chk_nav_integrity"
   "eval-corpus semver contract::chk_eval_semver"
   "eslint::chk_eslint"
 )
+
+# --only=fn[,fn...] : keep just the named checks (CI invokes per-job subsets).
+if [ -n "$ONLY" ]; then
+  filtered=()
+  for entry in ${CHECKS[@]+"${CHECKS[@]}"}; do
+    fn="${entry##*::}"
+    case ",$ONLY," in *",$fn,"*) filtered+=("$entry") ;; esac
+  done
+  if [ "${#filtered[@]}" -eq 0 ]; then
+    printf '%s%sNo checks matched --only=%s%s\n' "$bold" "$red" "$ONLY" "$reset" >&2
+    exit 2
+  fi
+  CHECKS=(${filtered[@]+"${filtered[@]}"})
+fi
 
 # --- dispatch (bounded FIFO pool; no `wait -n`, so portable to bash 3.2) ----
 RUNDIR="$(mktemp -d)"

--- a/tests/repo/cost_regression_ci_tests.bats
+++ b/tests/repo/cost_regression_ci_tests.bats
@@ -52,5 +52,13 @@ EOF
 }
 
 @test "ci-cost: registered as a step in plugin-tests.yml" {
-  grep -q "cost-regression-check.sh" "$REPO_ROOT/.github/workflows/plugin-tests.yml"
+  # Wired either directly or through the shared gate (scripts/ci-local.sh's
+  # chk_cost_regression — single source of truth for CI and pre-push). For the
+  # indirect form, confirm ci-local actually maps the check to the script.
+  local wf="$REPO_ROOT/.github/workflows/plugin-tests.yml"
+  if grep -q "cost-regression-check.sh" "$wf"; then
+    return 0
+  fi
+  grep -q "chk_cost_regression" "$wf" \
+    && grep -q "chk_cost_regression.*cost-regression-check.sh" "$REPO_ROOT/scripts/ci-local.sh"
 }

--- a/tests/security-assessment/scripts/ci-wiring.test.sh
+++ b/tests/security-assessment/scripts/ci-wiring.test.sh
@@ -21,9 +21,19 @@ test_workflow_exists() {
 
 test_workflow_runs_tests() {
   [[ -f "$WORKFLOW" ]] || { fail "workflow missing; prerequisite"; return; }
-  grep -q 'tests/security-assessment/scripts/run-all.sh' "$WORKFLOW" \
-    || { fail "workflow does not invoke tests/security-assessment/scripts/run-all.sh"; return; }
-  ok "workflow invokes tests/security-assessment/scripts/run-all.sh"
+  # The suite runs either directly or through the shared local gate
+  # (scripts/ci-local.sh's chk_sa_shell_suite — single source of truth for CI
+  # and pre-push). Accept either wiring, but for the indirect form confirm the
+  # ci-local check actually reaches run-all.sh so the assertion stays real.
+  local cilocal="$REPO_ROOT/scripts/ci-local.sh"
+  if grep -q 'tests/security-assessment/scripts/run-all.sh' "$WORKFLOW"; then
+    ok "workflow invokes tests/security-assessment/scripts/run-all.sh"
+  elif grep -q 'chk_sa_shell_suite' "$WORKFLOW" \
+       && grep -q 'chk_sa_shell_suite.*run-all.sh' "$cilocal"; then
+    ok "workflow invokes run-all.sh via ci-local (chk_sa_shell_suite)"
+  else
+    fail "workflow does not invoke run-all.sh (directly or via ci-local chk_sa_shell_suite)"
+  fi
 }
 
 test_workflow_runs_shellcheck() {


### PR DESCRIPTION
Closes the gap behind two recent requests: **all critical validations should run in the local pre-push gate**, and the CI workflows should be **optimized so they can't drift** from it.

## Problem
The critical-validation checks were defined twice — in `scripts/ci-local.sh` (pre-push) and inline in the CI workflow YAML — so they drifted. `semgrep-fixtures`, the red-team `harness-smoke`, the `rules-vs-prompts` audit, and the new `nav-integrity` check ran in CI but were **missing from the local gate**, even though `requirements-dev.txt`/CLAUDE.md already declared their deps.

## Change — `ci-local.sh` becomes the single source of truth
- **New checks** added to `ci-local.sh`: `chk_semgrep_fixtures`, `chk_harness_smoke`, `chk_rules_vs_prompts`, and a lightweight `chk_nav_integrity` (assemble + assert every nav entry resolves to a file). The **heavy docs tooling stays CI-only** — full `mkdocs build` + `lychee` body-link scan remain in `link-check.yml`, so `mkdocs`/`lychee` never become local prereqs (per the chosen scope). `semgrep` + `httpx` join the local prereq gate (already declared dev deps).
- **`--only=fn[,fn...]` selector**: each CI job invokes the same definitions this script owns; the global prereq gate is skipped under `--only` since each job installs only its subset's tools.
- **Rewired** `plugin-tests.yml`'s five jobs and `link-check.yml`'s nav assert to call `ci-local.sh` / the shared `scripts/check_nav_integrity.py`. **Job names (the required-status-check contexts) are unchanged.**
- **Updated** two wiring tests (`ci-wiring`, `ci-cost`) to accept the indirect wiring and confirm `ci-local` actually maps the check to its script.

`agent-eval.yml` is intentionally left as-is — its structural/semver gates already invoke standalone shared scripts that `ci-local` mirrors, so they were never a drift source.

## Verification
- Full local gate green; each rewired `--only` set (`shell-tests`, `bats-tests`, `cost-regression`, `semgrep-fixtures`, `harness-smoke`, `nav-integrity`) run and pass individually.
- The PR's own required checks exercise the rewired jobs end-to-end.

Touches CI + test fixtures — **requires human merge**.