### PR TITLE
docs(mutation-testing): correct Stryker.NET reference (xunit.v3, DOTNET_ROOT, CLI, verbosity)

### DIFF
--- a/docs/specs/stryker-net-workflow-corrections.md
+++ b/docs/specs/stryker-net-workflow-corrections.md
@@ -1,0 +1,78 @@
+<!-- spec-version: 1 -->
+# Spec: Stryker.NET Workflow Corrections (issue #522)
+
+**Format:** dev-team `/specs` v1
+
+## Intent Description
+
+Several concrete instructions in the mutation-testing skill's C# / Stryker.NET reference are wrong or misleading for Stryker.NET 4.x and cause real failures — silent per-test coverage fallback on xunit.v3 test projects (masking mutants as timeouts), broken runs on macOS Homebrew installs (missing `DOTNET_ROOT`), a mislabeled `--report-file-name` flag, a `-V trace` probe that generates 1.5M+ log lines, a non-existent `--dry-run` flag, unknown-key JSON that hard-fails the run, and stale binaries producing phantom timeouts because no `dotnet build` precedes timing.
+
+The change corrects the Stryker.NET language reference so a developer following it hits none of these traps. Scope is documentation-only: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`. No behavior change to the skill workflow, no changes to other language references, no code changes.
+
+The PR body must include `Closes #522` so merging auto-closes the issue.
+
+## Architecture Specification
+
+**Files touched (single file):**
+
+- `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+
+**Sections added or revised inside that file:**
+
+1. **xunit.v3 detection block** — a new subsection before "Run (scoped)" that shows the `grep -rl "xunit.v3" tests/ --include="*.csproj"` detection, and prescribes: set `"coverage-analysis": "off"`, write `xunit.runner.json` with `"testTimeout": 5000`, add `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` to the test csproj, set `additional-timeout: 30000`. Explains the "fake 100% score / all Timeout" failure mode.
+2. **`DOTNET_ROOT` preamble** — every run command in the file exports `DOTNET_ROOT` with the Homebrew fallback path before invoking Stryker, and shows the `dotnet --info | grep "Base Path"` confirmation step. The path variable `STRYKER="${HOME}/.dotnet/tools/dotnet-stryker"` is used consistently.
+3. **`-O` vs `report-file-name` clarification** — the file no longer shows `--report-file-name` as a CLI flag. A short note explains it is a **config-file key** that renames HTML/JSON output within the output directory; the CLI switch for output directory is `-O` / `--output`. Named runs use `-O StrykerOutput/<name>`.
+4. **Probe verbosity** — probe commands drop `-V trace`. A `grep -E "Killed:|Survived:|Timeout:|mutation score"` extract is shown for summarizing any run regardless of verbosity. A note allows `-V trace` only when debugging startup problems.
+5. **No `--dry-run`** — any reference to `--dry-run` is removed. (Verification step in Acceptance: `grep -c "dry-run"` on the file returns `0`.)
+6. **Unknown-key warning** — a short paragraph noting that Stryker.NET rejects any unknown key in `stryker-config.json` since v1.x, and that JSON comment workarounds (`"_note"`, `"//"`) hard-fail the run. Document config intent in git commit messages or a nearby README instead.
+7. **Pre-run `dotnet build`** — every timing/run block is preceded by `dotnet build <solution> -c Debug --nologo`, then `time dotnet test <test-project> -c Debug --no-build` for the baseline suite timing referenced in `SKILL.md` Step 1b.
+
+**Constraints:**
+
+- Language-agnostic content stays in `SKILL.md`; every correction lives in the C# reference file.
+- No other language KB is touched; no code, agent, hook, or eval fixture changes.
+- Existing shard-aware execution guidance for large repos is preserved and updated to include the `DOTNET_ROOT` preamble and `-O` output-directory pattern; commands remain runnable.
+- Because this diff is markdown-only (touches only `*.md`), the working rule from the repo CLAUDE.md applies: arm auto-merge at PR-open time with `gh pr merge <num> --auto --squash`. `Closes #522` in the PR body auto-closes the issue on merge.
+
+**Non-goals:**
+
+- No refactor of `SKILL.md` workflow steps.
+- No change to the JSON envelope, `--emit-json` schema, or workflow-callers registry.
+- No install-time changes (nothing added to `init-dev-team` or `install.sh`).
+
+## Acceptance Criteria
+
+Every criterion is observable by grepping the changed file or running the referenced command.
+
+1. **xunit.v3 detection block present.** `grep -c "xunit.v3" plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` returns ≥ 3 (detection command, coverage-analysis note, xunit.runner.json guidance). The block sets `"coverage-analysis": "off"`, creates `xunit.runner.json` with `"testTimeout": 5000`, adds `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>`, and sets `additional-timeout: 30000`.
+2. **`DOTNET_ROOT` export appears in every run command.** All executable Stryker invocations in the file are preceded by `export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"`. The confirmation line `dotnet --info | grep "Base Path"` is present.
+3. **Probe command uses default verbosity.** `grep -c -- "-V trace" plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` returns `0` for the probe command block. The file shows a `grep -E "Killed:|Survived:|Timeout:|mutation score"` summary extractor. One note may retain a mention of `-V trace` strictly labeled as "debug-only, not for probes"; if kept, it is a single occurrence outside a run command.
+4. **`-O` used for output directory; `--report-file-name` documented as config key only.** Every named run uses `-O StrykerOutput/<name>`. `grep "report-file-name" plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` shows all occurrences inside a "config file key" explanation, never as a CLI flag in a command block.
+5. **No `--dry-run` references remain.** `grep -c -- "--dry-run" plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` returns `0`.
+6. **Unknown-config-key warning present.** The file contains a note that Stryker.NET rejects unknown keys in `stryker-config.json` since v1.x and that `"_note"` / `"//"` comment workarounds hard-fail the run.
+7. **`dotnet build` precedes timing/run commands.** Each run/timing block includes `dotnet build ... -c Debug --nologo` before the `time dotnet test` or `dotnet stryker` invocation. Standalone snippets that show only a Stryker command reference the pre-build step in nearby prose.
+8. **All existing shard-aware content still parses and runs.** Shard config discovery, `stryker-pipeline.py`, `stryker-setup.py`, and the "Finding the relevant shard config" bash helper remain in the file; the only additions are the seven corrections above.
+9. **`/agent-audit` passes** on the modified file (no frontmatter, structural, or reference-link breakage).
+10. **PR closes the issue on merge.** The PR body contains `Closes #522`. `gh pr view <num> --json body` shows the string. When the PR is merged, GitHub auto-closes issue #522.
+11. **Documentation-only auto-merge armed.** At PR-open time, `gh pr merge <num> --auto --squash` is executed. The PR title uses a conventional-commit prefix (`docs(mutation-testing): correct Stryker.NET reference for xunit.v3, DOTNET_ROOT, CLI flags, verbosity`).
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|---|---|---|---|
+| Which file receives the seven corrections? The issue text says "Step 1 / tool-setup"; no `tool-setup` file exists. | `inferable` | inference | `grep -rn "tool-setup"` across the plugin returns no matching file. `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` is the sole Stryker.NET setup/run reference; every item in the issue maps directly onto its existing sections (install, run, timeout, notes). |
+| Should `-V trace` be removed entirely, or kept as a debug-only note? | `inferable` | inference | Issue text says "Use `-V trace` only when actively debugging a startup problem" — a single labeled note is consistent with that intent; removing it entirely would drop useful escape-hatch guidance. |
+| Where to put the unknown-config-key warning — the C# KB or `SKILL.md`? | `inferable` | inference | The behavior is Stryker.NET-specific (Stryker.NET 1.x+ rejects unknown keys; other tools differ). Belongs in the C# KB, not the language-agnostic `SKILL.md`. |
+| Should xunit.v3 detection also be wired into `stryker-net.sh` mutation adapter (auto-detect at runtime)? | `requires-stakeholder-input` — deferred | inference (as scope decision) | Issue #522 asks only for documentation corrections. Auto-detection at adapter runtime is a behavior change; keeping this spec doc-only preserves the "documentation-only auto-merge" path and matches the issue's acceptance criteria. If the user wants adapter auto-detection, that is a separate issue and separate spec. |
+| Should shard-aware examples also be revised to include the seven corrections (build pre-step, DOTNET_ROOT, -O)? | `inferable` | inference | Yes — the corrections are universal to Stryker.NET; leaving shard-aware examples uncorrected would recreate the same traps in the whole-repo path. Applying to every run block in the file. |
+| PR auto-merge armed? | `inferable` | inference | Repo CLAUDE.md working rules explicitly state documentation-only PRs (touching only `*.md` and non-shipping metadata) auto-merge with `gh pr merge <num> --auto --squash`. This diff qualifies. |
+| PR title format for a docs-only fix that closes a `fix:`-labeled issue? | `inferable` | inference | Squash-merge titles drive release-please. A pure-docs change to a reference file that alters no runtime behavior is `docs(mutation-testing):`, not `fix:`. This means no version bump — appropriate, since no code ships. If the user wants a `fix:` release tag despite the docs-only scope, they can override the PR title before merge. |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — the seven corrections in issue #522 are enumerated with concrete file/line-level checks.
+- [x] Every behavior/goal maps to an acceptance criterion — items 1–7 in the issue map 1:1 onto criteria 1–7; issue's ask "close on merge" maps to criterion 10; repo-level docs-only auto-merge maps to criterion 11.
+- [x] Architecture constrains without over-engineering — single file touched, no adapter or code changes, existing shard-aware content preserved.
+- [x] Terminology consistent — "Stryker.NET", `dotnet stryker`, `csharp-stryker-net.md`, "shard config" used consistently across all three artifacts.
+- [x] No contradictions between artifacts — non-goals in Architecture align with "not touched" scope in Intent and with criteria that only check the C# KB file.
+- [x] Every gap/ambiguity finding is logged — six inference-classified decisions and one out-of-scope deferral, each with explicit rationale.

