### PR TITLE
chore(hooks): port model-resolve shared lib to python (#572.C0)

### DIFF
--- a/plugins/dev-team/hooks/lib/model_resolve.py
+++ b/plugins/dev-team/hooks/lib/model_resolve.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Pre-dispatch effort band → model resolver (Python port of model-resolve.sh, #577).
+
+Maps an effort band (low|medium|high) to an Anthropic model using:
+  1. an optional ordered ladder at .claude/model-ladder.json — a JSON array
+     of model IDs from least to most capable — via
+     index = round_half_up(weight·(N−1)) with weights low=0, medium=0.5,
+     high=1; OR
+  2. the shipped default map in knowledge/model-routing.json, used whenever
+     no ladder exists or the ladder is malformed/empty.
+
+Legacy tier aliases (haiku|sonnet|opus) are accepted for the migration
+window and normalized to bands (haiku→low, sonnet→medium, opus→high).
+
+A missing or malformed ladder degrades to the default map and never aborts
+dispatch. This resolver does NOT log routing bumps — the dispatch hook
+(agent-model-resolve) owns that single site, so there is no double-log.
+
+Called by:
+  - hooks/agent-model-resolve.sh (PreToolUse hook on the Agent matcher)
+  - skills/model-routing-check/SKILL.md (via --dump-map)
+
+CLI usage (mirrors model-resolve.sh):
+  python3 model_resolve.py <band|tier> [--caller <name>]
+  python3 model_resolve.py --dump-map
+
+Library usage:
+  from model_resolve import resolve_band, dump_map
+  model_id = resolve_band("medium")
+
+Env vars (TEST-ONLY injection seams — do not document as user-facing):
+  MODEL_ROUTING_JSON   defaults to <plugin>/knowledge/model-routing.json
+  MODEL_LADDER_JSON    defaults to .claude/model-ladder.json
+
+Exit codes:
+  0 — resolved
+  2 — unknown band/tier or missing argument (caller error)
+  4 — knowledge/model-routing.json missing
+
+Note: the legacy deny-relevant exits (3 exhausted/cycle, 5 malformed
+overrides) are no longer reachable — band resolution always succeeds once
+routing.json is present, because a bad ladder degrades to the default map.
+
+Stdlib-only (subprocess/pathlib/json/argparse only). Python 3.8+.
+See docs/adr/0014-python-for-cross-os-scripts.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Public exit codes — kept identical to model-resolve.sh so callers that pipe
+# through subprocess don't need to change behavior.
+# ---------------------------------------------------------------------------
+EXIT_OK = 0
+EXIT_CALLER_ERROR = 2
+EXIT_ROUTING_MISSING = 4
+
+
+# ---------------------------------------------------------------------------
+# _resolve_paths — populate input paths with defaults if env vars aren't set.
+# Test isolation hinges on these env vars.
+# ---------------------------------------------------------------------------
+def _resolve_paths() -> Tuple[Path, Path]:
+    script_dir = Path(__file__).resolve().parent
+    routing = Path(
+        os.environ.get(
+            "MODEL_ROUTING_JSON",
+            str(script_dir / ".." / ".." / "knowledge" / "model-routing.json"),
+        )
+    )
+    ladder = Path(
+        os.environ.get(
+            "MODEL_LADDER_JSON",
+            ".claude/model-ladder.json",
+        )
+    )
+    return routing, ladder
+
+
+# ---------------------------------------------------------------------------
+# _normalize_band — map a band or legacy tier to a canonical band.
+# Returns "" for an unrecognized token (matches the .sh's echo "").
+# ---------------------------------------------------------------------------
+def _normalize_band(token: str) -> str:
+    if token in ("low", "haiku"):
+        return "low"
+    if token in ("medium", "sonnet"):
+        return "medium"
+    if token in ("high", "opus"):
+        return "high"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# _band_weight — the ladder weight for a band (low=0, medium=0.5, high=1).
+# ---------------------------------------------------------------------------
+def _band_weight(band: str) -> float:
+    return {"low": 0.0, "medium": 0.5, "high": 1.0}[band]
+
+
+# ---------------------------------------------------------------------------
+# _load_json — read a JSON file if present; return None on any failure.
+# ---------------------------------------------------------------------------
+def _load_json(path: Path) -> Optional[object]:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# _ladder_is_valid — true iff the ladder file exists and is a non-empty JSON
+# array of strings. Anything else degrades to the default map.
+# ---------------------------------------------------------------------------
+def _ladder_is_valid(ladder_path: Path) -> bool:
+    if not ladder_path.exists():
+        return False
+    data = _load_json(ladder_path)
+    if not isinstance(data, list):
+        return False
+    if len(data) == 0:
+        return False
+    return all(isinstance(x, str) for x in data)
+
+
+# ---------------------------------------------------------------------------
+# _default_for_band — the shipped default snapshot for a band.
+# Returns "" when the band key is absent (matches jq's // empty behavior).
+# ---------------------------------------------------------------------------
+def _default_for_band(routing_path: Path, band: str) -> str:
+    data = _load_json(routing_path)
+    if not isinstance(data, dict):
+        return ""
+    value = data.get(band)
+    return value if isinstance(value, str) else ""
+
+
+# ---------------------------------------------------------------------------
+# _round_half_up — the pinned rounding convention. floor(x + 0.5) for x ≥ 0
+# reproduces the bash `awk 'printf "%d", int(w*(n-1)+0.5)'` byte-for-byte.
+# ---------------------------------------------------------------------------
+def _round_half_up(weight: float, n: int) -> int:
+    return int(weight * (n - 1) + 0.5)
+
+
+# ---------------------------------------------------------------------------
+# resolve_band — map a canonical band to a model: ladder when valid, else
+# the shipped default map. Public API for downstream consumers (#585-#587).
+# ---------------------------------------------------------------------------
+def resolve_band(
+    band: str, routing_path: Optional[Path] = None, ladder_path: Optional[Path] = None
+) -> str:
+    if routing_path is None or ladder_path is None:
+        r, l = _resolve_paths()
+        routing_path = routing_path or r
+        ladder_path = ladder_path or l
+
+    if _ladder_is_valid(ladder_path):
+        ladder = _load_json(ladder_path)
+        # _ladder_is_valid guarantees list[str] with len ≥ 1.
+        assert isinstance(ladder, list)
+        n = len(ladder)
+        weight = _band_weight(band)
+        idx = _round_half_up(weight, n)
+        return str(ladder[idx])
+
+    return _default_for_band(routing_path, band)
+
+
+# ---------------------------------------------------------------------------
+# dump_map — pretty-print the effective band → model map. Used by
+# /model-routing-check.
+#
+# Format matches model-resolve.sh's `printf '  %-7s → %s\n'` — two leading
+# spaces, band left-padded to width 7, " → ", model id, newline.
+# ---------------------------------------------------------------------------
+def dump_map(
+    routing_path: Optional[Path] = None, ladder_path: Optional[Path] = None
+) -> str:
+    lines: List[str] = []
+    for band in ("low", "medium", "high"):
+        model = resolve_band(band, routing_path=routing_path, ladder_path=ladder_path)
+        lines.append(f"  {band:<7} → {model}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# _die_missing_routing — the one surviving fatal case (exit 4).
+# ---------------------------------------------------------------------------
+def _die_missing_routing(routing_path: Path) -> None:
+    sys.stderr.write(
+        f"Model routing file missing: {routing_path}\n"
+        "  This file ships with the plugin and must be present.\n"
+        "  Restore with: git checkout knowledge/model-routing.json\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+def main(argv: Optional[List[str]] = None) -> int:
+    args = sys.argv[1:] if argv is None else list(argv)
+
+    if len(args) < 1:
+        sys.stderr.write(
+            "Usage: model_resolve.py <band> [--caller <name>]\n"
+            "       model_resolve.py --dump-map\n"
+            "Valid bands: low, medium, high\n"
+        )
+        return EXIT_CALLER_ERROR
+
+    routing_path, ladder_path = _resolve_paths()
+
+    # All paths require routing.json — fail early with the proper template.
+    if not routing_path.is_file():
+        _die_missing_routing(routing_path)
+        return EXIT_ROUTING_MISSING
+
+    # --dump-map mode
+    if args[0] == "--dump-map":
+        sys.stdout.write(dump_map(routing_path=routing_path, ladder_path=ladder_path))
+        return EXIT_OK
+
+    requested = args[0]
+    band = _normalize_band(requested)
+    if not band:
+        sys.stderr.write(
+            f"Unknown effort band '{requested}'. Valid bands: low, medium, "
+            "high (legacy tiers haiku, sonnet, opus accepted).\n"
+        )
+        return EXIT_CALLER_ERROR
+
+    # Parse optional --caller flag. Accepted but ignored: the dispatch hook
+    # owns bump logging, so the resolver no longer needs the caller name.
+    remaining = args[1:]
+    i = 0
+    while i < len(remaining):
+        arg = remaining[i]
+        if arg == "--caller":
+            # consume the caller name if present, otherwise silently accept.
+            i += 2
+            continue
+        sys.stderr.write(f"Unknown argument: {arg}\n")
+        return EXIT_CALLER_ERROR
+
+    sys.stdout.write(
+        resolve_band(band, routing_path=routing_path, ladder_path=ladder_path) + "\n"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/tests/hooks/test_model_resolve.py
+++ b/plugins/dev-team/tests/hooks/test_model_resolve.py
@@ -1,0 +1,613 @@
+"""Unit tests for the Python port of hooks/lib/model-resolve.sh (#577).
+
+Mirrors tests/hooks/model_resolve_tests.bats one-for-one. The two suites
+run against sibling implementations of the same library-only slice — the
+bash consumers (agent-model-resolve.sh, session-model-banner.sh,
+scripts/build-worktree-baseref.sh) still source the .sh in this slice, so
+byte-parity beyond stdout/stderr/exit code isn't yet enforced by the
+parity harness; that arrives with the hook-level ports in #585-#587.
+
+These tests are white-box: they call resolve_band/dump_map directly and
+also exercise the CLI via subprocess to cover exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_HOOKS_LIB) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB))
+
+import model_resolve  # type: ignore[import-not-found]  # noqa: E402
+
+
+_MODEL_LOW = "claude-haiku-4-5-20251001"
+_MODEL_MEDIUM = "claude-sonnet-4-6"
+_MODEL_HIGH = "claude-opus-4-8"
+
+
+_DEFAULT_ROUTING = {
+    "low": _MODEL_LOW,
+    "medium": _MODEL_MEDIUM,
+    "high": _MODEL_HIGH,
+    "haiku": _MODEL_LOW,
+    "sonnet": _MODEL_MEDIUM,
+    "opus": _MODEL_HIGH,
+    "rounding": "round_half_up",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def routing_json(tmp_path: Path) -> Path:
+    """A default routing.json fixture that mirrors the shipped map.
+
+    Decouples the test from drift in the shipped file (see the .bats sibling).
+    """
+    path = tmp_path / "routing.json"
+    path.write_text(json.dumps(_DEFAULT_ROUTING) + "\n")
+    return path
+
+
+@pytest.fixture
+def ladder_json(tmp_path: Path) -> Path:
+    """A ladder path that does NOT exist yet — tests write to it as needed."""
+    return tmp_path / "model-ladder.json"
+
+
+@pytest.fixture
+def resolver_env(monkeypatch, routing_json: Path, ladder_json: Path) -> None:
+    """Wire the test-only injection seams to the fixture files."""
+    monkeypatch.setenv("MODEL_ROUTING_JSON", str(routing_json))
+    monkeypatch.setenv("MODEL_LADDER_JSON", str(ladder_json))
+
+
+def _run_cli(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Invoke the resolver CLI via a subprocess to cover main() and exit codes."""
+    resolver = _HOOKS_LIB / "model_resolve.py"
+    proc_env = dict(env) if env is not None else {}
+    return subprocess.run(
+        [sys.executable, str(resolver), *args],
+        capture_output=True,
+        env=proc_env,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default map (no ladder) — migration safety
+# ---------------------------------------------------------------------------
+
+
+def test_low_band_resolves_to_haiku_default(
+    routing_json: Path, ladder_json: Path
+) -> None:
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_LOW
+    )
+
+
+def test_medium_band_resolves_to_sonnet_default(
+    routing_json: Path, ladder_json: Path
+) -> None:
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+
+
+def test_high_band_resolves_to_opus_default(
+    routing_json: Path, ladder_json: Path
+) -> None:
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+
+
+def test_no_ladder_bands_equal_pre_migration_snapshots(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_LOW
+    )
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy tier acceptance (migration window) — tier → band normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tier,expected",
+    [("haiku", _MODEL_LOW), ("sonnet", _MODEL_MEDIUM), ("opus", _MODEL_HIGH)],
+)
+def test_legacy_tier_normalizes_to_band(resolver_env, tier: str, expected: str) -> None:
+    result = _run_cli(
+        tier,
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        },
+    )
+    assert result.returncode == 0
+    assert result.stdout.decode().strip() == expected
+
+
+def _os_env_get(name: str) -> str:
+    """Read env set by monkeypatch — subprocess call needs the concrete value."""
+    import os
+
+    return os.environ[name]
+
+
+# ---------------------------------------------------------------------------
+# Caller errors
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_band_exits_2_with_actionable_stderr(resolver_env) -> None:
+    result = _run_cli(
+        "frontier",
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        },
+    )
+    assert result.returncode == 2
+    stderr = result.stderr.decode()
+    assert "Unknown" in stderr
+    assert "low" in stderr
+    assert "medium" in stderr
+    assert "high" in stderr
+
+
+def test_missing_band_argument_exits_2(resolver_env) -> None:
+    result = _run_cli(
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        }
+    )
+    assert result.returncode == 2
+
+
+def test_caller_flag_accepted_and_ignored(resolver_env) -> None:
+    result = _run_cli(
+        "medium",
+        "--caller",
+        "naming-review",
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        },
+    )
+    assert result.returncode == 0
+    assert result.stdout.decode().strip() == _MODEL_MEDIUM
+
+
+def test_unknown_flag_exits_2(resolver_env) -> None:
+    result = _run_cli(
+        "medium",
+        "--frobnicate",
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        },
+    )
+    assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Ladder path — index = round_half_up(weight·(N−1))
+# ---------------------------------------------------------------------------
+
+
+def test_ladder_n3_reproduces_default_map(
+    routing_json: Path, ladder_json: Path
+) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_LOW, _MODEL_MEDIUM, _MODEL_HIGH]))
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_LOW
+    )
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+
+
+def test_ladder_n2_low_to_sonnet_medium_and_high_to_opus(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_MEDIUM, _MODEL_HIGH]))
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+
+
+def test_ladder_n1_collapses_every_band_to_single_model(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_MEDIUM]))
+    for band in ("low", "medium", "high"):
+        assert (
+            model_resolve.resolve_band(
+                band,
+                routing_path=routing_json,
+                ladder_path=ladder_json,
+            )
+            == _MODEL_MEDIUM
+        )
+
+
+def test_ladder_n4_medium_lands_on_index_2_round_half_up(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(
+        json.dumps(
+            [
+                _MODEL_LOW,
+                _MODEL_MEDIUM,
+                _MODEL_HIGH,
+                "claude-opusmax-9",
+            ]
+        )
+    )
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_LOW
+    )
+    # weight 0.5 * (4-1) + 0.5 = 2.0 → int() → 2 → opus
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+    # weight 1.0 * (4-1) + 0.5 = 3.5 → int() → 3 → opusmax
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == "claude-opusmax-9"
+    )
+
+
+def test_ladder_feeds_legacy_tiers_too(routing_json: Path, ladder_json: Path) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_MEDIUM, _MODEL_HIGH]))
+    # CLI path so we exercise legacy normalization + ladder together.
+    result = _run_cli(
+        "sonnet",
+        env={
+            "MODEL_ROUTING_JSON": str(routing_json),
+            "MODEL_LADDER_JSON": str(ladder_json),
+        },
+    )
+    assert result.returncode == 0
+    assert result.stdout.decode().strip() == _MODEL_HIGH
+
+
+# ---------------------------------------------------------------------------
+# Malformed / degenerate ladder → degrade to the default map (never abort)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_ladder_invalid_json_degrades_to_default(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text("[not valid json")
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+
+
+def test_ladder_that_is_object_not_array_degrades_to_default(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text('{"low": "x"}')
+    assert (
+        model_resolve.resolve_band(
+            "high",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_HIGH
+    )
+
+
+def test_empty_ladder_array_degrades_to_default(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text("[]")
+    assert (
+        model_resolve.resolve_band(
+            "low",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_LOW
+    )
+
+
+def test_ladder_with_non_string_elements_degrades_to_default(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(json.dumps([1, 2, 3]))
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+
+
+def test_ladder_with_mixed_string_and_non_string_degrades_to_default(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_LOW, 42, _MODEL_HIGH]))
+    assert (
+        model_resolve.resolve_band(
+            "medium",
+            routing_path=routing_json,
+            ladder_path=ladder_json,
+        )
+        == _MODEL_MEDIUM
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing routing.json (the one surviving deny-relevant exit)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_routing_json_exits_4_with_remediation(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    ladder = tmp_path / "ladder.json"
+    result = _run_cli(
+        "low",
+        env={
+            "MODEL_ROUTING_JSON": str(missing),
+            "MODEL_LADDER_JSON": str(ladder),
+        },
+    )
+    assert result.returncode == 4
+    stderr = result.stderr.decode()
+    assert "Model routing file missing:" in stderr
+    assert "git checkout knowledge/model-routing.json" in stderr
+
+
+# ---------------------------------------------------------------------------
+# --dump-map flag
+# ---------------------------------------------------------------------------
+
+
+def test_dump_map_prints_three_bands_with_default_snapshots(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    output = model_resolve.dump_map(
+        routing_path=routing_json,
+        ladder_path=ladder_json,
+    )
+    for band in ("low", "medium", "high"):
+        assert band in output
+    for model in (_MODEL_LOW, _MODEL_MEDIUM, _MODEL_HIGH):
+        assert model in output
+
+
+def test_dump_map_reflects_ladder_when_present(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    ladder_json.write_text(json.dumps([_MODEL_MEDIUM, _MODEL_HIGH]))
+    output = model_resolve.dump_map(
+        routing_path=routing_json,
+        ladder_path=ladder_json,
+    )
+    # low now resolves to sonnet (bottom of the ladder)
+    assert _MODEL_MEDIUM in output
+    # high still resolves to opus (top)
+    assert _MODEL_HIGH in output
+
+
+def test_dump_map_writes_no_files(routing_json: Path, ladder_json: Path) -> None:
+    _ = model_resolve.dump_map(
+        routing_path=routing_json,
+        ladder_path=ladder_json,
+    )
+    assert not ladder_json.exists()
+
+
+def test_dump_map_cli_exits_0(resolver_env) -> None:
+    result = _run_cli(
+        "--dump-map",
+        env={
+            "MODEL_ROUTING_JSON": _os_env_get("MODEL_ROUTING_JSON"),
+            "MODEL_LADDER_JSON": _os_env_get("MODEL_LADDER_JSON"),
+        },
+    )
+    assert result.returncode == 0
+    stdout = result.stdout.decode()
+    for band in ("low", "medium", "high"):
+        assert band in stdout
+
+
+def test_dump_map_format_matches_bash_printf(
+    routing_json: Path,
+    ladder_json: Path,
+) -> None:
+    """Format must be `  {band:<7} → {model}\\n` per band, no extras.
+
+    Verifies byte-level format parity with the .sh's
+    `printf '  %-7s → %s\\n'`.
+    """
+    output = model_resolve.dump_map(
+        routing_path=routing_json,
+        ladder_path=ladder_json,
+    )
+    lines = output.split("\n")
+    assert lines[0] == f"  low     → {_MODEL_LOW}"
+    assert lines[1] == f"  medium  → {_MODEL_MEDIUM}"
+    assert lines[2] == f"  high    → {_MODEL_HIGH}"
+    # final trailing newline → last element empty after split
+    assert lines[3] == ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helper coverage — _normalize_band / _band_weight / _round_half_up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [
+        ("low", "low"),
+        ("haiku", "low"),
+        ("medium", "medium"),
+        ("sonnet", "medium"),
+        ("high", "high"),
+        ("opus", "high"),
+        ("frontier", ""),
+        ("", ""),
+        ("LOW", ""),
+    ],
+)
+def test_normalize_band(token: str, expected: str) -> None:
+    assert model_resolve._normalize_band(token) == expected
+
+
+@pytest.mark.parametrize(
+    "band,weight",
+    [("low", 0.0), ("medium", 0.5), ("high", 1.0)],
+)
+def test_band_weight(band: str, weight: float) -> None:
+    assert model_resolve._band_weight(band) == weight
+
+
+@pytest.mark.parametrize(
+    "weight,n,expected",
+    [
+        # Reproduces the .sh's `awk 'printf "%d", int(w*(n-1)+0.5)'`
+        (0.0, 3, 0),
+        (0.5, 3, 1),
+        (1.0, 3, 2),
+        (0.0, 2, 0),
+        (0.5, 2, 1),
+        (1.0, 2, 1),
+        (0.0, 1, 0),
+        (0.5, 1, 0),
+        (1.0, 1, 0),
+        (0.0, 4, 0),
+        (0.5, 4, 2),  # medium on N=4 → index 2 (round half up: 1.5 → 2)
+        (1.0, 4, 3),
+    ],
+)
+def test_round_half_up(weight: float, n: int, expected: int) -> None:
+    assert model_resolve._round_half_up(weight, n) == expected

--- a/tests/repo/no_pinned_snapshots_test.bats
+++ b/tests/repo/no_pinned_snapshots_test.bats
@@ -14,7 +14,10 @@ REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 #   docs/specs/, plans/, docs/spikes/ — design artifacts that name the
 #     values exactly because they describe the migration.
 #   evals/ — semgrep fixtures for OTHER plugins' LLM model strings.
-#   tests/  — bats fixtures that depend on the literal values.
+#   tests/  — bats + pytest fixtures that depend on the literal values.
+#     Includes plugins/dev-team/tests/ (the plugin's own pytest suite) — same
+#     exemption reason: fixture-test code legitimately names the literals to
+#     assert byte-for-byte against them.
 #   knowledge/model-pricing.json — cost meter's pricing table (#102); must key
 #     by model snapshot because the transcript usage records emit snapshot IDs.
 ALLOWED_PATHS=(
@@ -35,6 +38,7 @@ ALLOWED_PATHS=(
     ':!plugins/dev-team/docs/model-routing-overrides.md' \
     ':!plugins/dev-team/templates/agents/agent-template.md' \
     ':!plugins/dev-team/knowledge/model-pricing.json' \
+    ':!plugins/dev-team/tests/' \
     2>/dev/null || true)
   if [[ -n "$raw" ]]; then
     echo "Pinned snapshot IDs found in non-approved plugin source files:" >&2


### PR DESCRIPTION
Ports `plugins/dev-team/hooks/lib/model-resolve.sh` (193 LOC, 9 fns) to `plugins/dev-team/hooks/lib/model_resolve.py` — the largest shared lib in the bash→python migration and Cluster C's prerequisite for the three downstream hook slices (#585 agent-model-resolve, #586 session-model-banner, #587 build-worktree-baseref).

**Library-only slice** — consumers still `source` the .sh in this PR. Byte-parity with the .sh is confirmed for every band/tier input + `--dump-map` + error paths (missing routing.json → exit 4, unknown band → exit 2, malformed ladder → default-map fallback). The parity harness will gate the hook-level ports in #585-#587.

Stdlib-only (`json`/`argparse`/`pathlib`/`os`/`sys`), Python 3.8+, per [ADR 0014](docs/adr/0014-python-for-cross-os-scripts.md).

## Coverage

- **51 pytest cases** in `plugins/dev-team/tests/hooks/test_model_resolve.py` mirroring the bats fixture matrix one-for-one, plus parametrized coverage of `_normalize_band` / `_band_weight` / `_round_half_up`.
- **Existing** `tests/hooks/model_resolve_tests.bats` stays green against the .sh (23/23 pass) — nothing removed in this slice.
- `bash scripts/ci-local.sh` clean (parity harness runs alongside the new pytest module).

## Guard update

Extended `tests/repo/no_pinned_snapshots_test.bats` to exempt `plugins/dev-team/tests/` from the pinned-snapshot-ID check — same rationale the existing exemption for root-level `tests/` names ('fixture-test code legitimately names the literals to assert byte-for-byte against them'). The nested pytest tree is symmetric with the nested bats tree and needs the same allow.

Closes #577
Refs #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)