### PR TITLE
docs: show build health in the README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Agentic Dev Team
 
-[![Docs](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
+[![Tests](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml)
+[![Link check](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml)
+[![Docs](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
 
 📖 **[Documentation](https://docs.bryanfinster.com/)**
 


### PR DESCRIPTION
The README only badged the **docs** deploy, so build/test health wasn't visible.

Add two badges alongside Docs, all pinned to `main`:
- **Tests** → `plugin-tests` workflow (the bats / shell / semgrep / harness / cost-regression suite — the critical validations, which run on every push to main).
- **Link check** → `link-check` workflow (mkdocs nav integrity + offline link check).

`agent-eval` is intentionally not badged — it runs on `pull_request` only (no main-push trigger), so its badge wouldn't reflect main's health.

README-only change.