### PR TITLE
chore(ci): rename Tests/Eval workflows and route eval structural-gate through ci-local.sh (#531)

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -1,4 +1,4 @@
-name: Eval
+name: Agent eval
 
 # Agent-eval regression gate (issue #99).
 #
@@ -66,8 +66,11 @@ jobs:
       - name: Install bats + jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
 
+      # Delegate through ci-local.sh --only so this check stays in sync with
+      # the local gate — a rename of scripts/eval_grade.py can't silently break
+      # CI without breaking `bash scripts/ci-local.sh` too. (Issue #531.)
       - name: Eval corpus integrity check
-        run: python3 scripts/eval_grade.py --check-corpus
+        run: bash scripts/ci-local.sh --only=chk_eval_corpus
 
       - name: Grader, cache & integration-tier unit tests
         run: |
@@ -78,8 +81,10 @@ jobs:
 
       # Citation drift lint (#312). Advisory in Phase 1 — always exits 0, so it
       # surfaces drift warnings in the log without blocking the gate.
+      # Delegated through ci-local.sh --only for the same drift-safety reason
+      # as the corpus integrity check above. (Issue #531.)
       - name: Citation drift lint (advisory)
-        run: python3 scripts/citation_lint.py --all
+        run: bash scripts/ci-local.sh --only=chk_citation_lint
 
   semver-contract:
     # Job name is a REQUIRED status-check context (renovate-require-tests

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,6 +3,13 @@ name: Docs checks
 # Catches broken documentation links before they merge — the class of breakage a
 # deleted or renamed doc leaves behind (e.g. a nav entry or README link pointing at
 # a file that no longer exists).
+#
+# Relationship to the local gate (issue #531): the `nav-integrity` job below is
+# the CI superset of `chk_nav_integrity` in `scripts/ci-local.sh`. Both assert
+# every nav entry resolves to a file (via `check_nav_integrity.py`); CI *also*
+# runs `mkdocs build` and offline `lychee` on top. Those two tools are kept
+# CI-only intentionally so contributors don't have to install them locally —
+# `chk_nav_integrity` is the fast subset every developer can run before pushing.
 
 on:
   # No 'paths' filter, on purpose. nav-integrity and body-links are REQUIRED

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Plugin tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Dev Team
 
-[![Tests](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml)
+[![Plugin tests](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/plugin-tests.yml)
 [![Docs checks](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml)
 [![Docs deploy](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
 

--- a/docs/specs/workflow-audit-fixes.md
+++ b/docs/specs/workflow-audit-fixes.md
@@ -1,0 +1,98 @@
+<!-- spec-version: 1 -->
+# Spec: rename Tests/Eval workflows, route eval structural-gate through ci-local.sh
+
+**Format:** dev-team specs v1
+**Issue:** <https://github.com/bdfinst/agentic-dev-team/issues/531>
+
+## Intent Description
+
+The GitHub Actions PR-checks page groups by workflow name, but two of the biggest workflows (`.github/workflows/plugin-tests.yml` and `.github/workflows/agent-eval.yml`) name themselves `Tests` and `Eval` — labels so generic they give a failing-check reader no signal about which file to open. When any check under those workflows fails, discovering the source file requires knowing an out-of-band mapping. A second, less visible issue in the same workflow family: `agent-eval.yml`'s `structural-gate` job inlines commands that `scripts/ci-local.sh` already exposes as `chk_eval_corpus` and `chk_citation_lint`. That inline duplication means a rename of `scripts/eval_grade.py` (or a change to its flags) would break the CI gate without breaking the local gate — the two surfaces can drift silently.
+
+This change makes three fixes that improve discoverability and remove one real drift risk, with zero behavioral impact on what runs:
+
+1. Rename `plugin-tests.yml`'s `name:` from `Tests` to `Plugin tests`.
+2. Rename `agent-eval.yml`'s `name:` from `Eval` to `Agent eval`.
+3. In `agent-eval.yml`'s `structural-gate` job, replace the two direct command invocations (`python3 scripts/eval_grade.py --check-corpus` and `python3 scripts/citation_lint.py --all`) with `bash scripts/ci-local.sh --only=chk_eval_corpus` and `--only=chk_citation_lint` — matching the delegation pattern `plugin-tests.yml` already uses.
+4. Add a one-paragraph comment near the top of `link-check.yml` documenting the intentional local/CI split for `chk_nav_integrity` (local version is the fast subset; CI version adds `mkdocs build` + `lychee` to keep those tools off the local prereq list).
+
+## Architecture Specification
+
+**Files edited (four):**
+
+- `.github/workflows/plugin-tests.yml` — one-token rename on line 1 (`name: Tests` → `name: Plugin tests`).
+- `.github/workflows/agent-eval.yml` — one-token rename on line 1 (`name: Eval` → `name: Agent eval`); replace the "Eval corpus integrity check" step and the "Citation drift lint (advisory)" step in the `structural-gate` job with `bash scripts/ci-local.sh --only=<check>` invocations.
+- `.github/workflows/link-check.yml` — add a comment block near the top documenting the local/CI split relative to `chk_nav_integrity` in `scripts/ci-local.sh`.
+- No other files.
+
+**Public surface preserved:**
+
+- **Job names** are unchanged. Branch protection rules match on job name, not workflow name. The four PR checks that exist today (`Eval corpus & graders`, `Eval corpus semver`, `Eval live regression (opt-in)`, `Eval integration tier (opt-in)`, `Plugin content & hooks`, `Shell scripts & suite`, `Cost regression`, `Semgrep rule fixtures`, `Red-team harness smoke`) continue to exist with those exact names.
+- **Trigger events** are unchanged (`push`, `pull_request`).
+- **Job order and dependencies** are unchanged.
+- **The set of commands each job runs** is functionally unchanged: `--only=chk_eval_corpus` runs exactly `python3 scripts/eval_grade.py --check-corpus` (line 154 of ci-local.sh); `--only=chk_citation_lint` runs exactly `python3 scripts/citation_lint.py --all` (line 156). Same commands, one indirection layer.
+
+**Explicit non-changes (rejected before spec-writing):**
+
+- The `structural-gate`'s explicit `bats tests/repo/eval_grader_tests.bats ...` step (four bats files) is **left inline**. Migrating it to `--only=chk_bats_repo` would broaden the CI job to run all of `tests/repo/`, which `plugin-tests.yml`'s `bats-tests` job (Plugin content & hooks) already does — introducing a duplicate run per PR. This spec's fix removes drift risk; it doesn't consolidate everything.
+- **Apt-cache block deduplication** across four jobs → deferred to a separate PR (would require extracting a composite action; new file surface).
+- **Adding `chk_eslint` to `pr-title-lint.yml`** → deferred (audit-suggested but out of the rename scope; policy call on whether npm's eslint should gate PR titles).
+- **Adding `chk_oe_staleness` to any CI job** → deferred (policy question on whether local-only checks should promote to CI).
+
+**Risk surface:**
+
+- **Branch protection compatibility.** The rename risks nothing because branch protection matches on job names, not workflow names. Job names are untouched. Verified during spec-writing by inspecting `agent-eval.yml` lines 82-90: each job explicitly documents "Job name is a REQUIRED status-check context ... Keep it paren-free and issue-number-free" — the workflow authors already understood this distinction.
+- **Actions tab lookup by workflow name.** External integrations (dashboards, log-searches) that filter by workflow name will see the new labels. This repo has no such known integration. Verified by grepping for `workflow: Tests` and `workflow: Eval` — no other file references them.
+- **Cache invalidation.** The apt-cache keys use `${{ hashFiles('**/*.yml') }}` which will change when the workflow files are edited — one cache miss on first run after merge, no ongoing impact.
+
+## Acceptance Criteria
+
+Each criterion is a deterministic check.
+
+**A1 — `plugin-tests.yml` renamed.**
+`grep -c '^name: Plugin tests$' .github/workflows/plugin-tests.yml` returns exactly `1`; `grep -c '^name: Tests$' .github/workflows/plugin-tests.yml` returns exactly `0`.
+
+**A2 — `agent-eval.yml` renamed.**
+`grep -c '^name: Agent eval$' .github/workflows/agent-eval.yml` returns exactly `1`; `grep -c '^name: Eval$' .github/workflows/agent-eval.yml` returns exactly `0`.
+
+**A3 — `agent-eval.yml`'s structural-gate delegates two checks through `ci-local.sh --only`.**
+Within the `structural-gate` job's steps, there is exactly one step whose `run:` contains `--only=chk_eval_corpus` and one whose `run:` contains `--only=chk_citation_lint`. There is zero remaining occurrence of `scripts/eval_grade.py --check-corpus` or `scripts/citation_lint.py --all` as direct commands within that job. The bats-specific step (running `eval_grader_tests.bats` and friends) is preserved unchanged.
+
+**A4 — `link-check.yml` documents the local/CI split.**
+`.github/workflows/link-check.yml` contains a comment block (any placement above the `jobs:` line) that: (a) names `chk_nav_integrity` in `scripts/ci-local.sh`; (b) states that this workflow is a superset that additionally runs `mkdocs build` and `lychee`; (c) states that those tools intentionally stay CI-only. Verified by grep: `grep -c 'chk_nav_integrity' .github/workflows/link-check.yml` ≥ 1 AND `grep -c 'mkdocs' .github/workflows/link-check.yml` ≥ 1 AND `grep -c 'lychee' .github/workflows/link-check.yml` ≥ 1.
+
+**A5 — Job names, triggers, and dependencies unchanged.**
+Diff verification: `git diff origin/main..HEAD -- .github/workflows/*.yml | grep -E '^-\s*name:' | grep -Ev '^-name: Tests|-name: Eval'` returns empty (no job name touched other than the two workflow-level renames). `git diff origin/main..HEAD -- .github/workflows/*.yml | grep -E '^[+-]\s*(push:|pull_request:|workflow_dispatch:)'` returns empty (no trigger touched).
+
+**A6 — Local dry-run of the two migrated commands.**
+`bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint` exits 0 (or the same status the current inline commands produce today, verified against `python3 scripts/eval_grade.py --check-corpus; python3 scripts/citation_lint.py --all`). This proves the delegation runs the same commands with the same exit semantics.
+
+**A7 — CI/release hygiene.**
+
+- `bash scripts/ci-local.sh` exits 0 (full local gate green).
+- PR title prefix `chore(ci):` — matches release-please's non-shipping convention (no user-visible behavior change, workflow-only touches).
+- PR opened with `--no-auto-merge` per CLAUDE.md (touches `.github/workflows/`).
+- On the PR checks page after merge: `Plugin tests / Plugin content & hooks` and `Agent eval / Eval corpus & graders` appear as PR checks (manual verification, screenshot in PR body).
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|----------|---------------|-------------|-------------------|
+| Which structural-gate steps to migrate to `--only` | `requires-stakeholder-input`, resolved at spec-write time | inference from ci-local.sh grep | Only `chk_eval_corpus` and `chk_citation_lint` — those are the two ci-local functions with an exact 1:1 command match. The bats-list step (4 specific files) has no matching helper; migrating it would double-run the whole `tests/repo/` dir. |
+| Workflow renames — should we also touch job names? | `inferable` | inference | No. Job names are branch-protection contexts. Touching them would require updating branch protection rules externally, which is out of scope. Issue #531 also explicitly says "Job names are unchanged (they're what branch protection matches on)." |
+| Comment format in `link-check.yml` | `inferable` | inference | YAML `#`-prefixed comment block above `jobs:`. Matches the comment style already used in `agent-eval.yml` (lines 82-90) and `pr-title-lint.yml`. No new format invented. |
+| PR title convention (`chore(ci):` vs `refactor(ci):` vs `feat(ci):`) | `inferable` | inference | `chore(ci):` — this is workflow-config maintenance with no user-visible behavior change and no functional change to the checks CI runs. release-please treats `chore:` as no-version-bump, which is correct: neither the plugin ships nor changes. |
+| Whether to remove the workflow-name literal from job body-comment references | `inferable` | inference | No changes to internal comments referencing the old names (if any exist) — spec is bounded to the four surfaces named in Architecture Specification. A grep-cleanup could be done in a follow-up if drift becomes visible. |
+| Add-eslint-to-CI and apt-cache-extraction | `requires-stakeholder-input`, resolved by user in issue #531 body | issue #531 out-of-scope section | Both parked for future PRs. Not touching them. |
+
+No `LOW_VALUE` items.
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — *rename two workflow names for discoverability, route two commands through `ci-local.sh --only` for consistency with `plugin-tests.yml`'s existing pattern, add a comment to `link-check.yml` explaining a documented split. Zero behavioral change to what CI runs.*
+- [x] Every behavior/goal maps to an acceptance criterion — A1 (rename plugin-tests), A2 (rename agent-eval), A3 (delegate structural-gate), A4 (document local/CI split), A5 (no other diff), A6 (local dry-run), A7 (CI + PR hygiene).
+- [x] Architecture constrains without over-engineering — four files edited, no new files, no new abstractions, only the changes issue #531 called out with the out-of-scope items explicitly excluded.
+- [x] Terminology consistent across artifacts — *rename*, *delegate*, *local/CI split*, *branch protection matches job names* used identically.
+- [x] No contradictions between artifacts — the four decisions and their rationales appear identically in Intent, Architecture, and Ambiguity Log.
+- [x] Every gap/ambiguity finding is logged — six findings, two resolved by human via issue text, four inferable with explicit rationale.
+
+**Verdict: PASS.** Ready for `/plan`.

--- a/docs/specs/workflow-audit-fixes.md
+++ b/docs/specs/workflow-audit-fixes.md
@@ -26,7 +26,7 @@ This change makes three fixes that improve discoverability and remove one real d
 
 **Public surface preserved:**
 
-- **Job names** are unchanged. Branch protection rules match on job name, not workflow name. The four PR checks that exist today (`Eval corpus & graders`, `Eval corpus semver`, `Eval live regression (opt-in)`, `Eval integration tier (opt-in)`, `Plugin content & hooks`, `Shell scripts & suite`, `Cost regression`, `Semgrep rule fixtures`, `Red-team harness smoke`) continue to exist with those exact names.
+- **Job names** are unchanged. Branch protection rules match on job name, not workflow name. The nine PR checks that exist today (`Eval corpus & graders`, `Eval corpus semver`, `Eval live regression (opt-in)`, `Eval integration tier (opt-in)`, `Plugin content & hooks`, `Shell scripts & suite`, `Cost regression`, `Semgrep rule fixtures`, `Red-team harness smoke`) continue to exist with those exact names.
 - **Trigger events** are unchanged (`push`, `pull_request`).
 - **Job order and dependencies** are unchanged.
 - **The set of commands each job runs** is functionally unchanged: `--only=chk_eval_corpus` runs exactly `python3 scripts/eval_grade.py --check-corpus` (line 154 of ci-local.sh); `--only=chk_citation_lint` runs exactly `python3 scripts/citation_lint.py --all` (line 156). Same commands, one indirection layer.
@@ -40,7 +40,7 @@ This change makes three fixes that improve discoverability and remove one real d
 
 **Risk surface:**
 
-- **Branch protection compatibility.** The rename risks nothing because branch protection matches on job names, not workflow names. Job names are untouched. Verified during spec-writing by inspecting `agent-eval.yml` lines 82-90: each job explicitly documents "Job name is a REQUIRED status-check context ... Keep it paren-free and issue-number-free" — the workflow authors already understood this distinction.
+- **Branch protection compatibility.** The rename risks nothing because branch protection matches on job names, not workflow names. Job names are untouched. Verified during spec-writing by inspecting `agent-eval.yml` the semver-contract job header comment: each job explicitly documents "Job name is a REQUIRED status-check context ... Keep it paren-free and issue-number-free" — the workflow authors already understood this distinction.
 - **Actions tab lookup by workflow name.** External integrations (dashboards, log-searches) that filter by workflow name will see the new labels. This repo has no such known integration. Verified by grepping for `workflow: Tests` and `workflow: Eval` — no other file references them.
 - **Cache invalidation.** The apt-cache keys use `${{ hashFiles('**/*.yml') }}` which will change when the workflow files are edited — one cache miss on first run after merge, no ongoing impact.
 
@@ -79,7 +79,7 @@ Diff verification: `git diff origin/main..HEAD -- .github/workflows/*.yml | grep
 |----------|---------------|-------------|-------------------|
 | Which structural-gate steps to migrate to `--only` | `requires-stakeholder-input`, resolved at spec-write time | inference from ci-local.sh grep | Only `chk_eval_corpus` and `chk_citation_lint` — those are the two ci-local functions with an exact 1:1 command match. The bats-list step (4 specific files) has no matching helper; migrating it would double-run the whole `tests/repo/` dir. |
 | Workflow renames — should we also touch job names? | `inferable` | inference | No. Job names are branch-protection contexts. Touching them would require updating branch protection rules externally, which is out of scope. Issue #531 also explicitly says "Job names are unchanged (they're what branch protection matches on)." |
-| Comment format in `link-check.yml` | `inferable` | inference | YAML `#`-prefixed comment block above `jobs:`. Matches the comment style already used in `agent-eval.yml` (lines 82-90) and `pr-title-lint.yml`. No new format invented. |
+| Comment format in `link-check.yml` | `inferable` | inference | YAML `#`-prefixed comment block above `jobs:`. Matches the comment style already used in `agent-eval.yml` (the semver-contract job header comment) and `pr-title-lint.yml`. No new format invented. |
 | PR title convention (`chore(ci):` vs `refactor(ci):` vs `feat(ci):`) | `inferable` | inference | `chore(ci):` — this is workflow-config maintenance with no user-visible behavior change and no functional change to the checks CI runs. release-please treats `chore:` as no-version-bump, which is correct: neither the plugin ships nor changes. |
 | Whether to remove the workflow-name literal from job body-comment references | `inferable` | inference | No changes to internal comments referencing the old names (if any exist) — spec is bounded to the four surfaces named in Architecture Specification. A grep-cleanup could be done in a follow-up if drift becomes visible. |
 | Add-eslint-to-CI and apt-cache-extraction | `requires-stakeholder-input`, resolved by user in issue #531 body | issue #531 out-of-scope section | Both parked for future PRs. Not touching them. |

--- a/plans/workflow-audit-fixes.md
+++ b/plans/workflow-audit-fixes.md
@@ -120,7 +120,7 @@ Feature: link-check.yml documents its intentional local/CI split
 #### Step 3.1: Add local/CI split comment + regression bats
 
 **Complexity**: trivial
-**RED**: Extend `tests/repo/workflow-audit-531.bats` with three `@test` blocks asserting `chk_nav_integrity`, `mkdocs`, and `lychee` each appear at least once in `.github/workflows/link-check.yml`. Run `bats`; all three fail.
+**RED (honest — lock-in rather than TDD-first)**: Extend `tests/repo/workflow-audit-531.bats` with `@test` blocks asserting `chk_nav_integrity`, `mkdocs`, and `lychee` each appear at least once in `.github/workflows/link-check.yml`, AND a `531-3.1d` block requiring the top-level `# Relationship to the local gate` comment header (added by this slice). The three token-presence assertions were already green against the pre-existing file — those tokens appear inline in step comments and action names. They land as regression lock-in against a future removal of `mkdocs`/`lychee` from CI. Only 3.1d (the comment-header assertion) is a true RED-first driver: it fails until this slice's edit lands.
 **GREEN**: Edit `.github/workflows/link-check.yml`: add a `#`-prefixed comment block near the top (above `jobs:`) explaining that this workflow is a CI-only superset of `chk_nav_integrity` in `scripts/ci-local.sh`, and that `mkdocs build` + `lychee` stay CI-only so they don't become local prereqs. Run `bats`; all assertions pass.
 **REFACTOR**: None.
 **Files**: `.github/workflows/link-check.yml`, `tests/repo/workflow-audit-531.bats`
@@ -164,7 +164,7 @@ No `complex` steps.
 ## Risks & Open Questions
 
 - **Risk:** The `structural-gate` bats extraction (Slice 2) uses `awk` to scope grep to the job block. If YAML indentation shifts (e.g. someone re-indents the file to 4-space), the awk pattern breaks. **Mitigation:** the pattern `awk '/^  structural-gate:/,/^  [a-z_-]+:$/'` anchors on GitHub Actions' canonical 2-space indent, matching what the file uses today. If the file is ever re-indented, the bats test fails loudly (not silently) — pointing directly at the assumption.
-- **Risk:** Branch protection rules on the repo may reference workflow names *as well as* job names (e.g. required check `Tests / Plugin content & hooks` in the ruleset). Verified during spec-writing: `agent-eval.yml` lines 82-90 already document that "Job name is a REQUIRED status-check context" — the ruleset is on job names, not workflow prefixes. **Mitigation:** if this turns out to be wrong at merge time, revert this PR (safe rename) and reopen with a `renovate-require-tests` update.
+- **Risk:** Branch protection rules on the repo may reference workflow names *as well as* job names (e.g. required check `Tests / Plugin content & hooks` in the ruleset). Verified during spec-writing: `agent-eval.yml`'s `semver-contract` job header comment already documents that "Job name is a REQUIRED status-check context" — the ruleset is on job names, not workflow prefixes. **Mitigation:** if this turns out to be wrong at merge time, revert this PR (safe rename) and reopen with a `renovate-require-tests` update.
 - **Open question:** None — all decisions locked in the spec's Ambiguity Log.
 
 ## Build Progress

--- a/plans/workflow-audit-fixes.md
+++ b/plans/workflow-audit-fixes.md
@@ -1,0 +1,197 @@
+# Plan: rename Tests/Eval workflows and route eval structural-gate through ci-local.sh
+
+**Created**: 2026-07-01
+**Branch**: feat/531-workflow-rename
+**Status**: approved
+**Spec**: docs/specs/workflow-audit-fixes.md
+**Issue**: <https://github.com/bdfinst/agentic-dev-team/issues/531>
+
+## Goal
+
+Rename two GitHub Actions workflows (`Tests` → `Plugin tests`, `Eval` → `Agent eval`) so PR checks self-locate to their source file, delegate two direct commands in `agent-eval.yml`'s `structural-gate` through `bash scripts/ci-local.sh --only=...` to match the pattern `plugin-tests.yml` already uses (removes silent-drift risk on a `scripts/eval_grade.py` rename), and add a comment to `link-check.yml` documenting why its `chk_nav_integrity` is a CI-only superset of the local one. Zero behavioral change; branch-protection contexts (job names, triggers) untouched.
+
+## Approach stance (high-reversal-cost axes)
+
+- **Scope** — touch only `.github/workflows/plugin-tests.yml`, `.github/workflows/agent-eval.yml`, `.github/workflows/link-check.yml`, plus the plan/spec artifacts. No new files, no other workflow touched.
+- **Migrate vs. edit stub** — n/a.
+- **Replace vs. merge** — pure additive/rename edits within existing files.
+- **Auto-merge** — disabled (`/pr --no-auto-merge`). Touches `.github/workflows/`.
+- **Format fidelity** — n/a.
+
+## Acceptance Criteria
+
+- [ ] A1: `plugin-tests.yml` renamed — `grep -c '^name: Plugin tests$'` = 1; `grep -c '^name: Tests$'` = 0.
+- [ ] A2: `agent-eval.yml` renamed — `grep -c '^name: Agent eval$'` = 1; `grep -c '^name: Eval$'` = 0.
+- [ ] A3: `agent-eval.yml`'s structural-gate delegates two steps through `--only` — exactly one step contains `--only=chk_eval_corpus`, exactly one contains `--only=chk_citation_lint`; zero remaining occurrences of `scripts/eval_grade.py --check-corpus` or `scripts/citation_lint.py --all` as direct commands within the `structural-gate` job. The bats-specific step is preserved unchanged.
+- [ ] A4: `link-check.yml` comment block references `chk_nav_integrity`, `mkdocs`, and `lychee` — three greps ≥ 1 each.
+- [ ] A5: No job-name, trigger, or dependency changes — diff scan returns no touched `name:` other than the two workflow-level renames, no touched `push:`/`pull_request:`/`workflow_dispatch:`.
+- [ ] A6: `bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint` exits 0 locally — proves the delegation runs correctly.
+- [ ] A7: `bash scripts/ci-local.sh` exits 0; PR title prefix `chore(ci):`; opened with `--no-auto-merge`.
+
+## Slices
+
+Three independent slices, each editing a distinct workflow file — no file collisions, safe to parallelize by `plan-waves.sh`. Each has a single TDD step: grep-based bats fixture asserting the target state, then the edit.
+
+### Slice 1: Rename `plugin-tests.yml`
+
+**Depends-on:** none
+**Files:** `.github/workflows/plugin-tests.yml`, `tests/repo/workflow-audit-531.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: plugin-tests.yml declares itself with a discoverable name
+
+  Scenario: Workflow-level name is "Plugin tests"
+    Given the workflow file "plugin-tests.yml"
+    When the top-level `name:` field is read
+    Then it equals "Plugin tests"
+    And no lingering `name: Tests` line remains
+```
+
+**Steps:**
+
+#### Step 1.1: Rename `plugin-tests.yml` + add regression bats
+
+**Complexity**: trivial
+**RED**: Create `tests/repo/workflow-audit-531.bats` with `@test` blocks asserting `grep -c '^name: Plugin tests$'` = 1 and `grep -c '^name: Tests$'` = 0 on `.github/workflows/plugin-tests.yml`. Run `bats tests/repo/workflow-audit-531.bats`; both fail (current state is `name: Tests`).
+**GREEN**: Edit `.github/workflows/plugin-tests.yml` line 1: `name: Tests` → `name: Plugin tests`. Run `bats`; both assertions pass.
+**REFACTOR**: None — single-token change.
+**Files**: `.github/workflows/plugin-tests.yml`, `tests/repo/workflow-audit-531.bats`
+**Commit**: `chore(ci): rename plugin-tests workflow from Tests to Plugin tests (#531)`
+
+### Slice 2: Rename `agent-eval.yml` + delegate structural-gate through `--only`
+
+**Depends-on:** 1
+**Files:** `.github/workflows/agent-eval.yml`, `tests/repo/workflow-audit-531.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: agent-eval.yml declares itself with a discoverable name and delegates to ci-local.sh
+
+  Scenario: Workflow-level name is "Agent eval"
+    Given the workflow file "agent-eval.yml"
+    When the top-level `name:` field is read
+    Then it equals "Agent eval"
+    And no lingering `name: Eval` line remains
+
+  Scenario: structural-gate delegates through ci-local.sh --only
+    Given the workflow file "agent-eval.yml"
+    When the "structural-gate" job body is scanned
+    Then exactly one `run:` step contains "--only=chk_eval_corpus"
+    And exactly one `run:` step contains "--only=chk_citation_lint"
+    And no `run:` step contains "scripts/eval_grade.py --check-corpus" as a direct command
+    And no `run:` step contains "scripts/citation_lint.py --all" as a direct command
+    And the bats-specific step (running `eval_grader_tests.bats` and friends) is preserved unchanged
+```
+
+**Steps:**
+
+#### Step 2.1: Rename `agent-eval.yml` + delegate two steps + regression bats
+
+**Complexity**: standard
+**RED**: Extend `tests/repo/workflow-audit-531.bats` with (a) two `@test` blocks for the name rename (mirroring Slice 1), (b) two `@test` blocks asserting `--only=chk_eval_corpus` and `--only=chk_citation_lint` each appear exactly once inside the `structural-gate` job section, (c) two `@test` blocks asserting `scripts/eval_grade.py --check-corpus` and `scripts/citation_lint.py --all` do NOT appear as direct commands within `structural-gate` (they may still appear elsewhere, e.g. inside `ci-local.sh` itself which is fine — the scoping helper below extracts the job block). Job-block extraction helper: `awk '/^  structural-gate:/,/^  [a-z_-]+:$/'` with a guard that drops the terminating heading line. Also assert the bats-step (`eval_grader_tests.bats`) is preserved. Run `bats`; the new assertions fail.
+**GREEN**: Edit `.github/workflows/agent-eval.yml`: (a) line 1 `name: Eval` → `name: Agent eval`; (b) in `structural-gate`, replace the "Eval corpus integrity check" step's `run:` with `bash scripts/ci-local.sh --only=chk_eval_corpus`; (c) replace the "Citation drift lint (advisory)" step's `run:` with `bash scripts/ci-local.sh --only=chk_citation_lint`. Preserve step names, `if:` conditions, and the intervening bats step unchanged. Run `bats`; all assertions pass.
+**REFACTOR**: None expected. The delegation preserves the step's `name:` (workflow-visible label) — no reason to change it.
+**Files**: `.github/workflows/agent-eval.yml`, `tests/repo/workflow-audit-531.bats`
+**Commit**: `chore(ci): rename agent-eval workflow and delegate structural-gate through ci-local.sh --only (#531)`
+
+### Slice 3: Document local/CI split in `link-check.yml`
+
+**Depends-on:** 2
+**Files:** `.github/workflows/link-check.yml`, `tests/repo/workflow-audit-531.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: link-check.yml documents its intentional local/CI split
+
+  Scenario: A comment block near the top explains the split
+    Given the workflow file "link-check.yml"
+    When the file's leading comment lines (before `jobs:`) are read
+    Then they name `chk_nav_integrity` (the local counterpart)
+    And they mention `mkdocs` as a CI-only tool
+    And they mention `lychee` as a CI-only tool
+```
+
+**Steps:**
+
+#### Step 3.1: Add local/CI split comment + regression bats
+
+**Complexity**: trivial
+**RED**: Extend `tests/repo/workflow-audit-531.bats` with three `@test` blocks asserting `chk_nav_integrity`, `mkdocs`, and `lychee` each appear at least once in `.github/workflows/link-check.yml`. Run `bats`; all three fail.
+**GREEN**: Edit `.github/workflows/link-check.yml`: add a `#`-prefixed comment block near the top (above `jobs:`) explaining that this workflow is a CI-only superset of `chk_nav_integrity` in `scripts/ci-local.sh`, and that `mkdocs build` + `lychee` stay CI-only so they don't become local prereqs. Run `bats`; all assertions pass.
+**REFACTOR**: None.
+**Files**: `.github/workflows/link-check.yml`, `tests/repo/workflow-audit-531.bats`
+**Commit**: `docs(ci): document intentional local/CI split for chk_nav_integrity (#531)`
+
+## Parallelization
+
+`plan-waves.sh` derives waves from `Depends-on:` declarations. All three slices touch distinct workflow files, so they're independent in terms of behavior — but they all mutate `tests/repo/workflow-audit-531.bats` (each slice extends it with its own assertions). To avoid a same-wave file collision, serialize the chain via `Depends-on`: Slice 2 → 1, Slice 3 → 2.
+
+```mermaid
+graph TD
+  S1[Slice 1: rename plugin-tests.yml] --> S2[Slice 2: rename + delegate agent-eval.yml]
+  S2 --> S3[Slice 3: document link-check.yml]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+| 2 | 2 |
+| 3 | 3 |
+
+## Complexity Classification
+
+| Step | Rating | Why |
+|------|--------|-----|
+| 1.1 | trivial | Single-token rename + 2 bats assertions |
+| 2.1 | standard | Rename + two step-body swaps + 6 bats assertions with awk-scoped extraction |
+| 3.1 | trivial | Comment addition + 3 bats greps |
+
+No `complex` steps.
+
+## Pre-PR Quality Gate
+
+- [ ] `bats tests/repo/workflow-audit-531.bats` exits 0
+- [ ] `bash scripts/ci-local.sh` exits 0
+- [ ] `bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint` exits 0 (A6 dry-run)
+- [ ] `/code-review` passes on the diff
+- [ ] PR title is `chore(ci): rename Tests/Eval workflows and delegate eval structural-gate through ci-local.sh (#531)`
+- [ ] PR opened with `--no-auto-merge`
+
+## Risks & Open Questions
+
+- **Risk:** The `structural-gate` bats extraction (Slice 2) uses `awk` to scope grep to the job block. If YAML indentation shifts (e.g. someone re-indents the file to 4-space), the awk pattern breaks. **Mitigation:** the pattern `awk '/^  structural-gate:/,/^  [a-z_-]+:$/'` anchors on GitHub Actions' canonical 2-space indent, matching what the file uses today. If the file is ever re-indented, the bats test fails loudly (not silently) — pointing directly at the assumption.
+- **Risk:** Branch protection rules on the repo may reference workflow names *as well as* job names (e.g. required check `Tests / Plugin content & hooks` in the ruleset). Verified during spec-writing: `agent-eval.yml` lines 82-90 already document that "Job name is a REQUIRED status-check context" — the ruleset is on job names, not workflow prefixes. **Mitigation:** if this turns out to be wrong at merge time, revert this PR (safe rename) and reopen with a `renovate-require-tests` update.
+- **Open question:** None — all decisions locked in the spec's Ambiguity Log.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Rename `plugin-tests.yml`
+  - [ ] Step 1.1: Rename `plugin-tests.yml` + add regression bats
+
+#### Wave 2
+
+- [ ] Slice 2: Rename `agent-eval.yml` + delegate structural-gate through `--only`
+  - [ ] Step 2.1: Rename `agent-eval.yml` + delegate two steps + regression bats
+
+#### Wave 3
+
+- [ ] Slice 3: Document local/CI split in `link-check.yml`
+  - [ ] Step 3.1: Add local/CI split comment + regression bats
+
+### Acceptance Criteria
+
+- [ ] A1: plugin-tests renamed
+- [ ] A2: agent-eval renamed
+- [ ] A3: structural-gate delegates two steps through --only
+- [ ] A4: link-check.yml documents local/CI split
+- [ ] A5: No job-name, trigger, or dependency changes
+- [ ] A6: Local --only dry-run exits 0
+- [ ] A7: ci-local green, PR title chore(ci):, --no-auto-merge

--- a/plans/workflow-audit-fixes.md
+++ b/plans/workflow-audit-fixes.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-01
 **Branch**: feat/531-workflow-rename
-**Status**: approved
+**Status**: implemented
 **Spec**: docs/specs/workflow-audit-fixes.md
 **Issue**: <https://github.com/bdfinst/agentic-dev-team/issues/531>
 
@@ -173,25 +173,25 @@ No `complex` steps.
 
 #### Wave 1
 
-- [ ] Slice 1: Rename `plugin-tests.yml`
-  - [ ] Step 1.1: Rename `plugin-tests.yml` + add regression bats
+- [x] Slice 1: Rename `plugin-tests.yml`
+  - [x] Step 1.1: Rename `plugin-tests.yml` + add regression bats
 
 #### Wave 2
 
-- [ ] Slice 2: Rename `agent-eval.yml` + delegate structural-gate through `--only`
-  - [ ] Step 2.1: Rename `agent-eval.yml` + delegate two steps + regression bats
+- [x] Slice 2: Rename `agent-eval.yml` + delegate structural-gate through `--only`
+  - [x] Step 2.1: Rename `agent-eval.yml` + delegate two steps + regression bats
 
 #### Wave 3
 
-- [ ] Slice 3: Document local/CI split in `link-check.yml`
-  - [ ] Step 3.1: Add local/CI split comment + regression bats
+- [x] Slice 3: Document local/CI split in `link-check.yml`
+  - [x] Step 3.1: Add local/CI split comment + regression bats
 
 ### Acceptance Criteria
 
-- [ ] A1: plugin-tests renamed
-- [ ] A2: agent-eval renamed
-- [ ] A3: structural-gate delegates two steps through --only
-- [ ] A4: link-check.yml documents local/CI split
-- [ ] A5: No job-name, trigger, or dependency changes
-- [ ] A6: Local --only dry-run exits 0
-- [ ] A7: ci-local green, PR title chore(ci):, --no-auto-merge
+- [x] A1: plugin-tests renamed
+- [x] A2: agent-eval renamed
+- [x] A3: structural-gate delegates two steps through --only
+- [x] A4: link-check.yml documents local/CI split
+- [x] A5: No job-name, trigger, or dependency changes
+- [x] A6: Local --only dry-run exits 0
+- [x] A7: ci-local green, PR title chore(ci):, --no-auto-merge

--- a/tests/repo/workflow-audit-531.bats
+++ b/tests/repo/workflow-audit-531.bats
@@ -32,3 +32,60 @@ LINK_CHECK="$REPO_ROOT/.github/workflows/link-check.yml"
   count=$(grep -c '^name: Tests$' "$PLUGIN_TESTS" || true)
   [ "$count" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Slice 2 — agent-eval.yml workflow name + structural-gate delegation
+# ---------------------------------------------------------------------------
+
+# Extract the `structural-gate:` job block only. Range starts at the job
+# heading and ends just before the next `  <name>:` job heading at the same
+# indent level. Used to scope grep assertions so they don't accidentally match
+# on other jobs in the same file.
+structural_gate_block() {
+  awk '
+    /^  structural-gate:/ { flag=1; next }
+    flag && /^  [a-z_-]+:[[:space:]]*$/ { flag=0 }
+    flag { print }
+  ' "$AGENT_EVAL"
+}
+
+@test "531-2.1a: agent-eval.yml declares 'name: Agent eval'" {
+  run grep -c '^name: Agent eval$' "$AGENT_EVAL"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "531-2.1b: agent-eval.yml no longer declares 'name: Eval'" {
+  count=$(grep -c '^name: Eval$' "$AGENT_EVAL" || true)
+  [ "$count" -eq 0 ]
+}
+
+@test "531-2.1c: structural-gate has exactly one --only=chk_eval_corpus step" {
+  block=$(structural_gate_block)
+  count=$(echo "$block" | grep -c -- '--only=chk_eval_corpus' || true)
+  [ "$count" -eq 1 ]
+}
+
+@test "531-2.1d: structural-gate has exactly one --only=chk_citation_lint step" {
+  block=$(structural_gate_block)
+  count=$(echo "$block" | grep -c -- '--only=chk_citation_lint' || true)
+  [ "$count" -eq 1 ]
+}
+
+@test "531-2.1e: structural-gate no longer invokes 'scripts/eval_grade.py --check-corpus' directly" {
+  block=$(structural_gate_block)
+  count=$(echo "$block" | grep -c 'scripts/eval_grade.py --check-corpus' || true)
+  [ "$count" -eq 0 ]
+}
+
+@test "531-2.1f: structural-gate no longer invokes 'scripts/citation_lint.py --all' directly" {
+  block=$(structural_gate_block)
+  count=$(echo "$block" | grep -c 'scripts/citation_lint.py --all' || true)
+  [ "$count" -eq 0 ]
+}
+
+@test "531-2.1g: structural-gate preserves the bats step running eval_grader_tests.bats" {
+  block=$(structural_gate_block)
+  count=$(echo "$block" | grep -c 'eval_grader_tests.bats' || true)
+  [ "$count" -ge 1 ]
+}

--- a/tests/repo/workflow-audit-531.bats
+++ b/tests/repo/workflow-audit-531.bats
@@ -89,3 +89,25 @@ structural_gate_block() {
   count=$(echo "$block" | grep -c 'eval_grader_tests.bats' || true)
   [ "$count" -ge 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# Slice 3 — link-check.yml documents its intentional local/CI split
+# ---------------------------------------------------------------------------
+
+@test "531-3.1a: link-check.yml references chk_nav_integrity (the local counterpart)" {
+  run grep -c 'chk_nav_integrity' "$LINK_CHECK"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "531-3.1b: link-check.yml names mkdocs as a CI-only tool" {
+  run grep -ci 'mkdocs' "$LINK_CHECK"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "531-3.1c: link-check.yml names lychee as a CI-only tool" {
+  run grep -ci 'lychee' "$LINK_CHECK"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}

--- a/tests/repo/workflow-audit-531.bats
+++ b/tests/repo/workflow-audit-531.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+#
+# Regression coverage for the workflow-audit fixes in issue #531:
+#   - plugin-tests.yml renamed from "Tests" to "Plugin tests"
+#   - agent-eval.yml renamed from "Eval" to "Agent eval" AND its
+#     structural-gate job delegates two commands through
+#     `bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint`
+#     rather than invoking them directly
+#   - link-check.yml documents the intentional local/CI split for
+#     chk_nav_integrity
+#
+# These assertions guard against a silent revert of the rename or a
+# refactor that reintroduces the drift between ci-local.sh and the CI job.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+PLUGIN_TESTS="$REPO_ROOT/.github/workflows/plugin-tests.yml"
+AGENT_EVAL="$REPO_ROOT/.github/workflows/agent-eval.yml"
+LINK_CHECK="$REPO_ROOT/.github/workflows/link-check.yml"
+
+# ---------------------------------------------------------------------------
+# Slice 1 — plugin-tests.yml workflow name
+# ---------------------------------------------------------------------------
+
+@test "531-1.1a: plugin-tests.yml declares 'name: Plugin tests'" {
+  run grep -c '^name: Plugin tests$' "$PLUGIN_TESTS"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "531-1.1b: plugin-tests.yml no longer declares 'name: Tests'" {
+  # grep -c returns 0 when the pattern is not found — assert exactly zero matches.
+  count=$(grep -c '^name: Tests$' "$PLUGIN_TESTS" || true)
+  [ "$count" -eq 0 ]
+}

--- a/tests/repo/workflow-audit-531.bats
+++ b/tests/repo/workflow-audit-531.bats
@@ -41,12 +41,28 @@ LINK_CHECK="$REPO_ROOT/.github/workflows/link-check.yml"
 # heading and ends just before the next `  <name>:` job heading at the same
 # indent level. Used to scope grep assertions so they don't accidentally match
 # on other jobs in the same file.
+#
+# Boundary regex tolerates lowercase, uppercase, digits, underscore, and dash
+# so a future job like `slice2-gate:` or `structural_gate_v2:` still terminates
+# the range correctly. Assumes canonical 2-space YAML indent.
+#
+# Callers must invoke `assert_gate_block_present "$block"` before running
+# negative assertions on the output — an empty block (job renamed away) would
+# trivially satisfy any `grep -c 0` check and silently mask a regression.
 structural_gate_block() {
   awk '
     /^  structural-gate:/ { flag=1; next }
-    flag && /^  [a-z_-]+:[[:space:]]*$/ { flag=0 }
+    flag && /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ { flag=0 }
     flag { print }
   ' "$AGENT_EVAL"
+}
+
+assert_gate_block_present() {
+  local block="$1"
+  [ -n "$block" ] || {
+    echo "structural-gate: block not found in agent-eval.yml — job renamed?" >&2
+    false
+  }
 }
 
 @test "531-2.1a: agent-eval.yml declares 'name: Agent eval'" {
@@ -62,30 +78,35 @@ structural_gate_block() {
 
 @test "531-2.1c: structural-gate has exactly one --only=chk_eval_corpus step" {
   block=$(structural_gate_block)
+  assert_gate_block_present "$block"
   count=$(echo "$block" | grep -c -- '--only=chk_eval_corpus' || true)
   [ "$count" -eq 1 ]
 }
 
 @test "531-2.1d: structural-gate has exactly one --only=chk_citation_lint step" {
   block=$(structural_gate_block)
+  assert_gate_block_present "$block"
   count=$(echo "$block" | grep -c -- '--only=chk_citation_lint' || true)
   [ "$count" -eq 1 ]
 }
 
 @test "531-2.1e: structural-gate no longer invokes 'scripts/eval_grade.py --check-corpus' directly" {
   block=$(structural_gate_block)
+  assert_gate_block_present "$block"
   count=$(echo "$block" | grep -c 'scripts/eval_grade.py --check-corpus' || true)
   [ "$count" -eq 0 ]
 }
 
 @test "531-2.1f: structural-gate no longer invokes 'scripts/citation_lint.py --all' directly" {
   block=$(structural_gate_block)
+  assert_gate_block_present "$block"
   count=$(echo "$block" | grep -c 'scripts/citation_lint.py --all' || true)
   [ "$count" -eq 0 ]
 }
 
 @test "531-2.1g: structural-gate preserves the bats step running eval_grader_tests.bats" {
   block=$(structural_gate_block)
+  assert_gate_block_present "$block"
   count=$(echo "$block" | grep -c 'eval_grader_tests.bats' || true)
   [ "$count" -ge 1 ]
 }
@@ -110,4 +131,15 @@ structural_gate_block() {
   run grep -ci 'lychee' "$LINK_CHECK"
   [ "$status" -eq 0 ]
   [ "$output" -ge 1 ]
+}
+
+@test "531-3.1d: link-check.yml has a top-level 'Relationship to the local gate' block naming chk_nav_integrity as the local counterpart" {
+  # Guards the doctrine itself: the previous three assertions could pass on
+  # inline mentions alone. This one requires the header block that names
+  # chk_nav_integrity as the LOCAL counterpart and mkdocs/lychee as the
+  # CI-only additions. Deleting the top-of-file comment (the review flagged
+  # this as a vacuous-test risk) fails HERE, not silently.
+  grep -q '^# Relationship to the local gate' "$LINK_CHECK"
+  grep -q 'chk_nav_integrity' "$LINK_CHECK"
+  grep -q 'CI-only' "$LINK_CHECK"
 }


### PR DESCRIPTION
Closes #531.

## Summary

- **Rename `plugin-tests.yml`** from `Tests` → `Plugin tests` so PR checks self-locate to their source file (checks page now reads `Plugin tests / Plugin content & hooks` instead of `Tests / Plugin content & hooks`).
- **Rename `agent-eval.yml`** from `Eval` → `Agent eval`, and **route two direct commands in `structural-gate` through `bash scripts/ci-local.sh --only=chk_eval_corpus` and `--only=chk_citation_lint`** — same delegation pattern `plugin-tests.yml` already uses. Removes silent-drift risk on a `scripts/eval_grade.py` rename.
- **Document the intentional local/CI split** in `link-check.yml` — the CI job is a superset of local `chk_nav_integrity`; `mkdocs build` and `lychee` stay CI-only so contributors don't have to install them locally.

Job names are unchanged (branch protection matches on those, not workflow names). Zero behavioral change to what CI runs — verified locally with `bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint` exits 0.

## Quality Gate

- [x] Tests: 13 new bats assertions in `tests/repo/workflow-audit-531.bats`, all green. Verified the block-extractor guard by simulating a `structural-gate:` rename — the 5 dependent tests correctly fail with a clear diagnostic message.
- [x] Local CI: `bash scripts/ci-local.sh` exits 0 (all shell/bats/knowledge-index/eslint checks pass).
- [x] Code review: 3 reviewers dispatched (arch, test, doc). 8 actionable findings addressed in one iteration:
  - Guard against silent false-pass if `structural-gate:` is renamed away.
  - Slice 3 vacuous-test smell fixed — new `531-3.1d` asserts the top-level comment header specifically, not just token presence.
  - Stale line-number references replaced with durable anchors.
  - Spec's "four PR checks" → "nine" count correction.
  - Slice 3 RED narrative reframed as honest lock-in vs TDD-first.
  - README badge caption updated (`Tests` → `Plugin tests`).
- [x] Plan completion gate: `progress_guardian.py --pre-pr --skip-llm` exits 2 (advisory only — README.md not declared in plan's slice `**Files:**` line, added during review-fix iteration).

## Test Plan

- [ ] Reviewer: run `bats tests/repo/workflow-audit-531.bats` locally — expect 13/13 green.
- [ ] Reviewer: check the PR checks page shows `Plugin tests / Plugin content & hooks` and `Agent eval / Eval corpus & graders` prefixes.
- [ ] Reviewer: confirm branch protection rules on `main` still match on the underlying job names (they do — nothing else changed).
- [ ] Reviewer: verify `bash scripts/ci-local.sh --only=chk_eval_corpus,chk_citation_lint` exits 0.

## Notes for reviewers

- **Scope bounded** to `.github/workflows/*.yml` (three files), one new bats file, spec/plan artifacts, and the README badge caption.
- **`--no-auto-merge`** — touches `.github/workflows/`, per CLAUDE.md requires explicit human merge.
- **Follow-ups explicitly parked** (documented in issue #531's out-of-scope section): apt-cache block deduplication across four jobs; adding `chk_eslint` to CI; `chk_oe_staleness` policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)