### PR TITLE
chore(hooks): port mutation-gate to python (#572)

### DIFF
--- a/plugins/dev-team/hooks/mutation_gate.py
+++ b/plugins/dev-team/hooks/mutation_gate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""mutation_gate.py — PostToolUse hook (Python port of mutation-gate.sh).
+
+After each RED-to-GREEN test transition, runs mutation testing scoped to
+the affected test file and blocks tests that kill zero mutants.
+
+Output protocol (PostToolUse):
+  Blocking : `emit_block` JSON on stdout, exit 0.
+  Advisory : `emit_advisory` JSON on stdout, exit 0.
+  Silent   : no stdout, exit 0.
+
+Delegates to `hooks.mutation_adapters` for detection, dispatch, and per-
+adapter execution — the same Python library shipped in #572.D0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+_HOOK_DIR = Path(__file__).resolve().parent
+# Add the plugin hooks dir to sys.path so the mutation_adapters package resolves.
+sys.path.insert(0, str(_HOOK_DIR))
+
+from mutation_adapters import lib as adapter_lib  # noqa: E402
+from mutation_adapters import mutmut, pitest, stryker, stryker_net  # noqa: E402
+
+
+_JQ_MISSING_MESSAGE = (
+    "MUTATION GATE ADVISORY: jq is required but not installed. Run "
+    "/init-dev-team to install it, or: brew install jq (macOS) / apt install jq "
+    "(Linux) / winget install jqlang.jq (Windows)."
+)
+
+
+def _emit_advisory_pretty(message: str) -> None:
+    """Emit an advisory in bash `jq -n`'s pretty format (2-space indent + \\n).
+
+    `mutation-gate.sh` prints its advisories with `jq -n` so downstream Claude
+    Code output stays visually indented. This matches that shape byte-for-byte
+    for the paths the mutation-gate hook itself dispatches; the adapters still
+    print compact JSON (their internal `emit_advisory` returns compact),
+    tracked for the next release cycle when the settings-toggle flips
+    default to `.py`.
+    """
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": message,
+                }
+            },
+            indent=2,
+        )
+    )
+
+
+def _emit_block_pretty(reason: str) -> None:
+    print(json.dumps({"decision": "block", "reason": reason}, indent=2))
+
+
+def main() -> int:
+    # Hard dependency guards — mirror the bash order.
+    if shutil.which("jq") is None:
+        _emit_advisory_pretty(_JQ_MISSING_MESSAGE)
+        return 0
+    # python3 is by definition available here (we are python3), but if the
+    # bash sibling migrates a caller through the settings-toggle env var, the
+    # advisory would already have fired. Keep the branch for parity of the
+    # shape, harmlessly no-op.
+
+    if os.environ.get("MUTATION_GATE_SKIP") == "1":
+        return 0
+
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    command = ""
+    tool_input = payload.get("tool_input") or {}
+    if isinstance(tool_input, dict):
+        candidate = tool_input.get("command")
+        if isinstance(candidate, str):
+            command = candidate
+    if not command:
+        return 0
+
+    if not adapter_lib.is_test_command(command):
+        return 0
+
+    event_json = raw
+    current_result = adapter_lib.detect_result(event_json)
+
+    prev_state = adapter_lib.read_state()
+    prev_result = "none"
+    if prev_state:
+        try:
+            prev_result = json.loads(prev_state).get("result") or "none"
+        except (TypeError, ValueError):
+            prev_result = "none"
+
+    adapter_lib.write_state(current_result, event_json)
+
+    if not adapter_lib.is_red_to_green(prev_result, current_result):
+        return 0
+
+    adapter = adapter_lib.detect_adapter(command)
+    if adapter == "none":
+        _emit_advisory_pretty(
+            "MUTATION GATE ADVISORY: no mutation testing adapter for this "
+            "language. Run /init-dev-team to install one (supports JS/TS via "
+            "Stryker, Java via pitest, C# via Stryker.NET)."
+        )
+        return 0
+
+    zero_kills_dir = Path(os.environ.get("TMPDIR", "/tmp")) / "mutation-gate"
+    zero_kills_file = zero_kills_dir / "zero-kills.json"
+    zero_kills_dir.mkdir(parents=True, exist_ok=True)
+
+    os.environ["ADAPTER_TIMEOUT"] = os.environ.get("MUTATION_GATE_TIMEOUT", "60")
+    os.environ["ADAPTER_COMMAND"] = command
+
+    runner_stdout = ""
+    if prev_state:
+        try:
+            runner_stdout = json.loads(prev_state).get("runner_stdout") or ""
+        except (TypeError, ValueError):
+            runner_stdout = ""
+    os.environ["ADAPTER_RUNNER_STDOUT"] = runner_stdout
+
+    if adapter == "stryker":
+        if not stryker.stryker_detect():
+            return 0
+        # bash derives ADAPTER_SOURCE_FILE from the last word of the command.
+        last_arg = command.rsplit(" ", 1)[-1] if command else ""
+        source_file = stryker.derive_source_file(last_arg) if last_arg else ""
+        os.environ["ADAPTER_SOURCE_FILE"] = source_file
+        stryker.stryker_run(zero_kills_file)
+    elif adapter == "pitest":
+        if not pitest.pitest_detect():
+            return 0
+        pitest.pitest_run(zero_kills_file)
+    elif adapter == "stryker-net":
+        if not stryker_net.stryker_net_detect():
+            return 0
+        stryker_net.stryker_net_run(zero_kills_file)
+    elif adapter == "mutmut":
+        if not mutmut.mutmut_detect():
+            return 0
+        mutmut.mutmut_run(zero_kills_file)
+
+    # Emit block if zero-kill tests found.
+    if zero_kills_file.is_file():
+        try:
+            data = json.loads(zero_kills_file.read_text())
+        except (OSError, ValueError):
+            data = []
+        if isinstance(data, list) and data:
+            reason = adapter_lib.format_blocking_reason(zero_kills_file, command)
+            _emit_block_pretty(reason)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/malformed_stdin_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/malformed_stdin_silent/stdin.json
@@ -1,0 +1,1 @@
+not-json

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/non_test_command_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/non_test_command_silent/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_input": { "command": "npm run build" } }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/red_first_touch_no_transition/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/red_first_touch_no_transition/stdin.json
@@ -1,0 +1,4 @@
+{
+  "tool_input": { "command": "npm test" },
+  "tool_response": { "exit_code": 1, "output": "1 failing" }
+}

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/skip_env_silent/env.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/skip_env_silent/env.json
@@ -1,0 +1,1 @@
+{ "MUTATION_GATE_SKIP": "1" }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/skip_env_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/skip_env_silent/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_input": { "command": "npm test" }, "tool_response": { "exit_code": 0 } }

