### PR TITLE
ci: give workflows and required checks descriptive names

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -1,4 +1,4 @@
-name: agent-eval-gate
+name: Eval
 
 # Agent-eval regression gate (issue #99).
 #
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   structural-gate:
-    name: Structural gate (model-free)
+    name: Eval corpus & graders
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -85,7 +85,7 @@ jobs:
     # Job name is a REQUIRED status-check context (renovate-require-tests
     # ruleset). Keep it paren-free and issue-number-free so it is stable and
     # can't be truncated mid-token when typed into branch rules. (Issue #101.)
-    name: Eval-corpus prompt-semver gate
+    name: Eval corpus semver
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -104,7 +104,7 @@ jobs:
             "${{ github.event.pull_request.head.sha }}"
 
   live-gate:
-    name: Live regression gate (model-dependent)
+    name: Eval live regression (opt-in)
     runs-on: ubuntu-latest
     needs: structural-gate
     # The live gate dispatches the agents through the bare `claude` CLI (see the
@@ -374,7 +374,7 @@ jobs:
           retention-days: 7
 
   integration-gate:
-    name: Integration eval tier (golden-repo, opt-in)
+    name: Eval integration tier (opt-in)
     runs-on: ubuntu-latest
     needs: structural-gate
     # Opt-in tier (#313): dispatches the orchestrator in an ephemeral worktree

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Docs deploy
 
 on:
   push:
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   deploy:
+    name: Deploy docs site
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,4 +1,4 @@
-name: link-check
+name: Docs checks
 
 # Catches broken documentation links before they merge — the class of breakage a
 # deleted or renamed doc leaves behind (e.g. a nav entry or README link pointing at
@@ -22,6 +22,7 @@ permissions:
 jobs:
   # Validates the MkDocs nav: a nav entry pointing at a missing file fails the build.
   nav-integrity:
+    name: Docs nav integrity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +48,7 @@ jobs:
   # Validates relative links and anchors inside the documentation bodies. Offline:
   # only local file links are resolved, so external link rot never flakes the gate.
   body-links:
+    name: Docs link check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1,4 +1,4 @@
-name: plugin-tests
+name: Tests
 
 on:
   push:
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   shell-tests:
+    name: Shell scripts & suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -41,6 +42,7 @@ jobs:
         run: bash scripts/ci-local.sh --only=chk_shellcheck_helpers,chk_shellcheck_tests,chk_sa_shell_suite
 
   bats-tests:
+    name: Plugin content & hooks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -60,9 +62,9 @@ jobs:
       - name: Install bats + jq
         # Across-file parallelism comes from scripts/run-bats-parallel.sh
         # (xargs -P, built into the runner) — no GNU `parallel` package needed,
-        # so local pre-push and CI use the exact same portable mechanism. Job
-        # topology is unchanged so the `bats-tests` required-status-check name
-        # stays stable.
+        # so local pre-push and CI use the exact same portable mechanism. The
+        # job id stays `bats-tests`; its required-status-check context is the
+        # job name "Plugin content & hooks".
         run: sudo apt-get update && sudo apt-get install -y bats jq python3-yaml
 
       # Content-validation suites: repo invariants, knowledge-index shape,
@@ -93,6 +95,7 @@ jobs:
   # broader test jobs. The self-test step always runs (blocking); the telemetry
   # clone + real cross-machine baseline only run where the secret is available.
   cost-regression:
+    name: Cost regression
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -142,6 +145,7 @@ jobs:
   # (not just file presence, which the bats job covers). Heavier than the
   # bats/jq/python gate — semgrep install — so it is its own job.
   semgrep-fixtures:
+    name: Semgrep rule fixtures
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -172,6 +176,7 @@ jobs:
   # --dry-run path, so the sole runtime dep is httpx (numpy/scipy/scikit-learn
   # are used lazily inside probe run() bodies the smoke test never reaches).
   harness-smoke:
+    name: Red-team harness smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Agentic Dev Team
 
 [![Tests](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml)
-[![Link check](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml)
-[![Docs](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
+[![Docs checks](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml)
+[![Docs deploy](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
 
 📖 **[Documentation](https://docs.bryanfinster.com/)**
 


### PR DESCRIPTION
Renames the CI workflows and the required-check job contexts from implementation-named (bats-tests, shell-tests, agent-eval-gate) to descriptive names, and updates both branch rulesets + the README badges to match.

## Renames
Workflows: `plugin-tests`→**Tests**, `agent-eval-gate`→**Eval**, `link-check`→**Docs checks**, `docs`→**Docs deploy**.

Job contexts (job **ids unchanged**, so docs/comments referencing ids still hold):
| Old context | New |
|---|---|
| bats-tests | Plugin content & hooks |
| shell-tests | Shell scripts & suite |
| cost-regression | Cost regression |
| semgrep-fixtures | Semgrep rule fixtures |
| harness-smoke | Red-team harness smoke |
| Structural gate (model-free) | Eval corpus & graders |
| Eval-corpus prompt-semver gate | Eval corpus semver |
| nav-integrity / body-links | Docs nav integrity / Docs link check |

## Ruleset coordination
Both rulesets (`main`, `renovate-require-tests`) are updated **out-of-band via the API** to require the new contexts. Consequently the other open PRs block until rebased onto this change (expected — done as part of landing this).

README badge labels updated to the new workflow names.