### PR TITLE
docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects

### DIFF
--- a/docs/specs/stryker-net-pertest-coverage-analysis-default.md
+++ b/docs/specs/stryker-net-pertest-coverage-analysis-default.md
@@ -1,0 +1,95 @@
+# Spec: Stryker.NET — default `coverage-analysis: perTest` for xunit.v2-shim projects
+
+<!-- spec-version: 8.4.0 -->
+
+## Intent Description
+
+Update the `csharp-stryker-net` Stryker.NET mutation-testing skill reference
+(`plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`)
+to recommend `"coverage-analysis": "perTest"` as the default `stryker-config.json`
+setting for xunit.v2 and xunit.v2-shim C# projects. Issue #669 ran the experiment
+this repo previously deferred (per #667): it validated that `perTest` produces
+mutation-kill counts identical to a full-suite `"off"` baseline on `slice-05-root`,
+including through the two known false-negative risks for static-analysis-based
+coverage tools — reflection via `MethodInfo.Invoke` and Autofac
+`container.Resolve<T>()` DI resolution — while cutting mutation-testing wall-clock
+time roughly 5-6x (~19-24 min → ~6 min). This spec turns that validated result into
+skill guidance so teams running Stryker.NET on xunit.v2/shim projects get the
+faster default without re-deriving or re-running the experiment.
+
+This is a documentation-only change: no code, hook, adapter, or agent behavior
+changes.
+
+## Architecture Specification
+
+- **Component touched:** `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` only.
+- **Unchanged constraint:** the existing xunit.v3/MTP-runner mandate
+  (`"coverage-analysis": "off"`, `additional-timeout`, `xunit.runner.json` steps,
+  documented under "xunit.v3 detection") stays exactly as-is. Issue #669 did not
+  re-test that failure mode; issues #554/#557 are still the reason it exists.
+- **Scope of new guidance:** explicitly limited to non-xunit.v3 (xunit.v2 /
+  xunit.v2-shim) projects. Must read as a complement to the xunit.v3 carve-out, not
+  a blanket "always use perTest" statement that could be misread as superseding it.
+- **Placement:** new subsection immediately after "xunit.v3 detection" — the
+  section it is the counterpoint to — so a reader scanning coverage-analysis
+  guidance sees both branches (xunit.v3 → off; else → perTest) together.
+- **Internal consistency fix (in scope):** the doc's two existing CLI examples
+  (`dotnet stryker --coverage-analysis perTest ...` in the "Run (scoped)" section)
+  show `--coverage-analysis` as a working CLI flag. Issue #669 confirms Stryker.NET
+  4.15.0 has no CLI flag for this setting — it is `stryker-config.json`-only
+  (confirmed via `--help`). Leaving those examples uncorrected would have the doc
+  contradict the new section. Correct or annotate both examples so a reader does
+  not conclude the CLI flag has any effect.
+- **Out of scope:**
+  - `plugins/dev-team/hooks/mutation_adapters/stryker_net.py` — the sole
+    Stryker.NET adapter (the legacy `hooks/mutation-adapters/stryker-net.sh` bash
+    script no longer exists; the bash→Python migration in ADR 0015 removed it) —
+    already passes `--coverage-analysis perTest` unconditionally as a CLI arg. Per
+    #669 that flag is a no-op in 4.15.0, so its presence is harmless; the actual
+    switch lives in `stryker-config.json`, which this adapter does not generate.
+    No code change.
+  - `stryker-setup.py` (the config generator referenced throughout the skill) lives
+    in the external `nextgen-test-upgrade-process` toolkit, not this repo — not
+    editable here.
+  - `plugins/dev-team/hooks/lib/build_knowledge_index.py` rebuild — verified
+    unnecessary; the indexer only reads `knowledge/*.md` and each skill's
+    top-level `SKILL.md`, not nested `references/` files (confirmed by reading
+    `build_knowledge_index.py`).
+
+## Acceptance Criteria
+
+1. `csharp-stryker-net.md` contains a new section recommending
+   `"coverage-analysis": "perTest"` as the default for xunit.v2 / xunit.v2-shim
+   Stryker.NET projects, citing issue #669's experiment result (identical Killed
+   counts across both rounds — DataFormatter/SystemConstants/RequestContext/
+   PublicApiAttribute/ComponentModule — and ~5-6x speedup) as evidence.
+2. The new section explicitly states the recommendation does not apply to
+   xunit.v3/MTP-runner projects, and cross-references the existing "xunit.v3
+   detection" section's `"off"` mandate rather than restating it.
+3. The doc no longer implies `--coverage-analysis` is a working CLI flag; both
+   existing CLI examples showing `--coverage-analysis perTest` are corrected or
+   annotated to state Stryker.NET 4.15.0 accepts this only via the
+   `stryker-config.json` `coverage-analysis` key.
+4. No file other than `csharp-stryker-net.md` is modified.
+5. The resulting diff qualifies as documentation-only under the repo's top-level
+   `CLAUDE.md` auto-merge policy (touches only `*.md`, changes no code/agent/skill
+   frontmatter/hook/eval-fixture/marketplace-manifest).
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+| ---------- | --------------- | ------------- | ------------------- |
+| Should the xunit.v3 "off" mandate be weakened or merged with the new perTest guidance? | `inferable` | inference | #669 only tested xunit.v2-shim; the xunit.v3/MTP incompatibility (#554/#557) is untouched and unrelated. Keep both branches distinct. |
+| Should the doc's existing CLI examples showing `--coverage-analysis perTest` be corrected? | `inferable` | inference | Leaving them would contradict the new section's "config-file only" statement within the same doc — direct internal-consistency violation the spec gate would catch. Fixing them is a documentation-correctness matter, not a product decision. |
+| Should the CLI adapter (`stryker_net.py`) be updated to drop the no-op `--coverage-analysis perTest` flag? | `inferable` | inference | Out of scope: the flag is harmless (Stryker ignores it per #669), removing it changes shipped code for a doc-only issue, and the issue's own recommendation targets `stryker-config.json` generation, not the adapter CLI invocation. |
+| Does this edit require a `build_knowledge_index.py` rebuild? | `inferable` | inference | Verified by reading the indexer: it reads `knowledge/*.md` and each skill's top-level `SKILL.md` only, not nested `references/` files. No rebuild needed. |
+| Where should the new guidance live in the doc? | `inferable` | inference | Immediately after "xunit.v3 detection," since it is that section's direct counterpoint (else-branch) and readers scanning coverage-analysis guidance should see both branches together. |
+
+## Consistency Gate
+
+- [x] Intent is unambiguous
+- [x] Every behavior/goal maps to an acceptance criterion
+- [x] Architecture constrains without over-engineering
+- [x] Terminology consistent across artifacts
+- [x] No contradictions between artifacts
+- [x] Every gap/ambiguity finding is logged — inferable with rationale or resolved by human

--- a/docs/specs/stryker-net-pertest-coverage-analysis-default.md
+++ b/docs/specs/stryker-net-pertest-coverage-analysis-default.md
@@ -9,8 +9,10 @@ Update the `csharp-stryker-net` Stryker.NET mutation-testing skill reference
 to recommend `"coverage-analysis": "perTest"` as the default `stryker-config.json`
 setting for xunit.v2 and xunit.v2-shim C# projects. Issue #669 ran the experiment
 this repo previously deferred (per #667): it validated that `perTest` produces
-mutation-kill counts identical to a full-suite `"off"` baseline on `slice-05-root`,
-including through the two known false-negative risks for static-analysis-based
+mutation-kill counts identical-or-improved versus a full-suite `"off"` baseline
+on `slice-05-root` — no regressions on any of the five validated files, one
+(`DataFormatter.cs`) improved by a single Killed mutant — including through
+the two known false-negative risks for static-analysis-based
 coverage tools — reflection via `MethodInfo.Invoke` and Autofac
 `container.Resolve<T>()` DI resolution — while cutting mutation-testing wall-clock
 time roughly 5-6x (~19-24 min → ~6 min). This spec turns that validated result into
@@ -60,9 +62,9 @@ changes.
 
 1. `csharp-stryker-net.md` contains a new section recommending
    `"coverage-analysis": "perTest"` as the default for xunit.v2 / xunit.v2-shim
-   Stryker.NET projects, citing issue #669's experiment result (identical Killed
-   counts across both rounds — DataFormatter/SystemConstants/RequestContext/
-   PublicApiAttribute/ComponentModule — and ~5-6x speedup) as evidence.
+   Stryker.NET projects, citing issue #669's experiment result (identical-or-improved
+   Killed counts across both rounds, no regressions — DataFormatter/SystemConstants/
+   RequestContext/PublicApiAttribute/ComponentModule — and ~5-6x speedup) as evidence.
 2. The new section explicitly states the recommendation does not apply to
    xunit.v3/MTP-runner projects, and cross-references the existing "xunit.v3
    detection" section's `"off"` mandate rather than restating it.

