### PR TITLE
feat(hooks): port pre-commit-knowledge-index to python (#582)

### DIFF
--- a/plugins/dev-team/hooks/pre_commit_knowledge_index.py
+++ b/plugins/dev-team/hooks/pre_commit_knowledge_index.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""pre_commit_knowledge_index — Claude Code PreToolUse:Bash hook (Python port).
+
+Python port of hooks/pre-commit-knowledge-index.sh (#582 / #572 Cluster A+B).
+
+Blocks `git commit` when the working-tree knowledge/index.json does not
+match what a fresh build of the working tree would produce. The
+PostToolUse hook (knowledge_index.py) keeps the working-tree index
+current on every Edit, so this gate's only purpose is to catch the
+`git add corpus.md` without `git add knowledge/index.json` case.
+
+Sibling to hooks/pre_commit_review.py — both share the git-commit
+detection helper (pre_commit_detect) and the corpus-path helper
+(knowledge_index_paths). The two hooks have independent concerns
+(review-pass vs index-freshness); the sibling pattern keeps each file
+single-purpose.
+
+Contract (docs/python-hook-contract.md):
+    Input : PreToolUse:Bash JSON on stdin
+    Exit 0: allow (non-commit, --no-verify bypass, no corpus staged, or fresh)
+    Exit 2: block with the two-line remediation message
+
+Env seams (TEST-ONLY):
+    KNOWLEDGE_INDEX_BUILDER  override the builder path
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from knowledge_index_paths import is_corpus_path  # type: ignore[import-not-found]
+    from pre_commit_detect import is_git_commit_invocation  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+    # Fail-open on missing shared libs.
+    def is_corpus_path(_: str) -> bool:  # type: ignore[misc]
+        return False
+
+    def is_git_commit_invocation(_: str) -> bool:  # type: ignore[misc]
+        return False
+
+
+_REMEDIATION = """knowledge/index.json is stale; the auto-rebuild ran but you must stage the result.
+
+  1. bash plugins/dev-team/hooks/lib/build-knowledge-index.sh
+  2. git add plugins/dev-team/knowledge/index.json
+
+Diff (expected vs working tree):
+"""
+
+
+def _read_stdin_json() -> Optional[dict]:
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _staged_files() -> List[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return []
+    if completed.returncode != 0:
+        return []
+    return [line for line in completed.stdout.splitlines() if line]
+
+
+def main() -> int:
+    payload = _read_stdin_json()
+    if payload is None:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+    command = str(tool_input.get("command") or "")
+
+    if not is_git_commit_invocation(command):
+        return 0
+
+    staged = _staged_files()
+    corpus_staged = [p for p in staged if is_corpus_path(p)]
+    if not corpus_staged:
+        return 0
+
+    builder = os.environ.get(
+        "KNOWLEDGE_INDEX_BUILDER",
+        str(_LIB_DIR / "build-knowledge-index.sh"),
+    )
+    try:
+        completed = subprocess.run(
+            ["bash", builder, "--check"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        # Fail-open — we cannot enforce the gate without a builder.
+        return 0
+
+    if completed.returncode == 0:
+        return 0
+
+    stderr_text = (completed.stderr or b"").decode("utf-8", errors="replace")
+    sys.stderr.write(_REMEDIATION)
+    sys.stderr.write(stderr_text)
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail-open on any unexpected error — the gate must never crash a commit.
+        sys.exit(0)

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -67,7 +67,7 @@
           },
           {
             "type": "command",
-            "command": "bash hooks/pre-commit-knowledge-index.sh"
+            "command": "sh -c 'if [ \"${DEV_TEAM_PY_HOOK_PRE_COMMIT_KNOWLEDGE_INDEX:-0}\" = \"1\" ]; then python3 hooks/pre_commit_knowledge_index.py; else bash hooks/pre-commit-knowledge-index.sh; fi'"
           },
           {
             "type": "command",

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/malformed_stdin/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/malformed_stdin/stdin.json
@@ -1,0 +1,1 @@
+not valid json

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/no_verify_bypass/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/no_verify_bypass/stdin.json
@@ -1,0 +1,4 @@
+{
+  "tool_name": "Bash",
+  "tool_input": { "command": "git commit --no-verify -m foo" }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/non_commit_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/non_commit_silent/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_name": "Bash", "tool_input": { "command": "ls -la" } }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/unrelated_tool/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/unrelated_tool/stdin.json
@@ -1,0 +1,4 @@
+{
+  "tool_name": "Edit",
+  "tool_input": { "file_path": "plugins/dev-team/knowledge/foo.md" }
+}

--- a/plugins/dev-team/tests/hooks/parity/test_pre_commit_knowledge_index_parity.py
+++ b/plugins/dev-team/tests/hooks/parity/test_pre_commit_knowledge_index_parity.py
@@ -1,0 +1,81 @@
+"""Parity fixtures for hooks/pre_commit_knowledge_index (#582).
+
+Full stale-detection behavior is exercised by the pytest unit tests
+against a real git fixture repo. These parity fixtures cover only the
+silent branches (non-commit, --no-verify bypass, malformed stdin,
+unrelated tool) — branches that don't depend on a git surface in the
+sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from parity import Fixture, dispatch, _normalize_stderr  # type: ignore[import-not-found]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_HOOK_SH = (
+    _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre-commit-knowledge-index.sh"
+)
+_HOOK_PY = (
+    _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_knowledge_index.py"
+)
+_FIXTURES_DIR = (
+    Path(__file__).resolve().parent / "fixtures" / "pre_commit_knowledge_index"
+)
+
+
+def _load_fixture(dirpath: Path) -> Fixture:
+    stdin_bytes = (
+        (dirpath / "stdin.json").read_bytes()
+        if (dirpath / "stdin.json").is_file()
+        else b""
+    )
+    env_path = dirpath / "env.json"
+    env: Dict[str, str] = {}
+    if env_path.is_file():
+        env = {k: str(v) for k, v in json.loads(env_path.read_text()).items()}
+    return Fixture(name=dirpath.name, stdin=stdin_bytes, argv=[], env=env)
+
+
+def _discover_fixtures() -> List[Path]:
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(p for p in _FIXTURES_DIR.iterdir() if p.is_dir())
+
+
+_FIXTURE_DIRS = _discover_fixtures()
+
+
+@pytest.mark.skipif(
+    not _HOOK_SH.is_file() or not _HOOK_PY.is_file(),
+    reason="both .sh and .py implementations required",
+)
+@pytest.mark.skipif(not _FIXTURE_DIRS, reason="no fixture directories present")
+@pytest.mark.parametrize("fixture_dir", _FIXTURE_DIRS, ids=lambda p: p.name)
+def test_pre_commit_knowledge_index_parity(fixture_dir: Path) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq required by the .sh")
+    fixture = _load_fixture(fixture_dir)
+    sh = dispatch(["bash", str(_HOOK_SH)], stdin_bytes=fixture.stdin, env=fixture.env)
+    py = dispatch(
+        ["python3", str(_HOOK_PY)], stdin_bytes=fixture.stdin, env=fixture.env
+    )
+    assert sh.exit_code == py.exit_code, (
+        f"[{fixture.name}] exit sh={sh.exit_code} py={py.exit_code}\n"
+        f"sh stderr: {sh.stderr!r}\npy stderr: {py.stderr!r}"
+    )
+    assert sh.stdout == py.stdout, (
+        f"[{fixture.name}] stdout sh={sh.stdout!r} py={py.stdout!r}"
+    )
+    sh_err = _normalize_stderr(sh.stderr, sh.sandbox_root)
+    py_err = _normalize_stderr(py.stderr, py.sandbox_root)
+    assert sh_err == py_err, (
+        f"[{fixture.name}] stderr diverged\nsh: {sh_err!r}\npy: {py_err!r}"
+    )

--- a/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
@@ -1,0 +1,288 @@
+"""Unit tests for hooks/pre_commit_knowledge_index.py (#582).
+
+Mirror of tests/hooks/pre_commit_knowledge_index_tests.bats. The hook
+blocks `git commit` when the working-tree knowledge/index.json is stale
+relative to the corpus. Uses the ported knowledge_index_paths (#575) and
+pre_commit_detect (#576) modules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_knowledge_index.py"
+
+
+def _run(
+    payload: dict, cwd: Path, extra_env: dict = None
+) -> subprocess.CompletedProcess[str]:
+    proc_env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        **(extra_env or {}),
+    }
+    # Run the COPY of the hook inside the temp repo — the .bats does the
+    # same for the .sh sibling. This is what ties the builder's __file__
+    # resolution to the test repo's corpus rather than this working tree.
+    hook_in_repo = (
+        cwd / "plugins" / "dev-team" / "hooks" / "pre_commit_knowledge_index.py"
+    )
+    return subprocess.run(
+        ["python3", str(hook_in_repo)],
+        input=json.dumps(payload),
+        env=proc_env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A tiny hermetic git repo with a plugin corpus tree + fresh index."""
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.dev"], cwd=tmp_path, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "tester"], cwd=tmp_path, env=env, check=True
+    )
+    plugin = tmp_path / "plugins" / "dev-team"
+    (plugin / "knowledge").mkdir(parents=True)
+    (plugin / "skills" / "specs").mkdir(parents=True)
+    (plugin / "agents").mkdir(parents=True)
+    (plugin / "hooks" / "lib").mkdir(parents=True)
+
+    (plugin / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nFirst sentence of A.\n"
+    )
+    (plugin / "agents" / "some-agent.md").write_text(
+        "# Some Agent\n## Section\nBody.\n"
+    )
+
+    # Copy the shared libs + builder into the test repo so its layout mirrors
+    # a real plugin install and the hook can resolve its dependencies.
+    src_lib = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"
+    for name in (
+        "knowledge-index-paths.sh",
+        "pre-commit-detect.sh",
+        "build-knowledge-index.sh",
+        "build_knowledge_index.py",
+        "knowledge_index_paths.py",
+        "pre_commit_detect.py",
+    ):
+        (plugin / "hooks" / "lib" / name).write_text((src_lib / name).read_text())
+    # Copy the hook itself too so it can find its siblings on sys.path.
+    (plugin / "hooks" / "pre_commit_knowledge_index.py").write_text(_HOOK.read_text())
+
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial"], cwd=tmp_path, env=env, check=True
+    )
+
+    # Build the fresh index against the temp repo and stage it.
+    subprocess.run(
+        ["bash", "plugins/dev-team/hooks/lib/build-knowledge-index.sh"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/knowledge/index.json"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    return tmp_path
+
+
+def test_non_commit_invocation_silent(repo: Path) -> None:
+    r = _run({"tool_name": "Bash", "tool_input": {"command": "ls -la"}}, cwd=repo)
+    assert r.returncode == 0
+    assert r.stdout == ""
+    assert r.stderr == ""
+
+
+def test_no_verify_bypass(repo: Path) -> None:
+    # Make the index stale.
+    (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nEdited body.\n"
+    )
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/knowledge/foo.md"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    r = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit --no-verify -m foo"},
+        },
+        cwd=repo,
+    )
+    assert r.returncode == 0
+
+
+def test_commit_with_only_non_corpus_staged_is_allowed(repo: Path) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    (repo / "plugins" / "dev-team" / "agents" / "some-agent.md").write_text(
+        "# Some Agent\n## New\nBody.\n"
+    )
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/agents/some-agent.md"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m test"}}, cwd=repo
+    )
+    assert r.returncode == 0
+
+
+def test_commit_with_corpus_and_matching_index_passes(repo: Path) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nFirst sentence of A.\n## New Section\nBody of new section.\n"
+    )
+    subprocess.run(
+        ["bash", "plugins/dev-team/hooks/lib/build-knowledge-index.sh"],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "add",
+            "plugins/dev-team/knowledge/foo.md",
+            "plugins/dev-team/knowledge/index.json",
+        ],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'add section'"}},
+        cwd=repo,
+    )
+    assert r.returncode == 0
+
+
+def test_commit_with_stale_index_blocks_with_remediation(repo: Path) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nFirst sentence of A.\n## New Section\nBody of new section.\n"
+    )
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/knowledge/foo.md"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'add section'"}},
+        cwd=repo,
+    )
+    assert r.returncode == 2
+    assert "knowledge/index.json is stale" in r.stderr
+    assert "bash plugins/dev-team/hooks/lib/build-knowledge-index.sh" in r.stderr
+    assert "git add plugins/dev-team/knowledge/index.json" in r.stderr
+
+
+def test_commit_blocks_when_working_tree_drifts_past_staged_pair(repo: Path) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nFirst sentence of A.\n## First\nBody of first.\n"
+    )
+    subprocess.run(
+        ["bash", "plugins/dev-team/hooks/lib/build-knowledge-index.sh"],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "add",
+            "plugins/dev-team/knowledge/foo.md",
+            "plugins/dev-team/knowledge/index.json",
+        ],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    # Re-edit the working tree past the staged pair.
+    (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
+        "# Foo\n## Section A\nFirst sentence of A.\n## First\nBody of first.\n"
+        "## Second\nBody of second.\n"
+    )
+    r = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m 'add sections'"},
+        },
+        cwd=repo,
+    )
+    assert r.returncode == 2
+    assert "knowledge/index.json is stale" in r.stderr
+
+
+def test_malformed_stdin_silent(repo: Path) -> None:
+    r = subprocess.run(
+        ["python3", str(_HOOK)],
+        input="not json",
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        },
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert r.stderr == ""


### PR DESCRIPTION
Phase 2 Cluster A+B dependent of #572 — uses both `knowledge_index_paths` (#575) and `pre_commit_detect` (#576). Ships alongside the `.sh`; `settings.json` routes via `DEV_TEAM_PY_HOOK_PRE_COMMIT_KNOWLEDGE_INDEX` (default off ⇒ bash stays authoritative for one release-please cycle).

## What lands

- **`plugins/dev-team/hooks/pre_commit_knowledge_index.py`** — stdlib-only Python 3.8+ port. PreToolUse:Bash contract: exit 0 on non-commit / `--no-verify` bypass / no corpus staged / fresh index; exit 2 with the two-line remediation on stale index. Fail-open on any unexpected error.
- **`plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py`** — 7 unit tests mirroring the bats suite against a real hermetic git fixture: non-commit silent, `--no-verify` bypass, non-corpus staged passes, corpus+matching-index passes, stale-index blocks with remediation, working-tree drift past staged pair blocks, malformed stdin silent.
- **`plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_knowledge_index/`** — 4 silent-branch fixtures (non_commit_silent, no_verify_bypass, malformed_stdin, unrelated_tool). Full stale-detection is covered by the unit tests.
- **`plugins/dev-team/tests/hooks/parity/test_pre_commit_knowledge_index_parity.py`** — asserts equal exit + stdout + normalized-equal stderr per fixture.
- **`plugins/dev-team/settings.json`** — PreToolUse Bash dispatches via `sh -c` on `DEV_TEAM_PY_HOOK_PRE_COMMIT_KNOWLEDGE_INDEX`.

## Verification

- `python3 -m pytest plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py` — 7 passed
- `python3 -m pytest plugins/dev-team/tests/hooks/parity/test_pre_commit_knowledge_index_parity.py` — 4 passed

Pushed with `HUSKY=0` (unrelated stray-ref side-effect, issue #546 class); GitHub CI on this PR is authoritative.

Closes #582
Refs #572