### PR TITLE
fix(pre-push): hermetic fixtures + ref-integrity guard for issue #546

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -31,8 +31,55 @@ done
 [ -z "$BASE" ] && BASE="$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || true)"
 
 # 1. Deterministic CI mirror — blocks the push on failure.
+# Wrapped in a ref-integrity guard (issue #546): if any refs/heads/* changes
+# during ci-local's execution (because of a fixture bats bug or any other
+# reason), refuse the push loudly instead of proceeding on corrupted local
+# state. POSIX sh only — no [[, no arrays, no process substitution.
+PRE_REFS_FILE="$(mktemp -t prepush-refs-pre-XXXXXX)"
+POST_REFS_FILE="$(mktemp -t prepush-refs-post-XXXXXX)"
+trap 'rm -f "$PRE_REFS_FILE" "$POST_REFS_FILE"' EXIT
+git for-each-ref --format='%(refname) %(objectname)' refs/heads/ > "$PRE_REFS_FILE"
+
 echo "pre-push: running local CI mirror (scripts/ci-local.sh)…"
-bash scripts/ci-local.sh "$BASE" "$HEAD" || exit 1
+# `|| true` so a non-zero exit from ci-local doesn't trip husky's `sh -e`
+# before we can capture the code and run the ref-integrity check.
+CI_EXIT=0
+bash scripts/ci-local.sh "$BASE" "$HEAD" || CI_EXIT=$?
+
+git for-each-ref --format='%(refname) %(objectname)' refs/heads/ > "$POST_REFS_FILE"
+if ! cmp -s "$PRE_REFS_FILE" "$POST_REFS_FILE"; then
+  # Any drift is a corruption signal — refuse regardless of ci-local exit.
+  printf '\npre-push: ABORT — refs/heads/* changed during hook execution.\n' >&2
+  printf 'This usually means a fixture test corrupted your local refs. See issue #546.\n\n' >&2
+  # Emit each changed ref with pre / post SHA. Use awk on the two snapshot
+  # files: build a pre-map, then walk the post-map to detect mutation and
+  # creation; walk the pre-map for deletions.
+  awk '
+    NR==FNR { pre[$1]=$2; next }
+    {
+      post[$1]=$2
+      if (!($1 in pre)) {
+        printf "  %s: pre=<absent> post=%s (created)\n", $1, $2
+      } else if (pre[$1] != $2) {
+        printf "  %s: pre=%s post=%s\n", $1, pre[$1], $2
+      }
+    }
+    END {
+      for (ref in pre) {
+        if (!(ref in post)) {
+          printf "  %s: pre=%s post=<absent> (deleted)\n", ref, pre[ref]
+        }
+      }
+    }
+  ' "$PRE_REFS_FILE" "$POST_REFS_FILE" >&2
+  printf '\nRecover from your reflog:\n' >&2
+  printf '  git update-ref <refname> <pre-sha>       # for mutated / deleted refs\n' >&2
+  printf '  git update-ref -d <refname>              # for stray created refs\n' >&2
+  exit 1
+fi
+
+# Refs stable — honor ci-local's exit code (existing behavior).
+[ "$CI_EXIT" -ne 0 ] && exit "$CI_EXIT"
 
 # 2. Opt-in live agent-eval, diff-scoped to changed agents/skills.
 answer=n

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ Every shell script — both the dev/CI scripts and the ones shipped inside the p
 - **macOS vs Linux command differences**: avoid Linux-only flags (`readlink -f`, `sed -i` semantics, `date +%N`, `stat -c`, `find -printf`, `timeout`) or guard them with a fallback (e.g. `recon-inventory.sh`'s `readlink -f || python3`, `_lib.sh`'s `date +%s%3N || python3`, `mutation-adapters/lib.sh`'s `timeout`→`gtimeout`→unbounded).
 - **Windows = Git Bash.** Native `cmd.exe`/PowerShell are not targets; the plugin's hooks and helper scripts run under [Git Bash](https://git-scm.com/download/win) (the POSIX shell Claude Code uses for its Bash tool on Windows). Each plugin's `install.sh` detects Windows-without-Git-Bash and tells the user to install it; `scripts/dev-setup.sh` does the same for contributors.
 
+### Hermetic bats fixtures
+
+Every `.bats` file under `tests/` that runs state-mutating git commands (`init`, `commit`, `push`, `update-ref`, `checkout`, `branch`, `add`, `clone`, `merge`, `rebase`, `reset`, ...) **must** `load '../lib/hermetic'` and wire `hermetic_setup` + `hermetic_teardown` into its `setup()`/`teardown()` blocks. `tests/repo/hermetic_adoption_tests.bats` enforces this at CI time.
+
+Rationale: git exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE`/`GIT_PREFIX`/`GIT_REFLOG_ACTION` into the pre-push hook's environment. Without scrubbing, fixture bats tests inherit those vars and their `git init`/`git commit`/`git push` operations target the parent worktree's gitdir instead of their tempdirs, silently rewriting `refs/heads/*` on the pushing repo. See [`.triage/pre-push-corrupts-local-branch-refs.md`](.triage/pre-push-corrupts-local-branch-refs.md) and issue #546.
+
 ### Testing locally
 
 Register the local checkout as a marketplace, then install from it into a test project:

--- a/docs/specs/pre-push-hook-hermetic-fixtures.md
+++ b/docs/specs/pre-push-hook-hermetic-fixtures.md
@@ -1,0 +1,68 @@
+<!-- spec-version: 8.3.4 -->
+# Spec: Pre-push hook hermetic fixtures (issue #546)
+
+## Intent Description
+
+The pre-push hook (`.husky/pre-push` → `scripts/ci-local.sh`) currently corrupts local branch refs — including `main` — during real `git push` invocations, silently rewriting them to a chain of fixture-repo commits authored `Test <test@test.com>`. The corruption does not reproduce when the hook is invoked directly with the same stdin. Root cause: git exports `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_PREFIX`, and `GIT_REFLOG_ACTION` into the pre-push hook's environment; nothing in the hook chain scrubs them; fixture bats tests that run `git init`/`git commit`/`git push` inherit those env vars and target the parent worktree's gitdir instead of their tempdirs.
+
+This spec fixes the corruption at three layers of defense: hermetic isolation in every fixture bats `setup()` (via a shared helper), the same env-scrub at the top of `scripts/ci-local.sh`, and a post-hook ref-integrity guard in `.husky/pre-push` that refuses to complete if any local ref moved during the hook run. It also standardizes fixture tempdirs on a per-worker prefix and adds a PWD-guard so any future drift fails a test instead of clobbering a worktree.
+
+The outcome: `git push` on this repo never mutates local refs as a side effect of hook execution, regardless of parallel bats scheduling, fixture bugs, or future env inheritance surprises. The relative `hooksPath` in the shared bare repo is out of scope — env-scrub alone closes the corruption channel; changing shared bare config is a separate concern.
+
+## Architecture Specification
+
+**Components touched:**
+
+- `tests/lib/hermetic.bash` — **new.** Shared bats helper. Exports a single function (e.g. `hermetic_setup`) that: (a) `unset`s `GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION`; (b) exports `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`; (c) creates a per-worker tempdir via `mktemp -d -t "bats-$$-XXXX"` and cds into it; (d) installs a `DEBUG`/`RETURN` trap that fails the test if `PWD` ever leaves the tempdir root. Bash-3.2 safe (macOS).
+- `scripts/ci-local.sh` — add env-scrub as the first executable lines, before the existing `cd "$(git rev-parse --show-toplevel)"`. `unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION`. Do not set `GIT_CONFIG_GLOBAL=/dev/null` here — ci-local reads real repo state; only the bats fixtures need config isolation.
+- `.husky/pre-push` — capture `git for-each-ref refs/heads/` before invoking `ci-local.sh`, and re-read it after. On mismatch, abort with a loud diagnostic naming the changed refs and their pre/post SHAs. This runs even when `ci-local.sh` exits zero.
+- Fixture bats files under `tests/scripts/` and `tests/repo/` (and any other `.bats` file that calls `git init`/`git commit`/`git push` in `setup()`) — source `tests/lib/hermetic.bash` and call `hermetic_setup` at the top of `setup()`, replacing the ad-hoc `mktemp -d` + `cd` pattern. Existing `|| return 1` cd guards can stay (harmless) or be removed as the shared helper's PWD trap subsumes them.
+
+**Constraints:**
+
+- Bash 3.2 compatible (macOS ships 3.2): no `mapfile`, no `declare -A`, no `wait -n`, empty-safe array expansion.
+- Cross-platform: macOS, Linux, Windows Git Bash. `mktemp -d -t "PREFIX-XXXX"` works on all three (macOS puts prefix in name, Linux/Git Bash accept `-t`).
+- The shared bare repo's `hooksPath = .husky/_` is **not** modified. This spec closes the corruption channel; the relative-hooksPath amplifier is a separate concern.
+- The new post-hook ref guard in `.husky/pre-push` must not itself corrupt refs — it only reads via `git for-each-ref` and compares strings.
+- Fixture bats tests that legitimately need `git push` to a fixture-local `origin` continue to work — env scrubbing does not remove the fixture's own git operations, only prevents them from finding a parent gitdir.
+- All existing bats tests continue to pass on `bash scripts/ci-local.sh` (direct invocation) and under `git push` (hook invocation).
+
+**Dependencies:** No new runtime dependencies. Uses only bash builtins, `mktemp`, `git for-each-ref`, and standard test tooling already required.
+
+## Acceptance Criteria
+
+1. Running `git push` on any branch in this repo (with the pre-push hook active) leaves every ref under `refs/heads/*` unchanged from its pre-hook value — regardless of whether `ci-local.sh` passes or fails.
+2. Given a hostile environment (`GIT_DIR=<decoy-gitdir> GIT_INDEX_FILE=<decoy-index>`), invoking `bash scripts/ci-local.sh` does not mutate the decoy gitdir's refs, and its child bats processes see empty `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE`/`GIT_PREFIX`/`GIT_REFLOG_ACTION`.
+3. Given a hostile environment (same decoy vars), invoking any fixture bats test's `setup()` (via `hermetic_setup`) does not mutate the decoy gitdir's refs, and the fixture's git operations target only its own tempdir.
+4. If a fixture bats test's `PWD` ever leaves the per-worker tempdir root created by `hermetic_setup`, the test fails loudly with a diagnostic naming the drift — never silently proceeds.
+5. If any ref under `refs/heads/*` changes during `.husky/pre-push` execution, the hook exits non-zero with a diagnostic listing every changed ref, its pre-hook SHA, and its post-hook SHA — even if `ci-local.sh` itself exits zero.
+6. Two fixture bats tests running concurrently (`bats --jobs 2` or `run-bats-parallel.sh -j 2`) each get a distinct tempdir root; neither can observe or mutate the other's fixture.
+7. `bash scripts/ci-local.sh` (direct invocation, no hook) continues to pass on a clean tree.
+8. Running the full test suite under a real `git push` on a scratch branch completes without corrupting any local ref on any worktree of the shared bare repo.
+9. All acceptance criteria are enforced by automated tests that fail without the fix and pass with it.
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|----------|---------------|-------------|-------------------|
+| Fix scope (root-cause only vs. full 4-step + REFACTOR) | `requires-stakeholder-input` | human | "Full 4-step plan + REFACTOR" — env-scrub in fixtures + ci-local.sh + post-hook ref guard + per-worker tempdirs + shared hermetic helper |
+| Whether to change shared bare repo's `hooksPath = .husky/_` to absolute | `requires-stakeholder-input` | human | "Leave as-is" — env-scrub closes the corruption channel; hooksPath is a compounding factor, not root cause, and changing it touches config outside the checkout |
+| Which env vars to scrub | `inferable` | inference | Triage investigation identified `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_PREFIX`, `GIT_REFLOG_ACTION` as git-exported; `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` isolate global config. Standard git-hermeticity pattern |
+| Whether ci-local.sh scrubs `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` | `inferable` | inference | No — ci-local.sh reads real repo state and may need real config (e.g. user.email for signed commits). Only the bats fixtures need config isolation |
+| Which refs the post-hook guard checks | `inferable` | inference | All `refs/heads/*` via `git for-each-ref` — cheap, comprehensive, avoids false-negatives if corruption hits a ref other than the pushing branch (issue #546 explicitly notes `main` also gets clobbered) |
+| Whether the post-hook guard runs when ci-local.sh exits non-zero | `inferable` | inference | Yes — corruption in #546 is silent regardless of ci-local exit code. Guard runs unconditionally |
+| Location of the shared helper | `inferable` | inference | `tests/lib/hermetic.bash` per triage record; matches bats convention (`load '../lib/hermetic'`) |
+| Whether existing `|| return 1` cd guards from PR #545 must be removed | `inferable` | inference | No — they are harmless once the shared helper's PWD trap is in place. Removal is a follow-up cleanup, not part of this fix |
+| Tempdir prefix format | `inferable` | inference | `mktemp -d -t "bats-$$-XXXX"` — `$$` gives per-worker namespace (bats PID), `XXXX` is mktemp's own randomness. Cross-platform (macOS, Linux, Git Bash) |
+| Whether to file separately the observation that `hooksPath` is relative | `inferable` | inference (LOW_VALUE for this spec) | Note in code review but out of scope here; env-scrub alone satisfies acceptance criteria |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous — two developers would interpret it the same way (scrub env, add guard, add per-worker tempdirs, extract shared helper; leave hooksPath alone)
+- [x] Every behavior/goal maps to an acceptance criterion (AC1 = intent's "never mutates refs"; AC2/3 = env-scrub in ci-local + fixtures; AC4 = PWD guard; AC5 = post-hook guard; AC6 = per-worker tempdirs; AC7 = direct invocation still works; AC8 = end-to-end; AC9 = tests enforce all of the above)
+- [x] Architecture constrains without over-engineering (one new helper file, edits to two hook/script files, sourcing the helper from existing bats files; no new dependencies, no shared-bare-repo config changes)
+- [x] Terminology consistent across artifacts (hermetic, env-scrub, per-worker tempdir, post-hook ref guard, shared helper)
+- [x] No contradictions between artifacts
+- [x] Every gap/ambiguity finding is logged — two `requires-stakeholder-input` items resolved by human via /ship, the rest classified `inferable` with explicit rationale
+
+**Verdict: PASS.**

--- a/plans/pre-push-hook-hermetic-fixtures.md
+++ b/plans/pre-push-hook-hermetic-fixtures.md
@@ -394,10 +394,10 @@ Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end
 
 #### Wave 2
 
-- [ ] Slice 3: Adopt hermetic helper in fixture bats tests
-  - [ ] Step 3.1: `progress_guardian_tests.bats`
-  - [ ] Step 3.2: `codebase_recon` and `pre_commit_knowledge_index`
-  - [ ] Step 3.3: Remaining fixture bats files
+- [x] Slice 3: Adopt hermetic helper in fixture bats tests
+  - [x] Step 3.1: `progress_guardian_tests.bats`
+  - [x] Step 3.2: `codebase_recon` and `pre_commit_knowledge_index`
+  - [x] Step 3.3: Remaining fixture bats files
 - [x] Slice 4: Post-hook ref-integrity guard in `.husky/pre-push`
   - [x] Step 4.1: RED ref-guard bats test
   - [x] Step 4.2: GREEN ref-integrity guard

--- a/plans/pre-push-hook-hermetic-fixtures.md
+++ b/plans/pre-push-hook-hermetic-fixtures.md
@@ -388,9 +388,9 @@ Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end
 - [x] Slice 1: Shared hermetic bats helper
   - [x] Step 1.1: Author `hermetic_setup` in `tests/lib/hermetic.bash`
   - [x] Step 1.2: `hermetic_assert_pwd` + parallel-safety
-- [ ] Slice 2: Env scrub in `scripts/ci-local.sh`
-  - [ ] Step 2.1: RED env-scrub test for ci-local
-  - [ ] Step 2.2: Scrub git env vars in ci-local
+- [x] Slice 2: Env scrub in `scripts/ci-local.sh`
+  - [x] Step 2.1: RED env-scrub test for ci-local
+  - [x] Step 2.2: Scrub git env vars in ci-local
 
 #### Wave 2
 

--- a/plans/pre-push-hook-hermetic-fixtures.md
+++ b/plans/pre-push-hook-hermetic-fixtures.md
@@ -398,9 +398,9 @@ Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end
   - [ ] Step 3.1: `progress_guardian_tests.bats`
   - [ ] Step 3.2: `codebase_recon` and `pre_commit_knowledge_index`
   - [ ] Step 3.3: Remaining fixture bats files
-- [ ] Slice 4: Post-hook ref-integrity guard in `.husky/pre-push`
-  - [ ] Step 4.1: RED ref-guard bats test
-  - [ ] Step 4.2: GREEN ref-integrity guard
+- [x] Slice 4: Post-hook ref-integrity guard in `.husky/pre-push`
+  - [x] Step 4.1: RED ref-guard bats test
+  - [x] Step 4.2: GREEN ref-integrity guard
 
 #### Wave 3
 

--- a/plans/pre-push-hook-hermetic-fixtures.md
+++ b/plans/pre-push-hook-hermetic-fixtures.md
@@ -1,0 +1,454 @@
+# Plan: Pre-push hook hermetic fixtures (issue #546)
+
+**Created**: 2026-07-01
+**Branch**: issue-546
+**Status**: in-progress
+
+## Goal
+
+Stop the pre-push hook from silently corrupting local branch refs during real `git push` invocations. Root cause: git exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE`/`GIT_PREFIX`/`GIT_REFLOG_ACTION` into the hook environment, and nothing in the hook chain (`.husky/pre-push` → `scripts/ci-local.sh` → `scripts/run-bats-parallel.sh` → bats fixtures) scrubs them. Fixture bats tests running `git init`/`git commit`/`git push` then target the parent worktree's gitdir instead of their tempdirs. Fix at three defenses in depth: env-scrub in a new shared bats helper (`tests/lib/hermetic.bash`), env-scrub at the top of `scripts/ci-local.sh`, and a post-hook ref-integrity guard in `.husky/pre-push` that refuses the push if any local ref moved. Also standardize fixture tempdirs on a per-worker prefix and add a PWD-guard trap so any future drift fails a test loudly instead of clobbering a worktree.
+
+Approach stance on decision-defaults axes:
+
+- **Replace vs. merge** (`.husky/pre-push`, `scripts/ci-local.sh`, existing bats setups): **merge** — preserve current behavior, add scrub + guard on top; do not rewrite the hook.
+- **Scope**: **touch only what was requested** — env scrub, ref guard, shared helper, per-worker tempdirs. `hooksPath = .husky/_` relative-path amplifier is out of scope (confirmed by human at spec time).
+- **Auto-merge**: **auto-merge PR gated on green checks** (default `/ship` flow; touches code so still requires explicit human merge per repo rules).
+
+## Acceptance Criteria
+
+- [ ] Running `git push` on any branch leaves every `refs/heads/*` unchanged from its pre-hook value regardless of ci-local pass/fail.
+- [ ] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, `bash scripts/ci-local.sh` does not mutate the decoy gitdir and its child bats processes see empty git env vars.
+- [ ] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, a fixture bats test using `hermetic_setup` does not mutate the decoy gitdir; the fixture's git operations target only its tempdir.
+- [ ] If a fixture bats test's `PWD` leaves the per-worker tempdir root created by `hermetic_setup`, the test fails loudly.
+- [ ] If any `refs/heads/*` changes during `.husky/pre-push` execution, the hook exits non-zero with a diagnostic listing every changed ref and its pre/post SHAs — even if `ci-local.sh` exits zero.
+- [ ] Two fixture bats tests running concurrently each get a distinct tempdir root.
+- [ ] `bash scripts/ci-local.sh` (direct invocation) continues to pass on a clean tree.
+- [ ] End-to-end: running the full test suite under a real `git push` on a scratch branch completes without corrupting any local ref on any worktree.
+- [ ] All acceptance criteria are enforced by automated tests that fail without the fix and pass with it.
+
+## Slices
+
+### Slice 1: Shared hermetic bats helper
+
+**Depends-on:** none
+**Files:** `tests/lib/hermetic.bash`, `tests/lib/hermetic_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: Hermetic bats fixture isolation
+
+  Scenario: git env vars are scrubbed
+    Given the calling process has GIT_DIR=/tmp/decoy.git and GIT_INDEX_FILE=/tmp/decoy.idx exported
+    When a bats setup() calls hermetic_setup
+    Then GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE, GIT_PREFIX, and GIT_REFLOG_ACTION are all unset in the test's environment
+    And GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM are exported to /dev/null
+
+  Scenario: per-worker tempdir is created and entered
+    Given hermetic_setup is called
+    When it returns
+    Then PWD is a fresh directory under $TMPDIR (or /tmp) whose basename contains "bats-<pid>-"
+    And the directory is empty
+
+  Scenario: two concurrent fixtures do not share a tempdir root
+    Given two bats workers each call hermetic_setup concurrently
+    When both return
+    Then their tempdir roots differ
+    And neither can list files inside the other's root
+
+  Scenario: git init in the tempdir stays hermetic even with hostile GIT_DIR
+    Given /tmp/decoy.git is a real bare git repo at a known HEAD
+    And GIT_DIR=/tmp/decoy.git and GIT_INDEX_FILE=/tmp/decoy.idx are exported
+    And hermetic_setup was called
+    When the test runs "git init -q && git commit --allow-empty -m x"
+    Then /tmp/decoy.git is unchanged (HEAD, refs, and objects intact)
+    And the fresh commit lives inside the tempdir's .git
+
+  Scenario: PWD drift is caught by hermetic_assert_pwd
+    Given hermetic_setup was called and $HERMETIC_ROOT is the recorded root
+    When the test cds outside $HERMETIC_ROOT and calls hermetic_assert_pwd
+    Then hermetic_assert_pwd fails with a diagnostic naming the drifted PWD and the expected root
+
+  Scenario: fixture-local push to a fixture's own origin still works
+    Given hermetic_setup was called establishing $HERMETIC_ROOT
+    And $HERMETIC_ROOT/origin.git is a bare repo and $HERMETIC_ROOT/work is a clone of it
+    When the test runs "cd $HERMETIC_ROOT/work && git push origin main"
+    Then the push succeeds and $HERMETIC_ROOT/origin.git's refs/heads/main matches the pushed commit
+```
+
+**Steps:**
+
+#### Step 1.1: Author `hermetic_setup` and `hermetic_assert_pwd` in `tests/lib/hermetic.bash`
+
+**Complexity**: standard
+**RED**: In a new bats file `tests/lib/hermetic_tests.bats`, add tests covering scenarios 1, 2, and 4 (env scrub, tempdir shape, hermetic git init under hostile GIT_DIR).
+**GREEN**: Create `tests/lib/hermetic.bash` exporting `hermetic_setup` — unsets `GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION`, exports `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`, creates `T="$(mktemp -d -t "bats-$$-XXXX")"`, records it in `HERMETIC_ROOT`, and cds into it. Bash-3.2 safe. Include the copyright/CLAUDE.md convention header used by other repo shell files.
+**REFACTOR**: None needed.
+**Files**: `tests/lib/hermetic.bash`, `tests/lib/hermetic_tests.bats`
+**Commit**: `feat(tests): add tests/lib/hermetic.bash — env scrub + per-worker tempdir`
+
+#### Step 1.2: Add concurrent-safety and PWD-guard tests to the helper
+
+**Complexity**: standard
+**RED**: Extend `tests/lib/hermetic_tests.bats` with three cases: (a) two concurrent subshells each call `hermetic_setup` and echo `$HERMETIC_ROOT`, asserting the paths differ; (b) `hermetic_assert_pwd` succeeds when `PWD` is under `$HERMETIC_ROOT`; (c) `hermetic_assert_pwd` fails with a diagnostic when `PWD` is outside `$HERMETIC_ROOT`. Also add a case for the fixture-local-push scenario from the Gherkin above.
+**GREEN**: Add an explicit `hermetic_assert_pwd` function to `tests/lib/hermetic.bash` — fails if `$PWD` is not under `$HERMETIC_ROOT`, printing both the drifted PWD and the expected root. **Design decision**: use explicit callable rather than a `DEBUG`/`RETURN` trap. Rationale: `RETURN` fires only on `hermetic_setup` return (not during test body execution), and `DEBUG` traps interact fragilely with `set -e`/pipefail across bash versions and Git Bash on Windows. The explicit-call design is deterministic and matches the existing `|| return 1` convention already used in the repo's bats fixtures; `hermetic_teardown` (called from the fixture's `teardown()` block) invokes `hermetic_assert_pwd` as a matter of course, so any adopting bats file gets automatic drift detection at test-end without relying on trap semantics. Confirm `mktemp -d -t "bats-$$-XXXX"` yields distinct paths under parallel invocation on macOS + Linux + Git Bash.
+**REFACTOR**: None needed.
+**Files**: `tests/lib/hermetic.bash`, `tests/lib/hermetic_tests.bats`
+**Commit**: `feat(tests): hermetic_assert_pwd + parallel-safety for hermetic.bash`
+
+### Slice 2: Env scrub in `scripts/ci-local.sh`
+
+**Depends-on:** none
+**Files:** `scripts/ci-local.sh`, `tests/scripts/ci_local_hermetic_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: ci-local.sh is hermetic against inherited git env
+
+  Scenario: ci-local scrubs git env vars for its own execution
+    Given GIT_DIR=/tmp/decoy.git and GIT_INDEX_FILE=/tmp/decoy.idx are exported
+    When scripts/ci-local.sh is invoked with CI_LOCAL_PROBE_ENV=1
+    Then it exits 0
+    And its stdout matches the empty set (no lines starting with GIT_DIR=, GIT_INDEX_FILE=, GIT_WORK_TREE=, GIT_PREFIX=, or GIT_REFLOG_ACTION=)
+
+  Scenario: ci-local does not clobber a decoy gitdir when invoked with hostile env
+    Given /tmp/decoy.git is a fresh bare repo at a known ref
+    And GIT_DIR=/tmp/decoy.git and GIT_INDEX_FILE=/tmp/decoy.idx are exported
+    When scripts/ci-local.sh is invoked with CI_LOCAL_PROBE_ENV=1
+    Then /tmp/decoy.git's HEAD, refs/, and objects/ are byte-identical to the pre-invocation snapshot
+```
+
+**Steps:**
+
+#### Step 2.1: Add env-scrub test for `scripts/ci-local.sh`
+
+**Complexity**: standard
+**RED**: Author `tests/scripts/ci_local_hermetic_tests.bats` with two `@test` blocks matching the two Slice-2 Gherkin scenarios: (a) env-scrub probe — exports `GIT_DIR=$(mktemp)` and `GIT_INDEX_FILE=$(mktemp)`, invokes `CI_LOCAL_PROBE_ENV=1 bash scripts/ci-local.sh`, and asserts stdout contains no lines starting with `GIT_DIR=`/`GIT_INDEX_FILE=`/`GIT_WORK_TREE=`/`GIT_PREFIX=`/`GIT_REFLOG_ACTION=`; (b) decoy-non-mutation — creates `/tmp/decoy-<mktemp>.git` via `git init --bare`, snapshots its `HEAD`+`refs/`+`objects/` (via a recursive `find | sort | sha256sum`), exports `GIT_DIR=<decoy>`, invokes `CI_LOCAL_PROBE_ENV=1 bash scripts/ci-local.sh`, re-snapshots, asserts the two snapshots match byte-for-byte. Both tests should fail before Step 2.2 lands because ci-local currently neither scrubs nor honors `CI_LOCAL_PROBE_ENV`.
+**GREEN**: Not yet — the assertions should fail.
+**REFACTOR**: None needed.
+**Files**: `tests/scripts/ci_local_hermetic_tests.bats`
+**Commit**: `test(ci-local): RED — env scrub not yet in place`
+
+#### Step 2.2: Scrub git env vars in `scripts/ci-local.sh`
+
+**Complexity**: standard
+**RED**: (Step 2.1 test still red.)
+**GREEN**: Immediately after the shebang/comment block and before `set -uo pipefail` at line 31 (or between `set -uo pipefail` and `cd` at line 33, whichever is safe under `set -u`), add:
+
+```
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION
+```
+
+Also allow a short-circuit probe: `[ "${CI_LOCAL_PROBE_ENV:-}" = 1 ] && { env | grep '^GIT_' || true; exit 0; }` — placed after the unset so the test can assert scrub happened. Guard the probe behind an env var so it never fires in real runs.
+**REFACTOR**: None needed — this is a two-line addition.
+**Files**: `scripts/ci-local.sh`
+**Commit**: `fix(ci-local): unset git env vars leaked by pre-push hook`
+
+### Slice 3: Adopt hermetic helper in fixture bats tests
+
+**Depends-on:** 1
+**Files:** `tests/scripts/progress_guardian_tests.bats`, `tests/scripts/codebase_recon_tests.bats`, `tests/hooks/pre_commit_knowledge_index_tests.bats`, `tests/repo/hermetic_adoption_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: Fixture bats setups are hermetic
+
+  Scenario: progress_guardian fixture push does not target parent gitdir
+    Given GIT_DIR=<parent-gitdir> is exported (simulating pre-push hook environment)
+    When tests/scripts/progress_guardian_tests.bats runs (any test that calls setup_stale_main_repo)
+    Then <parent-gitdir>'s refs are unchanged after the suite completes
+
+  Scenario: every fixture-touching bats file sources the shared helper
+    Given the shared helper tests/lib/hermetic.bash exists
+    When we grep the fixture bats files (progress_guardian, codebase_recon, pre_commit_knowledge_index, and any repo/*.bats doing git ops)
+    Then each file loads the helper (load '../lib/hermetic')
+    And each setup() calls hermetic_setup before its first git command
+```
+
+**Steps:**
+
+#### Step 3.1: Wire helper into `tests/scripts/progress_guardian_tests.bats`
+
+**Complexity**: complex (many setup helpers; largest offender per triage)
+**RED**: Add an integration test `tests/scripts/progress_guardian_hermetic_tests.bats` that exports `GIT_DIR=<mktemp bare-repo>`, runs a representative subset of the file's tests via `bats`, and asserts the decoy bare repo's refs are unchanged.
+**GREEN**: At the top of `progress_guardian_tests.bats` add `load '../lib/hermetic'`. In `setup()` and in `setup_stale_main_repo`, call `hermetic_setup` before the first `mktemp -d`/`cd`. Replace bare `mktemp -d` with the helper-provided root; every fixture tempdir must be a subdirectory of `$HERMETIC_ROOT` (`T="$HERMETIC_ROOT/work"`, `T="$HERMETIC_ROOT/sibling"`, etc.). This is the largest offender per triage and gets the most rigorous treatment — no ad-hoc `mktemp -d` calls survive in this file. Keep the existing `|| return 1` cd guards (harmless).
+**REFACTOR**: Consolidate all `T="$(mktemp -d)"` sites in `setup_stale_main_repo` and every test's setup block onto `$HERMETIC_ROOT/<name>`. Do this in the same commit — no threshold-based defer clause.
+**Files**: `tests/scripts/progress_guardian_tests.bats`, `tests/scripts/progress_guardian_hermetic_tests.bats`
+**Commit**: `fix(tests): use hermetic helper in progress_guardian fixtures`
+
+#### Step 3.2: Wire helper into `tests/scripts/codebase_recon_tests.bats` and `tests/hooks/pre_commit_knowledge_index_tests.bats`
+
+**Complexity**: standard
+**RED**: Extend the hermetic integration test (or add a sibling) to assert the same non-mutation invariant when these two files run under hostile `GIT_DIR`.
+**GREEN**: `load '../lib/hermetic'` + `hermetic_setup` in each `setup()`.
+**REFACTOR**: None needed.
+**Files**: `tests/scripts/codebase_recon_tests.bats`, `tests/hooks/pre_commit_knowledge_index_tests.bats`
+**Commit**: `fix(tests): use hermetic helper in codebase_recon and knowledge_index fixtures`
+
+#### Step 3.3: Wire helper into remaining fixture bats files
+
+**Complexity**: standard
+**RED**: Add a repo-level bats test at `tests/repo/hermetic_adoption_tests.bats`. The detection query is: "any `.bats` file under `tests/` that (a) calls `mktemp -d` **or** contains any occurrence of `git` (with a trailing space) or `git$` in a shell context, **and** (b) does not `load '../lib/hermetic'` in the file body **or** does not call `hermetic_teardown` from a `teardown()` block". This is broader than the literal `git init`/`git commit`/`git push` grep in the triage — it also catches indirect git usage via sourced helpers and fixture-local functions, and ensures automatic PWD-drift detection is wired (AC4 depends on `hermetic_teardown` running). The test enumerates every offender and prints their paths; assertion is that the offender list is empty.
+**GREEN**: Apply the `load '../lib/hermetic'` + `hermetic_setup` pattern to every offender from Step 3.3's detection query. The initial known set (from `grep -l "git init\|git commit\|git push" tests/scripts tests/repo tests/hooks`) is: `tests/repo/eval_semver_classify_tests.bats`, `tests/repo/gate_correlation_tests.bats`, `tests/repo/multiplayer_collision_tests.bats`, `tests/repo/review_gate_hash_tests.bats`, `tests/repo/telemetry_tests.bats`. The broader `mktemp -d`+`git` query may surface additional files — the plan does not enumerate them here (the RED test's failure will); every offender the test names must be fixed before Step 3.3 is complete. If any file legitimately does not need the helper (e.g. tests that only run git as a subject-under-test in a controlled way), whitelist it explicitly in the test with a one-line comment rationale — no silent skips.
+**REFACTOR**: None needed.
+**Files**: multiple `tests/**/*.bats` (per detection query), `tests/repo/hermetic_adoption_tests.bats`
+**Commit**: `fix(tests): adopt hermetic helper across all fixture bats files`
+
+### Slice 4: Post-hook ref-integrity guard in `.husky/pre-push`
+
+**Depends-on:** 1
+**Files:** `.husky/pre-push`, `tests/repo/pre_push_ref_guard_tests.bats`
+
+**Behavior:**
+
+```gherkin
+Feature: Pre-push hook refuses to complete on ref mutation
+
+  Scenario: refs unchanged during hook — push proceeds
+    Given all refs/heads/* are stable during the hook run
+    When .husky/pre-push executes ci-local.sh and returns zero
+    Then the hook exits zero
+    And no diagnostic about ref drift is printed
+
+  Scenario: pushing branch's ref changes during hook — hook refuses
+    Given refs/heads/<branch> has SHA A before ci-local.sh runs
+    When ci-local.sh (or anything it spawns) rewrites refs/heads/<branch> to SHA B
+    Then .husky/pre-push exits non-zero
+    And stderr names the changed ref, the pre-hook SHA (A), and the post-hook SHA (B)
+    And the diagnostic instructs the developer how to recover (git update-ref from reflog)
+
+  Scenario: unrelated ref changes during hook — hook still refuses
+    Given refs/heads/main has SHA X before ci-local.sh runs
+    When ci-local.sh (or anything it spawns) rewrites refs/heads/main to SHA Y
+    Then .husky/pre-push exits non-zero even if the pushing branch was untouched
+    And stderr names refs/heads/main and its pre/post SHAs
+
+  Scenario: ref deleted during hook — hook refuses
+    Given refs/heads/feature exists at SHA A before ci-local.sh runs
+    When ci-local.sh (or anything it spawns) deletes refs/heads/feature
+    Then .husky/pre-push exits non-zero
+    And stderr names refs/heads/feature with pre=A and post=<deleted>
+
+  Scenario: ref created during hook — hook refuses
+    Given refs/heads/stray does not exist before ci-local.sh runs
+    When ci-local.sh (or anything it spawns) creates refs/heads/stray at SHA B
+    Then .husky/pre-push exits non-zero
+    And stderr names refs/heads/stray with pre=<absent> and post=B
+
+  Scenario: ref-guard exit code actually blocks the remote push
+    Given a scratch remote and refs/heads/<branch> drifts during the hook
+    When git push triggers .husky/pre-push and the guard exits non-zero
+    Then git itself reports the push as rejected
+    And the scratch remote's ref for <branch> is NOT updated
+
+  Scenario: hook refuses when ci-local passes but refs drifted
+    Given ci-local.sh exits zero
+    And any refs/heads/* changed during the hook
+    Then .husky/pre-push exits non-zero — the guard runs unconditionally
+
+  Scenario: hook still refuses when ci-local failed and refs also drifted
+    Given ci-local.sh exits non-zero
+    And any refs/heads/* changed during the hook
+    Then .husky/pre-push exits non-zero
+    And the diagnostic surfaces both the ci-local failure and the ref drift
+```
+
+**Steps:**
+
+#### Step 4.1: RED — write the ref-guard bats test
+
+**Complexity**: standard
+**RED**: Author `tests/repo/pre_push_ref_guard_tests.bats`. Each scenario builds a scratch bare repo + worktree in a hermetic tempdir (via `hermetic_setup` — Slice 1's helper), **copies the real `.husky/pre-push` into the scratch repo**, and **shadows `scripts/ci-local.sh` with a per-scenario stub** (via a scratch `scripts/` directory) that induces the specific ref-mutation-or-not the scenario needs (no-op / update-ref / delete-ref / create-ref / exit-non-zero). Feed the hook a realistic stdin (`<local-ref> <local-sha> <remote-ref> <remote-sha>\n`) and assert (a) exit code and (b) diagnostic text on stderr. **Design decision**: test the shipped `.husky/pre-push` verbatim — never a hand-written stand-in — so this test verifies the actual guard, not a reimplementation. The only substitution is `scripts/ci-local.sh`, which is treated as a boundary (its exit code and side effects are what the guard reads).
+**GREEN**: Not yet — assertions fail because `.husky/pre-push` does not yet guard.
+**REFACTOR**: Factor the "copy hook + stub ci-local + build scratch repo" setup into a bats helper if it's needed by more than one test file.
+**Files**: `tests/repo/pre_push_ref_guard_tests.bats`
+**Commit**: `test(husky): RED — pre-push ref-integrity guard missing`
+
+#### Step 4.2: GREEN — add the ref-integrity guard
+
+**Complexity**: standard
+**RED**: (Step 4.1 test still red.)
+**GREEN**: In `.husky/pre-push` (which is `#!/usr/bin/env sh` — **POSIX sh, not bash**; avoid `[[`, arrays, `<()`, and other bash-only syntax): immediately before the `bash scripts/ci-local.sh "$BASE" "$HEAD"` line at ~line 36 (after the existing BASE/HEAD stdin-parsing block, which only reads refs and does not mutate them), capture `PRE_REFS="$(git for-each-ref --format='%(refname) %(objectname)' refs/heads/)"`. Change the ci-local invocation to save the exit code (`bash scripts/ci-local.sh "$BASE" "$HEAD"; CI_EXIT=$?`) rather than `|| exit 1`. Then capture `POST_REFS` the same way. Compare with `printf '%s\n' "$PRE_REFS" | diff - <(printf '%s\n' "$POST_REFS")` — or, since process substitution is bash-only, write both to tempfiles and `diff` them. If different, iterate the diff and print each changed ref: `<refname>: pre=<sha-or-absent> post=<sha-or-absent>`. Handle three cases explicitly: mutation (both SHAs present, different), deletion (post absent), creation (pre absent). Print a recovery hint (`git update-ref <refname> <pre-sha>` — omitted for created refs, which should be `git update-ref -d`). If the diff is non-empty, exit 1 regardless of `CI_EXIT`. If refs are stable and `CI_EXIT` is non-zero, exit `CI_EXIT` (preserve existing behavior). If both stable and passing, continue to the live-eval prompt as before.
+**REFACTOR**: None needed — the guard is a discrete block inserted between existing hook steps.
+**Files**: `.husky/pre-push`
+**Commit**: `fix(husky): refuse push if any local ref changes during hook`
+
+### Slice 5: End-to-end verification and CLAUDE.md note
+
+**Depends-on:** 1, 2, 3, 4
+**Files:** `tests/repo/pre_push_end_to_end_tests.bats`, `CLAUDE.md`
+
+**Behavior:**
+
+```gherkin
+Feature: End-to-end: real git push does not corrupt refs
+
+  Scenario: full pre-push run on a scratch bare repo leaves refs stable
+    Given a scratch bare repo with a worktree, a feature branch with N commits ahead of main, and the repo's real .husky/pre-push installed
+    When the test drives a real "git push -u origin <branch>" (letting it fail on the fixture — we assert on ref stability, not push success)
+    Then every ref under refs/heads/* on both the bare repo and the worktree matches its pre-push value
+    And no logs/HEAD entry contains "Test <test@test.com>" commits authored during the push
+
+  Scenario: reproduction of the original #546 bug (regression backstop)
+    Given a scratch bare repo with the fix REVERTED (no scrub in ci-local, no hermetic_setup in fixtures, no ref guard in .husky/pre-push)
+    When the same "git push -u origin <branch>" runs
+    Then refs are observed to change (corruption reproduces)
+    And when the fix is re-applied, the corruption stops
+    Note: this scenario documents a manual pre-merge check — not an automated test — since a "revert the fix and re-apply it" test is impractical for CI. Executor runs it once on a scratch branch before merging.
+
+  Scenario: CLAUDE.md documents the hermetic isolation contract
+    Given a developer opens CLAUDE.md
+    Then they find a note stating that fixture bats tests must source tests/lib/hermetic.bash and call hermetic_setup, and why (linked to issue #546)
+```
+
+**Steps:**
+
+#### Step 5.1: End-to-end bats test
+
+**Complexity**: complex
+**RED**: Write `tests/repo/pre_push_end_to_end_tests.bats` that stands up a hermetic bare+worktree, copies the repo's `.husky/` and `scripts/` into it (or `git clone --local .` into the tempdir and switch to a scratch branch), then invokes `git push origin <branch>` inside it. Asserts ref stability on both the bare and the worktree.
+**GREEN**: This is a validation-only step; there is no additional production change in Step 5.1 itself. RED and GREEN point at the same test file. If any assertion fails after slices 1–4 land, treat the failure as a defect in the originating slice and fix it in that slice's commit history — not as a new ad-hoc patch scoped to Step 5.1. If the failure is legitimately new (e.g. reveals an interaction slices 1–4 did not cover), file a new slice or step rather than patching in place.
+**REFACTOR**: If the test setup is heavy, factor a helper into `tests/lib/hermetic.bash` (e.g. `hermetic_scratch_repo`).
+**Files**: `tests/repo/pre_push_end_to_end_tests.bats`, possibly `tests/lib/hermetic.bash`
+**Commit**: `test(husky): end-to-end pre-push ref-stability guarantee`
+
+#### Step 5.2: Document the hermetic contract
+
+**Complexity**: trivial
+**RED**: N/A (documentation).
+**GREEN**: Add one paragraph to `CLAUDE.md` (or `plugins/dev-team/CLAUDE.md`, whichever is the appropriate contributor doc) stating: "Every fixture bats file that touches git must `load '../lib/hermetic'` and call `hermetic_setup` in `setup()`. Rationale: issue #546 — git exports `GIT_DIR`/`GIT_INDEX_FILE` into pre-push hooks; fixtures that inherit them corrupt the parent worktree's refs." Reference the triage record.
+**REFACTOR**: None needed.
+**Files**: `CLAUDE.md` or `plugins/dev-team/CLAUDE.md`
+**Commit**: `docs: require hermetic_setup in fixture bats setups`
+
+## Parallelization
+
+Slices 1 and 2 are independent. Slices 3 and 4 both depend on Slice 1's helper (Slice 3 adopts it in fixtures; Slice 4's ref-guard test uses `hermetic_setup` to build its scratch scaffolding). Slice 5 depends on all four.
+
+```mermaid
+graph TD
+  S1[Slice 1: hermetic.bash helper] --> S3[Slice 3: adopt helper in fixtures]
+  S1 --> S4[Slice 4: pre-push ref guard]
+  S1 --> S5[Slice 5: end-to-end + docs]
+  S2[Slice 2: ci-local env scrub] --> S5
+  S3 --> S5
+  S4 --> S5
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1, 2 |
+| 2 | 3, 4 |
+| 3 | 5 |
+
+No same-wave file collisions: Wave 1 — Slice 1 touches only `tests/lib/`, Slice 2 touches only `scripts/ci-local.sh` + `tests/scripts/ci_local_hermetic_tests.bats`. Wave 2 — Slice 3 touches fixture bats files under `tests/scripts/`, `tests/hooks/`, `tests/repo/` (excluding `tests/repo/pre_push_ref_guard_tests.bats`); Slice 4 touches only `.husky/pre-push` and `tests/repo/pre_push_ref_guard_tests.bats`. Confirmed via `plan-waves.sh`.
+
+## Complexity Classification
+
+Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end harness).
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (`bash scripts/ci-local.sh`)
+- [ ] Shellcheck clean on new/edited shell files
+- [ ] `/code-review` passes
+- [ ] Documentation updated (`CLAUDE.md` note)
+- [ ] End-to-end test demonstrates ref stability under real `git push`
+
+## Risks & Open Questions
+
+- **Risk**: The end-to-end test (Step 5.1) may be slow or hard to make deterministic across macOS/Linux/Git Bash. Mitigation: use a minimal ci-local surrogate (env-check only) for the end-to-end assertion; the full ci-local coverage is already exercised by the direct-invocation path.
+- **Risk**: The end-to-end test itself drives a real `git push`, the same class of operation that caused the incident. Mitigation: Step 5.1 depends on slices 1+2+4 landing first (env scrub + ref guard in place), and the test must be run once manually on a scratch branch before it's trusted to run repeatedly in CI. State this in the test's own comments.
+- **Risk**: Wiring the hermetic helper into many bats files (Slice 3) may surface fixtures that already relied on inheriting the parent's git config. Mitigation: run each modified file individually after adoption; adjust the helper's config isolation if a specific fixture legitimately needs a real config value.
+- **Open question**: Should `hermetic_setup` also isolate `HOME=$T` to prevent inherited `~/.gitconfig` reads? Deferred — `GIT_CONFIG_GLOBAL=/dev/null` already achieves this for git; other tools that read `$HOME` can be addressed if a symptom appears.
+
+## Acceptance-Criteria → Test Traceability
+
+| # | Acceptance Criterion | Enforced by |
+|---|---------------------|-------------|
+| 1 | `git push` leaves refs unchanged regardless of ci-local pass/fail | Step 4.1 (all ref-guard scenarios) + Step 5.1 (end-to-end) |
+| 2 | Hostile `GIT_DIR` → ci-local does not mutate decoy | Step 2.1 (both @test blocks) |
+| 3 | Hostile `GIT_DIR` → fixture `hermetic_setup` does not mutate decoy | Step 1.1 (hermetic scenario) + Step 3.1 (progress_guardian hermetic integration test) |
+| 4 | PWD drift in a fixture fails loudly | Step 1.2 (hermetic_assert_pwd tests) |
+| 5 | Any `refs/heads/*` change during hook → non-zero exit with SHAs | Step 4.1 (mutation + deletion + creation scenarios) + Step 4.2 |
+| 6 | Two concurrent fixture bats tests get distinct tempdir roots | Step 1.2 (concurrent-safety test) |
+| 7 | `bash scripts/ci-local.sh` direct invocation still passes | Pre-PR quality gate + all-tests-pass verification |
+| 8 | Full suite under real `git push` doesn't corrupt any local ref | Step 5.1 (end-to-end) |
+| 9 | All ACs enforced by tests that fail without fix / pass with fix | This traceability table + RED-first commits for every GREEN step |
+| — | Fixture-local push to fixture's own origin still works | Step 1.1 (fixture-local-push scenario) |
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [x] Slice 1: Shared hermetic bats helper
+  - [x] Step 1.1: Author `hermetic_setup` in `tests/lib/hermetic.bash`
+  - [x] Step 1.2: `hermetic_assert_pwd` + parallel-safety
+- [ ] Slice 2: Env scrub in `scripts/ci-local.sh`
+  - [ ] Step 2.1: RED env-scrub test for ci-local
+  - [ ] Step 2.2: Scrub git env vars in ci-local
+
+#### Wave 2
+
+- [ ] Slice 3: Adopt hermetic helper in fixture bats tests
+  - [ ] Step 3.1: `progress_guardian_tests.bats`
+  - [ ] Step 3.2: `codebase_recon` and `pre_commit_knowledge_index`
+  - [ ] Step 3.3: Remaining fixture bats files
+- [ ] Slice 4: Post-hook ref-integrity guard in `.husky/pre-push`
+  - [ ] Step 4.1: RED ref-guard bats test
+  - [ ] Step 4.2: GREEN ref-integrity guard
+
+#### Wave 3
+
+- [ ] Slice 5: End-to-end verification and CLAUDE.md note
+  - [ ] Step 5.1: End-to-end bats test
+  - [ ] Step 5.2: Document the hermetic contract
+
+### Acceptance Criteria
+
+- [ ] `git push` leaves every `refs/heads/*` unchanged regardless of ci-local pass/fail
+- [ ] Hostile `GIT_DIR` does not mutate decoy gitdir via `ci-local.sh`; child bats see empty git env
+- [ ] Hostile `GIT_DIR` does not mutate decoy gitdir via fixture `hermetic_setup`
+- [ ] PWD drift inside a hermetic fixture fails the test loudly
+- [ ] Any `refs/heads/*` change during `.husky/pre-push` yields a non-zero exit with pre/post SHAs
+- [ ] Two concurrent fixture bats tests get distinct tempdir roots
+- [ ] `bash scripts/ci-local.sh` (direct invocation) continues to pass
+- [ ] Full test suite under real `git push` does not corrupt any local ref
+- [ ] All acceptance criteria enforced by tests that fail without the fix and pass with it
+
+## Plan Review Summary
+
+**Plan tier: complex** — reviewers: Acceptance Test Critic, Design & Architecture Critic, Strategic Critic, Parallelization Critic. UX Critic skipped (no user-facing/UI surface — this is a hook + shell-test change).
+
+**Round 1 verdicts:**
+
+- Acceptance Test Critic: `needs-revision` — 2 blockers (PWD-guard mechanism fork in Step 1.2; ref-guard test fork in Step 4.1) + several warnings.
+- Design & Architecture Critic: `needs-revision` — 4 warnings (Slice 3 detection breadth, PWD-guard mechanism, progress_guardian consolidation deferral, POSIX-sh constraint on `.husky/pre-push`).
+- Strategic Critic: `approve` — 2 observation-level warnings noted (step-count threshold, self-referential test risk); minimum-viable subset identified (slices 1+2+4).
+- Parallelization Critic: `approve` — no collisions, genuine parallelism, no hidden coupling.
+
+**Revisions applied:**
+
+- Step 1.2 committed definitively to explicit `hermetic_assert_pwd` invoked via `hermetic_teardown`, rejecting DEBUG/RETURN traps on bash-3.2 + Git Bash compatibility grounds. Gherkin scenario tightened.
+- Step 4.1 committed to testing the shipped `.husky/pre-push` verbatim, shadowing only `scripts/ci-local.sh` via a scratch `scripts/` directory. Slice 4 `Depends-on` updated to `1` (reuses `hermetic_setup` for scratch scaffolding).
+- Slice 2 Gherkin + Step 2.1 committed to `CI_LOCAL_PROBE_ENV=1` mechanism upfront with concrete assertions.
+- Slice 4 Gherkin expanded: ref deletion, ref creation, and "guard exit code actually blocks the remote push" scenarios added. Step 4.2 handles all three ref-shape cases (mutate/create/delete) and calls out the `#!/usr/bin/env sh` POSIX-sh constraint explicitly (no `[[`, arrays, or process substitution).
+- Step 3.3 detection query broadened from literal `git init`/`git commit`/`git push` grep to `mktemp -d` OR any `git` invocation, and also checks `hermetic_teardown` wiring in `teardown()` (residual warning from Acceptance re-review).
+- Step 3.1 REFACTOR committed to same-commit consolidation of all `mktemp -d` sites onto `$HERMETIC_ROOT/<name>`. No threshold-based defer.
+- Slice 1 Gherkin added fixture-local-push scenario. Decoy-gitdir Given tightened to require pre-existing bare repo.
+- Step 5.1 relabeled as validation-only step; defect fixes route back to originating slice.
+- Acceptance-Criteria → Test traceability table added.
+- Parallelization re-derived: waves = [[1,2],[3,4],[5]], collisions = []. Confirmed via `plan-waves.sh`.
+
+**Round 2 verdicts (after revision):**
+
+- Acceptance Test Critic: `approve` — both blockers resolved with concrete design commitments. One residual observation (also apply `hermetic_teardown` check) — applied in this revision.
+- Design & Architecture Critic: `approve` — all four warnings resolved with in-plan commitments (not deferred).
+- Strategic Critic: `approve` (from Round 1).
+- Parallelization Critic: `approve` (from Round 1).
+
+All reviewers approve.

--- a/plans/pre-push-hook-hermetic-fixtures.md
+++ b/plans/pre-push-hook-hermetic-fixtures.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-01
 **Branch**: issue-546
-**Status**: in-progress
+**Status**: implemented
 
 ## Goal
 
@@ -16,15 +16,15 @@ Approach stance on decision-defaults axes:
 
 ## Acceptance Criteria
 
-- [ ] Running `git push` on any branch leaves every `refs/heads/*` unchanged from its pre-hook value regardless of ci-local pass/fail.
-- [ ] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, `bash scripts/ci-local.sh` does not mutate the decoy gitdir and its child bats processes see empty git env vars.
-- [ ] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, a fixture bats test using `hermetic_setup` does not mutate the decoy gitdir; the fixture's git operations target only its tempdir.
-- [ ] If a fixture bats test's `PWD` leaves the per-worker tempdir root created by `hermetic_setup`, the test fails loudly.
-- [ ] If any `refs/heads/*` changes during `.husky/pre-push` execution, the hook exits non-zero with a diagnostic listing every changed ref and its pre/post SHAs — even if `ci-local.sh` exits zero.
-- [ ] Two fixture bats tests running concurrently each get a distinct tempdir root.
-- [ ] `bash scripts/ci-local.sh` (direct invocation) continues to pass on a clean tree.
-- [ ] End-to-end: running the full test suite under a real `git push` on a scratch branch completes without corrupting any local ref on any worktree.
-- [ ] All acceptance criteria are enforced by automated tests that fail without the fix and pass with it.
+- [x] Running `git push` on any branch leaves every `refs/heads/*` unchanged from its pre-hook value regardless of ci-local pass/fail.
+- [x] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, `bash scripts/ci-local.sh` does not mutate the decoy gitdir and its child bats processes see empty git env vars.
+- [x] With a hostile `GIT_DIR`/`GIT_INDEX_FILE` in the environment, a fixture bats test using `hermetic_setup` does not mutate the decoy gitdir; the fixture's git operations target only its tempdir.
+- [x] If a fixture bats test's `PWD` leaves the per-worker tempdir root created by `hermetic_setup`, the test fails loudly.
+- [x] If any `refs/heads/*` changes during `.husky/pre-push` execution, the hook exits non-zero with a diagnostic listing every changed ref and its pre/post SHAs — even if `ci-local.sh` exits zero.
+- [x] Two fixture bats tests running concurrently each get a distinct tempdir root.
+- [x] `bash scripts/ci-local.sh` (direct invocation) continues to pass on a clean tree.
+- [x] End-to-end: running the full test suite under a real `git push` on a scratch branch completes without corrupting any local ref on any worktree.
+- [x] All acceptance criteria are enforced by automated tests that fail without the fix and pass with it.
 
 ## Slices
 
@@ -351,11 +351,11 @@ Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end
 
 ## Pre-PR Quality Gate
 
-- [ ] All tests pass (`bash scripts/ci-local.sh`)
-- [ ] Shellcheck clean on new/edited shell files
-- [ ] `/code-review` passes
-- [ ] Documentation updated (`CLAUDE.md` note)
-- [ ] End-to-end test demonstrates ref stability under real `git push`
+- [x] All tests pass (`bash scripts/ci-local.sh`)
+- [x] Shellcheck clean on new/edited shell files
+- [x] `/code-review` passes
+- [x] Documentation updated (`CLAUDE.md` note)
+- [x] End-to-end test demonstrates ref stability under real `git push`
 
 ## Risks & Open Questions
 
@@ -404,21 +404,21 @@ Summary: 1 trivial (docs), 8 standard, 2 complex (broad fixture edit, end-to-end
 
 #### Wave 3
 
-- [ ] Slice 5: End-to-end verification and CLAUDE.md note
-  - [ ] Step 5.1: End-to-end bats test
-  - [ ] Step 5.2: Document the hermetic contract
+- [x] Slice 5: End-to-end verification and CLAUDE.md note
+  - [x] Step 5.1: End-to-end bats test
+  - [x] Step 5.2: Document the hermetic contract
 
 ### Acceptance Criteria
 
-- [ ] `git push` leaves every `refs/heads/*` unchanged regardless of ci-local pass/fail
-- [ ] Hostile `GIT_DIR` does not mutate decoy gitdir via `ci-local.sh`; child bats see empty git env
-- [ ] Hostile `GIT_DIR` does not mutate decoy gitdir via fixture `hermetic_setup`
-- [ ] PWD drift inside a hermetic fixture fails the test loudly
-- [ ] Any `refs/heads/*` change during `.husky/pre-push` yields a non-zero exit with pre/post SHAs
-- [ ] Two concurrent fixture bats tests get distinct tempdir roots
-- [ ] `bash scripts/ci-local.sh` (direct invocation) continues to pass
-- [ ] Full test suite under real `git push` does not corrupt any local ref
-- [ ] All acceptance criteria enforced by tests that fail without the fix and pass with it
+- [x] `git push` leaves every `refs/heads/*` unchanged regardless of ci-local pass/fail
+- [x] Hostile `GIT_DIR` does not mutate decoy gitdir via `ci-local.sh`; child bats see empty git env
+- [x] Hostile `GIT_DIR` does not mutate decoy gitdir via fixture `hermetic_setup`
+- [x] PWD drift inside a hermetic fixture fails the test loudly
+- [x] Any `refs/heads/*` change during `.husky/pre-push` yields a non-zero exit with pre/post SHAs
+- [x] Two concurrent fixture bats tests get distinct tempdir roots
+- [x] `bash scripts/ci-local.sh` (direct invocation) continues to pass
+- [x] Full test suite under real `git push` does not corrupt any local ref
+- [x] All acceptance criteria enforced by tests that fail without the fix and pass with it
 
 ## Plan Review Summary
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -39,11 +39,17 @@ set -uo pipefail
 # child process can see them.
 unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION
 
-# CI_LOCAL_PROBE_ENV=1 short-circuits ci-local to dump its post-scrub
-# GIT_* env vars and exit 0. Used by tests/scripts/ci_local_hermetic_tests.bats
-# to assert the scrub happened without running the full suite.
+# CI_LOCAL_PROBE_ENV=1 short-circuits ci-local to report the state of the
+# five scrubbed vars and exit 0. Used by tests/scripts/ci_local_hermetic_tests.bats
+# to assert the scrub happened without running the full suite. Deliberately
+# NARROW — only reports the exact names the unset targeted so the probe
+# cannot exfiltrate unrelated GIT_* secrets (GIT_HTTP_EXTRAHEADER carries
+# bearer tokens, GIT_ASKPASS carries credential-helper paths, etc.).
 if [ "${CI_LOCAL_PROBE_ENV:-}" = "1" ]; then
-  env | grep '^GIT_' || true
+  for _v in GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION; do
+    eval "_val=\${$_v-__unset__}"
+    printf '%s=%s\n' "$_v" "$_val"
+  done
   exit 0
 fi
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -30,6 +30,23 @@
 
 set -uo pipefail
 
+# --- git env scrub (issue #546) -------------------------------------------
+# Git exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX /
+# GIT_REFLOG_ACTION into the pre-push hook's environment. Left in place,
+# fixture bats tests that run `git init` / `git commit` / `git push`
+# inherit them and target the parent worktree's gitdir instead of their
+# tempdirs, silently rewriting refs/heads/*. Scrub at the boundary so no
+# child process can see them.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION
+
+# CI_LOCAL_PROBE_ENV=1 short-circuits ci-local to dump its post-scrub
+# GIT_* env vars and exit 0. Used by tests/scripts/ci_local_hermetic_tests.bats
+# to assert the scrub happened without running the full suite.
+if [ "${CI_LOCAL_PROBE_ENV:-}" = "1" ]; then
+  env | grep '^GIT_' || true
+  exit 0
+fi
+
 cd "$(git rev-parse --show-toplevel)" || exit 2
 
 # --- argument parsing ------------------------------------------------------

--- a/tests/hooks/pre_commit_knowledge_index_tests.bats
+++ b/tests/hooks/pre_commit_knowledge_index_tests.bats
@@ -8,12 +8,14 @@ HOOK="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/pre-commit-knowledge-index
 DETECT_LIB="$BATS_TEST_DIRNAME/../../plugins/dev-team/hooks/lib/pre-commit-detect.sh"
 SETTINGS_JSON="$BATS_TEST_DIRNAME/../../plugins/dev-team/settings.json"
 
+load '../lib/hermetic'
+
 setup() {
-  BATS_TMPDIR_CASE="$(mktemp -d)"
+  hermetic_setup  # scrubs GIT_DIR/etc + cds into $HERMETIC_ROOT — issue #546
+  BATS_TMPDIR_CASE="$HERMETIC_ROOT"
   # Build a tiny temp git repo. The hook reads `git diff --cached` to
   # decide which corpus files are staged, so the test repo needs the
   # plugin layout.
-  cd "$BATS_TMPDIR_CASE" || return 1
   git init -q
   git config user.email "test@example.com"
   git config user.name "Test"
@@ -49,8 +51,7 @@ EOF
 }
 
 teardown() {
-  cd /
-  rm -rf "$BATS_TMPDIR_CASE"
+  hermetic_teardown
 }
 
 _bash_input() {

--- a/tests/lib/hermetic.bash
+++ b/tests/lib/hermetic.bash
@@ -56,8 +56,21 @@ hermetic_assert_pwd() {
 }
 
 # hermetic_teardown — called from the fixture's teardown() block.
-# Asserts PWD did not drift; leaves cleanup of $HERMETIC_ROOT to
-# BATS_TEST_TMPDIR / the OS (mktemp -d roots are per-test and short-lived).
+# Asserts PWD did not drift, then removes $HERMETIC_ROOT so parallel bats
+# workers don't accumulate scratch git repos in $TMPDIR (mktemp -d -t roots
+# are NOT under $BATS_TEST_TMPDIR, so bats' own cleanup won't reap them).
+# The rm is guarded on the path prefix looking like a real tempdir so a
+# misconfigured $TMPDIR can't escalate the delete to an unexpected path.
 hermetic_teardown() {
-  hermetic_assert_pwd
+  local rc=0
+  hermetic_assert_pwd || rc=$?
+  if [ -n "${HERMETIC_ROOT:-}" ] && [ -d "$HERMETIC_ROOT" ]; then
+    case "$HERMETIC_ROOT" in
+      /tmp/*|/var/folders/*|/private/var/folders/*|/private/tmp/*)
+        cd / && rm -rf "$HERMETIC_ROOT"
+        ;;
+    esac
+  fi
+  unset HERMETIC_ROOT
+  return "$rc"
 }

--- a/tests/lib/hermetic.bash
+++ b/tests/lib/hermetic.bash
@@ -1,0 +1,63 @@
+# tests/lib/hermetic.bash — shared bats helper for fixture isolation.
+#
+# Issue #546: git exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX
+# / GIT_REFLOG_ACTION into pre-push hooks, and nothing in the hook chain
+# scrubs them. Fixture bats tests that call `git init` / `git commit` /
+# `git push` then target the parent worktree's gitdir instead of their
+# tempdirs, silently rewriting refs/heads/* on the pushing repo.
+#
+# Every fixture bats file that runs git operations must:
+#   load '../lib/hermetic'      # (relative to the file's own directory)
+#   setup()    { hermetic_setup; ... }
+#   teardown() { hermetic_teardown; }
+#
+# Bash-3.2 safe (macOS default). POSIX-portable across macOS / Linux /
+# Windows Git Bash.
+
+# hermetic_setup — scrub inherited git env, create a per-worker tempdir,
+# cd into it, and record HERMETIC_ROOT for hermetic_assert_pwd.
+hermetic_setup() {
+  # 1. Scrub git envs the parent process may have inherited (e.g. git
+  #    exports these into a pre-push hook's environment).
+  unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_REFLOG_ACTION
+
+  # 2. Isolate git config to prevent global/system config bleed-through
+  #    (~/.gitconfig, /etc/gitconfig).
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export GIT_CONFIG_SYSTEM=/dev/null
+
+  # 3. Per-worker tempdir — the "bats-<pid>-" prefix namespaces roots per
+  #    parallel bats worker so concurrent workers never collide.
+  HERMETIC_ROOT="$(mktemp -d -t "bats-$$-XXXXXX")" || return 1
+  export HERMETIC_ROOT
+
+  # 4. cd into it so ambient git commands can't walk up to a parent gitdir.
+  cd "$HERMETIC_ROOT" || return 1
+}
+
+# hermetic_assert_pwd — fail if PWD has drifted outside HERMETIC_ROOT.
+# Fixtures that legitimately cd into subdirectories are fine; anything
+# outside the tempdir is a drift bug that would otherwise corrupt the
+# parent worktree.
+hermetic_assert_pwd() {
+  if [ -z "${HERMETIC_ROOT:-}" ]; then
+    printf 'hermetic_assert_pwd: HERMETIC_ROOT is unset — hermetic_setup was not called\n' >&2
+    return 1
+  fi
+  case "$PWD/" in
+    "$HERMETIC_ROOT"/*) return 0 ;;
+    *)
+      printf 'hermetic_assert_pwd: PWD drifted outside HERMETIC_ROOT\n' >&2
+      printf '  PWD          = %s\n' "$PWD" >&2
+      printf '  HERMETIC_ROOT = %s\n' "$HERMETIC_ROOT" >&2
+      return 1
+      ;;
+  esac
+}
+
+# hermetic_teardown — called from the fixture's teardown() block.
+# Asserts PWD did not drift; leaves cleanup of $HERMETIC_ROOT to
+# BATS_TEST_TMPDIR / the OS (mktemp -d roots are per-test and short-lived).
+hermetic_teardown() {
+  hermetic_assert_pwd
+}

--- a/tests/lib/hermetic_tests.bats
+++ b/tests/lib/hermetic_tests.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+# Tests for tests/lib/hermetic.bash — issue #546.
+#
+# Verifies the shared bats helper that isolates fixture bats tests from any
+# inherited git env vars (GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE/GIT_PREFIX/
+# GIT_REFLOG_ACTION) so pre-push-invoked fixtures cannot corrupt the parent
+# worktree's refs.
+
+HELPER="$BATS_TEST_DIRNAME/hermetic.bash"
+
+# ---------------------------------------------------------------------------
+# Step 1.1: env-scrub + per-worker tempdir + hermetic git init
+# ---------------------------------------------------------------------------
+
+@test "1.1a: hermetic_setup unsets git env vars leaked by the caller" {
+  export GIT_DIR=/tmp/decoy-h1a.git
+  export GIT_INDEX_FILE=/tmp/decoy-h1a.idx
+  export GIT_WORK_TREE=/tmp/decoy-h1a-wt
+  export GIT_PREFIX=subdir/
+  export GIT_REFLOG_ACTION=push
+
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  [ -z "${GIT_DIR:-}" ]
+  [ -z "${GIT_INDEX_FILE:-}" ]
+  [ -z "${GIT_WORK_TREE:-}" ]
+  [ -z "${GIT_PREFIX:-}" ]
+  [ -z "${GIT_REFLOG_ACTION:-}" ]
+}
+
+@test "1.1b: hermetic_setup exports GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM to /dev/null" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  [ "$GIT_CONFIG_GLOBAL" = "/dev/null" ]
+  [ "$GIT_CONFIG_SYSTEM" = "/dev/null" ]
+}
+
+@test "1.1c: hermetic_setup creates a per-worker tempdir, cds into it, records HERMETIC_ROOT" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  [ -n "$HERMETIC_ROOT" ]
+  [ -d "$HERMETIC_ROOT" ]
+  [ "$PWD" = "$HERMETIC_ROOT" ]
+  # basename should carry the pid marker
+  case "$(basename "$HERMETIC_ROOT")" in
+    bats-$$-*) ;;
+    *) printf 'HERMETIC_ROOT basename %q does not carry the pid marker "bats-%s-"\n' "$(basename "$HERMETIC_ROOT")" "$$" >&2; return 1 ;;
+  esac
+}
+
+@test "1.1d: git init in the tempdir stays hermetic under hostile GIT_DIR" {
+  # Set up a real decoy bare repo with a known ref.
+  DECOY="$(mktemp -d)/decoy.git"
+  mkdir -p "$DECOY"
+  ( cd "$DECOY" && git init -q --bare )
+  # Snapshot the decoy's directory tree (relative paths + file hashes).
+  PRE="$(cd "$DECOY" && find . -type f -exec sha256sum {} + 2>/dev/null | sort)"
+  DECOY_HEAD_PRE="$(cd "$DECOY" && cat HEAD 2>/dev/null || printf '')"
+
+  export GIT_DIR="$DECOY"
+  export GIT_INDEX_FILE="$DECOY/index"
+
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  # Run a legitimate fixture-shaped sequence.
+  git init -q
+  git config user.email "t@t"
+  git config user.name "T"
+  git commit -q --allow-empty -m "hermetic canary"
+
+  # Decoy must be byte-identical.
+  POST="$(cd "$DECOY" && find . -type f -exec sha256sum {} + 2>/dev/null | sort)"
+  DECOY_HEAD_POST="$(cd "$DECOY" && cat HEAD 2>/dev/null || printf '')"
+  [ "$PRE" = "$POST" ]
+  [ "$DECOY_HEAD_PRE" = "$DECOY_HEAD_POST" ]
+
+  # The fresh .git lives inside HERMETIC_ROOT.
+  [ -d "$HERMETIC_ROOT/.git" ]
+}
+
+@test "1.1e: fixture-local push to its own origin still works" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  mkdir -p "$HERMETIC_ROOT/origin.git"
+  ( cd "$HERMETIC_ROOT/origin.git" && git init -q --bare )
+
+  mkdir -p "$HERMETIC_ROOT/work"
+  cd "$HERMETIC_ROOT/work"
+  git init -q -b main
+  git config user.email "t@t"
+  git config user.name "T"
+  git commit -q --allow-empty -m "init"
+  git remote add origin "$HERMETIC_ROOT/origin.git"
+  git push -q origin main
+
+  # The bare's refs/heads/main should point at HEAD.
+  HEAD_SHA="$(git rev-parse HEAD)"
+  ORIGIN_SHA="$(git --git-dir="$HERMETIC_ROOT/origin.git" rev-parse refs/heads/main)"
+  [ "$HEAD_SHA" = "$ORIGIN_SHA" ]
+}
+
+# ---------------------------------------------------------------------------
+# Step 1.2: hermetic_assert_pwd + parallel-safety
+# ---------------------------------------------------------------------------
+
+@test "1.2a: hermetic_assert_pwd succeeds when PWD is inside HERMETIC_ROOT" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  mkdir -p "$HERMETIC_ROOT/subdir"
+  cd "$HERMETIC_ROOT/subdir"
+  run hermetic_assert_pwd
+  [ "$status" -eq 0 ]
+}
+
+@test "1.2b: hermetic_assert_pwd fails when PWD drifts outside HERMETIC_ROOT" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+
+  cd /
+  run hermetic_assert_pwd
+  [ "$status" -ne 0 ]
+  # Diagnostic names both drift and expected root.
+  [[ "$output" == *"$HERMETIC_ROOT"* ]]
+  [[ "$output" == *"/"* ]]
+}
+
+@test "1.2c: two concurrent hermetic_setup invocations produce distinct roots" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+
+  # Run in two subshells sequentially — mktemp -d guarantees distinct paths
+  # even without concurrency, but the -t "bats-$$-XXXX" prefix means paths
+  # under different bats worker pids also namespace apart.
+  R1="$(
+    hermetic_setup >/dev/null
+    printf '%s' "$HERMETIC_ROOT"
+  )"
+  R2="$(
+    hermetic_setup >/dev/null
+    printf '%s' "$HERMETIC_ROOT"
+  )"
+
+  [ -n "$R1" ]
+  [ -n "$R2" ]
+  [ "$R1" != "$R2" ]
+}
+
+@test "1.2d: hermetic_teardown invokes hermetic_assert_pwd" {
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  hermetic_setup
+  # Simulate a fixture that drifted.
+  cd /
+  run hermetic_teardown
+  [ "$status" -ne 0 ]
+}

--- a/tests/lib/hermetic_tests.bats
+++ b/tests/lib/hermetic_tests.bats
@@ -132,27 +132,29 @@ HELPER="$BATS_TEST_DIRNAME/hermetic.bash"
   cd /
   run hermetic_assert_pwd
   [ "$status" -ne 0 ]
-  # Diagnostic names both drift and expected root.
+  # Diagnostic names both the drifted PWD and the expected root.
+  [[ "$output" == *"drifted outside HERMETIC_ROOT"* ]]
   [[ "$output" == *"$HERMETIC_ROOT"* ]]
-  [[ "$output" == *"/"* ]]
+  [[ "$output" == *"PWD"* ]]
 }
 
-@test "1.2c: two concurrent hermetic_setup invocations produce distinct roots" {
+@test "1.2c: two hermetic_setup invocations (parallel background) produce distinct roots" {
   # shellcheck disable=SC1090
   source "$HELPER"
 
-  # Run in two subshells sequentially — mktemp -d guarantees distinct paths
-  # even without concurrency, but the -t "bats-$$-XXXX" prefix means paths
-  # under different bats worker pids also namespace apart.
-  R1="$(
-    hermetic_setup >/dev/null
-    printf '%s' "$HERMETIC_ROOT"
-  )"
-  R2="$(
-    hermetic_setup >/dev/null
-    printf '%s' "$HERMETIC_ROOT"
-  )"
+  # Fork two real subshells in parallel via background jobs, each writing
+  # its HERMETIC_ROOT to its own file. bats --jobs forks per test, so this
+  # exercises the same collision surface a parallel-worker run would.
+  F1="$BATS_TEST_TMPDIR/root1"
+  F2="$BATS_TEST_TMPDIR/root2"
+  ( hermetic_setup >/dev/null; printf '%s' "$HERMETIC_ROOT" > "$F1" ) &
+  P1=$!
+  ( hermetic_setup >/dev/null; printf '%s' "$HERMETIC_ROOT" > "$F2" ) &
+  P2=$!
+  wait "$P1" "$P2"
 
+  R1="$(cat "$F1")"
+  R2="$(cat "$F2")"
   [ -n "$R1" ]
   [ -n "$R2" ]
   [ "$R1" != "$R2" ]

--- a/tests/repo/eval_semver_classify_tests.bats
+++ b/tests/repo/eval_semver_classify_tests.bats
@@ -5,7 +5,14 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/eval_semver_classify.sh"
 
-setup() { source "$SCRIPT"; }
+load '../lib/hermetic'
+
+setup() {
+  hermetic_setup  # scrubs GIT_DIR/etc + cds into $HERMETIC_ROOT — issue #546
+  source "$SCRIPT"
+}
+
+teardown() { hermetic_teardown; }
 
 # --- classify_change_class ------------------------------------------------
 
@@ -108,7 +115,7 @@ setup() { source "$SCRIPT"; }
 # --- end-to-end via a throwaway git repo ----------------------------------
 
 _mkrepo() {
-  REPO="$(mktemp -d)"
+  REPO="$HERMETIC_ROOT"
   cd "$REPO" || return 1
   git init -q
   git config user.email t@t.t
@@ -177,7 +184,7 @@ _mkrepo() {
 # --- #136: threshold-only edits classify as minor, not major --------------
 
 _mkrepo_thresh() {
-  REPO="$(mktemp -d)"; cd "$REPO" || return 1
+  REPO="$HERMETIC_ROOT"; cd "$REPO" || return 1
   git init -q; git config user.email t@t.t; git config user.name t
   git config commit.gpgsign false; git config tag.gpgsign false
   mkdir -p evals/expected

--- a/tests/repo/hermetic_adoption_tests.bats
+++ b/tests/repo/hermetic_adoption_tests.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Enforces that every fixture bats file that does git operations sources
+# tests/lib/hermetic.bash and wires hermetic_setup + hermetic_teardown into
+# its setup()/teardown() blocks. Issue #546 — without this, fixtures inherit
+# git env vars git exports into pre-push hooks and corrupt the parent
+# worktree's refs.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+# Files that legitimately do NOT need hermetic_setup. Add one line per
+# entry with a short rationale — no silent skips.
+_is_whitelisted() {
+  case "$1" in
+    # The hermetic helper's OWN tests source the helper directly and
+    # source-then-invoke it per-test rather than via bats setup/teardown.
+    */tests/lib/hermetic_tests.bats) return 0 ;;
+    # Tests that assert the adoption contract itself — they read files,
+    # they do not run git operations.
+    */tests/repo/hermetic_adoption_tests.bats) return 0 ;;
+  esac
+  return 1
+}
+
+# _needs_hermetic <file> — returns 0 iff the file directly invokes any git
+# command that mutates state at shell-command position. Only lines that
+# START with (optionally-indented) `git <mutating-verb>` count — this
+# excludes JSON test payloads like `"command":"git commit -m x"` where the
+# fixture is describing a git op the SUT will interpret, not running it.
+#
+# Mutating verbs: init, commit, push, update-ref, checkout, branch, tag,
+# add, clone, fetch, pull, merge, rebase, reset, apply, cherry-pick,
+# revert, worktree, stash. Read-only ops (log, rev-parse, for-each-ref,
+# config --get) do not risk ref corruption and are ignored.
+_needs_hermetic() {
+  grep -q -E '^[[:space:]]*git[[:space:]]+(init|commit|push|update-ref|checkout|branch|tag|add|clone|fetch|pull|merge|rebase|reset|apply|cherry-pick|revert|worktree|stash)([[:space:]]|$)' "$1"
+}
+
+# _is_hermetic <file> — returns 0 iff the file both loads the hermetic
+# helper AND wires hermetic_setup in its setup() and hermetic_teardown in
+# its teardown().
+_is_hermetic() {
+  grep -q "load '../lib/hermetic'" "$1" \
+    && grep -q "hermetic_setup" "$1" \
+    && grep -q "hermetic_teardown" "$1"
+}
+
+@test "every fixture bats file that runs git ops loads tests/lib/hermetic" {
+  # Enumerate every .bats file under tests/, skip whitelisted paths.
+  offenders=""
+  while IFS= read -r -d '' f; do
+    _is_whitelisted "$f" && continue
+    _needs_hermetic "$f" || continue
+    _is_hermetic "$f" || offenders="$offenders $f"
+  done < <(find "$REPO_ROOT/tests" -name "*.bats" -print0)
+
+  if [ -n "$offenders" ]; then
+    printf 'The following bats files do fixture git operations but do not\n' >&2
+    printf 'source tests/lib/hermetic.bash + wire hermetic_setup/hermetic_teardown.\n' >&2
+    printf 'See issue #546 for why this matters.\n\n' >&2
+    for f in $offenders; do
+      printf '  %s\n' "$f" >&2
+    done
+    return 1
+  fi
+}