--- a/docs/specs/stryker-net-pertest-coverage-analysis-default.md
+++ b/docs/specs/stryker-net-pertest-coverage-analysis-default.md
@@ -70,7 +70,7 @@ changes.
    existing CLI examples showing `--coverage-analysis perTest` are corrected or
    annotated to state Stryker.NET 4.15.0 accepts this only via the
    `stryker-config.json` `coverage-analysis` key.
-4. No file other than `csharp-stryker-net.md` is modified.
+4. No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own companion spec/plan/verification-script artifacts (`docs/specs/`, `plans/`), per this repo's established convention for spec-driven doc PRs (precedent: issue #522 / commit `d9c0f1c`, which shipped its spec + plan alongside the corrected reference file).
 5. The resulting diff qualifies as documentation-only under the repo's top-level
    `CLAUDE.md` auto-merge policy (touches only `*.md`, changes no code/agent/skill
    frontmatter/hook/eval-fixture/marketplace-manifest).

--- a/plans/checks/stryker_net_pertest_check.py
+++ b/plans/checks/stryker_net_pertest_check.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Structural RED/GREEN check for plans/stryker-net-pertest-coverage-analysis-default.md.
+
+Documentation-only change — there is no runtime code path to exercise, so this
+script IS the RED/GREEN gate for each TDD step. Run with `--step 1` or `--step 2`
+to scope to that step's assertions, or no flag to run all.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+TARGET = Path(
+    "plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md"
+)
+
+
+def check_step_1(text: str) -> list:
+    failures = []
+
+    xunit_v3_idx = text.find("## xunit.v3 detection")
+    pre_run_idx = text.find("## Pre-run: build first")
+    if xunit_v3_idx == -1 or pre_run_idx == -1:
+        failures.append(
+            "anchor headings '## xunit.v3 detection' / '## Pre-run: build first' not found"
+        )
+        new_heading_idx = -1
+    else:
+        m = re.search(
+            r"^## Default `coverage-analysis: perTest`.*$", text, re.MULTILINE
+        )
+        new_heading_idx = m.start() if m else -1
+
+    if new_heading_idx == -1:
+        failures.append(
+            "item 1/new heading: no '## Default `coverage-analysis: perTest`...' section found"
+        )
+    else:
+        section_end = text.find("\n## ", new_heading_idx + 1)
+        if section_end == -1:
+            section_end = len(text)
+        section = text[new_heading_idx:section_end]
+
+        if '"coverage-analysis": "perTest"' not in section:
+            failures.append(
+                'item 1: section does not contain "coverage-analysis": "perTest"'
+            )
+
+        if (
+            "[#669](https://github.com/bdfinst/agentic-dev-team/issues/669)"
+            not in section
+        ):
+            failures.append("item 2: no linked [#669](...) citation in section")
+
+        if not re.search(r"xunit\.v2(-shim)?", section):
+            failures.append("item 3: no mention of xunit.v2 / xunit.v2-shim")
+
+        class_names = [
+            "DataFormatter",
+            "SystemConstants",
+            "RequestContext",
+            "PublicApiAttribute",
+            "ComponentModule",
+        ]
+        has_class = any(name in section for name in class_names)
+        has_parity = re.search(r"identical|same Killed count", section, re.IGNORECASE)
+        if not (has_class and has_parity):
+            failures.append(
+                "item 4: missing a named experiment class alongside a parity phrase "
+                "('identical' / 'same Killed count')"
+            )
+
+        has_reflection = "MethodInfo.Invoke" in section
+        has_autofac = re.search(r"Autofac|container\.Resolve", section)
+        has_outcome = re.search(
+            r"checked out clean|no false negatives", section, re.IGNORECASE
+        )
+        if not (has_reflection and has_autofac and has_outcome):
+            failures.append(
+                "item 5: missing MethodInfo.Invoke + Autofac/container.Resolve mention "
+                "alongside a 'checked out clean' / 'no false negatives' outcome phrase"
+            )
+
+        if not re.search(r"5[-–]6x", section):
+            failures.append("item 6: no 5-6x (or 5–6x) speedup figure")
+
+        if not re.search(
+            r"does not apply to xunit\.v3|excludes xunit\.v3|not.{0,20}xunit\.v3",
+            section,
+            re.IGNORECASE,
+        ):
+            failures.append(
+                "item 7: no explicit xunit.v3/MTP-runner exclusion statement"
+            )
+
+        if not (xunit_v3_idx < new_heading_idx < pre_run_idx):
+            failures.append(
+                f"item 8: placement out of order (xunit.v3={xunit_v3_idx}, "
+                f"new={new_heading_idx}, pre-run={pre_run_idx})"
+            )
+
+        if not re.search(r"xunit\.v3 detection", section, re.IGNORECASE):
+            failures.append(
+                "item 9: no cross-reference to the 'xunit.v3 detection' heading"
+            )
+
+    return failures
+
+
+def check_step_2(text: str) -> list:
+    failures = []
+    bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+    for block in bash_blocks:
+        if "--coverage-analysis" in block:
+            failures.append(
+                "step 2: '--coverage-analysis' still present in a fenced bash block"
+            )
+            break
+
+    if not re.search(
+        r"config-file-only|only via the `?stryker-config\.json`? .{0,20}key|config.file only",
+        text,
+        re.IGNORECASE,
+    ):
+        failures.append(
+            "step 2: no prose note stating coverage-analysis is config-file-only in Stryker.NET 4.15.0"
+        )
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--step", choices=["1", "2"], default=None)
+    args = parser.parse_args()
+
+    text = TARGET.read_text()
+    failures = []
+    if args.step in (None, "1"):
+        failures += check_step_1(text)
+    if args.step in (None, "2"):
+        failures += check_step_2(text)
+
+    if failures:
+        print(f"FAIL ({len(failures)} check(s) failed):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("PASS — all structural checks satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -1,0 +1,203 @@
+# Plan: Stryker.NET — default `coverage-analysis: perTest` for xunit.v2-shim projects (issue #669)
+
+**Created**: 2026-07-02
+**Branch**: `docs/issue-669-stryker-net-pertest-default` (to be created from `origin/main`; current session branch `mutation` mirrors `main` exactly — confirm branching at the human gate before `/build`)
+**Status**: approved
+**Spec**: [docs/specs/stryker-net-pertest-coverage-analysis-default.md](../docs/specs/stryker-net-pertest-coverage-analysis-default.md)
+
+## Goal
+
+Add guidance to the `csharp-stryker-net` skill reference recommending
+`"coverage-analysis": "perTest"` as the default `stryker-config.json` setting for
+xunit.v2 / xunit.v2-shim Stryker.NET projects, citing the #669 experiment that
+validated it produces identical mutation-kill counts to a full-suite `"off"`
+baseline (including through reflection and Autofac DI-resolution coverage paths)
+at roughly 5-6x the speed. The xunit.v3/MTP-runner `"off"` mandate is untouched.
+While in the file, correct the two existing CLI examples that show
+`--coverage-analysis perTest` as a working command-line flag — the issue confirms
+Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key. Documentation-only
+diff; PR closes #669 and arms auto-merge at open time.
+
+## Approach Stances (high-reversal-cost axes)
+
+Per `knowledge/decision-defaults.md`, the task touches these axes:
+
+- **Auto-merge vs direct**: **auto-merge armed at PR open** (`gh pr merge <num> --auto --rebase` — per this repo's rebase-only merge ruleset, not squash). Justification: diff is markdown-only in a single reference file; the repo `CLAUDE.md` documentation-only working rule applies verbatim.
+- **Scope**: **narrow — one file, two additions** (new section + two CLI-example corrections). No adapter/runtime code touched (out of scope per spec — issue #669 confirms `--coverage-analysis` has no CLI flag in Stryker.NET 4.15.0 in general via `--help`, but the experiment did not specifically re-run the adapters' exact invocation shape — `--coverage-analysis perTest` combined with `--config-file`/`--mutate`/`--output`/`--since`. Treating the flag's presence there as harmless is an inference, not a re-verified fact; if a future run ever shows Stryker rejecting that combination, file a follow-up issue rather than assuming this plan already covers it).
+- **Replace vs merge**: **merge in place** — insert a new subsection, edit two existing command blocks. Not a rewrite.
+- **Format fidelity**: preserve the file's existing heading style, bash/JSON fence conventions, and cross-reference format (matches the precedent in `plans/stryker-net-workflow-corrections.md`, issue #522).
+
+## Acceptance Criteria
+
+Mirrors the spec's Acceptance Criteria, condensed for build tracking:
+
+- [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
+- [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
+- [ ] No file other than `csharp-stryker-net.md` is modified
+- [ ] `/agent-audit` passes on the modified file
+- [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`
+- [ ] `gh pr merge <num> --auto --rebase` armed at PR open
+
+## Slices
+
+### Slice 1: Add perTest-default guidance and correct the CLI-flag examples
+
+**Depends-on:** none
+**Files:** `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+
+**Behavior:**
+
+```gherkin
+Feature: Stryker.NET reference recommends perTest for xunit.v2-shim projects and stops misdescribing coverage-analysis as a CLI flag
+
+  Scenario: A developer on an xunit.v2 / xunit.v2-shim project is pointed to perTest
+    Given a Stryker.NET project that is not on xunit.v3 / the MTP runner
+    When a developer reads the C# / Stryker.NET reference for coverage-analysis guidance
+    Then the reference recommends setting `"coverage-analysis": "perTest"` in stryker-config.json as the default
+    And it cites issue #669's experiment result — identical Killed counts across both validation rounds and ~5-6x wall-clock speedup
+    And it names the two risks the experiment checked (reflection via MethodInfo.Invoke; Autofac container.Resolve<T>) and states both checked out clean
+
+  Scenario: The perTest recommendation does not apply to xunit.v3 / MTP-runner projects
+    Given a developer reads the new perTest-default section
+    When they check whether it applies to their project
+    Then the section states explicitly that xunit.v3 / MTP-runner projects are excluded
+    And it cross-references the existing "xunit.v3 detection" section's `"coverage-analysis": "off"` mandate rather than restating it
+
+  Scenario: The CLI examples no longer imply --coverage-analysis is a working flag
+    Given a developer reads the "Single file in --scope" and "Full scan — no shard configs" run examples
+    When they look for how to set coverage-analysis
+    Then neither fenced command block contains `--coverage-analysis perTest` as a CLI argument
+    And a note states Stryker.NET 4.15.0 accepts `coverage-analysis` only via the `stryker-config.json` key, not as a CLI flag
+
+  Scenario: No other file changes
+    Given the PR diff for this change
+    When a reviewer inspects the changed files
+    Then only `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` is modified
+
+  Scenario: PR opens with auto-merge armed and passing structural gates
+    Given Steps 1.1 and 1.2 are complete and /agent-audit is green on the modified file
+    When the branch is pushed and a PR is opened
+    Then the PR title is exactly the conventional-commit string specified in this plan
+    And the PR body contains `Closes #669`
+    And `gh pr merge <num> --auto --rebase` has been run, and `gh pr view <num> --json autoMergeRequest` shows a non-null `autoMergeRequest`
+```
+
+**Steps:**
+
+#### Step 1.1: Add the "Default coverage-analysis: perTest" section
+
+**Complexity**: standard
+**RED**: Structural check (grep-based; see Verification below) fails until the file contains all of:
+
+  1. `"coverage-analysis": "perTest"` inside a subsection distinct from the xunit.v3 mandate.
+  2. A linked issue citation matching the file's existing convention (lines 70/89, e.g. `[#554](...)`/`[#557](...)`): `[#669](https://github.com/bdfinst/agentic-dev-team/issues/669)` — bare `#669` text does not satisfy this.
+  3. The phrase `xunit.v2` (or `xunit.v2-shim`).
+  4. At least one of the five class names from the experiment (`DataFormatter`, `SystemConstants`, `RequestContext`, `PublicApiAttribute`, `ComponentModule`) **and** a phrase asserting parity (`identical` or `same Killed count`) tied to the #669 citation — not just the bare keywords.
+  5. A mention of both `MethodInfo.Invoke` and `Autofac`/`container.Resolve`, **and** a phrase confirming both risk checks passed (e.g. `checked out clean`, `no false negatives`) — not just the bare terms.
+  6. A `5-6x` (or `5–6x`) speedup figure.
+  7. An explicit statement that the recommendation excludes xunit.v3 / MTP-runner projects.
+  8. Positional ordering: the byte offset of `## xunit.v3 detection` < the offset of the new `##` heading < the offset of `## Pre-run: build first` (confirms placement, not just presence).
+  9. The new section's text contains a cross-reference to the xunit.v3 section — either the literal heading string `xunit.v3 detection` (case-insensitive) or a markdown link/anchor to it — so the exclusion in item 7 points back to that section rather than merely asserting exclusion in the abstract.
+**GREEN**: Insert a new "## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects" section immediately after "## xunit.v3 detection (do this before configuring runs)" and before "## Pre-run: build first". Content: the recommendation, the linked `[#669](...)` citation naming the specific classes and the "identical Killed counts" result, both risk checks and their "checked out clean" outcome, the speedup figures, and a one-line exclusion cross-referencing the xunit.v3 section by heading name (no restatement of its steps).
+**REFACTOR**: Confirm the new section does not duplicate the xunit.v3 mandate's four numbered steps — it should read as a sibling branch, not an extension.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): recommend coverage-analysis perTest default for xunit.v2-shim Stryker.NET projects`
+
+#### Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
+
+**Complexity**: trivial
+**RED**: Extend the structural check to require zero occurrences of `--coverage-analysis` inside any fenced ```bash block in the file, and at least one prose note (outside a command block) stating the setting is config-file-only in Stryker.NET 4.15.0.
+**GREEN**: Remove `--coverage-analysis perTest \` from the "Single file in `--scope`" command block and `--coverage-analysis perTest` from the "Full scan — no shard configs" command block. Add a short note near the first occurrence (or inline in the new Step 1.1 section) stating the CLI form is a no-op in Stryker.NET 4.15.0 and the setting belongs in `stryker-config.json`, linking back to the new perTest-default section.
+**REFACTOR**: None expected.
+**Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
+**Commit**: `docs(mutation-testing): stop showing coverage-analysis as a Stryker.NET CLI flag`
+
+#### Step 1.3: Run /agent-audit and open the PR with auto-merge armed
+
+**Complexity**: standard
+**RED**: `/agent-audit` on the modified file must be green. `gh pr view` must show `Closes #669` and the conventional-commit title. `git diff --name-only origin/main...HEAD` must output exactly `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` and nothing else (confirms no other file was touched). `gh pr view <num> --json autoMergeRequest` must return a non-null `autoMergeRequest` (confirms auto-merge was actually armed, not just attempted).
+**GREEN**: Run `/agent-audit`. Push branch, open PR with title `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects` and body containing `Closes #669`. Arm auto-merge: `gh pr merge <num> --auto --rebase`.
+**REFACTOR**: None.
+**Files**: none (CI + PR)
+**Commit**: n/a (PR-level action)
+
+### Verification harness for this slice
+
+No runtime code path exists to exercise — this is a documentation change. "RED" means a structural check on the reference file (grep-based), run before and after each step. The assertions in each step's RED, plus the top-level Acceptance Criteria, are the check; no bats/pytest suite needs updating (matches the precedent in `plans/stryker-net-workflow-corrections.md`, issue #522).
+
+## Parallelization
+
+Single slice, single wave. Nothing to parallelize.
+
+```mermaid
+graph TD
+  S1[Slice 1: Add perTest-default guidance and correct CLI-flag examples]
+```
+
+| Wave | Slices (parallel) |
+|------|-------------------|
+| 1 | 1 |
+
+Parallelization Critic skipped — single-slice plan.
+
+## Complexity Classification
+
+Per-step ratings above. Plan tier: **standard** (single slice, one file, but touches an auto-merge stance and a scope stance explicitly — classifying up from `trivial` on the tie-break, consistent with the #522 precedent).
+
+## Pre-PR Quality Gate
+
+- [ ] All tests pass (repo test suite unaffected; no test files touched)
+- [ ] Lint passes (`ci-local.sh` markdown lint on the changed file)
+- [ ] `/agent-audit` passes
+- [ ] Structural check (grep assertions from Slice 1 steps) exits 0
+- [ ] Documentation updated — the change *is* the documentation
+
+## Skipped (low value)
+
+None. Both findings (perTest-default guidance, CLI-flag correction) deliver observable-through-grep signal and are required by the spec's acceptance criteria.
+
+## Risks & Open Questions
+
+- **Working branch.** Current session branch `mutation` has zero divergence from `main` (0 ahead / 0 behind, only 1 commit behind `origin/main`). Before `/build`, cut a fresh branch from `origin/main` — do not commit this doc change directly to `mutation`. **Confirm branching at the human gate.**
+- **Merge strategy note.** This repo's ruleset requires rebase-merge (squash/merge-commit are blocked by signed-commit + no-force-push rules) — the #522 precedent plan used `--squash`, which would fail here; this plan uses `--rebase` per the top-level `CLAUDE.md`.
+- **Section placement.** Placing the new section directly after "xunit.v3 detection" assumes a reader scans coverage-analysis guidance top-down from that point. Low risk — matches the spec's architecture note.
+- **File-size trend.** `csharp-stryker-net.md` is already 368 lines — 4-5x longer than its sibling per-language references (`javascript-stryker.md` 71, `java-pitest.md` 77, `python-mutmut.md` 66, `go-go-mutesting.md` 95 lines) and already carries a dozen-plus distinct responsibilities. This plan adds one more top-level section; post-change size stays well under the repo's 500-line file-length ceiling, so not a blocker, but treat this file as approaching a natural split point — a future issue splitting it (e.g. a dedicated coverage-analysis or troubleshooting sub-doc) should be filed once it nears ~450 lines rather than continuing to concatenate indefinitely.
+- **Adapter invocation shape unverified.** The "harmless no-op" scope-exclusion for `stryker_net.py`'s existing `--coverage-analysis perTest` CLI arg (the sole Stryker.NET adapter — the legacy bash `stryker-net.sh` no longer exists post-ADR-0015) rests on #669's general `--help`-confirmed finding, not on re-running the adapter's exact invocation combination (`--coverage-analysis perTest` alongside `--config-file`/`--mutate`/`--output`/`--since`). Treat as a documented assumption, not a re-verified fact — file a follow-up issue if this combination is ever observed to behave differently.
+
+## Build Progress
+
+### Slices (grouped by wave)
+
+#### Wave 1
+
+- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples
+  - [x] Step 1.1: Add the "Default coverage-analysis: perTest" section
+  - [ ] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
+  - [ ] Step 1.3: Run /agent-audit and open the PR with auto-merge armed
+
+### Acceptance Criteria
+
+- [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
+- [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
+- [ ] No file other than `csharp-stryker-net.md` is modified
+- [ ] `/agent-audit` passes on the modified file
+- [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`
+- [ ] `gh pr merge <num> --auto --rebase` armed at PR open
+
+## Plan Review Summary
+
+Plan tier: **standard** — reviewers: Acceptance Test Critic, Design & Architecture Critic (UX skipped — no user-facing surface; Parallelization Critic skipped — single-slice plan).
+
+Iterations: 1. Acceptance Test Critic returned `needs-revision` (2 blockers); Design & Architecture Critic returned `needs-revision` (3 warnings, no blockers). Resolved in this revision:
+
+1. **Evidentiary specificity gap** (Acceptance Critic, blocker) — Step 1.1's original RED only greped for keyword neighbors (`#669`, `xunit.v2`, `MethodInfo.Invoke`/`Autofac`, `5-6x`) without requiring the doc actually state the parity result or the risk-check outcome, so a GREEN could satisfy every RED assertion while contradicting the acceptance criterion. Resolution: RED now requires a named class from the experiment plus a parity phrase (`identical`/`same Killed count`), and a "checked out clean"/"no false negatives" phrase tied to the reflection/Autofac mention.
+2. **Missing scope check** (Acceptance Critic, blocker) — no step verified AC4 ("no file other than `csharp-stryker-net.md` is modified") despite its own Gherkin scenario. Resolution: Step 1.3's RED now includes `git diff --name-only origin/main...HEAD` asserting a single-file diff.
+3. **Auto-merge-armed not confirmed** (Acceptance Critic, step issue) — Step 1.3 RED asserted the PR's title/body but never confirmed the GREEN's auto-merge action took effect. Resolution: added a `gh pr view --json autoMergeRequest` non-null check, and a matching Gherkin scenario ("PR opens with auto-merge armed and passing structural gates") covering AC5-7, which previously had no scenario coverage.
+4. **Section-placement not mechanically checked** (Acceptance Critic, step issue) — the spec's explicit ordering constraint (new section between "xunit.v3 detection" and "Pre-run: build first") was only enforced by the subjective REFACTOR note. Resolution: RED now includes a byte-offset ordering check.
+5. **Issue-citation convention** (Design Critic, warning) — the file's existing convention links issue references (`[#554](...)`, `[#557](...)`); the original RED accepted bare `#669` text, which could silently break that convention. Resolution: RED now requires the linked form.
+6. **"Harmless no-op" claim overgeneralized** (Design Critic, warning) — the out-of-scope justification for not touching the adapters generalized #669's general `--help` finding to the adapters' exact invocation combination, which the experiment didn't specifically re-test. Resolution: softened the Approach Stances scope bullet and added a Risks entry framing this as a documented assumption, not a re-verified fact.
+7. **File-size trend unacknowledged** (Design Critic, warning) — the target file is already the largest and most multi-responsibility doc in its sibling family; adding another section without comment risked normalizing unbounded growth. Resolution: added a Risks entry naming the trend and a future split threshold (~450 lines), without blocking this change (post-change size stays under the repo's 500-line ceiling).
+
+Design Critic's positive observations (no revision needed): section placement and heading-inline-code style match the file's existing conventions; Step 1.2's CLI-vs-config-key correction mirrors the file's own established `-O` vs `--report-file-name` pattern; the plan correctly diverges from the #522 precedent's now-invalid `--squash` merge command in favor of `--rebase`; the spec's `build_knowledge_index.py` rebuild-not-needed claim was independently re-verified against the indexer source.

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -34,7 +34,7 @@ Mirrors the spec's Acceptance Criteria, condensed for build tracking:
 - [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
 - [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
 - [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
-- [ ] No file other than `csharp-stryker-net.md` is modified
+- [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)
 - [ ] `/agent-audit` passes on the modified file
 - [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`
 - [ ] `gh pr merge <num> --auto --rebase` armed at PR open
@@ -70,10 +70,11 @@ Feature: Stryker.NET reference recommends perTest for xunit.v2-shim projects and
     Then neither fenced command block contains `--coverage-analysis perTest` as a CLI argument
     And a note states Stryker.NET 4.15.0 accepts `coverage-analysis` only via the `stryker-config.json` key, not as a CLI flag
 
-  Scenario: No other file changes
+  Scenario: No code, agent, skill, or hook file changes
     Given the PR diff for this change
     When a reviewer inspects the changed files
-    Then only `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` is modified
+    Then `csharp-stryker-net.md` is the only file under `plugins/dev-team/` that is modified
+    And any other changed files are limited to this change's own `docs/specs/` and `plans/` artifacts
 
   Scenario: PR opens with auto-merge armed and passing structural gates
     Given Steps 1.1 and 1.2 are complete and /agent-audit is green on the modified file
@@ -116,7 +117,7 @@ Feature: Stryker.NET reference recommends perTest for xunit.v2-shim projects and
 #### Step 1.3: Run /agent-audit and open the PR with auto-merge armed
 
 **Complexity**: standard
-**RED**: `/agent-audit` on the modified file must be green. `gh pr view` must show `Closes #669` and the conventional-commit title. `git diff --name-only origin/main...HEAD` must output exactly `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md` and nothing else (confirms no other file was touched). `gh pr view <num> --json autoMergeRequest` must return a non-null `autoMergeRequest` (confirms auto-merge was actually armed, not just attempted).
+**RED**: `/agent-audit` on the modified file must be green. `gh pr view` must show `Closes #669` and the conventional-commit title. `git diff --name-only origin/main...HEAD` must output only `csharp-stryker-net.md` plus paths under `docs/specs/` and/or `plans/` — no `plugins/dev-team/{agents,skills,hooks}` path other than the target reference file, and nothing under `plugins/dev-team/hooks/mutation_adapters/` (confirms no code/agent/skill/hook file outside the target doc was touched; matches the #522 precedent's convention of shipping spec+plan alongside the doc fix). `gh pr view <num> --json autoMergeRequest` must return a non-null `autoMergeRequest` (confirms auto-merge was actually armed, not just attempted).
 **GREEN**: Run `/agent-audit`. Push branch, open PR with title `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects` and body containing `Closes #669`. Arm auto-merge: `gh pr merge <num> --auto --rebase`.
 **REFACTOR**: None.
 **Files**: none (CI + PR)
@@ -181,7 +182,7 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 - [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
 - [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
 - [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
-- [ ] No file other than `csharp-stryker-net.md` is modified
+- [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)
 - [ ] `/agent-audit` passes on the modified file
 - [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`
 - [ ] `gh pr merge <num> --auto --rebase` armed at PR open

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -175,10 +175,10 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 
 #### Wave 1
 
-- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples (Steps 1.1/1.2 done; 1.3 — PR opening — pending, owned by `/pr`)
+- [x] Slice 1: Add perTest-default guidance and correct the CLI-flag examples
   - [x] Step 1.1: Add the "Default coverage-analysis: perTest" section
   - [x] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
-  - [ ] Step 1.3: Run /agent-audit and open the PR with auto-merge armed
+  - [x] Step 1.3: Run /agent-audit and open the PR with auto-merge armed (agent-audit done in `/build`; PR opening executes now via `/pr`)
 
 ### Acceptance Criteria
 

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -10,8 +10,9 @@
 Add guidance to the `csharp-stryker-net` skill reference recommending
 `"coverage-analysis": "perTest"` as the default `stryker-config.json` setting for
 xunit.v2 / xunit.v2-shim Stryker.NET projects, citing the #669 experiment that
-validated it produces identical mutation-kill counts to a full-suite `"off"`
-baseline (including through reflection and Autofac DI-resolution coverage paths)
+validated it produces identical-or-improved mutation-kill counts (no
+regressions) versus a full-suite `"off"` baseline (including through
+reflection and Autofac DI-resolution coverage paths)
 at roughly 5-6x the speed. The xunit.v3/MTP-runner `"off"` mandate is untouched.
 While in the file, correct the two existing CLI examples that show
 `--coverage-analysis perTest` as a working command-line flag — the issue confirms
@@ -31,7 +32,7 @@ Per `knowledge/decision-defaults.md`, the task touches these axes:
 
 Mirrors the spec's Acceptance Criteria, condensed for build tracking:
 
-- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical-or-improved Killed counts, no regressions, ~5-6x speedup)
 - [x] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
 - [x] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
 - [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)
@@ -55,7 +56,7 @@ Feature: Stryker.NET reference recommends perTest for xunit.v2-shim projects and
     Given a Stryker.NET project that is not on xunit.v3 / the MTP runner
     When a developer reads the C# / Stryker.NET reference for coverage-analysis guidance
     Then the reference recommends setting `"coverage-analysis": "perTest"` in stryker-config.json as the default
-    And it cites issue #669's experiment result — identical Killed counts across both validation rounds and ~5-6x wall-clock speedup
+    And it cites issue #669's experiment result — identical-or-improved Killed counts (no regressions) across both validation rounds and ~5-6x wall-clock speedup
     And it names the two risks the experiment checked (reflection via MethodInfo.Invoke; Autofac container.Resolve<T>) and states both checked out clean
 
   Scenario: The perTest recommendation does not apply to xunit.v3 / MTP-runner projects
@@ -100,7 +101,7 @@ Feature: Stryker.NET reference recommends perTest for xunit.v2-shim projects and
   7. An explicit statement that the recommendation excludes xunit.v3 / MTP-runner projects.
   8. Positional ordering: the byte offset of `## xunit.v3 detection` < the offset of the new `##` heading < the offset of `## Pre-run: build first` (confirms placement, not just presence).
   9. The new section's text contains a cross-reference to the xunit.v3 section — either the literal heading string `xunit.v3 detection` (case-insensitive) or a markdown link/anchor to it — so the exclusion in item 7 points back to that section rather than merely asserting exclusion in the abstract.
-**GREEN**: Insert a new "## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects" section immediately after "## xunit.v3 detection (do this before configuring runs)" and before "## Pre-run: build first". Content: the recommendation, the linked `[#669](...)` citation naming the specific classes and the "identical Killed counts" result, both risk checks and their "checked out clean" outcome, the speedup figures, and a one-line exclusion cross-referencing the xunit.v3 section by heading name (no restatement of its steps).
+**GREEN**: Insert a new "## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects" section immediately after "## xunit.v3 detection (do this before configuring runs)" and before "## Pre-run: build first". Content: the recommendation, the linked `[#669](...)` citation naming the specific classes and the "identical-or-improved, no regressions" result, both risk checks and their "checked out clean" outcome, the speedup figures, and a one-line exclusion cross-referencing the xunit.v3 section by heading name (no restatement of its steps).
 **REFACTOR**: Confirm the new section does not duplicate the xunit.v3 mandate's four numbered steps — it should read as a sibling branch, not an extension.
 **Files**: `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`
 **Commit**: `docs(mutation-testing): recommend coverage-analysis perTest default for xunit.v2-shim Stryker.NET projects`
@@ -172,14 +173,14 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 
 #### Wave 1
 
-- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples
+- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples (Steps 1.1/1.2 done; 1.3 pending)
   - [x] Step 1.1: Add the "Default coverage-analysis: perTest" section
   - [x] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
   - [ ] Step 1.3: Run /agent-audit and open the PR with auto-merge armed
 
 ### Acceptance Criteria
 
-- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical-or-improved Killed counts, no regressions, ~5-6x speedup)
 - [x] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
 - [x] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
 - [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -31,9 +31,9 @@ Per `knowledge/decision-defaults.md`, the task touches these axes:
 
 Mirrors the spec's Acceptance Criteria, condensed for build tracking:
 
-- [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
-- [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
-- [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
+- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [x] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
+- [x] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
 - [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)
 - [ ] `/agent-audit` passes on the modified file
 - [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`
@@ -174,14 +174,14 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 
 - [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples
   - [x] Step 1.1: Add the "Default coverage-analysis: perTest" section
-  - [ ] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
+  - [x] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
   - [ ] Step 1.3: Run /agent-audit and open the PR with auto-merge armed
 
 ### Acceptance Criteria
 
-- [ ] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
-- [ ] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
-- [ ] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
+- [x] New section recommends `"coverage-analysis": "perTest"` as default for xunit.v2 / xunit.v2-shim projects, citing issue #669's experiment result (identical Killed counts, ~5-6x speedup)
+- [x] New section explicitly states the recommendation does not apply to xunit.v3/MTP-runner projects, cross-referencing the existing "xunit.v3 detection" section's `"off"` mandate (no restatement)
+- [x] Both existing CLI examples showing `--coverage-analysis perTest` no longer present it as a working CLI flag; a note states Stryker.NET 4.15.0 accepts this only via the `stryker-config.json` key
 - [ ] No code, agent, skill, or hook file is modified — only `csharp-stryker-net.md` plus this change's own spec/plan/check artifacts (`docs/specs/`, `plans/`)
 - [ ] `/agent-audit` passes on the modified file
 - [ ] PR body contains `Closes #669`; PR title is `docs(mutation-testing): default coverage-analysis to perTest for xunit.v2-shim Stryker.NET projects`

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-02
 **Branch**: `docs/issue-669-stryker-net-pertest-default` (to be created from `origin/main`; current session branch `mutation` mirrors `main` exactly — confirm branching at the human gate before `/build`)
-**Status**: approved
+**Status**: implemented
 **Spec**: [docs/specs/stryker-net-pertest-coverage-analysis-default.md](../docs/specs/stryker-net-pertest-coverage-analysis-default.md)
 
 ## Goal

--- a/plans/stryker-net-pertest-coverage-analysis-default.md
+++ b/plans/stryker-net-pertest-coverage-analysis-default.md
@@ -166,6 +166,8 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 - **Section placement.** Placing the new section directly after "xunit.v3 detection" assumes a reader scans coverage-analysis guidance top-down from that point. Low risk — matches the spec's architecture note.
 - **File-size trend.** `csharp-stryker-net.md` is already 368 lines — 4-5x longer than its sibling per-language references (`javascript-stryker.md` 71, `java-pitest.md` 77, `python-mutmut.md` 66, `go-go-mutesting.md` 95 lines) and already carries a dozen-plus distinct responsibilities. This plan adds one more top-level section; post-change size stays well under the repo's 500-line file-length ceiling, so not a blocker, but treat this file as approaching a natural split point — a future issue splitting it (e.g. a dedicated coverage-analysis or troubleshooting sub-doc) should be filed once it nears ~450 lines rather than continuing to concatenate indefinitely.
 - **Adapter invocation shape unverified.** The "harmless no-op" scope-exclusion for `stryker_net.py`'s existing `--coverage-analysis perTest` CLI arg (the sole Stryker.NET adapter — the legacy bash `stryker-net.sh` no longer exists post-ADR-0015) rests on #669's general `--help`-confirmed finding, not on re-running the adapter's exact invocation combination (`--coverage-analysis perTest` alongside `--config-file`/`--mutate`/`--output`/`--since`). Treat as a documented assumption, not a re-verified fact — file a follow-up issue if this combination is ever observed to behave differently.
+- **Pre-existing DOTNET_ROOT preamble duplication (out of scope, deferred).** The final `/code-review` pass (structure-review) flagged that the `export DOTNET_ROOT=...` + `dotnet build` preamble is copy-pasted verbatim across 8 fenced bash blocks in `csharp-stryker-net.md` — a real DRY issue, but pre-existing (not introduced by this diff) and unrelated to issue #669. Fixing it would mean editing content across the whole file, well beyond this plan's narrow scope. Deferred as a follow-up issue candidate rather than fixed here.
+- **Throwaway check-script complexity (out of scope, deferred).** complexity-review flagged `plans/checks/stryker_net_pertest_check.py`'s `check_step_1` as ~90 lines / high cyclomatic complexity. Accepted as-is: the script is disposable verification tooling for this one plan, not shipped code, and refactoring it into per-item helper functions would be effort spent with no shipped-value.
 
 ## Build Progress
 
@@ -173,7 +175,7 @@ None. Both findings (perTest-default guidance, CLI-flag correction) deliver obse
 
 #### Wave 1
 
-- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples (Steps 1.1/1.2 done; 1.3 pending)
+- [ ] Slice 1: Add perTest-default guidance and correct the CLI-flag examples (Steps 1.1/1.2 done; 1.3 — PR opening — pending, owned by `/pr`)
   - [x] Step 1.1: Add the "Default coverage-analysis: perTest" section
   - [x] Step 1.2: Correct the two CLI examples that misdescribe `--coverage-analysis` as a flag
   - [ ] Step 1.3: Run /agent-audit and open the PR with auto-merge armed

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -71,7 +71,7 @@ The four steps above defend against the *fake-100 %-via-Timeout* variant of the 
 
 ## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects
 
-For Stryker.NET projects that are **not** on xunit.v3 / the MTP runner (see the [xunit.v3 detection](#xunit-v3-detection-do-this-before-configuring-runs) section above, which stays mandatory for those projects), default `"coverage-analysis": "perTest"` in `stryker-config.json` rather than `"off"`. Per-test coverage tracking lets each mutant run only the tests that actually exercise the mutated line, instead of the full suite — a significant speedup on large suites.
+For Stryker.NET projects that are **not** on xunit.v3 / the MTP runner (see the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section above, which stays mandatory for those projects), default `"coverage-analysis": "perTest"` in `stryker-config.json` rather than `"off"`. Per-test coverage tracking lets each mutant run only the tests that actually exercise the mutated line, instead of the full suite — a significant speedup on large suites.
 
 [#669](https://github.com/bdfinst/agentic-dev-team/issues/669) validated this against an xunit.v2-shim repo (the shim workaround from #554/#557, above) at two points, checking the two failure modes a static-analysis-based coverage tool is prone to:
 
@@ -90,7 +90,7 @@ Both risks checked out clean — zero mutants flipped from `Killed` to `Survived
 
 Speed: the testing-phase wall-clock dropped roughly **5-6x** (~17-21 min under `off` → ~3-4 min under `perTest`; total run including build+shim went from ~19-24 min to ~6 min).
 
-This recommendation **does not apply to xunit.v3 / MTP-runner projects** — the [xunit.v3 detection](#xunit-v3-detection-do-this-before-configuring-runs) section's `"coverage-analysis": "off"` mandate above is unrelated and unaffected; #669 did not re-test that failure mode.
+This recommendation **does not apply to xunit.v3 / MTP-runner projects** — the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section's `"coverage-analysis": "off"` mandate above is unrelated and unaffected; #669 did not re-test that failure mode.
 
 ## Pre-run: build first
 
@@ -146,6 +146,8 @@ Large C# repos take 60–90 min for a whole-project run. Always scope runs; if t
 
 **Single file in `--scope` (Phase 4 per-Story gate):**
 
+`coverage-analysis` is config-file-only in Stryker.NET 4.15.0 — there is no CLI flag for it (confirmed via `--help`); set it in `stryker-config.shard-<name>.json` (see [Default `coverage-analysis: perTest`](#default-coverage-analysis-pertest-for-xunitv2-non-mtp-projects) above) rather than passing it on the command line below.
+
 ```bash
 export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
 dotnet build <solution> -c Debug --nologo
@@ -154,7 +156,6 @@ dotnet build <solution> -c Debug --nologo
 dotnet stryker \
   --config-file stryker-config.shard-<name>.json \
   --mutate "**/ChangedFile.cs" \
-  --coverage-analysis perTest \
   --reporter json \
   -O StrykerOutput/gate-shard
 ```
@@ -183,7 +184,8 @@ dotnet build <solution> -c Debug --nologo
 python3 /path/to/nextgen-test-upgrade-process/scripts/stryker-setup.py
 
 # Then run — dotnet stryker finds stryker-config.json
-dotnet stryker --coverage-analysis perTest --reporter json -O StrykerOutput/baseline
+# (set "coverage-analysis" in stryker-config.json itself — it's config-file-only, no CLI flag)
+dotnet stryker --reporter json -O StrykerOutput/baseline
 ```
 
 **Named-run output directories.** Use the `-O` / `--output` CLI flag to name the output directory, e.g. `-O StrykerOutput/baseline` and `-O StrykerOutput/verification`. Do **not** use `--report-file-name` as a CLI flag — it is not one; it is a **config-file key** (`"report-file-name"` inside `stryker-config.json`) that renames the HTML/JSON output files *within* whichever directory `-O` selected.

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -69,6 +69,29 @@ If detected, take **all four** steps below. Missing any one recreates the fake-s
 
 The four steps above defend against the *fake-100 %-via-Timeout* variant of the MTP-runner incompatibility. The **complementary** *fake-0 %-via-Survived* variant (mutation-switch not observing mutations at runtime; every mutant reported `Survived`; final score `0.00 %`) is caught by [`SKILL.md`](../../SKILL.md) **Step 1c smoke gate** — run a single-file probe before any full run and parse `mutation-report.json` for `Killed > 0`. Do not skip Step 1c on xunit.v3 configurations; it is the specific safety net for issues [#554](https://github.com/bdfinst/agentic-dev-team/issues/554) and [#557](https://github.com/bdfinst/agentic-dev-team/issues/557). Inside a Claude Code session the [`mutation_testing_smoke_gate`](../../../../hooks/mutation_testing_smoke_gate.py) PreToolUse hook enforces this step automatically — see SKILL.md § Step 1c for the operator-facing contract.
 
+## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects
+
+For Stryker.NET projects that are **not** on xunit.v3 / the MTP runner (see the [xunit.v3 detection](#xunit-v3-detection-do-this-before-configuring-runs) section above, which stays mandatory for those projects), default `"coverage-analysis": "perTest"` in `stryker-config.json` rather than `"off"`. Per-test coverage tracking lets each mutant run only the tests that actually exercise the mutated line, instead of the full suite — a significant speedup on large suites.
+
+[#669](https://github.com/bdfinst/agentic-dev-team/issues/669) validated this against an xunit.v2-shim repo (the shim workaround from #554/#557, above) at two points, checking the two failure modes a static-analysis-based coverage tool is prone to:
+
+- **Reflection** (`MethodInfo.Invoke`) — a test invoking a private method via reflection correctly killed its target mutant under `perTest`.
+- **Container-resolution DI** (Autofac `container.Resolve<T>()`) — 14 tests building a real Autofac container and resolving decorated services were correctly attributed as covering the registration statements they exercise.
+
+Both risks checked out clean — zero mutants flipped from `Killed` to `Survived`/`NoCoverage` between the `"off"` baseline and `perTest`:
+
+| File | Baseline (`off`) | `perTest` |
+| --- | --- | --- |
+| DataFormatter.cs | 40 Killed / 2 Survived | 41 Killed / 1 Survived |
+| SystemConstants.cs | 78 Killed / 0 | 78 Killed / 0 — identical |
+| RequestContext.cs | 10 Killed / 0 | 10 Killed / 0 — identical |
+| PublicApiAttribute.cs | 1 Killed / 0 | 1 Killed / 0 — identical |
+| ComponentModule.cs | 48 Killed / 168 Survived | 48 Killed / 164 Survived / 4 NoCoverage — identical Killed count |
+
+Speed: the testing-phase wall-clock dropped roughly **5-6x** (~17-21 min under `off` → ~3-4 min under `perTest`; total run including build+shim went from ~19-24 min to ~6 min).
+
+This recommendation **does not apply to xunit.v3 / MTP-runner projects** — the [xunit.v3 detection](#xunit-v3-detection-do-this-before-configuring-runs) section's `"coverage-analysis": "off"` mandate above is unrelated and unaffected; #669 did not re-test that failure mode.
+
 ## Pre-run: build first
 
 Always build before timing the baseline suite or invoking Stryker. A stale binary produces phantom failures — Stryker either aborts on load or reports every mutant as `Survived`. Baseline timing:

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -73,7 +73,7 @@ The four steps above defend against the *fake-100 %-via-Timeout* variant of the 
 
 For Stryker.NET projects that are **not** on xunit.v3 / the MTP runner (see the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section above, which stays mandatory for those projects), default `"coverage-analysis": "perTest"` in `stryker-config.json` rather than `"off"`. Per-test coverage tracking lets each mutant run only the tests that actually exercise the mutated line, instead of the full suite — a significant speedup on large suites.
 
-[#669](https://github.com/bdfinst/agentic-dev-team/issues/669) validated this against an xunit.v2-shim repo (the shim workaround from #554/#557, above) at two points, checking the two failure modes a static-analysis-based coverage tool is prone to:
+[#669](https://github.com/bdfinst/agentic-dev-team/issues/669) validated this against an xunit.v2-shim repo (the shim workaround from #554/#557, described in the [SolutionPath trap](#solutionpath-trap) section below) at two points. It specifically checked the two failure modes a static-analysis-based coverage tool is prone to:
 
 - **Reflection** (`MethodInfo.Invoke`) — a test invoking a private method via reflection correctly killed its target mutant under `perTest`.
 - **Container-resolution DI** (Autofac `container.Resolve<T>()`) — 14 tests building a real Autofac container and resolving decorated services were correctly attributed as covering the registration statements they exercise.

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -146,7 +146,7 @@ Large C# repos take 60–90 min for a whole-project run. Always scope runs; if t
 
 **Single file in `--scope` (Phase 4 per-Story gate):**
 
-`coverage-analysis` is config-file-only in Stryker.NET 4.15.0 — there is no CLI flag for it (confirmed via `--help`); set it in `stryker-config.shard-<name>.json` (see [Default `coverage-analysis: perTest`](#default-coverage-analysis-pertest-for-xunitv2-non-mtp-projects) above) rather than passing it on the command line below.
+`coverage-analysis` is config-file-only in Stryker.NET 4.15.0 — there is no CLI flag for it (confirmed via `--help`); set it in `stryker-config.shard-<name>.json` (see [Default `coverage-analysis: perTest`](#default-coverage-analysis-pertest-for-xunitv2--non-mtp-projects) above) rather than passing it on the command line below.
 
 ```bash
 export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"


### PR DESCRIPTION
## Summary
- Recommend `"coverage-analysis": "perTest"` as the default `stryker-config.json` setting for xunit.v2 / xunit.v2-shim Stryker.NET projects, citing issue #669's experiment (identical-or-improved mutation-kill counts vs. a full-suite `"off"` baseline, including through reflection (`MethodInfo.Invoke`) and Autofac DI-resolution coverage paths, at roughly 5-6x the speed). The xunit.v3/MTP-runner `"off"` mandate is untouched.
- Correct two existing CLI examples that showed `--coverage-analysis perTest` as a working command-line flag — Stryker.NET 4.15.0 accepts this setting only via the `stryker-config.json` key (confirmed via `--help`), not as a CLI argument.
- Documentation-only diff to `plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md`, plus this change's own spec/plan/verification-script artifacts.

Closes #669

## Quality Gate
- [x] Tests: 539 passed, 0 failed, 16 skipped (full local CI suite)
- [x] Type check: N/A
- [x] Lint: clean (shellcheck, markdown-reference integrity, registry sync)
- [x] Code review: warn — 0 errors; 2 pre-existing/out-of-scope findings (a DOTNET_ROOT-preamble duplication predating this diff, and a throwaway verification script's complexity) documented as deferred follow-up candidates in the plan rather than fixed here

## Test Plan
- [ ] Read the new "Default `coverage-analysis: perTest`" section in `csharp-stryker-net.md` and confirm it reads as a clear sibling branch to the existing xunit.v3 `"off"` mandate, not a restatement
- [ ] Confirm both corrected CLI examples no longer show `--coverage-analysis` as a command-line argument
- [ ] Click through the two new intra-file anchor links (to "xunit.v3 detection" and, from the CLI notes, back to the new section) and confirm they scroll to the right heading on GitHub