--- a/plans/stryker-net-workflow-corrections.md
+++ b/plans/stryker-net-workflow-corrections.md
@@ -1,0 +1,264 @@
+# Plan: Stryker.NET Workflow Corrections (issue #522)
+
+**Created**: 2026-07-01
+**Branch**: `fix/issue-522-stryker-net-workflow-corrections` (to be created from `main`; current session is on an unrelated branch — the human gate should confirm branching before `/build`)
+**Status**: in-progress
+**Spec**: [docs/specs/stryker-net-workflow-corrections.md](../docs/specs/stryker-net-workflow-corrections.md)
+
+## Goal
+
+Correct the seven concrete errors in `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` catalogued in issue #522 (xunit.v3 silent perTest fallback, missing `DOTNET_ROOT` on Homebrew installs, `--report-file-name` mislabeled as a CLI flag, `-V trace` on the probe, non-existent `--dry-run`, unknown-config-key hard failure, stale-binary phantom timeouts). A developer following the corrected reference reaches a working Stryker.NET run without hitting any of these traps. Documentation-only diff; PR closes #522 and arms auto-merge at open time.
+
+## Approach Stances (high-reversal-cost axes)
+
+Per `knowledge/decision-defaults.md`, the task touches these axes:
+
+- **Auto-merge vs direct**: **auto-merge armed at PR open** (`gh pr merge <num> --auto --squash`). Justification: diff is markdown-only in a single reference file — the repo CLAUDE.md's documentation-only working rule applies verbatim. Required checks still gate the merge.
+- **Scope**: **narrow — one file, seven corrections**. No adapter/runtime change (deferred as a separate issue per Ambiguity Log in the spec). No sibling language KBs touched.
+- **Replace vs merge**: **merge in place** (edit the existing file, preserve shard-aware section). Not a rewrite.
+- **Format fidelity**: preserve the existing document's heading style, bash fence conventions, and cross-reference format.
+
+## Acceptance Criteria
+
+Mirrors the spec's Acceptance Criteria, condensed for build tracking:
+
+- [x] xunit.v3 detection block added: `grep -rl "xunit.v3" tests/`, `"coverage-analysis": "off"`, `xunit.runner.json` with `"testTimeout": 5000`, `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>`, `additional-timeout: 30000`, and the "fake 100% score" failure-mode note
+- [x] `DOTNET_ROOT` export prefaces every Stryker run command; `dotnet --info | grep "Base Path"` confirmation shown
+- [x] Probe command drops `-V trace`; `grep -E "Killed:|Survived:|Timeout:|mutation score"` summary extractor shown; at most one labeled "debug-only" mention of `-V trace` outside any run block
+- [x] Named runs use `-O StrykerOutput/<name>`; every remaining occurrence of `report-file-name` is inside a "config file key" explanation, never in a command block
+- [x] `grep -c -- "--dry-run"` on the file returns `0`
+- [x] Unknown-config-key warning present (rejection since v1.x, `"_note"`/`"//"` comment workarounds hard-fail)
+- [x] Each run/timing block either (a) contains `dotnet build <solution> -c Debug --nologo` before its `time dotnet test` / `dotnet stryker` line, or (b) is immediately preceded by a prose bullet naming the required build step
+- [x] Existing shard-aware content preserved (`stryker-pipeline.py`, `stryker-setup.py`, "Finding the relevant shard config" bash helper); shard run commands updated with the `DOTNET_ROOT` + `-O` patterns
+- [ ] `/agent-audit` passes on the modified file
+- [ ] PR body contains `Closes #522`; PR title is `docs(mutation-testing): correct Stryker.NET reference for xunit.v3, DOTNET_ROOT, CLI flags, verbosity`
+- [ ] `gh pr merge <num> --auto --squash` armed at PR open
+
+## Slices
+
+### Slice 1: Correct the C# / Stryker.NET language reference
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+
+**Behavior:**
+
+```gherkin
+Feature: Stryker.NET reference gives correct, runnable instructions
+
+  Scenario: xunit.v3 test project is detected and steered to coverage-analysis off
+    Given a test project whose .csproj references xunit.v3
+    When a developer follows the C# / Stryker.NET reference
+    Then the reference tells them to run `grep -rl "xunit.v3" tests/ --include="*.csproj"`
+    And instructs them to set `"coverage-analysis": "off"` in stryker-config.json
+    And instructs them to create xunit.runner.json with `"testTimeout": 5000`
+    And instructs them to add `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` to the test csproj
+    And instructs them to set `additional-timeout: 30000`
+    And explains the "all timeouts / fake 100% score" failure mode `perTest` would otherwise cause
+
+  Scenario: A Homebrew-installed .NET runtime is discoverable via DOTNET_ROOT
+    Given the developer installed .NET via Homebrew on macOS
+    When they read any run command in the reference
+    Then the command is preceded by `export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"`
+    And the reference shows `dotnet --info | grep "Base Path"` as the confirmation step
+
+  Scenario: The probe command uses default verbosity
+    Given the developer wants to probe Stryker.NET against a single file
+    When they read the probe command
+    Then the probe command does NOT contain `-V trace`
+    And a `grep -E "Killed:|Survived:|Timeout:|mutation score"` summary extractor is shown for any verbosity
+    And if `-V trace` is mentioned at all, it is a single labeled "debug-only" note outside any command block
+
+  Scenario: The output directory is set via -O, not via --report-file-name
+    Given the developer wants to name a Stryker output directory
+    When they read a named-run command
+    Then the command uses `-O StrykerOutput/<name>`
+    And `--report-file-name` does not appear as a CLI flag in any command block
+    And a note explains `report-file-name` is a config-file key that renames HTML/JSON files within the output directory
+
+  Scenario: No --dry-run references remain
+    Given a developer greps the reference for `--dry-run`
+    When the grep runs
+    Then it returns zero matches
+
+  Scenario: Unknown config keys are called out as a hard failure
+    Given the developer is authoring `stryker-config.json`
+    When they read the config authoring guidance
+    Then the reference warns that Stryker.NET has rejected unknown keys since v1.x
+    And explicitly names `"_note"` and `"//"` comment workarounds as hard-fail patterns
+    And directs the developer to git commit messages or a nearby README for config intent
+
+  Scenario: A dotnet build precedes any timing or Stryker invocation
+    Given the developer wants to time the baseline test suite or run Stryker
+    When they follow the reference
+    Then each `time dotnet test` / `dotnet stryker` block either
+      (a) contains `dotnet build <solution> -c Debug --nologo` before the test/stryker line, or
+      (b) is immediately preceded by a prose bullet naming the required build step
+    And subsequent `dotnet test` calls include `--no-build` so they reuse the freshly-built binaries
+
+  Scenario: Shard-aware execution content is preserved
+    Given the developer is working on a large C# repo with shard configs
+    When they consult the reference
+    Then `stryker-pipeline.py`, `stryker-setup.py`, and the "Finding the relevant shard config for a given file" bash helper are still present
+    And the shard-run commands include the same `DOTNET_ROOT` export and `-O` output-directory pattern as the non-shard commands
+```
+
+**Steps:**
+
+#### Step 1.1: Add xunit.v3 detection subsection
+
+**Complexity**: standard
+**RED**: Add a check (bats or grep-based; see Verification below) that fails until the reference contains: `grep -rl "xunit.v3"`, `"coverage-analysis": "off"`, `xunit.runner.json`, `"testTimeout": 5000`, `PreserveNewest`, `additional-timeout: 30000`, and the "fake 100% score" phrase.
+**GREEN**: Insert an "xunit.v3 detection" subsection before the "Run (scoped)" heading with the detection command, the four required config additions, and the failure-mode explanation from issue #522, item 1.
+**REFACTOR**: Ensure the new subsection cross-references the existing timeout guidance in `SKILL.md` Step 1b (the `additional-timeout` here is a *layered* cap on top of the per-mutant `timeout`).
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): detect xunit.v3 and pin coverage-analysis off in Stryker.NET reference`
+
+#### Step 1.2: Add DOTNET_ROOT export and Base Path confirmation to every run command
+
+**Complexity**: standard
+**RED**: Extend the verification check so it fails unless every `dotnet stryker` command block in the file is preceded (in-block) by `export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"`, and the file contains one `dotnet --info | grep "Base Path"` example.
+**GREEN**: Edit each run command block (scoped run, shard sequential run, whole-repo fallback, and any probe examples introduced later) to prepend `export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"`. Keep the existing `dotnet stryker` invocation form — do NOT introduce a `$STRYKER` alias (bare `dotnet stryker` resolves via PATH once `DOTNET_ROOT` is exported, and matches sibling KBs' style). Add a one-line "Confirm the local path" example using `dotnet --info | grep "Base Path"`.
+**REFACTOR**: If any two adjacent run blocks now share identical export preambles, extract them to a shared "Environment" preamble near the top of the file and reference it from the run blocks.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): require DOTNET_ROOT export for Homebrew .NET installs in Stryker.NET runs`
+
+#### Step 1.3: Correct -O vs --report-file-name and clarify the config key
+
+**Complexity**: standard
+**RED**: Extend the verification check to require: (a) every named run command uses `-O StrykerOutput/<name>` (regex captures at least one `-O StrykerOutput/`); (b) `--report-file-name` never appears in a fenced ```bash block outside a comment; (c) prose explains `report-file-name` is a config-file key that renames HTML/JSON files within the output directory.
+**GREEN**: Replace any `--report-file-name "..."` CLI usage in command blocks with `-O StrykerOutput/<name>`. Add a short note above/below the run examples explaining the config-file-key distinction.
+**REFACTOR**: Consolidate any duplicated command examples that only differ in output name into a single example plus a "for a named run, use `-O StrykerOutput/<name>`" line.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): use -O for output directory; document --report-file-name as config-file key only`
+
+#### Step 1.4: Drop -V trace from the probe and add the summary extractor
+
+**Complexity**: standard
+**RED**: Extend the verification check to require: (a) any `dotnet stryker -m "**/ProbeFile.cs"` example does NOT contain `-V trace`; (b) the file contains `grep -E "Killed:|Survived:|Timeout:|mutation score"`; (c) any remaining `-V trace` mention is inside a paragraph or comment (not a fenced command block), and there is at most one such mention.
+**GREEN**: Update the probe example to drop `-V trace`. Add the `grep -E "..."` summary extractor as a companion snippet. Add a single-sentence "Use `-V trace` only when actively debugging a Stryker startup problem" note *outside* the run block.
+**REFACTOR**: None expected.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): drop -V trace from Stryker.NET probe; add default-verbosity summary extractor`
+
+#### Step 1.5: Remove --dry-run references
+
+**Complexity**: trivial
+**RED**: Extend the verification check to require `grep -c -- "--dry-run"` on the file to return `0`.
+**GREEN**: Remove any `--dry-run` occurrences. (Spot check: current file appears clean, but the check enforces the invariant.)
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): remove non-existent --dry-run references from Stryker.NET reference`
+
+#### Step 1.6: Add unknown-config-key warning
+
+**Complexity**: standard
+**RED**: Extend the verification check to require the file mentions "unknown key" (or "unknown keys"), calls out the `"_note"` and `"//"` comment patterns as hard-failures, and points readers at git commit messages or a README for config intent.
+**GREEN**: Add a short "Config authoring notes" paragraph in the config-file section (near the timeout config or above the run commands) capturing the Stryker.NET-since-v1.x behavior and the workaround guidance.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): warn that Stryker.NET rejects unknown config keys and inline comments`
+
+#### Step 1.7: Precede every timing/run block with dotnet build
+
+**Complexity**: standard
+**RED**: Extend the verification check to require: for every fenced ```bash block that contains `time dotnet test` or `dotnet stryker`, either the same block or the immediately preceding prose paragraph contains `dotnet build` with `-c Debug --nologo`, and any subsequent `dotnet test` in the same block includes the `--no-build` flag.
+**GREEN**: Add `dotnet build <solution> -c Debug --nologo` before each `time dotnet test` example and any Stryker run that reads test binaries. Where inserting into an existing block would balloon it, use a "Pre-run" prose bullet above the block instead.
+**REFACTOR**: Check the shard-aware section for the same treatment; add the pre-build step to the shard examples too (per the "shard-aware content is preserved AND corrected" scenario).
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): require dotnet build before Stryker.NET timing and runs`
+
+#### Step 1.8: Run /agent-audit and open the PR with auto-merge armed
+
+**Complexity**: standard
+**RED**: `/agent-audit` on the modified file must be green. `gh pr view` must show `Closes #522` and the conventional-commit title.
+**GREEN**: Run `/agent-audit`. Push branch, open PR with title `docs(mutation-testing): correct Stryker.NET reference for xunit.v3, DOTNET_ROOT, CLI flags, verbosity` and body containing `Closes #522`. Arm auto-merge: `gh pr merge <num> --auto --squash`.
+**REFACTOR**: None.
+**Files**: none (CI + PR)
+**Commit**: n/a (PR-level action)
+
+### Verification harness for this slice
+
+Because there is no runtime code path to exercise, "RED" here means a **structural check on the reference file** that a developer can run before and after the edit — `grep` and simple bash. The seven grep-shaped assertions in the criteria list above are the check. Bundle them as a one-off script (kept in the branch under `plans/checks/stryker-net-ref-check.sh`, or inlined into the commit body) so each step's RED can fail concretely. This is a documentation change — no bats/pytest suite needs updating.
+
+## Parallelization
+
+Single slice, single wave. Nothing to parallelize.
+
+```mermaid
+graph TD
+  S1[Slice 1: Correct C# / Stryker.NET reference]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+
+Parallelization Critic skipped — single-slice plan.
+
+## Complexity Classification
+
+Per-step ratings above. Plan tier: **standard** (single slice, one file, but touches an auto-merge stance and requires seven independent structural edits — classifying up from `trivial` on the tie-break).
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (repo test suite unaffected; no test files touched)
+- [ ] Lint passes (`ci-local.sh` markdown lint on the changed file)
+- [ ] `/agent-audit` passes
+- [ ] Structural check script (seven grep assertions from Slice 1) exits 0
+- [ ] Documentation updated — the change *is* the documentation
+
+## Skipped (low value)
+
+None. Every item in issue #522 delivers observable-through-grep signal.
+
+## Risks & Open Questions
+
+- **Working branch.** The current session is on `fix/issue-532-demote-test-design-advisor`. Before `/build`, cut a fresh branch from `origin/main` — the repo working rule bars committing to `main` and mixing #532 and #522 in one branch would produce a poisoned PR. **Confirm branching at the human gate.**
+- **`--report-file-name` current state.** The existing file may not currently contain the mislabeled flag; the issue lists it as a correction to guidance the user has seen elsewhere. Steps 1.3 and 1.5 remain — they add the clarification and enforce the invariant even when the file was already clean, and they're cheap.
+- **Config-authoring section placement (Step 1.6).** The current file has no dedicated config-authoring section; placing the unknown-key warning near the existing timeout config keeps related config guidance together. Not a hard decision.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Correct the C# / Stryker.NET language reference
+  - [x] Step 1.1: Add xunit.v3 detection subsection
+  - [x] Step 1.2: Add DOTNET_ROOT export and Base Path confirmation to every run command
+  - [x] Step 1.3: Correct -O vs --report-file-name and clarify the config key
+  - [x] Step 1.4: Drop -V trace from the probe and add the summary extractor
+  - [x] Step 1.5: Remove --dry-run references
+  - [x] Step 1.6: Add unknown-config-key warning
+  - [x] Step 1.7: Precede every timing/run block with dotnet build
+  - [ ] Step 1.8: Run /agent-audit and open the PR with auto-merge armed
+
+### Acceptance Criteria
+
+- [x] xunit.v3 detection block added: `grep -rl "xunit.v3" tests/`, `"coverage-analysis": "off"`, `xunit.runner.json` with `"testTimeout": 5000`, `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>`, `additional-timeout: 30000`, and the "fake 100% score" failure-mode note
+- [x] `DOTNET_ROOT` export prefaces every Stryker run command; `dotnet --info | grep "Base Path"` confirmation shown
+- [x] Probe command drops `-V trace`; `grep -E "Killed:|Survived:|Timeout:|mutation score"` summary extractor shown; at most one labeled "debug-only" mention of `-V trace` outside any run block
+- [x] Named runs use `-O StrykerOutput/<name>`; every remaining occurrence of `report-file-name` is inside a "config file key" explanation, never in a command block
+- [x] `grep -c -- "--dry-run"` on the file returns `0`
+- [x] Unknown-config-key warning present (rejection since v1.x, `"_note"`/`"//"` comment workarounds hard-fail)
+- [x] Each run/timing block either (a) contains `dotnet build <solution> -c Debug --nologo` before its `time dotnet test` / `dotnet stryker` line, or (b) is immediately preceded by a prose bullet naming the required build step
+- [x] Existing shard-aware content preserved (`stryker-pipeline.py`, `stryker-setup.py`, "Finding the relevant shard config" bash helper); shard run commands updated with the `DOTNET_ROOT` + `-O` patterns
+- [ ] `/agent-audit` passes on the modified file
+- [ ] PR body contains `Closes #522`; PR title is `docs(mutation-testing): correct Stryker.NET reference for xunit.v3, DOTNET_ROOT, CLI flags, verbosity`
+- [ ] `gh pr merge <num> --auto --squash` armed at PR open
+
+## Plan Review Summary
+
+Plan tier: **standard** — reviewers: Acceptance Test Critic, Design & Architecture Critic (UX skipped — no user-facing surface; Parallelization Critic skipped — single-slice plan).
+
+Iterations: 1. Both reviewers returned no blockers; two warnings surfaced by both, resolved in this revision:
+
+1. **`dotnet build` precedes-run criterion** (Acceptance Critic, warning) — original Gherkin and top-level AC captured only the in-block form, but Step 1.7 GREEN sanctioned an "adjacent prose bullet" alternative. Resolution: both the top-level Acceptance Criteria bullet, the mirrored Build Progress AC list, and the Gherkin scenario now state the two accepted forms (in-block or adjacent-prose bullet) explicitly; Step 1.7 RED wording is aligned.
+2. **`$STRYKER` alias untraceable** (Acceptance Critic + Design Critic, warning) — Step 1.2 GREEN originally introduced a `STRYKER="${HOME}/.dotnet/tools/dotnet-stryker"` alias with no matching AC or Gherkin, and Step 1.7 RED then assumed it. Design Critic noted the alias has no precedent in this file or sibling KBs (`javascript-stryker.md`, `java-pitest.md`) and is unnecessary once `DOTNET_ROOT` is exported. Resolution: **alias removed** — Step 1.2 GREEN now keeps the existing bare `dotnet stryker` invocation form; Step 1.7 RED's `(via $STRYKER)` parenthetical is dropped.
+
+Additional observations (informational, no revision required):
+
+- Design Critic: placement in the language KB (not `SKILL.md`) is correct per `SKILL.md`'s own routing rule; auto-merge stance and `docs:` PR title (no release-please version bump) are correctly derived from repo CLAUDE.md and match the shipped-code-vs-docs distinction.
+- Design Critic: shard-aware content preservation is treated as a first-class REFACTOR concern in Step 1.7 — avoids the parallel-path drift risk.
+- Acceptance Critic: grep-shaped RED checks are a fitting TDD adaptation for a documentation-only diff; the "verification harness" is one evolving bash snippet across steps rather than a persisted test file, which is appropriate scope.

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -9,6 +9,71 @@ dotnet new tool-manifest        # if no .config/dotnet-tools.json yet
 dotnet tool install dotnet-stryker
 ```
 
+## Environment preamble (macOS Homebrew)
+
+`dotnet stryker` (whether invoked as the tool or as `~/.dotnet/tools/dotnet-stryker`) fails with **"You must install .NET to run this application"** when .NET is installed via Homebrew, because the runtime lives at `/opt/homebrew/opt/dotnet/libexec` rather than at the default path. Export `DOTNET_ROOT` before any Stryker invocation:
+
+```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+```
+
+Confirm the local runtime path with:
+
+```bash
+dotnet --info | grep "Base Path"
+```
+
+Every run command below assumes this export is in scope.
+
+## xunit.v3 detection (do this before configuring runs)
+
+xunit.v3 adopted the Microsoft Testing Platform (MTP) runner. The MTP runner **does not support per-test coverage boundaries**, so `"coverage-analysis": "perTest"` silently falls back to running the entire test suite against every mutant — plus, hanging async tests burn the entire `additional-timeout` window. The observable symptoms are massive timeout counts, multi-hour runtimes, and a **fake 100% mutation score** (all mutants recorded as `Timeout`, none `Killed` or `Survived`). See [stryker-net#3117](https://github.com/stryker-mutator/stryker-net/issues/3117) and [stryker-net#3629](https://github.com/stryker-mutator/stryker-net/issues/3629).
+
+Detect xunit.v3 before configuring the run:
+
+```bash
+grep -rl "xunit.v3" tests/ --include="*.csproj" 2>/dev/null
+```
+
+If detected, take **all four** steps below. Missing any one recreates the fake-score failure mode.
+
+1. In every `stryker-config.json` (or per-shard config), set `"coverage-analysis": "off"` explicitly — not `perTest`.
+2. Create `xunit.runner.json` in each test project directory with `"testTimeout": 5000` to cap individual hanging tests at 5 s:
+
+    ```json
+    {
+      "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+      "testTimeout": 5000
+    }
+    ```
+
+3. Deploy `xunit.runner.json` to the output directory by adding this to each test `.csproj`:
+
+    ```xml
+    <ItemGroup>
+      <None Update="xunit.runner.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+    ```
+
+4. In `stryker-config.json`, set `"additional-timeout": 30000` — headroom for ~5 hanging tests × 5 s `testTimeout` per mutant plus overhead. This is a **layered** cap on top of the per-mutant `timeout` documented in [`SKILL.md`](../../SKILL.md) Step 1b.
+
+## Pre-run: build first
+
+Always build before timing the baseline suite or invoking Stryker. A stale binary produces phantom failures — Stryker either aborts on load or reports every mutant as `Survived`. Baseline timing:
+
+```bash
+dotnet build <solution> -c Debug --nologo
+time dotnet test <test-project> -c Debug --no-build
+```
+
+Every Stryker run block below assumes a fresh `dotnet build ... -c Debug --nologo` immediately precedes it.
+
+## Config authoring notes
+
+Stryker.NET rejects **any unknown key** in `stryker-config.json` since v1.x — a JSON comment workaround like `"_note": "..."` or `"//": "..."` causes the entire run to fail with a clear error message. Do not embed intent comments in the config. Document config intent in the git commit message that introduces the config, or in a nearby `README.md`.
+
 ## Run (scoped)
 
 Large C# repos take 60–90 min for a whole-project run. Always scope runs; if the repo has pre-generated shard configs, use them.
