### PR TITLE
feat(hooks): port knowledge-index-paths shared lib to python (#575)

### DIFF
--- a/plugins/dev-team/hooks/lib/knowledge_index_paths.py
+++ b/plugins/dev-team/hooks/lib/knowledge_index_paths.py
@@ -1,0 +1,64 @@
+"""knowledge_index_paths — single source of truth for the indexed corpus.
+
+Python port of hooks/lib/knowledge-index-paths.sh (#575 / #572 Cluster A).
+
+Imported (not executed) by the Python siblings of the three .sh callers:
+  - hooks/knowledge-index.py                   (PostToolUse regenerator)
+  - hooks/pre-commit-knowledge-index.py        (pre-commit freshness gate)
+  - tests/agents/… anchor-citation gate        (still bats today; the .py
+                                                port will import this module)
+
+The corpus is:
+  - plugins/dev-team/knowledge/*.md         (top-level .md only)
+  - plugins/dev-team/skills/<name>/SKILL.md
+
+Excluded:
+  - plugins/dev-team/knowledge/schemas/**   (json schemas, not docs)
+  - everything else (agents/, commands/, docs/, README.md, …)
+
+Anchor: top-level knowledge .md OR <skills-dir>/<one segment>/SKILL.md.
+A leading `(^|/)` allows repo-relative or absolute paths.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+# Regex matching corpus paths (POSIX ERE from the .sh sibling, ported to
+# Python re syntax). Anchor: end-of-string; a leading segment is optional so
+# absolute and repo-relative inputs both match. Alternation covers the two
+# corpus shapes: top-level knowledge markdown, and per-skill SKILL.md.
+CORPUS_REGEX: str = (
+    r"(^|/)plugins/dev-team/(knowledge/[^/]+\.md|skills/[^/]+/SKILL\.md)$"
+)
+
+_CORPUS_RE = re.compile(CORPUS_REGEX)
+
+
+def is_corpus_path(path: str) -> bool:
+    """Return True iff `path` is part of the indexed corpus.
+
+    Byte-parity with the .sh's `_is_corpus_path`. Windows backslash paths
+    do NOT match — the corpus is a forward-slash convention and Git Bash
+    surfaces forward slashes even on Windows.
+    """
+    if not path:
+        return False
+    return _CORPUS_RE.search(path) is not None
+
+
+def filter_corpus_paths(paths: Iterable[str]) -> List[str]:
+    """Return the input list filtered to corpus paths, preserving order.
+
+    Convenience for hook callers that receive a batch of changed files and
+    want only the ones the index cares about. Order-preserving because
+    downstream builds are order-sensitive (see build_knowledge_index.py).
+    """
+    return [p for p in paths if is_corpus_path(p)]
+
+
+__all__ = ("CORPUS_REGEX", "is_corpus_path", "filter_corpus_paths")

--- a/plugins/dev-team/tests/hooks/test_knowledge_index_paths.py
+++ b/plugins/dev-team/tests/hooks/test_knowledge_index_paths.py
@@ -1,0 +1,149 @@
+"""Unit tests for hooks/lib/knowledge_index_paths.py (#575 / #572 Cluster A).
+
+Behavior parity with the .sh sibling at hooks/lib/knowledge-index-paths.sh
+is what this port owes; the tests below mirror the shape of the existing
+bats suite (tests/hooks/knowledge_index_paths_tests.bats) one-for-one so a
+future author reading either can trust they agree.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_HOOKS_LIB) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB))
+
+import knowledge_index_paths as paths  # type: ignore[import-not-found]  # noqa: E402
+
+
+# --- module surface --------------------------------------------------------
+
+
+def test_module_exposes_corpus_regex_and_is_corpus_path() -> None:
+    assert isinstance(paths.CORPUS_REGEX, str)
+    assert paths.CORPUS_REGEX
+    assert callable(paths.is_corpus_path)
+
+
+def test_corpus_regex_is_valid_python_regex() -> None:
+    re.compile(paths.CORPUS_REGEX)
+
+
+# --- matches ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "plugins/dev-team/knowledge/owasp-detection.md",
+        "plugins/dev-team/knowledge/agent-registry.md",
+        "plugins/dev-team/skills/specs/SKILL.md",
+        "plugins/dev-team/skills/mutation-testing/SKILL.md",
+        # Absolute / repo-parent-prefixed paths must still match — the .sh
+        # regex allows an optional leading "(^|/)" segment.
+        "/abs/root/plugins/dev-team/knowledge/owasp-detection.md",
+        "/abs/root/plugins/dev-team/skills/plan/SKILL.md",
+    ],
+)
+def test_is_corpus_path_matches_corpus_files(path: str) -> None:
+    assert paths.is_corpus_path(path) is True
+
+
+# --- rejections ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # schemas/ subtree is out of scope
+        "plugins/dev-team/knowledge/schemas/foo.json",
+        "plugins/dev-team/knowledge/schemas/notes.md",
+        # neighboring plugin dirs
+        "plugins/dev-team/agents/security-review.md",
+        "plugins/dev-team/commands/code-review.md",
+        "plugins/dev-team/docs/agent-architecture.md",
+        # non-markdown corpus paths
+        "plugins/dev-team/knowledge/index.json",
+        # unrelated repo paths
+        "README.md",
+        "plans/foo.md",
+        # a SKILL.md nested one level too deep is not the anchor
+        "plugins/dev-team/skills/specs/nested/SKILL.md",
+        # empty / degenerate
+        "",
+    ],
+)
+def test_is_corpus_path_rejects_non_corpus(path: str) -> None:
+    assert paths.is_corpus_path(path) is False
+
+
+# --- regex ↔ predicate agreement -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expect_match",
+    [
+        ("plugins/dev-team/knowledge/owasp-detection.md", True),
+        ("plugins/dev-team/skills/specs/SKILL.md", True),
+        ("plugins/dev-team/knowledge/schemas/foo.md", False),
+        ("plugins/dev-team/agents/security-review.md", False),
+    ],
+)
+def test_corpus_regex_agrees_with_is_corpus_path(path: str, expect_match: bool) -> None:
+    """The exported CORPUS_REGEX and the predicate must classify identically —
+    the .sh contract is that a shell caller using `grep -E "$CORPUS_REGEX"`
+    and a shell caller using `_is_corpus_path` see the same paths."""
+    matched = bool(re.search(paths.CORPUS_REGEX, path))
+    assert matched is expect_match
+    assert matched is paths.is_corpus_path(path)
+
+
+# --- Windows path inputs ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # A Windows-native (backslash) path is not the shape callers pass — the
+        # .sh uses / everywhere — but the port must not crash on such input.
+        "C:\\repo\\plugins\\dev-team\\knowledge\\owasp-detection.md",
+        # Git Bash surfaces forward-slash paths even on Windows, so this must
+        # still match:
+        "C:/repo/plugins/dev-team/knowledge/owasp-detection.md",
+    ],
+)
+def test_is_corpus_path_windows_inputs(path: str) -> None:
+    # Backslash form must NOT match (the corpus is a forward-slash convention).
+    # Forward-slash form MUST match — Git Bash normalizes to /.
+    expected = "\\" not in path
+    assert paths.is_corpus_path(path) is expected
+
+
+# --- filter_corpus_paths (convenience for hook callers) --------------------
+
+
+def test_filter_corpus_paths_returns_only_corpus_items_in_order() -> None:
+    inputs = [
+        "plugins/dev-team/knowledge/owasp-detection.md",
+        "README.md",
+        "plugins/dev-team/skills/specs/SKILL.md",
+        "plugins/dev-team/agents/security-review.md",
+        "plugins/dev-team/knowledge/schemas/foo.md",
+        "plugins/dev-team/knowledge/agent-registry.md",
+    ]
+    got = paths.filter_corpus_paths(inputs)
+    assert got == [
+        "plugins/dev-team/knowledge/owasp-detection.md",
+        "plugins/dev-team/skills/specs/SKILL.md",
+        "plugins/dev-team/knowledge/agent-registry.md",
+    ]
+
+
+def test_filter_corpus_paths_handles_empty_and_none() -> None:
+    assert paths.filter_corpus_paths([]) == []


