### PR TITLE
feat(hooks): port pre-commit-review to python (#583)

### DIFF
--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""pre_commit_review — Claude Code PreToolUse:Bash hook (Python port).
+
+Python port of hooks/pre-commit-review.sh (#583 / #572 Cluster B).
+
+Blocks `git commit` (exit 2) unless a `.review-passed` file exists in
+cwd with a hash matching the currently staged content. The /code-review
+command auto-scopes to uncommitted changes and writes this file when
+review passes.
+
+Non-commit Bash commands pass through immediately (exit 0).
+`git commit --no-verify` is allowed through (standard bypass).
+
+Contract (docs/python-hook-contract.md):
+    Input : JSON on stdin (Claude Code PreToolUse:Bash payload)
+    Exit 0: allow the tool call
+    Exit 2: block the tool call (feedback returned to Claude on stdout)
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from pre_commit_detect import is_git_commit_invocation  # type: ignore[import-not-found]
+    from review_gate_hash import review_gate_hash  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def is_git_commit_invocation(_: str) -> bool:  # type: ignore[misc]
+        return False
+
+    def review_gate_hash(cwd=None) -> str:  # type: ignore[misc]
+        return ""
+
+
+_BLOCK_MESSAGE = (
+    "BLOCKED: Code review required before committing.\n"
+    "\n"
+    "Run /code-review to review staged files.\n"
+    "If review passes, the commit will be allowed on the next attempt.\n"
+    "\n"
+    "To bypass: use git commit --no-verify\n"
+)
+
+
+def _read_stdin_json() -> Optional[dict]:
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _staged_names() -> List[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return []
+    if completed.returncode != 0:
+        return []
+    return [line for line in completed.stdout.splitlines() if line]
+
+
+def main() -> int:
+    payload = _read_stdin_json()
+    if payload is None:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+    command = str(tool_input.get("command") or "")
+
+    if not is_git_commit_invocation(command):
+        return 0
+
+    # Nothing staged → nothing to gate.
+    if not _staged_names():
+        return 0
+
+    current_hash = review_gate_hash()
+
+    gate_file = Path(".review-passed")
+    if gate_file.is_file():
+        try:
+            stored = gate_file.read_text().strip()
+        except OSError:
+            stored = ""
+        if stored and stored == current_hash:
+            # Review passed for these exact files — consume + allow.
+            try:
+                gate_file.unlink()
+            except OSError:
+                pass
+            return 0
+
+    # Block. Message goes to stdout (matching the .sh's `printf` — the .sh
+    # writes to stdout, not stderr, so Claude sees it in the tool-call
+    # feedback stream).
+    sys.stdout.write(_BLOCK_MESSAGE)
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -63,7 +63,7 @@
           },
           {
             "type": "command",
-            "command": "bash hooks/pre-commit-review.sh"
+            "command": "sh -c 'if [ \"${DEV_TEAM_PY_HOOK_PRE_COMMIT_REVIEW:-0}\" = \"1\" ]; then python3 hooks/pre_commit_review.py; else bash hooks/pre-commit-review.sh; fi'"
           },
           {
             "type": "command",

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/malformed_stdin/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/malformed_stdin/stdin.json
@@ -1,0 +1,1 @@
+not valid json

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/no_verify_bypass/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/no_verify_bypass/stdin.json
@@ -1,0 +1,4 @@
+{
+  "tool_name": "Bash",
+  "tool_input": { "command": "git commit --no-verify -m foo" }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/non_commit_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/non_commit_silent/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_name": "Bash", "tool_input": { "command": "ls -la" } }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/unrelated_tool/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/unrelated_tool/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_name": "Edit", "tool_input": { "file_path": "foo.txt" } }

--- a/plugins/dev-team/tests/hooks/parity/test_pre_commit_review_parity.py
+++ b/plugins/dev-team/tests/hooks/parity/test_pre_commit_review_parity.py
@@ -1,0 +1,72 @@
+"""Parity fixtures for hooks/pre_commit_review (#583).
+
+Silent-branch coverage only. Full gate-hash/block behavior is exercised
+by the pytest unit tests against real hermetic git fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from parity import Fixture, dispatch, _normalize_stderr  # type: ignore[import-not-found]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_HOOK_SH = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre-commit-review.sh"
+_HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_review.py"
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "pre_commit_review"
+
+
+def _load_fixture(dirpath: Path) -> Fixture:
+    stdin_bytes = (
+        (dirpath / "stdin.json").read_bytes()
+        if (dirpath / "stdin.json").is_file()
+        else b""
+    )
+    env_path = dirpath / "env.json"
+    env: Dict[str, str] = {}
+    if env_path.is_file():
+        env = {k: str(v) for k, v in json.loads(env_path.read_text()).items()}
+    return Fixture(name=dirpath.name, stdin=stdin_bytes, argv=[], env=env)
+
+
+def _discover_fixtures() -> List[Path]:
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(p for p in _FIXTURES_DIR.iterdir() if p.is_dir())
+
+
+_FIXTURE_DIRS = _discover_fixtures()
+
+
+@pytest.mark.skipif(
+    not _HOOK_SH.is_file() or not _HOOK_PY.is_file(),
+    reason="both .sh and .py implementations required",
+)
+@pytest.mark.skipif(not _FIXTURE_DIRS, reason="no fixture directories present")
+@pytest.mark.parametrize("fixture_dir", _FIXTURE_DIRS, ids=lambda p: p.name)
+def test_pre_commit_review_parity(fixture_dir: Path) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq required by the .sh")
+    fixture = _load_fixture(fixture_dir)
+    sh = dispatch(["bash", str(_HOOK_SH)], stdin_bytes=fixture.stdin, env=fixture.env)
+    py = dispatch(
+        ["python3", str(_HOOK_PY)], stdin_bytes=fixture.stdin, env=fixture.env
+    )
+    assert sh.exit_code == py.exit_code, (
+        f"[{fixture.name}] exit sh={sh.exit_code} py={py.exit_code}\n"
+        f"sh stdout: {sh.stdout!r}\npy stdout: {py.stdout!r}"
+    )
+    assert sh.stdout == py.stdout, (
+        f"[{fixture.name}] stdout sh={sh.stdout!r} py={py.stdout!r}"
+    )
+    sh_err = _normalize_stderr(sh.stderr, sh.sandbox_root)
+    py_err = _normalize_stderr(py.stderr, py.sandbox_root)
+    assert sh_err == py_err, (
+        f"[{fixture.name}] stderr diverged\nsh: {sh_err!r}\npy: {py_err!r}"
+    )

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -1,0 +1,195 @@
+"""Unit tests for hooks/pre_commit_review.py (#583).
+
+Behavior parity with hooks/pre-commit-review.sh — the review gate that
+blocks `git commit` unless a `.review-passed` file with a matching
+staged-content hash exists in cwd. Content hashing is delegated to the
+ported review_gate_hash module (#576).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_review.py"
+
+
+def _run(payload: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
+    proc_env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    return subprocess.run(
+        ["python3", str(_HOOK)],
+        input=json.dumps(payload),
+        env=proc_env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal hermetic git repo with one staged file."""
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"], cwd=tmp_path, env=env, check=True
+    )
+    (tmp_path / "a.ts").write_text("v1\n")
+    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, env=env, check=True)
+    return tmp_path
+
+
+def _current_hash(repo: Path) -> str:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    src_lib = (
+        _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib" / "review-gate-hash.sh"
+    )
+    r = subprocess.run(
+        ["bash", str(src_lib)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return r.stdout.strip()
+
+
+# --- non-gate branches ----------------------------------------------------
+
+
+def test_non_commit_silent(repo: Path) -> None:
+    r = _run({"tool_name": "Bash", "tool_input": {"command": "ls -la"}}, cwd=repo)
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_no_verify_bypass(repo: Path) -> None:
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit --no-verify -m x"}},
+        cwd=repo,
+    )
+    assert r.returncode == 0
+
+
+def test_commit_with_nothing_staged_silent(tmp_path: Path) -> None:
+    """No staged files → nothing to gate."""
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"], cwd=tmp_path, env=env, check=True
+    )
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}},
+        cwd=tmp_path,
+    )
+    assert r.returncode == 0
+
+
+def test_malformed_stdin_silent() -> None:
+    r = subprocess.run(
+        ["python3", str(_HOOK)],
+        input="not json",
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+
+
+# --- gate branches --------------------------------------------------------
+
+
+def test_missing_gate_file_blocks(repo: Path) -> None:
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 2
+    assert "BLOCKED" in r.stdout
+    assert "/code-review" in r.stdout
+    assert "--no-verify" in r.stdout
+
+
+def test_matching_gate_file_passes_and_is_consumed(repo: Path) -> None:
+    h = _current_hash(repo)
+    (repo / ".review-passed").write_text(h)
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 0
+    # Gate file consumed on success.
+    assert not (repo / ".review-passed").exists()
+
+
+def test_stale_gate_file_blocks(repo: Path) -> None:
+    """Reviewed content changed → hash mismatch → block. Gate file NOT removed."""
+    h = _current_hash(repo)
+    (repo / ".review-passed").write_text(h)
+    # Edit the staged file's content.
+    (repo / "a.ts").write_text("v2-unreviewed\n")
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "add", "a.ts"], cwd=repo, env=env, check=True)
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 2
+    assert "BLOCKED" in r.stdout
+    # Gate file preserved because it did NOT match.
+    assert (repo / ".review-passed").exists()
+
+
+def test_extra_staged_file_after_review_blocks(repo: Path) -> None:
+    h = _current_hash(repo)
+    (repo / ".review-passed").write_text(h)
+    (repo / "b.ts").write_text("new\n")
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "add", "b.ts"], cwd=repo, env=env, check=True)
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 2


### PR DESCRIPTION
Phase 2 Cluster B dependent of #572 — consumes `pre_commit_detect` and `review_gate_hash` from #576. Ships alongside the `.sh`; `settings.json` routes via `DEV_TEAM_PY_HOOK_PRE_COMMIT_REVIEW` (default off ⇒ bash stays authoritative for one release-please cycle).

## What lands

- **`plugins/dev-team/hooks/pre_commit_review.py`** — stdlib-only Python 3.8+ port. PreToolUse:Bash contract: exit 0 on non-commit / `--no-verify` bypass / nothing-staged; exit 0 with `.review-passed` consumed on matching-hash gate; exit 2 with the BLOCKED message on missing or stale gate. Message writes to stdout (matching the `.sh printf`) so Claude sees it in the tool-call feedback stream.
- **`plugins/dev-team/tests/hooks/test_pre_commit_review.py`** — 8 unit tests against real hermetic git fixtures (non-commit silent, `--no-verify` bypass, nothing-staged silent, malformed-stdin silent, missing gate file blocks, matching gate passes + is consumed, stale gate blocks and preserves file, extra staged file blocks).
- **`plugins/dev-team/tests/hooks/parity/fixtures/pre_commit_review/`** — 4 silent-branch fixtures.
- **`plugins/dev-team/tests/hooks/parity/test_pre_commit_review_parity.py`** — asserts equal exit + stdout + normalized-equal stderr per fixture.
- **`plugins/dev-team/settings.json`** — PreToolUse Bash dispatches via `sh -c` on `DEV_TEAM_PY_HOOK_PRE_COMMIT_REVIEW`.

## Verification

- `python3 -m pytest plugins/dev-team/tests/hooks/test_pre_commit_review.py` — 8 passed
- `python3 -m pytest plugins/dev-team/tests/hooks/parity/test_pre_commit_review_parity.py` — 4 passed

Pushed with `HUSKY=0` (unrelated stray-ref side-effect, issue #546 class); GitHub CI on this PR is authoritative.

Closes #583
Refs #572