--- a/tests/repo/multiplayer_collision_tests.bats
+++ b/tests/repo/multiplayer_collision_tests.bats
@@ -10,14 +10,16 @@ REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 HOOK="$REPO_ROOT/plugins/dev-team/hooks/pre-commit-review.sh"
 GATEHASH="$REPO_ROOT/plugins/dev-team/hooks/lib/review-gate-hash.sh"
 
+load '../lib/hermetic'
+
 setup() {
-  WORK="$(mktemp -d)"
-  cd "$WORK" || return 1
+  hermetic_setup  # scrubs GIT_DIR/etc + cds into $HERMETIC_ROOT — issue #546
+  WORK="$HERMETIC_ROOT"
   git init -q
   git config user.email t@t.dev
   git config user.name tester
 }
-teardown() { cd / || true; rm -rf "$WORK"; }
+teardown() { hermetic_teardown; }
 
 _commit_hook() { echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK"; }
 _write_gate()  { bash "$GATEHASH" > .review-passed; }

--- a/tests/repo/pre_push_end_to_end_tests.bats
+++ b/tests/repo/pre_push_end_to_end_tests.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# End-to-end proof for issue #546: a full pre-push run against a real git
+# push leaves refs stable.
+#
+# Depends on: slices 1 (hermetic helper), 2 (ci-local env scrub), 4 (ref
+# guard). This test drives a real `git push` inside a hermetic scratch
+# repo — the same class of operation that caused the original incident —
+# so it is guarded from itself by hermetic_setup and only enabled after
+# slices 1-4 land. See docs/specs/pre-push-hook-hermetic-fixtures.md.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+REAL_HOOK="$REPO_ROOT/.husky/pre-push"
+
+load '../lib/hermetic'
+
+setup() {
+  hermetic_setup
+}
+
+teardown() {
+  hermetic_teardown
+}
+
+@test "e2e: real git push through the shipped pre-push hook leaves refs stable" {
+  # Build a scratch bare + worktree scaffold.
+  BARE="$HERMETIC_ROOT/remote.git"
+  WORK="$HERMETIC_ROOT/work"
+  mkdir -p "$BARE" && ( cd "$BARE" && git init -q --bare -b main )
+
+  git init -q -b main "$WORK"
+  cd "$WORK"
+  git config user.email "t@t"
+  git config user.name "T"
+  git commit -q --allow-empty -m "seed"
+  git remote add origin "$BARE"
+  git push -q origin main
+
+  git checkout -q -b feature
+  git commit -q --allow-empty -m "feat"
+
+  # Install the real hook + a fast-passing ci-local.sh stub. The stub is
+  # necessary because the shipped ci-local.sh runs the entire suite —
+  # too heavy for this test. We are asserting on ref-stability under
+  # the *shipped hook framework*, not re-running the CI mirror.
+  mkdir -p "$WORK/.husky" "$WORK/scripts"
+  cp "$REAL_HOOK" "$WORK/.husky/pre-push"
+  cat > "$WORK/scripts/ci-local.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$WORK/scripts/ci-local.sh"
+
+  # Configure the local hooks path (the real repo uses husky's .husky/_,
+  # which resolves relatively; for the scratch, wire the hook directly).
+  git config core.hooksPath "$WORK/.husky"
+
+  # Snapshot refs on BOTH the bare and the worktree BEFORE the push.
+  PRE_BARE="$(git --git-dir="$BARE" for-each-ref --format='%(refname) %(objectname)' refs/heads/)"
+  PRE_WORK="$(git for-each-ref --format='%(refname) %(objectname)' refs/heads/)"
+
+  # Drive the push. HUSKY_RUN_EVALS=0 short-circuits the live-eval prompt.
+  HUSKY_RUN_EVALS=0 git push -q origin feature
+
+  # Snapshot after.
+  POST_BARE="$(git --git-dir="$BARE" for-each-ref --format='%(refname) %(objectname)' refs/heads/)"
+  POST_WORK="$(git for-each-ref --format='%(refname) %(objectname)' refs/heads/)"
+
+  # The bare's feature ref DID advance (that was the push's purpose).
+  # But the worktree's local refs must be byte-identical before and after.
+  [ "$PRE_WORK" = "$POST_WORK" ]
+  # And the bare's `main` (unrelated to the push) must be unchanged.
+  echo "$PRE_BARE" | grep 'refs/heads/main' > /tmp/e2e-pre-main
+  echo "$POST_BARE" | grep 'refs/heads/main' > /tmp/e2e-post-main
+  diff /tmp/e2e-pre-main /tmp/e2e-post-main
+}
+
+@test "e2e: shipped pre-push refuses to complete if a ref moves during the hook" {
+  # Build a scratch worktree + bare.
+  BARE="$HERMETIC_ROOT/remote.git"
+  WORK="$HERMETIC_ROOT/work"
+  mkdir -p "$BARE" && ( cd "$BARE" && git init -q --bare -b main )
+
+  git init -q -b main "$WORK"
+  cd "$WORK"
+  git config user.email "t@t"
+  git config user.name "T"
+  git commit -q --allow-empty -m "seed"
+  git remote add origin "$BARE"
+  git push -q origin main
+
+  git checkout -q -b feature
+  git commit -q --allow-empty -m "feat"
+
+  # Install the real hook + an evil ci-local.sh stub that mutates
+  # refs/heads/main during the hook (simulating a fixture bug).
+  mkdir -p "$WORK/.husky" "$WORK/scripts"
+  cp "$REAL_HOOK" "$WORK/.husky/pre-push"
+  cat > "$WORK/scripts/ci-local.sh" <<STUB
+#!/usr/bin/env bash
+cd "$WORK"
+git checkout -q main
+git commit -q --allow-empty -m evil
+git update-ref refs/heads/main HEAD
+git checkout -q feature
+exit 0
+STUB
+  chmod +x "$WORK/scripts/ci-local.sh"
+
+  git config core.hooksPath "$WORK/.husky"
+
+  # Attempt the push. The ref-guard should refuse it.
+  run env HUSKY_RUN_EVALS=0 git push -q origin feature
+  [ "$status" -ne 0 ]
+
+  # The bare's feature ref must NOT have been created (push refused).
+  ! git --git-dir="$BARE" show-ref --verify refs/heads/feature 2>/dev/null
+}

--- a/tests/repo/pre_push_end_to_end_tests.bats
+++ b/tests/repo/pre_push_end_to_end_tests.bats
@@ -69,9 +69,11 @@ STUB
   # But the worktree's local refs must be byte-identical before and after.
   [ "$PRE_WORK" = "$POST_WORK" ]
   # And the bare's `main` (unrelated to the push) must be unchanged.
-  echo "$PRE_BARE" | grep 'refs/heads/main' > /tmp/e2e-pre-main
-  echo "$POST_BARE" | grep 'refs/heads/main' > /tmp/e2e-post-main
-  diff /tmp/e2e-pre-main /tmp/e2e-post-main
+  # Scratch files live under $HERMETIC_ROOT so parallel bats workers can't
+  # race and hermetic_teardown reclaims them with the rest of the tempdir.
+  echo "$PRE_BARE" | grep 'refs/heads/main' > "$HERMETIC_ROOT/e2e-pre-main"
+  echo "$POST_BARE" | grep 'refs/heads/main' > "$HERMETIC_ROOT/e2e-post-main"
+  diff "$HERMETIC_ROOT/e2e-pre-main" "$HERMETIC_ROOT/e2e-post-main"
 }
 
 @test "e2e: shipped pre-push refuses to complete if a ref moves during the hook" {
@@ -111,6 +113,11 @@ STUB
   # Attempt the push. The ref-guard should refuse it.
   run env HUSKY_RUN_EVALS=0 git push -q origin feature
   [ "$status" -ne 0 ]
+
+  # Assert the guard fired for the RIGHT reason — the diagnostic must
+  # name the drifted ref and mention the "changed during hook" wording.
+  [[ "$output" == *"refs/heads/main"* ]]
+  [[ "$output" == *"changed during hook"* ]]
 
   # The bare's feature ref must NOT have been created (push refused).
   ! git --git-dir="$BARE" show-ref --verify refs/heads/feature 2>/dev/null

--- a/tests/repo/pre_push_ref_guard_tests.bats
+++ b/tests/repo/pre_push_ref_guard_tests.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Post-hook ref-integrity guard in .husky/pre-push — issue #546.
+#
+# Runs the shipped .husky/pre-push against a scratch repo (isolated via
+# hermetic_setup). Only scripts/ci-local.sh is shadowed with a per-scenario
+# stub that induces the ref-mutation-or-not the scenario needs; the hook
+# itself is the shipped artifact so the test verifies the actual guard,
+# not a reimplementation.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+REAL_HOOK="$REPO_ROOT/.husky/pre-push"
+
+load '../lib/hermetic'
+
+setup() {
+  hermetic_setup
+
+  # Build a scratch repo with a copy of the shipped pre-push hook.
+  cd "$HERMETIC_ROOT"
+  git init -q -b main
+  git config user.email "t@t"
+  git config user.name "T"
+  git commit -q --allow-empty -m "init"
+
+  # Stage a feature branch with one commit.
+  git checkout -q -b feature
+  git commit -q --allow-empty -m "feat"
+
+  # Install the shipped hook + a scripts/ dir we'll populate per scenario.
+  mkdir -p "$HERMETIC_ROOT/.husky" "$HERMETIC_ROOT/scripts"
+  cp "$REAL_HOOK" "$HERMETIC_ROOT/.husky/pre-push"
+
+  # Realistic pre-push stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>.
+  # remote-sha is all-zeros to simulate a brand-new branch push.
+  FEATURE_SHA="$(git rev-parse HEAD)"
+  STDIN="refs/heads/feature $FEATURE_SHA refs/heads/feature 0000000000000000000000000000000000000000"
+}
+
+teardown() {
+  hermetic_teardown
+}
+
+# Helper: write a scripts/ci-local.sh stub whose behavior is the shell body
+# passed in $1. Marked executable. HUSKY_RUN_EVALS=0 disables the live-eval
+# prompt so the hook doesn't hang on a controlling terminal.
+_stub_ci_local() {
+  cat > "$HERMETIC_ROOT/scripts/ci-local.sh" <<STUB
+#!/usr/bin/env bash
+$1
+STUB
+  chmod +x "$HERMETIC_ROOT/scripts/ci-local.sh"
+}
+
+@test "guard: refs stable + ci-local passes → hook exits 0" {
+  _stub_ci_local ':'  # no-op, exit 0
+  cd "$HERMETIC_ROOT"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -eq 0 ]
+  # No drift diagnostic.
+  ! grep -qi "ref.*drift\|ref.*changed during hook" <<<"$output"
+}
+
+@test "guard: pushing branch's ref mutated during hook → hook exits non-zero with pre/post SHAs" {
+  cd "$HERMETIC_ROOT"
+  ORIG="$(git rev-parse refs/heads/feature)"
+  # Stub rewrites feature to a different commit while ci-local "runs".
+  _stub_ci_local "cd \"$HERMETIC_ROOT\" && git commit -q --allow-empty -m evil && git update-ref refs/heads/feature HEAD"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  # Diagnostic names the ref and both SHAs.
+  [[ "$output" == *"refs/heads/feature"* ]]
+  [[ "$output" == *"$ORIG"* ]]
+  # Recovery hint present.
+  [[ "$output" == *"git update-ref"* ]]
+}
+
+@test "guard: unrelated ref (main) mutated → hook still exits non-zero" {
+  cd "$HERMETIC_ROOT"
+  ORIG_MAIN="$(git rev-parse refs/heads/main)"
+  _stub_ci_local "cd \"$HERMETIC_ROOT\" && git checkout -q main && git commit -q --allow-empty -m evil && git update-ref refs/heads/main HEAD && git checkout -q feature"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refs/heads/main"* ]]
+  [[ "$output" == *"$ORIG_MAIN"* ]]
+}
+
+@test "guard: ref deleted during hook → hook exits non-zero" {
+  cd "$HERMETIC_ROOT"
+  git branch victim
+  ORIG_VICTIM="$(git rev-parse refs/heads/victim)"
+  _stub_ci_local "cd \"$HERMETIC_ROOT\" && git update-ref -d refs/heads/victim"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refs/heads/victim"* ]]
+  [[ "$output" == *"$ORIG_VICTIM"* ]]
+  [[ "$output" == *"deleted"* ]]
+}
+
+@test "guard: ref created during hook → hook exits non-zero" {
+  cd "$HERMETIC_ROOT"
+  _stub_ci_local "cd \"$HERMETIC_ROOT\" && git update-ref refs/heads/stray HEAD"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refs/heads/stray"* ]]
+  [[ "$output" == *"created"* ]] || [[ "$output" == *"absent"* ]]
+}
+
+@test "guard: ci-local fails AND refs drifted → hook still exits non-zero and names the drift" {
+  cd "$HERMETIC_ROOT"
+  ORIG="$(git rev-parse refs/heads/feature)"
+  _stub_ci_local "cd \"$HERMETIC_ROOT\" && git commit -q --allow-empty -m evil && git update-ref refs/heads/feature HEAD; exit 1"
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refs/heads/feature"* ]]
+  [[ "$output" == *"$ORIG"* ]]
+}
+
+@test "guard: ci-local fails but refs stable → hook exits non-zero from ci-local (existing behavior)" {
+  cd "$HERMETIC_ROOT"
+  _stub_ci_local 'exit 3'
+
+  run env HUSKY_RUN_EVALS=0 bash -c "printf '%s\n' \"$STDIN\" | sh -e .husky/pre-push"
+  [ "$status" -ne 0 ]
+  # No drift diagnostic since no refs changed.
+  ! grep -qi "ref.*drift\|ref.*changed during hook\|refs/heads/feature" <<<"$output"
+}

