### PR TITLE
chore(scripts): port plan-parse shared lib to python (#572.E0)

### DIFF
--- a/plugins/dev-team/scripts/lib/plan_parse.py
+++ b/plugins/dev-team/scripts/lib/plan_parse.py
@@ -1,0 +1,135 @@
+"""plan_parse — extract per-slice (id, depends_on, files) from a plan markdown.
+
+Python port of `plugins/dev-team/scripts/lib/plan-parse.sh` (#579).
+
+Contract mirrors the bash: emit one TSV row per slice:
+
+    id<TAB>depends<TAB>files
+
+- `depends` is `"none"`, a raw list (`"1, 2"`), or the sentinel `"__MISSING__"`
+  when the slice has no `Depends-on` line at the slice level.
+- `files` is a raw list (`"a, b"`) or the empty string when the slice has no
+  slice-level `Files` line.
+
+Slice-level fields are the first `Depends-on` / `Files` lines under a
+`### Slice <id>:` heading and BEFORE that slice's first `#### Step` heading,
+so per-step `**Files**:` lines are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, TextIO, Tuple
+
+
+_SLICE_RE = re.compile(r"^#+\s+[Ss]lice\s+([^:]+)")
+_STEP_RE = re.compile(r"^#{4,}\s")
+_DEPENDS_RE = re.compile(r"[Dd]epends-[Oo]n\**\s*:\s*(.*)")
+_FILES_RE = re.compile(r"[Ff]iles\**\s*:\s*(.*)")
+_MARKDOWN_NOISE_RE = re.compile(r"[*`]")
+
+
+def _clean_value(raw: str) -> str:
+    """Strip `**` / backticks and surrounding whitespace from a field value."""
+    return _MARKDOWN_NOISE_RE.sub("", raw).strip()
+
+
+def _slice_id(header_line: str) -> str:
+    """Extract the slice id from a `### Slice <id>:` header line.
+
+    Mirrors the bash sed pipeline: strip the leading `#+ Slice ` prefix, then
+    everything after (and including) the first colon, then trim whitespace.
+    """
+    match = _SLICE_RE.match(header_line)
+    if not match:
+        return ""
+    tail = match.group(1)
+    # Trim leading whitespace already stripped by `\s+` in the pattern; strip
+    # trailing content after `:` and whitespace.
+    return tail.split(":", 1)[0].strip()
+
+
+def parse_slices(lines: Iterable[str]) -> List[Tuple[str, str, str]]:
+    """Return a list of `(id, depends, files)` rows in source order."""
+    rows: List[Tuple[str, str, str]] = []
+
+    current_id: str = ""
+    deps: str = ""
+    deps_seen: bool = False
+    files: str = ""
+    in_step: bool = False
+
+    def flush() -> None:
+        if current_id:
+            rows.append((current_id, deps if deps_seen else "__MISSING__", files))
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        # New slice header — flush the previous slice's row.
+        if _SLICE_RE.match(line):
+            flush()
+            current_id = _slice_id(line)
+            deps = ""
+            deps_seen = False
+            files = ""
+            in_step = False
+            continue
+
+        # #### Step heading turns off slice-level field collection for the
+        # rest of this slice — mirrors the bash `instep=1` flag.
+        if _STEP_RE.match(line):
+            in_step = True
+            continue
+
+        if not current_id or in_step:
+            continue
+
+        lowered = line.lower()
+
+        if not deps_seen and "depends-on" in lowered:
+            match = _DEPENDS_RE.search(line)
+            if match is not None:
+                deps = _clean_value(match.group(1))
+                deps_seen = True
+                continue
+
+        if not files and "files" in lowered:
+            match = _FILES_RE.search(line)
+            if match is not None:
+                files = _clean_value(match.group(1))
+
+    flush()
+    return rows
+
+
+def plan_parse(path: Path) -> str:
+    """Return the TSV rendering of `parse_slices` on the file at `path`."""
+    with open(path, encoding="utf-8") as handle:
+        rows = parse_slices(handle)
+    return "".join(f"{sid}\t{deps}\t{files}\n" for sid, deps, files in rows)
+
+
+def _write_rows(rows: List[Tuple[str, str, str]], stream: TextIO) -> None:
+    for sid, deps, files in rows:
+        stream.write(f"{sid}\t{deps}\t{files}\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="plan_parse.py",
+        description="Extract slice (id, Depends-on, Files) tuples from a plan markdown.",
+    )
+    parser.add_argument("plan", type=Path, help="Path to the plan markdown file")
+    args = parser.parse_args(argv)
+    with open(args.plan, encoding="utf-8") as handle:
+        rows = parse_slices(handle)
+    _write_rows(rows, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/tests/scripts/test_plan_parse.py
+++ b/plugins/dev-team/tests/scripts/test_plan_parse.py
@@ -1,0 +1,147 @@
+"""Unit tests for scripts/lib/plan_parse.py (#579).
+
+Two layers of coverage:
+
+1. Behavioural — exercises `parse_slices` on a small hand-authored fixture set
+   to lock down the API-level contract (missing depends line yields
+   `__MISSING__`, step-level Files lines are ignored, etc.).
+2. Byte-parity — dispatches every fixture in `tests/fixtures/plans/` at both
+   the `.sh` and `.py` implementations and asserts identical stdout. This is
+   the check that guards the eventual rewire in #589 (plan-waves).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))
+
+import plan_parse  # noqa: E402
+
+
+_PLAN_PARSE_SH = (
+    _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib" / "plan-parse.sh"
+)
+_PLAN_PARSE_PY = (
+    _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib" / "plan_parse.py"
+)
+_FIXTURES_DIR = _REPO_ROOT / "tests" / "fixtures" / "plans"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests — API surface
+# ---------------------------------------------------------------------------
+
+
+def _rows(source: str) -> List[tuple]:
+    return plan_parse.parse_slices(source.splitlines())
+
+
+def test_single_slice_with_deps_and_files():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `one.ts`
+"""
+    assert _rows(md) == [("1", "none", "one.ts")]
+
+
+def test_step_level_files_ignored():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `one.ts`
+#### Step 1.1: do it
+**Files**: `step-level-should-be-ignored.ts`
+"""
+    assert _rows(md) == [("1", "none", "one.ts")]
+
+
+def test_missing_depends_yields_sentinel():
+    md = """### Slice A: alpha
+**Files:** `a.ts`
+### Slice B: beta
+**Depends-on:** A
+"""
+    assert _rows(md) == [
+        ("A", "__MISSING__", "a.ts"),
+        ("B", "A", ""),
+    ]
+
+
+def test_backticks_and_bold_stripped_from_values():
+    md = """### Slice 1: First
+**Depends-on:** `2, 3`
+**Files:** **`a.ts`, `b.ts`**
+"""
+    assert _rows(md) == [("1", "2, 3", "a.ts, b.ts")]
+
+
+def test_slice_id_is_before_first_colon():
+    md = """### Slice foo: descriptive title with: colons
+**Depends-on:** none
+"""
+    assert _rows(md) == [("foo", "none", "")]
+
+
+def test_case_insensitive_depends_and_files_labels():
+    md = """### Slice 1: First
+depends-on: none
+files: `x.ts`
+"""
+    assert _rows(md) == [("1", "none", "x.ts")]
+
+
+def test_multiple_slices_ordered_by_source():
+    md = """### Slice B: second in file
+**Depends-on:** A
+### Slice A: first in file after B
+**Depends-on:** none
+"""
+    # Slices come out in source order, not sorted.
+    assert _rows(md) == [("B", "A", ""), ("A", "none", "")]
+
+
+def test_no_slices_yields_empty():
+    assert _rows("just a plain markdown file\nwith no slice headers\n") == []
+
+
+# ---------------------------------------------------------------------------
+# Byte-parity against the bash implementation
+# ---------------------------------------------------------------------------
+
+
+def _fixture_paths() -> List[Path]:
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(_FIXTURES_DIR.glob("*.md"))
+
+
+_FIXTURE_PARAMS = _fixture_paths()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required for parity")
+@pytest.mark.skipif(not _PLAN_PARSE_SH.is_file(), reason="plan-parse.sh not present")
+@pytest.mark.skipif(not _FIXTURE_PARAMS, reason="no plan fixtures present")
+@pytest.mark.parametrize("fixture", _FIXTURE_PARAMS, ids=lambda p: p.name)
+def test_byte_parity_with_bash(fixture: Path) -> None:
+    """Stdout of `plan-parse.sh <fixture>` must equal `plan_parse.py <fixture>`."""
+    sh = subprocess.run(
+        ["bash", str(_PLAN_PARSE_SH), str(fixture)],
+        capture_output=True,
+        check=True,
+    )
+    py = subprocess.run(
+        [sys.executable, str(_PLAN_PARSE_PY), str(fixture)],
+        capture_output=True,
+        check=True,
+    )
+    assert py.stdout == sh.stdout, (
+        f"Byte divergence on {fixture.name}:\nsh: {sh.stdout!r}\npy: {py.stdout!r}"
+    )


### PR DESCRIPTION
Phase 1, Cluster E of #572 — port the plan-parse library.

## Scope

Library-only port. `scripts/plan-waves.sh` still sources the `.sh` version; the switchover ships as **#589** (Phase 2 dependent).

- `plugins/dev-team/scripts/lib/plan_parse.py` — Python port of `plan-parse.sh`. Public entry points:
  - `parse_slices(lines) -> List[(id, depends, files)]` — API-friendly form.
  - `plan_parse(path) -> str` — TSV rendering (byte-parity with bash).
  - `python3 plan_parse.py <plan.md>` — CLI mirrors the bash.
- `plugins/dev-team/tests/scripts/test_plan_parse.py` — pytest port + byte-parity harness.

## Verification

- **`python3 -m pytest plugins/dev-team/tests/scripts/test_plan_parse.py`** — **16/16 pass**:
  - **8 behavioural cases** — missing depends → `__MISSING__`, step-level `**Files**` lines ignored, case-insensitive labels, slice id ends at first colon, backticks/bold stripped from values, ordering follows source not id.
  - **8 byte-parity cases** — parametrized over every fixture in `tests/fixtures/plans/` (`collision`, `cycle`, `dag-order`, `diamond`, `linear`, `missing`, `nodeps`, `unknown`). Each dispatches both implementations and asserts `subprocess.stdout` equal. Zero divergence.
- **`bash scripts/ci-local.sh`** — clean.

## Acceptance criteria (#579)

- [x] `plan_parse.py` stdlib-only, Python 3.8+, importable.
- [x] Byte-parity with `.sh` on the plan-parsing output (all 8 fixtures under `tests/fixtures/plans/`).
- [x] pytest tests use fixtures under `tests/fixtures/plans/`.
- [x] `bash scripts/ci-local.sh` clean.

Closes #579
Refs #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)