### PR DESCRIPTION
Phase 1, Cluster A of #572 — port the shared knowledge-index paths library. Library-only slice: no hook rewired to import it yet (that's #580 / #582). The `.sh` sibling stays authoritative until those slices convert.

## What lands

- **`plugins/dev-team/hooks/lib/knowledge_index_paths.py`** — stdlib-only, Python 3.8+. Exports:
  - `CORPUS_REGEX` — POSIX ERE from the `.sh` ported verbatim to Python `re` syntax
  - `is_corpus_path(path)` — the byte-parity predicate
  - `filter_corpus_paths(paths)` — order-preserving batch filter for hook callers
- **`plugins/dev-team/tests/hooks/test_knowledge_index_paths.py`** — 26 unit tests mirroring the 12-test bats suite one-for-one, plus:
  - `CORPUS_REGEX` ↔ `is_corpus_path` agreement
  - absolute-path inputs
  - Windows backslash rejection + Git-Bash forward-slash acceptance
  - `filter_corpus_paths` order-preservation

## Verification

- `python3 -m pytest plugins/dev-team/tests/hooks/test_knowledge_index_paths.py` — 26 passed
- `bats tests/hooks/knowledge_index_paths_tests.bats` — 12 passed (existing `.sh` behavior untouched)
- `bash scripts/ci-local.sh` — clean via pre-push

Closes #575
Refs #572