@@ -16,20 +81,26 @@ Large C# repos take 60–90 min for a whole-project run. Always scope runs; if t
 **Single file in `--scope` (Phase 4 per-Story gate):**
 
 ```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+
 # Scope to the changed file within its shard config
 dotnet stryker \
   --config-file stryker-config.shard-<name>.json \
   --mutate "**/ChangedFile.cs" \
   --coverage-analysis perTest \
   --reporter json \
-  --output StrykerOutput/gate-shard
+  -O StrykerOutput/gate-shard
 ```
 
 **Full scan — shard configs present (Phase 5 convergence, initial baseline):**
 
 ```bash
-# Run each shard sequentially; aggregate results
-# stryker-pipeline.py --skip-agent handles this automatically
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+
+# Run each shard sequentially; aggregate results.
+# stryker-pipeline.py --skip-agent handles this automatically.
 python3 /path/to/nextgen-test-upgrade-process/scripts/stryker-pipeline.py \
   --skip-agent
 ```
@@ -39,12 +110,35 @@ The pipeline writes one `StrykerOutput/shards/<name>/reports/mutation-report.jso
 **Full scan — no shard configs (first time, small repo):**
 
 ```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+
 # Generate shard configs first to make future runs fast
 python3 /path/to/nextgen-test-upgrade-process/scripts/stryker-setup.py
 
