### PR TITLE
docs(mutation-testing): warn that '<tool> | tee' masks exit code (#550)

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3722,6 +3722,10 @@
       "summary": "Run scoped to user-specified files or changed files.",
       "anchor": "step-2-run-the-tool-scoped-to-target"
     },
+    "Capturing run output safely": {
+      "summary": "Do **not** wrap the mutation tool in a bare `<tool> 2>&1 | tee run.log` pipeline.",
+      "anchor": "capturing-run-output-safely"
+    },
     "Probe file selection": {
       "summary": "Before scoping the full run, pick a **probe file** — one file to shake out configuration and get a first honest signal.",
       "anchor": "probe-file-selection"

--- a/plugins/dev-team/skills/mutation-testing/SKILL.md
+++ b/plugins/dev-team/skills/mutation-testing/SKILL.md
@@ -60,6 +60,23 @@ For tool-specific flag names and config-file keys (e.g. Stryker's `timeoutMS`, p
 
 Run scoped to user-specified files or changed files. Capture full output and note any HTML report paths. Per-language commands and scoping idioms — including the C# shard-aware execution path for large repos — live in [`references/languages/<lang>.md`](references/languages/).
 
+### Capturing run output safely
+
+Do **not** wrap the mutation tool in a bare `<tool> 2>&1 | tee run.log` pipeline. Bash pipeline exit status defaults to the last command's — `tee` always exits 0 on a successful write — so any Stryker / mutmut / pitest / go-mutesting startup failure (missing tool manifest, invalid config key, wrong `DOTNET_ROOT`, compile-error abort) is silently masked. Downstream automation (background tasks, CI wrappers, this plugin's own monitor loops) then sees "success" and moves on, and the failure is discovered only when the report JSON is missing.
+
+Two safe patterns — pick by whether you need live tail:
+
+```bash
+# One-shot run — direct redirect, simpler, no shell-option side effect.
+dotnet stryker --config-file stryker-config.json >StrykerOutput/full-run.log 2>&1
+
+# Live-tail run — pipefail makes the pipeline exit the leftmost non-zero.
+set -o pipefail
+dotnet stryker --config-file stryker-config.json 2>&1 | tee StrykerOutput/full-run.log
+```
+
+This trap is portable across all languages the skill supports; the same rule applies to `npx stryker run ... | tee`, `mutmut run ... | tee`, `mvn pitest:mutationCoverage ... | tee`, and `go-mutesting ... | tee`. If you rely on `$?` or a monitor's exit-code trigger, always use one of the two safe patterns above.
+
 ### Probe file selection
 
 Before scoping the full run, pick a **probe file** — one file to shake out configuration and get a first honest signal. A good probe exercises both fast kills and the timeout ceiling, so the run tells you whether the tool is configured correctly. A bad probe produces a mass-CompileError smoke plume that validates nothing.

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -85,6 +85,8 @@ The language-agnostic probe rule (≥ 50 mutants, highest existing mutation scor
 
 Large C# repos take 60–90 min for a whole-project run. Always scope runs; if the repo has pre-generated shard configs, use them.
 
+> When capturing run output to a log file, do **not** use a bare `dotnet stryker ... 2>&1 | tee run.log` — the pipeline exit code is `tee`'s (always 0), so a Stryker failure is silently masked. Use `>run.log 2>&1` for one-shot runs or `set -o pipefail` for live tail. See [`SKILL.md` → Capturing run output safely](../../SKILL.md#capturing-run-output-safely).
+
 **Single file in `--scope` (Phase 4 per-Story gate):**
 
 ```bash

--- a/plugins/dev-team/skills/mutation-testing/references/languages/go-go-mutesting.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/go-go-mutesting.md
@@ -12,6 +12,8 @@ go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest
 
 ## Run (scoped)
 
+> When capturing run output to a log file, do **not** use a bare `go-mutesting ... 2>&1 | tee run.log` — the pipeline exit code is `tee`'s (always 0), so a tool failure is silently masked. Use `>run.log 2>&1` for one-shot runs or `set -o pipefail` for live tail. See [`SKILL.md` → Capturing run output safely](../../SKILL.md#capturing-run-output-safely).
+
 ```bash
 # Whole module
 go-mutesting ./...

--- a/plugins/dev-team/skills/mutation-testing/references/languages/java-pitest.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/java-pitest.md
@@ -18,6 +18,8 @@ Gradle: add the `info.solidsoft.pitest` plugin.
 
 ## Run (scoped)
 
+> When capturing run output to a log file, do **not** use a bare `mvn pitest:mutationCoverage ... 2>&1 | tee run.log` — the pipeline exit code is `tee`'s (always 0), so a tool failure is silently masked. Use `>run.log 2>&1` for one-shot runs or `set -o pipefail` for live tail. See [`SKILL.md` → Capturing run output safely](../../SKILL.md#capturing-run-output-safely).
+
 ```bash
 # Specific class
 mvn pitest:mutationCoverage -DtargetClasses="com.example.Calculator"

--- a/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
@@ -11,6 +11,8 @@ npx stryker init
 
 ## Run (scoped)
 
+> When capturing run output to a log file, do **not** use a bare `npx stryker run ... 2>&1 | tee run.log` — the pipeline exit code is `tee`'s (always 0), so a tool failure is silently masked. Use `>run.log 2>&1` for one-shot runs or `set -o pipefail` for live tail. See [`SKILL.md` → Capturing run output safely](../../SKILL.md#capturing-run-output-safely).
+
 ```bash
 # Specific files
 npx stryker run --mutate "src/calculator.ts"

--- a/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
@@ -11,6 +11,8 @@ pip install mutmut
 
 ## Run (scoped)
 
+> When capturing run output to a log file, do **not** use a bare `mutmut run ... 2>&1 | tee run.log` — the pipeline exit code is `tee`'s (always 0), so a tool failure is silently masked. Use `>run.log 2>&1` for one-shot runs or `set -o pipefail` for live tail. See [`SKILL.md` → Capturing run output safely](../../SKILL.md#capturing-run-output-safely).
+
 ```bash
 mutmut run --paths-to-mutate=src/calculator.py
 ```


### PR DESCRIPTION
## Summary

Fixes issue #550 — the mutation-testing skill and its five per-language references show run commands as bare invocations without warning that the common Bash idiom `<tool> 2>&1 | tee run.log` silently masks the tool's non-zero exit code (pipeline exit status defaults to `tee`'s, always 0).

Adds:

- A new **"Capturing run output safely"** subsection to the language-agnostic `SKILL.md` at Step 2, documenting the exit-code-masking trap and showing both safe patterns (direct redirect `>run.log 2>&1` for one-shot; `set -o pipefail` for live tail).
- A one-line pointer note at the top of each `## Run (scoped)` section in `csharp-stryker-net.md`, `javascript-stryker.md`, `python-mutmut.md`, `java-pitest.md`, and `go-go-mutesting.md`, linking back to the SKILL.md subsection.

## Rationale

The reporter was bitten in production: their background monitor's exit-code trigger fired "success" while Stryker had aborted at startup; they only realised when the report JSON was missing. Every language the skill supports has the same pipeline-semantics trap.

## Quality Gate

- [x] Docs-only diff — 6 files, 27 insertions, no code / agent behavior / hook changes
- [x] Push through the (new, from #551) pre-push ref-integrity guard clean

## Test Plan

- [ ] Read `plugins/dev-team/skills/mutation-testing/SKILL.md` — verify "Capturing run output safely" appears under Step 2 with both safe patterns shown
- [ ] Read each of the 5 files under `plugins/dev-team/skills/mutation-testing/references/languages/` — verify the pointer note appears immediately under `## Run (scoped)`
- [ ] Follow the "SKILL.md → Capturing run output safely" anchor from any language reference — should land at the correct subsection

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)