--- a/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/windows_command_silent/stdin.json
+++ b/plugins/dev-team/tests/hooks/parity/fixtures/mutation_gate/windows_command_silent/stdin.json
@@ -1,0 +1,1 @@
+{ "tool_input": { "command": "C:\\Users\\dev\\build.bat" } }

--- a/plugins/dev-team/tests/hooks/parity/test_mutation_gate_parity.py
+++ b/plugins/dev-team/tests/hooks/parity/test_mutation_gate_parity.py
@@ -1,0 +1,88 @@
+"""Parity fixtures for hooks/mutation-gate (#588 / #572 Phase 2 D1).
+
+Six fixtures span the fast-path branches the hook itself dispatches — the
+paths that never reach the per-adapter modules. The adapter-invocation paths
+(stryker/pitest/etc. running real mutation tools) are covered by the
+Cluster D unit tests in `tests/hooks/test_mutation_adapters_lib.py` and by
+manual smoke runs in real projects; the parity harness does NOT reproduce
+the mutation-tool subprocess trees because they take minutes and touch the
+real filesystem.
+
+  empty_stdin_silent               — empty body → exit 0 silent.
+  malformed_stdin_silent           — invalid JSON → exit 0 silent.
+  non_test_command_silent          — `npm run build` → is_test_command false.
+  skip_env_silent                  — MUTATION_GATE_SKIP=1 → exit 0 silent.
+  red_first_touch_no_transition    — failing test with no prior state → no
+                                     RED→GREEN transition → exit 0 silent
+                                     (state file gets written, and hashes
+                                     match because the state format is jq-
+                                     parity across implementations).
+  windows_command_silent           — Windows batch path → is_test_command
+                                     false → exit 0 silent.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from parity import Fixture, assert_parity  # type: ignore[import-not-found]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_HOOK_SH = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "mutation-gate.sh"
+_HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "mutation_gate.py"
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "mutation_gate"
+
+
+def _load_fixture(dirpath: Path) -> Fixture:
+    stdin_path = dirpath / "stdin.json"
+    stdin_bytes = stdin_path.read_bytes() if stdin_path.is_file() else b""
+    env_path = dirpath / "env.json"
+    env: Dict[str, str] = {}
+    if env_path.is_file():
+        env = {k: str(v) for k, v in json.loads(env_path.read_text()).items()}
+    initial_tree: Dict[str, str] = {}
+    tree_root = dirpath / "initial_tree"
+    if tree_root.is_dir():
+        for path in tree_root.rglob("*"):
+            if path.is_file():
+                rel = str(path.relative_to(tree_root))
+                initial_tree[rel] = path.read_text()
+    return Fixture(
+        name=dirpath.name,
+        stdin=stdin_bytes,
+        argv=[],
+        env=env,
+        initial_tree=initial_tree,
+    )
+
+
+def _discover_fixtures() -> List[Path]:
+    if not _FIXTURES_DIR.is_dir():
+        return []
+    return sorted(p for p in _FIXTURES_DIR.iterdir() if p.is_dir())
+
+
+_FIXTURE_DIRS = _discover_fixtures()
+
+
+@pytest.mark.skipif(
+    not _HOOK_SH.is_file() or not _HOOK_PY.is_file(),
+    reason="both .sh and .py implementations required",
+)
+@pytest.mark.skipif(not _FIXTURE_DIRS, reason="no fixture directories present")
+@pytest.mark.parametrize("fixture_dir", _FIXTURE_DIRS, ids=lambda p: p.name)
+def test_parity(fixture_dir: Path) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq required by the .sh")
+    fixture = _load_fixture(fixture_dir)
+    assert_parity(
+        sh_argv=["bash", str(_HOOK_SH)],
+        py_argv=["python3", str(_HOOK_PY)],
+        fixture=fixture,
+    )

--- a/plugins/dev-team/tests/hooks/test_mutation_gate.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_gate.py
@@ -1,0 +1,186 @@
+"""Unit tests for hooks/mutation_gate.py (#588 / #572 Phase 2 D1).
+
+Focus on the hook's dispatch logic — the branches that decide whether to
+invoke an adapter. The adapter-level behaviours are covered in
+`tests/hooks/test_mutation_adapters_lib.py` (Cluster D unit tests).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
+
+import mutation_gate  # noqa: E402
+
+
+def _feed(monkeypatch, text: str) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(text))
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_tmpdir(monkeypatch, tmp_path):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MUTATION_GATE_SKIP", raising=False)
+    monkeypatch.delenv("MUTATION_GATE_TIMEOUT", raising=False)
+
+
+def test_main_returns_zero_on_empty_stdin(monkeypatch):
+    _feed(monkeypatch, "")
+    assert mutation_gate.main() == 0
+
+
+def test_main_returns_zero_on_malformed_stdin(monkeypatch):
+    _feed(monkeypatch, "not-json")
+    assert mutation_gate.main() == 0
+
+
+def test_main_returns_zero_when_command_missing(monkeypatch):
+    _feed(monkeypatch, "{}")
+    assert mutation_gate.main() == 0
+
+
+def test_main_returns_zero_when_skip_env(monkeypatch):
+    monkeypatch.setenv("MUTATION_GATE_SKIP", "1")
+    _feed(monkeypatch, '{"tool_input":{"command":"npm test"}}')
+    assert mutation_gate.main() == 0
+
+
+def test_main_returns_zero_on_non_test_command(monkeypatch):
+    _feed(monkeypatch, '{"tool_input":{"command":"npm run build"}}')
+    assert mutation_gate.main() == 0
+
+
+def test_main_records_result_but_no_transition_on_first_red(monkeypatch, tmp_path):
+    # No prior state — a fail on first touch cannot be a RED→GREEN transition.
+    payload = json.dumps(
+        {
+            "tool_input": {"command": "npm test"},
+            "tool_response": {"exit_code": 1, "output": "1 failing"},
+        }
+    )
+    _feed(monkeypatch, payload)
+    assert mutation_gate.main() == 0
+    # State file created under the mocked TMPDIR.
+    state_files = list((tmp_path / "mutation-gate").glob("session-*"))
+    assert state_files, "expected a state file to be recorded"
+    payload = json.loads(state_files[0].read_text())
+    assert payload["result"] == "fail"
+
+
+def test_main_transitions_dispatches_and_emits_no_block_when_zero_kills_empty(
+    monkeypatch, tmp_path, capsys
+):
+    from mutation_adapters import lib as adapter_lib
+
+    # Seed a prior RED state so this run is a RED→GREEN transition.
+    adapter_lib.write_state(
+        "fail",
+        json.dumps({"tool_response": {"exit_code": 1, "output": "1 failing"}}),
+    )
+
+    # Stub the adapter dispatch — pretend Stryker was detected but produced
+    # an empty zero-kill list (all mutants killed). No block should emit.
+    def fake_detect():
+        return True
+
+    def fake_run(output_path):
+        Path(output_path).write_text("[]")
+        return 0
+
+    monkeypatch.setattr(mutation_gate.stryker, "stryker_detect", fake_detect)
+    monkeypatch.setattr(mutation_gate.stryker, "stryker_run", fake_run)
+
+    _feed(
+        monkeypatch,
+        json.dumps(
+            {
+                "tool_input": {"command": "npm test"},
+                "tool_response": {"exit_code": 0, "output": "5 passing"},
+            }
+        ),
+    )
+    assert mutation_gate.main() == 0
+    out = capsys.readouterr().out
+    assert "decision" not in out  # no block emitted
+
+
+def test_main_emits_block_when_zero_kills_present(monkeypatch, capsys):
+    from mutation_adapters import lib as adapter_lib
+
+    adapter_lib.write_state(
+        "fail",
+        json.dumps({"tool_response": {"exit_code": 1, "output": "1 failing"}}),
+    )
+
+    def fake_detect():
+        return True
+
+    def fake_run(output_path):
+        Path(output_path).write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "flakyTest",
+                        "file": "src/calc.ts",
+                        "line": 10,
+                        "covered": 3,
+                    }
+                ]
+            )
+        )
+        return 0
+
+    monkeypatch.setattr(mutation_gate.stryker, "stryker_detect", fake_detect)
+    monkeypatch.setattr(mutation_gate.stryker, "stryker_run", fake_run)
+
+    _feed(
+        monkeypatch,
+        json.dumps(
+            {
+                "tool_input": {"command": "npm test"},
+                "tool_response": {"exit_code": 0, "output": "5 passing"},
+            }
+        ),
+    )
+    assert mutation_gate.main() == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["decision"] == "block"
+    assert "MUTATION GATE BLOCKED" in payload["reason"]
+    assert "flakyTest" in payload["reason"]
+
+
+def test_main_emits_no_adapter_advisory(monkeypatch, capsys):
+    from mutation_adapters import lib as adapter_lib
+
+    adapter_lib.write_state(
+        "fail",
+        json.dumps({"tool_response": {"exit_code": 1, "output": "1 failing"}}),
+    )
+    _feed(
+        monkeypatch,
+        json.dumps(
+            {
+                "tool_input": {"command": "go test ./..."},
+                "tool_response": {"exit_code": 0, "output": "ok"},
+            }
+        ),
+    )
+    assert mutation_gate.main() == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert (
+        "no mutation testing adapter"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )


### PR DESCRIPTION
Phase 2 Cluster D dependent of #572 — port `hooks/mutation-gate.sh` (128 LOC) to Python. The `.sh` stays for one release cycle per the parallel-ship contract.

Rewires to the Python `mutation_adapters` package shipped in #572.D0 (#625): `mutation_adapters.lib` for state / detection / dispatch, and per-adapter `stryker.stryker_run` / `pitest.pitest_run` / `stryker_net.stryker_net_run` / `mutmut.mutmut_run` for the actual mutation-tool invocation.

## What ships

- **`hooks/mutation_gate.py`** — stdlib-only PostToolUse hook. Preserves the bash decision tree exactly: hard-dep guards (jq → advisory), skip env (`MUTATION_GATE_SKIP=1`), test-command fast-path, RED→GREEN transition detection, per-language adapter dispatch, block-when-zero-kills emission. Advisory + block JSON emitted with `jq -n`-style 2-space indent to match bash byte-for-byte on the hook's own outputs.
- **`tests/hooks/test_mutation_gate.py`** — 9 pytest cases: empty/malformed stdin, missing command, `MUTATION_GATE_SKIP=1`, non-test command, first-touch RED records state but doesn't transition, RED→GREEN with zero-kills empty emits nothing, RED→GREEN with zero-kills present emits a block referencing the finding, no-adapter language emits the "no adapter" advisory.
- **`tests/hooks/parity/fixtures/mutation_gate/`** — 6 parity fixtures for the hook's own dispatch paths. The mutation-tool invocation paths (real stryker/pitest) are NOT covered by the parity harness — they take minutes and touch real disk; per-adapter parity is validated separately in `tests/hooks/test_mutation_adapters_lib.py` (Cluster D unit tests).
- **`tests/hooks/parity/test_mutation_gate_parity.py`** — parametrized parity module.

## Verification

- `python3 -m pytest plugins/dev-team/tests/hooks/test_mutation_gate.py plugins/dev-team/tests/hooks/parity/test_mutation_gate_parity.py` — **15/15 pass** (9 unit + 6 parity).
- `bash scripts/ci-local.sh` — clean.

## Acceptance criteria (#588)

- [x] `.py` version ships alongside `.sh`, rewired to the Python `mutation_adapters` package.
- [x] Parity harness green for the hook's own dispatch paths (empty/malformed stdin, non-test command, skip env, first-touch RED, Windows path).
- [x] pytest coverage on the adapter-dispatch decision tree (RED→GREEN empty kill list, RED→GREEN with block, no-adapter advisory).
- [x] `bash scripts/ci-local.sh` clean.
- [ ] Follow-up PR (one release cycle later) flips default to `.py` and deletes `.sh` — deferred; adapter internal JSON compact/pretty divergence will be resolved then.

Closes #588
Refs #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)