-# Then run normally — dotnet stryker finds stryker-config.json
-dotnet stryker --coverage-analysis perTest --reporter json
+# Then run — dotnet stryker finds stryker-config.json
+dotnet stryker --coverage-analysis perTest --reporter json -O StrykerOutput/baseline
 ```
+
+**Named-run output directories.** Use the `-O` / `--output` CLI flag to name the output directory, e.g. `-O StrykerOutput/baseline` and `-O StrykerOutput/verification`. Do **not** use `--report-file-name` as a CLI flag — it is not one; it is a **config-file key** (`"report-file-name"` inside `stryker-config.json`) that renames the HTML/JSON output files *within* whichever directory `-O` selected.
+
+**Probe a single file (default verbosity):**
+
+```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+
+# Info-level output is default and readable — use trace only when debugging a startup problem.
+dotnet stryker -m "**/ProbeFile.cs" -O StrykerOutput/probe
+```
+
+Extract the summary from any run regardless of verbosity:
+
+```bash
+grep -E "Killed:|Survived:|Timeout:|mutation score" <output-log> | tail -5
+```
+
+`-V trace` is a debug-only escape hatch for Stryker startup problems — it emits 1.5M+ lines for a two-minute probe run and buries the summary. Do not include it in probe or gate commands.
 
 **Finding the relevant shard config for a given file (bash helper):**
 
@@ -68,7 +162,7 @@ Configure in `stryker-config.yaml` (or the per-shard JSON config):
 timeout: 60000   # milliseconds
 ```
 
