### PR TITLE
fix(progress-guardian): correct four pre-PR gate false positives (#525)

### DIFF
--- a/docs/specs/progress-guardian-fixes.md
+++ b/docs/specs/progress-guardian-fixes.md
@@ -1,5 +1,5 @@
 <!-- spec-version: 1 -->
-# Spec: progress_guardian — fix three pre-PR gate false positives
+# Spec: progress_guardian — fix four pre-PR gate false positives
 
 **Format:** dev-team specs v1
 **Issue:** <https://github.com/bdfinst/agentic-dev-team/issues/525>
@@ -8,19 +8,22 @@
 
 `scripts/progress_guardian.py` is the pre-PR gate run by `/pr` (and the `progress-guardian` agent) to prove that a branch's plan is complete, every `[x]` step has a matching commit, and the branch hasn't sprawled outside its declared file scope. It is supposed to *catch* plan-discipline failures. Today it fires on every Conventional-Commits-following branch with a normal `## Build Progress` + `## Acceptance Criteria` plan layout — producing noise that trains contributors to ignore the gate, the exact failure mode the gate exists to prevent.
 
-The root cause is three independent bugs, each documented in issue #525 with concrete reproducers on the #524 branch:
+The root cause is **four** false-positive bugs (three identified upfront in issue #525 and a fourth discovered during build):
 
-1. **`check_scope` prefers stale local `main` over `origin/main`** (line 248). Local `main` lags `origin/main` from the moment any work begins; the resulting merge-base sweeps in every commit landed on trunk while the contributor worked, producing dozens of false "out-of-plan file" warnings.
-2. **`check_commit_discipline` requires a substring of the plan-step header in commit subjects** (lines 156–170). CLAUDE.md mandates Conventional Commits (`feat(scope): summary`); plan headers like *"Wire stack detection into test-smell-review"* never appear verbatim in `feat(test-smell-review): detect stack from manifests…`. The matcher and the repo's own commit policy structurally collide.
-3. **`parse_plan` scans every checkbox in the file** (lines 32, 110–126). The `## Acceptance Criteria` section uses the same `- [ ]` syntax as `## Build Progress`, so the pre-PR gate then demands each AC be `[x]` — producing false "Pre-PR gate: step 'A1: …'" findings on plans where the AC list is correctly aspirational.
+1. **`check_scope` prefers stale local `main` over `origin/main`** (pre-fix line 248). Local `main` lags `origin/main` from the moment any work begins; the resulting merge-base sweeps in every commit landed on trunk while the contributor worked, producing dozens of false "out-of-plan file" warnings.
+2. **`check_commit_discipline` requires a substring of the plan-step header in commit subjects** (pre-fix lines 156–170). CLAUDE.md mandates Conventional Commits (`feat(scope): summary`); plan headers like *"Wire stack detection into test-smell-review"* never appear verbatim in `feat(test-smell-review): detect stack from manifests…`. The matcher and the repo's own commit policy structurally collide.
+3. **`parse_plan` scans every checkbox in the file** (pre-fix lines 32, 110–126). The `## Acceptance Criteria` section uses the same `- [ ]` syntax as `## Build Progress`, so the pre-PR gate then demands each AC be `[x]` — producing false "Pre-PR gate: step 'A1: …'" findings on plans where the AC list is correctly aspirational.
+4. **`parse_plan` also reads the `### Acceptance Criteria` mirror inside `## Build Progress`.** Discovered during build: the `/plan` skill's Build Progress template renders a documentation-only mirror of the top-level AC list. With Change 3 narrowing parse_plan to the Build Progress section, that mirror still trips the gate. Fixed in-place by extending the section anchor with an inner skip for the H3 AC sub-heading. The underlying structural issue — that AC items are checkbox-tracked without work-tracking semantics — is tracked separately as **issue #526** for future redesign; this PR ships the workaround.
 
-This change fixes all three with the minimum-blast-radius implementations chosen in the approach contract: tuple reorder for (1), file-path matching for (2), `## Build Progress` heading anchor for (3). Each fix is independent and additive; none break existing passing fixtures.
+This change fixes all four with the minimum-blast-radius implementations chosen in the approach contract: tuple reorder for (1), file-path matching for (2), `## Build Progress` heading anchor for (3), inner H3 skip for (4). Each fix is independent and additive; none break existing passing fixtures.
+
+Pre-fix line numbers above reference the script's state on `origin/main` at the start of this PR. After the fix the `check_scope` tuple lives inside the new `_branch_base_sha` helper, and `check_commit_discipline` spans roughly 247-340 with two new helpers added above it.
 
 ## Architecture Specification
 
 **Single file edited:** `scripts/progress_guardian.py`. No new modules, no helper-script extraction, no public-API changes — the script's three CLI flags (`--plan`, `--pre-pr`, `--skip-llm`) and three exit codes (`0` pass, `1` fail, `2` warn) are unchanged.
 
-**Test files touched:** `tests/scripts/progress_guardian_tests.bats` (extended with regression coverage for all three bugs). The existing 11 `@test` blocks must remain green.
+**Test files touched:** `tests/scripts/progress_guardian_tests.bats` (extended with regression coverage for all four bugs — the original three regression sections 4.1–4.3 plus `4.3-mirror` for bug 4). The existing 11 `@test` blocks must remain green.
 
 **Change 1 — `check_scope`: prefer remote tracking refs.**
 
@@ -48,6 +51,10 @@ When the plan contains a `## Build Progress` heading, only parse checkbox lines 
 
 This narrows the gate to where the `/plan` skill actually stores step-completion state.
 
+**Change 4 — `parse_plan`: skip the `### Acceptance Criteria` mirror inside Build Progress.**
+
+Discovered during build. The `/plan` skill's Build Progress template renders an inner mirror of the top-level AC list under a `### Acceptance Criteria` H3 subheading. Those mirror items have no `### Slice N:` heading and no `**Files:**` line, so the file-path matcher (Change 2) and the substring fallback both fail — manifesting as "no matching commit" errors for every AC item. `parse_plan` now carries a second flag (`in_acceptance`) alongside `in_build_progress`: when an H3 named exactly `### Acceptance Criteria` is seen inside the Build Progress section, the inner-skip flag flips on and stays on until either another H3 opens or the section closes on its next H2. The legacy whole-file fallback is unaffected. **Issue #526** tracks the structural redesign of how ACs live in plans (operator evidence, per-AC verify commands, or removing the mirror entirely); this PR ships the surgical workaround so the gate stops false-positiving today.
+
 **Constraints:**
 
 - All 11 existing bats tests in `tests/scripts/progress_guardian_tests.bats` must remain green — these document the contract for minimal plans without `## Build Progress` or `**Files:**` lines.
@@ -60,7 +67,8 @@ This narrows the gate to where the `/plan` skill actually stores step-completion
 
 - No `git fetch` added to refresh `origin/main` before merge-base. Approach contract resolved this as "additive only" — the cost of network in the gate exceeds the marginal value over "trust the tracking ref."
 - No scope-token matching against Conventional Commit `feat(scope)` syntax. File-path matching is the chosen strategy; scope-token was rejected in the approach contract as fragile for slices whose title doesn't translate cleanly.
-- No structural refactor of `progress_guardian.py` (no class extraction, no module split). The three changes are surgical edits in the existing function bodies.
+- No structural refactor of `progress_guardian.py` (no class extraction, no module split). The four changes are surgical edits in the existing function bodies.
+- No redesign of where AC items live in plan files — tracked in **issue #526**. The Change 4 workaround makes the gate pass on plans the `/plan` skill emits today; the underlying "ACs lack work-tracking semantics" problem is left to a separate spec.
 - No changes to the `progress-guardian` agent's prompt template (`plugins/dev-team/agents/progress-guardian.md`). The agent uses the script's output verbatim — fixing the script fixes its findings.
 - No changes to other plan-consuming tools (`build-wave.sh`, `plan-waves.sh`, etc.). They parse plans for different purposes and aren't affected.
 
@@ -90,6 +98,10 @@ Each criterion is a deterministic, observable check.
 - Behavioral check via new bats test: same plan but the `## Build Progress` slice is `[ ]`. `progress_guardian --pre-pr --skip-llm` exits 1 naming the unchecked slice.
 - Behavioral check (fallback path) via existing test 3.3a: minimal plan with no `## Build Progress` heading — every checkbox in the file is parsed (today's behavior). Test stays green.
 
+**A3b — AC mirror inside Build Progress is skipped (Change 4 / #526 workaround).**
+
+Discovered during build. Plan with a `### Acceptance Criteria` H3 sub-heading inside `## Build Progress` containing `[ ]` AC mirror items, plus an outer `[x]` slice with a matching commit. `progress_guardian --pre-pr --skip-llm` exits 0 — the inner AC mirror items are ignored. Verified by bats test `4.3-mirror`. Structural redesign of where ACs live in plans is tracked in **issue #526**; this criterion only locks in the workaround.
+
 **A4 — Real-world reproduction passes.**
 
 - Manual verification step run from the #524 branch (or any future branch with the same plan layout): `python3 scripts/progress_guardian.py --pre-pr --plan plans/stack-aware-reference-loading.md` exits 0. PR description captures the before/after output as evidence.
@@ -101,7 +113,7 @@ Each criterion is a deterministic, observable check.
 
 **A6 — CI/release hygiene.**
 
-- PR title `fix(progress-guardian): correct three pre-PR gate false positives (#525)` — `fix:` prefix for release-please patch bump.
+- PR title `fix(progress-guardian): correct four pre-PR gate false positives (#525)` — `fix:` prefix for release-please patch bump.
 - PR opened with `--no-auto-merge` per CLAUDE.md (touches `scripts/`).
 - `/code-review` passes after auto-fix loop.
 
@@ -124,7 +136,7 @@ No `LOW_VALUE` items.
 ## Consistency Gate
 
 - [x] Intent is unambiguous — *Three independent bugs in `scripts/progress_guardian.py`; fix each with the minimum-blast-radius implementation chosen in the approach contract; preserve all existing exit codes, JSON shape, and 11 passing bats tests.*
-- [x] Every behavior/goal maps to an acceptance criterion — A1 (Change 1: stale main), A2 (Change 2: commit matcher), A3 (Change 3: parse_plan anchor), A4 (real-world repro), A5 (no regressions), A6 (CI).
+- [x] Every behavior/goal maps to an acceptance criterion — A1 (Change 1: stale main), A2 (Change 2: commit matcher), A3 (Change 3: parse_plan anchor), A3b (Change 4: AC mirror skip), A4 (real-world repro), A5 (no regressions), A6 (CI).
 - [x] Architecture constrains without over-engineering — one file edited, no new modules, no helper extraction, no API changes, three surgical fixes.
 - [x] Terminology consistent across artifacts — *Build Progress*, *Acceptance Criteria*, *file-path matcher*, *substring fallback*, *origin/main preference* used identically.
 - [x] No contradictions between artifacts — the three locked decisions and the four `inferable` decisions appear identically in Intent, Architecture, Acceptance, and Ambiguity Log.

--- a/docs/specs/progress-guardian-fixes.md
+++ b/docs/specs/progress-guardian-fixes.md
@@ -1,0 +1,133 @@
+<!-- spec-version: 1 -->
+# Spec: progress_guardian — fix three pre-PR gate false positives
+
+**Format:** dev-team specs v1
+**Issue:** <https://github.com/bdfinst/agentic-dev-team/issues/525>
+
+## Intent Description
+
+`scripts/progress_guardian.py` is the pre-PR gate run by `/pr` (and the `progress-guardian` agent) to prove that a branch's plan is complete, every `[x]` step has a matching commit, and the branch hasn't sprawled outside its declared file scope. It is supposed to *catch* plan-discipline failures. Today it fires on every Conventional-Commits-following branch with a normal `## Build Progress` + `## Acceptance Criteria` plan layout — producing noise that trains contributors to ignore the gate, the exact failure mode the gate exists to prevent.
+
+The root cause is three independent bugs, each documented in issue #525 with concrete reproducers on the #524 branch:
+
+1. **`check_scope` prefers stale local `main` over `origin/main`** (line 248). Local `main` lags `origin/main` from the moment any work begins; the resulting merge-base sweeps in every commit landed on trunk while the contributor worked, producing dozens of false "out-of-plan file" warnings.
+2. **`check_commit_discipline` requires a substring of the plan-step header in commit subjects** (lines 156–170). CLAUDE.md mandates Conventional Commits (`feat(scope): summary`); plan headers like *"Wire stack detection into test-smell-review"* never appear verbatim in `feat(test-smell-review): detect stack from manifests…`. The matcher and the repo's own commit policy structurally collide.
+3. **`parse_plan` scans every checkbox in the file** (lines 32, 110–126). The `## Acceptance Criteria` section uses the same `- [ ]` syntax as `## Build Progress`, so the pre-PR gate then demands each AC be `[x]` — producing false "Pre-PR gate: step 'A1: …'" findings on plans where the AC list is correctly aspirational.
+
+This change fixes all three with the minimum-blast-radius implementations chosen in the approach contract: tuple reorder for (1), file-path matching for (2), `## Build Progress` heading anchor for (3). Each fix is independent and additive; none break existing passing fixtures.
+
+## Architecture Specification
+
+**Single file edited:** `scripts/progress_guardian.py`. No new modules, no helper-script extraction, no public-API changes — the script's three CLI flags (`--plan`, `--pre-pr`, `--skip-llm`) and three exit codes (`0` pass, `1` fail, `2` warn) are unchanged.
+
+**Test files touched:** `tests/scripts/progress_guardian_tests.bats` (extended with regression coverage for all three bugs). The existing 11 `@test` blocks must remain green.
+
+**Change 1 — `check_scope`: prefer remote tracking refs.**
+
+```python
+# Before (line 248)
+for branch in ("main", "master", "origin/main", "origin/master"):
+
+# After
+for branch in ("origin/main", "origin/master", "main", "master"):
+```
+
+Pure tuple reorder. Behavior is unchanged in the fully-fresh case (origin/main == main), and corrected in the realistic case (origin/main is ahead of local main). No network call added — relies on whatever the local clone's tracking ref already says.
+
+**Change 2 — `check_commit_discipline`: switch to file-path matching.**
+
+Replace substring matching of step headers against commit subjects with: parse each slice's `**Files:**` line from the plan, and for each `[x]` slice verify at least one commit since branch base touched at least one of those declared files. A slice "is committed" iff there's a commit on the branch that modified one of its declared files. Commit subjects can use any wording — Conventional Commits, descriptive sentences, or anything else.
+
+Plan-format contract: `/plan` emits per-slice `**Files:**` lines as bulleted-or-bold text like `**Files:** \`path/one\`, \`path/two\``. The matcher reads backtick-quoted paths from each`**Files:**` line. When a slice has no `**Files:**` line, the matcher falls through to the existing substring matcher (covers legacy plans + minimal plans where steps don't declare files).
+
+Branch base resolution reuses `check_scope`'s logic (prefer `origin/main`).
+
+**Change 3 — `parse_plan`: anchor on `## Build Progress`.**
+
+When the plan contains a `## Build Progress` heading, only parse checkbox lines *between that heading and the next H2 (or EOF)*. When the plan has no `## Build Progress` heading (legacy or minimal plan), fall back to whole-file scanning — preserves backward compatibility with the existing test fixtures (the 11 existing `@test` blocks construct minimal plans with no Build Progress section).
+
+This narrows the gate to where the `/plan` skill actually stores step-completion state.
+
+**Constraints:**
+
+- All 11 existing bats tests in `tests/scripts/progress_guardian_tests.bats` must remain green — these document the contract for minimal plans without `## Build Progress` or `**Files:**` lines.
+- New tests live in the same bats file (one section per regression). Each uses a tmp git repo with synthetic commits, mirroring the existing helper pattern (`make_plan` + `git init -q` + synthetic commits).
+- Exit codes (`0` / `1` / `2`) and JSON output schema (`{"status", "issues": [{"severity", "confidence", "file", "line", "message", "suggestedFix"}]}`) are unchanged. The `progress-guardian` agent and `/pr` skill consume this surface — breaking it ripples.
+- `--skip-llm` flag and behavior unchanged.
+- No new dependencies. Python 3 stdlib only (matches the existing script).
+
+**Out of scope (rejected explicitly, do not bundle):**
+
+- No `git fetch` added to refresh `origin/main` before merge-base. Approach contract resolved this as "additive only" — the cost of network in the gate exceeds the marginal value over "trust the tracking ref."
+- No scope-token matching against Conventional Commit `feat(scope)` syntax. File-path matching is the chosen strategy; scope-token was rejected in the approach contract as fragile for slices whose title doesn't translate cleanly.
+- No structural refactor of `progress_guardian.py` (no class extraction, no module split). The three changes are surgical edits in the existing function bodies.
+- No changes to the `progress-guardian` agent's prompt template (`plugins/dev-team/agents/progress-guardian.md`). The agent uses the script's output verbatim — fixing the script fixes its findings.
+- No changes to other plan-consuming tools (`build-wave.sh`, `plan-waves.sh`, etc.). They parse plans for different purposes and aren't affected.
+
+**Risk surface:**
+
+- Test 3.2a in the existing suite asserts `[x] Step 1.1: add checkbox parser` + commit `feat: add checkbox parser` exits 0 under the substring matcher. Under the new file-path matcher with no `**Files:**` declared, the substring fallback must still fire — the test must remain green. (This is the explicit fallback in Change 2.)
+- The plan-file format `**Files:** \`a\`, \`b\`` is a `/plan` convention, not a hard syntax requirement on every plan. The fallback to substring matching protects legacy plans.
+
+## Acceptance Criteria
+
+Each criterion is a deterministic, observable check.
+
+**A1 — Stale-main fix (`check_scope`).**
+
+- Source check: `scripts/progress_guardian.py` contains the literal tuple `("origin/main", "origin/master", "main", "master")` (in that order). Grep: `grep -F '"origin/main", "origin/master", "main", "master"' scripts/progress_guardian.py` returns ≥ 1.
+- Behavioral check via new bats test: in a tmp repo where local `main` lags `origin/main` (simulated with a separate "remote" bare repo and `git push`/`git fetch` to set up the divergence), `progress_guardian --skip-llm` against a plan declaring files A and B, with the branch touching only A and B, reports zero out-of-plan files. The same scenario under the old tuple order would report files that landed on `main` while the branch was working.
+
+**A2 — Conventional-Commits compatible matcher (`check_commit_discipline`).**
+
+- Behavioral check via new bats test: plan with `## Build Progress` containing `- [x] Slice 1: …` and a `**Files:** \`a.py\`` line. Branch has a single commit `feat(scope): wording unrelated to the plan header` that modified `a.py`.`progress_guardian --skip-llm` exits 0. (Under today's matcher this exits 1 with "no matching commit.")
+- Behavioral check via new bats test: same setup, but the commit modifies `b.py` (not declared). `progress_guardian --skip-llm` exits 1 with "no matching commit" — the matcher still catches actual undisciplined work.
+- Behavioral check (fallback path) via existing test 3.2a: when no `**Files:**` line exists, the substring matcher still runs and the test stays green.
+
+**A3 — Build Progress anchor (`parse_plan`).**
+
+- Behavioral check via new bats test: plan with both `## Build Progress` (one `[x]` slice with matching commit) and `## Acceptance Criteria` (several `[ ]` AC items). `progress_guardian --pre-pr --skip-llm` exits 0 — the AC checkboxes are ignored.
+- Behavioral check via new bats test: same plan but the `## Build Progress` slice is `[ ]`. `progress_guardian --pre-pr --skip-llm` exits 1 naming the unchecked slice.
+- Behavioral check (fallback path) via existing test 3.3a: minimal plan with no `## Build Progress` heading — every checkbox in the file is parsed (today's behavior). Test stays green.
+
+**A4 — Real-world reproduction passes.**
+
+- Manual verification step run from the #524 branch (or any future branch with the same plan layout): `python3 scripts/progress_guardian.py --pre-pr --plan plans/stack-aware-reference-loading.md` exits 0. PR description captures the before/after output as evidence.
+
+**A5 — Existing test suite remains green.**
+
+- `bats tests/scripts/progress_guardian_tests.bats` exits 0 (all 11 pre-existing tests + new tests added in this PR all pass).
+- `bash scripts/ci-local.sh` exits 0.
+
+**A6 — CI/release hygiene.**
+
+- PR title `fix(progress-guardian): correct three pre-PR gate false positives (#525)` — `fix:` prefix for release-please patch bump.
+- PR opened with `--no-auto-merge` per CLAUDE.md (touches `scripts/`).
+- `/code-review` passes after auto-fix loop.
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|----------|---------------|-------------|-------------------|
+| Matcher strategy: substring / file-path / scope-token / either | `requires-stakeholder-input` | human (approach contract) | File-path match against the slice's declared `**Files:**` line. No scope-token, no permissive fallback. |
+| STEP_PATTERN scope | `requires-stakeholder-input` | human (approach contract) | Anchor on `## Build Progress` heading, scan until next H2. |
+| Stale-main fix scope | `requires-stakeholder-input` | human (approach contract) | Pure tuple reorder, no `git fetch`. |
+| Behavior when plan has no `## Build Progress` heading | `inferable` | inference | Fall back to whole-file scanning — backward-compatible with the 11 existing bats tests, which construct minimal plans with no Build Progress section. Deleting that fallback would break the existing suite without delivering value. |
+| Behavior when slice has no `**Files:**` line | `inferable` | inference | Fall back to the existing substring matcher — backward-compatible with existing tests (3.2a constructs a plan with no Files declaration). The new file-path path covers the new code; the fallback path covers the legacy. |
+| Branch base for file-path matcher | `inferable` | inference | Reuse `check_scope`'s `for branch in ("origin/main", ...)` resolution. Single source of truth for "what is trunk?" across the script. |
+| `--pre-pr` behavior on AC checkboxes after the fix | `inferable` | inference | ACs are silently ignored by parse_plan — they are not steps. The gate becomes "all Build Progress steps `[x]`," which matches what the gate's name implies. The pre-merge contract is that the build is done, not that every aspirational AC has been re-checked at gate time. |
+| Plan-format contract change | `inferable` | inference | None required. `**Files:** \`a\`, \`b\`` is already what `/plan` emits per-slice; the matcher just consumes it. No new plan-format rules invented. |
+| Where new bats tests live | `inferable` | inference | Same file as existing tests (`tests/scripts/progress_guardian_tests.bats`), new section "Step 4 — Issue #525 regressions" with three subsections (4.1 origin-main preference, 4.2 file-path matcher, 4.3 Build Progress anchor). Co-located coverage; no fixture sprawl. |
+
+No `LOW_VALUE` items.
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — *Three independent bugs in `scripts/progress_guardian.py`; fix each with the minimum-blast-radius implementation chosen in the approach contract; preserve all existing exit codes, JSON shape, and 11 passing bats tests.*
+- [x] Every behavior/goal maps to an acceptance criterion — A1 (Change 1: stale main), A2 (Change 2: commit matcher), A3 (Change 3: parse_plan anchor), A4 (real-world repro), A5 (no regressions), A6 (CI).
+- [x] Architecture constrains without over-engineering — one file edited, no new modules, no helper extraction, no API changes, three surgical fixes.
+- [x] Terminology consistent across artifacts — *Build Progress*, *Acceptance Criteria*, *file-path matcher*, *substring fallback*, *origin/main preference* used identically.
+- [x] No contradictions between artifacts — the three locked decisions and the four `inferable` decisions appear identically in Intent, Architecture, Acceptance, and Ambiguity Log.
+- [x] Every gap/ambiguity finding is logged — nine findings, three resolved by human, six inferable with explicit rationale, zero undocumented assumptions, zero `LOW_VALUE`.
+
+**Verdict: PASS.** Ready for `/plan`.

--- a/plans/progress-guardian-fixes.md
+++ b/plans/progress-guardian-fixes.md
@@ -272,31 +272,31 @@ No `complex` steps. The plan touches one high-reversal-cost axis (Scope — kept
 
 #### Wave 1
 
-- [ ] Slice 1: Prefer origin/main over local main in `check_scope`
-  - [ ] Step 1.1: Reorder the branch tuple and add regression bats coverage
+- [x] Slice 1: Prefer origin/main over local main in `check_scope`
+  - [x] Step 1.1: Reorder the branch tuple and add regression bats coverage
 
 #### Wave 2
 
-- [ ] Slice 2: File-path commit-discipline matcher (with substring fallback)
-  - [ ] Step 2.1: Implement file-path matcher with substring fallback + regression coverage
+- [x] Slice 2: File-path commit-discipline matcher (with substring fallback)
+  - [x] Step 2.1: Implement file-path matcher with substring fallback + regression coverage
 
 #### Wave 3
 
-- [ ] Slice 3: parse_plan anchored on `## Build Progress`
-  - [ ] Step 3.1: Anchor parse_plan on `## Build Progress` with whole-file fallback + regression coverage
+- [x] Slice 3: parse_plan anchored on `## Build Progress`
+  - [x] Step 3.1: Anchor parse_plan on `## Build Progress` with whole-file fallback + regression coverage
 
 #### Wave 4
 
-- [ ] Slice 4: Real-world reproduction smoke test
-  - [ ] Step 4.1: Add an end-to-end bats fixture combining all three patterns
+- [x] Slice 4: Real-world reproduction smoke test
+  - [x] Step 4.1: Add an end-to-end bats fixture combining all three patterns
 
 ### Acceptance Criteria
 
-- [ ] A1: Stale-main fix (tuple reorder + bats regression)
-- [ ] A2: File-path commit matcher (with substring fallback + bats regression)
-- [ ] A3: Build Progress anchor (with whole-file fallback + bats regression)
-- [ ] A4: End-to-end bats fixture (Slice 4) combines all three patterns and passes
-- [ ] A5: All 19 bats tests (11 existing + 8 new across 4 slices) green
+- [x] A1: Stale-main fix (tuple reorder + bats regression)
+- [x] A2: File-path commit matcher (with substring fallback + bats regression)
+- [x] A3: Build Progress anchor (with whole-file fallback + bats regression)
+- [x] A4: End-to-end bats fixture (Slice 4) combines all three patterns and passes
+- [x] A5: All 21 bats tests (11 existing + 10 new across 4 slices) green
 - [ ] A6: ci-local green, PR title `fix:`, --no-auto-merge
 
 ## Plan Review Summary

--- a/plans/progress-guardian-fixes.md
+++ b/plans/progress-guardian-fixes.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-06-30
 **Branch**: feat/525-guardian-fixes
-**Status**: approved
+**Status**: implemented
 **Spec**: docs/specs/progress-guardian-fixes.md
 **Issue**: <https://github.com/bdfinst/agentic-dev-team/issues/525>
 
@@ -297,7 +297,7 @@ No `complex` steps. The plan touches one high-reversal-cost axis (Scope — kept
 - [x] A3: Build Progress anchor (with whole-file fallback + bats regression)
 - [x] A4: End-to-end bats fixture (Slice 4) combines all three patterns and passes
 - [x] A5: All 21 bats tests (11 existing + 10 new across 4 slices) green
-- [ ] A6: ci-local green, PR title `fix:`, --no-auto-merge
+- [x] A6: ci-local green, PR title `fix:`, --no-auto-merge
 
 ## Plan Review Summary
 

--- a/plans/progress-guardian-fixes.md
+++ b/plans/progress-guardian-fixes.md
@@ -1,0 +1,323 @@
+# Plan: progress_guardian — fix three pre-PR gate false positives
+
+**Created**: 2026-06-30
+**Branch**: feat/525-guardian-fixes
+**Status**: approved
+**Spec**: docs/specs/progress-guardian-fixes.md
+**Issue**: <https://github.com/bdfinst/agentic-dev-team/issues/525>
+
+## Goal
+
+Fix three independent false-positive bugs in `scripts/progress_guardian.py` that block clean PRs on every Conventional-Commits-following branch with a normal `## Build Progress` + `## Acceptance Criteria` plan layout: (1) prefer `origin/main` over stale local `main`; (2) match commits to slices by declared file path instead of step-header substring; (3) parse only the `## Build Progress` section's checkboxes, not the `## Acceptance Criteria` section's. All three fixes are additive — every existing bats fixture remains green via fallback paths for plans that don't carry the new format conventions.
+
+## Approach stance (high-reversal-cost axes)
+
+- **Scope** — touch only `scripts/progress_guardian.py` and `tests/scripts/progress_guardian_tests.bats`. No refactor of the guardian agent prompt. *Internal* signature changes (passing `plan_text` to `check_commit_discipline`, extracting a `_branch_base_sha` helper) are allowed and expected — they de-risk Slice 1 by ensuring the two callers of base-ref resolution cannot drift. The **public** surface (the three CLI flags, the three exit codes, the JSON shape) is unchanged.
+- **Migrate vs. edit stub** — n/a; the script is canonical (not deprecated).
+- **Replace vs. merge** — Change 1 is a literal token reorder. Changes 2 and 3 *extend* existing functions with new branches; the old behavior remains the fallback so existing tests stay green. No section is wholesale replaced.
+- **Auto-merge** — disabled (`/pr --no-auto-merge`). Touches `scripts/` (the gate logic itself), so CLAUDE.md requires explicit human merge.
+- **Format fidelity** — n/a.
+
+## Acceptance Criteria
+
+- [ ] A1: `scripts/progress_guardian.py` contains the literal tuple `("origin/main", "origin/master", "main", "master")` in that order; the prior order is gone. Behavioral check via new bats test: in a tmp repo where local `main` lags `origin/main`, the guardian reports zero out-of-plan files when the branch only touched declared files.
+- [ ] A2: New bats test — plan with `## Build Progress` containing `- [x] Slice 1: …` + `**Files:** \`a.py\``; branch has one Conventional Commit`feat(scope): wording` that modified `a.py` — guardian exits 0. Counterpart test: same plan, commit modified `b.py` (not declared) — guardian exits 1 naming the slice. Substring-fallback test: plan with no `**Files:**` line still passes the existing 3.2a test under the old matcher path.
+- [ ] A3: New bats test — plan with `## Build Progress` (one `[x]` slice with matching commit) AND `## Acceptance Criteria` (several `[ ]` items) — `--pre-pr` exits 0; AC checkboxes ignored. Counterpart test: same plan, Build Progress slice is `[ ]` — `--pre-pr` exits 1 naming that slice. Fallback test: plan with no `## Build Progress` heading still parses every checkbox in the file (existing test 3.3a stays green).
+- [ ] A4: An end-to-end bats fixture (Step 4.1) constructs a tmp repo combining all three patterns — `origin/main` ahead of local `main`, a Conventional Commit subject that does NOT substring-match the slice header, a `**Files:**` line whose declared path the commit modified, AND both `## Build Progress` + `## Acceptance Criteria` sections — and exits 0 with an empty `issues` array. This is the deterministic verification of "all three fixes compose."
+- [ ] A5: `bats tests/scripts/progress_guardian_tests.bats` exits 0. Count: 11 pre-existing tests + 8 new tests (Slice 1: 2 scenarios = 2 tests; Slice 2: 4 scenarios = 4 tests; Slice 3: 4 scenarios = 4 tests including the new "Build Progress empty" case; Slice 4: 1 end-to-end test) = 19 total. If any scenario is implemented as a parametrized `@test` instead of a separate one, A5 still requires every scenario to be independently asserted.
+- [ ] A6: `bash scripts/ci-local.sh` exits 0; PR title prefix `fix:` for release-please patch bump; PR opened with `--no-auto-merge`.
+
+## Slices
+
+Three independent fixes; each slice has a single TDD step that adds bats regression coverage for the bug, watches it fail, applies the surgical edit, and watches it pass without disturbing the existing fixtures.
+
+### Slice 1: Prefer origin/main over local main in `check_scope`
+
+**Depends-on:** none
+**Files:** `scripts/progress_guardian.py`, `tests/scripts/progress_guardian_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: progress_guardian uses origin/main when local main has fallen behind
+
+  Scenario: Local main lags origin/main by exactly one commit
+    Given a tmp git repo with a single declared plan path "a.py"
+    And origin/main is exactly one commit ahead of local main; that single ahead-commit touches "unrelated.py"
+    And a branch from origin/main with exactly one commit "feat: do thing" that touches only "a.py"
+    When progress_guardian.py runs with --skip-llm against the plan
+    Then it exits 0
+    And the JSON issues array is empty
+
+  Scenario: Local main equals origin/main (no regression)
+    Given a tmp git repo where origin/main and local main both point to the same commit
+    And a plan declaring "a.py"
+    And a branch with one commit "feat: do thing" that touches only "a.py"
+    When progress_guardian.py runs with --skip-llm against the plan
+    Then it exits 0
+    And the JSON issues array is empty
+```
+
+**Steps:**
+
+#### Step 1.1: Reorder the branch tuple and add regression bats coverage
+
+**Complexity**: standard
+**RED**: Append a new section "Step 4.1 — Issue #525 regressions: origin/main preference" to `tests/scripts/progress_guardian_tests.bats` with two `@test`s covering the two scenarios above. Setup pattern: create a bare repo (the "remote") in `$T/remote.git`, clone it to `$T/work`, commit + push an initial commit + `unrelated.py` so `origin/main` advances, fetch back to make `origin/main` ahead of local `main`, then branch from `origin/main` and commit `a.py`. Run the guardian against a plan declaring `\`a.py\``. Assertion:`[ "$status" -eq 0 ]` AND `python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"`. Run`bats`; the lag scenario fails (current tuple-order resolves to stale local`main`, so diff`local-main..HEAD` reports the ahead-commit's `unrelated.py` as out-of-plan).
+**GREEN**: Edit `scripts/progress_guardian.py` line 248 — replace the tuple `("main", "master", "origin/main", "origin/master")` with `("origin/main", "origin/master", "main", "master")`. Run`bats tests/scripts/progress_guardian_tests.bats`; the new test passes AND all 11 existing tests stay green (the existing tests create tmp repos without a remote, so iteration order doesn't affect them).
+**REFACTOR**: None expected — pure token reorder.
+**Files**:`scripts/progress_guardian.py`,`tests/scripts/progress_guardian_tests.bats`
+**Commit**: `fix(progress-guardian): prefer origin/main over local main when computing branch base (#525)`
+
+### Slice 2: File-path commit-discipline matcher (with substring fallback)
+
+**Depends-on:** 1
+**Files:** `scripts/progress_guardian.py`, `tests/scripts/progress_guardian_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: progress_guardian matches commits to slices by declared file path
+
+  Scenario: Conventional Commit on declared file satisfies the matcher
+    Given a tmp git repo where origin/main points at an initial commit
+    And a plan with one [x] slice declaring **Files:** `a.py`
+    And a branch with a single commit "feat(scope): wording unrelated to the slice header" that touched a.py
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 0
+    And the JSON issues array is empty
+
+  Scenario: Commit on declared multi-path matches when any one path was touched
+    Given a tmp git repo where origin/main points at an initial commit
+    And a plan with one [x] slice declaring **Files:** `a.py`, `b.py`
+    And a branch with a single commit "feat: anything" that touched only b.py
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 0
+    And the JSON issues array is empty
+
+  Scenario: Commit modifies only undeclared files
+    Given a tmp git repo where origin/main points at an initial commit with zero commits touching a.py or b.py
+    And a plan with one [x] slice declaring **Files:** `a.py`
+    And a branch with a single commit "feat: anything" that touched only b.py
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 1
+    And the JSON issues array contains exactly one error whose message includes the slice header text
+
+  Scenario: Slice declares no Files line (legacy plan)
+    Given a plan with one [x] slice and no **Files:** line
+    And a branch with a commit whose subject contains the slice header substring
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 0
+    And the JSON issues array is empty
+```
+
+**Steps:**
+
+#### Step 2.1: Implement file-path matcher with substring fallback + regression coverage
+
+**Complexity**: standard
+**RED**: Append "Step 4.2 — Issue #525 regressions: file-path matcher" to the bats file with four `@test` blocks covering the four scenarios above. Assertions follow the existing pattern: `[ "$status" -eq <N> ]` plus a Python one-liner against the JSON. Run `bats`; the three new file-path tests fail (today's substring matcher does not match Conventional Commit subjects against the slice header), the fallback test already passes.
+**GREEN**: Edit `scripts/progress_guardian.py` with the **minimum** to make the new tests pass:
+
+- Add `_parse_slice_files(plan_text: str, slice_header: str) -> List[str]`: locate the slice's heading line (the line whose text contains `slice_header` after `STEP_PATTERN` match), scan forward to the next `**Files:**` line within the same heading block, and return the backtick-quoted paths. Empty list when not found.
+- Extend `check_commit_discipline`'s signature to `(steps, repo_root, plan_text)` and pass `plan_text` from `main`. For each `[x]` step:
+  - **File-path path:** if `_parse_slice_files` returns a non-empty list, run `git log --name-only --no-merges <base>..HEAD` (using the same branch-base resolution as `check_scope` — see REFACTOR below) and pass when any commit's file list intersects the declared paths (any-of semantics).
+  - **Substring fallback:** when no `**Files:**` line was found, run the existing matcher. **Important alignment fix:** scope the substring fallback to `<base>..HEAD` too (matching what the new file-path path uses), so the two branches use the same commit range and cannot diverge. Existing test 3.2a's tmp repo has the commit as the merge-base-resolution target (no remote, falls through to `--max-parents=0` root), and the commit is on `HEAD`, so `<base>..HEAD` includes it — fallback test stays green.
+
+Run `bats`; all new tests pass AND all 11 existing tests stay green.
+**REFACTOR**: Extract `_branch_base_sha(repo_root: str) -> Optional[str]` from `check_scope`'s existing inline loop (lines 246-255). Both `check_scope` and `check_commit_discipline` call it — single source of truth. This is a behavior-preserving structural change, separated from GREEN so a test fails in isolation if the extraction breaks anything. Run `bats` once more; everything stays green.
+**Files**: `scripts/progress_guardian.py`, `tests/scripts/progress_guardian_tests.bats`
+**Commit**: `fix(progress-guardian): match commits to slices by declared **Files:** path (#525)`
+
+### Slice 3: parse_plan anchored on `## Build Progress`
+
+**Depends-on:** 2
+**Files:** `scripts/progress_guardian.py`, `tests/scripts/progress_guardian_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: progress_guardian only reads checkboxes from the Build Progress section
+
+  Scenario: Plan has both Build Progress and Acceptance Criteria sections
+    Given a plan with "## Build Progress" containing one [x] slice "Slice 1: do thing" with a matching commit
+    And the same plan has "## Acceptance Criteria" with three [ ] AC items "A1: foo", "A2: bar", "A3: baz"
+    When progress_guardian.py runs with --pre-pr --skip-llm
+    Then it exits 0
+    And the JSON issues array is empty
+
+  Scenario: Build Progress slice is unchecked while AC items are also unchecked
+    Given a plan with "## Build Progress" containing one [ ] slice "Slice 1: do thing"
+    And the same plan has "## Acceptance Criteria" with three [ ] AC items "A1: foo", "A2: bar", "A3: baz"
+    When progress_guardian.py runs with --pre-pr --skip-llm
+    Then it exits 1
+    And the JSON issues array contains exactly one error whose message includes "Slice 1: do thing"
+    And no issue message mentions "A1:", "A2:", or "A3:"
+
+  Scenario: Build Progress section exists but contains no checkboxes
+    Given a plan with "## Build Progress" heading followed only by non-checkbox prose
+    And the same plan has "## Acceptance Criteria" with one [ ] AC item "A1: foo"
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 1
+    And the JSON issues array contains an error whose message names the plan file (no checkbox steps found)
+    And no issue message mentions "A1:"
+
+  Scenario: Plan has no Build Progress heading (legacy / minimal)
+    Given a plan with no "## Build Progress" heading, just bare "- [x] Step 1.1: do thing" lines and a matching commit
+    When progress_guardian.py runs with --skip-llm
+    Then it exits 0
+    And the JSON issues array is empty
+```
+
+**Steps:**
+
+#### Step 3.1: Anchor parse_plan on `## Build Progress` with whole-file fallback + regression coverage
+
+**Complexity**: standard
+**RED**: Append "Step 4.3 — Issue #525 regressions: Build Progress anchor" to the bats file with four `@test` blocks for the four scenarios above. Run `bats`; the two positive/negative scenarios fail (today's parse_plan reads AC checkboxes and treats them as undone Build Progress steps under `--pre-pr`), the empty-Build-Progress scenario also fails (today's whole-file scan finds the AC checkboxes so it doesn't hit the "no checkboxes" error path), the legacy-fallback test already passes.
+**GREEN**: Edit `scripts/progress_guardian.py`:
+
+- Modify `parse_plan` to first scan for a `## Build Progress` heading. If found, restrict checkbox parsing to lines between that heading and the next `##` H2 (or EOF). If not found, fall back to whole-file scanning (current behavior — preserves the 11 existing tests).
+- Implement as a one-pass loop with a `in_build_progress: bool` flag that toggles on the heading and off on the next H2.
+
+Run `bats`; all new tests pass AND all 11 existing tests stay green.
+**REFACTOR**: Confirm the new `in_build_progress` logic doesn't shadow the existing `parse_plan` error path (no checkboxes found). The fallback path must still return the same error finding for plans that genuinely have no checkboxes anywhere.
+**Files**: `scripts/progress_guardian.py`, `tests/scripts/progress_guardian_tests.bats`
+**Commit**: `fix(progress-guardian): anchor parse_plan on Build Progress heading, ignore AC checkboxes (#525)`
+
+### Slice 4: Real-world reproduction smoke test
+
+**Depends-on:** 1, 2, 3
+**Files:** `tests/scripts/progress_guardian_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: The three fixes together resolve the issue #525 reproducer
+
+  Scenario: A plan with Build Progress + AC + Conventional Commits + a fresh branch base passes the pre-PR gate
+    Given a tmp git repo where origin/main is exactly one commit ahead of local main; that ahead-commit touched "unrelated.py"
+    And a plan with "## Build Progress" containing one [x] slice "Slice 1: do thing" declaring **Files:** `a.py`
+    And the same plan has "## Acceptance Criteria" with three [ ] AC items "A1: foo", "A2: bar", "A3: baz"
+    And a branch from origin/main with one commit "feat(scope): wording unrelated to the slice header" that touched only "a.py"
+    When progress_guardian.py runs with --pre-pr --skip-llm against that plan
+    Then it exits 0
+    And the JSON issues array is empty
+```
+
+**Steps:**
+
+#### Step 4.1: Add an end-to-end bats fixture combining all three patterns
+
+**Complexity**: standard
+**RED**: Append "Step 4.4 — Issue #525 end-to-end: realistic plan with all three patterns" to the bats file with one `@test`. The test constructs the exact scenario above: a bare-repo "remote" with one extra commit on `main` touching `unrelated.py`; a clone with `origin/main` ahead of local `main`; a branch from `origin/main`; one commit `feat(scope): wording unrelated to the slice header` touching `a.py`; a plan with `## Build Progress` (one `[x]` slice "Slice 1: do thing" + `**Files:** \`a.py\``) and`## Acceptance Criteria` (three `[ ]` items). Assertion: `[ "$status" -eq 0 ]` AND `python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"`. Run`bats`; the test fails (any one of the three bugs makes it fail).
+**GREEN**: Slices 1, 2, 3 are already in place by the wave structure. Confirm by running the whole bats file; the end-to-end test now passes alongside all 18 prior tests.
+**REFACTOR**: None.
+**Files**:`tests/scripts/progress_guardian_tests.bats`
+**Commit**: `test(progress-guardian): add end-to-end fixture covering all three #525 regressions`
+
+## Parallelization
+
+`plan-waves.sh` derives waves from the `Depends-on:` declarations. Slices 1, 2, and 3 are independent (each edits a different function and adds its own bats section); Slice 4 is the integration check that depends on all three.
+
+**Important parallelization caveat:** Slices 1, 2, and 3 all touch the same two files (`scripts/progress_guardian.py` and `tests/scripts/progress_guardian_tests.bats`). `plan-waves.sh` will report this as a Wave-1 file collision. The fix is to declare a serial dependency chain (1 → 2 → 3 → 4) so each slice's edits land in sequence in the same worktree. The behaviors are still independent — but the file mutations need to serialize.
+
+```mermaid
+graph TD
+  S1[Slice 1: origin/main preference] --> S2[Slice 2: file-path matcher]
+  S2 --> S3[Slice 3: Build Progress anchor]
+  S3 --> S4[Slice 4: end-to-end fixture]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+| 2 | 2 |
+| 3 | 3 |
+| 4 | 4 |
+
+Single-slice waves throughout — no concurrency to exploit because every slice mutates the same script. Wall-clock is bounded by sequential execution; that's correct for this plan.
+
+## Complexity Classification
+
+| Step | Rating | Why |
+|------|--------|-----|
+| 1.1 | standard | Token reorder + new bats fixture exercising remote-vs-local git setup |
+| 2.1 | standard | New helper functions + extension to existing function + 3 new bats tests |
+| 3.1 | standard | New section-anchor branch in parse_plan + 3 new bats tests |
+| 4.1 | standard | End-to-end fixture combining all three patterns |
+
+No `complex` steps. The plan touches one high-reversal-cost axis (Scope — kept to two files, additive only), documented in the Approach stance above.
+
+## Pre-PR Quality Gate
+
+- [ ] `bats tests/scripts/progress_guardian_tests.bats` exits 0
+- [ ] `bash scripts/ci-local.sh` exits 0
+- [ ] `/code-review` passes on the diff
+- [ ] Real-world reproduction documented in PR body (before/after output)
+- [ ] PR title is `fix(progress-guardian): correct three pre-PR gate false positives (#525)`
+- [ ] PR opened with `--no-auto-merge`
+
+## Risks & Open Questions
+
+- **Risk:** Existing test 3.2a constructs `[x] Step 1.1: add checkbox parser` + commit `feat: add checkbox parser` and asserts exit 0. Under the file-path matcher this plan has no `**Files:**` line, so the fallback substring matcher must fire — and `add checkbox parser` is a substring of `feat: add checkbox parser`. Verified during planning. If the fallback regresses, this test catches it immediately.
+- **Risk:** Slice 1's bats test needs to manipulate `origin/main` independently of local `main`. The standard pattern is a sibling bare repo as the "remote" — slower than tmp dirs but deterministic. The existing bats file already uses tmp git repos for every test, so this extends a working pattern.
+- **Risk:** Refactoring `check_scope` to extract `_branch_base_sha` in Slice 2 could subtly change `check_scope`'s behavior. Mitigation: run the full existing bats suite after each slice — 3.3d in particular drives the `check_scope` → `llm-skipped` warning path through a committed-diff out-of-plan file, exercising the base-resolution loop. After the extraction, 3.3d must still emit `rule_id == 'llm-skipped'` for the same fixture. The REFACTOR phase of Step 2.1 explicitly runs bats again to catch any regression here.
+- **Note (parallelization):** the `Depends-on` chain (Slice 2 → 1, Slice 3 → 2, Slice 4 → 1,2,3) reflects file-mutation serialization in a single worktree, not pure logical coupling. Slice 2 does have a real logical dependency on Slice 1 (Slice 2's REFACTOR consumes Slice 1's branch tuple). Slice 3 is logically independent of Slices 1-2 — its dependency is solely to avoid a same-file collision.
+- **Open question:** None — all three high-reversal-cost decisions were resolved in the approach contract before `/specs` ran.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Prefer origin/main over local main in `check_scope`
+  - [ ] Step 1.1: Reorder the branch tuple and add regression bats coverage
+
+#### Wave 2
+
+- [ ] Slice 2: File-path commit-discipline matcher (with substring fallback)
+  - [ ] Step 2.1: Implement file-path matcher with substring fallback + regression coverage
+
+#### Wave 3
+
+- [ ] Slice 3: parse_plan anchored on `## Build Progress`
+  - [ ] Step 3.1: Anchor parse_plan on `## Build Progress` with whole-file fallback + regression coverage
+
+#### Wave 4
+
+- [ ] Slice 4: Real-world reproduction smoke test
+  - [ ] Step 4.1: Add an end-to-end bats fixture combining all three patterns
+
+### Acceptance Criteria
+
+- [ ] A1: Stale-main fix (tuple reorder + bats regression)
+- [ ] A2: File-path commit matcher (with substring fallback + bats regression)
+- [ ] A3: Build Progress anchor (with whole-file fallback + bats regression)
+- [ ] A4: End-to-end bats fixture (Slice 4) combines all three patterns and passes
+- [ ] A5: All 19 bats tests (11 existing + 8 new across 4 slices) green
+- [ ] A6: ci-local green, PR title `fix:`, --no-auto-merge
+
+## Plan Review Summary
+
+**Plan tier:** `complex` — reviewers: Acceptance, Design, Strategic, Parallelization (UX skipped — no UI surface). All four approved (Acceptance after one revision iteration; the other three on first pass).
+
+**Iteration 1 changes — Acceptance Critic blockers + Design Critic high-value warning:**
+
+- A4 made deterministic — replaced the manual #524-branch reproduction with an end-to-end bats fixture that constructs the realistic scenario from scratch (Slice 4 Step 4.1).
+- Slice 1 scenarios pinned `N = exactly one commit`; assertion specifies `[ "$status" -eq 0 ]` AND `d['issues']==[]`.
+- Slice 2 missing-base-state Given added; "via the substring-matcher fallback" implementation leak removed; multi-path any-of scenario added (covers acceptance criterion A2 fully).
+- Slice 2 GREEN aligned substring-fallback `git log` range to `<base>..HEAD` so it cannot diverge from the file-path path (Design Critic's only behavioral warning).
+- Slice 2 REFACTOR phase now isolates the `_branch_base_sha` extraction from GREEN, so a regression there fails in isolation.
+- Slice 3 unchecked-slice scenario now asserts both positive (slice header in error message) and negative (no AC item names in any error message); "parse_plan falls back to whole-file scanning" implementation leak removed; empty-`## Build Progress` scenario added (covers the corner case where the heading exists but contains zero checkboxes).
+- A5 count corrected from "15" to "19" (8 new tests, not 4).
+- Approach stance clarified — "no signature change" refers to the public CLI surface; internal signatures may change.
+- Risks now names 3.3d as the explicit regression for the `_branch_base_sha` extraction.
+- Risks annotates Slice 3's `Depends-on: 2` as file-mutation serialization (Parallelization Critic observation).
+
+**Design + Strategic + Parallelization observations (recorded, not actioned):**
+
+- The `Depends-on` chain serializes file mutations in a single worktree — no logical concurrency to exploit. The `## Parallelization` section already documents this honestly.
+- Slice 4 adds no new production behavior; it's the compositing smoke test. Strategic Critic confirmed this is the right cut.
+- Scope is small (two files) and tightly bounded; no slice can be safely subdivided further.

--- a/plans/progress-guardian-fixes.md
+++ b/plans/progress-guardian-fixes.md
@@ -1,4 +1,4 @@
-# Plan: progress_guardian — fix three pre-PR gate false positives
+# Plan: progress_guardian — fix four pre-PR gate false positives
 
 **Created**: 2026-06-30
 **Branch**: feat/525-guardian-fixes
@@ -8,7 +8,7 @@
 
 ## Goal
 
-Fix three independent false-positive bugs in `scripts/progress_guardian.py` that block clean PRs on every Conventional-Commits-following branch with a normal `## Build Progress` + `## Acceptance Criteria` plan layout: (1) prefer `origin/main` over stale local `main`; (2) match commits to slices by declared file path instead of step-header substring; (3) parse only the `## Build Progress` section's checkboxes, not the `## Acceptance Criteria` section's. All three fixes are additive — every existing bats fixture remains green via fallback paths for plans that don't carry the new format conventions.
+Fix four false-positive bugs in `scripts/progress_guardian.py` that block clean PRs on every Conventional-Commits-following branch with the standard `/plan` template layout: (1) prefer `origin/main` over stale local `main`; (2) match commits to slices by declared file path instead of step-header substring; (3) parse only the `## Build Progress` section's checkboxes, not the top-level `## Acceptance Criteria` section's; (4) also skip the `### Acceptance Criteria` mirror nested inside `## Build Progress`. Bugs 1–3 were identified in issue #525 upfront; bug 4 was discovered mid-build (commit `a978a29`). All four fixes are additive — every existing bats fixture remains green via fallback paths for plans that don't carry the new format conventions. The structural design problem behind bug 4 (AC mirror items track no work) is carved out as **issue #526** for separate redesign.
 
 ## Approach stance (high-reversal-cost axes)
 
@@ -24,7 +24,7 @@ Fix three independent false-positive bugs in `scripts/progress_guardian.py` that
 - [ ] A2: New bats test — plan with `## Build Progress` containing `- [x] Slice 1: …` + `**Files:** \`a.py\``; branch has one Conventional Commit`feat(scope): wording` that modified `a.py` — guardian exits 0. Counterpart test: same plan, commit modified `b.py` (not declared) — guardian exits 1 naming the slice. Substring-fallback test: plan with no `**Files:**` line still passes the existing 3.2a test under the old matcher path.
 - [ ] A3: New bats test — plan with `## Build Progress` (one `[x]` slice with matching commit) AND `## Acceptance Criteria` (several `[ ]` items) — `--pre-pr` exits 0; AC checkboxes ignored. Counterpart test: same plan, Build Progress slice is `[ ]` — `--pre-pr` exits 1 naming that slice. Fallback test: plan with no `## Build Progress` heading still parses every checkbox in the file (existing test 3.3a stays green).
 - [ ] A4: An end-to-end bats fixture (Step 4.1) constructs a tmp repo combining all three patterns — `origin/main` ahead of local `main`, a Conventional Commit subject that does NOT substring-match the slice header, a `**Files:**` line whose declared path the commit modified, AND both `## Build Progress` + `## Acceptance Criteria` sections — and exits 0 with an empty `issues` array. This is the deterministic verification of "all three fixes compose."
-- [ ] A5: `bats tests/scripts/progress_guardian_tests.bats` exits 0. Count: 11 pre-existing tests + 8 new tests (Slice 1: 2 scenarios = 2 tests; Slice 2: 4 scenarios = 4 tests; Slice 3: 4 scenarios = 4 tests including the new "Build Progress empty" case; Slice 4: 1 end-to-end test) = 19 total. If any scenario is implemented as a parametrized `@test` instead of a separate one, A5 still requires every scenario to be independently asserted.
+- [ ] A5: `bats tests/scripts/progress_guardian_tests.bats` exits 0. Final count: 11 pre-existing tests + 10 new tests (Slice 1: 2 tests; Slice 2: 3 tests; Slice 3: 4 tests; Slice 4: 1 end-to-end test) = 21 total. (The originally planned 8 new tests grew to 10 after Slice 3 added its "Build Progress empty" scenario, picked up during plan review iteration 1.)
 - [ ] A6: `bash scripts/ci-local.sh` exits 0; PR title prefix `fix:` for release-please patch bump; PR opened with `--no-auto-merge`.
 
 ## Slices
@@ -265,6 +265,10 @@ No `complex` steps. The plan touches one high-reversal-cost axis (Scope — kept
 - **Risk:** Refactoring `check_scope` to extract `_branch_base_sha` in Slice 2 could subtly change `check_scope`'s behavior. Mitigation: run the full existing bats suite after each slice — 3.3d in particular drives the `check_scope` → `llm-skipped` warning path through a committed-diff out-of-plan file, exercising the base-resolution loop. After the extraction, 3.3d must still emit `rule_id == 'llm-skipped'` for the same fixture. The REFACTOR phase of Step 2.1 explicitly runs bats again to catch any regression here.
 - **Note (parallelization):** the `Depends-on` chain (Slice 2 → 1, Slice 3 → 2, Slice 4 → 1,2,3) reflects file-mutation serialization in a single worktree, not pure logical coupling. Slice 2 does have a real logical dependency on Slice 1 (Slice 2's REFACTOR consumes Slice 1's branch tuple). Slice 3 is logically independent of Slices 1-2 — its dependency is solely to avoid a same-file collision.
 - **Open question:** None — all three high-reversal-cost decisions were resolved in the approach contract before `/specs` ran.
+
+**Build-time discoveries:**
+
+- **Bug 4 — `### Acceptance Criteria` mirror inside `## Build Progress`.** Discovered when running the freshly-fixed guardian against this PR's own plan: every AC item in the Build Progress mirror produced a "no matching commit" error. Patched in commit `a978a29` by extending `parse_plan` with a second flag (`in_acceptance`) that skips the H3 AC sub-heading inside Build Progress. The underlying structural problem — that AC items are checkbox-tracked without work-tracking semantics (no `### Slice` heading, no `**Files:**` line, no commit message draft) — is captured separately as **issue #526** for redesign in a follow-up PR. This PR ships the surgical workaround so the gate stops false-positiving today; #526 will revisit whether the AC mirror should be removed, evidence-tied, or per-AC verified.
 
 ## Build Progress
 

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -109,11 +109,25 @@ def run_git(args: List[str], cwd: str) -> str:
 def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
     """Parse plan file and return (steps, errors).
 
-    When the plan contains a `## Build Progress` heading, only checkboxes
-    between that heading and the next H2 are parsed. This prevents the
-    `## Acceptance Criteria` section's checkboxes from being treated as
-    Build Progress steps (issue #525). When no `## Build Progress` heading
-    is present (legacy/minimal plans), falls back to whole-file scanning.
+    Scopes checkbox parsing with two flags when a Build Progress section
+    exists (issue #525):
+
+    - `in_build_progress` (outer scope) — when the plan contains a
+      `## Build Progress` heading, only lines between that heading and the
+      next `## ` H2 are eligible for step parsing. This prevents the
+      top-level `## Acceptance Criteria` section's checkboxes from being
+      treated as Build Progress steps.
+    - `in_acceptance` (inner skip) — within the Build Progress section,
+      the `/plan` skill renders a documentation mirror of the top-level
+      AC list under a `### Acceptance Criteria` H3 sub-heading. Those
+      mirror items lack work-tracking semantics (no `### Slice` heading,
+      no `**Files:**` line, no commit subject anchor). They are skipped
+      so the pre-PR gate doesn't demand a commit for each one. The
+      structural problem behind the workaround is tracked in #526.
+
+    When no `## Build Progress` heading is present (legacy/minimal plans),
+    falls back to whole-file scanning — preserves backward compatibility
+    with the pre-existing bats fixtures that construct minimal plans.
 
     Returns an error finding (naming the file) if no checkboxes found.
     """
@@ -145,7 +159,9 @@ def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
             # The `### Acceptance Criteria` subheading inside Build Progress
             # is a documentation mirror — the same items appear in the
             # top-level `## Acceptance Criteria`. Skip its checkboxes so
-            # they don't demand commits of their own. See issue #525.
+            # they don't demand commits of their own. The structural
+            # redesign of where ACs live is tracked in #526; this PR
+            # ships the workaround so the gate stops false-positiving.
             if in_build_progress and line.startswith("### Acceptance Criteria"):
                 in_acceptance = True
                 continue

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -34,6 +34,10 @@ STEP_PATTERN = re.compile(r"^-\s+\[( |x|X)\]\s+(?:Step\s+[\d.]+:\s+)?(.+)$")
 # Matches backtick-quoted paths in plan text (declared file references)
 BACKTICK_PATH_RE = re.compile(r"`([^`\s]+\.[a-zA-Z0-9_]+)`")
 
+# Matches a slice's `**Files:** ...` declaration line. Captures the
+# remainder of the line so BACKTICK_PATH_RE can extract the paths from it.
+SLICE_FILES_RE = re.compile(r"^\*\*Files:\*\*\s*(.+)$")
+
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -126,34 +130,138 @@ def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
     return steps, []
 
 
-def check_commit_discipline(steps: List[Step], repo_root: str) -> List[dict]:
-    """For each done step, verify a matching commit exists in git log.
+def _parse_slice_files(plan_text: str, slice_header: str) -> List[str]:
+    """Return backtick-quoted paths from the `**Files:**` line that follows
+    the slice declaring `slice_header`. Empty list when not found.
 
-    Matching: case-insensitive substring of step header in commit subject line.
+    The slice block is the run of lines starting at the heading whose text
+    contains `slice_header` (after the STEP_PATTERN match strips the
+    `- [x] Step N.M: ` prefix), and ending at the next blank line followed
+    by another `- [` checkbox, or at the next `## ` H2. We scan forward
+    looking for a `**Files:**` line within that block.
+    """
+    lines = plan_text.splitlines()
+    in_block = False
+    for raw in lines:
+        line = raw.rstrip()
+        # Start the block when we see the checkbox line whose header matches.
+        m = STEP_PATTERN.match(line)
+        if m:
+            header = m.group(2).strip()
+            if header == slice_header:
+                in_block = True
+                continue
+            if in_block:
+                # A different checkbox closes the block.
+                break
+        if not in_block:
+            continue
+        # Within the block: stop at next H2.
+        if line.startswith("## "):
+            break
+        # Look for the **Files:** line.
+        fm = SLICE_FILES_RE.match(line)
+        if fm:
+            return BACKTICK_PATH_RE.findall(fm.group(1))
+    return []
+
+
+def _branch_base_sha(repo_root: str) -> Optional[str]:
+    """Resolve the branch base SHA (the merge-base with trunk).
+
+    Prefers remote tracking refs over local refs — local main lags
+    origin/main the moment any work begins. Returns None when no
+    trunk-like ref resolves to a divergence point; callers should
+    treat None as "no meaningful branch base — use whole history."
+    See issue #525.
+    """
+    head_sha = run_git(["rev-parse", "HEAD"], repo_root).strip()
+    for branch in ("origin/main", "origin/master", "main", "master"):
+        out = run_git(["merge-base", "HEAD", branch], repo_root).strip()
+        if out and out != head_sha:
+            return out
+    return None
+
+
+def check_commit_discipline(
+    steps: List[Step], repo_root: str, plan_text: str = ""
+) -> List[dict]:
+    """For each done step, verify a matching commit exists on this branch.
+
+    Two strategies, tried in order per step:
+      1. **File-path match (preferred).** When the slice declares
+         `**Files:** ...`, pass when any commit since the branch base
+         touched one of the declared files. This decouples the gate
+         from commit-subject wording so Conventional Commits work.
+      2. **Substring fallback.** When the slice has no `**Files:**`
+         line (legacy plans), pass when any commit subject since the
+         branch base contains the slice header. Same matcher as before,
+         but scoped to `<base>..HEAD` so both strategies see the same
+         commit range (cannot diverge — see issue #525).
+
     Returns error findings for any done step with no matching commit.
     """
     done_steps = [s for s in steps if s.done]
     if not done_steps:
         return []
 
-    log_output = run_git(["log", "--oneline", "--no-merges", "HEAD"], repo_root)
-    if not log_output.strip():
-        # Zero commits — emit a warning (repo may be fresh), not a hard error
+    base_sha = _branch_base_sha(repo_root)
+
+    # Build the commit range. When no base resolves (orphan HEAD), fall
+    # back to whole-history matching so legacy behavior is preserved.
+    if base_sha:
+        range_arg = f"{base_sha}..HEAD"
+        log_subjects_out = run_git(
+            ["log", "--no-merges", "--format=%s", range_arg], repo_root
+        )
+    else:
+        range_arg = "HEAD"
+        log_subjects_out = run_git(
+            ["log", "--no-merges", "--format=%s", "HEAD"], repo_root
+        )
+    if not log_subjects_out.strip():
+        # Zero commits on this branch — emit a warning, not a hard error.
         return [
             _make_warning(
-                message="No commits found in git log — cannot verify commit discipline.",
+                message="No commits found on this branch — cannot verify commit discipline.",
                 suggested_fix="Commit work before marking steps done.",
             )
         ]
-
-    log_lines = log_output.strip().splitlines()
-    # Strip the short hash prefix from each line for matching
     commit_subjects = [
-        " ".join(line.split()[1:]).lower() for line in log_lines if line.strip()
+        s.lower() for s in log_subjects_out.strip().splitlines() if s.strip()
     ]
+
+    # Collect file paths touched by commits in the range (file-path path).
+    if base_sha:
+        diff_out = run_git(["diff", "--name-only", range_arg], repo_root)
+    else:
+        diff_out = run_git(
+            ["log", "--name-only", "--pretty=format:", "HEAD"], repo_root
+        )
+    branch_files = {p for p in diff_out.strip().splitlines() if p.strip()}
 
     errors: List[dict] = []
     for step in done_steps:
+        declared = _parse_slice_files(plan_text, step.header) if plan_text else []
+        if declared:
+            # File-path path: pass when any declared path was touched on this branch.
+            if any(p in branch_files for p in declared):
+                continue
+            errors.append(
+                _make_error(
+                    message=(
+                        f"Done step '{step.header}' has no matching commit in git log. "
+                        f"Expected a commit on this branch that touched one of: "
+                        f"{', '.join(declared)}"
+                    ),
+                    suggested_fix=(
+                        f"Commit your work touching one of the declared files "
+                        f"({', '.join(declared)}) before marking '{step.header}' done."
+                    ),
+                )
+            )
+            continue
+        # Substring fallback: no `**Files:**` declared.
         header_lower = step.header.lower()
         if not any(header_lower in subject for subject in commit_subjects):
             errors.append(
@@ -241,20 +349,13 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     text = plan_path.read_text(encoding="utf-8")
     declared_paths = set(BACKTICK_PATH_RE.findall(text))
 
-    # Find the base commit: try merge-base with main/master, fall back to root commit.
-    # Skip candidates where merge-base == HEAD (we ARE on that branch — no divergence).
-    head_sha = run_git(["rev-parse", "HEAD"], repo_root).strip()
-    base_ref = ""
-    # Prefer remote tracking refs over local refs — local main lags origin/main
-    # the moment any work begins, and the resulting merge-base would sweep in
-    # every commit landed on trunk while the contributor was working. See #525.
-    for branch in ("origin/main", "origin/master", "main", "master"):
-        out = run_git(["merge-base", "HEAD", branch], repo_root).strip()
-        if out and out != head_sha:
-            base_ref = out
-            break
+    # Single source of truth for base-ref resolution — shared with
+    # check_commit_discipline so the two checks cannot drift on what
+    # counts as "trunk" (see issue #525). When no meaningful divergence
+    # point exists (no remote, no local trunk), fall back to the root
+    # commit so check_scope can still flag every file touched in the repo.
+    base_ref = _branch_base_sha(repo_root)
     if not base_ref:
-        # Fall back to the very first commit (root) — captures all changes in the repo
         base_ref = run_git(["rev-list", "--max-parents=0", "HEAD"], repo_root).strip()
 
     # Collect files changed in commits since base_ref
@@ -393,6 +494,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     steps, parse_errors = parse_plan(plan_path)
     errors.extend(parse_errors)
 
+    # Pre-read the plan text once so check_commit_discipline can locate
+    # per-slice `**Files:**` declarations (file-path matcher path).
+    plan_text = plan_path.read_text(encoding="utf-8")
     if not parse_errors:
         # 2. Uncommitted change check (always runs; ignore the plan file itself)
         uncommitted_issues = check_uncommitted(
@@ -401,7 +505,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         errors.extend(uncommitted_issues)
 
         # 3. Commit discipline (runs regardless of uncommitted state — both issues matter)
-        commit_issues = check_commit_discipline(steps, repo_root)
+        commit_issues = check_commit_discipline(steps, repo_root, plan_text)
         for issue in commit_issues:
             if issue["severity"] == "error":
                 errors.append(issue)

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -130,17 +130,29 @@ def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
 
     steps: List[Step] = []
     in_build_progress = not has_build_progress  # legacy plans: scan everything
+    in_acceptance = False
     for raw in lines:
         line = raw.rstrip()
         if has_build_progress:
             if line.startswith("## Build Progress"):
                 in_build_progress = True
+                in_acceptance = False
                 continue
             # Any other H2 closes the section.
             if in_build_progress and line.startswith("## "):
                 in_build_progress = False
                 continue
-        if not in_build_progress:
+            # The `### Acceptance Criteria` subheading inside Build Progress
+            # is a documentation mirror — the same items appear in the
+            # top-level `## Acceptance Criteria`. Skip its checkboxes so
+            # they don't demand commits of their own. See issue #525.
+            if in_build_progress and line.startswith("### Acceptance Criteria"):
+                in_acceptance = True
+                continue
+            # Any other H3 within Build Progress exits the AC subsection.
+            if in_acceptance and line.startswith("### "):
+                in_acceptance = False
+        if not in_build_progress or in_acceptance:
             continue
         m = STEP_PATTERN.match(line)
         if m:
@@ -159,20 +171,43 @@ def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
 
 
 def _parse_slice_files(plan_text: str, slice_header: str) -> List[str]:
-    """Return backtick-quoted paths from the `**Files:**` line that follows
-    the slice declaring `slice_header`. Empty list when not found.
+    """Return backtick-quoted paths from the `**Files:**` line declared
+    under the slice identified by `slice_header`. Empty list when not found.
 
-    The slice block is the run of lines starting at the heading whose text
-    contains `slice_header` (after the STEP_PATTERN match strips the
-    `- [x] Step N.M: ` prefix), and ending at the next blank line followed
-    by another `- [` checkbox, or at the next `## ` H2. We scan forward
-    looking for a `**Files:**` line within that block.
+    Two layouts are supported:
+      1. **Heading-anchored** (the /plan skill convention): the slice is
+         declared with `### Slice N: title` and `**Files:** ...` lives in
+         that section's body. Build Progress checkboxes mirror the heading
+         text — we match the heading and scan forward.
+      2. **Inline** (minimal plans): `- [x] Slice N: title` followed by a
+         `**Files:** ...` line in the same checkbox block. Scan forward
+         from the checkbox until another checkbox or a heading.
+
+    Heading-anchored is tried first because real plans always use it. The
+    inline form preserves a smaller fixture surface for tests and the
+    minimal plans the existing bats fixtures construct.
     """
     lines = plan_text.splitlines()
+
+    # Try heading-anchored layout first.
     in_block = False
     for raw in lines:
         line = raw.rstrip()
-        # Start the block when we see the checkbox line whose header matches.
+        if line.startswith("### ") and line[4:].strip() == slice_header:
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if line.startswith("## ") or line.startswith("### "):
+            break
+        fm = SLICE_FILES_RE.match(line)
+        if fm:
+            return BACKTICK_PATH_RE.findall(fm.group(1))
+
+    # Fall back to inline layout: `**Files:**` line near a `- [x] <header>`.
+    in_block = False
+    for raw in lines:
+        line = raw.rstrip()
         m = STEP_PATTERN.match(line)
         if m:
             header = m.group(2).strip()
@@ -184,10 +219,8 @@ def _parse_slice_files(plan_text: str, slice_header: str) -> List[str]:
                 break
         if not in_block:
             continue
-        # Within the block: stop at next H2.
-        if line.startswith("## "):
+        if line.startswith("## ") or line.startswith("### "):
             break
-        # Look for the **Files:** line.
         fm = SLICE_FILES_RE.match(line)
         if fm:
             return BACKTICK_PATH_RE.findall(fm.group(1))

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -109,12 +109,40 @@ def run_git(args: List[str], cwd: str) -> str:
 def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
     """Parse plan file and return (steps, errors).
 
+    When the plan contains a `## Build Progress` heading, only checkboxes
+    between that heading and the next H2 are parsed. This prevents the
+    `## Acceptance Criteria` section's checkboxes from being treated as
+    Build Progress steps (issue #525). When no `## Build Progress` heading
+    is present (legacy/minimal plans), falls back to whole-file scanning.
+
     Returns an error finding (naming the file) if no checkboxes found.
     """
     text = path.read_text(encoding="utf-8")
+
+    # First, see whether the plan has a `## Build Progress` heading. If it
+    # does, narrow the scan to that section only. Otherwise, scan the whole
+    # file (preserves backward compatibility with plans that don't carry
+    # the section structure).
+    lines = text.splitlines()
+    has_build_progress = any(
+        line.rstrip().startswith("## Build Progress") for line in lines
+    )
+
     steps: List[Step] = []
-    for line in text.splitlines():
-        m = STEP_PATTERN.match(line.rstrip())
+    in_build_progress = not has_build_progress  # legacy plans: scan everything
+    for raw in lines:
+        line = raw.rstrip()
+        if has_build_progress:
+            if line.startswith("## Build Progress"):
+                in_build_progress = True
+                continue
+            # Any other H2 closes the section.
+            if in_build_progress and line.startswith("## "):
+                in_build_progress = False
+                continue
+        if not in_build_progress:
+            continue
+        m = STEP_PATTERN.match(line)
         if m:
             flag, header = m.group(1), m.group(2).strip()
             steps.append(Step(done=(flag.lower() == "x"), header=header))

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -245,7 +245,10 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     # Skip candidates where merge-base == HEAD (we ARE on that branch — no divergence).
     head_sha = run_git(["rev-parse", "HEAD"], repo_root).strip()
     base_ref = ""
-    for branch in ("main", "master", "origin/main", "origin/master"):
+    # Prefer remote tracking refs over local refs — local main lags origin/main
+    # the moment any work begins, and the resulting merge-base would sweep in
+    # every commit landed on trunk while the contributor was working. See #525.
+    for branch in ("origin/main", "origin/master", "main", "master"):
         out = run_git(["merge-base", "HEAD", branch], repo_root).strip()
         if out and out != head_sha:
             base_ref = out

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -270,15 +270,22 @@ setup_stale_main_repo() {
   parent="$(dirname "$work")"
   local remote="$parent/remote.git"
   local sibling="$parent/sibling"
-  # Bare remote
-  git init -q --bare "$remote"
-  # Working clone seeded with an initial commit
-  git init -q "$work"
+  # Bare remote. Force HEAD to main so `git clone` from it later
+  # doesn't warn about a nonexistent ref.
+  git init -q --bare --initial-branch=main "$remote" 2>/dev/null \
+    || { git init -q --bare "$remote"; git -C "$remote" symbolic-ref HEAD refs/heads/main; }
+  # Working clone seeded with an initial commit on `main`. Use
+  # --initial-branch=main so the branch exists from the start regardless of
+  # the host git's `init.defaultBranch` config (CI runners often default to
+  # `master` or leave it unset, which causes `git push origin main` to fail
+  # with "src refspec main does not match any" when the branch only becomes
+  # real via `git checkout -b main` before the first commit).
+  git init -q --initial-branch=main "$work" 2>/dev/null \
+    || { git init -q "$work"; git -C "$work" symbolic-ref HEAD refs/heads/main; }
   cd "$work"
   git config user.email "test@test.com"
   git config user.name "Test"
   git remote add origin "$remote"
-  git checkout -q -b main
   echo "seed" > seed.txt
   git add seed.txt
   git commit -q -m "chore: seed"
@@ -289,6 +296,7 @@ setup_stale_main_repo() {
   cd "$sibling"
   git config user.email "test@test.com"
   git config user.name "Test"
+  # Sibling clone inherits its default branch from the remote HEAD (main).
   echo "ahead" > "$ahead_file"
   git add "$ahead_file"
   git commit -q -m "feat: ahead on main"
@@ -326,14 +334,17 @@ setup_stale_main_repo() {
   T="$(mktemp -d)"
   WORK="$T/work"
   # Set up a repo where origin/main == local main (no remote advance).
+  # Use --initial-branch=main (with fallback) so this works on CI runners
+  # whose git default branch is not `main`.
   REMOTE="$T/remote.git"
-  git init -q --bare "$REMOTE"
-  git init -q "$WORK"
+  git init -q --bare --initial-branch=main "$REMOTE" 2>/dev/null \
+    || { git init -q --bare "$REMOTE"; git -C "$REMOTE" symbolic-ref HEAD refs/heads/main; }
+  git init -q --initial-branch=main "$WORK" 2>/dev/null \
+    || { git init -q "$WORK"; git -C "$WORK" symbolic-ref HEAD refs/heads/main; }
   cd "$WORK"
   git config user.email "test@test.com"
   git config user.name "Test"
   git remote add origin "$REMOTE"
-  git checkout -q -b main
   echo "seed" > seed.txt
   git add seed.txt
   git commit -q -m "chore: seed"

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -424,3 +424,128 @@ errs = [i for i in d['issues'] if i['severity'] == 'error' and 'Slice 1: do thin
 assert len(errs) == 1, d
 "
 }
+
+# ---------------------------------------------------------------------------
+# Step 4.3 — Issue #525 regressions: Build Progress anchor
+# Bug: STEP_PATTERN matched every checkbox in the plan. The
+# `## Acceptance Criteria` section uses the same `- [ ]` syntax, so the
+# pre-PR gate demanded each AC be checked too — false positives on every
+# plan with both sections.
+#
+# Fix: parse_plan only reads checkboxes in the `## Build Progress`
+# section. Falls back to whole-file scanning when no `## Build Progress`
+# heading is present (preserves the existing 11 tests).
+# ---------------------------------------------------------------------------
+
+@test "4.3a: Build Progress [x] + AC [ ] items; --pre-pr exits 0 (ACs ignored)" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  # Isolates parse_plan / pre-PR scoping from commit-discipline by making the
+  # slice header substring-match the commit subject (Slice 2's file-path
+  # matcher is exercised in 4.2*; this test only verifies AC ignoring).
+  git commit -q --allow-empty -m "feat: do the slice work"
+  PLAN="$T/plan.md"
+  printf '%s\n' \
+    "## Build Progress" \
+    "" \
+    "- [x] do the slice work" \
+    "" \
+    "## Acceptance Criteria" \
+    "" \
+    "- [ ] A1: foo" \
+    "- [ ] A2: bar" \
+    "- [ ] A3: baz" \
+    > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}
+
+@test "4.3b: Build Progress [ ] + AC [ ] items; --pre-pr exits 1 naming the slice, not ACs" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: initial"
+  PLAN="$T/plan.md"
+  printf '%s\n' \
+    "## Build Progress" \
+    "" \
+    "- [ ] Slice 1: do thing" \
+    "" \
+    "## Acceptance Criteria" \
+    "" \
+    "- [ ] A1: foo" \
+    "- [ ] A2: bar" \
+    "- [ ] A3: baz" \
+    > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 1 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+errs = [i for i in d['issues'] if i['severity'] == 'error']
+assert any('Slice 1: do thing' in i['message'] for i in errs), d
+for i in errs:
+    msg = i['message']
+    assert 'A1:' not in msg and 'A2:' not in msg and 'A3:' not in msg, \
+        'AC item leaked into errors: ' + msg
+"
+}
+
+@test "4.3c: Build Progress section exists but contains no checkboxes; exits 1 naming the plan file" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: initial"
+  PLAN="$T/plan.md"
+  printf '%s\n' \
+    "## Build Progress" \
+    "" \
+    "Some prose, no checkboxes." \
+    "" \
+    "## Acceptance Criteria" \
+    "" \
+    "- [ ] A1: foo" \
+    > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 1 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+errs = [i for i in d['issues'] if i['severity'] == 'error']
+assert any('plan.md' in (i.get('message','') + i.get('file','')) for i in errs), d
+for i in errs:
+    assert 'A1:' not in i['message'], 'AC item leaked into errors: ' + i['message']
+"
+}
+
+@test "4.3d: legacy plan with no '## Build Progress' heading falls back to whole-file scan" {
+  # This scenario mirrors the existing 3.3a test's plan format. Verifies the
+  # backward-compatibility fallback is intact.
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "feat: do thing"
+  PLAN="$T/plan.md"
+  printf '%s\n' "- [x] Step 1.1: do thing" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -549,3 +549,41 @@ for i in errs:
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
+
+# ---------------------------------------------------------------------------
+# Step 4.4 — Issue #525 end-to-end: realistic plan with all three patterns
+# Smoke test that all three Slices compose: origin/main ahead of local main,
+# Conventional Commit subject that does NOT substring-match the slice
+# header, **Files:** line driving the file-path matcher, AND a separate
+# `## Acceptance Criteria` section the gate must ignore.
+# ---------------------------------------------------------------------------
+
+@test "4.4: realistic plan with all three #525 patterns passes the pre-PR gate" {
+  T="$(mktemp -d)"
+  WORK="$T/work"
+  setup_stale_main_repo "$WORK" "unrelated.py"
+  cd "$WORK"
+  echo "branch work" > a.py
+  git add a.py
+  # Conventional Commit subject that does NOT substring-match the slice header.
+  git commit -q -m "feat(scope): wording unrelated to the slice header"
+  PLAN="$WORK/plan.md"
+  printf '%s\n' \
+    "## Build Progress" \
+    "" \
+    "- [x] Slice 1: do thing" \
+    "" \
+    "**Files:** \`a.py\`" \
+    "" \
+    "## Acceptance Criteria" \
+    "" \
+    "- [ ] A1: foo" \
+    "- [ ] A2: bar" \
+    "- [ ] A3: baz" \
+    > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -347,3 +347,80 @@ setup_stale_main_repo() {
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
+
+# ---------------------------------------------------------------------------
+# Step 4.2 — Issue #525 regressions: file-path matcher
+# Bug: check_commit_discipline required a substring of the slice header in
+# the commit subject. Conventional Commits (mandated by CLAUDE.md) never
+# contain plan-step header text verbatim, so the gate fired on every
+# normally-disciplined branch.
+#
+# Fix: parse each [x] slice's `**Files:**` line, then for each declared
+# path check whether any commit on this branch touched it. Fall back to
+# the substring matcher when no `**Files:**` line is declared (legacy
+# plans + the existing 11 tests).
+# ---------------------------------------------------------------------------
+
+@test "4.2a: Conventional Commit on declared file satisfies the matcher" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: initial"
+  echo "branch work" > a.py
+  git add a.py
+  # Conventional Commit subject that does NOT substring-match the slice header.
+  git commit -q -m "feat(scope): wording unrelated to the slice header"
+  PLAN="$T/plan.md"
+  printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}
+
+@test "4.2b: commit touches one of multiple declared files (any-of semantics)" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: initial"
+  echo "branch work" > b.py
+  git add b.py
+  git commit -q -m "feat: anything"
+  PLAN="$T/plan.md"
+  printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`, \`b.py\`" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}
+
+@test "4.2c: commit modifies only undeclared files; matcher fails naming the slice" {
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: initial"
+  echo "branch work" > b.py
+  git add b.py
+  git commit -q -m "feat: anything"
+  PLAN="$T/plan.md"
+  printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 1 ]
+  # Exactly one commit-discipline error whose message includes the slice header.
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+errs = [i for i in d['issues'] if i['severity'] == 'error' and 'Slice 1: do thing' in i['message']]
+assert len(errs) == 1, d
+"
+}

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -261,7 +261,15 @@ make_plan() {
 setup_stale_main_repo() {
   local work="$1"
   local ahead_file="$2"
-  local remote="$work/../remote.git"
+  # All three working areas (the bare remote, the working clone, and the
+  # sibling clone used to advance the remote) live as siblings under
+  # $work's PARENT directory. Callers create $work as `$T/work` for some
+  # mktemp-d $T, so `rm -rf $T` covers everything this helper allocates —
+  # no detached tmpdirs leak under /tmp.
+  local parent
+  parent="$(dirname "$work")"
+  local remote="$parent/remote.git"
+  local sibling="$parent/sibling"
   # Bare remote
   git init -q --bare "$remote"
   # Working clone seeded with an initial commit
@@ -275,10 +283,8 @@ setup_stale_main_repo() {
   git add seed.txt
   git commit -q -m "chore: seed"
   git push -q origin main
-  # Advance the remote with an ahead-commit touching <ahead_file>, via a
+  # Advance the remote with an ahead-commit touching <ahead_file>, via the
   # sibling clone so this clone's local main stays at the seed.
-  local sibling
-  sibling="$(mktemp -d)/sibling"
   git clone -q "$remote" "$sibling"
   cd "$sibling"
   git config user.email "test@test.com"
@@ -401,6 +407,12 @@ setup_stale_main_repo() {
 }
 
 @test "4.2c: commit modifies only undeclared files; matcher fails naming the slice" {
+  # Tightening note: the commit subject is constructed to substring-MATCH the
+  # slice header ("do thing" in "feat: do thing" matches the literal
+  # "do thing"). If the production code regressed to the substring fallback
+  # despite the **Files:** declaration, this test would false-pass with exit
+  # 0. The current file-path matcher correctly rejects (b.py not in declared
+  # [a.py]), so exit 1 here proves the file-path matcher is the active path.
   T="$(mktemp -d)"
   cd "$T"
   git init -q
@@ -409,9 +421,9 @@ setup_stale_main_repo() {
   git commit -q --allow-empty -m "chore: initial"
   echo "branch work" > b.py
   git add b.py
-  git commit -q -m "feat: anything"
+  git commit -q -m "feat: do thing"
   PLAN="$T/plan.md"
-  printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`" > "$PLAN"
+  printf '%s\n' "- [x] do thing" "" "**Files:** \`a.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
   rm -rf "$T"
@@ -420,22 +432,60 @@ setup_stale_main_repo() {
   echo "$output" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
-errs = [i for i in d['issues'] if i['severity'] == 'error' and 'Slice 1: do thing' in i['message']]
+errs = [i for i in d['issues'] if i['severity'] == 'error' and \"'do thing'\" in i['message']]
 assert len(errs) == 1, d
 "
 }
 
 # ---------------------------------------------------------------------------
-# Step 4.3 — Issue #525 regressions: Build Progress anchor
-# Bug: STEP_PATTERN matched every checkbox in the plan. The
-# `## Acceptance Criteria` section uses the same `- [ ]` syntax, so the
-# pre-PR gate demanded each AC be checked too — false positives on every
-# plan with both sections.
+# Step 4.3 — Issue #525 regressions: Build Progress anchor + AC mirror skip
+# Two related bugs:
+#   (3) STEP_PATTERN matched every checkbox in the plan, including the
+#       top-level `## Acceptance Criteria` section.
+#   (4) Discovered during build: the /plan template ALSO renders an inner
+#       mirror of the AC list under a `### Acceptance Criteria` H3 inside
+#       `## Build Progress`. Those mirror items lack work-tracking semantics
+#       and produce "no matching commit" errors. Structural redesign tracked
+#       in #526.
 #
-# Fix: parse_plan only reads checkboxes in the `## Build Progress`
-# section. Falls back to whole-file scanning when no `## Build Progress`
-# heading is present (preserves the existing 11 tests).
+# Fix: parse_plan now uses two flags. `in_build_progress` scopes parsing
+# to lines between `## Build Progress` and the next H2. `in_acceptance`
+# skips the inner `### Acceptance Criteria` subheading within that scope.
+# Plans with no `## Build Progress` heading fall back to whole-file
+# scanning (preserves the existing 11 tests).
 # ---------------------------------------------------------------------------
+
+@test "4.3-mirror: ### Acceptance Criteria mirror INSIDE Build Progress is skipped (bug 4 / #526 workaround)" {
+  # The /plan template emits an inner `### Acceptance Criteria` subheading
+  # inside the `## Build Progress` section, mirroring the top-level AC list.
+  # parse_plan must skip those mirror items because they have no
+  # work-tracking semantics (no `### Slice` heading, no `**Files:**` line).
+  # Structural redesign tracked in #526; this test guards the workaround.
+  T="$(mktemp -d)"
+  cd "$T"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "feat: do the slice work"
+  PLAN="$T/plan.md"
+  printf '%s\n' \
+    "## Build Progress" \
+    "" \
+    "### Slices (grouped by wave)" \
+    "" \
+    "- [x] do the slice work" \
+    "" \
+    "### Acceptance Criteria" \
+    "" \
+    "- [ ] A1: aspirational outcome 1" \
+    "- [ ] A2: aspirational outcome 2" \
+    > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}
 
 @test "4.3a: Build Progress [x] + AC [ ] items; --pre-pr exits 0 (ACs ignored)" {
   T="$(mktemp -d)"

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -240,3 +240,110 @@ make_plan() {
   [ "$status" -eq 2 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any(i.get('rule_id') == 'llm-skipped' for i in d['issues']), d"
 }
+
+# ---------------------------------------------------------------------------
+# Step 4.1 — Issue #525 regressions: origin/main preference
+# Bug: check_scope's branch tuple was ("main", "master", "origin/main",
+# "origin/master") — preferring stale local main. When local main lags
+# origin/main, the resulting merge-base sweeps in every commit landed on
+# trunk while the contributor was working.
+# ---------------------------------------------------------------------------
+
+# Helper: set up a tmp dir with a bare "remote" repo and a working clone where
+# origin/main is exactly one commit ahead of local main. Both refs are real;
+# the test exercises check_scope's branch-resolution order.
+#
+# Usage: setup_stale_main_repo <work_dir> <ahead_commit_file>
+# After this returns, <work_dir> is a git repo with:
+#   - origin/main pointing at HEAD~1 + an "ahead" commit on the remote
+#   - local main pointing at HEAD~1 (the shared base) — lagging by 1
+#   - HEAD on a feature branch off origin/main
+setup_stale_main_repo() {
+  local work="$1"
+  local ahead_file="$2"
+  local remote="$work/../remote.git"
+  # Bare remote
+  git init -q --bare "$remote"
+  # Working clone seeded with an initial commit
+  git init -q "$work"
+  cd "$work"
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git remote add origin "$remote"
+  git checkout -q -b main
+  echo "seed" > seed.txt
+  git add seed.txt
+  git commit -q -m "chore: seed"
+  git push -q origin main
+  # Advance the remote with an ahead-commit touching <ahead_file>, via a
+  # sibling clone so this clone's local main stays at the seed.
+  local sibling
+  sibling="$(mktemp -d)/sibling"
+  git clone -q "$remote" "$sibling"
+  cd "$sibling"
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  echo "ahead" > "$ahead_file"
+  git add "$ahead_file"
+  git commit -q -m "feat: ahead on main"
+  git push -q origin main
+  # Back to the working clone; fetch so origin/main moves but local main stays.
+  cd "$work"
+  git fetch -q origin
+  # Cut the feature branch off origin/main (the new tip).
+  git checkout -q -b feature origin/main
+}
+
+@test "4.1a: local main lags origin/main by one commit; on-branch file is not reported as out-of-plan" {
+  T="$(mktemp -d)"
+  WORK="$T/work"
+  setup_stale_main_repo "$WORK" "unrelated.py"
+  # Commit a.py on the feature branch.
+  cd "$WORK"
+  echo "branch work" > a.py
+  git add a.py
+  # Slice 1 isolates scope-check; the commit subject must substring-match
+  # the slice header so commit-discipline passes and only scope-check is
+  # under test. (Slice 2 covers the Conventional-Commits scenario where
+  # subject and header don't substring-match.)
+  git commit -q -m "feat: write a.py for the slice"
+  PLAN="$WORK/plan.md"
+  printf '%s\n' "- [x] write a.py for the slice" "" "**Files:** \`a.py\`" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}
+
+@test "4.1b: local main equals origin/main; on-branch file is not reported as out-of-plan (no regression)" {
+  T="$(mktemp -d)"
+  WORK="$T/work"
+  # Set up a repo where origin/main == local main (no remote advance).
+  REMOTE="$T/remote.git"
+  git init -q --bare "$REMOTE"
+  git init -q "$WORK"
+  cd "$WORK"
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git remote add origin "$REMOTE"
+  git checkout -q -b main
+  echo "seed" > seed.txt
+  git add seed.txt
+  git commit -q -m "chore: seed"
+  git push -q origin main
+  git fetch -q origin
+  # Branch off and commit a.py. Slice header substring-matches the commit
+  # subject so commit-discipline passes and only scope-check is under test.
+  git checkout -q -b feature
+  echo "branch work" > a.py
+  git add a.py
+  git commit -q -m "feat: write a.py for the slice"
+  PLAN="$WORK/plan.md"
+  printf '%s\n' "- [x] write a.py for the slice" "" "**Files:** \`a.py\`" > "$PLAN"
+
+  run python3 "$PG" --plan "$PLAN" --skip-llm
+  rm -rf "$T"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
+}


### PR DESCRIPTION
Closes #525. References #526 (structural AC redesign, future work).

## Summary

Fix four false-positive bugs in `scripts/progress_guardian.py` that made the pre-PR gate fire on every Conventional-Commits-following branch with the standard `/plan` template layout:

1. **Stale-main preference** — `check_scope`'s tuple was `("main", "master", "origin/main", "origin/master")`. Local `main` lags `origin/main` from the moment any work begins, so the resulting merge-base swept in every commit landed on trunk while the contributor was working — producing dozens of false "out-of-plan file" warnings. Fixed by reordering the tuple to prefer remote tracking refs.
2. **Substring-matcher hostility to Conventional Commits** — `check_commit_discipline` required a substring of the plan-step header in commit subjects. CLAUDE.md mandates Conventional Commits (`feat(scope): summary`); plan headers never appear verbatim there. Fixed with a file-path matcher that reads the `**Files:**` line under each slice and passes when a commit on the branch touched one of them. Substring fallback preserved for legacy plans with no `**Files:**` declaration.
3. **AC checkboxes treated as Build Progress steps** — `parse_plan` matched every `- [ ]` in the file, including the top-level `## Acceptance Criteria` section. Fixed by anchoring parsing to `## Build Progress` when present; whole-file scan preserved for legacy/minimal plans.
4. **`### Acceptance Criteria` mirror inside `## Build Progress`** — discovered during build. The `/plan` template renders a documentation mirror of the AC list inside Build Progress, and those items have no work-tracking semantics. Fixed with a second flag (`in_acceptance`) in `parse_plan` that skips the inner H3. Structural redesign of where ACs live is tracked in **#526**.

The guardian now dogfoods this PR's own plan cleanly (`--pre-pr` exits 0, zero issues).

## Quality Gate

- [x] Tests: 22 bats tests pass (11 existing + 11 new — 10 regression tests across four sections + 1 AC-mirror lock-in)
- [x] Lint / shellcheck / knowledge-index / agent-audit / eslint: all green (`bash scripts/ci-local.sh`)
- [x] Code review: 2 iterations, all 11 high-confidence findings addressed (spec/plan/docstring accuracy, tmpdir leak, matcher-vs-fallback disambiguation, AC-mirror regression coverage)
- [x] Plan completion gate: `progress_guardian.py --pre-pr --plan plans/progress-guardian-fixes.md --skip-llm` exits 0

## Test Plan

- [ ] Reviewer: run `bats tests/scripts/progress_guardian_tests.bats` — expect 22/22 green.
- [ ] Reviewer: run `python3 scripts/progress_guardian.py --pre-pr --plan plans/progress-guardian-fixes.md --skip-llm` from this branch — expect exit 0 (dogfood check).
- [ ] Reviewer: check that pre-existing tests 3.1a–3.3d still pass unchanged (the fallback paths preserve legacy behavior).
- [ ] Reviewer: confirm no changes to CLI flags, exit codes, or JSON output schema — the public surface is unchanged.

## Notes for reviewers

- **Commits are Conventional** and each commit is self-contained (one slice per commit).
- **Scope is bounded** to two files: `scripts/progress_guardian.py` and `tests/scripts/progress_guardian_tests.bats` (plus the spec/plan artifacts).
- **Follow-up work parked in #526**: the AC-mirror skip in change 4 is a surgical workaround. The underlying "ACs are checkbox-tracked without work-tracking semantics" issue deserves a proper redesign — not in this PR.
- **Deferred quality suggestions** (documented in the code-review iteration): `parse_plan` and `check_commit_discipline` both exceed the 20-line function threshold, and there's an opportunity to extract a `Plan` dataclass so the plan file isn't read in three places. Both are legitimate refactors but inflate this PR's blast radius; they belong to a follow-up focused on structure, not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)