### PR TITLE
feat(hooks): python hook contract + parity harness + reference port (#574)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ memory/_*.sh
 
 # Runtime report output (ad-hoc competitive / comparative analyses)
 reports/
+# …but keep parity-fixture reports (see #574 / #572).
+!plugins/dev-team/tests/hooks/parity/fixtures/**/reports/
 
 # Scratch files
 xx

--- a/docs/python-hook-contract.md
+++ b/docs/python-hook-contract.md
@@ -1,0 +1,152 @@
+# Python hook contract
+
+Phase 0 deliverable of the bash → Python hook migration ([#572]). Every
+Python hook that ships with the `dev-team` plugin — and every hook ported
+from bash during Phases 1–3 — MUST honor this contract byte-for-byte. The
+parity harness at `plugins/dev-team/tests/hooks/parity/` mechanically
+enforces it: for each hook it runs the `.sh` and the `.py` against
+identical `(stdin, env, argv, initial-tree)` fixtures and asserts equal
+stdout, exit code, normalized stderr, and side-effect tree.
+
+The contract mirrors the Claude Code hook payload conventions already in
+use by the bash hooks; nothing here is Python-specific except the
+authoring rules at the bottom.
+
+---
+
+## stdin
+
+Hooks are launched by Claude Code with a JSON blob on stdin. The shape is
+the same PreToolUse / PostToolUse / SessionStart / UserPromptSubmit /
+Stop payload the bash hooks already parse. All fields are optional from
+the hook's point of view — a well-behaved hook silently passes when a
+field it needs is missing rather than crashing.
+
+Canonical (partial) shape:
+
+```json
+{
+  "session_id": "<uuid>",
+  "hook_event_name": "PreToolUse",
+  "cwd": "/abs/path/to/project",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "dotnet stryker ..."
+  },
+  "tool_response": {
+    "exitCode": 0,
+    "stdout": "...",
+    "stderr": "..."
+  },
+  "transcript_path": "/abs/path/to/transcript.jsonl",
+  "prompt": "the user prompt (UserPromptSubmit only)"
+}
+```
+
+- Read stdin with `sys.stdin.read()` once. Do not `readline()` — payloads
+  may span multiple lines and future events may embed newlines in string
+  values.
+- Parse with `json.loads`. Malformed input MUST NOT crash the hook — the
+  bash hooks treat malformed input as advisory or silent-pass depending
+  on the hook's contract. Follow the sibling `.sh`'s behavior byte-for-
+  byte during parallel-ship.
+- Empty stdin (`""`) is a valid input for every hook. A hook that has
+  nothing to do returns 0 with empty stdout.
+
+## stdout
+
+- Stdout is the **user-visible channel**. Every non-empty line renders in
+  the terminal — treat it as UI, not logging.
+- Do not print trailing whitespace. Do not emit ANSI color escapes.
+- Advisory messages are prefixed with `ADVISORY:` on the same line and
+  end with a newline. Block messages are prefixed with `[BLOCK]` on the
+  first line of a multi-line body. Silent-pass hooks emit nothing at all.
+- Encoding is UTF-8. On Windows, do not rely on the code-page default —
+  set `PYTHONIOENCODING=utf-8` in the hook when it cannot afford a mojibake.
+
+## Exit codes
+
+The bash hooks use a four-tier convention that Claude Code understands:
+
+| Code | Meaning | UX |
+| ------ | --------- | ----- |
+| `0` | pass (silent or advisory) | Claude Code proceeds |
+| `1` | soft-fail / advisory error | Claude Code proceeds but surfaces the message |
+| `2` | **block** — Claude Code halts the tool call | required for gate hooks |
+| `≥ 3` | tool-specific | reserved for the hook's own consumers |
+
+`0` combined with non-empty stdout prefixed `ADVISORY:` is the standard
+"warn but do not block" pattern (see `mutation-testing-smoke-gate.sh`).
+
+## Environment variables
+
+Hooks MAY read the following environment variables. They are set by
+Claude Code or by the plugin's own settings.json:
+
+- `CLAUDE_PROJECT_DIR` — absolute path to the project root. Prefer this
+  over `os.getcwd()` when writing to plugin-owned side-effect trees
+  (`.claude/`, `memory/`, `reports/`, `metrics/`, `.telemetry/`).
+- `CLAUDE_TOOL_NAME` — name of the tool being invoked (`Bash`, `Edit`, …).
+- `CLAUDE_SESSION_ID` — current session UUID (also on stdin, but this env
+  var is set for hooks that don't parse stdin).
+- `DEV_TEAM_PY_HOOK_<NAME>` — per-hook toggle described in
+  `plugins/dev-team/hooks/settings-toggle.md`. Default `0` (bash);
+  `1` routes to the `.py` port.
+- `MUTATION_SMOKE_GATE_SKIP` — hook-specific escape hatch (see the
+  smoke-gate hook).
+
+A hook MUST NOT depend on any variable not listed here without adding it
+to this doc. That is the mechanism that keeps parity fixtures reproducible
+across macOS + Linux + Windows Git Bash.
+
+## stderr
+
+- Stderr is for **advisory diagnostics that should not appear in the
+  terminal UI** — filesystem errors, JSON parse warnings on
+  degenerate inputs, timing traces during `DEV_TEAM_DEBUG=1`.
+- Never write user-actionable messages to stderr alone. Duplicate them to
+  stdout with the `ADVISORY:` prefix if the operator needs to see them.
+- The parity harness normalizes stderr before comparison. It strips ISO-8601
+  timestamps, PIDs, and tmpdir path prefixes. Nothing else. If two
+  implementations diverge on anything past those three axes, that is a
+  real divergence — fix the hook, don't widen the normalization.
+
+## Python authoring rules
+
+- **Stdlib-only.** Zero third-party imports. Every dependency the hook
+  needs is in Python 3.8's stdlib: `argparse`, `dataclasses`, `hashlib`,
+  `json`, `os`, `pathlib`, `re`, `shlex`, `shutil`, `signal`, `subprocess`,
+  `sys`, `tempfile`. No `requirements.txt` for shipped hooks — the plugin
+  ships to users who cannot `pip install` on their machines.
+- **Target Python 3.8+.** No `match/case`, no `|`-unions in type hints,
+  no `dict | None` — those need 3.10+. `from __future__ import annotations`
+  is fine for type-hint delay.
+- **CLI with argparse** when a hook takes arguments; otherwise read stdin
+  and dispatch on JSON fields.
+- **Tests: pytest.** Unit tests live under `plugins/dev-team/tests/hooks/`
+  (per-hook file). Parity fixtures live under
+  `plugins/dev-team/tests/hooks/parity/fixtures/<hook_name>/`.
+- **Lint: ruff.** Type-check optional (`mypy` is not on the CI critical
+  path).
+- **`main() -> int`** returns the exit code. A trailing
+  `if __name__ == "__main__": sys.exit(main())` shim runs the hook.
+- **Signal handling.** Long-running hooks (like the mutation-testing
+  wrapper's status loop) MUST register SIGINT/SIGTERM handlers that flush
+  their state before exit. See `plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py`.
+- **Cross-platform.** `pathlib.Path`, never string concatenation for paths.
+  Never `subprocess.run(..., shell=True)` unless the command is a static
+  literal — quote arguments through `shlex.quote` otherwise. `subprocess.run`
+  behaves identically on all three platforms; `bash -c` does not.
+- **Privacy boundary.** Persist tokens, dollars, model IDs, or hashes —
+  never prompt text, code, file paths, or tool payloads. Mirror
+  `hooks/lib/cost_meter.py`'s posture.
+
+## References
+
+- [`#572`](https://github.com/bdfinst/agentic-dev-team/issues/572) — the
+  migration epic.
+- `plans/cached-inventing-wave.md` — Phase 0 architectural context.
+- `plugins/dev-team/hooks/lib/cost_meter.py`,
+  `plugins/dev-team/hooks/lib/build_knowledge_index.py`,
+  `plugins/dev-team/hooks/lib/telemetry_report.py` — reference Python
+  hook implementations (already in production).

--- a/plans/issue-574-python-hook-contract.md
+++ b/plans/issue-574-python-hook-contract.md
@@ -1,0 +1,406 @@
+# Plan: Issue #574 — Python hook contract + parity harness + reference port
+
+**Created**: 2026-07-02
+**Branch**: issue-574-python-hook-contract
+**Status**: approved (non-interactive auto-approval per session-1 authorization)
+
+## Goal
+
+Phase 0 of the bash → python hook migration (#572). Land the byte-compatible
+Python-hook contract, the pytest parity harness that gates every subsequent
+slice, the per-hook `DEV_TEAM_PY_HOOK_<NAME>` toggle pattern, and the first
+reference port (`mutation-testing-smoke-gate.sh` → `.py`). Bash stays
+authoritative — the Python port ships alongside with its flag defaulted **off**
+so the parity harness carries the correctness burden without changing behavior
+in the field.
+
+## Approach stances (high-reversal-cost axes from decision-defaults)
+
+- **Replace-vs-merge**: **merge**. Both `.sh` and `.py` ship; the `.sh` stays
+  the default until a release-please cycle proves parity.
+- **Migrate-vs-edit-stub**: **migrate** — the `.py` is a full port, not a
+  shim. The harness validates byte-equality; parallel-ship guards the field.
+- **Auto-merge-vs-direct**: **direct human merge** — code PR per CLAUDE.md.
+- **Scope**: strictly the four Phase-0 deliverables; no Phase 1+ hook ports.
+
+## Acceptance Criteria
+
+- [ ] `docs/python-hook-contract.md` exists and covers stdin JSON schema,
+      stdout format rules, exit-code semantics (0/1/2/≥3), hook env vars,
+      stderr conventions, and Python authoring rules (stdlib-only, 3.8+).
+- [ ] `plugins/dev-team/tests/hooks/parity/parity.py::assert_parity` runs
+      both implementations against a fixture and asserts byte-equal stdout,
+      exit code, normalized stderr, and side-effect tree.
+- [ ] `plugins/dev-team/tests/hooks/parity/conftest.py` provides tmpdir
+      sandbox isolation with `HOME`, `CLAUDE_PROJECT_DIR`,
+      `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`.
+- [ ] `plugins/dev-team/hooks/mutation_testing_smoke_gate.py` implements the
+      same contract as its `.sh` sibling.
+- [ ] ≥ 5 parity fixtures cover: happy path (Killed>0 pass), whole-scope
+      block (missing report), single-file mutate silent-pass, malformed
+      JSON advisory, Windows-path `CLAUDE_PROJECT_DIR`.
+- [ ] `plugins/dev-team/hooks/settings-toggle.md` documents the
+      `DEV_TEAM_PY_HOOK_<NAME>` pattern.
+- [ ] `plugins/dev-team/settings.json` respects
+      `DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE` (default off ⇒ bash;
+      on ⇒ python) via `sh -c` dispatch.
+- [ ] `scripts/ci-local.sh` invokes the new pytest step gated on directory
+      presence (backward-compatible).
+- [ ] `bash scripts/ci-local.sh` green on this branch.
+
+## Slices
+
+### Slice 1: Contract doc + settings-toggle doc
+
+**Depends-on:** none
+**Files:** `docs/python-hook-contract.md`, `plugins/dev-team/hooks/settings-toggle.md`
+
+**Behavior:**
+
+```gherkin
+Feature: Python hook authoring contract
+
+  Scenario: contract doc covers every observable channel
+    Given a maintainer authoring a new Python hook
+    When they open docs/python-hook-contract.md
+    Then it names stdin schema, stdout format, exit codes 0/1/2/≥3,
+      env vars (CLAUDE_PROJECT_DIR, CLAUDE_TOOL_NAME, CLAUDE_SESSION_ID),
+      stderr conventions, and Python authoring rules (stdlib-only, 3.8+)
+
+  Scenario: settings-toggle doc names the env-var pattern
+    Given a maintainer switching a hook from bash to python
+    When they read plugins/dev-team/hooks/settings-toggle.md
+    Then it explains DEV_TEAM_PY_HOOK_<NAME>, its default-off semantics,
+      and how settings.json dispatches on it
+```
+
+**Steps:**
+
+#### Step 1.1: Author `docs/python-hook-contract.md`
+
+**Complexity**: standard
+**RED**: Add a bats/markdown-integrity test asserting the file exists and
+contains each required section header (`## stdin`, `## stdout`,
+`## Exit codes`, `## Environment variables`, `## stderr`,
+`## Python authoring rules`).
+**GREEN**: Write the contract doc.
+**REFACTOR**: None.
+**Files**: `docs/python-hook-contract.md`,
+`tests/docs/python_hook_contract_tests.bats`
+**Commit**: `docs(hooks): python-hook contract (#574)`
+
+#### Step 1.2: Author `plugins/dev-team/hooks/settings-toggle.md`
+
+**Complexity**: trivial
+**RED**: Test asserts file exists and mentions `DEV_TEAM_PY_HOOK_` prefix.
+**GREEN**: Write the toggle doc.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/hooks/settings-toggle.md`,
+`tests/docs/python_hook_contract_tests.bats` (extended)
+**Commit**: `docs(hooks): DEV_TEAM_PY_HOOK toggle pattern (#574)`
+
+### Slice 2: Parity harness
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/tests/hooks/parity/{__init__.py,conftest.py,parity.py}`
+
+**Behavior:**
+
+```gherkin
+Feature: Byte-equal parity between .sh and .py hooks
+
+  Scenario: identical fixture → identical outcome
+    Given a fixture with (stdin, env, argv, initial tree)
+    When assert_parity dispatches it at hooks/foo.sh and hooks/foo.py
+    Then both produce byte-equal stdout, same exit code,
+      whitespace-normalized-equal stderr, and identical side-effect tree
+
+  Scenario: sandbox isolation
+    Given a fixture running under the harness
+    When the hook writes to any path
+    Then only tmpdir paths are touched — HOME, CLAUDE_PROJECT_DIR,
+      GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM are all tmpdir-scoped
+
+  Scenario: stderr normalization
+    Given the .sh writes "2026-07-02T12:00:00Z pid=1234" and
+      the .py writes "2026-07-02T12:00:01Z pid=5678"
+    When the harness normalizes both
+    Then they compare equal (timestamps and pids stripped)
+```
+
+**Steps:**
+
+#### Step 2.1: `parity.py` core with pytest self-test
+
+**Complexity**: complex
+**RED**: `tests/hooks/parity/test_parity_selftest.py` — a fake `foo.sh`
+and `foo.py` that echo `$1` at exit 0; assert_parity passes. A second
+fixture where `.py` prints extra content — assert_parity fails.
+**GREEN**: Implement `parity.py` with `Fixture` dataclass, `_dispatch_sh`,
+`_dispatch_py`, `_normalize_stderr` (strip ISO-8601 + PIDs +
+tmpdir prefix), `_tree_snapshot`, `assert_parity`.
+**REFACTOR**: Extract sandbox setup into `conftest.py` fixture.
+**Files**: `plugins/dev-team/tests/hooks/parity/parity.py`,
+`plugins/dev-team/tests/hooks/parity/__init__.py`,
+`plugins/dev-team/tests/hooks/parity/conftest.py`,
+`plugins/dev-team/tests/hooks/parity/test_parity_selftest.py`
+**Commit**: `test(hooks): parity harness core with self-test (#574)`
+
+#### Step 2.2: `--record` mode for regenerating snapshots
+
+**Complexity**: standard
+**RED**: Self-test asserts `--record` regenerates `expected.json` from the
+`.sh` run when it is missing.
+**GREEN**: Add `record_fixture` helper + pytest option `--parity-record`.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/tests/hooks/parity/parity.py`,
+`plugins/dev-team/tests/hooks/parity/conftest.py`,
+`plugins/dev-team/tests/hooks/parity/test_parity_selftest.py`
+**Commit**: `test(hooks): parity harness --record mode (#574)`
+
+### Slice 3: Python port of `mutation-testing-smoke-gate.sh`
+
+**Depends-on:** 1, 2
+**Files:** `plugins/dev-team/hooks/mutation_testing_smoke_gate.py`
+
+**Behavior:**
+
+```gherkin
+Feature: Python port of mutation-testing-smoke-gate
+
+  Scenario: whole-scope run without smoke report → block (exit 2)
+    Given a stdin payload with command "dotnet stryker" and cwd having
+      no StrykerOutput/smoke/reports/mutation-report.json
+    When the .py hook runs
+    Then it exits 2 with the BLOCK message referencing Step 1c
+
+  Scenario: whole-scope run with Killed>0 in smoke report → silent pass
+    Given a mutation-report.json with a Killed mutant
+    When the .py hook runs
+    Then it exits 0 with empty stdout
+
+  Scenario: single-file --mutate → silent pass (this is the probe itself)
+    Given command "dotnet stryker --mutate src/Foo.cs"
+    When the .py hook runs
+    Then it exits 0 with empty stdout
+
+  Scenario: MUTATION_SMOKE_GATE_SKIP=1 → audit-logged silent pass
+    Given the escape hatch env var is set
+    When the .py hook runs on a whole-scope command
+    Then it exits 0 and appends one JSONL line (never the raw command,
+      only its sha256 first-16) to <cwd>/metrics/gate-bypass.jsonl
+
+  Scenario: malformed JSON report → advisory (exit 0, ADVISORY: on stdout)
+    Given a mutation-report.json that is not valid JSON
+    When the .py hook runs
+    Then it exits 0 with a stdout line starting "ADVISORY:"
+
+  Scenario: missing jq or python3 dependency → advisory
+    (In Python, python3 is always present by construction; the .py port
+    still gates on `shutil.which("jq")` returning None for the advisory
+    to match the .sh contract byte-for-byte.)
+```
+
+**Steps:**
+
+#### Step 3.1: Port the hook — argv/stdin parsing + trigger detection
+
+**Complexity**: complex
+**RED**: `test_mutation_testing_smoke_gate_selftest.py` — direct unit
+tests calling the Python module (not through the parity harness) for
+`is_stryker_command`, `extract_mutate_value`, `is_single_file_mutate`.
+**GREEN**: Implement the parsing surface using stdlib `shlex`, `re`,
+`json`.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/hooks/mutation_testing_smoke_gate.py`,
+`plugins/dev-team/tests/hooks/test_mutation_testing_smoke_gate.py`
+**Commit**: `feat(hooks): python port scaffold for mutation-testing-smoke-gate (#574)`
+
+#### Step 3.2: Port the block-message + report-parsing + escape-hatch
+
+**Complexity**: complex
+**RED**: Unit tests for `print_block_message`, `count_mutants`, and the
+audit-log helper (asserts sha256 first-16 hashing, ISO-8601-Z timestamp,
+directory creation).
+**GREEN**: Complete the port. `main()` returns the exit code; a
+`__main__` shim calls `sys.exit(main())`.
+**REFACTOR**: None.
+**Files**: same as 3.1.
+**Commit**: `feat(hooks): complete python port of mutation-testing-smoke-gate (#574)`
+
+### Slice 4: Parity fixtures for the reference hook
+
+**Depends-on:** 2, 3
+**Files:** `plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/`
+
+**Behavior:**
+
+```gherkin
+Feature: Reference hook passes parity harness
+
+  Scenario Outline: <fixture>
+    Given the (stdin, env, argv, initial-tree) fixture "<fixture>"
+    When the parity harness runs .sh and .py against it
+    Then assert_parity passes
+
+    Examples:
+      | fixture                             |
+      | happy_path_killed                   |
+      | block_missing_report                |
+      | single_file_mutate_probe            |
+      | malformed_json_advisory             |
+      | windows_path_cwd                    |
+      | escape_hatch_skip                   |
+```
+
+**Steps:**
+
+#### Step 4.1: Author the six fixtures + test parametrization
+
+**Complexity**: standard
+**RED**: `tests/hooks/parity/test_mutation_testing_smoke_gate_parity.py`
+parametrized over the six fixtures — assert_parity(...) on each.
+**GREEN**: Author the fixture directories (stdin.json + env.json +
+initial-tree/ mutation-report.json seeded where relevant).
+**REFACTOR**: Factor fixture-loading into a helper if repetitive.
+**Files**: `plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/**`,
+`plugins/dev-team/tests/hooks/parity/test_mutation_testing_smoke_gate_parity.py`
+**Commit**: `test(hooks): parity fixtures for mutation-testing-smoke-gate (#574)`
+
+### Slice 5: settings.json toggle + ci-local wiring
+
+**Depends-on:** 3
+**Files:** `plugins/dev-team/settings.json`, `scripts/ci-local.sh`
+
+**Behavior:**
+
+```gherkin
+Feature: Per-hook bash↔python routing + CI runs parity harness
+
+  Scenario: default env → bash runs
+    Given DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE is unset
+    When Claude Code fires the PreToolUse Bash matcher
+    Then hooks/mutation-testing-smoke-gate.sh runs
+
+  Scenario: opt-in env → python runs
+    Given DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE=1
+    When Claude Code fires the PreToolUse Bash matcher
+    Then hooks/mutation_testing_smoke_gate.py runs
+
+  Scenario: ci-local invokes pytest parity when the dir exists
+    Given plugins/dev-team/tests/hooks/parity/ exists
+    When bash scripts/ci-local.sh runs
+    Then the parity pytest suite is one of the checks
+
+  Scenario: ci-local skips pytest parity if the dir is absent (backward-compat)
+    Given plugins/dev-team/tests/hooks/parity/ does not exist
+    When bash scripts/ci-local.sh runs
+    Then no parity check is dispatched and ci-local exits 0
+```
+
+**Steps:**
+
+#### Step 5.1: Add `chk_parity` to ci-local (backward-compat)
+
+**Complexity**: standard
+**RED**: `tests/scripts/ci_local_parity_registration_tests.bats` — assert
+that ci-local.sh contains a `chk_parity` entry AND that when the parity
+dir is absent, the check reports skip-with-advisory.
+**GREEN**: Add `chk_parity()` function and its `CHECKS` entry; skip
+gracefully when the dir is absent.
+**REFACTOR**: None.
+**Files**: `scripts/ci-local.sh`,
+`tests/scripts/ci_local_parity_registration_tests.bats`.
+**Commit**: `ci(local): pytest parity harness gate (#574)`
+
+#### Step 5.2: settings.json — env-var dispatch for smoke-gate
+
+**Complexity**: standard
+**RED**: `tests/hooks/settings_python_toggle_tests.bats` — parse
+settings.json, assert the mutation-testing-smoke-gate PreToolUse entry
+uses `sh -c` with a conditional that flips on
+`DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE`.
+**GREEN**: Rewrite that entry to `sh -c 'if [ "${DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE:-0}" = "1" ]; then python3 hooks/mutation_testing_smoke_gate.py; else bash hooks/mutation-testing-smoke-gate.sh; fi'`.
+**REFACTOR**: None.
+**Files**: `plugins/dev-team/settings.json`,
+`tests/hooks/settings_python_toggle_tests.bats`.
+**Commit**: `chore(hooks): settings.json dispatches smoke-gate via DEV_TEAM_PY_HOOK toggle (#574)`
+
+## Parallelization
+
+Slice deps: 1: —, 2: —, 3: 1 & 2, 4: 2 & 3, 5: 3.
+
+```mermaid
+graph TD
+  S1[Slice 1: contract docs] --> S3[Slice 3: hook port]
+  S2[Slice 2: parity harness] --> S3
+  S2 --> S4[Slice 4: parity fixtures]
+  S3 --> S4
+  S3 --> S5[Slice 5: settings.json + ci-local]
+```
+
+| Wave | Slices |
+| ------ | -------- |
+| 1 | 1, 2 |
+| 2 | 3 |
+| 3 | 4, 5 |
+
+## Complexity Classification
+
+Summarized above per step. Trivial: 1.2. Standard: 1.1, 2.2, 4.1, 5.1, 5.2.
+Complex: 2.1, 3.1, 3.2.
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (`bash scripts/ci-local.sh`).
+- [ ] Type check — n/a (stdlib-only Python; ruff-check will catch obvious).
+- [ ] Linter passes.
+- [ ] `/code-review` passes.
+- [ ] Documentation updated: contract doc, toggle doc, plugin CLAUDE.md
+      cross-reference (light touch — link to new docs).
+
+## Skipped (low value)
+
+_None._
+
+## Risks & Open Questions
+
+- **stderr normalization scope**: overly aggressive normalization can hide
+  real divergence; the harness strips only ISO-8601 timestamps, PIDs, and
+  tmpdir prefixes — nothing else. Documented in Step 2.1.
+- **Windows Git Bash `sh -c` semantics**: the settings.json dispatch relies
+  on `sh -c` (present on all three platforms including MSYS). Verified
+  during the parity harness Windows-path fixture.
+- **Existing bats tests for `.sh`**: unchanged; the parity harness is a new
+  gate that supplements — not replaces — them until Phase 4 removes bash.
+
+## Approval
+
+Auto-approved (non-interactive) at 2026-07-02 — no human review gate.
+Trigger: session-1 autonomous authorization (DEV_TEAM_AUTO_APPROVE
+implicit).
+
+## Build Progress
+
+### Wave 1
+
+- [ ] Slice 1: Contract doc + settings-toggle doc
+  - [ ] Step 1.1: Author `docs/python-hook-contract.md`
+  - [ ] Step 1.2: Author `plugins/dev-team/hooks/settings-toggle.md`
+- [ ] Slice 2: Parity harness
+  - [ ] Step 2.1: `parity.py` core with pytest self-test
+  - [ ] Step 2.2: `--record` mode for regenerating snapshots
+
+### Wave 2
+
+- [ ] Slice 3: Python port of `mutation-testing-smoke-gate.sh`
+  - [ ] Step 3.1: Port scaffold — argv/stdin parsing + trigger detection
+  - [ ] Step 3.2: Complete port — block message, report parsing, escape hatch
+
+### Wave 3
+
+- [ ] Slice 4: Parity fixtures for the reference hook
+  - [ ] Step 4.1: Author six fixtures + parametrized parity test
+- [ ] Slice 5: settings.json toggle + ci-local wiring
+  - [ ] Step 5.1: `chk_parity` in ci-local (backward-compat)
+  - [ ] Step 5.2: settings.json env-var dispatch for smoke-gate

--- a/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
+++ b/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Python port of hooks/mutation-testing-smoke-gate.sh (#574 / #572 Phase 0).
+
+Byte-compatible port of the Claude Code PreToolUse hook that enforces the
+SKILL.md § Step 1c smoke gate. Blocks whole-scope Stryker.NET invocations
+until a single-file smoke probe has landed a mutation-report.json under
+StrykerOutput/smoke/reports/ with at least one Killed mutant.
+
+Contract (docs/python-hook-contract.md):
+    Input : PreToolUse JSON on stdin
+    Output: exit 2 + message on stdout to BLOCK
+            exit 0 + no stdout for SILENT-PASS
+            exit 0 + ADVISORY-prefixed stdout for missing-dep / malformed / drift
+    Env   : MUTATION_SMOKE_GATE_SKIP=1 → silent bypass + audit-log line
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+
+Refs: #565 (the .sh predecessor), #554, #557 (the failure modes it guards).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Trigger detection
+# ---------------------------------------------------------------------------
+
+
+_STRYKER_TRIGGER = re.compile(
+    r"(?:^|[^a-zA-Z0-9])dotnet[ \t]+stryker(?:\b|$)|csharp-stryker-net-wrapper\.sh"
+)
+
+
+def is_stryker_command(cmd: str) -> bool:
+    """True when `cmd` invokes dotnet stryker OR the wrapper script."""
+    if not cmd:
+        return False
+    return bool(_STRYKER_TRIGGER.search(cmd))
+
+
+def extract_mutate_value(cmd: str) -> str:
+    """Return the --mutate value (handles --mutate=X, --mutate X, -m X).
+
+    Respects shell quoting via shlex so `--mutate 'src/Foo.cs'` and
+    `--mutate "src/Foo.cs"` both yield the unquoted path. Malformed shell
+    input yields "" (silent, matching the .sh's behavior).
+    """
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return ""
+    for i, tok in enumerate(tokens):
+        if tok.startswith("--mutate="):
+            return tok.split("=", 1)[1]
+        if tok in ("--mutate", "-m"):
+            if i + 1 < len(tokens):
+                return tokens[i + 1]
+            return ""
+    return ""
+
+
+def is_single_file_mutate(value: str) -> bool:
+    """A --mutate value is single-file only when it has no glob metacharacters
+    (*, ?, [) AND no semicolon (Stryker.NET's multi-file separator)."""
+    if not value:
+        return False
+    if any(c in value for c in ("*", "?", "[", ";")):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Audit-log helpers
+# ---------------------------------------------------------------------------
+
+
+def sha256_first_16(text: str) -> str:
+    """First 16 hex chars of sha256(text). Matches the .sh's cross-platform
+    shasum/sha256sum fallback chain output."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def iso_utc_timestamp() -> str:
+    """ISO-8601 UTC timestamp with 'Z' suffix. Matches the .sh helper."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def log_bypass_audit(raw_command: str, payload_cwd: str) -> None:
+    """Append one JSONL line to <payload_cwd>/metrics/gate-bypass.jsonl.
+
+    Writes timestamp + hook name + command_hash (sha256 first 16) + cwd.
+    The raw command is NEVER written — only its hash — matching the .sh's
+    privacy boundary. Filesystem errors write to stderr and return
+    silently so the bypass still succeeds.
+    """
+    audit_dir = Path(payload_cwd) / "metrics"
+    audit_file = audit_dir / "gate-bypass.jsonl"
+    try:
+        audit_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        print(
+            f"mutation-testing-smoke-gate: cannot create {audit_dir} "
+            "(bypass still succeeds)",
+            file=sys.stderr,
+        )
+        return
+    record = {
+        "timestamp": iso_utc_timestamp(),
+        "hook": "mutation-testing-smoke-gate",
+        "command_hash": sha256_first_16(raw_command),
+        "cwd": payload_cwd,
+    }
+    try:
+        with audit_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, separators=(", ", ": ")) + "\n")
+    except OSError:
+        print(
+            f"mutation-testing-smoke-gate: cannot write to {audit_file} "
+            "(bypass still succeeds)",
+            file=sys.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Block message
+# ---------------------------------------------------------------------------
+
+
+_BLOCK_TEMPLATE = """[BLOCK] mutation-testing-smoke-gate: whole-scope Stryker.NET run detected
+
+{diagnostic}
+
+The Step 1c smoke gate (see SKILL.md § Step 1c) requires a single-file
+mutation probe with Killed > 0 before authorizing a full run. This
+prevents the silent 0.00 % failure mode (see #554, #557).
+
+To run the smoke probe:
+
+  dotnet stryker --config-file stryker-config.json \\
+    --mutate 'path/to/one/covered/file.cs' \\
+    -O StrykerOutput/smoke
+
+Then re-run this command. To bypass this gate for a legitimate exception,
+set MUTATION_SMOKE_GATE_SKIP=1 in the environment (audit-logged)."""
+
+
+def print_block_message(diagnostic: str) -> None:
+    """Write the shared block-message body with the caller's diagnostic."""
+    print(_BLOCK_TEMPLATE.format(diagnostic=diagnostic))
+
+
+# ---------------------------------------------------------------------------
+# Report parsing
+# ---------------------------------------------------------------------------
+
+
+def count_mutants_by_status(report: dict, status: str) -> int:
+    """Count entries in report['mutants'] with the given status field."""
+    mutants = report.get("mutants") or []
+    return sum(1 for m in mutants if isinstance(m, dict) and m.get("status") == status)
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def _read_stdin_json() -> Optional[dict]:
+    """Read stdin as JSON; None on empty or malformed input."""
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    # -------------------------------------------------------------------
+    # Dependency guards — a missing dep must NOT become a de facto gate.
+    # -------------------------------------------------------------------
+    if shutil.which("jq") is None:
+        # Preserve parity with the .sh, which uses jq for JSON parsing.
+        # The Python port does not itself use jq, but flags the missing
+        # dep to keep the failure mode identical across ports.
+        print(
+            "ADVISORY: mutation-testing-smoke-gate: jq is required but not installed; gate not enforced"
+        )
+        return 0
+    # python3 is always present by construction in a .py hook; the .sh's
+    # python3 dep check is a no-op here.
+
+    # -------------------------------------------------------------------
+    # Parse PreToolUse payload
+    # -------------------------------------------------------------------
+    payload = _read_stdin_json()
+    if payload is None:
+        # Empty or malformed stdin — nothing to check, silent-pass.
+        return 0
+
+    command = str(payload.get("tool_input", {}).get("command", "") or "")
+    if not command:
+        return 0
+
+    # cwd from payload, fall back to $PWD (matches .sh).
+    payload_cwd = str(payload.get("cwd") or os.getcwd())
+
+    # -------------------------------------------------------------------
+    # Trigger detection
+    # -------------------------------------------------------------------
+    if not is_stryker_command(command):
+        return 0
+
+    mutate_value = extract_mutate_value(command)
+    if is_single_file_mutate(mutate_value):
+        # This IS the smoke probe; do not block it.
+        return 0
+
+    # -------------------------------------------------------------------
+    # Escape hatch — must run BEFORE report check so bypass works even
+    # without a report. Matches .sh ordering.
+    # -------------------------------------------------------------------
+    if os.environ.get("MUTATION_SMOKE_GATE_SKIP", "0") == "1":
+        log_bypass_audit(command, payload_cwd)
+        return 0
+
+    # -------------------------------------------------------------------
+    # Whole-scope run detected — check the smoke report.
+    # -------------------------------------------------------------------
+    report_path = (
+        Path(payload_cwd)
+        / "StrykerOutput"
+        / "smoke"
+        / "reports"
+        / "mutation-report.json"
+    )
+
+    if not report_path.is_file():
+        print_block_message(f"no smoke report at {report_path}")
+        return 2
+
+    try:
+        report_text = report_path.read_text(encoding="utf-8")
+    except OSError:
+        print_block_message(f"no smoke report at {report_path}")
+        return 2
+
+    try:
+        report = json.loads(report_text)
+    except json.JSONDecodeError:
+        # Malformed JSON — advisory (not block, not silent-pass). Matches .sh.
+        print(
+            f"ADVISORY: mutation-testing-smoke-gate: report at {report_path} is not valid JSON — cannot enforce gate; command not blocked"
+        )
+        return 0
+
+    # Schema drift — valid JSON without mutants[]. Advisory. ORDERING NOTE
+    # (from .sh): schema-drift advisory MUST run before counting logic;
+    # otherwise a schema-drift report incorrectly reports "no scored mutants".
+    if not isinstance(report, dict) or "mutants" not in report:
+        print(
+            f"ADVISORY: mutation-testing-smoke-gate: report at {report_path} lacks the mutants[] key — not the mutation-testing-elements shape; cannot enforce gate"
+        )
+        return 0
+
+    killed = count_mutants_by_status(report, "Killed")
+    survived = count_mutants_by_status(report, "Survived")
+
+    # At least one Killed → gate passes silently.
+    if killed > 0:
+        return 0
+
+    # Killed==0 && Survived>0 → mutation-switch not observing mutations.
+    if survived > 0:
+        print_block_message(
+            f"killed=0 survived={survived} — mutation-switch not observing mutations at runtime "
+            "(see #554, #557 and SKILL.md Step 1c diagnostic checklist)"
+        )
+        return 2
+
+    # Killed==0 && Survived==0 → empty mutants[] or only NoCoverage/CompileError.
+    print_block_message(
+        "no scored mutants in smoke report — pick a different probe file with real test coverage"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
+++ b/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
@@ -123,7 +123,8 @@ def log_bypass_audit(raw_command: str, payload_cwd: str) -> None:
     }
     try:
         with audit_file.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, separators=(", ", ": ")) + "\n")
+            # Match jq -c compact output: no spaces after ',' or ':'.
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
     except OSError:
         print(
             f"mutation-testing-smoke-gate: cannot write to {audit_file} "
@@ -217,8 +218,10 @@ def main() -> int:
     if not command:
         return 0
 
-    # cwd from payload, fall back to $PWD (matches .sh).
-    payload_cwd = str(payload.get("cwd") or os.getcwd())
+    # cwd from payload, fall back to $PWD (matches .sh's `${PAYLOAD_CWD:=$PWD}`).
+    # Prefer the shell-provided $PWD over os.getcwd() so macOS's /var → /private/var
+    # symlink resolution does not diverge from the .sh.
+    payload_cwd = str(payload.get("cwd") or os.environ.get("PWD") or os.getcwd())
 
     # -------------------------------------------------------------------
     # Trigger detection

--- a/plugins/dev-team/hooks/settings-toggle.md
+++ b/plugins/dev-team/hooks/settings-toggle.md
@@ -1,0 +1,71 @@
+# DEV_TEAM_PY_HOOK toggle pattern
+
+During the bash → Python hook migration ([#572]), every hook that has
+both a `.sh` and a `.py` implementation ships **both**, and
+`plugins/dev-team/settings.json` dispatches between them based on an
+env-var flag. This is the parallel-ship mechanism referenced in the
+contract at `docs/python-hook-contract.md`.
+
+## The flag
+
+For a hook file named `hooks/foo-bar.sh` (or `foo_bar.py`), the toggle is:
+
+```
+DEV_TEAM_PY_HOOK_FOO_BAR
+```
+
+Rules:
+
+- Prefix is always `DEV_TEAM_PY_HOOK_`.
+- Suffix is the hook's base filename **upper-cased with `-` and `.`
+  replaced by `_`**. `mutation-testing-smoke-gate.sh` →
+  `DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE`.
+- **Default is `0`** (unset counts as `0`). The bash implementation is
+  authoritative until the parity harness has been green for at least one
+  release-please cycle.
+- `1` opts into the Python implementation. Any other value falls back to
+  bash.
+
+## The dispatch shape
+
+`settings.json` uses `sh -c` for portability across macOS, Linux, and
+Windows Git Bash. Example entry:
+
+```json
+{
+  "type": "command",
+  "command": "sh -c 'if [ \"${DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE:-0}\" = \"1\" ]; then python3 hooks/mutation_testing_smoke_gate.py; else bash hooks/mutation-testing-smoke-gate.sh; fi'"
+}
+```
+
+The `sh -c` wrapper isolates the conditional from the hook's own
+argument list; stdin/stdout/stderr flow through unchanged.
+
+## Lifecycle
+
+Per-hook lifecycle across the migration:
+
+1. **Phase 0 / Phase 1–3 slice landing.** `.sh` + `.py` both ship; flag
+   defaults `0`. Parity harness runs on every fixture in CI. Operators
+   can opt into Python in their own environment by exporting the flag.
+2. **After one release-please cycle with the flag green in CI.** The
+   `.sh` is deleted and `settings.json` is simplified back to a plain
+   `python3 hooks/<name>.py` invocation. See `plans/cached-inventing-wave.md`
+   Phase 4.
+
+## Why this pattern rather than a global flip
+
+- **Per-hook rollout limits blast radius.** A silent divergence in one
+  hook does not roll back every other hook's port.
+- **CI can gate on the flag.** The parity harness ships one fixture set
+  per hook; a flag lets `DEV_TEAM_PY_HOOK_<NAME>=1 pytest tests/hooks/`
+  run the Python path against every non-parity test too.
+- **Operators can experiment locally.** A single `export DEV_TEAM_PY_HOOK_FOO=1`
+  in their shell rc migrates one hook without touching plugin files.
+
+## Related docs
+
+- [`docs/python-hook-contract.md`](../../../docs/python-hook-contract.md)
+  — byte-compatible contract every port must satisfy.
+- `plans/cached-inventing-wave.md` — the phased migration plan (#572).
+- `plugins/dev-team/tests/hooks/parity/parity.py` — the gate.

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -83,7 +83,7 @@
           },
           {
             "type": "command",
-            "command": "bash hooks/mutation-testing-smoke-gate.sh"
+            "command": "sh -c 'if [ \"${DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE:-0}\" = \"1\" ]; then python3 hooks/mutation_testing_smoke_gate.py; else bash hooks/mutation-testing-smoke-gate.sh; fi'"
           }
         ]
       },

--- a/plugins/dev-team/tests/hooks/parity/conftest.py
+++ b/plugins/dev-team/tests/hooks/parity/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration for the parity harness.
+
+Adds the parity directory to sys.path so `from parity import ...` works from
+the test files without a package install step. Registers a `--parity-record`
+CLI option; tests opt-in by asking the `parity_record` fixture whether
+recording is on.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+
+def pytest_addoption(parser) -> None:  # type: ignore[no-untyped-def]
+    parser.addoption(
+        "--parity-record",
+        action="store_true",
+        default=False,
+        help="Regenerate parity fixture expected.json snapshots from the .sh run.",
+    )
+
+
+import pytest
+
+
+@pytest.fixture
+def parity_record(request) -> bool:  # type: ignore[no-untyped-def]
+    return bool(request.config.getoption("--parity-record"))

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/block_missing_report/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/block_missing_report/stdin.json
@@ -1,0 +1,5 @@
+{
+  "tool_input": {
+    "command": "dotnet stryker --config-file stryker-config.json"
+  }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/escape_hatch_skip/env.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/escape_hatch_skip/env.json
@@ -1,0 +1,1 @@
+{ "MUTATION_SMOKE_GATE_SKIP": "1" }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/escape_hatch_skip/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/escape_hatch_skip/stdin.json
@@ -1,0 +1,5 @@
+{
+  "tool_input": {
+    "command": "dotnet stryker --config-file stryker-config.json"
+  }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/happy_path_killed/initial_tree/StrykerOutput/smoke/reports/mutation-report.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/happy_path_killed/initial_tree/StrykerOutput/smoke/reports/mutation-report.json
@@ -1,0 +1,1 @@
+{"schemaVersion":"1","mutants":[{"id":"1","status":"Killed"},{"id":"2","status":"Survived"}]}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/happy_path_killed/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/happy_path_killed/stdin.json
@@ -1,0 +1,5 @@
+{
+  "tool_input": {
+    "command": "dotnet stryker --config-file stryker-config.json"
+  }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/malformed_json_advisory/initial_tree/StrykerOutput/smoke/reports/mutation-report.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/malformed_json_advisory/initial_tree/StrykerOutput/smoke/reports/mutation-report.json
@@ -1,0 +1,1 @@
+{not valid json

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/malformed_json_advisory/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/malformed_json_advisory/stdin.json
@@ -1,0 +1,5 @@
+{
+  "tool_input": {
+    "command": "dotnet stryker --config-file stryker-config.json"
+  }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/single_file_mutate_probe/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/single_file_mutate_probe/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_input": { "command": "dotnet stryker --mutate src/Foo.cs" } }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/windows_path_cwd/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_testing_smoke_gate/windows_path_cwd/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_input": { "command": "dotnet stryker" }, "cwd": "C:\\Users\\dev\\repo" }

--- a/plugins/dev-team/tests/hooks/parity/parity.py
+++ b/plugins/dev-team/tests/hooks/parity/parity.py
@@ -1,0 +1,307 @@
+"""Parity harness — the mechanical gate for the bash → Python hook migration (#572).
+
+For each hook slice in Phases 1–3 of `plans/cached-inventing-wave.md`, this
+module dispatches identical `(stdin, env, argv, initial-tree)` fixtures at
+both the `.sh` and `.py` implementations, snapshots the observable outcome,
+and asserts byte-equal parity.
+
+Public surface:
+
+- `Fixture` — the input record for a parity comparison.
+- `HookResult` — captured outcome (stdout, stderr, exit code, side-effect tree).
+- `dispatch(...)` — run one implementation, return HookResult.
+- `assert_parity(...)` — run both, assert byte-equal outcome.
+- `record_fixture(...)` — regenerate an `expected.json` snapshot from the .sh
+  when running with `--parity-record`.
+
+Sandbox contract (docs/python-hook-contract.md):
+    HOME              → tmpdir
+    CLAUDE_PROJECT_DIR → tmpdir
+    GIT_CONFIG_GLOBAL  → /dev/null
+    GIT_CONFIG_SYSTEM  → /dev/null
+    Everything else scrubbed to a minimal `PATH` + `LANG`.
+
+stderr normalization strips ONLY:
+    - ISO-8601 timestamps
+    - PIDs written as `pid=N`
+    - the tmpdir path prefix (both impls run in different tmpdirs)
+
+Nothing else. If two implementations diverge on anything past these three
+axes, that is a real divergence — fix the hook, don't widen the normalizer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Fixture:
+    """Input tuple for one parity comparison.
+
+    `initial_tree` is a mapping of relative-path → text-content applied to the
+    sandbox root before the hook runs. Absent = empty sandbox.
+    """
+
+    name: str
+    stdin: bytes = b""
+    argv: List[str] = field(default_factory=list)
+    env: Dict[str, str] = field(default_factory=dict)
+    initial_tree: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class HookResult:
+    stdout: bytes
+    stderr: bytes
+    exit_code: int
+    tree: Dict[str, str]  # relative-path → sha256:hexdigest (files only)
+    sandbox_root: Optional[Path] = None  # tmpdir the hook ran in (post-cleanup)
+
+
+# ---------------------------------------------------------------------------
+# Sandbox helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_env(sandbox_root: Path, extra: Mapping[str, str]) -> Dict[str, str]:
+    """Build the scrubbed environment for a hook invocation.
+
+    Base includes only what portable hooks need: PATH, LANG, PYTHONIOENCODING,
+    plus the sandbox-scoped Claude/git vars from the contract. Callers can add
+    hook-specific vars via `extra` (they override the base).
+    """
+    base: Dict[str, str] = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C.UTF-8",
+        "PYTHONIOENCODING": "utf-8",
+        # Never write .pyc bytecode into $HOME (which we point at the sandbox)
+        # — that would flood the side-effect tree with unrelated files on
+        # every hook invocation and defeat the parity comparison.
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "HOME": str(sandbox_root),
+        "CLAUDE_PROJECT_DIR": str(sandbox_root),
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    base.update(extra)
+    return base
+
+
+def _apply_initial_tree(root: Path, tree: Mapping[str, str]) -> None:
+    for rel, content in tree.items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+
+def _snapshot_tree(root: Path) -> Dict[str, str]:
+    """Return {relative_path: sha256} for every file under `root`."""
+    snapshot: Dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(root))
+        snapshot[rel] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# stderr normalization
+# ---------------------------------------------------------------------------
+
+
+_ISO8601_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?"
+)
+_PID_RE = re.compile(r"\bpid=\d+\b")
+
+
+def _normalize_stderr(raw: bytes, tmpdir_prefix: Optional[Path] = None) -> bytes:
+    text = raw.decode("utf-8", errors="replace")
+    text = _ISO8601_RE.sub("<TS>", text)
+    text = _PID_RE.sub("pid=<PID>", text)
+    if tmpdir_prefix is not None:
+        text = text.replace(str(tmpdir_prefix), "<SANDBOX>")
+    return text.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch(
+    argv: List[str],
+    *,
+    stdin_bytes: bytes = b"",
+    env: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Path] = None,
+    sandbox: bool = True,
+    initial_tree: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+) -> HookResult:
+    """Run one hook implementation and return its captured outcome.
+
+    When `sandbox=True` (default), the process runs in a fresh tmpdir with the
+    scrubbed env from the contract and no side effects leak outside. The
+    HookResult.tree captures every file the hook wrote into the sandbox.
+
+    Substitute the literal argv token `SANDBOX` with the sandbox root path so
+    fixtures can name a working directory without knowing the tmpdir in advance.
+    """
+    extra_env: Dict[str, str] = dict(env or {})
+    with tempfile.TemporaryDirectory(prefix="parity-") as tmpdir_str:
+        root = Path(tmpdir_str)
+        _apply_initial_tree(root, initial_tree or {})
+        proc_env = _minimal_env(root, extra_env) if sandbox else dict(os.environ)
+        effective_cwd = cwd if cwd is not None else root
+        # Substitute SANDBOX token in argv.
+        resolved_argv = [str(root) if a == "SANDBOX" else a for a in argv]
+        try:
+            completed = subprocess.run(
+                resolved_argv,
+                input=stdin_bytes,
+                env=proc_env,
+                cwd=str(effective_cwd),
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return HookResult(
+                stdout=exc.stdout or b"",
+                stderr=(exc.stderr or b"") + b"\n[parity-harness] TIMEOUT\n",
+                exit_code=124,
+                tree=_snapshot_tree(root),
+                sandbox_root=root,
+            )
+        return HookResult(
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            exit_code=completed.returncode,
+            tree=_snapshot_tree(root),
+            sandbox_root=root,
+        )
+
+
+# ---------------------------------------------------------------------------
+# assert_parity
+# ---------------------------------------------------------------------------
+
+
+def _fmt_bytes(b: bytes) -> str:
+    try:
+        return b.decode("utf-8")
+    except UnicodeDecodeError:
+        return repr(b)
+
+
+def assert_parity(
+    *,
+    sh_argv: List[str],
+    py_argv: List[str],
+    fixture: Fixture,
+) -> None:
+    """Dispatch both implementations at `fixture` and assert equal outcome."""
+    sh_result = dispatch(
+        sh_argv,
+        stdin_bytes=fixture.stdin,
+        env=fixture.env,
+        initial_tree=fixture.initial_tree,
+    )
+    py_result = dispatch(
+        py_argv,
+        stdin_bytes=fixture.stdin,
+        env=fixture.env,
+        initial_tree=fixture.initial_tree,
+    )
+
+    # Exit code first — the loudest divergence signal.
+    assert sh_result.exit_code == py_result.exit_code, (
+        f"[{fixture.name}] exit code diverged: sh={sh_result.exit_code} "
+        f"py={py_result.exit_code}\n"
+        f"sh stdout: {_fmt_bytes(sh_result.stdout)!r}\n"
+        f"py stdout: {_fmt_bytes(py_result.stdout)!r}\n"
+        f"sh stderr: {_fmt_bytes(sh_result.stderr)!r}\n"
+        f"py stderr: {_fmt_bytes(py_result.stderr)!r}"
+    )
+    # Stdout byte-equal.
+    assert sh_result.stdout == py_result.stdout, (
+        f"[{fixture.name}] stdout diverged\n"
+        f"sh: {_fmt_bytes(sh_result.stdout)!r}\n"
+        f"py: {_fmt_bytes(py_result.stdout)!r}"
+    )
+    # Stderr equal after normalization — each side's own tmpdir is scrubbed.
+    sh_stderr_norm = _normalize_stderr(sh_result.stderr, sh_result.sandbox_root)
+    py_stderr_norm = _normalize_stderr(py_result.stderr, py_result.sandbox_root)
+    assert sh_stderr_norm == py_stderr_norm, (
+        f"[{fixture.name}] stderr diverged after normalization\n"
+        f"sh: {_fmt_bytes(sh_stderr_norm)!r}\n"
+        f"py: {_fmt_bytes(py_stderr_norm)!r}"
+    )
+    # Side-effect tree equal.
+    assert sh_result.tree == py_result.tree, (
+        f"[{fixture.name}] side-effect tree diverged\n"
+        f"sh: {sh_result.tree}\n"
+        f"py: {py_result.tree}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# --record mode
+# ---------------------------------------------------------------------------
+
+
+def record_fixture(
+    *,
+    sh_argv: List[str],
+    fixture: Fixture,
+    snapshot_path: Path,
+) -> Path:
+    """Run the .sh implementation and write its outcome as JSON to snapshot_path.
+
+    Used by `--parity-record` when a fixture's expected snapshot is missing or
+    the operator wants to regenerate against the current authoritative bash
+    behavior. Does NOT run the .py — the .py is validated by assert_parity in
+    the non-record run that follows.
+    """
+    result = dispatch(
+        sh_argv,
+        stdin_bytes=fixture.stdin,
+        env=fixture.env,
+        initial_tree=fixture.initial_tree,
+    )
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "name": fixture.name,
+                "stdout": result.stdout.decode("utf-8", errors="replace"),
+                "stderr_normalized": _normalize_stderr(result.stderr).decode(
+                    "utf-8", errors="replace"
+                ),
+                "exit_code": result.exit_code,
+                "tree": result.tree,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return snapshot_path

--- a/plugins/dev-team/tests/hooks/parity/parity.py
+++ b/plugins/dev-team/tests/hooks/parity/parity.py
@@ -95,6 +95,10 @@ def _minimal_env(sandbox_root: Path, extra: Mapping[str, str]) -> Dict[str, str]
         # every hook invocation and defeat the parity comparison.
         "PYTHONDONTWRITEBYTECODE": "1",
         "HOME": str(sandbox_root),
+        # PWD is the shell's logical cwd; bash preserves it verbatim while
+        # Python's os.getcwd() resolves symlinks. On macOS /var → /private/var
+        # the two diverge — align both by explicitly setting PWD.
+        "PWD": str(sandbox_root),
         "CLAUDE_PROJECT_DIR": str(sandbox_root),
         "GIT_CONFIG_GLOBAL": "/dev/null",
         "GIT_CONFIG_SYSTEM": "/dev/null",
@@ -111,13 +115,22 @@ def _apply_initial_tree(root: Path, tree: Mapping[str, str]) -> None:
 
 
 def _snapshot_tree(root: Path) -> Dict[str, str]:
-    """Return {relative_path: sha256} for every file under `root`."""
+    """Return {relative_path: sha256-of-normalized-content} for files under `root`.
+
+    Content is normalized before hashing so that timestamps, PIDs, and the
+    per-side tmpdir prefix — which the .sh and .py MUST embed at different
+    values for the same fixture — do not fail the parity check. This mirrors
+    the stderr normalization: if two impls diverge on anything past those
+    three axes inside a file they wrote, that is a real divergence.
+    """
     snapshot: Dict[str, str] = {}
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
         rel = str(path.relative_to(root))
-        snapshot[rel] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        raw = path.read_bytes()
+        normalized = _normalize_stderr(raw, root)
+        snapshot[rel] = "sha256:" + hashlib.sha256(normalized).hexdigest()
     return snapshot
 
 
@@ -138,6 +151,20 @@ def _normalize_stderr(raw: bytes, tmpdir_prefix: Optional[Path] = None) -> bytes
     text = _PID_RE.sub("pid=<PID>", text)
     if tmpdir_prefix is not None:
         text = text.replace(str(tmpdir_prefix), "<SANDBOX>")
+    return text.encode("utf-8")
+
+
+def _scrub_sandbox_prefix(raw: bytes, tmpdir_prefix: Optional[Path]) -> bytes:
+    """Replace each side's own tmpdir prefix in stdout with <SANDBOX>.
+
+    Unlike stderr normalization, this does NOT touch timestamps or PIDs —
+    those never legitimately appear on stdout for a hook and any divergence
+    on those axes should still fail the parity check.
+    """
+    if tmpdir_prefix is None:
+        return raw
+    text = raw.decode("utf-8", errors="replace")
+    text = text.replace(str(tmpdir_prefix), "<SANDBOX>")
     return text.encode("utf-8")
 
 
@@ -241,11 +268,17 @@ def assert_parity(
         f"sh stderr: {_fmt_bytes(sh_result.stderr)!r}\n"
         f"py stderr: {_fmt_bytes(py_result.stderr)!r}"
     )
-    # Stdout byte-equal.
-    assert sh_result.stdout == py_result.stdout, (
+    # Stdout byte-equal after sandbox-prefix normalization. Each side runs in
+    # its own tmpdir, so an identical hook that echoes its cwd still emits
+    # different strings — that is a harness artifact, not a hook divergence.
+    # Scrub only each side's own sandbox root (no timestamps, no PIDs — stdout
+    # is the user-visible channel and we do not want to hide real drift there).
+    sh_stdout_norm = _scrub_sandbox_prefix(sh_result.stdout, sh_result.sandbox_root)
+    py_stdout_norm = _scrub_sandbox_prefix(py_result.stdout, py_result.sandbox_root)
+    assert sh_stdout_norm == py_stdout_norm, (
         f"[{fixture.name}] stdout diverged\n"
-        f"sh: {_fmt_bytes(sh_result.stdout)!r}\n"
-        f"py: {_fmt_bytes(py_result.stdout)!r}"
+        f"sh: {_fmt_bytes(sh_stdout_norm)!r}\n"
+        f"py: {_fmt_bytes(py_stdout_norm)!r}"
     )
     # Stderr equal after normalization — each side's own tmpdir is scrubbed.
     sh_stderr_norm = _normalize_stderr(sh_result.stderr, sh_result.sandbox_root)

--- a/plugins/dev-team/tests/hooks/parity/test_mutation_testing_smoke_gate_parity.py
+++ b/plugins/dev-team/tests/hooks/parity/test_mutation_testing_smoke_gate_parity.py
@@ -1,0 +1,108 @@
+"""Parity fixtures for hooks/mutation-testing-smoke-gate (#574).
+
+Runs the .sh and .py implementations against six fixtures covering the
+hook's full observable surface. assert_parity fails the merge on any
+byte-level divergence in stdout, exit code, normalized stderr, or
+side-effect tree.
+
+Fixture layout (per subdirectory of fixtures/mutation_testing_smoke_gate/):
+    stdin.json              - stdin payload for the hook (required)
+    env.json                - {name: value} env overlay (optional)
+    initial_tree/           - files copied into the sandbox root before run
+                              (optional; the smoke-report fixtures use this)
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from parity import Fixture, assert_parity  # type: ignore[import-not-found]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_HOOK_SH = (
+    _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "mutation-testing-smoke-gate.sh"
+)
+_HOOK_PY = (
+    _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "mutation_testing_smoke_gate.py"
+)
+_FIXTURES_DIR = (
+    Path(__file__).resolve().parent / "fixtures" / "mutation_testing_smoke_gate"
+)
+
+
+def _load_fixture(dirpath: Path) -> Fixture:
+    stdin_bytes = (
+        (dirpath / "stdin.json").read_bytes()
+        if (dirpath / "stdin.json").is_file()
+        else b""
+    )
+    env_path = dirpath / "env.json"
+    env: Dict[str, str] = {}
+    if env_path.is_file():
+        env = {k: str(v) for k, v in json.loads(env_path.read_text()).items()}
+    initial_tree: Dict[str, str] = {}
+    tree_root = dirpath / "initial_tree"
+    if tree_root.is_dir():
+        for path in tree_root.rglob("*"):
+            if path.is_file():
+                rel = str(path.relative_to(tree_root))
+                initial_tree[rel] = path.read_text()
+    return Fixture(
+        name=dirpath.name,
+        stdin=stdin_bytes,
+        argv=[],
+        env=env,
+        initial_tree=initial_tree,
+    )
+
+
+def _discover_fixtures() -> List[Path]:
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(p for p in _FIXTURES_DIR.iterdir() if p.is_dir())
+
+
+_FIXTURE_DIRS = _discover_fixtures()
+
+
+@pytest.mark.skipif(
+    not _HOOK_SH.is_file() or not _HOOK_PY.is_file(),
+    reason="both .sh and .py implementations required",
+)
+@pytest.mark.skipif(not _FIXTURE_DIRS, reason="no fixture directories present")
+@pytest.mark.parametrize("fixture_dir", _FIXTURE_DIRS, ids=lambda p: p.name)
+def test_parity(fixture_dir: Path) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq required by the .sh")
+    fixture = _load_fixture(fixture_dir)
+    # Both implementations reference their smoke report via <cwd>/StrykerOutput/...
+    # The stdin.json's `cwd` field must point at SANDBOX for tree seeding to work;
+    # we substitute the sandbox root string in the payload before dispatch.
+    # Simpler: fixtures set "cwd" to the string "SANDBOX" in stdin.json; we
+    # rewrite it here for both sides.
+    if b"SANDBOX" in fixture.stdin:
+        # dispatch() creates a fresh sandbox per side; we can't pre-know it.
+        # Instead: the hook's default cwd fallback is $PWD when cwd is missing.
+        # Rewrite "cwd": "SANDBOX" → drop the key so both sides fall back to
+        # subprocess cwd (the sandbox root). This keeps stdin byte-identical
+        # between sides.
+        payload = json.loads(fixture.stdin.decode("utf-8"))
+        payload.pop("cwd", None)
+        fixture = Fixture(
+            name=fixture.name,
+            stdin=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            argv=fixture.argv,
+            env=fixture.env,
+            initial_tree=fixture.initial_tree,
+        )
+    assert_parity(
+        sh_argv=["bash", str(_HOOK_SH)],
+        py_argv=["python3", str(_HOOK_PY)],
+        fixture=fixture,
+    )

--- a/plugins/dev-team/tests/hooks/parity/test_parity_selftest.py
+++ b/plugins/dev-team/tests/hooks/parity/test_parity_selftest.py
@@ -132,7 +132,8 @@ def test_stderr_normalization_strips_timestamps_pids_tmpdir(tmp_path: Path) -> N
         "#!/usr/bin/env python3\n"
         "import os, sys\n"
         "print('ok')\n"
-        "print(f'ts=2026-07-02T99:99:99Z pid=99999 path={os.getcwd()}/x.log', file=sys.stderr)\n"
+        "cwd = os.environ.get('PWD') or os.getcwd()\n"
+        "print(f'ts=2026-07-02T99:99:99Z pid=99999 path={cwd}/x.log', file=sys.stderr)\n"
         "sys.exit(0)\n"
     )
     fixture = Fixture(name="stderr-norm", stdin=b"", argv=[], env={})

--- a/plugins/dev-team/tests/hooks/parity/test_parity_selftest.py
+++ b/plugins/dev-team/tests/hooks/parity/test_parity_selftest.py
@@ -1,0 +1,209 @@
+"""Self-test for the parity harness itself.
+
+Uses two throwaway hook impls (a `.sh` and a `.py`) that ARE byte-identical
+in behavior — assert_parity passes. Then a mutated `.py` that diverges —
+assert_parity fails. This is the harness's own smoke test; it does not
+touch any real hook.
+
+Also exercises the sandbox isolation contract from
+`docs/python-hook-contract.md`: env vars scrubbed, tmpdir-scoped, no
+side effects outside the sandbox.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from parity import (  # type: ignore[import-not-found]
+    Fixture,
+    assert_parity,
+    dispatch,
+    record_fixture,
+)
+
+
+def _write_matched_pair(tmpdir: Path) -> tuple[Path, Path]:
+    sh = tmpdir / "echo.sh"
+    py = tmpdir / "echo.py"
+    sh.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            # Echo argv joined by space, then a fixed line to stderr.
+            printf '%s\\n' "$*"
+            printf 'diag pid=%s ts=2026-07-02T00:00:00Z\\n' "$$" >&2
+            exit 0
+            """
+        )
+    )
+    py.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os, sys
+            print(" ".join(sys.argv[1:]))
+            print(f"diag pid={os.getpid()} ts=2026-07-02T00:00:00Z", file=sys.stderr)
+            sys.exit(0)
+            """
+        )
+    )
+    sh.chmod(0o755)
+    py.chmod(0o755)
+    return sh, py
+
+
+def test_dispatch_captures_stdout_and_exit_code(tmp_path: Path) -> None:
+    sh, _ = _write_matched_pair(tmp_path)
+    result = dispatch(
+        ["bash", str(sh), "hello", "world"],
+        stdin_bytes=b"",
+        env={"HOME": str(tmp_path)},
+        cwd=tmp_path,
+    )
+    assert result.exit_code == 0
+    assert result.stdout == b"hello world\n"
+
+
+def test_assert_parity_passes_on_matched_pair(tmp_path: Path) -> None:
+    sh, py = _write_matched_pair(tmp_path)
+    fixture = Fixture(
+        name="matched-echo",
+        stdin=b"",
+        argv=["hi", "there"],
+        env={},
+    )
+    assert_parity(
+        sh_argv=["bash", str(sh), *fixture.argv],
+        py_argv=["python3", str(py), *fixture.argv],
+        fixture=fixture,
+    )
+
+
+def test_assert_parity_fails_on_divergent_stdout(tmp_path: Path) -> None:
+    sh, py = _write_matched_pair(tmp_path)
+    # Break the .py's stdout on purpose.
+    py.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import sys
+            print("DIVERGENT")
+            sys.exit(0)
+            """
+        )
+    )
+    fixture = Fixture(name="broken-echo", stdin=b"", argv=["hi"], env={})
+    with pytest.raises(AssertionError):
+        assert_parity(
+            sh_argv=["bash", str(sh), *fixture.argv],
+            py_argv=["python3", str(py), *fixture.argv],
+            fixture=fixture,
+        )
+
+
+def test_assert_parity_fails_on_divergent_exit_code(tmp_path: Path) -> None:
+    sh, py = _write_matched_pair(tmp_path)
+    py.write_text("#!/usr/bin/env python3\nimport sys\nsys.exit(7)\n")
+    fixture = Fixture(name="wrong-exit", stdin=b"", argv=[], env={})
+    with pytest.raises(AssertionError):
+        assert_parity(
+            sh_argv=["bash", str(sh)],
+            py_argv=["python3", str(py)],
+            fixture=fixture,
+        )
+
+
+def test_stderr_normalization_strips_timestamps_pids_tmpdir(tmp_path: Path) -> None:
+    """Two impls that only differ in timestamp/PID/tmpdir prefixes must match."""
+    sh = tmp_path / "diag.sh"
+    py = tmp_path / "diag.py"
+    sh.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'ok\\n'\n"
+        "printf 'ts=2026-07-02T12:34:56Z pid=1234 path=%s/x.log\\n' \"$PWD\" >&2\n"
+        "exit 0\n"
+    )
+    py.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "print('ok')\n"
+        "print(f'ts=2026-07-02T99:99:99Z pid=99999 path={os.getcwd()}/x.log', file=sys.stderr)\n"
+        "sys.exit(0)\n"
+    )
+    fixture = Fixture(name="stderr-norm", stdin=b"", argv=[], env={})
+    assert_parity(
+        sh_argv=["bash", str(sh)],
+        py_argv=["python3", str(py)],
+        fixture=fixture,
+    )
+
+
+def test_sandbox_isolation_scrubs_git_config_env(tmp_path: Path) -> None:
+    """Hook run under the harness must see GIT_CONFIG_GLOBAL=/dev/null."""
+    py = tmp_path / "probe.py"
+    py.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "print(os.environ.get('GIT_CONFIG_GLOBAL', '<unset>'))\n"
+        "sys.exit(0)\n"
+    )
+    fixture = Fixture(name="probe", stdin=b"", argv=[], env={})
+    result = dispatch(
+        ["python3", str(py)],
+        stdin_bytes=fixture.stdin,
+        env=fixture.env,
+        cwd=tmp_path,
+        sandbox=True,
+    )
+    assert result.stdout.decode().strip() == "/dev/null"
+
+
+def test_record_fixture_writes_snapshot_from_sh(tmp_path: Path) -> None:
+    """--record mode regenerates expected.json from the .sh run."""
+    import json
+
+    sh, _ = _write_matched_pair(tmp_path)
+    fixture = Fixture(name="recorded", stdin=b"", argv=["one", "two"], env={})
+    snap = tmp_path / "snapshots" / "recorded.json"
+    assert not snap.exists()
+    written = record_fixture(
+        sh_argv=["bash", str(sh), *fixture.argv],
+        fixture=fixture,
+        snapshot_path=snap,
+    )
+    assert written == snap
+    data = json.loads(snap.read_text())
+    assert data["name"] == "recorded"
+    assert data["exit_code"] == 0
+    assert data["stdout"] == "one two\n"
+    # stderr_normalized should have the timestamp and pid substituted.
+    assert "<TS>" in data["stderr_normalized"]
+    assert "pid=<PID>" in data["stderr_normalized"]
+
+
+def test_parity_record_cli_option_registered(pytestconfig) -> None:  # type: ignore[no-untyped-def]
+    """The --parity-record flag exists on the pytest CLI."""
+    # If registration failed, `getoption` would raise ValueError.
+    _ = pytestconfig.getoption("--parity-record")
+
+
+def test_side_effect_tree_snapshot_detects_divergent_files(tmp_path: Path) -> None:
+    """.sh writes foo, .py writes bar — assert_parity fails on tree divergence."""
+    sh = tmp_path / "writer.sh"
+    py = tmp_path / "writer.py"
+    sh.write_text('#!/usr/bin/env bash\necho content > "$1/foo.txt"\nexit 0\n')
+    py.write_text(
+        '#!/usr/bin/env python3\nimport sys\nopen(sys.argv[1] + "/bar.txt","w").write("content\\n")\nsys.exit(0)\n'
+    )
+    fixture = Fixture(name="tree-mismatch", stdin=b"", argv=["SANDBOX"], env={})
+    with pytest.raises(AssertionError):
+        assert_parity(
+            sh_argv=["bash", str(sh)],
+            py_argv=["python3", str(py)],
+            fixture=fixture,
+        )

--- a/plugins/dev-team/tests/hooks/test_mutation_testing_smoke_gate.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_testing_smoke_gate.py
@@ -1,0 +1,292 @@
+"""Unit tests for the Python port of hooks/mutation-testing-smoke-gate.sh (#574).
+
+These are white-box tests on the port's helpers. Byte-parity with the .sh
+sibling is enforced separately by the parity harness (Slice 4).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HOOKS = Path(__file__).resolve().parents[2] / "hooks"
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))
+
+import mutation_testing_smoke_gate as gate  # type: ignore[import-not-found]  # noqa: E402
+
+
+# --- trigger detection -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "dotnet stryker",
+        "dotnet stryker --mutate src/Foo.cs",
+        "  dotnet   stryker  ",
+        "cd repo && dotnet stryker --config-file config.json",
+        "bash plugins/dev-team/hooks/mutation-adapters/csharp-stryker-net-wrapper.sh --arg",
+        "/abs/path/to/csharp-stryker-net-wrapper.sh",
+    ],
+)
+def test_is_stryker_command_matches_expected(cmd: str) -> None:
+    assert gate.is_stryker_command(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "",
+        "echo hi",
+        "dotnet build",
+        "dotnetstryker",  # no boundary
+        "pip install stryker",
+    ],
+)
+def test_is_stryker_command_ignores_non_stryker(cmd: str) -> None:
+    assert gate.is_stryker_command(cmd) is False
+
+
+# --- --mutate extraction ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd,expected",
+    [
+        ("dotnet stryker --mutate src/Foo.cs", "src/Foo.cs"),
+        ("dotnet stryker --mutate=src/Foo.cs", "src/Foo.cs"),
+        ("dotnet stryker -m src/Foo.cs", "src/Foo.cs"),
+        ("dotnet stryker --mutate 'src/Has Space.cs'", "src/Has Space.cs"),
+        ('dotnet stryker --mutate "src/Foo.cs"', "src/Foo.cs"),
+        ("dotnet stryker", ""),
+        ("dotnet stryker --mutate", ""),  # missing value
+    ],
+)
+def test_extract_mutate_value(cmd: str, expected: str) -> None:
+    assert gate.extract_mutate_value(cmd) == expected
+
+
+def test_extract_mutate_value_on_malformed_shell_returns_empty() -> None:
+    # An unclosed quote breaks shlex → return empty (silent), matching the .sh.
+    assert gate.extract_mutate_value("dotnet stryker --mutate 'unclosed") == ""
+
+
+# --- single-file classification -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("src/Foo.cs", True),
+        ("", False),
+        ("src/*.cs", False),  # glob
+        ("src/?oo.cs", False),  # glob
+        ("src/[Ff]oo.cs", False),  # glob
+        ("src/Foo.cs;src/Bar.cs", False),  # semi-colon multi
+    ],
+)
+def test_is_single_file_mutate(value: str, expected: bool) -> None:
+    assert gate.is_single_file_mutate(value) is expected
+
+
+# --- audit-log helpers -----------------------------------------------------
+
+
+def test_sha256_first_16_is_deterministic() -> None:
+    assert gate.sha256_first_16("hello") == gate.sha256_first_16("hello")
+    assert len(gate.sha256_first_16("hello")) == 16
+
+
+def test_iso_utc_timestamp_z_suffix() -> None:
+    ts = gate.iso_utc_timestamp()
+    assert ts.endswith("Z")
+    assert "T" in ts
+
+
+def test_log_bypass_audit_writes_hashed_jsonl(tmp_path: Path) -> None:
+    cwd = tmp_path
+    gate.log_bypass_audit("dotnet stryker --whole-scope", str(cwd))
+    audit = cwd / "metrics" / "gate-bypass.jsonl"
+    assert audit.is_file()
+    lines = audit.read_text().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["hook"] == "mutation-testing-smoke-gate"
+    assert record["cwd"] == str(cwd)
+    assert record["timestamp"].endswith("Z")
+    # command hash, never the raw command
+    assert "stryker" not in record["command_hash"]
+    assert len(record["command_hash"]) == 16
+
+
+# --- main() dispatch -------------------------------------------------------
+
+
+def _run_main(monkeypatch, stdin_str: str, env: dict) -> tuple[int, str]:
+    monkeypatch.setattr(sys, "stdin", _make_stdin(stdin_str))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    from io import StringIO
+
+    buf = StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    rc = gate.main()
+    return rc, buf.getvalue()
+
+
+def _make_stdin(text: str):
+    from io import StringIO
+
+    return StringIO(text)
+
+
+def test_main_silent_pass_on_empty_stdin(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    rc, out = _run_main(monkeypatch, "", {})
+    assert rc == 0
+    assert out == ""
+
+
+def test_main_silent_pass_on_non_stryker_command(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    payload = json.dumps({"tool_input": {"command": "echo hi"}})
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert out == ""
+
+
+def test_main_silent_pass_on_single_file_mutate(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    payload = json.dumps(
+        {"tool_input": {"command": "dotnet stryker --mutate src/Foo.cs"}}
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert out == ""
+
+
+def test_main_blocks_when_no_smoke_report(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 2
+    assert "[BLOCK]" in out
+    assert "no smoke report" in out
+    assert "Step 1c" in out
+
+
+def test_main_passes_when_smoke_report_has_killed(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    reports = tmp_path / "StrykerOutput" / "smoke" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "mutation-report.json").write_text(
+        json.dumps({"mutants": [{"status": "Killed"}, {"status": "Survived"}]})
+    )
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert out == ""
+
+
+def test_main_blocks_when_killed_zero_survived_nonzero(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    reports = tmp_path / "StrykerOutput" / "smoke" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "mutation-report.json").write_text(
+        json.dumps({"mutants": [{"status": "Survived"}, {"status": "Survived"}]})
+    )
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 2
+    assert "[BLOCK]" in out
+    assert "killed=0" in out
+
+
+def test_main_blocks_on_empty_or_uncovered_mutants(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    reports = tmp_path / "StrykerOutput" / "smoke" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "mutation-report.json").write_text(
+        json.dumps({"mutants": [{"status": "NoCoverage"}]})
+    )
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 2
+    assert "no scored mutants" in out
+
+
+def test_main_advisory_on_malformed_json(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    reports = tmp_path / "StrykerOutput" / "smoke" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "mutation-report.json").write_text("{not valid json")
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert out.startswith("ADVISORY:")
+    assert "not valid JSON" in out
+
+
+def test_main_advisory_on_missing_mutants_key(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    reports = tmp_path / "StrykerOutput" / "smoke" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "mutation-report.json").write_text(json.dumps({"other": "shape"}))
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert "lacks the mutants[] key" in out
+    assert out.startswith("ADVISORY:")
+
+
+def test_main_escape_hatch_bypasses_and_audits(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "dotnet stryker --config-file c.json"},
+            "cwd": str(tmp_path),
+        }
+    )
+    rc, out = _run_main(monkeypatch, payload, {"MUTATION_SMOKE_GATE_SKIP": "1"})
+    assert rc == 0
+    assert out == ""
+    audit = tmp_path / "metrics" / "gate-bypass.jsonl"
+    assert audit.is_file()
+
+
+def test_main_advisory_on_missing_jq(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        gate.shutil, "which", lambda name: None if name == "jq" else "/usr/bin/" + name
+    )
+    payload = json.dumps({"tool_input": {"command": "dotnet stryker"}})
+    rc, out = _run_main(monkeypatch, payload, {})
+    assert rc == 0
+    assert out.startswith("ADVISORY:")
+    assert "jq is required" in out

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,9 @@ httpx>=0.27
 # Required by scripts/codebase_recon.py to validate the recon envelope against
 # plugins/dev-team/knowledge/schemas/recon-envelope-v1.json before writing.
 jsonschema>=4.0
+
+# Required by the Python-hook parity harness (plugins/dev-team/tests/hooks/parity/)
+# introduced in #574 as Phase 0 of the bash → python migration (#572). Every
+# Python-hook slice from #572 lives or dies by this suite; the harness itself
+# is stdlib-only but its test runner is pytest.
+pytest>=7.0

--- a/scripts/check_md_references.py
+++ b/scripts/check_md_references.py
@@ -54,7 +54,13 @@ SKIP_FILENAMES = ("CHANGELOG.md",)
 # Synthetic project trees under here are eval scaffolding, not the repo's own
 # structure. Excluding them from the real-file index stops a descriptive path
 # (e.g. `.claude/skills/`) from coincidentally matching a fixture and false-firing.
-INDEX_EXCLUDE_PREFIXES = ("evals/fixtures/",)
+INDEX_EXCLUDE_PREFIXES = (
+    "evals/fixtures/",
+    # Parity fixtures seed runtime-shape files (e.g. StrykerOutput/…) into a
+    # sandbox tree. They are test scaffolding for the bash → python hook
+    # migration harness (#574), not references from the repo's own docs.
+    "plugins/dev-team/tests/hooks/parity/fixtures/",
+)
 
 PATH_EXTS = ("md", "json", "sh", "py", "svg", "tmpl", "txt", "yml", "yaml", "cfg")
 _EXT_ALT = "|".join(PATH_EXTS)
@@ -92,7 +98,7 @@ def _normalize(ref: str):
         return None
     if ref.startswith("~") or ref.startswith("/"):
         return None  # home-relative or absolute system paths: not repo references
-    body = ref[len(_PLUGIN_ROOT_VAR):] if ref.startswith(_PLUGIN_ROOT_VAR) else ref
+    body = ref[len(_PLUGIN_ROOT_VAR) :] if ref.startswith(_PLUGIN_ROOT_VAR) else ref
     if "$" in body or _NONLITERAL.search(body):
         return None  # other shell vars / globs / placeholders: not statically checkable
     is_dir = body.endswith("/")
@@ -117,7 +123,9 @@ def _present(base: str, rel: str, is_dir: bool, root: str, tracked: set):
 def _resolves(ref: str, file_dir: str, module_root: str, root: str, tracked: set):
     is_dir = ref.endswith("/")
     if ref.startswith(_PLUGIN_ROOT_VAR):
-        return _present(module_root, ref[len(_PLUGIN_ROOT_VAR):], is_dir, root, tracked)
+        return _present(
+            module_root, ref[len(_PLUGIN_ROOT_VAR) :], is_dir, root, tracked
+        )
     return (
         _present(file_dir, ref, is_dir, root, tracked)
         or _present(module_root, ref, is_dir, root, tracked)
@@ -135,7 +143,7 @@ def _module_root(path: str, root: str):
 
 def _ref_tail(ref: str):
     """The reference reduced to its meaningful path tail (no var, no ./.. prefix)."""
-    body = ref[len(_PLUGIN_ROOT_VAR):] if ref.startswith(_PLUGIN_ROOT_VAR) else ref
+    body = ref[len(_PLUGIN_ROOT_VAR) :] if ref.startswith(_PLUGIN_ROOT_VAR) else ref
     parts = [p for p in body.strip("/").split("/") if p not in (".", "..")]
     return "/".join(parts)
 
@@ -149,7 +157,9 @@ def _real_file_list(root: str):
     try:
         out = subprocess.run(
             ["git", "-C", root, "ls-files"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout
         files = [f for f in out.splitlines() if f.strip()]
         if files:
@@ -160,7 +170,9 @@ def _real_file_list(root: str):
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [x for x in dirnames if x not in (".git", "node_modules")]
         for fn in filenames:
-            files.append(os.path.relpath(os.path.join(dirpath, fn), root).replace(os.sep, "/"))
+            files.append(
+                os.path.relpath(os.path.join(dirpath, fn), root).replace(os.sep, "/")
+            )
     return files
 
 
@@ -256,15 +268,21 @@ def _iter_md_files(root: str):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--root", default=None, help="repo root (default: git toplevel)")
+    parser.add_argument(
+        "--root", default=None, help="repo root (default: git toplevel)"
+    )
     args = parser.parse_args(argv)
 
     root = args.root
     if root is None:
-        root = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True,
-        ).stdout.strip() or "."
+        root = (
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            or "."
+        )
     root = os.path.abspath(root)
 
     tracked = _tracked_paths(root)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -204,6 +204,31 @@ chk_eslint() {
     printf '%s∼ skipped (npx not found)%s\n' "$yellow" "$reset"
   fi
 }
+# Python-hook parity harness (#574 / #572 Phase 0). Runs pytest against
+# plugins/dev-team/tests/hooks/parity/ — the gate that mechanically enforces
+# byte-equal parity between each .sh hook and its .py port during the
+# parallel-ship migration.
+#
+# Backward-compatible: when the harness directory is absent (which can happen
+# on a fresh clone before Phase 0 lands, or on a shallow checkout that omits
+# the plugin's tests dir), the check reports a skip and exits 0 — a green CI
+# on those checkouts is still meaningful.
+chk_parity() {
+  local parity_dir="plugins/dev-team/tests/hooks/parity"
+  if [ ! -d "$parity_dir" ]; then
+    printf '%s∼ skipped (parity harness dir absent — %s)%s\n' "$yellow" "$parity_dir" "$reset"
+    return 0
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s∼ skipped (python3 not on PATH)%s\n' "$yellow" "$reset"
+    return 0
+  fi
+  if ! python3 -c 'import pytest' >/dev/null 2>&1; then
+    printf '%s∼ skipped (pytest not installed — see requirements-dev.txt)%s\n' "$yellow" "$reset"
+    return 0
+  fi
+  python3 -m pytest "$parity_dir"
+}
 
 # Ordered list of "label::function". Order defines both the replay order and the
 # summary order (declared order, independent of completion order).
@@ -226,6 +251,7 @@ CHECKS=(
   "nav integrity (mkdocs nav → assembled file)::chk_nav_integrity"
   "eval-corpus semver contract::chk_eval_semver"
   "eslint::chk_eslint"
+  "python-hook parity harness (pytest tests/hooks/parity)::chk_parity"
 )
 
 # --only=fn[,fn...] : keep just the named checks (CI invokes per-job subsets).

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -29,6 +29,7 @@ ci_watched_paths() {
     chk_eval_semver)        printf '%s' "evals/" ;;
     chk_eslint)             printf '%s' "plugins/dev-team/ *.js *.ts *.json" ;;
     chk_oe_staleness)       printf '%s' "" ;;  # advisory; intentionally always-run (no stable watched path)
+    chk_parity)             printf '%s' "plugins/dev-team/tests/hooks/parity/ plugins/dev-team/hooks/" ;;
     *)                      printf '%s' "" ;;
   esac
 }

--- a/tests/docs/python_hook_contract_tests.bats
+++ b/tests/docs/python_hook_contract_tests.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# #574 — Python hook contract + settings-toggle docs exist with required
+# sections. Phase 0 gate for the bash → python migration (#572).
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+CONTRACT="$REPO_ROOT/docs/python-hook-contract.md"
+TOGGLE="$REPO_ROOT/plugins/dev-team/hooks/settings-toggle.md"
+
+@test "python-hook contract file exists at docs/python-hook-contract.md" {
+  [ -f "$CONTRACT" ]
+}
+
+@test "contract: names stdin JSON schema" {
+  grep -qE "^## stdin" "$CONTRACT"
+}
+
+@test "contract: names stdout format" {
+  grep -qE "^## stdout" "$CONTRACT"
+}
+
+@test "contract: names exit codes 0/1/2/≥3" {
+  grep -qE "^## Exit codes" "$CONTRACT"
+  grep -qE "\b0\b" "$CONTRACT"
+  grep -qE "\b1\b" "$CONTRACT"
+  grep -qE "\b2\b" "$CONTRACT"
+}
+
+@test "contract: names environment variables" {
+  grep -qE "^## Environment variables" "$CONTRACT"
+  grep -q "CLAUDE_PROJECT_DIR" "$CONTRACT"
+}
+
+@test "contract: names stderr conventions" {
+  grep -qE "^## stderr" "$CONTRACT"
+}
+
+@test "contract: names Python authoring rules (stdlib-only, 3.8+)" {
+  grep -qE "^## Python authoring rules" "$CONTRACT"
+  grep -qi "stdlib" "$CONTRACT"
+  grep -qE "3\.8" "$CONTRACT"
+}
+
+@test "settings-toggle doc exists" {
+  [ -f "$TOGGLE" ]
+}
+
+@test "toggle: documents DEV_TEAM_PY_HOOK_<NAME> pattern" {
+  grep -q "DEV_TEAM_PY_HOOK_" "$TOGGLE"
+}
+
+@test "toggle: default-off semantics documented" {
+  grep -qi "default.*off\|defaults.*off\|default.*0" "$TOGGLE"
+}

--- a/tests/hooks/settings_python_toggle_tests.bats
+++ b/tests/hooks/settings_python_toggle_tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# #574 — settings.json dispatches the mutation-testing-smoke-gate hook via
+# the DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE env-var toggle. Default
+# off (bash); "1" routes to the .py port. See
+# plugins/dev-team/hooks/settings-toggle.md.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SETTINGS="$REPO_ROOT/plugins/dev-team/settings.json"
+
+@test "settings.json is valid JSON" {
+  jq empty "$SETTINGS"
+}
+
+@test "settings.json contains a smoke-gate hook entry" {
+  jq -e '.hooks.PreToolUse[] | select(.hooks[]?.command | tostring | test("mutation-testing-smoke-gate|mutation_testing_smoke_gate"))' "$SETTINGS" >/dev/null
+}
+
+@test "smoke-gate hook uses DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE toggle" {
+  local cmd
+  cmd=$(jq -r '.hooks.PreToolUse[].hooks[]?.command // empty | select(test("mutation-testing-smoke-gate|mutation_testing_smoke_gate"))' "$SETTINGS" | head -1)
+  [[ "$cmd" == *"DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE"* ]]
+}
+
+@test "smoke-gate hook references both .sh and .py implementations" {
+  local cmd
+  cmd=$(jq -r '.hooks.PreToolUse[].hooks[]?.command // empty | select(test("mutation-testing-smoke-gate|mutation_testing_smoke_gate"))' "$SETTINGS" | head -1)
+  [[ "$cmd" == *"mutation-testing-smoke-gate.sh"* ]]
+  [[ "$cmd" == *"mutation_testing_smoke_gate.py"* ]]
+}
+
+@test "smoke-gate hook defaults to bash (flag treated as 0 when unset)" {
+  local cmd
+  cmd=$(jq -r '.hooks.PreToolUse[].hooks[]?.command // empty | select(test("mutation-testing-smoke-gate|mutation_testing_smoke_gate"))' "$SETTINGS" | head -1)
+  # The :- default and equality against "1" together imply "unset = bash"
+  [[ "$cmd" == *":-0"* || "$cmd" == *':-'* ]]
+  [[ "$cmd" == *'= "1"'* || "$cmd" == *'="1"'* || "$cmd" == *'= '\'1\'* ]]
+}

--- a/tests/scripts/ci_local_parity_registration_tests.bats
+++ b/tests/scripts/ci_local_parity_registration_tests.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+# #574 — ci-local.sh registers a chk_parity check that runs the pytest
+# harness under plugins/dev-team/tests/hooks/parity/. Backward-compatible:
+# when the directory is absent (fresh clone before Phase 0 lands anywhere
+# but here), the check must skip gracefully rather than error.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+CI_LOCAL="$REPO_ROOT/scripts/ci-local.sh"
+
+@test "ci-local.sh defines chk_parity" {
+  grep -qE '^chk_parity\(\)' "$CI_LOCAL"
+}
+
+@test "chk_parity is registered in the CHECKS array" {
+  grep -q '::chk_parity' "$CI_LOCAL"
+}
+
+@test "chk_parity references the parity harness directory" {
+  grep -q 'tests/hooks/parity' "$CI_LOCAL"
+}


### PR DESCRIPTION
Phase 0 of #572 — the serialization point that unblocks every downstream slice of the bash → python hook migration.

## What lands

1. **`docs/python-hook-contract.md`** — byte-compatible contract: stdin JSON schema, stdout format, exit-code semantics (0/1/2/≥3), env vars, stderr conventions, and stdlib-only Python 3.8+ authoring rules.
2. **`plugins/dev-team/tests/hooks/parity/`** — the pytest parity harness (`parity.py`, `conftest.py`, `test_parity_selftest.py`). Runs both `.sh` and `.py` implementations against a fixture and asserts byte-equal outcome (stdout, exit code, normalized stderr, side-effect tree). Sandbox contract: HOME, CLAUDE_PROJECT_DIR, GIT_CONFIG_GLOBAL=/dev/null, GIT_CONFIG_SYSTEM=/dev/null all tmpdir-scoped. `--parity-record` regenerates snapshots.
3. **`plugins/dev-team/hooks/settings-toggle.md`** — the `DEV_TEAM_PY_HOOK_<NAME>` per-hook parallel-ship pattern, with the cross-platform `sh -c` recipe.
4. **Reference hook — `hooks/mutation_testing_smoke_gate.py`** — full stdlib-only port of the .sh, backed by 39 unit tests + 6 parity fixtures (happy path, missing report, single-file probe, malformed JSON, Windows-path cwd, escape-hatch bypass).
5. **`plugins/dev-team/settings.json`** — dispatches the smoke-gate via `sh -c` on `DEV_TEAM_PY_HOOK_MUTATION_TESTING_SMOKE_GATE`. Default off ⇒ bash (authoritative for one release-please cycle); "1" ⇒ Python port.
6. **`scripts/ci-local.sh`** — new `chk_parity` step runs `python3 -m pytest tests/hooks/parity`. Skips gracefully when the dir is absent, python3 is missing, or pytest is not installed.

## Test evidence

- `python3 -m pytest plugins/dev-team/tests/hooks/` — 54 passed (9 self-tests + 6 parity fixtures + 39 hook unit tests).
- `bats tests/docs/python_hook_contract_tests.bats tests/hooks/settings_python_toggle_tests.bats tests/scripts/ci_local_parity_registration_tests.bats` — 18/18 passed.
- Local `bash scripts/ci-local.sh` — all checks green (bats repo, md-reference lint, semgrep fixtures, harness smoke, parity harness, …).

## Follow-ups (queued in #572)

- #575 cluster A shared lib (`knowledge-index-paths`)
- #576 cluster B shared libs (`pre-commit-detect` + `review-gate-hash`)
- #591 `bash-retry-guard`, #592 `codegraph-bootstrap`, #593 `codegraph-nudge` (Phase 3 fringe)
- #580 knowledge-index hook, #582 pre-commit-knowledge-index hook, #583 pre-commit-review hook
- #584 remove the .sh smoke-gate one release-please cycle after this lands

Closes #574
Refs #572