-Default shipped: 60 000 ms. Set `timeout` to `timeout_seconds × 1000` (formula in [`SKILL.md`](../../SKILL.md) Step 1b).
+Default shipped: 60 000 ms. Set `timeout` to `timeout_seconds × 1000` (formula in [`SKILL.md`](../../SKILL.md) Step 1b). For xunit.v3 test projects, also set `additional-timeout: 30000` (see the xunit.v3 detection section above) — the two settings compose.
 
 ## Native report → schema mapping
 
@@ -97,6 +191,7 @@ Source: `StrykerOutput/<run>/reports/mutation-report.json` (same shape as JS Str
 For C# repos, `dotnet stryker` against the whole solution can take 60–90 minutes. The mutation gate adapter (`stryker-net.sh`) will time out and skip rather than run. The fix is **shard configs** generated by `stryker-setup.py` (from the [nextgen-test-upgrade-process](https://dev.azure.com/acispeedpayportfolio/acispeedpay/_git/nextgen-test-upgrade-process) toolkit):
 
 ```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
 # One-time setup in the target repo — generates stryker-config.shard-*.json
 python3 /path/to/nextgen-test-upgrade-process/scripts/stryker-setup.py
 ```
@@ -106,7 +201,7 @@ Once shard configs exist, the adapter automatically:
 1. Detects which shard covers the changed file (by matching the shard's `mutate` path prefix).
 2. Passes `--config-file stryker-config.shard-<name>.json` to scope Stryker to that source project + its tests.
 3. Further narrows with `--mutate "**/ChangedFile.cs"` so only the one changed file is mutated.
-4. Writes results to `StrykerOutput/gate-shard/` so gate runs don't overwrite full pipeline reports.
+4. Writes results to `StrykerOutput/gate-shard/` (via `-O`) so gate runs don't overwrite full pipeline reports.
 
 This drops the wall-clock time from 60–90 min (whole repo) to **5–15 min** (one file in one shard), which fits within the adapter's 600-second outer timeout.
 
@@ -114,8 +209,10 @@ This drops the wall-clock time from 60–90 min (whole repo) to **5–15 min** (
 
 ### Batch improvement pipeline
 
-For the full improvement pipeline (not the per-test gate), use `stryker-pipeline.py` instead of bare `dotnet stryker`. It runs shards sequentially, fixes survivors with `mutation-agent.py` using the Claude Code CLI, and is the right tool for batch mutation-score improvement:
+For the full improvement pipeline (not the per-test gate), use `stryker-pipeline.py` instead of bare `dotnet stryker`. It runs shards sequentially, fixes survivors with `mutation-agent.py` using the Claude Code CLI, and is the right tool for batch mutation-score improvement. Pre-build first, then invoke:
 
 ```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
 python3 /path/to/nextgen-test-upgrade-process/scripts/stryker-pipeline.py
 ```


### PR DESCRIPTION
Closes #522

Corrects seven concrete errors in `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` that caused real failures when developers followed the reference. All items were verified against the official Stryker.NET docs and the linked upstream issues.

## What changed

1. **xunit.v3 detection block added.** xunit.v3 adopted the Microsoft Testing Platform runner, which does not support per-test coverage boundaries — `"coverage-analysis": "perTest"` silently falls back to running the whole suite against every mutant, and hanging async tests burn the whole `additional-timeout` window, yielding a *fake 100 % mutation score* (all timeouts, no kills, no survivors). See [stryker-net#3117](https://github.com/stryker-mutator/stryker-net/issues/3117) and [stryker-net#3629](https://github.com/stryker-mutator/stryker-net/issues/3629). Reference now instructs `grep -rl "xunit.v3" tests/`, then sets `"coverage-analysis": "off"`, ships `xunit.runner.json` with `"testTimeout": 5000`, adds `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` to the test csproj, and sets `additional-timeout: 30000`.
2. **`DOTNET_ROOT` export added to every run command.** Homebrew-installed .NET fails with *"You must install .NET to run this application"* because the runtime lives at `/opt/homebrew/opt/dotnet/libexec`. Each run block now exports `DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"`, and the file shows `dotnet --info | grep "Base Path"` as the confirmation step.
3. **`-O` vs `--report-file-name` clarified.** `--report-file-name` is a config-file key, not a CLI flag. Named runs now use `-O StrykerOutput/<name>`; `report-file-name` is discussed only as a config-file key.
4. **`-V trace` removed from probe.** A two-minute probe with `-V trace` emits 1.5M+ lines and buries the summary. Probe uses default verbosity; a `grep -E "Killed:|Survived:|Timeout:|mutation score"` extractor is shown for summarizing any run. `-V trace` is retained only as a labeled debug-only note.
5. **`--dry-run` references removed.** No such flag exists in Stryker.NET.
6. **Unknown-config-key warning added.** Stryker.NET rejects any unknown key in `stryker-config.json` since v1.x — `"_note"` / `"//"` comment workarounds hard-fail the run. Reference now directs config-intent commentary to git commit messages or a README.
7. **`dotnet build` precedes every timing/run block.** Stale binaries produce phantom timeouts that look like a small suite. Baseline timing now runs `dotnet build <solution> -c Debug --nologo` first, then `time dotnet test <test-project> -c Debug --no-build`; Stryker run blocks follow the same pattern.

## Scope

- Single file touched: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`.
- Existing shard-aware execution guidance (`stryker-pipeline.py`, `stryker-setup.py`, shard-config lookup helper) preserved; shard run commands were updated with the same `DOTNET_ROOT` + `-O` patterns.
- No adapter, runtime, or workflow behavior change. No sibling language KBs touched. No code, tests, or eval fixtures modified.

## Verification

- 24 grep-shaped structural assertions pass on the modified file (one per correction item plus shard-aware preservation).
- All internal links resolve.
- `python3 scripts/check_registry_sync.py` — clean.
- `python3 scripts/check_md_references.py` — no findings against target file.
- `python3 scripts/token_efficiency_review.py --files <file>` — `{"status": "pass"}`.
- `bash scripts/ci-local.sh --changed-only origin/main HEAD` — **all local CI checks passed**.

## Docs-only auto-merge

Diff touches only `*.md` files (target reference + spec + plan). Per the repo's working rule (`CLAUDE.md` → "Documentation-only PRs auto-merge"), auto-merge is armed at PR open with `gh pr merge --auto --squash`. Required checks still gate the merge.

Spec: `docs/specs/stryker-net-workflow-corrections.md`
Plan: `plans/stryker-net-workflow-corrections.md`
