### PR TITLE
feat(scripts): default Stryker.NET wrapper concurrency to cores-2 via --stryker-concurrency

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -233,10 +233,38 @@ CLI flags (all optional; every one accepts an environment-variable equivalent so
 | `--shim-project PATH` | `SHIM_PROJECT` | (empty; no shim) |
 | `--stryker-bin CMD` | `STRYKER_BIN` | `dotnet-stryker` |
 | `--logfile PATH` | `LOGFILE` | `StrykerOutput/wrapper.log` |
+| `--stryker-concurrency N` | `STRYKER_MUTANT_CONCURRENCY` | `max(1, cpu_count - 2)` (computed) |
 
 Everything after those flags forwards to Stryker unchanged.
 
 `DOTNET_ROOT` is auto-probed across the standard install locations on all supported platforms; a pre-set value is respected. When no SDK is found the wrapper exits 3 with an actionable message.
+
+### Concurrency default
+
+The wrapper defaults Stryker's own mutant-testing-process concurrency (its
+`-c`/`--concurrency` flag) to `max(1, cpu_count - 2)` instead of Stryker's
+flat default of 5, computed from `os.cpu_count()`. Override precedence,
+highest to lowest: a pass-through `-c`/`--concurrency` already present in
+the args forwarded to Stryker (explicit caller intent, never overridden) >
+the `--stryker-concurrency` CLI flag > the `STRYKER_MUTANT_CONCURRENCY`
+env var > the computed `cores - 2` default. When a pass-through value
+conflicts with an explicit `--stryker-concurrency`/env value, the wrapper
+logs a one-line note to stderr naming which pass-through value overrode
+which explicit value — the override is never silent.
+
+`--stryker-concurrency`/`STRYKER_MUTANT_CONCURRENCY` is deliberately **not**
+named `--concurrency`/`-c`: that spelling is reserved for (a) Stryker's own
+pass-through flag — registering `-c` as a wrapper-owned option would make it
+structurally impossible for a caller's pass-through `-c` to ever reach the
+"already present" detection above — and (b) `mutation-kill`'s own
+pre-existing `--concurrency` flag (worktree fan-out, a different dial at a
+different layer) despite the shared "cores − 2" heuristic.
+
+**CI/cgroup caveat:** `os.cpu_count()` reads the host/system core count, not
+a container's cgroup quota. On resource-capped CI runners this can compute a
+concurrency value higher than the container's actual allotment — pass an
+explicit `--stryker-concurrency` value (or set `STRYKER_MUTANT_CONCURRENCY`)
+rather than rely on the computed default in those environments.
 
 ## Incremental runs with `--since`
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -204,6 +204,16 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=os.environ.get("LOGFILE", "StrykerOutput/wrapper.log"),
         help="Log redirect target (default: %(default)s)",
     )
+    p.add_argument(
+        "--stryker-concurrency",
+        default=os.environ.get("STRYKER_MUTANT_CONCURRENCY"),
+        help=(
+            "Stryker's own mutant-testing-process concurrency (its -c/"
+            "--concurrency flag). Deliberately NOT -c/--concurrency here — "
+            "see csharp-stryker-net.md. Env equivalent: "
+            "STRYKER_MUTANT_CONCURRENCY. Default: max(1, cpu_count - 2)."
+        ),
+    )
     return p.parse_known_args(list(argv))[0], p.parse_known_args(list(argv))[1]
 
 