--- a/tests/repo/review_gate_hash_tests.bats
+++ b/tests/repo/review_gate_hash_tests.bats
@@ -8,11 +8,14 @@ REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 HOOK="$REPO_ROOT/plugins/dev-team/hooks/pre-commit-review.sh"
 GATEHASH="$REPO_ROOT/plugins/dev-team/hooks/lib/review-gate-hash.sh"
 
+load '../lib/hermetic'
+
 setup() {
-  WORK="$(mktemp -d)"; cd "$WORK" || return 1
+  hermetic_setup  # scrubs GIT_DIR/etc + cds into $HERMETIC_ROOT — issue #546
+  WORK="$HERMETIC_ROOT"
   git init -q; git config user.email t@t.dev; git config user.name tester
 }
-teardown() { cd / || true; rm -rf "$WORK"; }
+teardown() { hermetic_teardown; }
 
 _commit_hook() { echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK"; }
 _write_gate()  { bash "$GATEHASH" > .review-passed; }   # the writer side

--- a/tests/scripts/ci_local_hermetic_tests.bats
+++ b/tests/scripts/ci_local_hermetic_tests.bats
@@ -23,7 +23,7 @@ teardown() {
   hermetic_teardown
 }
 
-@test "ci-local: env-scrub probe emits no GIT_* env vars" {
+@test "ci-local: env-scrub probe reports every targeted var as __unset__" {
   # Create the decoy first (in a clean env) so we don't fight git.
   DECOY="$HERMETIC_ROOT/decoy.git"
   mkdir -p "$DECOY" && ( cd "$DECOY" && git init -q --bare )
@@ -35,16 +35,24 @@ teardown() {
   export GIT_PREFIX="subdir/"
   export GIT_REFLOG_ACTION="push"
 
+  # Also export a UNRELATED GIT_* variable that the probe MUST NOT leak,
+  # simulating a real developer env with e.g. GIT_HTTP_EXTRAHEADER carrying
+  # a bearer token. The narrowed probe should never mention it.
+  export GIT_HTTP_EXTRAHEADER="Authorization: bearer SUPER_SECRET_TOKEN_XYZ"
+
   run env CI_LOCAL_PROBE_ENV=1 bash "$CI_LOCAL"
   [ "$status" -eq 0 ]
 
-  # After scrub, none of the GIT_* names the pre-push hook leaks should
-  # appear in ci-local's own env dump.
-  ! grep -q '^GIT_DIR=' <<<"$output"
-  ! grep -q '^GIT_INDEX_FILE=' <<<"$output"
-  ! grep -q '^GIT_WORK_TREE=' <<<"$output"
-  ! grep -q '^GIT_PREFIX=' <<<"$output"
-  ! grep -q '^GIT_REFLOG_ACTION=' <<<"$output"
+  # Each of the 5 scrubbed vars must report as unset.
+  [[ "$output" == *"GIT_DIR=__unset__"* ]]
+  [[ "$output" == *"GIT_INDEX_FILE=__unset__"* ]]
+  [[ "$output" == *"GIT_WORK_TREE=__unset__"* ]]
+  [[ "$output" == *"GIT_PREFIX=__unset__"* ]]
+  [[ "$output" == *"GIT_REFLOG_ACTION=__unset__"* ]]
+
+  # And critically — unrelated GIT_* secrets never appear in probe output.
+  ! grep -q 'SUPER_SECRET_TOKEN_XYZ' <<<"$output"
+  ! grep -q '^GIT_HTTP_EXTRAHEADER' <<<"$output"
 }
 
 @test "ci-local: hostile GIT_DIR does not mutate the decoy bare repo" {

--- a/tests/scripts/ci_local_hermetic_tests.bats
+++ b/tests/scripts/ci_local_hermetic_tests.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Tests that scripts/ci-local.sh scrubs the git env vars git exports into
+# pre-push hooks (GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX /
+# GIT_REFLOG_ACTION) before any of its own logic runs, and that a hostile
+# GIT_DIR pointing at a decoy bare repo does NOT get mutated by ci-local.sh.
+#
+# Uses CI_LOCAL_PROBE_ENV=1 to short-circuit ci-local: it prints the
+# post-scrub set of GIT_* env vars and exits 0, so the assertion runs in
+# milliseconds instead of triggering the full CI suite.
+#
+# Issue #546.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+CI_LOCAL="$REPO_ROOT/scripts/ci-local.sh"
+
+load '../lib/hermetic'
+
+setup() {
+  hermetic_setup
+}
+
+teardown() {
+  hermetic_teardown
+}
+
+@test "ci-local: env-scrub probe emits no GIT_* env vars" {
+  # Create the decoy first (in a clean env) so we don't fight git.
+  DECOY="$HERMETIC_ROOT/decoy.git"
+  mkdir -p "$DECOY" && ( cd "$DECOY" && git init -q --bare )
+
+  # Now export a full hostile set — every var the pre-push hook could leak.
+  export GIT_DIR="$DECOY"
+  export GIT_INDEX_FILE="$DECOY/index"
+  export GIT_WORK_TREE="$HERMETIC_ROOT/decoy-wt"
+  export GIT_PREFIX="subdir/"
+  export GIT_REFLOG_ACTION="push"
+
+  run env CI_LOCAL_PROBE_ENV=1 bash "$CI_LOCAL"
+  [ "$status" -eq 0 ]
+
+  # After scrub, none of the GIT_* names the pre-push hook leaks should
+  # appear in ci-local's own env dump.
+  ! grep -q '^GIT_DIR=' <<<"$output"
+  ! grep -q '^GIT_INDEX_FILE=' <<<"$output"
+  ! grep -q '^GIT_WORK_TREE=' <<<"$output"
+  ! grep -q '^GIT_PREFIX=' <<<"$output"
+  ! grep -q '^GIT_REFLOG_ACTION=' <<<"$output"
+}
+
+@test "ci-local: hostile GIT_DIR does not mutate the decoy bare repo" {
+  DECOY="$HERMETIC_ROOT/decoy.git"
+  mkdir -p "$DECOY"
+  ( cd "$DECOY" && git init -q --bare )
+
+  # Snapshot before.
+  PRE="$(cd "$DECOY" && find . -type f -exec sha256sum {} + 2>/dev/null | sort)"
+  PRE_HEAD="$(cat "$DECOY/HEAD" 2>/dev/null || printf '')"
+
+  export GIT_DIR="$DECOY"
+  export GIT_INDEX_FILE="$DECOY/index"
+  export GIT_WORK_TREE="$HERMETIC_ROOT"
+
+  run env CI_LOCAL_PROBE_ENV=1 bash "$CI_LOCAL"
+  [ "$status" -eq 0 ]
+
+  # Snapshot after.
+  POST="$(cd "$DECOY" && find . -type f -exec sha256sum {} + 2>/dev/null | sort)"
+  POST_HEAD="$(cat "$DECOY/HEAD" 2>/dev/null || printf '')"
+
+  [ "$PRE" = "$POST" ]
+  [ "$PRE_HEAD" = "$POST_HEAD" ]
+}

--- a/tests/scripts/codebase_recon_tests.bats
+++ b/tests/scripts/codebase_recon_tests.bats
@@ -5,9 +5,11 @@
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 SCRIPT="$REPO_ROOT/scripts/codebase_recon.py"
 
+load '../lib/hermetic'
+
 setup() {
-  T="$(mktemp -d)"
-  cd "$T" || return 1
+  hermetic_setup  # scrubs GIT_DIR/etc + cds into per-worker tempdir — issue #546
+  T="$HERMETIC_ROOT"
   git init -q
   git config user.email "t@t.com"
   git config user.name "T"
@@ -17,7 +19,7 @@ setup() {
 }
 
 teardown() {
-  rm -rf "$T"
+  hermetic_teardown
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/progress_guardian_tests.bats
+++ b/tests/scripts/progress_guardian_tests.bats
@@ -6,6 +6,21 @@
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 PG="$REPO_ROOT/scripts/progress_guardian.py"
 
+load '../lib/hermetic'
+
+# hermetic_setup scrubs the git env vars git exports into pre-push hooks
+# (GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX / GIT_REFLOG_ACTION)
+# and creates a per-worker tempdir at $HERMETIC_ROOT. Every fixture git
+# operation below runs against that tempdir, never the parent worktree's
+# gitdir. See tests/lib/hermetic.bash + issue #546.
+setup() {
+  hermetic_setup
+}
+
+teardown() {
+  hermetic_teardown
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -20,7 +35,7 @@ make_plan() {
 # ---------------------------------------------------------------------------
 
 @test "3.1a: done checkbox [x] is parsed as done=True with header captured" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: Do something"
 
@@ -31,14 +46,13 @@ make_plan() {
   git commit -q --allow-empty -m "initial commit"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   # [x] step present, no matching commit → exit 1 naming the step
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('Do something' in i['message'] for i in d['issues']), d"
 }
 
 @test "3.1b: undone checkbox [ ] is parsed as done=False (no error for it)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [ ] Step 1.2: Another thing"
 
@@ -49,14 +63,13 @@ make_plan() {
   git commit -q --allow-empty -m "initial commit"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   # [ ] step is not done — no commit-discipline error, but may get llm-skipped warning
   # status should NOT be 1 (fail) because the step is unchecked
   [ "$status" -ne 1 ]
 }
 
 @test "3.1c: plan file with no checkboxes exits 1 with file name in output" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "# Plan\n\nSome text without any checkboxes."
 
@@ -67,7 +80,6 @@ make_plan() {
   git commit -q --allow-empty -m "initial commit"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('plan.md' in i['message'] or 'plan.md' in i['file'] for i in d['issues']), d"
 }
@@ -77,7 +89,7 @@ make_plan() {
 # ---------------------------------------------------------------------------
 
 @test "3.2a: [x] step with matching commit exits 0 (clean tree)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser"
 
@@ -90,12 +102,11 @@ make_plan() {
   git commit -q -m "add plan"
 
   run python3 "$PG" --plan "$T/plan.md" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
 }
 
 @test "3.2b: [x] step with no matching commit exits 1 naming the step header" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: Add something specific"
 
@@ -106,13 +117,12 @@ make_plan() {
   git commit -q --allow-empty -m "feat: something unrelated"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('Add something specific' in i['message'] for i in d['issues']), d"
 }
 
 @test "3.2c: staged file with a [x] step exits 1 (uncommitted work)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser"
 
@@ -126,13 +136,12 @@ make_plan() {
   git add staged.txt
 
   run python3 "$PG" --plan "$T/plan.md" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('uncommit' in i['message'].lower() for i in d['issues']), d"
 }
 
 @test "3.2d: unstaged modification with a [x] step exits 1 (uncommitted work)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
 
   cd "$T" || return 1
@@ -148,7 +157,6 @@ make_plan() {
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('uncommit' in i['message'].lower() for i in d['issues']), d"
 }
@@ -158,7 +166,7 @@ make_plan() {
 # ---------------------------------------------------------------------------
 
 @test "3.3a: --pre-pr with all [x] steps + matching commits + clean tree exits 0" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser
 - [x] Step 1.2: add git log check"
@@ -171,12 +179,11 @@ make_plan() {
   git commit -q --allow-empty -m "feat: add git log check"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
 }
 
 @test "3.3b: --pre-pr with a [ ] (undone) step exits 1" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser
 - [ ] Step 1.2: add git log check"
@@ -188,13 +195,12 @@ make_plan() {
   git commit -q --allow-empty -m "feat: add checkbox parser"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any('incomplete' in i['message'].lower() or 'unchecked' in i['message'].lower() or 'not done' in i['message'].lower() for i in d['issues']), d"
 }
 
 @test "3.3c: --skip-llm with out-of-plan staged file adds warning finding (exit 2)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   # Plan declares no file paths; extra.py is out-of-plan
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser"
@@ -209,14 +215,13 @@ make_plan() {
   git add extra.py
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   # Uncommitted staged file → exit 1 (uncommitted check fires before scope check)
   # But we want to confirm scope check is included. The uncommitted check should fire.
   [ "$status" -eq 1 ]
 }
 
 @test "3.3d: --skip-llm with clean tree but out-of-plan file in committed diff emits warning (exit 2)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   PLAN="$T/plan.md"
   # Plan declares no backtick-paths; extra.py is out-of-plan
   make_plan "$PLAN" "- [x] Step 1.1: add checkbox parser"
@@ -235,7 +240,6 @@ make_plan() {
   git commit -q -m "feat: add checkbox parser extra"
 
   run python3 "$PG" --plan plan.md --skip-llm
-  rm -rf "$T"
   # With clean tree and [x] steps + matching commits, scope check fires → llm-skipped warning → exit 2
   [ "$status" -eq 2 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert any(i.get('rule_id') == 'llm-skipped' for i in d['issues']), d"
@@ -263,9 +267,9 @@ setup_stale_main_repo() {
   local ahead_file="$2"
   # All three working areas (the bare remote, the working clone, and the
   # sibling clone used to advance the remote) live as siblings under
-  # $work's PARENT directory. Callers create $work as `$T/work` for some
-  # mktemp-d $T, so `rm -rf $T` covers everything this helper allocates —
-  # no detached tmpdirs leak under /tmp.
+  # $work's PARENT directory (typically $HERMETIC_ROOT). hermetic_setup
+  # allocates $HERMETIC_ROOT per test, so everything lives under one root
+  # per test — no detached tmpdirs leak under /tmp.
   local parent
   parent="$(dirname "$work")"
   local remote="$parent/remote.git"
@@ -309,7 +313,7 @@ setup_stale_main_repo() {
 }
 
 @test "4.1a: local main lags origin/main by one commit; on-branch file is not reported as out-of-plan" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   WORK="$T/work"
   setup_stale_main_repo "$WORK" "unrelated.py"
   # Commit a.py on the feature branch.
@@ -325,13 +329,12 @@ setup_stale_main_repo() {
   printf '%s\n' "- [x] write a.py for the slice" "" "**Files:** \`a.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
 
 @test "4.1b: local main equals origin/main; on-branch file is not reported as out-of-plan (no regression)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   WORK="$T/work"
   # Set up a repo where origin/main == local main (no remote advance).
   # Use --initial-branch=main (with fallback) so this works on CI runners
@@ -360,7 +363,6 @@ setup_stale_main_repo() {
   printf '%s\n' "- [x] write a.py for the slice" "" "**Files:** \`a.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
@@ -379,7 +381,7 @@ setup_stale_main_repo() {
 # ---------------------------------------------------------------------------
 
 @test "4.2a: Conventional Commit on declared file satisfies the matcher" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -393,13 +395,12 @@ setup_stale_main_repo() {
   printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
 
 @test "4.2b: commit touches one of multiple declared files (any-of semantics)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -412,7 +413,6 @@ setup_stale_main_repo() {
   printf '%s\n' "- [x] Slice 1: do thing" "" "**Files:** \`a.py\`, \`b.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
@@ -424,7 +424,7 @@ setup_stale_main_repo() {
   # despite the **Files:** declaration, this test would false-pass with exit
   # 0. The current file-path matcher correctly rejects (b.py not in declared
   # [a.py]), so exit 1 here proves the file-path matcher is the active path.
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -437,7 +437,6 @@ setup_stale_main_repo() {
   printf '%s\n' "- [x] do thing" "" "**Files:** \`a.py\`" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   # Exactly one commit-discipline error whose message includes the slice header.
   echo "$output" | python3 -c "
@@ -472,7 +471,7 @@ assert len(errs) == 1, d
   # parse_plan must skip those mirror items because they have no
   # work-tracking semantics (no `### Slice` heading, no `**Files:**` line).
   # Structural redesign tracked in #526; this test guards the workaround.
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -493,13 +492,12 @@ assert len(errs) == 1, d
     > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
 
 @test "4.3a: Build Progress [x] + AC [ ] items; --pre-pr exits 0 (ACs ignored)" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -522,13 +520,12 @@ assert len(errs) == 1, d
     > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
 
 @test "4.3b: Build Progress [ ] + AC [ ] items; --pre-pr exits 1 naming the slice, not ACs" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -548,7 +545,6 @@ assert len(errs) == 1, d
     > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "
 import sys, json
@@ -563,7 +559,7 @@ for i in errs:
 }
 
 @test "4.3c: Build Progress section exists but contains no checkboxes; exits 1 naming the plan file" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -581,7 +577,6 @@ for i in errs:
     > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 1 ]
   echo "$output" | python3 -c "
 import sys, json
@@ -596,7 +591,7 @@ for i in errs:
 @test "4.3d: legacy plan with no '## Build Progress' heading falls back to whole-file scan" {
   # This scenario mirrors the existing 3.3a test's plan format. Verifies the
   # backward-compatibility fallback is intact.
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   cd "$T" || return 1
   git init -q
   git config user.email "test@test.com"
@@ -606,7 +601,6 @@ for i in errs:
   printf '%s\n' "- [x] Step 1.1: do thing" > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }
@@ -620,7 +614,7 @@ for i in errs:
 # ---------------------------------------------------------------------------
 
 @test "4.4: realistic plan with all three #525 patterns passes the pre-PR gate" {
-  T="$(mktemp -d)"
+  T="$HERMETIC_ROOT"
   WORK="$T/work"
   setup_stale_main_repo "$WORK" "unrelated.py"
   cd "$WORK" || return 1
@@ -644,7 +638,6 @@ for i in errs:
     > "$PLAN"
 
   run python3 "$PG" --plan "$PLAN" --pre-pr --skip-llm
-  rm -rf "$T"
   [ "$status" -eq 0 ]
   echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['issues']==[], d"
 }


### PR DESCRIPTION
## Summary

Fixes issue #546 — the pre-push hook silently corrupting local branch refs during real `git push` invocations. Root cause: git exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE`/`GIT_PREFIX`/`GIT_REFLOG_ACTION` into the hook environment, fixture bats tests inherit them, and their `git init`/`git commit`/`git push` calls target the parent worktree's gitdir instead of their tempdirs.

Three defenses in depth:

- **New shared bats helper** `tests/lib/hermetic.bash` — scrubs the leaked git env vars, isolates git config, creates a per-worker `mktemp -d -t "bats-$$-XXXXXX"` tempdir, and provides `hermetic_assert_pwd`/`hermetic_teardown` for PWD-drift detection and cleanup.
- **`scripts/ci-local.sh` env scrub** — unsets the same vars at the hook boundary before any child process (including parallel bats workers) can inherit them. Adds a `CI_LOCAL_PROBE_ENV=1` short-circuit for testing that reports only the 5 scrubbed names (never leaks unrelated `GIT_*` secrets).
- **`.husky/pre-push` ref-integrity guard** — snapshots `refs/heads/*` before ci-local runs and again after, refusing the push with pre/post SHAs and a recovery hint if any moved (mutate/delete/create). POSIX sh, runs regardless of ci-local's exit code.

Also adopts the hermetic helper across 7 fixture bats files (largest offender: `tests/scripts/progress_guardian_tests.bats` — 22 `mktemp -d` sites consolidated onto `$HERMETIC_ROOT`) and adds `tests/repo/hermetic_adoption_tests.bats` — a CI-time contract test that enumerates any bats file doing state-mutating git ops without the helper and fails.

Documented in `CLAUDE.md` under a new "Hermetic bats fixtures" section.

## Quality Gate

- [x] `bash scripts/ci-local.sh` — all local CI checks passed
- [x] shellcheck clean on new/edited shell files
- [x] `/code-review` — 6 findings (security/test/structure/concurrency), all addressed in commit `7a2b25b`

## Test Plan

- [ ] Run `bats tests/lib/hermetic_tests.bats` — 9 tests exercise env scrub, per-worker tempdir, hermetic git init under hostile `GIT_DIR`, PWD-drift detection, fixture-local push, and parallel-safety.
- [ ] Run `bats tests/scripts/ci_local_hermetic_tests.bats` — 2 tests verify ci-local's env scrub and confirm the probe never leaks unrelated `GIT_*` secrets (a `GIT_HTTP_EXTRAHEADER` bearer token would be exfiltrated by a naive `env | grep '^GIT_'` — narrowed to explicit allowlist).
- [ ] Run `bats tests/repo/pre_push_ref_guard_tests.bats` — 7 tests cover all ref-shape mutations (update, delete, create) plus ci-local pass/fail interactions.
- [ ] Run `bats tests/repo/pre_push_end_to_end_tests.bats` — 2 e2e tests drive a real `git push` through the shipped hook against a hermetic scratch bare+worktree.
- [ ] Verify `tests/repo/hermetic_adoption_tests.bats` reports zero offenders.

Closes #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)