### PR TITLE
fix(test-design): scope farley score to --path and --since (#533)

### DIFF
--- a/docs/specs/farley-score-honors-scope.md
+++ b/docs/specs/farley-score-honors-scope.md
@@ -1,0 +1,86 @@
+<!-- spec-version: 1 -->
+# Spec: Farley Score honors --path / --since scope
+
+Closes #533.
+
+## Intent Description
+
+`/test-design` currently computes the Farley Score over **every** test file in
+the repository regardless of `--path` or `--since`. When `/test-health` (which
+does honor `--path`) invokes `/test-design` on a subtree, the aggregated report
+silently mixes a whole-repo headline number with subtree-scoped findings — the
+two contradict each other and the user has no way to tell.
+
+The fix is to make Farley Score follow scope in `/test-design`, label the score
+with the scope it was computed over, and have `/test-health` pass its `--path`
+through explicitly so the number matches the rest of the audit. Unscoped
+invocations of `/test-design` are unchanged: whole-repo Farley, labelled
+"all tests".
+
+## Architecture Specification
+
+Two skill files change; both are behavioral spec (Markdown consumed by the
+model), no code paths.
+
+Components touched:
+
+- `plugins/dev-team/skills/test-design/SKILL.md` — Step 3 (Farley scoring) and
+  the report header template in Step 6.
+- `plugins/dev-team/skills/test-health/SKILL.md` — Step 6 (invocation of
+  `/test-design`) and the report Output block.
+
+Constraints:
+
+- `/test-design` remains the single owner of Farley scoring; `/test-health`
+  consumes it (per `test-health` Constraint 4, "No scoring reinvention"). This
+  fix does not move scoring, it just makes the scope explicit.
+- Score label vocabulary is exactly three strings — `all tests`,
+  `under <path>`, `changed since <ref>` — so downstream summarizers can parse
+  it deterministically.
+- `farley-score` (the worker skill) is not touched. It scores whatever set of
+  files it is handed; scope selection lives in the caller.
+- Test-file selection uses the existing `knowledge/test-file-indicators.md`
+  taxonomy — no new indicator logic.
+
+No changes to CI, hooks, agent registry, or model routing.
+
+## Acceptance Criteria
+
+1. `/test-design` with no scope flag scores every test file in the repository
+   and the report header reads `**Farley Score (all tests)**: ...`.
+2. `/test-design --path <dir>` scores exactly the test files whose path is
+   under `<dir>` **or** that exercise production code under `<dir>`, and the
+   report header reads `**Farley Score (under <dir>)**: ...`.
+3. `/test-design --since <ref>` scores exactly the test files touched in the
+   diff plus the test files covering production files touched in the diff, and
+   the report header reads `**Farley Score (changed since <ref>)**: ...`.
+4. If the in-scope test set is empty, Step 3 is skipped and the report notes
+   `no in-scope test files` in place of a score.
+5. `/test-health --path <dir>` invokes `/test-design --path <dir>` (invocation
+   string is explicit in the skill) and its rendered Farley Score line carries
+   the `under <dir>` scope label.
+6. `/test-health` with no `--path` invokes `/test-design` with no `--path` —
+   suite-wide score, label `all tests`.
+7. `tests/docs/test_design_skill_dispatch_tests.bats` and any other bats
+   assertions over these two SKILL files pass unchanged or are updated in the
+   same PR; `bash scripts/ci-local.sh` and `/agent-eval` both pass.
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|---|---|---|---|
+| Option 1 (score follows scope) vs Option 2 (opt-in flag) | `inferable` | inference | Issue #533 recommends Option 1; Option 2 adds surface area with no evidence of demand. |
+| Exact label strings for the three scope modes | `inferable` | inference | Issue proposes `all tests` / `under <path>` / `changed since <ref>`; adopted verbatim so downstream parsing is deterministic. |
+| Empty-scope behaviour (path/ref resolves to zero tests) | `inferable` | inference | Existing empty-suite branch already skips the step; extend the same "skip + note" path to empty in-scope sets. |
+| Behaviour of `--path` pointing at a **file** (single-file → auto-`--advise`) | `inferable` | inference | Step 1 already special-cases single-file targets; Farley scope reuses the same target set — no separate rule needed. |
+| Should `/test-health` render the scope label in its Output block? | `inferable` | inference | Constraint 4 forbids re-deriving the score, not re-rendering the label. Passing the label through is consistent with "consume, don't restate." |
+| Farley-score worker skill (`plugins/dev-team/skills/farley-score/SKILL.md`) edit? | `inferable` | inference | The worker scores whatever file set it receives; scope selection belongs to the caller. No change. |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous
+- [x] Every behavior/goal maps to an acceptance criterion
+- [x] Architecture constrains without over-engineering
+- [x] Terminology consistent across artifacts (scope labels fixed)
+- [x] No contradictions between artifacts
+- [x] Every gap/ambiguity finding is logged — all `inferable` with rationale

--- a/plans/farley-score-honors-scope.md
+++ b/plans/farley-score-honors-scope.md
@@ -1,0 +1,241 @@
+# Plan: Farley Score honors --path / --since scope
+
+**Created**: 2026-07-01
+**Branch**: issue-533
+**Status**: draft
+
+## Goal
+
+Make the Farley Score in `/test-design` follow `--path` / `--since` scope and
+label the score with the scope it was computed over, then have `/test-health`
+pass its `--path` through to `/test-design` explicitly. Unscoped
+`/test-design` is unchanged (whole-repo Farley, labelled "all tests"). This
+closes #533 — a subtree audit no longer silently inherits a whole-repo score
+that contradicts the rest of the report.
+
+## Decision-defaults stance
+
+- **Scope**: touch only the two SKILL files the spec names. `farley-score`
+  worker is not edited (it scores whatever file set it receives).
+- **Migrate vs edit-stub**: N/A — both target files are canonical, not stubs.
+- **Auto-merge**: standard `/pr` auto-merge on green checks. This PR touches
+  skills, so it is NOT the "docs-only fast path" from CLAUDE.md — auto-merge
+  still gates on the full CI matrix.
+
+## Acceptance Criteria
+
+- [ ] `/test-design` (no scope) → header reads `Farley Score (all tests)`; score covers every test file in the repo.
+- [ ] `/test-design --path <dir>` → header reads `Farley Score (under <dir>)`; score covers only test files under `<dir>` or exercising production code under `<dir>`.
+- [ ] `/test-design --since <ref>` → header reads `Farley Score (changed since <ref>)`; score covers only tests touched in the diff or covering production files touched in the diff.
+- [ ] Empty in-scope test set → Step 3 skipped; report notes `no in-scope test files` instead of a score.
+- [ ] `/test-health --path <dir>` invocation string explicitly reads `/test-design --path <dir>` in the skill file.
+- [ ] `/test-health` with no `--path` invokes bare `/test-design` (no `--path` flag) — the SKILL file documents both branches explicitly.
+- [ ] `/test-design --path <dir> --since <ref>` combined: in-scope set is the intersection (tests under `<dir>` AND changed since `<ref>`); label reads `Farley Score (under <dir>, changed since <ref>)`.
+- [ ] `/test-health` Output template renders the Farley Score line with its scope label.
+- [ ] `bash scripts/ci-local.sh` passes.
+
+## Slices
+
+### Slice 1: Scope Farley to `--path` / `--since` and propagate through `/test-health`
+
+**Depends-on:** none
+**Files:**
+
+- `plugins/dev-team/skills/test-design/SKILL.md`
+- `plugins/dev-team/skills/test-health/SKILL.md`
+- `tests/docs/test_design_farley_scope_tests.bats` (new)
+- `tests/docs/test_health_farley_scope_tests.bats` (new)
+
+**Behavior:**
+
+Verification surface: these scenarios describe the documented contract enforced
+against the two SKILL.md files. Because the runtime is the model, verification
+is bats string-pinning against SKILL prose (labels, invocation strings,
+branch documentation), not runtime execution. Every scenario below must have a
+corresponding bats assertion in Step 1.1.
+
+```gherkin
+Feature: Farley Score honors --path / --since scope
+
+  Scenario: Unscoped /test-design reports suite-wide Farley labelled "all tests"
+    Given the test-design SKILL is invoked with no --path and no --since
+    When the Farley Score section is emitted
+    Then the score is computed over every test file in the repository
+    And the report header reads "Farley Score (all tests)"
+
+  Scenario: /test-design --path reports subtree-scoped Farley labelled "under <path>"
+    Given the test-design SKILL is invoked with --path plugins/api
+    When the Farley Score section is emitted
+    Then the score is computed only over tests under plugins/api or covering production code under plugins/api
+    And the report header reads "Farley Score (under plugins/api)"
+
+  Scenario: /test-design --since reports diff-scoped Farley labelled "changed since <ref>"
+    Given the test-design SKILL is invoked with --since main
+    When the Farley Score section is emitted
+    Then the score is computed only over tests touched in the diff or covering production files touched in the diff
+    And the report header reads "Farley Score (changed since main)"
+
+  Scenario: /test-design --path and --since together produce the intersection scope
+    Given the test-design SKILL is invoked with --path plugins/api and --since main
+    When the Farley Score section is emitted
+    Then the score is computed only over tests that are both under plugins/api and touched (directly or via covered production code) since main
+    And the report header reads "Farley Score (under plugins/api, changed since main)"
+
+  Scenario: Empty in-scope test set skips the Farley step
+    Given the resolved in-scope set contains no test files
+    When Step 3 runs
+    Then no Farley Score is emitted
+    And the report notes "no in-scope test files" in place of a score
+
+  Scenario: /test-health --path passes the scope through explicitly
+    Given the test-health SKILL is invoked with --path plugins/api
+    When Step 6 dispatches /test-design
+    Then the invocation string is "/test-design --path plugins/api"
+    And the test-health Output block renders the Farley Score line with the scope label
+
+  Scenario: /test-health without --path invokes /test-design without --path
+    Given the test-health SKILL is invoked with no --path
+    When Step 6 dispatches /test-design
+    Then the invocation string is "/test-design" (no --path)
+    And the resulting Farley line carries the "all tests" label
+
+  Scenario: /test-health --path with an empty subtree propagates the empty-scope note
+    Given the test-health SKILL is invoked with --path plugins/empty-dir
+    When Step 6 dispatches /test-design --path plugins/empty-dir and the resolved in-scope set is empty
+    Then the test-health Output block's Farley Score line notes "no in-scope test files" instead of a numeric score or label
+```
+
+**Steps:**
+
+#### Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
+
+**Complexity**: standard
+**RED**: Write `tests/docs/test_design_farley_scope_tests.bats` asserting the test-design SKILL
+
+- contains the three scope labels `Farley Score (all tests)`, `Farley Score (under`, and `Farley Score (changed since` in Step 3 or its report template,
+- documents combined-scope behaviour — grep for the combined-label form `Farley Score (under <dir>, changed since <ref>)` (or the templated equivalent `under .*, changed since`) and for wording establishing intersection semantics (e.g. `intersection`, `both`, `AND`),
+- contains an explicit "empty in-scope set" branch (grep for `no in-scope test files`),
+- explicitly documents Step 3 consuming Step 1's already-resolved file set (grep for a phrase like `set resolved in Step 1` / `reuse Step 1` / `already-resolved`),
+- no longer contains the leaky phrase "This headline score is independent of `--path` / `--since`".
+
+Write `tests/docs/test_health_farley_scope_tests.bats` asserting the test-health SKILL
+
+- contains the exact invocation string `/test-design --path` for the scoped branch (proves pass-through wiring is documented),
+- documents the **unscoped** branch too — grep for a bare `/test-design` dispatch line that does not carry a `--path` token (e.g. `dispatch \`/test-design\`` on its own, matched by an awk/grep rule that rejects `/test-design --path`),
+- documents the empty-scope pass-through — grep the test-health SKILL for the literal `no in-scope test files` string (closes Scenario 8 on the test-health side),
+- Output block references the scope label (grep for one of the three labels).
+
+Run `bats tests/docs/test_design_farley_scope_tests.bats tests/docs/test_health_farley_scope_tests.bats` — must fail.
+**GREEN**: N/A — this step's GREEN is the bats file existing and failing on the current SKILLs.
+**REFACTOR**: None needed.
+**Files**: `tests/docs/test_design_farley_scope_tests.bats`, `tests/docs/test_health_farley_scope_tests.bats`
+**Commit**: `test(test-design): add bats guards for scoped Farley Score (RED) (#533)`
+
+#### Step 1.2: GREEN — edit `test-design/SKILL.md` Step 3 + report header
+
+**Complexity**: standard
+**RED**: (already red from Step 1.1)
+**GREEN**: Rewrite Step 3 of `plugins/dev-team/skills/test-design/SKILL.md` so the Farley Score is computed over the in-scope test set. **Step 3 consumes the file set already resolved in Step 1 — do not re-implement path/diff matching; there is one scope-resolution authority in this SKILL.**
+
+- No `--path` / no `--since` → whole repo; label `all tests`.
+- `--path <dir>` → tests under `<dir>` OR covering production code under `<dir>`; label `under <dir>`.
+- `--since <ref>` → tests touched in the diff plus tests covering production files touched in the diff; label `changed since <ref>`.
+- Both `--path <dir>` and `--since <ref>` → the **intersection** (tests under `<dir>` AND touched, directly or via covered production code, since `<ref>`); label `under <dir>, changed since <ref>`.
+- Empty in-scope test set → skip the step; note `no in-scope test files` in the report.
+- Test-file identification continues to use `knowledge/test-file-indicators.md`.
+
+Update the Step 6 report template header from `Farley Score (all existing tests)` to `Farley Score (<scope>)` where `<scope>` is one of the three labels above, and add a one-line legend under the header.
+
+Run `bash scripts/ci-local.sh` — the two new bats files and every existing suite must pass.
+**REFACTOR**: If Step 3's prose has grown, tighten to match the surrounding brevity. Keep the section under its current line count.
+**Files**: `plugins/dev-team/skills/test-design/SKILL.md`
+**Commit**: `fix(test-design): scope Farley Score to --path/--since with explicit label (#533)`
+
+#### Step 1.3: GREEN — pass scope through `/test-health` Step 6 and render it in Output
+
+**Complexity**: standard
+**RED**: (already red from Step 1.1's test-health bats)
+**GREEN**: Edit `plugins/dev-team/skills/test-health/SKILL.md`:
+
+- In Step 6, make the `/test-design` invocation string explicit for **both** branches: when `--path <dir>` is set on `/test-health`, dispatch `/test-design --path <dir>`; when `--path` is not set, dispatch bare `/test-design` (no scope flag). Document both branches in the skill text so bats can pin each.
+- Update the Output block's "Test-design & mutation health" line so the Farley Score is rendered with its scope label (`(all tests)` / `(under <path>)` / `(changed since <ref>)`), consistent with `/test-design`'s new header. When `/test-design` returned the empty-scope note, propagate `no in-scope test files` verbatim into the health report — do not synthesize a number.
+- Constraint 4 ("No scoring reinvention") is unchanged — the wording still says *consume, don't restate*. We are propagating the label, not re-deriving the score.
+
+Run `bash scripts/ci-local.sh` again.
+**REFACTOR**: None needed.
+**Files**: `plugins/dev-team/skills/test-health/SKILL.md`
+**Commit**: `fix(test-health): pass --path through to /test-design and render Farley scope label (#533)`
+
+#### Step 1.4: REFACTOR — final sweep + eval check
+
+**Complexity**: trivial
+**RED**: N/A
+**GREEN**: N/A
+**REFACTOR**: Grep the repo for the stale phrase "score always reflects the full suite" / "all existing tests" / "headline score is independent" — replace any residual copies with the new scope-aware phrasing. Run `bash scripts/ci-local.sh` once more and, if the `/agent-eval` fixtures reference Farley behaviour, run them; nothing in `evals/expected/` currently pins Farley labels, so this is a no-op check.
+**Files**: potentially docs under `plugins/dev-team/docs/` if a stale reference is found.
+**Commit**: `docs(test-design): mop up stale "whole-suite Farley" references (#533)` (only if a stale line is found; otherwise skip the commit).
+
+## Parallelization
+
+Single slice → single wave. Nothing to parallelize.
+
+```mermaid
+graph TD
+  S1[Slice 1: Scope Farley + propagate through test-health]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+
+## Complexity Classification
+
+Slice 1 is `standard` — behavioral change within existing patterns, no new abstraction, no security surface. Step 1.4 is `trivial` (a grep-based cleanup gated on findings).
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (`bash scripts/ci-local.sh`)
+- [ ] Type check passes — N/A (no code)
+- [ ] Linter passes — covered by `ci-local.sh`
+- [ ] `/code-review` passes
+- [ ] Documentation updated — the two SKILL files are the documentation
+
+## Risks & Open Questions
+
+- **Risk**: A downstream consumer parses the exact string `Farley Score (all existing tests)`. **Mitigation**: The repo grep run in Step 1.4 catches this. If a hit surfaces, add its file to the plan before landing.
+- **Risk**: Stack-aware / test-modernize bats suites assert Farley-related strings. **Mitigation**: Step 1.1 runs the full `ci-local.sh` — any surprise breakage becomes visible before Step 1.2 lands.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Scope Farley to --path / --since and propagate through /test-health
+  - [ ] Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
+  - [ ] Step 1.2: GREEN — edit test-design/SKILL.md Step 3 + report header
+  - [ ] Step 1.3: GREEN — pass scope through /test-health Step 6 and render it in Output
+  - [ ] Step 1.4: REFACTOR — final sweep + eval check
+
+### Acceptance Criteria
+
+- [ ] `/test-design` (no scope) → header reads `Farley Score (all tests)`; score covers every test file in the repo.
+- [ ] `/test-design --path <dir>` → header reads `Farley Score (under <dir>)`; score covers only test files under `<dir>` or exercising production code under `<dir>`.
+- [ ] `/test-design --since <ref>` → header reads `Farley Score (changed since <ref>)`; score covers only tests touched in the diff or covering production files touched in the diff.
+- [ ] Empty in-scope test set → Step 3 skipped; report notes `no in-scope test files` instead of a score.
+- [ ] `/test-health --path <dir>` invocation string explicitly reads `/test-design --path <dir>` in the skill file.
+- [ ] `/test-health` with no `--path` invokes bare `/test-design` (no `--path` flag) — SKILL documents both branches.
+- [ ] `/test-design --path <dir> --since <ref>` combined: intersection scope; label reads `Farley Score (under <dir>, changed since <ref>)`.
+- [ ] `/test-health` Output template renders the Farley Score line with its scope label.
+- [ ] `bash scripts/ci-local.sh` passes.
+
+## Plan Review Summary
+
+Plan tier: **standard** — 1 slice, ≤ 4 files, no `complex` step, no high-reversal-cost decision axis. Reviewers dispatched: Acceptance Test Critic, Design & Architecture Critic. UX Critic skipped (no UI surface). Parallelization Critic skipped (single-slice plan — no waves to parallelize).
+
+- **Acceptance Test Critic**: `approve` after one revision — closed the unscoped `/test-health` → bare `/test-design` blocker and the combined-scope (`--path` + `--since`) blocker with new AC, scenario, and matching bats guard; also folded in the verification-surface preamble and the empty-scope pass-through on the test-health side.
+- **Design & Architecture Critic**: `approve` — dependency direction sound (farley-score stays a pure scorer; scope selection lives in the caller); test-health continues to consume rather than re-derive. One warning folded in: Step 3 must reuse Step 1's already-resolved file set (added to Step 1.2 GREEN and pinned by a Step 1.1 bats grep) to prevent scope-resolution drift.
+  - [ ] Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
+  - [ ] Step 1.2: GREEN — edit test-design SKILL Step 3 + report header
+  - [ ] Step 1.3: GREEN — pass scope through /test-health Step 6 and render in Output
+  - [ ] Step 1.4: REFACTOR — final sweep + eval check

--- a/plans/farley-score-honors-scope.md
+++ b/plans/farley-score-honors-scope.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-01
 **Branch**: issue-533
-**Status**: draft
+**Status**: implemented
 
 ## Goal
 
@@ -211,23 +211,23 @@ Slice 1 is `standard` — behavioral change within existing patterns, no new abs
 
 #### Wave 1
 
-- [ ] Slice 1: Scope Farley to --path / --since and propagate through /test-health
-  - [ ] Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
-  - [ ] Step 1.2: GREEN — edit test-design/SKILL.md Step 3 + report header
-  - [ ] Step 1.3: GREEN — pass scope through /test-health Step 6 and render it in Output
-  - [ ] Step 1.4: REFACTOR — final sweep + eval check
+- [x] Slice 1: Scope Farley to --path / --since and propagate through /test-health
+  - [x] Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
+  - [x] Step 1.2: GREEN — edit test-design/SKILL.md Step 3 + report header
+  - [x] Step 1.3: GREEN — pass scope through /test-health Step 6 and render it in Output
+  - [x] Step 1.4: REFACTOR — final sweep + eval check
 
 ### Acceptance Criteria
 
-- [ ] `/test-design` (no scope) → header reads `Farley Score (all tests)`; score covers every test file in the repo.
-- [ ] `/test-design --path <dir>` → header reads `Farley Score (under <dir>)`; score covers only test files under `<dir>` or exercising production code under `<dir>`.
-- [ ] `/test-design --since <ref>` → header reads `Farley Score (changed since <ref>)`; score covers only tests touched in the diff or covering production files touched in the diff.
-- [ ] Empty in-scope test set → Step 3 skipped; report notes `no in-scope test files` instead of a score.
-- [ ] `/test-health --path <dir>` invocation string explicitly reads `/test-design --path <dir>` in the skill file.
-- [ ] `/test-health` with no `--path` invokes bare `/test-design` (no `--path` flag) — SKILL documents both branches.
-- [ ] `/test-design --path <dir> --since <ref>` combined: intersection scope; label reads `Farley Score (under <dir>, changed since <ref>)`.
-- [ ] `/test-health` Output template renders the Farley Score line with its scope label.
-- [ ] `bash scripts/ci-local.sh` passes.
+- [x] `/test-design` (no scope) → header reads `Farley Score (all tests)`; score covers every test file in the repo.
+- [x] `/test-design --path <dir>` → header reads `Farley Score (under <dir>)`; score covers only test files under `<dir>` or exercising production code under `<dir>`.
+- [x] `/test-design --since <ref>` → header reads `Farley Score (changed since <ref>)`; score covers only tests touched in the diff or covering production files touched in the diff.
+- [x] Empty in-scope test set → Step 3 skipped; report notes `no in-scope test files` instead of a score.
+- [x] `/test-health --path <dir>` invocation string explicitly reads `/test-design --path <dir>` in the skill file.
+- [x] `/test-health` with no `--path` invokes bare `/test-design` (no `--path` flag) — SKILL documents both branches.
+- [x] `/test-design --path <dir> --since <ref>` combined: intersection scope; label reads `Farley Score (under <dir>, changed since <ref>)`.
+- [x] `/test-health` Output template renders the Farley Score line with its scope label.
+- [x] `bash scripts/ci-local.sh` passes (content checks; eslint failure is a pre-existing environment issue on `main`, not caused by this branch).
 
 ## Plan Review Summary
 
@@ -235,7 +235,9 @@ Plan tier: **standard** — 1 slice, ≤ 4 files, no `complex` step, no high-rev
 
 - **Acceptance Test Critic**: `approve` after one revision — closed the unscoped `/test-health` → bare `/test-design` blocker and the combined-scope (`--path` + `--since`) blocker with new AC, scenario, and matching bats guard; also folded in the verification-surface preamble and the empty-scope pass-through on the test-health side.
 - **Design & Architecture Critic**: `approve` — dependency direction sound (farley-score stays a pure scorer; scope selection lives in the caller); test-health continues to consume rather than re-derive. One warning folded in: Step 3 must reuse Step 1's already-resolved file set (added to Step 1.2 GREEN and pinned by a Step 1.1 bats grep) to prevent scope-resolution drift.
-  - [ ] Step 1.1: RED — bats guards pin the new behavioural contract on both SKILL files
-  - [ ] Step 1.2: GREEN — edit test-design SKILL Step 3 + report header
-  - [ ] Step 1.3: GREEN — pass scope through /test-health Step 6 and render in Output
-  - [ ] Step 1.4: REFACTOR — final sweep + eval check
+
+## Slice Review Summary (batched at slice boundary)
+
+- **spec-compliance-review**: `pass` — all 7 spec ACs and 9 plan ACs met, all 8 Gherkin scenarios have bats guards, no scope violations.
+- **doc-review**: `warn` — flagged `<dir>` vs `<path>` metavariable drift across the two SKILLs. Fixed (standardised on `<dir>` everywhere).
+- **token-efficiency-review**: `warn` — flagged label-form enumeration restated across three sites. Fixed (collapsed the report-header restatement to a single line pointing at Step 3, trimmed hedging in Step 3 and Step 6).

--- a/plans/farley-score-honors-scope.md
+++ b/plans/farley-score-honors-scope.md
@@ -241,3 +241,11 @@ Plan tier: **standard** — 1 slice, ≤ 4 files, no `complex` step, no high-rev
 - **spec-compliance-review**: `pass` — all 7 spec ACs and 9 plan ACs met, all 8 Gherkin scenarios have bats guards, no scope violations.
 - **doc-review**: `warn` — flagged `<dir>` vs `<path>` metavariable drift across the two SKILLs. Fixed (standardised on `<dir>` everywhere).
 - **token-efficiency-review**: `warn` — flagged label-form enumeration restated across three sites. Fixed (collapsed the report-header restatement to a single line pointing at Step 3, trimmed hedging in Step 3 and Step 6).
+
+## Final /code-review Summary
+
+- **arch-review**: `pass` — dependency direction preserved (farley-score → test-design → test-health); no layer boundary violation; sibling-pattern consistency verified.
+- **claude-setup-review**: `warn` (3 findings) — 2 fixed: added `role: orchestrator` to test-design frontmatter; trimmed unreachable `(changed since <ref>)` label variants from test-health Output block (test-health parses only `--path`). 1 skipped: folded-scalar cosmetic on test-health `description:` — out of scope for #533.
+- **test-review**: `warn` (5 findings) — 5 fixed: intersection-semantics grep no longer matches bare English words; unscoped-branch assertion pins branch-specific phrasing; Output-block scope-label check is section-scoped; added negative assertions for the remaining stale whole-suite phrases; added positive assertion pinning "single scope-resolution authority". All four tightened guards verified to fail against origin/main.
+
+**Branch Farley Score**: 8.9 / 10 (Good, borderline Exemplary) — 6 Exemplary, 8 Good, 0 below.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4707,7 +4707,7 @@
       "anchor": "2-dispatch-review-agents-parallel"
     },
     "3. Score the in-scope tests (Farley Score)": {
-      "summary": "Compute a Farley Score over the same file set already resolved in Step 1 — do",
+      "summary": "Using the file set already resolved in Step 1 (Step 1 is the single",
       "anchor": "3-score-the-in-scope-tests-farley-score"
     },
     "4. Run the advisor (when applicable)": {

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4706,9 +4706,9 @@
       "summary": "Spawn both as sub-agents in one batch:",
       "anchor": "2-dispatch-review-agents-parallel"
     },
-    "3. Score all existing tests (Farley Score)": {
-      "summary": "A user-requested test review reports a quality score for the whole suite, not",
-      "anchor": "3-score-all-existing-tests-farley-score"
+    "3. Score the in-scope tests (Farley Score)": {
+      "summary": "Compute a Farley Score over the same file set already resolved in Step 1 — do",
+      "anchor": "3-score-the-in-scope-tests-farley-score"
     },
     "4. Run the advisor (when applicable)": {
       "summary": "If `--advise` is set (or auto-triggered), use the Skill tool (`Skill(test-design-advisor ...)`) on the production code to produce testability assessment, pyramid",
@@ -4819,7 +4819,7 @@
       "anchor": "5-delegate-architecture-pipeline"
     },
     "6. Test-design + mutation health (ROI)": {
-      "summary": "Invoke `/test-design` on the target and consume its results: the suite-wide **Farley Score**, the dominant `test-review` / `test-smell-review` themes (weak assertions, non-determinism, fixture/structure smells, testability blockers), and the advisor's testability verdicts.",
+      "summary": "Invoke `/test-design` on the target, passing the same scope this run was",
       "anchor": "6-test-design-mutation-health-roi"
     },
     "7. Flaky-test + automation maturity": {

--- a/plugins/dev-team/skills/test-design/SKILL.md
+++ b/plugins/dev-team/skills/test-design/SKILL.md
@@ -94,15 +94,27 @@ Spawn both as sub-agents in one batch:
 Each returns its standard JSON (`status`/`issues`/`summary`). If no test files
 exist, both skip — proceed to Step 4 with `--advise`.
 
-### 3. Score all existing tests (Farley Score)
+### 3. Score the in-scope tests (Farley Score)
 
-A user-requested test review reports a quality score for the whole suite, not
-just the changed slice. Use the Skill tool (`Skill(farley-score ...)`) over **all
-existing test files in the repository** (use the test-file indicators in
-`knowledge/test-file-indicators.md`) to produce the suite-level Farley Score, rating,
-and distribution. This headline score is independent of `--path` / `--since` —
-those scope the findings below; the score always reflects the full suite. If the
-repository has no test files, skip this step and note it in the report.
+Compute a Farley Score over the same file set already resolved in Step 1 — do
+**not** re-implement path/diff matching; Step 1 is the single scope-resolution
+authority in this skill. Use the Skill tool (`Skill(farley-score ...)`) over
+that set to produce the Farley Score, rating, and distribution. Label the
+score with the scope it was computed over so a subtree audit never surfaces a
+whole-repo number by accident:
+
+- No `--path` / no `--since` → the set is every test file in the repository
+  (test-file indicators in `knowledge/test-file-indicators.md`); label
+  `all tests`.
+- `--path <dir>` → tests under `<dir>` **or** covering production code under
+  `<dir>`; label `under <dir>`.
+- `--since <ref>` → tests touched in the diff **plus** tests covering
+  production files touched in the diff; label `changed since <ref>`.
+- `--path <dir>` **and** `--since <ref>` together → the **intersection** —
+  tests under `<dir>` **AND** touched (directly or via covered production
+  code) since `<ref>`; label `under <dir>, changed since <ref>`.
+- If the in-scope test set is empty, skip the score and print
+  `no in-scope test files` in the report instead of a number.
 
 ### 4. Run the advisor (when applicable)
 
@@ -125,7 +137,14 @@ for a module):
 ## Test Design Review — <target>
 
 **Health**: <pass|attention|critical>   **Test files**: N   **Findings**: N
-**Farley Score (all existing tests)**: <score> (<rating>) — Exemplary N · Good N · Adequate N · Poor N
+**Farley Score (<scope>)**: <score> (<rating>) — Exemplary N · Good N · Adequate N · Poor N
+
+`<scope>` is one of `all tests` (unscoped), `under <path>` (`--path`),
+`changed since <ref>` (`--since`), or `under <path>, changed since <ref>`
+(both). When the in-scope test set is empty, replace the whole line with
+`**Farley Score**: no in-scope test files`. Concrete forms rendered by this
+skill: `Farley Score (all tests)`, `Farley Score (under plugins/api)`,
+`Farley Score (changed since main)`, `Farley Score (under plugins/api, changed since main)`.
 
 ### Test type definitions used in this report
 <one-line glosses for MinimumCD terms appearing below; verbatim from

--- a/plugins/dev-team/skills/test-design/SKILL.md
+++ b/plugins/dev-team/skills/test-design/SKILL.md
@@ -96,25 +96,22 @@ exist, both skip — proceed to Step 4 with `--advise`.
 
 ### 3. Score the in-scope tests (Farley Score)
 
-Compute a Farley Score over the same file set already resolved in Step 1 — do
-**not** re-implement path/diff matching; Step 1 is the single scope-resolution
-authority in this skill. Use the Skill tool (`Skill(farley-score ...)`) over
-that set to produce the Farley Score, rating, and distribution. Label the
-score with the scope it was computed over so a subtree audit never surfaces a
-whole-repo number by accident:
+Using the file set already resolved in Step 1 (Step 1 is the single
+scope-resolution authority in this skill), invoke `Skill(farley-score ...)`
+to produce the Farley Score, rating, and distribution. Label the score with
+the scope it was computed over:
 
-- No `--path` / no `--since` → the set is every test file in the repository
-  (test-file indicators in `knowledge/test-file-indicators.md`); label
-  `all tests`.
-- `--path <dir>` → tests under `<dir>` **or** covering production code under
+- No `--path` / no `--since` → every test file in the repository (test-file
+  indicators in `knowledge/test-file-indicators.md`); label `all tests`.
+- `--path <dir>` → tests under `<dir>` or covering production code under
   `<dir>`; label `under <dir>`.
-- `--since <ref>` → tests touched in the diff **plus** tests covering
-  production files touched in the diff; label `changed since <ref>`.
-- `--path <dir>` **and** `--since <ref>` together → the **intersection** —
-  tests under `<dir>` **AND** touched (directly or via covered production
-  code) since `<ref>`; label `under <dir>, changed since <ref>`.
-- If the in-scope test set is empty, skip the score and print
-  `no in-scope test files` in the report instead of a number.
+- `--since <ref>` → tests touched in the diff plus tests covering production
+  files touched in the diff; label `changed since <ref>`.
+- `--path <dir>` and `--since <ref>` together → tests under `<dir>` that are
+  also touched (directly or via covered production code) since `<ref>` — the
+  intersection of both sets; label `under <dir>, changed since <ref>`.
+- Empty in-scope test set → skip the score and print `no in-scope test files`
+  in the report instead of a number.
 
 ### 4. Run the advisor (when applicable)
 
@@ -139,12 +136,11 @@ for a module):
 **Health**: <pass|attention|critical>   **Test files**: N   **Findings**: N
 **Farley Score (<scope>)**: <score> (<rating>) — Exemplary N · Good N · Adequate N · Poor N
 
-`<scope>` is one of `all tests` (unscoped), `under <path>` (`--path`),
-`changed since <ref>` (`--since`), or `under <path>, changed since <ref>`
-(both). When the in-scope test set is empty, replace the whole line with
-`**Farley Score**: no in-scope test files`. Concrete forms rendered by this
-skill: `Farley Score (all tests)`, `Farley Score (under plugins/api)`,
-`Farley Score (changed since main)`, `Farley Score (under plugins/api, changed since main)`.
+`<scope>` is the label produced by Step 3; render it verbatim. Concrete
+forms: `Farley Score (all tests)`, `Farley Score (under <dir>)`,
+`Farley Score (changed since <ref>)`, `Farley Score (under <dir>, changed since <ref>)`.
+When the in-scope set was empty, replace the whole line with
+`**Farley Score**: no in-scope test files`.
 
 ### Test type definitions used in this report
 <one-line glosses for MinimumCD terms appearing below; verbatim from

--- a/plugins/dev-team/skills/test-design/SKILL.md
+++ b/plugins/dev-team/skills/test-design/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   writing a suite for an untested module. For a single unit, pass
   --advise --path <file>. Advisory — it recommends, it does not edit.
 argument-hint: "[--path <dir>] [--since <ref>] [--advise]"
+role: orchestrator
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Bash(git diff *), Skill, Agent
 ---

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -57,9 +57,9 @@ inherits a whole-repo Farley Score:
 - `/test-health --path <dir>` → dispatch `/test-design --path <dir>`.
 - `/test-health` (unscoped) → dispatch `/test-design` with no scope flag.
 
-Consume its results: the scope-labelled **Farley Score** (`(all tests)` /
-`(under <dir>)` / `(changed since <ref>)` / `(under <dir>, changed since <ref>)`,
-or the empty-scope note `no in-scope test files`), the dominant
+Consume its results: the scope-labelled **Farley Score** (`(all tests)` when
+unscoped, `(under <dir>)` when passing `--path`, or the empty-scope note
+`no in-scope test files` when the in-scope set is empty), the dominant
 `test-review` / `test-smell-review` themes (weak assertions,
 non-determinism, fixture/structure smells, testability blockers), and the
 advisor's testability verdicts. Then invoke `mutation-testing` on the
@@ -116,10 +116,10 @@ Write `reports/test-health-<date>.md`.
 
 ### Test-design & mutation health (via /test-design + mutation-testing)
 <Farley Score — render the scope-labelled value from `/test-design`
-verbatim (one of `(all tests)`, `(under <dir>)`, `(changed since <ref>)`,
-`(under <dir>, changed since <ref>)`), or the literal `no in-scope test files`
-when the in-scope set was empty; do not synthesize a number. Top test-design
-themes · mutation ROI hotspots · under-covered critical logic>
+verbatim (`(all tests)` when this run is unscoped, `(under <dir>)` when
+`--path` is set), or the literal `no in-scope test files` when the in-scope
+set was empty; do not synthesize a number. Top test-design themes ·
+mutation ROI hotspots · under-covered critical logic>
 
 ### Gap classification
 | Gap | Class (NO_REFACTOR / REFACTOR_REQUIRED / LOW_VALUE) | Note |

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -115,11 +115,11 @@ Write `reports/test-health-<date>.md`.
 <one-paragraph summary + link to its report>
 
 ### Test-design & mutation health (via /test-design + mutation-testing)
-<Farley Score with scope label — one of `(all tests)`, `(under <path>)`,
-`(changed since <ref>)`, `(under <path>, changed since <ref>)`, or the
-literal `no in-scope test files` when the in-scope set was empty; render
-the label /test-design returned verbatim — do not synthesize a number.
-Top test-design themes · mutation ROI hotspots · under-covered critical logic>
+<Farley Score — render the scope-labelled value from `/test-design`
+verbatim (one of `(all tests)`, `(under <dir>)`, `(changed since <ref>)`,
+`(under <dir>, changed since <ref>)`), or the literal `no in-scope test files`
+when the in-scope set was empty; do not synthesize a number. Top test-design
+themes · mutation ROI hotspots · under-covered critical logic>
 
 ### Gap classification
 | Gap | Class (NO_REFACTOR / REFACTOR_REQUIRED / LOW_VALUE) | Note |

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -50,7 +50,26 @@ Invoke `cd-test-architecture` on the target. Summarize its findings (which tests
 
 ### 6. Test-design + mutation health (ROI)
 
-Invoke `/test-design` on the target and consume its results: the suite-wide **Farley Score**, the dominant `test-review` / `test-smell-review` themes (weak assertions, non-determinism, fixture/structure smells, testability blockers), and the advisor's testability verdicts. Then invoke `mutation-testing` on the **critical-logic** modules only (not the whole repo — that's the ROI framing). Roll both up: where is coverage high but mutation-weak (assertions that don't catch bugs)? Where do test-design smells concentrate? Where is critical logic under-covered? Prioritize by risk, not by raw %. Both feed the ordered plan (Step 8) — summarize the themes and link to the `/test-design` report for per-file detail; do not reproduce it.
+Invoke `/test-design` on the target, passing the same scope this run was
+invoked with — the dispatch must be explicit so a subtree audit never
+inherits a whole-repo Farley Score:
+
+- `/test-health --path <dir>` → dispatch `/test-design --path <dir>`.
+- `/test-health` (unscoped) → dispatch `/test-design` with no scope flag.
+
+Consume its results: the scope-labelled **Farley Score** (`(all tests)` /
+`(under <dir>)` / `(changed since <ref>)` / `(under <dir>, changed since <ref>)`,
+or the empty-scope note `no in-scope test files`), the dominant
+`test-review` / `test-smell-review` themes (weak assertions,
+non-determinism, fixture/structure smells, testability blockers), and the
+advisor's testability verdicts. Then invoke `mutation-testing` on the
+**critical-logic** modules only (not the whole repo — that's the ROI
+framing). Roll both up: where is coverage high but mutation-weak
+(assertions that don't catch bugs)? Where do test-design smells
+concentrate? Where is critical logic under-covered? Prioritize by risk,
+not by raw %. Both feed the ordered plan (Step 8) — summarize the themes
+and link to the `/test-design` report for per-file detail; do not
+reproduce it.
 
 ### 7. Flaky-test + automation maturity
 
@@ -96,7 +115,11 @@ Write `reports/test-health-<date>.md`.
 <one-paragraph summary + link to its report>
 
 ### Test-design & mutation health (via /test-design + mutation-testing)
-<Farley score · top test-design themes · mutation ROI hotspots · under-covered critical logic>
+<Farley Score with scope label — one of `(all tests)`, `(under <path>)`,
+`(changed since <ref>)`, `(under <path>, changed since <ref>)`, or the
+literal `no in-scope test files` when the in-scope set was empty; render
+the label /test-design returned verbatim — do not synthesize a number.
+Top test-design themes · mutation ROI hotspots · under-covered critical logic>
 
 ### Gap classification
 | Gap | Class (NO_REFACTOR / REFACTOR_REQUIRED / LOW_VALUE) | Note |

--- a/tests/docs/test_design_farley_scope_tests.bats
+++ b/tests/docs/test_design_farley_scope_tests.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Regression guard for #533: Farley Score in /test-design must honor
+# --path / --since scope and label the score with the scope it was
+# computed over.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-design/SKILL.md"
+
+@test "test-design SKILL declares the unscoped Farley Score label" {
+  run grep -c "Farley Score (all tests)" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL declares the --path Farley Score label" {
+  run grep -c "Farley Score (under" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL declares the --since Farley Score label" {
+  run grep -c "Farley Score (changed since" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL declares the combined --path + --since label" {
+  # e.g. "Farley Score (under <dir>, changed since <ref>)"
+  run grep -Ec "Farley Score \(under [^,)]+, changed since" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL documents intersection semantics for combined scope" {
+  # Any of: 'intersection', 'both ... and', 'AND'.
+  run grep -Eci "intersection|\\bboth\\b|\\bAND\\b" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL declares the empty-scope branch" {
+  run grep -c "no in-scope test files" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL directs Step 3 to reuse Step 1's resolved file set" {
+  run grep -Eci "set (already )?resolved in Step 1|reuse Step 1|already-resolved" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-design SKILL no longer claims Farley is independent of --path / --since" {
+  run grep -c "This headline score is independent of" "$SKILL"
+  [ "$output" -eq 0 ]
+}

--- a/tests/docs/test_design_farley_scope_tests.bats
+++ b/tests/docs/test_design_farley_scope_tests.bats
@@ -31,8 +31,9 @@ SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-design/SKILL.md"
 }
 
 @test "test-design SKILL documents intersection semantics for combined scope" {
-  # Any of: 'intersection', 'both ... and', 'AND'.
-  run grep -Eci "intersection|\\bboth\\b|\\bAND\\b" "$SKILL"
+  # Match specific phrases, not the bare word 'both' or 'and' which
+  # appear in ordinary prose all over the SKILL.
+  run grep -Ec "\\bintersection\\b|the intersection of both sets" "$SKILL"
   [ "$status" -eq 0 ]
   [ "$output" -gt 0 ]
 }
@@ -49,7 +50,19 @@ SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-design/SKILL.md"
   [ "$output" -gt 0 ]
 }
 
+@test "test-design SKILL names Step 1 as the single scope-resolution authority" {
+  # Collapse newlines before matching so a soft-wrapped phrase still hits.
+  run bash -c "tr '\n' ' ' < \"$SKILL\" | grep -Eci 'single[[:space:]]+scope-resolution authority|one[[:space:]]+scope-resolution authority'"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
 @test "test-design SKILL no longer claims Farley is independent of --path / --since" {
   run grep -c "This headline score is independent of" "$SKILL"
+  [ "$output" -eq 0 ]
+}
+
+@test "test-design SKILL no longer carries the whole-suite stale phrases" {
+  run grep -Ec "score always reflects the full suite|Farley Score \\(all existing tests\\)" "$SKILL"
   [ "$output" -eq 0 ]
 }

--- a/tests/docs/test_health_farley_scope_tests.bats
+++ b/tests/docs/test_health_farley_scope_tests.bats
@@ -5,25 +5,21 @@
 
 SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-health/SKILL.md"
 
-@test "test-health SKILL documents the scoped /test-design invocation string" {
-  # Explicit "when --path is set, dispatch /test-design --path <dir>".
-  run grep -c "/test-design --path" "$SKILL"
+@test "test-health SKILL documents the scoped /test-design invocation with a metavariable" {
+  # Require the templated form '/test-design --path <dir>' (or a
+  # ${var}-style substitution), not just the bare substring.
+  run grep -Ec "/test-design --path <[^>]+>|/test-design --path \\\$\\{[^}]+\\}" "$SKILL"
   [ "$status" -eq 0 ]
   [ "$output" -gt 0 ]
 }
 
-@test "test-health SKILL documents the unscoped /test-design invocation" {
-  # There must be at least one line that dispatches /test-design without
-  # a --path token — the unscoped branch. Reject lines that mention
-  # /test-design and also carry --path.
-  run awk '
-    BEGIN { found = 0 }
-    /\/test-design/ {
-      if ($0 !~ /--path/ && $0 !~ /--since/) { found = 1 }
-    }
-    END { exit(found ? 0 : 1) }
-  ' "$SKILL"
+@test "test-health SKILL documents the unscoped /test-design invocation branch" {
+  # Pin the specific branch phrasing rather than any incidental /test-design
+  # mention. Prior looser awk allowed lines like line 22's
+  # 'come from /test-design (Farley Score + ...)' to satisfy the assertion.
+  run grep -Eci "unscoped.*dispatch|dispatch .*/test-design.*(no scope flag|without --path|no --path)|/test-design.*with no scope flag" "$SKILL"
   [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
 }
 
 @test "test-health SKILL propagates the empty-scope note (no in-scope test files)" {
@@ -32,9 +28,13 @@ SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-health/SKILL.md"
   [ "$output" -gt 0 ]
 }
 
-@test "test-health SKILL renders a Farley Score scope label in its Output block" {
-  # Any of the three canonical labels must appear.
-  run grep -Ec "\(all tests\)|\(under [^)]+\)|\(changed since [^)]+\)" "$SKILL"
-  [ "$status" -eq 0 ]
-  [ "$output" -gt 0 ]
+@test "test-health SKILL renders a Farley Score scope label in the Output block" {
+  # Slice the Output-block section before matching, so an incidental label
+  # mention in Step 6 prose alone would not satisfy this assertion.
+  section="$(awk '
+    /^### Test-design & mutation health/ { on = 1; print; next }
+    on && /^### / { on = 0 }
+    on { print }
+  ' "$SKILL")"
+  echo "$section" | grep -Eq "\(all tests\)|\(under [^)]+\)"
 }

--- a/tests/docs/test_health_farley_scope_tests.bats
+++ b/tests/docs/test_health_farley_scope_tests.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# Regression guard for #533: /test-health must pass its --path through
+# to /test-design explicitly and render the scope label in its Output
+# block, so a subtree audit never inherits a whole-repo score.
+
+SKILL="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/test-health/SKILL.md"
+
+@test "test-health SKILL documents the scoped /test-design invocation string" {
+  # Explicit "when --path is set, dispatch /test-design --path <dir>".
+  run grep -c "/test-design --path" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-health SKILL documents the unscoped /test-design invocation" {
+  # There must be at least one line that dispatches /test-design without
+  # a --path token — the unscoped branch. Reject lines that mention
+  # /test-design and also carry --path.
+  run awk '
+    BEGIN { found = 0 }
+    /\/test-design/ {
+      if ($0 !~ /--path/ && $0 !~ /--since/) { found = 1 }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "test-health SKILL propagates the empty-scope note (no in-scope test files)" {
+  run grep -c "no in-scope test files" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test-health SKILL renders a Farley Score scope label in its Output block" {
+  # Any of the three canonical labels must appear.
+  run grep -Ec "\(all tests\)|\(under [^)]+\)|\(changed since [^)]+\)" "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}


### PR DESCRIPTION
Closes #533.

## Summary

- `/test-design` Farley Score now honors `--path` / `--since` and labels the score with the scope it was computed over (`all tests` / `under <dir>` / `changed since <ref>` / `under <dir>, changed since <ref>`). An empty in-scope set prints `no in-scope test files` instead of a number.
- `/test-health` Step 6 dispatches `/test-design --path <dir>` when its own `--path` is set (bare `/test-design` otherwise), and renders the scope label the child returned verbatim — Constraint 4 ("No scoring reinvention") preserved.
- Step 3 of test-design now consumes the file set already resolved in Step 1 — Step 1 is the single scope-resolution authority in the skill, so path/diff matching does not drift between the two steps.
- New bats suites at `tests/docs/test_design_farley_scope_tests.bats` (10 assertions) and `tests/docs/test_health_farley_scope_tests.bats` (4 assertions) pin the documented contract; all four tightened guards verified to fail against `origin/main`.

## Quality Gate

- [x] Content bats suites pass (`ci-local.sh --only=chk_bats_repo,chk_bats_content_rest,chk_md_references,chk_skills_index,chk_nav_integrity`)
- [x] `/code-review` — 3 agents (arch-review, claude-setup-review, test-review): 8 findings surfaced, 8 addressed (fix loop, 1 iteration)
- [x] Branch Farley Score: **8.9 / 10** (Good, borderline Exemplary — 6 Exemplary, 8 Good, 0 below)
- [x] Progress guardian: `warn` (scope-check LLM confirmed `knowledge/index.json` regen, not scope creep)
- ⚠ Pre-existing eslint env issue on `main` (`npm error npx canceled ... eslint@10.6.0`) — unrelated to this branch; GitHub Actions resolves its own deps

## Test Plan

- [ ] `bats tests/docs/test_design_farley_scope_tests.bats tests/docs/test_health_farley_scope_tests.bats` — 14 assertions all green
- [ ] Manual: invoke `/test-design --path <subdir>` and confirm the report header reads `Farley Score (under <subdir>)`, not `(all existing tests)`
- [ ] Manual: invoke `/test-health --path <subdir>` and confirm the Farley Score line in its report carries `(under <subdir>)`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
