### PR TITLE
feat(skills): python port of collect-domain-signals (#572 Phase 3)

### DIFF
--- a/plugins/dev-team/skills/ubiquitous-language/scripts/collect_domain_signals.py
+++ b/plugins/dev-team/skills/ubiquitous-language/scripts/collect_domain_signals.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Python port of collect-domain-signals.sh (#617 / #572 Phase 3).
+
+Gathers grep-based domain signals for the ubiquitous-language skill.
+
+Deliberate divergence from the .sh: the shipped
+`collect-domain-signals.sh` runs under `set -euo pipefail`, and every
+section is a `{ safe_grep ... } | grep -v ... | sed ... | sort -u` pipe.
+When any intermediate grep matches nothing (the common case for a real
+project — e.g. no Java code), the pipe returns non-zero → pipefail →
+`set -e` aborts. The script therefore stops after the first section, so
+only `class-names.txt` is ever written in practice.
+
+The .sh has zero bats coverage, so nothing tests (or depends on) the
+broken early-exit. This port implements the six-section contract the
+script's docstring + the ubiquitous-language SKILL.md both describe:
+class names, enum values, domain events, BDD names, validator rules,
+interface names — every section always runs and writes its file.
+
+Usage: python3 collect_domain_signals.py [source-root]
+
+Output: .plans/raw/domain-language/{class-names,enum-values,domain-events,
+        bdd-names,validator-rules,interface-names}.txt
+
+Uses `grep -rn --include=<glob> <pattern> -- <root>` under the hood (subprocess)
+because reproducing bash grep -r's file walk + include semantics natively in
+Python would drift on Windows line-endings and locale collation. The .sh is
+authoritative; this port dispatches the same greps so both sides find the same
+matches. Additional filtering + regex substitution is done in-process.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+
+def _safe_grep(glob: str, pattern: str, root: str) -> List[str]:
+    """`grep -rnE --include=<glob> <pattern> -- <root>`, silencing errors.
+
+    The .sh runs plain `grep -rn`, which uses BRE and treats the ERE
+    metachars in the shipped patterns (`(...|...)`, `[A-Z]+`) as
+    literals — so the shipped .sh finds nothing and writes empty files
+    on every real project. The port fixes this by using ERE (`grep -E`);
+    the SKILL.md intent is a working signal collector, not a broken
+    stub.
+    """
+    try:
+        r = subprocess.run(
+            ["grep", "-rnE", f"--include={glob}", pattern, "--", root],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return []
+    if r.returncode not in (0, 1):
+        # 0 = matches; 1 = no match; anything else is unexpected — treat as
+        # no matches (the .sh does `|| true`).
+        return []
+    return [line for line in r.stdout.splitlines() if line]
+
+
+def _sort_unique(lines: Iterable[str]) -> List[str]:
+    return sorted(set(lines))
+
+
+def _write_lines(path: Path, lines: List[str]) -> None:
+    path.write_text("".join(f"{line}\n" for line in lines))
+
+
+# Repeated exclusion list from the .sh's `grep -v` chain.
+_CLASS_EXCLUDES = re.compile(
+    r"Test|Spec|Mock|Fake|Stub|Builder|Factory|Repository|Controller|Handler"
+    r"|Middleware|Config|Settings|Helper|Util|Base|Abstract|Migration"
+)
+
+_INTERFACE_EXCLUDES = re.compile(
+    r"Repository|Controller|Handler|Middleware|Factory|Builder|Config"
+    r"|Logger|Cache|Queue|Bus|Mapper|Serializer|Parser"
+)
+
+# The .sh chains four `sed` substitutions to pull just the identifier out
+# of a matched line. Each one strips everything up to a keyword then keeps
+# only the [A-Z][a-zA-Z]* run and the trailing junk.
+_NAME_EXTRACT_PATTERNS = [
+    re.compile(r".*class ([A-Z][a-zA-Z]*).*"),
+    re.compile(r".*interface ([A-Z][a-zA-Z]*).*"),
+    re.compile(r".*struct ([A-Z][a-zA-Z]*).*"),
+    re.compile(r".*record ([A-Z][a-zA-Z]*).*"),
+]
+
+
+def _extract_name(line: str) -> str:
+    for pattern in _NAME_EXTRACT_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            return m.group(1)
+    return line
+
+
+def collect_class_names(root: str, out_dir: Path) -> int:
+    print("  → class names...")
+    raw: List[str] = []
+    raw.extend(_safe_grep("*.ts", "^export (abstract )?class [A-Z][a-zA-Z]+", root))
+    raw.extend(_safe_grep("*.ts", "^export (abstract )?interface [A-Z][a-zA-Z]+", root))
+    raw.extend(
+        _safe_grep(
+            "*.cs",
+            r"^[[:space:]]*(public|internal|sealed|abstract) (partial )?"
+            r"(class|record|struct) [A-Z][a-zA-Z]+",
+            root,
+        )
+    )
+    raw.extend(
+        _safe_grep(
+            "*.java",
+            "^public (abstract |final )?(class|interface|enum|record) [A-Z][a-zA-Z]+",
+            root,
+        )
+    )
+    raw.extend(_safe_grep("*.py", "^class [A-Z][a-zA-Z]+", root))
+    raw.extend(_safe_grep("*.go", "^type [A-Z][a-zA-Z]+ struct", root))
+    raw.extend(_safe_grep("*.go", "^type [A-Z][a-zA-Z]+ interface", root))
+    raw.extend(_safe_grep("*.rb", "^class [A-Z][a-zA-Z]+", root))
+
+    filtered = [line for line in raw if not _CLASS_EXCLUDES.search(line)]
+    names = [_extract_name(line) for line in filtered]
+    unique = _sort_unique(names)
+    _write_lines(out_dir / "class-names.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+def collect_enum_values(root: str, out_dir: Path) -> int:
+    print("  → enum values...")
+    raw: List[str] = []
+    raw.extend(_safe_grep("*.ts", "^export (const )?enum [A-Z]", root))
+    raw.extend(_safe_grep("*.cs", r"^[[:space:]]*(public|internal) enum [A-Z]", root))
+    raw.extend(_safe_grep("*.java", "^public enum [A-Z]", root))
+    raw.extend(
+        _safe_grep("*.py", r"class [A-Z][a-zA-Z]*(Enum|Status|Type|State)\b", root)
+    )
+    raw.extend(_safe_grep("*.go", "// [A-Z][a-zA-Z]+ (is|represents|indicates)", root))
+    unique = _sort_unique(raw)
+    _write_lines(out_dir / "enum-values.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+_EVENT_SUFFIXES = (
+    "Created|Updated|Submitted|Approved|Cancelled|Rejected|Completed|Failed"
+    "|Requested|Issued|Revoked|Expired|Activated|Deactivated|Shipped"
+    "|Delivered|Refunded|Disputed"
+)
+
+
+def collect_domain_events(root: str, out_dir: Path) -> int:
+    print("  → domain events...")
+    raw: List[str] = []
+    raw.extend(_safe_grep("*.ts", f"class [A-Z][a-zA-Z]*({_EVENT_SUFFIXES})", root))
+    raw.extend(_safe_grep("*.cs", f"class [A-Z][a-zA-Z]*({_EVENT_SUFFIXES})", root))
+    raw.extend(_safe_grep("*.java", f"class [A-Z][a-zA-Z]*({_EVENT_SUFFIXES})", root))
+    raw.extend(
+        _safe_grep("*.go", f"type [A-Z][a-zA-Z]*({_EVENT_SUFFIXES}) struct", root)
+    )
+
+    event_class = re.compile(r".*class ([A-Z][a-zA-Z]*).*")
+    event_type = re.compile(r".*type ([A-Z][a-zA-Z]*) struct.*")
+    names = []
+    for line in raw:
+        m = event_class.match(line) or event_type.match(line)
+        names.append(m.group(1) if m else line)
+
+    unique = _sort_unique(names)
+    _write_lines(out_dir / "domain-events.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+def collect_bdd_names(root: str, out_dir: Path) -> int:
+    print("  → BDD names...")
+    raw: List[str] = []
+    # Gherkin keywords: `Scenario:`, `Given x`, `When y`, etc. — the
+    # trailing char after the keyword is either whitespace or `:` (for
+    # `Scenario` outlines / `Feature`). The .sh required trailing `\s`,
+    # which never matches `Scenario:` — another bug we fix here.
+    raw.extend(
+        _safe_grep(
+            "*.feature",
+            r"^[[:space:]]*(Scenario|Given|When|Then|And)([[:space:]]|:)",
+            root,
+        )
+    )
+    raw.extend(_safe_grep("*.ts", "it\\(['\"].*['\"]", root))
+    raw.extend(_safe_grep("*.ts", "describe\\(['\"].*['\"]", root))
+    raw.extend(
+        _safe_grep("*.cs", r"\[Fact\]|public void (Given|When|Then|Should)[A-Z]", root)
+    )
+    raw.extend(
+        _safe_grep("*.java", r"@Test.*\n.*void (given|when|then|should)[A-Z]", root)
+    )
+    unique = _sort_unique(raw)
+    _write_lines(out_dir / "bdd-names.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+def collect_validator_rules(root: str, out_dir: Path) -> int:
+    print("  → validator rules...")
+    raw: List[str] = []
+    # ERE alternation (matches grep -E): raw `|` is the alternation
+    # operator, not the escaped BRE `\|` the .sh has (which grep -E treats
+    # as a literal `|` character).
+    raw.extend(
+        _safe_grep(
+            "*.ts",
+            r"\.withMessage|\.mustBe|\.isRequired|z\.string\(\)\.refine|yup\.",
+            root,
+        )
+    )
+    raw.extend(
+        _safe_grep("*.cs", r"RuleFor|\.Must|\.WithMessage|\.NotNull|\.NotEmpty", root)
+    )
+    raw.extend(
+        _safe_grep(
+            "*.java",
+            r"@NotNull|@NotBlank|@Size|@Min|@Max|@Pattern|@Valid|@Constraint",
+            root,
+        )
+    )
+    raw.extend(
+        _safe_grep("*.py", r"raise ValueError|raise TypeError|assert .*, ['\"]", root)
+    )
+    unique = _sort_unique(raw)
+    _write_lines(out_dir / "validator-rules.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+def collect_interface_names(root: str, out_dir: Path) -> int:
+    print("  → interface names...")
+    raw: List[str] = []
+    raw.extend(_safe_grep("*.ts", "^export interface [A-Z][a-zA-Z]+", root))
+    raw.extend(
+        _safe_grep(
+            "*.cs",
+            r"^[[:space:]]*(public|internal) interface I[A-Z][a-zA-Z]+",
+            root,
+        )
+    )
+    raw.extend(_safe_grep("*.java", "^public interface [A-Z][a-zA-Z]+", root))
+    raw.extend(_safe_grep("*.go", "type [A-Z][a-zA-Z]+ interface", root))
+
+    filtered = [line for line in raw if not _INTERFACE_EXCLUDES.search(line)]
+    iface_extract = re.compile(r".*interface (I?)([A-Z][a-zA-Z]*).*")
+    names = []
+    for line in filtered:
+        m = iface_extract.match(line)
+        names.append(m.group(2) if m else line)
+
+    unique = _sort_unique(names)
+    _write_lines(out_dir / "interface-names.txt", unique)
+    print(f"    {len(unique)} candidates")
+    return len(unique)
+
+
+def main(argv: list) -> int:
+    root = argv[1] if len(argv) > 1 else "."
+    out_dir = Path(".plans/raw/domain-language")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Collecting domain signals from: {root}")
+
+    collect_class_names(root, out_dir)
+    collect_enum_values(root, out_dir)
+    collect_domain_events(root, out_dir)
+    collect_bdd_names(root, out_dir)
+    collect_validator_rules(root, out_dir)
+    collect_interface_names(root, out_dir)
+
+    print("")
+    print(f"Signal collection complete. Results in {out_dir}/")
+
+    # Total unique candidates across all txt files.
+    combined = set()
+    for txt in out_dir.glob("*.txt"):
+        combined.update(txt.read_text().splitlines())
+    combined.discard("")
+    print(f"Total raw candidates: {len(combined)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/skills/test_collect_domain_signals.py
+++ b/tests/skills/test_collect_domain_signals.py
@@ -1,0 +1,183 @@
+"""Pytest tests for collect_domain_signals.py (#617 / #572 Phase 3).
+
+The port INTENTIONALLY diverges from the .sh behavior: the shipped
+`collect-domain-signals.sh` aborts under `set -euo pipefail` after the
+first section whose intermediate grep chain finds no matches (an empty
+`grep -v` in the pipeline returns exit 1 → pipefail → set -e → exit).
+That leaves only `class-names.txt` written even on a real project.
+
+The Python port avoids that trap and produces all six output files.
+This is a conscious behavior fix — the .sh has zero bats coverage today,
+so nothing depends on the buggy early-exit behavior; the ubiquitous-
+language skill only ever wanted the full six-file signal set.
+
+These tests validate the intended contract: given a source tree with
+domain symbols, all six output files exist under
+`.plans/raw/domain-language/` and contain the expected candidates.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PY = (
+    _REPO_ROOT
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "ubiquitous-language"
+    / "scripts"
+    / "collect_domain_signals.py"
+)
+
+
+def _run(*, root: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT_PY), root],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "LANG": "C.UTF-8"},
+    )
+
+
+def _mk_project(tree: Path) -> None:
+    """Create a mini project with symbols the collector should find."""
+    src = tree / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "a.ts").write_text(
+        "export class Customer {}\n"
+        "export class Order {}\n"
+        "export class OrderCreated {}\n"
+        "export class OrderRepository {}\n"
+        "export interface PaymentGateway {}\n"
+        "export interface UserRepository {}\n"
+        "export enum Status { Active }\n"
+        "it('does the thing')\n"
+        "z.string().refine(x => x)\n"
+    )
+    (src / "a.py").write_text(
+        "class Foo:\n    pass\n"
+        "class BarStatus(Enum):\n    pass\n"
+        "raise ValueError('bad')\n"
+    )
+    (src / "a.feature").write_text("Scenario: Sample\n  Given something\n")
+
+
+def test_all_six_output_files_exist(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    r = _run(root=str(project), cwd=workdir)
+    assert r.returncode == 0, r.stderr
+    out = workdir / ".plans" / "raw" / "domain-language"
+    for name in (
+        "class-names.txt",
+        "enum-values.txt",
+        "domain-events.txt",
+        "bdd-names.txt",
+        "validator-rules.txt",
+        "interface-names.txt",
+    ):
+        assert (out / name).is_file(), f"missing {name}"
+
+
+def test_class_names_filters_excluded_terms(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    _run(root=str(project), cwd=workdir)
+    class_names = (workdir / ".plans/raw/domain-language/class-names.txt").read_text()
+    # Domain nouns are extracted:
+    assert "Customer" in class_names
+    assert "Order" in class_names
+    # Infrastructure-y names filtered out (contains "Repository"):
+    assert "OrderRepository" not in class_names
+    assert "UserRepository" not in class_names
+
+
+def test_domain_events_extracted(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    _run(root=str(project), cwd=workdir)
+    events = (workdir / ".plans/raw/domain-language/domain-events.txt").read_text()
+    assert "OrderCreated" in events
+
+
+def test_interface_names_filtered(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    _run(root=str(project), cwd=workdir)
+    ifaces = (workdir / ".plans/raw/domain-language/interface-names.txt").read_text()
+    assert "PaymentGateway" in ifaces
+    assert "UserRepository" not in ifaces
+
+
+def test_bdd_scenarios_captured(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    _run(root=str(project), cwd=workdir)
+    bdd = (workdir / ".plans/raw/domain-language/bdd-names.txt").read_text()
+    assert "Scenario: Sample" in bdd
+    assert "Given" in bdd or "it('does the thing')" in bdd
+
+
+def test_validator_rules_captured(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _mk_project(project)
+    _run(root=str(project), cwd=workdir)
+    vr = (workdir / ".plans/raw/domain-language/validator-rules.txt").read_text()
+    # The Python raise ValueError line should be captured.
+    assert "raise ValueError" in vr
+
+
+def test_empty_project_produces_empty_files(tmp_path: Path) -> None:
+    """The port avoids the .sh's set-e trap: even with zero matches, all
+    six output files exist (they will just be empty). This IS a divergence
+    from the .sh; the docstring / commit message call it out explicitly."""
+    empty = tmp_path / "empty_project"
+    empty.mkdir()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    r = _run(root=str(empty), cwd=workdir)
+    assert r.returncode == 0
+    for name in (
+        "class-names.txt",
+        "enum-values.txt",
+        "domain-events.txt",
+        "bdd-names.txt",
+        "validator-rules.txt",
+        "interface-names.txt",
+    ):
+        p = workdir / ".plans/raw/domain-language" / name
+        assert p.is_file()
+        assert p.read_text() == ""
+
+
+def test_defaults_to_cwd(tmp_path: Path) -> None:
+    project = tmp_path / "cwd_project"
+    _mk_project(project)
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT_PY)],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert (project / ".plans/raw/domain-language/class-names.txt").is_file()


### PR DESCRIPTION
## Summary

Phase 3 slice of the bash → Python migration (#572). Ships `plugins/dev-team/skills/ubiquitous-language/scripts/collect_domain_signals.py` alongside the existing `.sh`.

## Deliberate divergence — the .sh is broken

Investigation while porting showed the shipped `.sh` **has never worked** in any project:

1. Uses `grep -rn` (BRE) with ERE-style patterns like `(A|B)`, `[A-Z]+`, `\s`. macOS BSD grep treats those as literal characters, so every pattern matches nothing.
2. Runs under `set -euo pipefail`. Each section is a `grep | grep -v | sed | sort` pipeline. When the intermediate `grep -v` returns exit 1 (no matches to filter — the common case), `pipefail` propagates, `set -e` aborts, and the script exits after the first section leaving five output files unwritten.
3. Feature-file pattern `^\s*(Scenario|...)\s` — `Scenario:` (colon directly after) never matches the trailing `\s`, so BDD signals would be silently dropped even if item 1 were fixed.

The `.sh` has zero bats coverage; nothing depends on the broken behavior. The port implements the six-section contract the script's docstring + the ubiquitous-language SKILL.md describe:

- Switches to `grep -E` (ERE) so `(A|B|C)` alternation works.
- Uses `[[:space:]]` (portable POSIX) instead of `\s`.
- Every section always runs to completion regardless of intermediate grep results.
- Feature-file pattern accepts `:` or whitespace after the keyword so `Scenario:` matches.

Outputs remain identical in shape: six files under `.plans/raw/domain-language/`, sorted-unique, plus a summary line on stdout with total unique candidates.

## Tests

- `tests/skills/test_collect_domain_signals.py` — 8 pytest cases: all six output files always exist, class-name extraction filters the exclude list, domain events extracted from event-suffix patterns, interface names filtered to domain terms, BDD scenarios captured, validator rules captured, empty project produces empty files (not missing files — divergence from `.sh`), `--path` defaults to cwd.

**Parity harness skipped intentionally** — the `.sh` produces no meaningful output to compare against.

Closes #617
Refs #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)