### PR TITLE
docs: render mermaid in MkDocs and unify the diagram strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,14 @@ Scaffold a new agent (review or team) with the authoring command:
 
 Every new or changed agent/skill/hook must pass `/agent-audit`.
 
+## Documentation diagrams
+
+The docs use three diagram formats, each for a distinct purpose — match the convention when adding or editing a diagram:
+
+- **Mermaid** (` ```mermaid ` fences) — the default for flow, sequence, and architecture diagrams authored inline. It is text-based (diffs cleanly), renders on GitHub natively, and renders on the [docs site](https://docs.bryanfinster.com/) (Material loads Mermaid.js via the `pymdownx.superfences` custom fence in `mkdocs.yml`). Reuse the shared `%%{init ...}%%` theme block from an existing diagram (e.g. `plugins/dev-team/docs/model-routing.md`) so diagrams look consistent.
+- **SVG** (`plugins/dev-team/docs/diagrams/*.svg`) — reserved for the polished, hand-tuned architecture diagrams that are laid out deliberately and tuned for dark mode. Don't auto-convert these to Mermaid; edit the SVG.
+- **ASCII** (plain ` ``` ` fences) — only for directory/file trees and short inline command flows, never for boxes-and-arrows diagrams (use Mermaid for those).
+
 ## Releasing
 
 Releases are managed by [release-please](https://github.com/googleapis/release-please). Push [conventional commits](https://www.conventionalcommits.org/) to `main`:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,13 @@ plugins:
 markdown_extensions:
     - admonition
     - pymdownx.details
-    - pymdownx.superfences
+    - pymdownx.superfences:
+          # Render ```mermaid fences as diagrams. Material for MkDocs loads
+          # Mermaid.js automatically once this custom fence is declared.
+          custom_fences:
+              - name: mermaid
+                class: mermaid
+                format: !!python/name:pymdownx.superfences.fence_code_format
     - pymdownx.highlight:
           anchor_linenums: true
     - pymdownx.inlinehilite

--- a/plugins/dev-team/docs/eval-system.md
+++ b/plugins/dev-team/docs/eval-system.md
@@ -27,19 +27,13 @@ procedure.
 
 ## Architecture
 
-```text
-┌──────────────────────────────────────────────────┐
-│              User Workflows                      │
-│  /code-review  /review-agent  /apply-fixes       │
-└──────────────────┬───────────────────────────────┘
-                   │
-        ┌──────────┼──────────┐
-        ▼          ▼          ▼
-┌──────────┐ ┌──────────┐ ┌──────────┐
-│ Layer 1  │ │ Layer 2  │ │ Layer 3  │
-│ Hooks    │ │ Agents   │ │ Human    │
-│ (determ.)│ │ (model)  │ │ (review) │
-└──────────┘ └──────────┘ └──────────┘
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#3b82f6', 'lineColor': '#64748b', 'secondaryColor': '#f1f5f9', 'tertiaryColor': '#e0f2fe', 'background': '#ffffff', 'mainBkg': '#dbeafe', 'nodeBorder': '#2563eb', 'clusterBkg': '#eff6ff', 'clusterBorder': '#bfdbfe', 'titleColor': '#1e3a5f', 'edgeLabelBackground': '#f8fafc'}}}%%
+flowchart TD
+    UW["User Workflows<br/>/code-review · /review-agent · /apply-fixes"]
+    UW --> L1["Layer 1 · Hooks<br/>(deterministic)"]
+    UW --> L2["Layer 2 · Agents<br/>(model)"]
+    UW --> L3["Layer 3 · Human<br/>(review)"]
 ```
 
 ## Grader Layers

--- a/scripts/check_nav_integrity.py
+++ b/scripts/check_nav_integrity.py
@@ -16,6 +16,13 @@ import yaml
 OUT = "_mkdocs_src"
 CONFIG = "mkdocs.yml"
 
+# mkdocs.yml carries the !!python/name: tag (e.g. the superfences mermaid fence
+# format). SafeLoader rejects it, so register a no-op multi-constructor — this
+# script only reads the nav, never those values.
+yaml.SafeLoader.add_multi_constructor(
+    "tag:yaml.org,2002:python/name:", lambda loader, suffix, node: None
+)
+
 
 def collect_missing(node, missing):
     if isinstance(node, list):


### PR DESCRIPTION
Implements the agreed **hybrid diagram strategy**: keep the polished hand-tuned SVGs, use Mermaid for inline diagrams (now that it renders), and reserve ASCII for file trees.

## Mermaid wasn't rendering
Two published pages (`model-routing.md`, `code-review-process.md`) had ```mermaid fences, but `pymdownx.superfences` had no custom fence — so they showed as raw code.
- Add the Material mermaid custom fence to `mkdocs.yml` (Material auto-loads Mermaid.js once declared).
- Its `format` uses a `!!python/name:` YAML tag that `yaml.safe_load` rejects, so `scripts/check_nav_integrity.py` now ignores that tag (it only reads the nav).

## Diagram cleanup
- Converted the **one** genuine ASCII boxes-and-arrows diagram in the published docs (`eval-system.md` layer diagram) to a Mermaid flowchart, reusing the shared theme block. The four ASCII **directory trees** are intentionally left as code blocks (ASCII is the right tool there). The 6 hand-tuned SVGs are untouched (they're dark-mode-tuned, recently maintained).
- Added a **Documentation diagrams** convention to `CONTRIBUTING.md` (Mermaid for inline diagrams, SVG for polished architecture, ASCII for trees/command flows).

## Verification
- `mkdocs build` clean; all four mermaid blocks (model-routing ×2, code-review-process, eval-system) emit `<div class="mermaid">`.
- nav-integrity + markdown-reference gates pass locally; full pre-push gate green.