### PR TITLE
chore(scripts): port plan-waves to python (#572)

### DIFF
--- a/plugins/dev-team/scripts/plan_waves.py
+++ b/plugins/dev-team/scripts/plan_waves.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""plan_waves.py — compute parallel build waves from a plan's slice DAG.
+
+Python port of `scripts/plan-waves.sh` (#589 / #572 Phase 2 Cluster E1).
+
+Parses each slice's `Depends-on`, topologically layers the DAG into waves
+(wave 1 = slices with no prerequisites), detects same-wave file collisions,
+and emits a stable JSON contract (schema `plan-waves/v1`) on stdout:
+
+    { "schema", "waves": [[id,...],...],
+      "slices": {id:{depends_on,files,wave}},
+      "collisions": [{wave, slices:[a,b], file}] }
+
+Rejects (exit 2, message on stderr):
+  - a dependency cycle
+  - a slice missing its Depends-on declaration
+  - an unknown dependency reference
+
+Uses `scripts/lib/plan_parse.py` for the parser stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "lib"))
+
+import plan_parse  # noqa: E402
+
+
+_TOKEN_SPLIT_RE = re.compile(r"[,\s]+")
+
+
+def _die(message: str) -> None:
+    sys.stderr.write("plan-waves: " + message + "\n")
+    sys.exit(2)
+
+
+def compute_waves(plan_path: Path) -> dict:
+    """Return the plan-waves/v1 JSON payload for `plan_path`."""
+    rows = plan_parse.parse_slices(plan_path.read_text().splitlines())
+
+    slices: Dict[str, dict] = {}
+    order: List[str] = []
+    for sid, deps_raw, files_raw in rows:
+        files = [f for f in _TOKEN_SPLIT_RE.split(files_raw) if f]
+        slices[sid] = {"deps_raw": deps_raw, "files": files}
+        order.append(sid)
+
+    if not slices:
+        _die("no slices found (expected '### Slice <id>: ...' headings)")
+
+    for sid in order:
+        deps_raw = slices[sid]["deps_raw"]
+        if deps_raw == "__MISSING__":
+            _die(
+                f"slice {sid!r} is missing its Depends-on declaration — "
+                "add 'Depends-on: none' if it has no prerequisites."
+            )
+        raw = deps_raw.strip()
+        if raw.lower() == "none" or raw == "":
+            slices[sid]["deps"] = []
+        else:
+            slices[sid]["deps"] = [d for d in _TOKEN_SPLIT_RE.split(raw) if d]
+
+    for sid in order:
+        for dep in slices[sid]["deps"]:
+            if dep not in slices:
+                _die(f"slice {sid!r} depends on unknown slice {dep!r}.")
+
+    remaining = {sid: set(slices[sid]["deps"]) for sid in order}
+    waves: List[List[str]] = []
+    placed: set = set()
+    while remaining:
+        ready = sorted(s for s, d in remaining.items() if d <= placed)
+        if not ready:
+            _die("dependency cycle among slices: " + ", ".join(sorted(remaining)) + ".")
+        waves.append(ready)
+        for s in ready:
+            placed.add(s)
+            del remaining[s]
+
+    wave_of = {s: i for i, wave in enumerate(waves, 1) for s in wave}
+
+    collisions: List[dict] = []
+    for i, wave in enumerate(waves, 1):
+        for a in range(len(wave)):
+            for b in range(a + 1, len(wave)):
+                shared = sorted(
+                    set(slices[wave[a]]["files"]) & set(slices[wave[b]]["files"])
+                )
+                for f in shared:
+                    collisions.append(
+                        {"wave": i, "slices": [wave[a], wave[b]], "file": f}
+                    )
+
+    return {
+        "schema": "plan-waves/v1",
+        "waves": waves,
+        "slices": {
+            sid: {
+                "depends_on": slices[sid]["deps"],
+                "files": slices[sid]["files"],
+                "wave": wave_of[sid],
+            }
+            for sid in order
+        },
+        "collisions": collisions,
+    }
+
+
+def main(argv: List[str] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="plan_waves.py",
+        description="Compute parallel build waves from a plan's slice DAG.",
+    )
+    parser.add_argument("plan", nargs="?", help="Path to the plan markdown file")
+    args = parser.parse_args(argv)
+    if not args.plan:
+        sys.stderr.write("usage: plan-waves.sh <plan.md>\n")
+        return 2
+    plan_path = Path(args.plan)
+    if not plan_path.is_file():
+        sys.stderr.write("usage: plan-waves.sh <plan.md>\n")
+        return 2
+    payload = compute_waves(plan_path)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/tests/scripts/test_plan_waves.py
+++ b/plugins/dev-team/tests/scripts/test_plan_waves.py
@@ -1,0 +1,146 @@
+"""Unit + byte-parity tests for scripts/plan_waves.py (#589).
+
+Follows the same pattern as test_plan_parse.py: a small number of API-level
+behavioural cases plus a parametrized byte-parity comparison against
+`plan-waves.sh` for every fixture under `tests/fixtures/plans/`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import plan_waves  # noqa: E402
+
+
+_PLAN_WAVES_SH = _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "plan-waves.sh"
+_PLAN_WAVES_PY = _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "plan_waves.py"
+_FIXTURES_DIR = _REPO_ROOT / "tests" / "fixtures" / "plans"
+
+
+# ---------------------------------------------------------------------------
+# API-level behavioural tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_waves_returns_schema(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `a.ts`\n"
+        "### Slice B: beta\n"
+        "**Depends-on:** A\n"
+        "**Files:** `b.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["schema"] == "plan-waves/v1"
+    assert payload["waves"] == [["A"], ["B"]]
+    assert payload["slices"]["A"]["wave"] == 1
+    assert payload["slices"]["B"]["depends_on"] == ["A"]
+
+
+def test_compute_waves_flags_collisions(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `shared.ts`\n"
+        "### Slice B: beta\n"
+        "**Depends-on:** none\n"
+        "**Files:** `shared.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["collisions"] == [
+        {"wave": 1, "slices": ["A", "B"], "file": "shared.ts"}
+    ]
+
+
+def test_compute_waves_rejects_missing_depends(tmp_path, capsys):
+    plan = tmp_path / "plan.md"
+    plan.write_text("### Slice A: alpha\n**Files:** `a.ts`\n")
+    with pytest.raises(SystemExit) as excinfo:
+        plan_waves.compute_waves(plan)
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "missing its Depends-on declaration" in err
+
+
+def test_compute_waves_rejects_unknown_reference(tmp_path, capsys):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n**Depends-on:** none\n"
+        "### Slice B: beta\n**Depends-on:** Z\n"
+    )
+    with pytest.raises(SystemExit):
+        plan_waves.compute_waves(plan)
+    err = capsys.readouterr().err
+    assert "depends on unknown slice" in err
+
+
+def test_compute_waves_rejects_cycle(tmp_path, capsys):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n**Depends-on:** B\n### Slice B: beta\n**Depends-on:** A\n"
+    )
+    with pytest.raises(SystemExit):
+        plan_waves.compute_waves(plan)
+    err = capsys.readouterr().err
+    assert "dependency cycle" in err
+
+
+def test_compute_waves_rejects_empty_plan(tmp_path, capsys):
+    plan = tmp_path / "plan.md"
+    plan.write_text("no slice headers here\n")
+    with pytest.raises(SystemExit):
+        plan_waves.compute_waves(plan)
+    err = capsys.readouterr().err
+    assert "no slices found" in err
+
+
+# ---------------------------------------------------------------------------
+# Byte-parity against plan-waves.sh
+# ---------------------------------------------------------------------------
+
+
+def _fixture_paths():
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(_FIXTURES_DIR.glob("*.md"))
+
+
+_FIXTURES = _fixture_paths()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required for parity")
+@pytest.mark.skipif(not _PLAN_WAVES_SH.is_file(), reason="plan-waves.sh not present")
+@pytest.mark.skipif(not _FIXTURES, reason="no plan fixtures present")
+@pytest.mark.parametrize("fixture", _FIXTURES, ids=lambda p: p.name)
+def test_byte_parity_with_bash(fixture: Path) -> None:
+    sh = subprocess.run(
+        ["bash", str(_PLAN_WAVES_SH), str(fixture)],
+        capture_output=True,
+        check=False,
+    )
+    py = subprocess.run(
+        [sys.executable, str(_PLAN_WAVES_PY), str(fixture)],
+        capture_output=True,
+        check=False,
+    )
+    assert sh.returncode == py.returncode
+    assert py.stdout == sh.stdout, (
+        f"stdout diverged on {fixture.name}\nsh: {sh.stdout!r}\npy: {py.stdout!r}"
+    )
+    # stderr is compared verbatim — plan-waves errors go there.
+    assert py.stderr == sh.stderr, (
+        f"stderr diverged on {fixture.name}\nsh: {sh.stderr!r}\npy: {py.stderr!r}"
+    )


### PR DESCRIPTION
Phase 2 Cluster E dependent of #572 — port `scripts/plan-waves.sh` (91 LOC) to Python. The `.sh` stays for one release cycle per the parallel-ship contract.

`scripts/lib/plan_parse.py` shipped in #572.E0 (merged as #627), so this port drops the awk/heredoc trampoline and calls `plan_parse.parse_slices` directly.

## What ships

- **`scripts/plan_waves.py`** — stdlib-only. `compute_waves(plan_path)` runs the Kahn layering, file-collision detection, and JSON assembly; CLI entry point mirrors bash. Emits identical `plan-waves/v1` JSON on stdout and identical error messages on stderr with exit code 2 for every rejection path (missing depends-on, unknown reference, cycle, empty plan).
- **`tests/scripts/test_plan_waves.py`** — 14 pytest cases:
  - **6 API-level behavioural tests** — schema shape, collision detection, missing-depends rejection, unknown-reference rejection, cycle rejection, empty-plan rejection.
  - **8 byte-parity cases** — parametrized over every fixture in `tests/fixtures/plans/`. Each dispatches both implementations and asserts `stdout` + `stderr` + exit code equal. Zero divergence.

## Verification

- `python3 -m pytest plugins/dev-team/tests/scripts/test_plan_waves.py` — **14/14 pass**.
- `bash scripts/ci-local.sh` — clean.

## Acceptance criteria (#589)

- [x] `.py` version ships alongside `.sh`.
- [x] Rewires to the Python `plan_parse` module (no more awk/heredoc trampoline).
- [x] Byte-parity for stdout + stderr + exit across every fixture in `tests/fixtures/plans/`.
- [x] `bash scripts/ci-local.sh` clean.
- [ ] Follow-up PR (one release cycle later) deletes `.sh` — deferred.

Closes #589
Refs #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)