@@ -219,6 +229,18 @@ def default_concurrency(cpu_count: Optional[int]) -> int:
     computed default is still 1 (never 0 or negative).
     """
     return max(1, (cpu_count or 2) - 2)
+
+
+def _pass_through_concurrency_flag(stryker_args: Sequence[str]) -> Optional[str]:
+    """Return the pass-through concurrency flag (``-c`` or ``--concurrency``)
+    present in ``stryker_args``, or ``None``. Consolidates the "does the
+    caller already specify concurrency" check used by both the explicit-
+    value and computed-default injection paths.
+    """
+    for flag in ("-c", "--concurrency"):
+        if flag in stryker_args:
+            return flag
+    return None
 
 
 def build_project(project: str, cwd: Optional[Path] = None) -> int:
@@ -351,14 +373,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         # Hide .sln during the run.
         hide_sln(sln, sln_hidden)
 
-        # Inject a computed default `-c` (mutant-testing concurrency) unless
-        # the caller's pass-through args already specify one.
-        if "-c" not in stryker_args and "--concurrency" not in stryker_args:
-            stryker_args = [
-                *stryker_args,
-                "-c",
-                str(default_concurrency(os.cpu_count())),
-            ]
+        # Inject Stryker's own mutant-testing concurrency (`-c`) unless the
+        # caller's pass-through args already specify one — pass-through
+        # always wins over both an explicit --stryker-concurrency/env value
+        # and the computed default; never silently override an explicit
+        # caller-supplied value.
+        pass_through_flag = _pass_through_concurrency_flag(stryker_args)
+        if pass_through_flag is None:
+            if args.stryker_concurrency is not None:
+                value = str(args.stryker_concurrency)
+            else:
+                value = str(default_concurrency(os.cpu_count()))
+            stryker_args = [*stryker_args, "-c", value]
+        elif args.stryker_concurrency is not None:
+            idx = stryker_args.index(pass_through_flag)
+            pass_through_value = (
+                stryker_args[idx + 1] if idx + 1 < len(stryker_args) else ""
+            )
+            sys.stderr.write(
+                f'note: pass-through "{pass_through_flag} '
+                f'{pass_through_value}" overrode explicit '
+                f'"--stryker-concurrency {args.stryker_concurrency}"\n'
+            )
 
         # Run Stryker; capture its exit code.
         exit_code = run_stryker(

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -207,6 +207,20 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     return p.parse_known_args(list(argv))[0], p.parse_known_args(list(argv))[1]
 
 
+# =============================================================================
+# Concurrency default — Stryker's own `-c`/`--concurrency` mutant-testing-
+# process count. Defaults to cores-2 instead of Stryker's flat default of 5.
+# =============================================================================
+def default_concurrency(cpu_count: Optional[int]) -> int:
+    """Return ``max(1, (cpu_count or 2) - 2)``.
+
+    ``cpu_count`` is normally ``os.cpu_count()``, which returns ``None`` when
+    the machine's core count can't be determined — falls back to 2 so the
+    computed default is still 1 (never 0 or negative).
+    """
+    return max(1, (cpu_count or 2) - 2)
+
+
 def build_project(project: str, cwd: Optional[Path] = None) -> int:
     """Run ``dotnet build <project> -c Debug --nologo`` in the given cwd.
     Returns the subprocess exit code.
@@ -336,6 +350,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         # Hide .sln during the run.
         hide_sln(sln, sln_hidden)
+
+        # Inject a computed default `-c` (mutant-testing concurrency) unless
+        # the caller's pass-through args already specify one.
+        if "-c" not in stryker_args and "--concurrency" not in stryker_args:
+            stryker_args = [
+                *stryker_args,
+                "-c",
+                str(default_concurrency(os.cpu_count())),
+            ]
 
         # Run Stryker; capture its exit code.
         exit_code = run_stryker(

--- a/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -463,6 +463,48 @@ class TestMainContract:
 
 
 # =============================================================================
+# default_concurrency + injection — cores-2 default (#667, #681)
+# =============================================================================
+class TestConcurrencyDefault:
+    """Step 2.1: wrapper injects a computed default `-c` value unless the
+    caller already forwards one. See plans/mutation-kill-slice-loop-
+    refinements.md Slice 2.
+    """
+
+    def test_injects_computed_default_when_no_concurrency_present(
+        self, hermetic, monkeypatch
+    ):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic)
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "6"]
+
+    def test_does_not_override_existing_short_form_pass_through(
+        self, hermetic, monkeypatch
+    ):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic, "-c", "3")
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "3"]
+
+    def test_default_concurrency_falls_back_when_cpu_count_is_none(self):
+        assert wrapper.default_concurrency(None) == 1
+
+    def test_default_concurrency_computes_cores_minus_two(self):
+        assert wrapper.default_concurrency(8) == 6
+
+    def test_default_concurrency_floors_at_one(self):
+        assert wrapper.default_concurrency(2) == 1
+        assert wrapper.default_concurrency(1) == 1
+
+
+# =============================================================================
 # Signal handling — POSIX only
 # =============================================================================
 # Windows signal semantics differ fundamentally from POSIX:

--- a/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -505,6 +505,74 @@ class TestConcurrencyDefault:
 
 
 # =============================================================================
