### PR TITLE
feat(hooks): port pre-commit-detect + review-gate-hash shared libs to python (#576)

### DIFF
--- a/plugins/dev-team/hooks/lib/pre_commit_detect.py
+++ b/plugins/dev-team/hooks/lib/pre_commit_detect.py
@@ -1,0 +1,47 @@
+"""pre_commit_detect — shared `git commit` detection for PreToolUse:Bash hooks.
+
+Python port of hooks/lib/pre-commit-detect.sh (#576 / #572 Cluster B).
+
+Imported by the Python siblings of the two callers:
+  - hooks/pre_commit_review.py
+  - hooks/pre_commit_knowledge_index.py
+
+Exposes one function:
+
+  is_git_commit_invocation(cmd: str) -> bool
+
+  True when `cmd` is a `git commit` we should gate on, False otherwise.
+  Treats `--no-verify` as the documented bypass — the standard git escape
+  hatch keeps working.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# Word-bounded `git commit` at the start of the (leading-whitespace-tolerant)
+# command line. Mirrors the .sh's `^[[:space:]]*git[[:space:]]+commit\b` ERE.
+_GIT_COMMIT_RE = re.compile(r"^\s*git\s+commit\b")
+
+# The documented bypass. Substring match (no word boundary) — mirrors the
+# .sh's `grep -qE -- '--no-verify'` byte-for-byte: `--no-verifying`, though
+# not a real git flag, also short-circuits under the .sh, so the port does
+# the same. Byte-parity is the migration contract.
+_NO_VERIFY_RE = re.compile(r"--no-verify")
+
+
+def is_git_commit_invocation(cmd: str) -> bool:
+    """Return True iff `cmd` is a gate-worthy `git commit` invocation."""
+    if not cmd:
+        return False
+    if not _GIT_COMMIT_RE.search(cmd):
+        return False
+    if _NO_VERIFY_RE.search(cmd):
+        return False
+    return True
+
+
+__all__ = ("is_git_commit_invocation",)

--- a/plugins/dev-team/hooks/lib/review_gate_hash.py
+++ b/plugins/dev-team/hooks/lib/review_gate_hash.py
@@ -1,0 +1,69 @@
+"""review_gate_hash — single source of truth for the .review-passed gate hash.
+
+Python port of hooks/lib/review-gate-hash.sh (#576 / #572 Cluster B, #193).
+
+The review gate binds to the STAGED CONTENT (the cached patch), not just
+the staged file PATHS. Hashing paths alone let a reviewed file's content
+change and still commit unreviewed. Hashing `git diff --cached` captures
+both which files are staged AND their staged content — so any edit after
+review invalidates the gate and forces a re-review.
+
+Both the writer (`/code-review` step 9) and the reader (pre_commit_review)
+MUST compute the hash identically. This module IS that shared computation.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+
+Byte-parity note: `git diff --cached --no-color` is invariant across bash
+and Python callers because git itself owns the format. sha256 hex-encoded
+matches the `shasum -a 256 | cut -d' ' -f1` pipeline the .sh uses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def review_gate_hash(cwd: Optional[Path] = None) -> str:
+    """Return the sha256 hex digest of `git diff --cached --no-color`.
+
+    Byte-parity with the .sh sibling:
+      - `git diff --cached --no-color 2>/dev/null` — same command
+      - sha256 hex-encoded — same digest
+      - empty output on git failure — same failure mode
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "diff", "--cached", "--no-color"],
+            cwd=str(cwd) if cwd is not None else None,
+            capture_output=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        # git not installed; the .sh would have `command not found` on stderr
+        # and an empty stdout piped through shasum → sha256 of empty input.
+        # We return the same empty-input digest to keep byte-parity.
+        return hashlib.sha256(b"").hexdigest()
+
+    if completed.returncode != 0:
+        # `git diff --cached` outside a repo prints to stderr and exits non-0
+        # with empty stdout; the .sh pipes that empty stdout into shasum,
+        # yielding the sha256 of empty input. Mirror that.
+        return hashlib.sha256(b"").hexdigest()
+
+    return hashlib.sha256(completed.stdout).hexdigest()
+
+
+def _main() -> int:
+    """When the .sh is executed directly it prints the hash. Same for us."""
+    print(review_gate_hash())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
+
+
+__all__ = ("review_gate_hash",)

--- a/plugins/dev-team/tests/hooks/test_pre_commit_detect.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_detect.py
@@ -1,0 +1,64 @@
+"""Unit tests for hooks/lib/pre_commit_detect.py (#576 / #572 Cluster B).
+
+Byte-parity with hooks/lib/pre-commit-detect.sh — the .sh's
+`_is_git_commit_invocation` is the whole exported surface.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_HOOKS_LIB) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB))
+
+import pre_commit_detect as detect  # type: ignore[import-not-found]  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git commit",
+        "git commit -m 'hi'",
+        "  git   commit  -a -m foo",
+        "git commit --amend",
+        "\tgit commit\t-m x",
+    ],
+)
+def test_detects_git_commit(cmd: str) -> None:
+    assert detect.is_git_commit_invocation(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "",
+        "echo git commit",
+        "git status",
+        "git-commit",  # hyphen, not a subcommand
+        "gitcommit",
+        "pipx run git-commit",
+        "notgit commit",
+        "git commitment",  # word-boundary must reject
+        # bypass
+        "git commit --no-verify",
+        "git commit -m x --no-verify",
+        "  git commit  --no-verify -m x",
+    ],
+)
+def test_rejects_non_gates(cmd: str) -> None:
+    assert detect.is_git_commit_invocation(cmd) is False
+
+
+def test_no_verify_bypass_substring_matches_sh() -> None:
+    """--no-verify is the documented bypass; parity with the .sh requires
+    substring match — `--no-verify` inside `--no-verifying` also bypasses.
+    A future author who wants word-boundary bypass should update both
+    implementations together (this port owes byte-parity, not opinions)."""
+    assert detect.is_git_commit_invocation("git commit --no-verify") is False
+    # Substring match — matches the .sh's plain grep behavior.
+    assert detect.is_git_commit_invocation("git commit --no-verifying") is False

