### PR TITLE
feat(mutation-testing): 8 improvements from .NET mutation drive

### DIFF
--- a/docs/specs/mutation-testing-net-improvements.md
+++ b/docs/specs/mutation-testing-net-improvements.md
@@ -1,0 +1,155 @@
+<!-- spec-version: 1 -->
+# Spec: .NET Mutation-Testing Improvements (issue #528)
+
+**Format:** dev-team `/specs` v1
+
+## Intent Description
+
+Eight improvements to the dev-team plugin's mutation-testing surface, derived from a real .NET 10 / ASP.NET Core mutation drive (57.69% → 75.75%, 448 new tests, 5 waves). The current agent spec and C# reference silently misrepresent the Stryker.NET score, offer no `NoCoverage`-first prioritization, force a serial file-by-file loop, and lack build/exclusion guardrails — each of which cost real time on the drive.
+
+The change updates three files:
+
+- `plugins/dev-team/agents/mutation-kill.md` — score formulas (report both honest and Stryker-reported), NoCoverage-first prioritization, infrastructure-exclusion detection, `--parallel <n>` flag and orchestration logic, stale-build step, structurally-untestable pattern catalog.
+- `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` — `--since` incremental-run pattern with the "verification-config-has-no-since" trap called out, infrastructure exclusion template, NoCoverage denominator note. The `--report-file-name` correction from issue #522 stays as-is (already landed).
+- `plugins/dev-team/hooks/mutation-adapters/stryker-net.sh` — env-var-gated `--since` pass-through: `STRYKER_SINCE_TARGET=<ref>` + `CI!=true` adds `--since:<ref>` to the run; unset in CI.
+
+Item 3 (parallel agents) lands as a real `--parallel <n>` flag with orchestration logic, per user decision. Item 7 lands as env-var-gated pass-through only, per user decision. Item 8 is a patch checklist; every row folds into items 1–7 or the two files above — no new `mutation-test-workflow.md` doc is created (that file does not exist and the issue's rows all have homes in existing files).
+
+The PR body must include `Closes #528`. This diff touches code and hook files, so **auto-merge is not armed** — merge requires explicit human approval per the repo working rules.
+
+## Architecture Specification
+
+**Files touched:**
+
+1. `plugins/dev-team/agents/mutation-kill.md`
+2. `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+3. `plugins/dev-team/hooks/mutation-adapters/stryker-net.sh`
+4. `tests/agents/mutation_kill_agent_tests.bats` — update existing formula assertion + add tests for new sections
+5. `tests/hooks/stryker_net_adapter_tests.bats` — add `--since` pass-through tests
+
+**Changes per file:**
+
+### `mutation-kill.md`
+
+- Replace the "The honest score — hard kills only" section:
+  - `honest_score = Killed / (Killed + Survived + NoCoverage)` (gates on this)
+  - `reported_score = (Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)` (reported for parity with Stryker HTML report)
+  - `NoCoverage` is a first-class signal: each NoCoverage→Killed conversion improves the score as much as killing a Survived mutant, and is usually easier (any test reaching the line, not one detecting a specific value change). Prioritize NoCoverage coverage **before** attacking hard Survived mutations.
+  - Timeout continues to be reported separately and excluded from the gate numerator; the change is that `NoCoverage` is now in the denominator, matching Stryker.NET 4.x.
+- Add a "Step 0: Build first" preamble to the Loop:
+  - `dotnet build <SOLUTION> -c Debug --nologo` (or language equivalent). Build failure = STOP. Never use `--no-build` when running mutation testing.
+- Add "Infrastructure exclusion detection" section (after baseline parse, before generation loop):
+  - Scan for files where `score < 15%` AND `NoCoverage > 50%` of effective mutants
+  - Match filenames: `Startup.cs`, `Program.cs`, `*Filter.cs`, `*Middleware.cs`, `*Logger*.cs`, `*HealthCheck*.cs`, `*.Designer.cs`
+  - For each match, ask: "DI registration / exception handlers / generated code that the test surface can't reach?" — yes → add to mutate exclusion list with a documented reason; no → keep in scope
+  - Log format: `EXCLUDED <file> — <reason>: <mutation types> are equivalent in <test surface>`
+- Add `--parallel <n>` flag to the Invocation block, and a new "Parallel execution (Phase 4)" section:
+  - With `--all --parallel <n>`: sort files by survivor count (desc), cap at first `4×n` candidates, group into `n` batches of up to 4 files each, spawn `n` sub-agents in parallel via the Agent tool (not git worktrees — test-file writes don't conflict with source-file reads), each sub-agent reads survivors from the baseline JSON and targets in priority order, synthesize results, repeat for next batch if survivors still exceed threshold
+  - Agent count per batch: 3–4 for easy types (String / Equality / ObjectInit), 1–2 for hard types (Statement / Block) to avoid conflicting test edits
+  - This is orthogonal to the existing `--concurrency` flag (which is for worktree-based file-level parallelism); `--parallel` is Agent-tool-based, in-process, targeted at Phase 4 sub-agent fan-out
+- Expand "Structurally unkillable files" section to catalog three specific patterns:
+  1. `#if DEBUG` / `#if RELEASE` compilation blocks — code under test doesn't exist in the test build
+  2. Service-locator pattern (`HttpContext.RequestServices.GetService<T>()`) — cannot inject mocks without full IServiceProvider per test; requires refactor
+  3. Pure DI registration (`services.AddX()`, `builder.Services.AddX()`) — TestStartup/TestServer overrides the real container; exclude the whole file from the mutate glob
+  - Each with the `EXCLUDED` log line format already documented in the file. Action: log as technical debt, never spend rounds trying to kill.
+
+### `csharp-stryker-net.md`
+
+- Add "`--since` incremental-run pattern" subsection under `## Run (scoped)`:
+  - Dev-shard config example with `"since": { "enabled": true, "target": "main" }`
+  - Explicit trap callout: **`--since` limits mutations to source files that changed since the git ref; test-file changes do NOT trigger source mutations. A verification run through a `--since` config silently produces 0 results — always use a separate verification config with no `since` block.**
+- Add "Infrastructure exclusion template" subsection with the `mutate` glob showing `!**/Startup.cs`, `!**/Program.cs`, `!**/*ExceptionFilter.cs`, `!**/*ExceptionFormatter.cs`, `!**/*LoggerService.cs`, `!**/*.Designer.cs`.
+- Add "NoCoverage denominator note" subsection:
+  - Stryker.NET score formula: `(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)`
+  - NoCoverage sits in the denominator even though those mutants are never tested. A file with 27 NoCoverage mutants at 0% score drags overall score down more than a file with 20 Survived at 70%. Fix NoCoverage first.
+- Preserve every existing correction from issue #522 (spec `stryker-net-workflow-corrections.md`); no rewrites.
+
+### `stryker-net.sh`
+
+- After `stryker_args` is built, before the `_timeout ... dotnet stryker` call, append this guarded block:
+
+  ```bash
+  # Dev-only: --since limits mutation to files changed vs the target ref.
+  # Skipped in CI (full run needed for the gate score).
+  if [ "${CI:-}" != "true" ] && [ -n "${STRYKER_SINCE_TARGET:-}" ]; then
+    stryker_args+=(--since:"$STRYKER_SINCE_TARGET")
+  fi
+  ```
+
+- No behavior change when `STRYKER_SINCE_TARGET` is unset or when `CI=true`.
+- Document the env var in the file header comment near `STRYKER_NET_REPORT`.
+
+**Test updates:**
+
+- `tests/agents/mutation_kill_agent_tests.bats`
+  - Update the honest-score assertion (line ~27) to match the new formula: `Killed / (Killed + Survived + NoCoverage)`.
+  - Add tests for: `--parallel` flag exists, NoCoverage-first prioritization is documented, infrastructure exclusion detection is documented, `dotnet build` step precedes the loop, all three structurally-untestable patterns are cataloged.
+- `tests/hooks/stryker_net_adapter_tests.bats`
+  - Add: `STRYKER_SINCE_TARGET` set + `CI` unset → args include `--since:<ref>`
+  - Add: `STRYKER_SINCE_TARGET` set + `CI=true` → args do NOT include `--since`
+  - Add: `STRYKER_SINCE_TARGET` unset → args do NOT include `--since` (baseline behavior preserved)
+
+**Constraints:**
+
+- Only the three files (plus their tests) change. No new files created; `mutation-test-workflow.md` is explicitly NOT created (does not exist; not in repo).
+- Shard-aware execution guidance in `csharp-stryker-net.md` is preserved; new sections are additive.
+- `--parallel` and `--concurrency` are orthogonal, independently overridable, both documented.
+- Every gate/exit condition documented in the existing agent (no-improvement exit, duplicate detection, revert on failure, structurally-unkillable exclusion) is preserved.
+- `/agent-audit` must pass on the modified agent file (structural / frontmatter / registry).
+- Bats suites (`stryker_net_adapter_tests.bats`, `mutation_kill_agent_tests.bats`) pass in `scripts/ci-local.sh`.
+- PR title uses conventional-commit prefix `feat(mutation-testing):` — this is a code + hook change that adds capability, so it's `feat:`, not `docs:`.
+
+**Non-goals:**
+
+- No refactor of `SKILL.md` workflow steps for mutation-testing.
+- No change to the JSON envelope, `--emit-json` schema, or workflow-callers registry.
+- No auto-detection of `--since` target — user must set `STRYKER_SINCE_TARGET` explicitly (per user decision).
+- No auto-detection of xunit.v3 in the adapter (that's issue #522's out-of-scope deferral, still deferred).
+- No worktree change; `--parallel` uses in-process Agent tool fan-out, not worktrees.
+
+## Acceptance Criteria
+
+Every criterion is observable by grepping a file or running a specific test suite.
+
+1. **Honest score formula updated.** `grep -F "Killed / (Killed + Survived + NoCoverage)" plugins/dev-team/agents/mutation-kill.md` returns 1 line. The reported-score formula `(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)` is also present. Both are labeled: `honest_score` gates; `reported_score` is for HTML-report parity.
+2. **NoCoverage-first prioritization documented.** `grep -c -i "NoCoverage" plugins/dev-team/agents/mutation-kill.md` returns ≥ 3 (formula, first-class-signal note, prioritization guidance). The file states NoCoverage → Killed is prioritized before hard Survived mutations, with the "any test reaching the line" rationale.
+3. **Infrastructure exclusion detection documented.** `mutation-kill.md` contains a section that names the score/NoCoverage thresholds (< 15% score, > 50% NoCoverage) and lists the file patterns (`Startup.cs`, `Program.cs`, `*Filter.cs`, `*Middleware.cs`, `*Logger*.cs`, `*HealthCheck*.cs`, `*.Designer.cs`). The `EXCLUDED <file> — <reason>:` log format is present.
+4. **`--parallel <n>` flag present and documented.** The Invocation block includes `[--parallel <n>]`. A "Parallel execution" section explains agent-tool fan-out (not worktrees), batch sizing (4 files per agent, 3–4 agents for easy types, 1–2 for hard), and the mutation-type gating for parallel dispatch.
+5. **Stale-build step documented.** `mutation-kill.md` contains a "Build first" step preceding the Loop, showing `dotnet build ... --nologo` and the rule "never use `--no-build` when running mutation testing".
+6. **Structurally untestable patterns cataloged.** The "Structurally unkillable files" section documents all three patterns (`#if DEBUG`/`#if RELEASE`, service-locator, pure DI registration) with the `EXCLUDED` log line for each.
+7. **`--since` incremental-run pattern added to C# reference.** `csharp-stryker-net.md` contains a subsection showing the `"since": { "enabled": true, "target": "main" }` config block and the explicit trap: "test-file changes do NOT trigger source mutations; verification runs must use a separate config with no `since` block".
+8. **Infrastructure exclusion template added to C# reference.** `csharp-stryker-net.md` contains a `mutate` glob template with `!**/Startup.cs`, `!**/Program.cs`, `!**/*ExceptionFilter.cs`, `!**/*ExceptionFormatter.cs`, `!**/*LoggerService.cs`, `!**/*.Designer.cs`.
+9. **NoCoverage denominator note added to C# reference.** `csharp-stryker-net.md` contains the Stryker.NET score formula `(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)` and the "fix NoCoverage first" rationale.
+10. **`--since` env-var pass-through added to adapter.** `stryker-net.sh` includes the guarded block: `if [ "${CI:-}" != "true" ] && [ -n "${STRYKER_SINCE_TARGET:-}" ]; then stryker_args+=(--since:"$STRYKER_SINCE_TARGET"); fi`. The env var is documented in the file header comment.
+11. **Adapter tests cover all three env-var branches.** `stryker_net_adapter_tests.bats` includes tests that verify: (a) `STRYKER_SINCE_TARGET=main` + `CI=` → `--since:main` in the command line; (b) `STRYKER_SINCE_TARGET=main` + `CI=true` → no `--since`; (c) `STRYKER_SINCE_TARGET=` → no `--since` (baseline preserved).
+12. **Agent tests updated for new formula.** `mutation_kill_agent_tests.bats` asserts `Killed */ *\(Killed \+ Survived \+ NoCoverage\)` (or an equivalent regex) rather than the old `Killed / (Total - Ignored - CompileError - Timeout)` form.
+13. **Existing invariants preserved.** All pre-existing tests in `mutation_kill_agent_tests.bats` still pass (frontmatter, 500-line ceiling, priority table, duplicate detection, no-improvement exit, revert-on-failure, structurally-unkillable exclusion, Go advisory).
+14. **Local CI gate green.** `bash scripts/ci-local.sh` (or the mutation-adapter and agent bats suites at minimum) exits 0.
+15. **`/agent-audit` passes.** Structural, frontmatter, and registry checks on the modified agent file pass.
+16. **PR closes the issue on merge.** PR body contains `Closes #528`. `gh pr view <num> --json body` shows the string. Merging the PR auto-closes issue #528.
+17. **PR title conventional.** PR title is `feat(mutation-testing): ...` (bumps minor version via release-please). Not `docs:`, not `fix:`.
+18. **Auto-merge NOT armed.** Because the diff touches `agents/`, `hooks/`, and `tests/`, the repo working rule mandates explicit human merge. Do not execute `gh pr merge <num> --auto`.
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|---|---|---|---|
+| Item 3 shape — doc-only pattern description vs real `--parallel <n>` flag with orchestration logic? | `requires-stakeholder-input` | human | User chose "Add `--parallel <n>` flag and orchestration logic". Larger surface than doc-only, but delivers the productivity win the issue describes. |
+| Item 7 shape — env-var-gated pass-through vs adapter-side auto-detection of `since` target? | `requires-stakeholder-input` | human | User chose env-var-gated pass-through. Auto-detection would risk silent zero-mutation runs users didn't ask for; explicit opt-in via `STRYKER_SINCE_TARGET` is the safer default. |
+| Item 8 target — patch a nonexistent `mutation-test-workflow.md`, or fold rows into existing files? | `requires-stakeholder-input` | human | User chose "fold into `mutation-kill.md` + `csharp-stryker-net.md`". `find . -name 'mutation-test-workflow*'` returns nothing; every row in the item-8 table maps directly onto items 1–7 or the C# reference. |
+| Where does `--parallel` live — flag on the mutation-kill agent, or a new orchestration skill? | `inferable` | inference | Issue text describes it as an agent-level fan-out pattern within the existing Phase 4 loop. `mutation-kill` already has `--concurrency` (worktree-based); adding `--parallel` (Agent-tool-based) as a sibling flag on the same agent is consistent with the existing surface. A new orchestration skill would duplicate scope. |
+| Should `--parallel` also use git worktrees? | `inferable` | inference | Issue text explicitly says "test files don't conflict with source files, so git worktrees aren't needed. Simple parallel Agent tool calls are sufficient." Documented accordingly. |
+| Priority: NoCoverage vs Survived. Should the agent be **required** to attack NoCoverage before Survived, or is this advisory? | `inferable` | inference | Issue text says "Prioritize NoCoverage coverage BEFORE attacking hard Survived mutations" — imperative. Documented as agent behavior, not advisory. |
+| Should `--since` pass-through also validate that `STRYKER_SINCE_TARGET` is a valid git ref before passing it? | `inferable` | inference | No. The adapter is a thin pass-through; Stryker.NET itself will surface the invalid-ref error clearly, and adding pre-validation would duplicate git plumbing in the hook. Keep the block minimal (matches the exact snippet in the issue). |
+| Auto-merge armed? | `inferable` | inference | Repo CLAUDE.md working rules: only diffs touching only `*.md` (+ non-shipping metadata) auto-merge. This diff touches `.sh`, `.bats`, and agent files — explicit human merge required. Do not arm auto-merge. |
+| Conventional-commit prefix — `feat:`, `fix:`, or `docs:`? | `inferable` | inference | This adds capabilities (`--parallel` flag, `--since` pass-through, NoCoverage prioritization) and changes agent behavior — `feat(mutation-testing):`. Bumps minor version via release-please, correct for user-visible new capability. The issue title uses `fix:` but the actual change set is additive; PR title takes precedence. |
+| Should `honest_score` denominator change break existing consumers? | `inferable` | inference | The formula is internal to the agent's decision-making and reporting. No JSON schema field, no `--emit-json` payload, no workflow-caller contract depends on the exact denominator. Only the agent test file (`mutation_kill_agent_tests.bats`) asserts it — updated in this same PR to match. Safe to change. |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — three files, eight items, decisions on all three ambiguous axes captured explicitly.
+- [x] Every behavior/goal maps to an acceptance criterion — item 1 → criterion 1–2; item 2 → criterion 3; item 3 → criterion 4; item 4 → criterion 5; item 5 → criterion 6; item 6 → criterion 7–9; item 7 → criterion 10–11; item 8 folded into criteria 1–9.
+- [x] Architecture constrains without over-engineering — three files, minimal new sections, no new abstractions, no worktree changes, no schema changes.
+- [x] Terminology consistent across artifacts — "honest_score", "reported_score", "NoCoverage", "STRYKER_SINCE_TARGET", "`--parallel <n>`" used identically in Intent, Architecture, and Acceptance Criteria.
+- [x] No contradictions — non-goals in Architecture align with Ambiguity Log deferrals; auto-merge policy in AC-18 aligns with Intent statement.
+- [x] Every gap/ambiguity finding is logged — three human-resolved items, seven inference-classified items, each with explicit rationale.

--- a/plans/mutation-testing-net-improvements.md
+++ b/plans/mutation-testing-net-improvements.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-01
 **Branch**: issue-528
-**Status**: in-progress
+**Status**: implemented
 **Spec**: docs/specs/mutation-testing-net-improvements.md
 **Issue**: #528
 
@@ -22,21 +22,21 @@ Land eight improvements from the .NET mutation drive into the plugin: honest/rep
 
 Mirrors `docs/specs/mutation-testing-net-improvements.md` § Acceptance Criteria (18 items). Restated here so `/build` can check them off:
 
-- [ ] AC1: Honest score formula updated to `Killed / (Killed + Survived + NoCoverage)`; reported-score formula also present.
-- [ ] AC2: NoCoverage-first prioritization documented in `mutation-kill.md` (≥ 3 mentions).
-- [ ] AC3: Infrastructure exclusion detection section present with thresholds (< 15% score, > 50% NoCoverage), file patterns, and `EXCLUDED` log format.
-- [ ] AC4: `--parallel <n>` flag added to Invocation and a Parallel-execution section documents Agent-tool fan-out, batching, and mutation-type gating.
-- [ ] AC5: "Build first" step precedes the Loop; `--no-build` prohibition documented.
-- [ ] AC6: Structurally-untestable patterns catalog covers `#if DEBUG`/`#if RELEASE`, service-locator, and pure DI registration — each with `EXCLUDED` log line.
-- [ ] AC7: `--since` incremental-run pattern in `csharp-stryker-net.md` with the verification-config trap called out.
-- [ ] AC8: Infrastructure exclusion `mutate` glob template in `csharp-stryker-net.md`.
-- [ ] AC9: NoCoverage denominator note in `csharp-stryker-net.md`.
-- [ ] AC10: `--since` env-var pass-through in `stryker-net.sh` with the exact guarded block; env var documented in header.
-- [ ] AC11: Adapter tests cover all three env-var branches (target-set-CI-unset, target-set-CI-set, target-unset).
-- [ ] AC12: Agent tests updated for the new formula regex.
-- [ ] AC13: All pre-existing agent-test invariants still pass.
-- [ ] AC14: `bash scripts/ci-local.sh` (or the two bats suites) exits 0.
-- [ ] AC15: `/agent-audit` passes on the modified agent file.
+- [x] AC1: Honest score formula updated to `Killed / (Killed + Survived + NoCoverage)`; reported-score formula also present.
+- [x] AC2: NoCoverage-first prioritization documented in `mutation-kill.md` (≥ 3 mentions).
+- [x] AC3: Infrastructure exclusion detection section present with thresholds (< 15% score, > 50% NoCoverage), file patterns, and `EXCLUDED` log format.
+- [x] AC4: `--parallel <n>` flag added to Invocation and a Parallel-execution section documents Agent-tool fan-out, batching, and mutation-type gating.
+- [x] AC5: "Build first" step precedes the Loop; `--no-build` prohibition documented.
+- [x] AC6: Structurally-untestable patterns catalog covers `#if DEBUG`/`#if RELEASE`, service-locator, and pure DI registration — each with `EXCLUDED` log line.
+- [x] AC7: `--since` incremental-run pattern in `csharp-stryker-net.md` with the verification-config trap called out.
+- [x] AC8: Infrastructure exclusion `mutate` glob template in `csharp-stryker-net.md`.
+- [x] AC9: NoCoverage denominator note in `csharp-stryker-net.md`.
+- [x] AC10: `--since` env-var pass-through in `stryker-net.sh` with the exact guarded block; env var documented in header.
+- [x] AC11: Adapter tests cover all three env-var branches (target-set-CI-unset, target-set-CI-set, target-unset).
+- [x] AC12: Agent tests updated for the new formula regex.
+- [x] AC13: All pre-existing agent-test invariants still pass.
+- [x] AC14: `bash scripts/ci-local.sh` (or the two bats suites) exits 0.
+- [x] AC15: `/agent-audit` passes on the modified agent file.
 - [ ] AC16: PR body contains `Closes #528`.
 - [ ] AC17: PR title is `feat(mutation-testing): ...`.
 - [ ] AC18: Auto-merge NOT armed.
@@ -372,13 +372,13 @@ Steps 1.6 (complex — new flag + orchestration section), 1.2/1.3/1.4/1.5/1.7/2.
   - [x] Step 1.6: Add `--parallel <n>` flag test + Parallel-execution section
   - [x] Step 1.7: Add structurally-untestable patterns test + expanded section
   - [x] Step 1.8: Verify agent-audit and full bats suite
-- [ ] Slice 2: Update `csharp-stryker-net.md` (`--since`, mutate-glob template, NoCoverage denominator note)
-  - [ ] Step 2.1: Add `--since` incremental-run subsection
-  - [ ] Step 2.2: Add infrastructure exclusion mutate-glob template
-  - [ ] Step 2.3: Add NoCoverage denominator note
-- [ ] Slice 3: `--since` env-var pass-through in `stryker-net.sh` adapter
-  - [ ] Step 3.1: Add adapter tests for all three env-var branches
-  - [ ] Step 3.2: Add the guarded `--since` block to `stryker_net_run`
+- [x] Slice 2: Update `csharp-stryker-net.md` (`--since`, mutate-glob template, NoCoverage denominator note)
+  - [x] Step 2.1: Add `--since` incremental-run subsection
+  - [x] Step 2.2: Add infrastructure exclusion mutate-glob template
+  - [x] Step 2.3: Add NoCoverage denominator note
+- [x] Slice 3: `--since` env-var pass-through in `stryker-net.sh` adapter
+  - [x] Step 3.1: Add adapter tests for all three env-var branches
+  - [x] Step 3.2: Add the guarded `--since` block to `stryker_net_run`
 
 ### Acceptance Criteria
 
@@ -388,15 +388,15 @@ Steps 1.6 (complex — new flag + orchestration section), 1.2/1.3/1.4/1.5/1.7/2.
 - [x] AC4: `--parallel <n>` flag + Parallel-execution section
 - [x] AC5: "Build first" step precedes the Loop
 - [x] AC6: Structurally-untestable patterns catalog (all three)
-- [ ] AC7: `--since` incremental-run pattern with verification-config trap
-- [ ] AC8: Infrastructure exclusion `mutate` glob template
-- [ ] AC9: NoCoverage denominator note
-- [ ] AC10: `--since` env-var pass-through in adapter
-- [ ] AC11: Adapter tests cover all three env-var branches
-- [ ] AC12: Agent tests updated for new formula
-- [ ] AC13: Pre-existing agent-test invariants still pass
-- [ ] AC14: `bash scripts/ci-local.sh` exits 0
-- [ ] AC15: `/agent-audit` passes
+- [x] AC7: `--since` incremental-run pattern with verification-config trap
+- [x] AC8: Infrastructure exclusion `mutate` glob template
+- [x] AC9: NoCoverage denominator note
+- [x] AC10: `--since` env-var pass-through in adapter
+- [x] AC11: Adapter tests cover all three env-var branches
+- [x] AC12: Agent tests updated for new formula
+- [x] AC13: Pre-existing agent-test invariants still pass
+- [x] AC14: `bash scripts/ci-local.sh` exits 0
+- [x] AC15: `/agent-audit` passes
 - [ ] AC16: PR body contains `Closes #528`
 - [ ] AC17: PR title is `feat(mutation-testing): ...`
 - [ ] AC18: Auto-merge NOT armed

--- a/plans/mutation-testing-net-improvements.md
+++ b/plans/mutation-testing-net-improvements.md
@@ -1,0 +1,415 @@
+# Plan: .NET Mutation-Testing Improvements
+
+**Created**: 2026-07-01
+**Branch**: issue-528
+**Status**: approved
+**Spec**: docs/specs/mutation-testing-net-improvements.md
+**Issue**: #528
+
+## Goal
+
+Land eight improvements from the .NET mutation drive into the plugin: honest/reported score formulas (with NoCoverage in the denominator), NoCoverage-first prioritization, infrastructure-exclusion detection, `--parallel <n>` flag with Agent-tool fan-out, stale-build guard, structurally-untestable pattern catalog (in `mutation-kill.md`); `--since` incremental-run pattern, infrastructure exclusion mutate-glob template, NoCoverage denominator note (in `csharp-stryker-net.md`); env-var-gated `--since` pass-through (in `stryker-net.sh`). Tests updated alongside each behavior change.
+
+## Approach stance (decision-defaults axes)
+
+- **Scope** — touch only the three files named in the spec + their two bats test files. No new files; explicitly not creating `mutation-test-workflow.md` (item-8 rows fold into existing files, per user decision).
+- **Integration** — PR + explicit human merge. Diff touches `agents/`, `hooks/`, `tests/` (not `*.md`-only), so the repo working rule requires a human merge; auto-merge is **not** armed.
+- **Replace-vs-merge** — all changes are additive edits to existing files. No wholesale replace. Existing shard-aware content and issue-#522 corrections in `csharp-stryker-net.md` are preserved.
+- **Format fidelity** — none of the files are structured/lossless assets; markdown edits and bash edits stay in-format.
+- **Migrate-vs-edit-stub** — n/a; no deprecated stubs involved.
+
+## Acceptance Criteria
+
+Mirrors `docs/specs/mutation-testing-net-improvements.md` § Acceptance Criteria (18 items). Restated here so `/build` can check them off:
+
+- [ ] AC1: Honest score formula updated to `Killed / (Killed + Survived + NoCoverage)`; reported-score formula also present.
+- [ ] AC2: NoCoverage-first prioritization documented in `mutation-kill.md` (≥ 3 mentions).
+- [ ] AC3: Infrastructure exclusion detection section present with thresholds (< 15% score, > 50% NoCoverage), file patterns, and `EXCLUDED` log format.
+- [ ] AC4: `--parallel <n>` flag added to Invocation and a Parallel-execution section documents Agent-tool fan-out, batching, and mutation-type gating.
+- [ ] AC5: "Build first" step precedes the Loop; `--no-build` prohibition documented.
+- [ ] AC6: Structurally-untestable patterns catalog covers `#if DEBUG`/`#if RELEASE`, service-locator, and pure DI registration — each with `EXCLUDED` log line.
+- [ ] AC7: `--since` incremental-run pattern in `csharp-stryker-net.md` with the verification-config trap called out.
+- [ ] AC8: Infrastructure exclusion `mutate` glob template in `csharp-stryker-net.md`.
+- [ ] AC9: NoCoverage denominator note in `csharp-stryker-net.md`.
+- [ ] AC10: `--since` env-var pass-through in `stryker-net.sh` with the exact guarded block; env var documented in header.
+- [ ] AC11: Adapter tests cover all three env-var branches (target-set-CI-unset, target-set-CI-set, target-unset).
+- [ ] AC12: Agent tests updated for the new formula regex.
+- [ ] AC13: All pre-existing agent-test invariants still pass.
+- [ ] AC14: `bash scripts/ci-local.sh` (or the two bats suites) exits 0.
+- [ ] AC15: `/agent-audit` passes on the modified agent file.
+- [ ] AC16: PR body contains `Closes #528`.
+- [ ] AC17: PR title is `feat(mutation-testing): ...`.
+- [ ] AC18: Auto-merge NOT armed.
+
+## Slices
+
+### Slice 1: Update `mutation-kill.md` (score formulas, NoCoverage, build-first, infra exclusion, `--parallel`, unkillable patterns)
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/agents/mutation-kill.md`, `tests/agents/mutation_kill_agent_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: mutation-kill agent honestly scores and prioritizes reduction work
+
+  Scenario: honest score excludes Timeout, includes NoCoverage in denominator
+    Given the agent's spec is rendered
+    Then the honest_score formula reads "Killed / (Killed + Survived + NoCoverage)"
+    And the reported_score formula reads "(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)"
+    And the spec explains honest_score gates and reported_score exists for HTML-report parity
+
+  Scenario: NoCoverage is prioritized before hard Survived mutations
+    Given a baseline report with both NoCoverage and hard Survived mutants
+    Then the agent's spec directs the operator to prioritize NoCoverage coverage first
+    And documents the rationale that any test reaching the line kills a NoCoverage mutant
+
+  Scenario: build is verified fresh before any mutation run
+    When the loop begins
+    Then Step 0 requires "dotnet build <SOLUTION> -c Debug --nologo"
+    And a failed build stops the run
+    And the spec prohibits "--no-build" on the test command during mutation testing
+
+  Scenario: infrastructure files are flagged for exclusion
+    Given a file with score < 15% and NoCoverage > 50% of effective mutants
+    And its name matches one of Startup.cs, Program.cs, *Filter.cs, *Middleware.cs, *Logger*.cs, *HealthCheck*.cs, *.Designer.cs
+    Then the agent asks whether the file is DI registration, exception handlers, or generated code
+    And on confirmation the file is added to the mutate exclusion list with a documented reason
+    And the exclusion is logged in the "EXCLUDED <file> — <reason>: <mutation types> are equivalent in <test surface>" format
+
+  Scenario: --parallel <n> fans out sub-agents (not worktrees) for Phase 4
+    Given --all --parallel <n> is passed
+    Then files are sorted by survivor count and capped at 4×n candidates
+    And grouped into n batches of up to 4 files each
+    And n sub-agents are spawned in parallel via the Agent tool
+    And each agent targets mutation types in the priority order
+    And 3–4 agents per batch are used for easy types (String/Equality/ObjectInit) and 1–2 for hard types (Statement/Block)
+
+  Scenario: structurally-untestable patterns are cataloged, not attacked
+    Then the "Structurally unkillable files" section documents #if DEBUG/#if RELEASE blocks
+    And documents the service-locator (HttpContext.RequestServices.GetService<T>()) pattern
+    And documents pure DI registration (services.AddX(), builder.Services.AddX())
+    And each pattern has an EXCLUDED log line
+    And the guidance is to log as technical debt, not to spend rounds attacking them
+
+  Scenario: retired honest_score formula is fully removed (not left dangling)
+    Given the previous formula "Killed / (Total - Ignored - CompileError - Timeout)" existed in the file
+    When the new formulas land
+    Then no occurrence of the retired formula string remains in the file
+    And the bats suite asserts the retired formula is absent
+
+  Scenario: pre-existing behavioral invariants survive the edit
+    Given the full mutation_kill_agent_tests.bats suite existed before this change
+    When all new sections are added
+    Then every pre-existing test (frontmatter, 500-line ceiling, priority table,
+      duplicate detection, no-improvement exit, revert-on-failure,
+      structurally-unkillable exclusion, Go advisory) still passes unmodified
+
+  Scenario: agent-audit passes after the edits
+    When /agent-audit runs against the edited mutation-kill.md
+    Then structural, frontmatter, and registry checks all pass
+
+  Scenario: --parallel and --concurrency compose predictably
+    Given both --parallel and --concurrency are set on the same invocation
+    Then the spec states how they compose (outer worktree fan-out × inner Agent-tool fan-out)
+    Or the spec states they are mutually exclusive and the agent fails fast
+```
+
+**Steps:**
+
+#### Step 1.1: Update the honest-score assertion in the bats suite
+
+**Complexity**: trivial
+**RED**: Modify `tests/agents/mutation_kill_agent_tests.bats:27` — change the positive assertion `grep -Eq 'Killed */ *\(Total' "$AGENT"` to `grep -Eq 'Killed */ *\(Killed \+ Survived \+ NoCoverage\)' "$AGENT"`. Add a **negative** assertion in the same `@test`: `! grep -Eq 'Killed */ *\(Total *- *Ignored' "$AGENT"` — the retired formula must be gone, not just supplemented. Run bats — the "defines the honest score formula" test now fails (old formula still in file).
+**GREEN**: n/a in this step — this is a pure RED move to lock in the target formula. The GREEN happens in Step 1.2.
+**REFACTOR**: None.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`
+**Commit**: `test(mutation-kill): assert new honest score formula and absence of retired formula`
+
+#### Step 1.2: Update honest score section + add reported score
+
+**Complexity**: standard
+**RED**: The bats test from 1.1 is red.
+**GREEN**: Rewrite the "The honest score — hard kills only" section in `plugins/dev-team/agents/mutation-kill.md` to introduce two formulas: `honest_score = Killed / (Killed + Survived + NoCoverage)` (gates), `reported_score = (Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)` (parity with Stryker HTML). Explain NoCoverage is in Stryker.NET 4.x's denominator. Keep the existing "Timeout inflates score / reported separately" guidance. Bats "defines the honest score formula" test passes; all other existing tests stay green.
+**REFACTOR**: Tighten wording; no code-shape refactor.
+**Files**: `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): honest score excludes Timeout; NoCoverage in denominator (matches Stryker.NET 4.x)`
+
+#### Step 1.3: Add NoCoverage-first prioritization bats test + section
+
+**Complexity**: standard
+**RED**: Add a bats test `@test "NoCoverage is prioritized before hard Survived mutations"` that asserts `grep -c -i "NoCoverage" "$AGENT"` returns ≥ 3 and that the file contains the phrase "prioritize NoCoverage" (or equivalent). Run bats — new test fails.
+**GREEN**: Add a subsection to `mutation-kill.md` right after the score-formulas section explaining NoCoverage as a first-class signal (each NoCoverage→Killed conversion = same score gain as killing a Survivor; any test reaching the line kills it; prioritize before hard Survived). Bats passes.
+**REFACTOR**: None.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`, `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): prioritize NoCoverage coverage before hard Survived mutations`
+
+#### Step 1.4: Add build-first step bats test + Step 0 in Loop
+
+**Complexity**: standard
+**RED**: Add a bats test `@test "loop starts with a fresh build; prohibits --no-build"` asserting the file contains `dotnet build` before the loop pseudo-code and contains a "Never use `--no-build`" (or equivalent negated rule). Fails.
+**GREEN**: Prepend a "Step 0: Build first" block to the Loop section in `mutation-kill.md`. Include the `dotnet build <SOLUTION> -c Debug --nologo` command, the "stop on build failure" rule, and the "never `--no-build` when running mutation testing" prohibition.
+**REFACTOR**: None.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`, `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): require fresh build before every mutation run (Step 0)`
+
+#### Step 1.5: Add infrastructure exclusion detection bats test + section
+
+**Complexity**: standard
+**RED**: Add a bats test asserting `mutation-kill.md` mentions all seven filename patterns (`Startup.cs`, `Program.cs`, `*Filter.cs`, `*Middleware.cs`, `*Logger*.cs`, `*HealthCheck*.cs`, `*.Designer.cs`) and the numeric thresholds `< 15%` and `> 50%`. Fails.
+**GREEN**: Insert an "Infrastructure exclusion detection" section between baseline parse and generation loop. Document the thresholds, filename patterns, the yes/no confirmation prompt, and the `EXCLUDED <file> — <reason>: <mutation types> are equivalent in <test surface>` log format.
+**REFACTOR**: None.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`, `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): detect and exclude infrastructure files (Startup/Program/Filter/etc.)`
+
+#### Step 1.6: Add `--parallel <n>` bats test + flag + Parallel-execution section
+
+**Complexity**: complex
+**RED**: Add bats test `@test "--parallel <n> is documented as an Invocation flag"` asserting the invocation line contains `--parallel`, a "Parallel execution" heading exists, the section mentions "Agent tool" (not worktrees), and both batch-size numbers (`3-4` for easy types and `1-2` for hard types) appear literally in the section body. Add a second bats test `@test "--parallel and --concurrency interaction rule is specified"` asserting the section defines how the two flags compose (grep for "concurrency" appearing in the Parallel-execution section within, say, 20 lines of "--parallel"). Fails.
+**GREEN**: Add `[--parallel <n>]` to the Invocation code block. Add a new "Parallel execution (Phase 4)" section documenting: file sort by survivor count (desc), cap at `4×n` candidates, group into `n` batches of up to 4 files, spawn `n` sub-agents via the Agent tool (not worktrees — test-file writes don't conflict with source-file reads), 3–4 agents per batch for easy types (String/Equality/ObjectInit), 1–2 for hard types (Statement/Block), synthesize and repeat until survivors ≤ threshold. **Interaction rule (default stance):** state that `--concurrency` governs the outer file-level (worktree) fan-out and `--parallel` governs sub-agent fan-out within each worktree's Phase 4 batch — the product is bounded by physical cores minus 2, and the agent fails fast if `concurrency × parallel > cores − 2`. (Alternative: mutually exclusive — if we prefer that stance during implementation, update the scenario/test to match.)
+**REFACTOR**: Ensure the Invocation code block still fits under the file's 500-line ceiling; trim redundant wording elsewhere if needed.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`, `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): add --parallel <n> Agent-tool fan-out for Phase 4`
+
+#### Step 1.7: Add structurally-untestable patterns bats test + expanded section
+
+**Complexity**: standard
+**RED**: Add bats test asserting the Structurally-Unkillable section names all three patterns: `#if DEBUG`, service-locator (`HttpContext.RequestServices`), pure DI registration (`services.AddX` or `AddX()`). Fails.
+**GREEN**: Expand the existing "Structurally unkillable files" section in `mutation-kill.md` to document all three patterns with `EXCLUDED` log lines and the "log as technical debt, never spend rounds" rule.
+**REFACTOR**: None.
+**Files**: `tests/agents/mutation_kill_agent_tests.bats`, `plugins/dev-team/agents/mutation-kill.md`
+**Commit**: `feat(mutation-kill): catalog #if DEBUG, service-locator, and pure DI as structurally unkillable`
+
+#### Step 1.8: Verify agent-audit, existing invariants, and full bats suite
+
+**Complexity**: trivial
+**RED**: n/a (verification step). The "Scenario: pre-existing behavioral invariants survive the edit" and "Scenario: agent-audit passes" are satisfied here.
+**GREEN**: Run `bash scripts/ci-local.sh` (or at minimum `bats tests/agents/mutation_kill_agent_tests.bats`) — every pre-existing test passes unmodified (frontmatter, 500-line ceiling, priority table, duplicate detection, no-improvement exit, revert-on-failure, structurally-unkillable exclusion, Go advisory). Run `/agent-audit` on `mutation-kill.md` — structural, frontmatter, and registry checks pass. Confirm the file is still < 500 lines.
+**REFACTOR**: If over the 500-line ceiling, tighten wording in the least-critical section.
+**Files**: n/a
+**Commit**: (no code commit — verification only; part of the previous step's PR)
+
+---
+
+### Slice 2: Update `csharp-stryker-net.md` (`--since`, mutate-glob template, NoCoverage denominator note)
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+
+**Behavior:**
+
+```gherkin
+Feature: Stryker.NET reference documents --since, infra exclusion glob, and NoCoverage denominator
+
+  Scenario: --since incremental-run pattern is documented with the verification trap
+    Given the C# reference is rendered
+    Then a subsection under "Run (scoped)" shows a dev-shard config with "since": { "enabled": true, "target": "main" }
+    And explicitly warns: "--since limits mutations to source files that changed; test-file changes do NOT trigger source mutations"
+    And directs verification runs to use a separate config with no "since" block
+
+  Scenario: infrastructure exclusion mutate glob template is provided
+    Then the file contains a mutate-glob template with "!**/Startup.cs", "!**/Program.cs", "!**/*ExceptionFilter.cs", "!**/*ExceptionFormatter.cs", "!**/*LoggerService.cs", "!**/*.Designer.cs"
+
+  Scenario: NoCoverage denominator note explains score-drag
+    Then the file contains the Stryker.NET score formula "(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)"
+    And explains that NoCoverage is in the denominator even though those mutants are never tested
+    And directs the reader to fix NoCoverage first
+```
+
+**Steps:**
+
+#### Step 2.1: Add `--since` incremental-run subsection
+
+**Complexity**: standard
+**RED**: Not test-driven at the bats level (no dedicated test suite for this file). Verification is grep-based (AC7). Before editing, run `grep -c -- '--since' plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` — expect 0.
+**GREEN**: Add a subsection under `## Run (scoped)` titled "Incremental runs with `--since`". Include:
+
+- A `stryker-config.shard-<name>.json` snippet with `"since": { "enabled": true, "target": "main" }`.
+- A `dotnet stryker --config-file stryker-config.shard-webapi.json` example.
+- The trap callout: **`--since` limits mutations to source files that changed since the git ref. Test-file changes do NOT trigger source-file mutations. A verification run through a `--since` config silently produces 0 results.** Direct verification runs to a separate config with no `since` block.
+
+Verify: `grep -c -- '--since' <file>` ≥ 3; `grep -c -i "verification" <file>` ≥ 1.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `feat(mutation-testing): document --since incremental-run pattern with verification-config trap`
+
+#### Step 2.2: Add infrastructure exclusion mutate-glob template
+
+**Complexity**: trivial
+**RED**: Grep-baseline: `grep -c '!\*\*/Startup.cs' <file>` → 0.
+**GREEN**: Add a subsection with a `stryker-config.shard-webapi.json` example whose `mutate` array includes:
+  `"**/MyProject.WebAPI/**/*.cs"`, `"!**/Startup.cs"`, `"!**/Program.cs"`, `"!**/*ExceptionFilter.cs"`, `"!**/*ExceptionFormatter.cs"`, `"!**/*LoggerService.cs"`, `"!**/*.Designer.cs"`.
+Verify grep on each pattern returns ≥ 1.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `feat(mutation-testing): add infrastructure exclusion mutate-glob template for Stryker.NET`
+
+#### Step 2.3: Add NoCoverage denominator note
+
+**Complexity**: trivial
+**RED**: `grep -c "NoCoverage" <file>` → baseline (whatever it is; expect low).
+**GREEN**: Add a "Score formula and NoCoverage" subsection stating the Stryker.NET score formula `(Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)` and the "NoCoverage drags the score down; fix NoCoverage first" rationale (referencing the mutation-kill agent's NoCoverage-first guidance for symmetry).
+Verify: `grep -c "NoCoverage" <file>` ≥ 3; formula string present.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `feat(mutation-testing): document NoCoverage in Stryker.NET score denominator`
+
+---
+
+### Slice 3: `--since` env-var pass-through in `stryker-net.sh` adapter
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/hooks/mutation-adapters/stryker-net.sh`, `tests/hooks/stryker_net_adapter_tests.bats`, `tests/hooks/fake-bin/dotnet`
+
+**Behavior:**
+
+```gherkin
+Feature: stryker-net adapter passes --since only when explicitly opted in and not in CI
+
+  Scenario: STRYKER_SINCE_TARGET set outside CI adds --since to the command
+    Given STRYKER_SINCE_TARGET=main
+    And CI is not set to "true"
+    When stryker_net_run is invoked
+    Then the dotnet stryker command line includes "--since:main"
+
+  Scenario: STRYKER_SINCE_TARGET is ignored inside CI
+    Given STRYKER_SINCE_TARGET=main
+    And CI="true"
+    When stryker_net_run is invoked
+    Then the dotnet stryker command line does NOT include "--since"
+
+  Scenario: STRYKER_SINCE_TARGET unset preserves baseline behavior
+    Given STRYKER_SINCE_TARGET is unset
+    When stryker_net_run is invoked
+    Then the dotnet stryker command line does NOT include "--since"
+    And every other flag from the pre-existing behavior is unchanged
+```
+
+**Steps:**
+
+#### Step 3.1: Extend `fake-bin/dotnet` argv-logging + add three adapter tests
+
+**Complexity**: standard
+**RED**: **First**, extend `tests/hooks/fake-bin/dotnet` to unconditionally append `"$@"` (one arg per line) to `${DOTNET_ARGV_LOG:-/dev/null}` before its existing branches. This is an unconditional additive change: when `DOTNET_ARGV_LOG` is unset the write is a no-op (redirect to `/dev/null`); when a test sets it, argv lands in the file for that test only. Verify all existing tests using the fake (stryker JS, pitest, mutation-gate, etc.) still pass — none assert on stdout that would collide with the new side-effect. **Then** add three bats tests to `tests/hooks/stryker_net_adapter_tests.bats`:
+
+  1. `stryker_net_run: STRYKER_SINCE_TARGET=main + CI unset → command includes --since:main`
+  2. `stryker_net_run: STRYKER_SINCE_TARGET=main + CI=true → command excludes --since`
+  3. `stryker_net_run: STRYKER_SINCE_TARGET unset → command excludes --since` (baseline; regardless of CI)
+
+Each test sets `DOTNET_ARGV_LOG=$TMPDIR/argv.log`, invokes `stryker_net_run`, and greps the log. Run bats — all three fail because the adapter has no `--since` handling yet.
+**GREEN**: n/a (pure RED — GREEN happens in Step 3.2).
+**REFACTOR**: None.
+**Files**: `tests/hooks/fake-bin/dotnet`, `tests/hooks/stryker_net_adapter_tests.bats`
+**Commit**: `test(stryker-net-adapter): capture dotnet argv in fake-bin; assert --since pass-through permutations`
+
+#### Step 3.2: Add the guarded `--since` block to `stryker_net_run`
+
+**Complexity**: standard
+**RED**: The three tests from 3.1 are red.
+**GREEN**: In `plugins/dev-team/hooks/mutation-adapters/stryker-net.sh`, after `stryker_args` is finalized and before the `_timeout` call, insert:
+
+```bash
+# Dev-only: --since limits mutations to files changed vs the target ref.
+# Skipped in CI (full run needed for the gate score).
+if [ "${CI:-}" != "true" ] && [ -n "${STRYKER_SINCE_TARGET:-}" ]; then
+  stryker_args+=(--since:"$STRYKER_SINCE_TARGET")
+fi
+```
+
+Also document the env var in the file's header comment, near `STRYKER_NET_REPORT`. Bats: all three tests pass; every pre-existing adapter test still passes.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/hooks/mutation-adapters/stryker-net.sh`
+**Commit**: `feat(stryker-net-adapter): pass --since:$STRYKER_SINCE_TARGET when set outside CI`
+
+## Parallelization
+
+All three slices are independent — different files, no shared symbols.
+
+```mermaid
+graph TD
+  S1[Slice 1: mutation-kill.md]
+  S2[Slice 2: csharp-stryker-net.md]
+  S3[Slice 3: stryker-net.sh]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1, 2, 3 |
+
+## Complexity Classification
+
+Steps 1.6 (complex — new flag + orchestration section), 1.2/1.3/1.4/1.5/1.7/2.1/3.1/3.2 (standard), 1.1/1.8/2.2/2.3 (trivial).
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (`bash scripts/ci-local.sh`)
+- [ ] `bats tests/agents/mutation_kill_agent_tests.bats` and `bats tests/hooks/stryker_net_adapter_tests.bats` green
+- [ ] `/agent-audit` passes on `mutation-kill.md`
+- [ ] `mutation-kill.md` stays under the 500-line ceiling
+- [ ] `/code-review` passes (fix loop converges)
+- [ ] PR body contains `Closes #528`
+- [ ] PR title is `feat(mutation-testing): ...`
+- [ ] Auto-merge NOT armed
+
+## Risks & Open Questions
+
+- **Test-argv capture for slice 3.** The existing `tests/hooks/fake-bin/dotnet` may not log argv to a file. If it doesn't, extending it to write argv to `${TMPDIR}/dotnet-argv.log` on invocation is the cleanest way to assert `--since:main` presence/absence — small, isolated change to a test-only fake. If that path proves fragile, fall back to a light shell wrapper that captures argv into a per-test file.
+- **Line-ceiling headroom for slice 1.** The agent file is 185 lines today; six new subsections could push it toward the 500-line ceiling. Step 1.6 REFACTOR budget is the escape hatch.
+- **Cross-file symmetry.** Slice 2's NoCoverage note (2.3) should cross-reference the agent's NoCoverage guidance (Step 1.3). Both sit in the same commit stream so drift is unlikely, but if slice 2 lands first the reference should point to the "planned" agent section — mitigated by landing both under one PR.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Update `mutation-kill.md` (scores, NoCoverage, build-first, infra exclusion, `--parallel`, unkillable patterns)
+  - [ ] Step 1.1: Update honest-score assertion in bats
+  - [ ] Step 1.2: Update honest score section + add reported score
+  - [ ] Step 1.3: Add NoCoverage-first prioritization test + section
+  - [ ] Step 1.4: Add build-first step test + Step 0 in Loop
+  - [ ] Step 1.5: Add infrastructure exclusion detection test + section
+  - [ ] Step 1.6: Add `--parallel <n>` flag test + Parallel-execution section
+  - [ ] Step 1.7: Add structurally-untestable patterns test + expanded section
+  - [ ] Step 1.8: Verify agent-audit and full bats suite
+- [ ] Slice 2: Update `csharp-stryker-net.md` (`--since`, mutate-glob template, NoCoverage denominator note)
+  - [ ] Step 2.1: Add `--since` incremental-run subsection
+  - [ ] Step 2.2: Add infrastructure exclusion mutate-glob template
+  - [ ] Step 2.3: Add NoCoverage denominator note
+- [ ] Slice 3: `--since` env-var pass-through in `stryker-net.sh` adapter
+  - [ ] Step 3.1: Add adapter tests for all three env-var branches
+  - [ ] Step 3.2: Add the guarded `--since` block to `stryker_net_run`
+
+### Acceptance Criteria
+
+- [ ] AC1: Honest score formula updated
+- [ ] AC2: NoCoverage-first prioritization documented (≥ 3 mentions)
+- [ ] AC3: Infrastructure exclusion detection section with thresholds + patterns + log format
+- [ ] AC4: `--parallel <n>` flag + Parallel-execution section
+- [ ] AC5: "Build first" step precedes the Loop
+- [ ] AC6: Structurally-untestable patterns catalog (all three)
+- [ ] AC7: `--since` incremental-run pattern with verification-config trap
+- [ ] AC8: Infrastructure exclusion `mutate` glob template
+- [ ] AC9: NoCoverage denominator note
+- [ ] AC10: `--since` env-var pass-through in adapter
+- [ ] AC11: Adapter tests cover all three env-var branches
+- [ ] AC12: Agent tests updated for new formula
+- [ ] AC13: Pre-existing agent-test invariants still pass
+- [ ] AC14: `bash scripts/ci-local.sh` exits 0
+- [ ] AC15: `/agent-audit` passes
+- [ ] AC16: PR body contains `Closes #528`
+- [ ] AC17: PR title is `feat(mutation-testing): ...`
+- [ ] AC18: Auto-merge NOT armed
+
+## Plan Review Summary
+
+Plan tier: **complex** — reviewers: Acceptance, Design, Strategic, Parallelization (UX skipped — no UI surface).
+
+Iteration 1 verdicts:
+
+- **Acceptance Test Critic** — needs-revision. Blockers: AC13 and AC15 had no Gherkin scenarios (fixed by adding "pre-existing invariants survive" and "agent-audit passes" scenarios to Slice 1); Step 1.1/1.2 had no negative assertion that the retired formula was removed (fixed by adding an explicit `! grep` assertion in Step 1.1 and a "retired formula fully removed" scenario). W2 (Slice 3 Scenario 3 `CI` value) addressed by the "regardless of CI" note added to the baseline scenario in Step 3.1.
+- **Design & Architecture Critic** — needs-revision (warnings only). Addressed: `--parallel` × `--concurrency` interaction now spelled out in Step 1.6 as "concurrency governs outer worktree fan-out, parallel governs inner sub-agent fan-out, product bounded by cores − 2, fail-fast otherwise" with a matching Gherkin scenario and bats assertion. Fake-bin argv-logging is now a committed design change in Step 3.1 (unconditional additive, no-op when `DOTNET_ARGV_LOG` unset), with `tests/hooks/fake-bin/dotnet` added to Slice 3's files list.
+- **Strategic Critic** — approve (2 warnings, both preferences: could split into three PRs; validate parallel-agent conflict handling on next real-world use). Plan intentionally lands as one PR to keep the eight-item drive coherent; noted for follow-up rather than gating.
+- **Parallelization Critic** — approve. `plan-waves.sh` reports zero collisions; the only cross-slice touchpoint is a prose cross-reference (NoCoverage in Slices 1 and 2), self-verifiable per file, not a runtime dependency.
+
+Iteration 2 not required (all blockers resolved; remaining warnings are preferences or scoped as follow-up).

--- a/plans/mutation-testing-net-improvements.md
+++ b/plans/mutation-testing-net-improvements.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-01
 **Branch**: issue-528
-**Status**: approved
+**Status**: in-progress
 **Spec**: docs/specs/mutation-testing-net-improvements.md
 **Issue**: #528
 
@@ -363,15 +363,15 @@ Steps 1.6 (complex — new flag + orchestration section), 1.2/1.3/1.4/1.5/1.7/2.
 
 #### Wave 1
 
-- [ ] Slice 1: Update `mutation-kill.md` (scores, NoCoverage, build-first, infra exclusion, `--parallel`, unkillable patterns)
-  - [ ] Step 1.1: Update honest-score assertion in bats
-  - [ ] Step 1.2: Update honest score section + add reported score
-  - [ ] Step 1.3: Add NoCoverage-first prioritization test + section
-  - [ ] Step 1.4: Add build-first step test + Step 0 in Loop
-  - [ ] Step 1.5: Add infrastructure exclusion detection test + section
-  - [ ] Step 1.6: Add `--parallel <n>` flag test + Parallel-execution section
-  - [ ] Step 1.7: Add structurally-untestable patterns test + expanded section
-  - [ ] Step 1.8: Verify agent-audit and full bats suite
+- [x] Slice 1: Update `mutation-kill.md` (scores, NoCoverage, build-first, infra exclusion, `--parallel`, unkillable patterns)
+  - [x] Step 1.1: Update honest-score assertion in bats
+  - [x] Step 1.2: Update honest score section + add reported score
+  - [x] Step 1.3: Add NoCoverage-first prioritization test + section
+  - [x] Step 1.4: Add build-first step test + Step 0 in Loop
+  - [x] Step 1.5: Add infrastructure exclusion detection test + section
+  - [x] Step 1.6: Add `--parallel <n>` flag test + Parallel-execution section
+  - [x] Step 1.7: Add structurally-untestable patterns test + expanded section
+  - [x] Step 1.8: Verify agent-audit and full bats suite
 - [ ] Slice 2: Update `csharp-stryker-net.md` (`--since`, mutate-glob template, NoCoverage denominator note)
   - [ ] Step 2.1: Add `--since` incremental-run subsection
   - [ ] Step 2.2: Add infrastructure exclusion mutate-glob template
@@ -382,12 +382,12 @@ Steps 1.6 (complex — new flag + orchestration section), 1.2/1.3/1.4/1.5/1.7/2.
 
 ### Acceptance Criteria
 
-- [ ] AC1: Honest score formula updated
-- [ ] AC2: NoCoverage-first prioritization documented (≥ 3 mentions)
-- [ ] AC3: Infrastructure exclusion detection section with thresholds + patterns + log format
-- [ ] AC4: `--parallel <n>` flag + Parallel-execution section
-- [ ] AC5: "Build first" step precedes the Loop
-- [ ] AC6: Structurally-untestable patterns catalog (all three)
+- [x] AC1: Honest score formula updated
+- [x] AC2: NoCoverage-first prioritization documented (≥ 3 mentions)
+- [x] AC3: Infrastructure exclusion detection section with thresholds + patterns + log format
+- [x] AC4: `--parallel <n>` flag + Parallel-execution section
+- [x] AC5: "Build first" step precedes the Loop
+- [x] AC6: Structurally-untestable patterns catalog (all three)
 - [ ] AC7: `--since` incremental-run pattern with verification-config trap
 - [ ] AC8: Infrastructure exclusion `mutate` glob template
 - [ ] AC9: NoCoverage denominator note

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -121,6 +121,40 @@ If the build fails, **stop** — do not proceed to any round. **Never use
 `--no-build` on the test command during mutation testing.** Stryker instruments
 the build; `--no-build` runs against whatever binary happens to be on disk.
 
+## Infrastructure exclusion detection (before the loop starts)
+
+After parsing the baseline report and before entering the file-by-file loop,
+scan the report for files that are almost certainly infrastructure — DI wiring,
+exception handlers, middleware, generated code — where mutations cannot be
+killed by the available test surface. Two signals in combination flag a file:
+
+- `score < 15%`
+- `NoCoverage > 50%` of effective mutants (total − Ignored − CompileError)
+
+If both hold **and** the filename matches one of:
+
+```
+Startup.cs        Program.cs         *Filter.cs        *Middleware.cs
+*Logger*.cs       *HealthCheck*.cs   *.Designer.cs
+```
+
+… ask (once, batched for the whole scan): *"Are these mutations in DI
+registration, exception handlers, middleware, or generated code that this
+test surface cannot reach?"*
+
+- **Yes** → add the file to the `mutate` exclusion list with a documented reason
+  and log:
+
+  ```
+  EXCLUDED <file> — <reason>: <mutation types> are equivalent in <test surface>
+  ```
+
+- **No** → keep in scope; the file's poor score is real coverage debt, not
+  infrastructure.
+
+This is the same `EXCLUDED` log format used for the [structurally unkillable
+files](#structurally-unkillable-files) section — a single audit trail either way.
+
 ## Loop (per file)
 
 ```

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -228,6 +228,42 @@ EXCLUDED <file> — <reason>: surviving mutations are structural guards reachabl
 only by direct invalid-input invocation; available test surface is <surface>.
 ```
 
+### Structurally untestable WITHOUT refactoring
+
+Three patterns are unkillable by the test suite as it stands — do not spend
+rounds attacking them. Log each as technical debt using the `EXCLUDED` format
+above and move on.
+
+1. **`#if DEBUG` / `#if RELEASE` compilation blocks.** The code under test
+   doesn't exist in the test build; mutations live in Release-only code while
+   the test suite always hits the Debug path.
+
+   ```
+   EXCLUDED <file>::<method> — #if DEBUG block; mutations are Release-only
+   ```
+
+2. **Service-locator pattern (`HttpContext.RequestServices.GetService<T>()`).**
+   Cannot inject mocks without constructing a full `IServiceProvider` per test.
+   Kills require refactoring to constructor injection.
+
+   ```
+   EXCLUDED <file> — service-locator pattern; requires refactor to
+     constructor injection before mutations become testable
+   ```
+
+3. **Pure DI registration (`services.AddX()`, `builder.Services.AddX()`).**
+   The test host's `TestStartup` / `TestServer` overrides the real DI
+   container, so removing a real registration is invisible to any test using
+   test doubles. Exclude the whole file from the `mutate` glob.
+
+   ```
+   EXCLUDED <file> — pure DI registration; TestStartup overrides the
+     container so mutations are unobservable to the test surface
+   ```
+
+Never spend rounds trying to kill these — they inflate the round count and
+produce zero kills.
+
 ## Parallelism
 
 With `--all`, run files in parallel via git worktrees (each shard gets its own

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -21,7 +21,7 @@ estimate or fabricate mutation outcomes.
 
 ```
 /mutation-kill [<repo-path>] [--file <path>] [--all] [--max-rounds <n>]
-               [--from-report <path>] [--concurrency <n>]
+               [--from-report <path>] [--concurrency <n>] [--parallel <n>]
 ```
 
 - `--file <path>` — target a single source file.
@@ -29,6 +29,7 @@ estimate or fabricate mutation outcomes.
 - `--from-report <path>` — load an existing report instead of running the tool (first round only).
 - `--max-rounds <n>` — maximum rounds per file (default: 5).
 - `--concurrency <n>` — parallel files via git worktrees when using `--all` (default: 2; max = physical cores − 2).
+- `--parallel <n>` — Phase 4 sub-agent fan-out via the Agent tool (in-process, no worktrees; see [Parallel execution (Phase 4)](#parallel-execution-phase-4)).
 
 ## The honest score — hard kills only
 
@@ -233,6 +234,39 @@ With `--all`, run files in parallel via git worktrees (each shard gets its own
 build-artifacts directory). Concurrent runs saturate CPU/RAM fast — honor
 `--concurrency` (default **2** per developer machine; configurable up to physical
 cores − 2).
+
+## Parallel execution (Phase 4)
+
+`--concurrency` fans **files** out across git worktrees. `--parallel <n>` fans
+**sub-agents** out **within** a file's Phase-4 survivor set, using the Agent
+tool directly — no worktrees, because test-file writes don't conflict with
+source-file reads. The two flags are orthogonal.
+
+With `--all --parallel <n>`:
+
+1. Sort files by survivor count (descending); cap at the first `4 × n`
+   candidates.
+2. Group into `n` batches of up to 4 files each.
+3. Spawn `n` sub-agents in parallel via the Agent tool. Each sub-agent reads
+   its files' survivor lists from the baseline JSON and targets mutation
+   types in the priority order (String → ObjectInit → Equality → Negate →
+   Conditional → Statement).
+4. Synthesize results at the barrier; if survivors still exceed the round's
+   threshold, repeat with the next batch.
+
+Agent count per batch — **3–4** for easy mutation types (String / Equality /
+ObjectInit), **1–2** for hard types (Statement / Block removal). Easy types
+tolerate more concurrent test edits because each survivor is fixed by an
+independent assertion; hard types require code-path additions where two
+concurrent edits to the same test class collide.
+
+### Interaction with `--concurrency`
+
+`--concurrency` governs the **outer** worktree fan-out (files × worktrees) and
+`--parallel` governs the **inner** Agent-tool fan-out (sub-agents per Phase-4
+batch). When both are set the effective concurrent-actor count is the product
+(`concurrency × parallel`), bounded by physical cores − 2. Fail fast when the
+product exceeds that ceiling rather than oversubscribing the machine.
 
 ## Go is advisory
 

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -37,14 +37,28 @@ observed run 76% of "kills" were timeouts; adding faster targeted tests let thos
 mutations *complete* instead of timing out, and the score fell from 61.3% to
 30.36%. A score inflated by timeouts is not evidence of good tests.
 
-Always gate and report on **hard kills only** (`status == Killed`):
+Gate on **hard kills only** (`status == Killed`); Stryker.NET 4.x keeps `NoCoverage`
+mutants in its own denominator, so the honest formula matches:
 
 ```
-honest_score = Killed / (Total - Ignored - CompileError - Timeout)
+honest_score  = Killed / (Killed + Survived + NoCoverage)
+reported_score = (Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)
 ```
 
-Report the `Timeout` count **separately**, never inside the gate denominator. The
-honest score is the only number that gates a round or a file.
+Report **both**. `honest_score` is the only number that gates a round or a file —
+Timeout stays out of the numerator. `reported_score` mirrors what the Stryker HTML
+report prints, so a reviewer comparing the two numbers gets an honest gap
+(numerator delta) rather than a formula mismatch. `Timeout` and `NoCoverage`
+counts always print separately alongside both scores.
+
+### NoCoverage is a first-class signal
+
+Each `NoCoverage → Killed` conversion improves the score as much as killing a
+`Survived` mutant — and NoCoverage paths are usually easier, because **any** test
+that reaches the line kills the mutant (no specific-value assertion required).
+**Prioritize NoCoverage coverage before attacking hard Survived mutations.** A
+file with 27 NoCoverage mutants at 0% score drags the overall number down more
+than a file with 20 Survived at 70%; fix the NoCoverage first.
 
 ## Shard vs full-run scores are not comparable
 

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -106,6 +106,21 @@ drops from full-suite time to the time of the tests covering the mutated line
 (observed 10–50× speedup). Use scoped + per-test for the development loop; reserve
 the full run (coverage-analysis off) for the CI gate only.
 
+## Step 0: build first (per file, before any round)
+
+Every mutation run assumes fresh binaries. A stale build produces phantom
+failures — Stryker either aborts on load or reports every mutant as `Survived`,
+and both the failures and the kills are meaningless. Before Round 1 (and again
+after every source edit outside the loop):
+
+```
+dotnet build <SOLUTION> -c Debug --nologo   # or the language equivalent
+```
+
+If the build fails, **stop** — do not proceed to any round. **Never use
+`--no-build` on the test command during mutation testing.** Stryker instruments
+the build; `--no-build` runs against whatever binary happens to be on disk.
+
 ## Loop (per file)
 
 ```

--- a/plugins/dev-team/hooks/mutation-adapters/stryker-net.sh
+++ b/plugins/dev-team/hooks/mutation-adapters/stryker-net.sh
@@ -10,6 +10,11 @@ source "$ADAPTER_LIB_DIR/lib.sh"
 
 STRYKER_NET_REPORT="${STRYKER_NET_REPORT:-StrykerOutput/mutation-report.json}"
 
+# Optional dev-loop opt-in: STRYKER_SINCE_TARGET=<git-ref> asks Stryker.NET
+# to mutate only source files changed since that ref (typically `main`). Set
+# on dev machines for fast iteration; leave unset in CI so the gate always
+# runs the full scan. Ignored when CI=true.
+
 # stryker_net_detect — returns 0 if Stryker.NET is available
 stryker_net_detect() {
   # Check dotnet-tools.json
@@ -123,6 +128,12 @@ stryker_net_run() {
 
   # Override output directory so gate runs don't stomp the full pipeline reports
   stryker_args+=(--output StrykerOutput/gate-shard)
+
+  # Dev-only: --since limits mutations to files changed vs the target ref.
+  # Skipped in CI (full run needed for the gate score).
+  if [ "${CI:-}" != "true" ] && [ -n "${STRYKER_SINCE_TARGET:-}" ]; then
+    stryker_args+=(--since:"$STRYKER_SINCE_TARGET")
+  fi
 
   local stryker_exit=0
   _timeout "$timeout" dotnet stryker "${stryker_args[@]}" \

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -154,6 +154,72 @@ print(p.split('/**')[0])
 done
 ```
 
+## Incremental runs with `--since`
+
+For fast iteration during Phase-4 test-fix work, add a `since` block to the dev shard config so Stryker only mutates source files that changed vs a reference (typically `main`):
+
+```json
+// stryker-config.shard-<name>.json — development / Phase 4 fix loop
+{
+  "stryker-config": {
+    "since": {
+      "enabled": true,
+      "target": "main"
+    }
+  }
+}
+```
+
+Run with the dev config for fast feedback:
+
+```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+dotnet stryker --config-file stryker-config.shard-webapi.json
+```
+
+**Trap — verification runs must NOT use `since`.** `--since` limits mutations to **source** files that changed since the git ref. Test-file changes do **not** trigger source-file mutations, so a verification run through a `--since` config silently produces **0 results** — no mutants, no report, no useful signal. Always keep a **separate** verification config (`stryker-config.verification.json` or equivalent) that is identical to the dev shard config **except** for having no `since` block:
+
+```bash
+# Full verification — no --since; mutates every source file in scope
+dotnet stryker --config-file stryker-config.verification.json -O StrykerOutput/verification
+```
+
+Adapter-side, `hooks/mutation-adapters/stryker-net.sh` reads `STRYKER_SINCE_TARGET` when `CI` is not `true` and appends `--since:$STRYKER_SINCE_TARGET` to the command line. Set the env var on dev machines; leave it unset in CI so the gate always runs the full scan.
+
+## Infrastructure exclusion `mutate` glob template
+
+DI wiring, exception handlers, and generated code produce mutations that no test surface can kill — dragging the score down without providing any signal. Exclude them from the `mutate` glob in the shard config:
+
+```json
+// stryker-config.shard-webapi.json
+{
+  "stryker-config": {
+    "mutate": [
+      "**/MyProject.WebAPI/**/*.cs",
+      "!**/Startup.cs",
+      "!**/Program.cs",
+      "!**/*ExceptionFilter.cs",
+      "!**/*ExceptionFormatter.cs",
+      "!**/*LoggerService.cs",
+      "!**/*.Designer.cs"
+    ]
+  }
+}
+```
+
+Pairs with the mutation-kill agent's [infrastructure exclusion detection](../../../../agents/mutation-kill.md#infrastructure-exclusion-detection-before-the-loop-starts) — the agent flags candidates at baseline scan time; this template is what actually removes them from the mutation set.
+
+## Score formula and NoCoverage
+
+Stryker.NET's own score formula (v4.x):
+
+```
+score = (Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage)
+```
+
+`NoCoverage` sits in the denominator even though those mutants are never executed. A file with 27 `NoCoverage` mutants at 0% score drags the overall score down more than a file with 20 `Survived` mutants at 70%. **Fix `NoCoverage` first** — any test that reaches the line kills a `NoCoverage` mutant, so ROI is higher than crafting value-specific assertions to kill hard `Survived` mutants. This mirrors the mutation-kill agent's [NoCoverage-first-class-signal](../../../../agents/mutation-kill.md#nocoverage-is-a-first-class-signal) guidance.
+
 ## Per-mutant timeout flag
 
 Configure in `stryker-config.yaml` (or the per-shard JSON config):

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -47,6 +47,23 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   grep -Eqi 'never.*--no-build|do not use.*--no-build|not.*--no-build' "$AGENT"
 }
 
+@test "infrastructure exclusion detection: thresholds, file patterns, and log format" {
+  # Numeric thresholds
+  grep -Eq '15%' "$AGENT"
+  grep -Eq '50%' "$AGENT"
+  # Filename patterns
+  grep -Eq 'Startup\.cs' "$AGENT"
+  grep -Eq 'Program\.cs' "$AGENT"
+  grep -Eq '\*Filter\.cs' "$AGENT"
+  grep -Eq '\*Middleware\.cs' "$AGENT"
+  grep -Eq '\*Logger\*\.cs' "$AGENT"
+  grep -Eq '\*HealthCheck\*\.cs' "$AGENT"
+  grep -Eq '\*\.Designer\.cs' "$AGENT"
+  # EXCLUDED log-line format is already asserted elsewhere; here just confirm
+  # the infra-exclusion section references it.
+  grep -Eqi 'EXCLUDED' "$AGENT"
+}
+
 @test "warns that shard and full-run scores are not comparable" {
   grep -Eqi 'shard' "$AGENT"
   grep -Eqi 'not comparable|never (mix|compare)|prohibit.*compar' "$AGENT"

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -40,6 +40,13 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   grep -Eqi 'prioritize NoCoverage|NoCoverage.*before.*Survived|NoCoverage.*first' "$AGENT"
 }
 
+@test "loop starts with a fresh build; prohibits --no-build on mutation runs" {
+  # The build-first step must precede the loop pseudo-code.
+  grep -Eq 'dotnet build' "$AGENT"
+  # The prohibition against --no-build during mutation runs must be explicit.
+  grep -Eqi 'never.*--no-build|do not use.*--no-build|not.*--no-build' "$AGENT"
+}
+
 @test "warns that shard and full-run scores are not comparable" {
   grep -Eqi 'shard' "$AGENT"
   grep -Eqi 'not comparable|never (mix|compare)|prohibit.*compar' "$AGENT"

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -44,7 +44,8 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   # The build-first step must precede the loop pseudo-code.
   grep -Eq 'dotnet build' "$AGENT"
   # The prohibition against --no-build during mutation runs must be explicit.
-  grep -Eqi 'never.*--no-build|do not use.*--no-build|not.*--no-build' "$AGENT"
+  # Flatten newlines so a line-broken sentence still matches.
+  tr '\n' ' ' < "$AGENT" | grep -Eqi 'never.*--no-build|do not use.*--no-build|not.*--no-build'
 }
 
 @test "--parallel <n> is documented as an Invocation flag with Agent-tool fan-out" {
@@ -60,9 +61,11 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
 }
 
 @test "--parallel and --concurrency interaction rule is specified" {
-  # The interaction rule must reference both flags (either as compose-together
-  # or mutually-exclusive) in the same neighborhood.
-  awk '/Parallel execution/,/^## /' "$AGENT" | grep -Eqi 'concurrency'
+  # The interaction rule must reference both flags in the "Parallel execution"
+  # section. Use sed to extract from the section header to the next top-level
+  # (^## ) header, dropping the header itself so its own regex doesn't close
+  # the range prematurely.
+  sed -n '/^## Parallel execution/,/^## [^P]/p' "$AGENT" | grep -Eqi 'concurrency'
 }
 
 @test "infrastructure exclusion detection: thresholds, file patterns, and log format" {

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -34,6 +34,12 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   grep -Eqi 'timeout.*separate|report.*timeout|never.*timeout|timeout.*not.*(count|gate)' "$AGENT"
 }
 
+@test "NoCoverage is a first-class signal, prioritized before hard Survived mutations" {
+  # NoCoverage must appear in the formula, first-class-signal note, and prioritization guidance.
+  [ "$(grep -c -F 'NoCoverage' "$AGENT")" -ge 3 ]
+  grep -Eqi 'prioritize NoCoverage|NoCoverage.*before.*Survived|NoCoverage.*first' "$AGENT"
+}
+
 @test "warns that shard and full-run scores are not comparable" {
   grep -Eqi 'shard' "$AGENT"
   grep -Eqi 'not comparable|never (mix|compare)|prohibit.*compar' "$AGENT"

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -47,6 +47,24 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   grep -Eqi 'never.*--no-build|do not use.*--no-build|not.*--no-build' "$AGENT"
 }
 
+@test "--parallel <n> is documented as an Invocation flag with Agent-tool fan-out" {
+  # Invocation surface
+  grep -Eq -- '--parallel' "$AGENT"
+  # Parallel-execution section exists
+  grep -Eqi '^## Parallel execution|^### Parallel execution' "$AGENT"
+  # Agent tool, not worktrees
+  grep -Eqi 'Agent tool' "$AGENT"
+  # Batch cardinality claims from the plan's scenario
+  grep -Eq '3.4' "$AGENT" || grep -Eq '3-4' "$AGENT"
+  grep -Eq '1.2' "$AGENT" || grep -Eq '1-2' "$AGENT"
+}
+
+@test "--parallel and --concurrency interaction rule is specified" {
+  # The interaction rule must reference both flags (either as compose-together
+  # or mutually-exclusive) in the same neighborhood.
+  awk '/Parallel execution/,/^## /' "$AGENT" | grep -Eqi 'concurrency'
+}
+
 @test "infrastructure exclusion detection: thresholds, file patterns, and log format" {
   # Numeric thresholds
   grep -Eq '15%' "$AGENT"

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -136,6 +136,17 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
   grep -Eqi 'reason|document the exclusion' "$AGENT"
 }
 
+@test "catalogs three structurally untestable patterns: #if DEBUG, service-locator, pure DI" {
+  # #if DEBUG / #if RELEASE
+  grep -Eq '#if DEBUG|#if RELEASE' "$AGENT"
+  # service-locator: HttpContext.RequestServices.GetService<T>
+  grep -Eq 'HttpContext\.RequestServices' "$AGENT"
+  grep -Eqi 'service.?locator' "$AGENT"
+  # pure DI registration
+  grep -Eq 'services\.AddX|builder\.Services\.AddX|services\.Add[A-Za-z]|AddX\(\)' "$AGENT"
+  grep -Eqi 'DI registration|test.?startup|TestStartup|TestServer' "$AGENT"
+}
+
 @test "Go runs advisory (logs, does not commit)" {
   grep -Eqi 'advisory' "$AGENT"
   grep -Eqi 'does not commit|not commit|operator applies' "$AGENT"

--- a/tests/agents/mutation_kill_agent_tests.bats
+++ b/tests/agents/mutation_kill_agent_tests.bats
@@ -24,8 +24,10 @@ REGISTRY="$BATS_TEST_DIRNAME/../../plugins/dev-team/knowledge/agent-registry.md"
 
 @test "defines the honest score formula (hard kills only, timeout excluded)" {
   grep -Eqi 'honest' "$AGENT"
-  grep -Eq 'Killed */ *\(Total' "$AGENT"
+  grep -Eq 'Killed */ *\(Killed \+ Survived \+ NoCoverage\)' "$AGENT"
   grep -Eqi 'timeout' "$AGENT"
+  # Retired formula must be gone, not just supplemented.
+  ! grep -Eq 'Killed */ *\(Total *- *Ignored' "$AGENT"
 }
 
 @test "reports timeout count separately and never gates on it" {

--- a/tests/hooks/fake-bin/dotnet
+++ b/tests/hooks/fake-bin/dotnet
@@ -3,6 +3,14 @@
 FIXTURE="${STRYKER_NET_FIXTURE:-}"
 REPORT_DIR="${STRYKER_NET_REPORT_DIR:-StrykerOutput}"
 mkdir -p "$REPORT_DIR"
+
+# Log every argv element (one per line) to DOTNET_ARGV_LOG when set,
+# so adapter tests can grep the exact command line. Redirect to /dev/null
+# when unset — no side-effect for tests that don't opt in.
+_argv_log="${DOTNET_ARGV_LOG:-/dev/null}"
+for _a in "$@"; do
+  printf '%s\n' "$_a" >>"$_argv_log"
+done
 if [ "${STRYKER_NET_TIMEOUT:-0}" = "1" ]; then
   exit 124
 fi

--- a/tests/hooks/stryker_net_adapter_tests.bats
+++ b/tests/hooks/stryker_net_adapter_tests.bats
@@ -114,6 +114,64 @@ assert 'MUTATION GATE SKIPPED' in d['hookSpecificOutput']['additionalContext']
   [ $? -eq 0 ]
 }
 
+# ---------------------------------------------------------------------------
+# --since env-var pass-through (STRYKER_SINCE_TARGET)
+# ---------------------------------------------------------------------------
+
+@test "stryker_net_run: STRYKER_SINCE_TARGET=main + CI unset → --since:main in argv" {
+  mkdir -p "$TEST_PWD/StrykerOutput"
+  run bash -c "
+    cd '$TEST_PWD'
+    export PATH=\"$FAKE_BIN:\$PATH\"
+    export STRYKER_NET_FIXTURE='$FIXTURES/mutation-report-zero-kill.json'
+    export ADAPTER_TIMEOUT=10
+    export DOTNET_ARGV_LOG='$TMPDIR/argv.log'
+    export STRYKER_SINCE_TARGET=main
+    unset CI
+    source '$PLUGIN_DIR/hooks/mutation-adapters/stryker-net.sh'
+    stryker_net_run '$TMPDIR/mutation-gate/zero-kills.json'
+  "
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR/argv.log" ]
+  grep -q -- '--since:main' "$TMPDIR/argv.log"
+}
+
+@test "stryker_net_run: STRYKER_SINCE_TARGET=main + CI=true → --since excluded" {
+  mkdir -p "$TEST_PWD/StrykerOutput"
+  run bash -c "
+    cd '$TEST_PWD'
+    export PATH=\"$FAKE_BIN:\$PATH\"
+    export STRYKER_NET_FIXTURE='$FIXTURES/mutation-report-zero-kill.json'
+    export ADAPTER_TIMEOUT=10
+    export DOTNET_ARGV_LOG='$TMPDIR/argv.log'
+    export STRYKER_SINCE_TARGET=main
+    export CI=true
+    source '$PLUGIN_DIR/hooks/mutation-adapters/stryker-net.sh'
+    stryker_net_run '$TMPDIR/mutation-gate/zero-kills.json'
+  "
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR/argv.log" ]
+  ! grep -q -- '--since' "$TMPDIR/argv.log"
+}
+
+@test "stryker_net_run: STRYKER_SINCE_TARGET unset → --since excluded (baseline preserved)" {
+  mkdir -p "$TEST_PWD/StrykerOutput"
+  run bash -c "
+    cd '$TEST_PWD'
+    export PATH=\"$FAKE_BIN:\$PATH\"
+    export STRYKER_NET_FIXTURE='$FIXTURES/mutation-report-zero-kill.json'
+    export ADAPTER_TIMEOUT=10
+    export DOTNET_ARGV_LOG='$TMPDIR/argv.log'
+    unset STRYKER_SINCE_TARGET
+    unset CI
+    source '$PLUGIN_DIR/hooks/mutation-adapters/stryker-net.sh'
+    stryker_net_run '$TMPDIR/mutation-gate/zero-kills.json'
+  "
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR/argv.log" ]
+  ! grep -q -- '--since' "$TMPDIR/argv.log"
+}
+
 @test "stryker_run and stryker_net_run are separate functions (not unified)" {
   run bash -c "
     source '$PLUGIN_DIR/hooks/mutation-adapters/stryker.sh'


### PR DESCRIPTION
## Summary

Eight improvements to the plugin's mutation-testing surface, derived from a real .NET 10 / ASP.NET Core mutation drive (57.69% → 75.75%, 448 new tests). Three files touched:

- **`agents/mutation-kill.md`** — honest score now `Killed / (Killed + Survived + NoCoverage)` (matches Stryker.NET 4.x); reported score also emitted for HTML-report parity. Adds NoCoverage-first prioritization, "build first" Step 0, infrastructure-file exclusion detection (thresholds + filename patterns), `--parallel <n>` Agent-tool fan-out (orthogonal to worktree-based `--concurrency`), and expanded structurally-untestable catalog (`#if DEBUG`, service-locator, pure DI).
- **`skills/mutation-testing/references/languages/csharp-stryker-net.md`** — `--since` incremental-run pattern with the "verification-config-must-have-no-since" trap called out; infrastructure exclusion `mutate` glob template; NoCoverage denominator note.
- **`hooks/mutation-adapters/stryker-net.sh`** — env-var-gated `--since` pass-through: `STRYKER_SINCE_TARGET=<ref>` + `CI≠true` appends `--since:$STRYKER_SINCE_TARGET` to the command; ignored in CI so the gate always runs the full scan.

## Quality Gate

- [x] Tests: `bats tests/agents/mutation_kill_agent_tests.bats` — 23 pass; `bats tests/hooks/stryker_net_adapter_tests.bats` — 10 pass (7 pre-existing + 3 new `--since` permutations)
- [x] Full local CI: `bash scripts/ci-local.sh` — all checks pass
- [x] Code review (per-slice spec-compliance + concurrency/security/doc review) — no blockers. One pre-existing security suggestion (Python `-c` interpolation in `_stryker_net_shard_for_file`) is outside this PR's diff and will be tracked separately.
- [x] Structural agent-audit: mutation-kill.md is 318 lines (< 500 ceiling), frontmatter/tools/registry entry all valid.

## Test Plan

- [ ] `bats tests/agents/mutation_kill_agent_tests.bats` — 23 tests green, including new assertions for the honest-score formula, NoCoverage prioritization, build-first step, `--parallel` flag + interaction rule, infrastructure exclusion detection, and three structurally-untestable patterns.
- [ ] `bats tests/hooks/stryker_net_adapter_tests.bats` — 10 tests green, including three new `STRYKER_SINCE_TARGET` × `CI` permutations.
- [ ] `bash scripts/ci-local.sh` exits 0.
- [ ] Cross-references between `mutation-kill.md` and `csharp-stryker-net.md` (NoCoverage and infrastructure-exclusion sections) resolve as GitHub anchors.

## Notes for reviewers

- Auto-merge is **not** armed. Repo working rule requires explicit human merge for diffs touching `agents/`, `hooks/`, or `tests/`.
- `--parallel <n>` is orthogonal to the existing `--concurrency <n>`: outer worktree fan-out × inner Agent-tool fan-out, product bounded by physical cores − 2.
- Item 8 of the source issue (a patch table for a nonexistent `mutation-test-workflow.md`) was folded into the two existing files per user direction — no new file created.

Closes #528