+# --stryker-concurrency / STRYKER_MUTANT_CONCURRENCY override (#667, #681)
+# =============================================================================
+class TestConcurrencyOverride:
+    """Step 2.2: explicit CLI flag / env var override the computed default,
+    with CLI winning over env, and pass-through always winning over both
+    (logging a one-line override note when it conflicts with an explicit
+    value). Deliberately NOT named `--concurrency`/`-c` — see the plan's
+    naming note (post-review-1 revision).
+    """
+
+    def test_explicit_stryker_concurrency_flag_is_forwarded(
+        self, hermetic, monkeypatch
+    ):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic, "--stryker-concurrency", "8")
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "8"]
+
+    def test_env_var_used_when_no_cli_flag(self, hermetic, monkeypatch):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        monkeypatch.setenv("STRYKER_MUTANT_CONCURRENCY", "6")
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic)
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "6"]
+
+    def test_cli_flag_wins_over_env_var(self, hermetic, monkeypatch):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        monkeypatch.setenv("STRYKER_MUTANT_CONCURRENCY", "6")
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic, "--stryker-concurrency", "8")
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "8"]
+
+    def test_does_not_override_existing_long_form_pass_through(
+        self, hermetic, monkeypatch
+    ):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic, "--concurrency", "3")
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["--concurrency", "3"]
+
+    def test_pass_through_wins_over_explicit_value_and_logs_override(
+        self, hermetic, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_wrapper(hermetic, "--stryker-concurrency", "8", "-c", "3")
+        assert rc == 0
+        strykers = [c for c in hermetic.calls if c["kind"] == "stryker"]
+        argv = strykers[0]["stryker_args"]
+        assert argv == ["-c", "3"]
+        captured = capsys.readouterr()
+        assert "-c 3" in captured.err
+        assert "--stryker-concurrency 8" in captured.err
+
+
+# =============================================================================
 # Signal handling — POSIX only
 # =============================================================================
 # Windows signal semantics differ fundamentally from POSIX:

--- a/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
+++ b/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# Doc-shape contract for issue #667 / #681 (plan: Slice 2 — Concurrency
+# default fix): plans/mutation-kill-slice-loop-refinements.md.
+#
+# Pattern mirrors tests/skills/mutation_testing_skill_doc_tests.bats — grep
+# guards against csharp-stryker-net.md's "Shipped wrapper" section. The
+# prose is the deliverable; these guards regress when the contract drifts.
+#
+# This file is the shared home for all four slices of the plan
+# (mutation-kill-slice-loop-refinements). Slice 2 (this PR) adds only the
+# concurrency-default doc-content test below; later slices append their own
+# tests here as those slices land.
+
+CSHARP="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md"
+
+# --- Slice 2 · AC-5: concurrency default documented in the C# reference ----
+
+@test "csharp-stryker-net.md documents the wrapper's concurrency default" {
+  run awk '
+    /^## Shipped wrapper/ { f=1 }
+    /^## / && !/^## Shipped wrapper/ && f { if (NR > 1) exit }
+    f { print }
+  ' "$CSHARP"
+  [ "$status" -eq 0 ]
+  section="$output"
+
+  # Wording near the CLI-flag table naming cores / cpu_count.
+  echo "$section" | grep -qE "cores|cpu_count"
+
+  # The flag name itself.
+  echo "$section" | grep -q -- "--stryker-concurrency"
+
+  # The env-var equivalent.
+  echo "$section" | grep -q "STRYKER_MUTANT_CONCURRENCY"
+
+  # A sentence distinguishing it from mutation-kill's own --concurrency
+  # (worktree fan-out).
+  echo "$section" | grep -q -- "--concurrency"
+  echo "$section" | grep -qi "worktree fan-out"
+
+  # The CI/cgroup caveat for os.cpu_count().
+  echo "$section" | grep -qi "cgroup"
+}


### PR DESCRIPTION
## Summary
- The Stryker.NET wrapper (`csharp_stryker_net_wrapper.py`) now defaults Stryker's own mutant-testing-process concurrency (`-c`/`--concurrency`) to `max(1, cpu_count - 2)` instead of Stryker's flat default of 5.
- Adds a wrapper-level `--stryker-concurrency` CLI flag with a `STRYKER_MUTANT_CONCURRENCY` env-var equivalent (CLI wins over env, env wins over the computed default). Deliberately **not** named `--concurrency`/`-c` — that spelling is reserved for Stryker's own pass-through flag (registering it as a wrapper-owned option would make a caller's pass-through `-c` structurally unreachable by the "already present" guard under `argparse.parse_known_args`) and for mutation-kill's own pre-existing `--concurrency` (worktree fan-out, a different dial).
- A pass-through `-c`/`--concurrency` already present in the caller's forwarded args always wins over both the explicit flag/env value and the computed default; when it conflicts with an explicit `--stryker-concurrency`/env value, the wrapper logs a one-line note to stderr naming the override so it's never silent.
- Documents the default, precedence, naming rationale, and the `os.cpu_count()` vs. CI-container-cgroup-quota caveat in `csharp-stryker-net.md`.

Implements Slice 2 ("Concurrency default fix") of `plans/mutation-kill-slice-loop-refinements.md` (parent issue #667).

Closes #681

## Quality Gate
- [x] Tests: 229 passed, 2 skipped (full `tests/` pytest suite)
- [x] New bats file (`mutation_kill_slice_loop_refinements_tests.bats`): 1 passed
- [x] Type check: n/a (no typed build step beyond pytest import-time checks)
- [x] Lint: `ruff check` on changed files shows only pre-existing unused-import warnings on `main` (unrelated to this change)
- [x] Semgrep: 0 findings on the wrapper script
- [x] Code review: pass — no actionable issues (see PR discussion)

## Test Plan
- [x] `python3 -m pytest tests/scripts/test_csharp_stryker_net_wrapper.py -q` — covers all 7 Gherkin scenarios in the plan (computed default, explicit flag, env var, CLI-wins-over-env, short-form pass-through guard, long-form pass-through guard, conflict+log-line override)
- [x] `bats tests/skills/mutation_kill_slice_loop_refinements_tests.bats` — doc-content contract for `csharp-stryker-net.md`
- [ ] CI checks pass