--- a/plugins/dev-team/tests/hooks/test_review_gate_hash.py
+++ b/plugins/dev-team/tests/hooks/test_review_gate_hash.py
@@ -1,0 +1,136 @@
+"""Unit tests for hooks/lib/review_gate_hash.py (#576 / #572 Cluster B).
+
+Byte-parity with hooks/lib/review-gate-hash.sh. The gate hash MUST equal
+the shell version bit-for-bit — otherwise the writer (/code-review step 9)
+and reader (pre-commit-review) diverge and #193 regresses.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_HOOKS_LIB) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB))
+
+import review_gate_hash as gate  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.dev"], cwd=tmp_path, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "tester"], cwd=tmp_path, env=env, check=True
+    )
+    return tmp_path
+
+
+def _sh_hash(cwd: Path) -> str:
+    """Call the .sh sibling and return its output — the authoritative reference."""
+    repo_root = Path(__file__).resolve().parents[4]
+    sh = repo_root / "plugins" / "dev-team" / "hooks" / "lib" / "review-gate-hash.sh"
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    completed = subprocess.run(
+        ["bash", str(sh)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+# --- API surface -----------------------------------------------------------
+
+
+def test_module_exposes_review_gate_hash() -> None:
+    assert callable(gate.review_gate_hash)
+
+
+# --- byte-parity vs the .sh -----------------------------------------------
+
+
+def test_empty_staged_area_matches_sh(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    py_hash = gate.review_gate_hash(cwd=tmp_path)
+    sh_hash = _sh_hash(tmp_path)
+    assert py_hash == sh_hash
+
+
+def test_single_staged_file_matches_sh(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "a.ts").write_text("hello\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    py_hash = gate.review_gate_hash(cwd=tmp_path)
+    sh_hash = _sh_hash(tmp_path)
+    assert py_hash == sh_hash
+
+
+def test_changed_content_changes_hash(tmp_path: Path) -> None:
+    """The whole point of #193 — content edits must alter the hash."""
+    _init_repo(tmp_path)
+    (tmp_path / "a.ts").write_text("v1\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    h1 = gate.review_gate_hash(cwd=tmp_path)
+    (tmp_path / "a.ts").write_text("v2\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    h2 = gate.review_gate_hash(cwd=tmp_path)
+    assert h1 != h2
+    # And still byte-parity with .sh at the new state.
+    assert h2 == _sh_hash(tmp_path)
+
+
+def test_extra_staged_file_changes_hash(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "a.ts").write_text("hi\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    h1 = gate.review_gate_hash(cwd=tmp_path)
+    (tmp_path / "b.ts").write_text("new\n")
+    subprocess.run(["git", "add", "b.ts"], cwd=tmp_path, check=True)
+    h2 = gate.review_gate_hash(cwd=tmp_path)
+    assert h1 != h2
+    assert h2 == _sh_hash(tmp_path)
+
+
+def test_deterministic_across_repeated_calls(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "a.ts").write_text("stable\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    hashes = {gate.review_gate_hash(cwd=tmp_path) for _ in range(5)}
+    assert len(hashes) == 1
+
+
+def test_hash_is_64_hex_chars(tmp_path: Path) -> None:
+    """sha256 hex-encoded → 64 chars."""
+    _init_repo(tmp_path)
+    (tmp_path / "a.ts").write_text("x\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    h = gate.review_gate_hash(cwd=tmp_path)
+    assert len(h) == 64
+    int(h, 16)  # raises if not hex
+
+
+def test_missing_git_returns_empty(tmp_path: Path) -> None:
+    """Not a git repo → the .sh emits empty; the .py must match."""
+    py_hash = gate.review_gate_hash(cwd=tmp_path)
+    sh_hash = _sh_hash(tmp_path)
+    assert py_hash == sh_hash
+    # Both should be empty (or a sha256 of empty input) — either way, equal.


### PR DESCRIPTION
Phase 1, Cluster B of #572 — port the shared pre-commit detection + review-gate hashing libraries. Both landed atomically because their consumers (`pre-commit-review.sh`, `pre-commit-knowledge-index.sh`) use them together. Library-only slice: no hook rewired yet; the `.sh` siblings stay authoritative.

## What lands

- **`plugins/dev-team/hooks/lib/pre_commit_detect.py`** — stdlib-only Python 3.8+. Exports `is_git_commit_invocation(cmd)` with byte-parity against the `.sh`'s `_is_git_commit_invocation`.
- **`plugins/dev-team/hooks/lib/review_gate_hash.py`** — stdlib-only. Exports `review_gate_hash(cwd=None)` computing `sha256(git diff --cached --no-color)`. Byte-parity is guaranteed because git itself owns the diff format and sha256 hex matches the `.sh`'s `shasum -a 256 | cut -d' ' -f1` pipeline. Missing-git or outside-repo → `sha256(b"")` — same fallback as the `.sh`'s implicit pipe behavior.
- **`plugins/dev-team/tests/hooks/test_pre_commit_detect.py`** — 17 unit tests (happy paths, whitespace, non-git commands, `--no-verify` bypass including its substring-match behavior — the `.sh` uses plain `grep -qE`, so `--no-verifying` also bypasses; the port preserves that byte-for-byte).
- **`plugins/dev-team/tests/hooks/test_review_gate_hash.py`** — 8 unit tests that shell out to the `.sh` and assert byte-for-byte digest equality across empty repo, single staged file, content-edited file, extra staged file, and non-git-repo scenarios.

## Verification

- `python3 -m pytest plugins/dev-team/tests/hooks/test_pre_commit_detect.py plugins/dev-team/tests/hooks/test_review_gate_hash.py` — 25 passed
- Existing bats suites (`tests/repo/review_gate_hash_tests.bats`) untouched — the `.sh` behavior is unchanged
- Local `bash scripts/ci-local.sh` clean via pre-push

Closes #576
Refs #572