### PR TITLE
feat(agents): mutation-kill persists convergence history across --all invocations

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -281,6 +281,30 @@ above and move on.
 Never spend rounds trying to kill these — they inflate the round count and
 produce zero kills.
 
+## Convergence history across --all invocations
+
+After each file's per-file loop concludes during an `--all` run, write or update
+one entry for that file in `StrykerOutput/mutation-kill-convergence.json` (in the
+target repo, alongside the other `StrykerOutput/` artifacts):
+
+```json
+{ "file": "<path>", "status": "converged", "reason": null, "commit": "<sha>" }
+```
+
+Entry shape: `file` (path, matches the mutate-glob entry), `status`
+(`"converged"` or `"excluded"`), `reason` (string for `"excluded"`, `null` for
+`"converged"`), `commit` (the SHA of `HEAD` at the moment the entry is written).
+
+Two write triggers, each tied to an existing point in this file's own loop:
+
+- **Converged** — the [per-file loop](#loop-per-file)'s `survivors == 0` exit
+  (loop step 3) writes or updates the file's entry with `status: "converged"`,
+  `reason: null`, and the current commit SHA.
+- **Excluded** — a confirmed [infrastructure exclusion](#infrastructure-exclusion-detection-before-the-loop-starts)
+  or [structurally-unkillable exclusion](#structurally-unkillable-files) writes
+  or updates the file's entry with `status: "excluded"`, the same `reason` text
+  used in the `EXCLUDED <file> — <reason>` log line, and the current commit SHA.
+
 ## Parallelism
 
 With `--all`, run files in parallel via git worktrees (each shard gets its own

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -305,6 +305,51 @@ Two write triggers, each tied to an existing point in this file's own loop:
   or updates the file's entry with `status: "excluded"`, the same `reason` text
   used in the `EXCLUDED <file> — <reason>` log line, and the current commit SHA.
 
+### Reading convergence history: staleness check and glob-shrinking
+
+On a fresh `--all` invocation, read `StrykerOutput/mutation-kill-convergence.json`
+**before the baseline scan** (before [infrastructure exclusion
+detection](#infrastructure-exclusion-detection-before-the-loop-starts) runs). For
+each entry, compare its recorded `commit` against the file's current last-commit
+SHA (`git log -1 --format=%H -- <file>`):
+
+- **Still valid** (recorded `commit` == current last-commit SHA) — this holds
+  **identically for both `"converged"` and `"excluded"` entries**, regardless of
+  status: append `"!<file>"` to the baseline `--mutate` glob and skip the file in
+  the per-file loop entirely. Log one of:
+
+  ```
+  SKIPPED <file> — already converged at <sha>
+  SKIPPED <file> — excluded: <reason>
+  ```
+
+  (matching the existing `EXCLUDED <file> — <reason>` file-first log convention).
+  Only the log-line wording differs between the two statuses — the glob-shrinking
+  and skip behavior are identical.
+- **Stale** (recorded `commit` != current last-commit SHA) — the file changed
+  since it was recorded. Drop the stale entry and include the file in scope as
+  normal, exactly as if no entry existed.
+
+Once the baseline scan completes, print a run-level summary:
+
+```
+convergence: skipped N (already converged/excluded), testing M
+```
+
+This mirrors the existing `mutation-history.json` reuse rule in
+`quality-targets-converge/SKILL.md`, which requires the analogous summary line for
+the same reason: without that line, the reuse rule is invisible and the operator
+can't tell whether the convergence-history mechanism actually paid off.
+
+**Distinct from `--since`.** This mechanism is complementary to, not a
+replacement for, the existing `--since` incremental-run pattern (see
+[`csharp-stryker-net.md`](../skills/mutation-testing/references/languages/csharp-stryker-net.md#incremental-runs-with---since)).
+`--since` answers "did this source file change vs. a git ref," which cannot
+express "this file's mutant set already converged under `mutation-kill`" — a file
+can be unchanged since `main` yet never have been scoped by `mutation-kill` at
+all. Both mechanisms can narrow the same shard config's `mutate` glob
+simultaneously.
+
 ## Parallelism
 
 With `--all`, run files in parallel via git worktrees (each shard gets its own

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -337,7 +337,8 @@ convergence: skipped N (already converged/excluded), testing M
 ```
 
 This mirrors the existing `mutation-history.json` reuse rule in
-`quality-targets-converge/SKILL.md`, which requires the analogous summary line for
+[`quality-targets-converge/SKILL.md`](../skills/quality-targets-converge/SKILL.md),
+which requires the analogous summary line for
 the same reason: without that line, the reuse rule is invisible and the operator
 can't tell whether the convergence-history mechanism actually paid off.
 

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -314,13 +314,26 @@ DI wiring, exception handlers, and generated code produce mutations that no test
       "!**/*ExceptionFilter.cs",
       "!**/*ExceptionFormatter.cs",
       "!**/*LoggerService.cs",
-      "!**/*.Designer.cs"
+      "!**/*.Designer.cs",
+      "!**/Validators/AddressValidator.cs"
     ]
   }
 }
 ```
 
 Pairs with the mutation-kill agent's [infrastructure exclusion detection](../../../../agents/mutation-kill.md#infrastructure-exclusion-detection-before-the-loop-starts) — the agent flags candidates at baseline scan time; this template is what actually removes them from the mutation set.
+
+The last entry (`!**/Validators/AddressValidator.cs`) is a **convergence-derived**
+negation, not an infra-exclusion one — the mutation-kill agent's [convergence
+history](../../../../agents/mutation-kill.md#convergence-history-across---all-invocations)
+mechanism added it because that file already converged (or was excluded) at a
+recorded commit that still matches the file's current last-commit SHA. The two
+kinds of negation share the same `mutate` array but differ in permanence: the
+Startup/Program/Filter/etc. negations above are **permanent** (infrastructure
+never becomes testable by adding more tests), while convergence-derived
+negations like `AddressValidator.cs` are **re-checked on every `--all`
+invocation and can drop out** the moment the file's source changes — at that
+point the entry goes stale and the file re-enters scope automatically.
 
 ## Score formula and NoCoverage
 

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -278,6 +278,33 @@ def test_convergence_history_persisted_entry_shape_and_write_triggers(
     )
 
 
+def test_convergence_history_staleness_check_and_glob_shrinking_read_path(
+    text: str, flat: str
+) -> None:
+    """Slice 3, Step 3.2 (#682)."""
+    # Reads the convergence file before the baseline scan.
+    assert re.search(r"before the baseline scan", flat, re.IGNORECASE)
+    # Commit-SHA staleness check.
+    assert re.search(r"commit-SHA|last-commit SHA|git log -1", text, re.IGNORECASE)
+    assert re.search(r"stale", text, re.IGNORECASE)
+    # Glob-shrinking negation for both converged and excluded entries.
+    assert "!<file>" in text
+    assert re.search(
+        r"both.*converged.*excluded|converged.*and.*excluded.*shrink|"
+        r"regardless of.*status",
+        flat,
+        re.IGNORECASE,
+    )
+    # The SKIPPED log-line pair.
+    assert "SKIPPED <file> — already converged at" in text
+    assert "SKIPPED <file> — excluded:" in text
+    # Run-level summary line.
+    assert re.search(r"convergence: skipped", text, re.IGNORECASE)
+    # --since differentiation sentence.
+    assert re.search(r"--since", text)
+    assert re.search(r"complementary", flat, re.IGNORECASE)
+
+
 def test_registered_in_agent_registry() -> None:
     registry_text = REGISTRY.read_text(encoding="utf-8")
     assert "agents/mutation-kill.md" in registry_text

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -253,6 +253,31 @@ def test_go_runs_advisory_logs_does_not_commit(text: str) -> None:
     )
 
 
+def test_convergence_history_persisted_entry_shape_and_write_triggers(
+    text: str, flat: str
+) -> None:
+    """Slice 3, Step 3.1 (#682)."""
+    # Persisted file path.
+    assert re.search(r"mutation-kill-convergence\.json", text)
+    # Entry shape fields.
+    assert '"file"' in text
+    assert '"status"' in text
+    assert '"reason"' in text
+    assert '"commit"' in text
+    # Both write triggers: converged (survivors == 0) and excluded.
+    assert re.search(
+        r"survivors *== *0.*(write|record|entry)|"
+        r"(write|record|entry).*survivors *== *0",
+        flat,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"excluded.*(write|record|entry)|(write|record|entry).*excluded",
+        flat,
+        re.IGNORECASE,
+    )
+
+
 def test_registered_in_agent_registry() -> None:
     registry_text = REGISTRY.read_text(encoding="utf-8")
     assert "agents/mutation-kill.md" in registry_text

--- a/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
+++ b/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
@@ -41,3 +41,21 @@ CSHARP="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/mutation-testing/refere
   # The CI/cgroup caveat for os.cpu_count().
   echo "$section" | grep -qi "cgroup"
 }
+
+# --- Slice 3 · convergence-derived glob negation example (#682) ------------
+
+@test "csharp-stryker-net.md infra-exclusion glob template shows a convergence-derived negation example" {
+  run awk '
+    /^## Infrastructure exclusion `mutate` glob template/ { f=1 }
+    /^## / && !/^## Infrastructure exclusion/ && f { if (NR > 1) exit }
+    f { print }
+  ' "$CSHARP"
+  [ "$status" -eq 0 ]
+  section="$output"
+
+  # A convergence-derived negation example, distinguished from the
+  # permanent infra-exclusion negations already in the template.
+  echo "$section" | grep -qi "convergence"
+  echo "$section" | grep -q -- "!"
+  echo "$section" | grep -qi "re-checked\|drop out\|permanent"
+}


### PR DESCRIPTION
## Summary
- Adds a persisted convergence-history mechanism to `mutation-kill.md`'s `--all` loop: each file that converges (0 survivors) or is excluded writes an entry (`file`, `status`, `reason`, `commit`) to `StrykerOutput/mutation-kill-convergence.json` in the target repo.
- Documents the read-path: before the baseline scan, entries whose recorded commit still matches the file's current last-commit SHA shrink the `--mutate` glob (`!<file>`) and are skipped with `SKIPPED <file> — already converged at <sha>` / `SKIPPED <file> — excluded: <reason>` log lines; stale entries are dropped. A run-level `convergence: skipped N, testing M` summary line reports the effect, and a sentence distinguishes this mechanism from the existing `--since` incremental-run pattern.
- Extends `csharp-stryker-net.md`'s infra-exclusion glob template with a convergence-derived `!<file>` negation example, distinguishing it (re-checked, can drop out) from the permanent infra-exclusion negations.

Implements Slice 3 ("Convergence history across --all invocations") of `plans/mutation-kill-slice-loop-refinements.md` — Steps 3.1, 3.2, 3.3. Depends on and lands after #680 and #681 (both merged).

Closes #682

## Quality Gate
- [x] Tests: 453 passed, 2 skipped (full pytest suite) + full bats suite (918 tests) green
- [x] Type check: n/a (prose/test-only change)
- [x] Lint: n/a
- [x] Code review: clean (claude_setup_review and token_efficiency_review script gates pass; semantic doc/arch/naming/structure/spec-compliance inspection found no issues)

## Test Plan
- [x] `python3 -m pytest tests/agents/test_mutation_kill_agent.py -q` — 26 passed
- [x] `bats tests/skills/mutation_kill_slice_loop_refinements_tests.bats` — 2 passed
- [x] `wc -l plugins/dev-team/agents/mutation-kill.md` — 403 lines, under the 500-line gate
- [x] Full `pytest tests/` and `bats -r tests` suites green (no regressions)