### PR TITLE
feat(agents): mutation-kill tiers Basic-then-Standard mutation levels

### DIFF
--- a/plans/mutation-kill-slice-loop-refinements.md
+++ b/plans/mutation-kill-slice-loop-refinements.md
@@ -27,26 +27,27 @@ adjacent refactor.
 
 ## Acceptance Criteria
 
-- [ ] `mutation-kill.md` documents the persisted convergence-history mechanism
+- [x] `mutation-kill.md` documents the persisted convergence-history mechanism
       (file path, entry shape, staleness check, glob-shrinking + skip-log
       behavior) — spec AC 1.
-- [ ] `mutation-kill.md` documents Basic → Standard tiering, including the
+- [x] `mutation-kill.md` documents Basic → Standard tiering, including the
       CompileError-trap interaction (drop to Basic-only + `EXCLUDED`, not a
       retry) — spec AC 2.
-- [ ] `mutation-kill.md`'s infra-exclusion section lists the five new filename
+- [x] `mutation-kill.md`'s infra-exclusion section lists the five new filename
       patterns and states the two numeric signals alone trigger the existing
       batched confirmation — spec AC 3.
-- [ ] `csharp_stryker_net_wrapper.py` injects a computed `-c` value unless the
+- [x] `csharp_stryker_net_wrapper.py` injects a computed `-c` value unless the
       caller already passed one (via `--stryker-concurrency`,
       `STRYKER_MUTANT_CONCURRENCY`, or pass-through `-c`/`--concurrency`);
       never overrides an explicit value — spec AC 4.
-- [ ] `csharp-stryker-net.md` documents tiering, the concurrency default, and
+- [x] `csharp-stryker-net.md` documents tiering, the concurrency default, and
       the convergence-glob template extension with runnable examples — spec
       AC 5.
-- [ ] `mutation_kill_agent_tests.bats` gains assertions for all three
+- [x] `mutation_kill_agent_tests.bats` gains assertions for all three
       `mutation-kill.md` additions; the file stays under its 500-line gate —
-      spec AC 6.
-- [ ] All pre-existing bats/pytest assertions for these files continue to pass
+      spec AC 6. (Ported to `tests/agents/test_mutation_kill_agent.py`,
+      issue #675.)
+- [x] All pre-existing bats/pytest assertions for these files continue to pass
       unchanged — spec AC 7.
 
 ## Slices
@@ -473,14 +474,15 @@ new mechanism).
 
 ## Pre-PR Quality Gate
 
-- [ ] All tests pass (`tests/agents/mutation_kill_agent_tests.bats`,
+- [x] All tests pass (`tests/agents/test_mutation_kill_agent.py` — ported from
+      `mutation_kill_agent_tests.bats`, issue #675 —,
       `tests/scripts/test_csharp_stryker_net_wrapper.py`,
       `tests/skills/mutation_kill_slice_loop_refinements_tests.bats`)
-- [ ] Type check passes (n/a — no typed build step for these files beyond
+- [x] Type check passes (n/a — no typed build step for these files beyond
       pytest's own import-time checks)
-- [ ] Linter passes (`shellcheck` n/a; Python via repo's standard lint step)
-- [ ] `/code-review` passes
-- [ ] Documentation updated (`csharp-stryker-net.md`, `mutation-kill.md`)
+- [x] Linter passes (`shellcheck` n/a; Python via repo's standard lint step)
+- [x] `/code-review` passes
+- [x] Documentation updated (`csharp-stryker-net.md`, `mutation-kill.md`)
 
 ## Risks & Open Questions
 
@@ -566,23 +568,23 @@ revision (see Risks & Open Questions) without requiring a second dispatch.
 
 #### Wave 1
 
-- [ ] Slice 1: Broaden infrastructure-exclusion heuristic
-  - [ ] Step 1.1: Extend the filename allowlist and loosen the trigger gate
-- [ ] Slice 2: Concurrency default fix
-  - [ ] Step 2.1: Inject a computed default concurrency
-  - [ ] Step 2.2: Add the --concurrency/env-var override surface
-  - [ ] Step 2.3: Document the default in the C# reference
+- [x] Slice 1: Broaden infrastructure-exclusion heuristic
+  - [x] Step 1.1: Extend the filename allowlist and loosen the trigger gate
+- [x] Slice 2: Concurrency default fix
+  - [x] Step 2.1: Inject a computed default concurrency
+  - [x] Step 2.2: Add the --concurrency/env-var override surface
+  - [x] Step 2.3: Document the default in the C# reference
 
 #### Wave 2
 
-- [ ] Slice 3: Convergence history across --all invocations
-  - [ ] Step 3.1: Document the convergence-history entry shape and write trigger
-  - [ ] Step 3.2: Document the staleness check and glob-shrinking read path
-  - [ ] Step 3.3: Extend the C# infra-exclusion glob template
+- [x] Slice 3: Convergence history across `--all` invocations
+  - [x] Step 3.1: Document the convergence-history entry shape and write trigger
+  - [x] Step 3.2: Document the staleness check and glob-shrinking read path
+  - [x] Step 3.3: Extend the C# infra-exclusion glob template
 
 #### Wave 3
 
-- [ ] Slice 4: Tiered mutation-level (Stryker.NET)
-  - [ ] Step 4.1: Document the Basic-first baseline and Standard-escalation rule
-  - [ ] Step 4.2: Document the CompileError-trap interaction and cross-reference concurrency
-  - [ ] Step 4.3: Document the tiering pattern in the C# reference with example commands
+- [x] Slice 4: Tiered mutation-level (Stryker.NET)
+  - [x] Step 4.1: Document the Basic-first baseline and Standard-escalation rule
+  - [x] Step 4.2: Document the CompileError-trap interaction and cross-reference concurrency
+  - [x] Step 4.3: Document the tiering pattern in the C# reference with example commands

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -351,6 +351,30 @@ can be unchanged since `main` yet never have been scoped by `mutation-kill` at
 all. Both mechanisms can narrow the same shard config's `mutate` glob
 simultaneously.
 
+## Tiered mutation-level (Stryker.NET only)
+
+The baseline `--all` scan runs at `--mutation-level Basic`. A file whose
+Basic-level rounds reach `survivors == 0` is done — no Standard-level pass, and
+no change from today's convergence-history write.
+
+A file whose Basic-level rounds stop via the [no-improvement or `--max-rounds`
+exit](#loop-per-file) with `survivors > 0` logs:
+
+```
+ESCALATING <file> — Standard pass: N survivors remaining after Basic
+```
+
+and gets **one** additional pass at `--mutation-level Standard`, scoped via
+`--mutate` to just that file only, to surface the pickier operators
+(`LinqMutation`, `StringMutation`, etc.) that `Basic` doesn't generate.
+
+If that Standard-level pass itself stops (no-improvement / `--max-rounds`) with
+`survivors > 0`, the file is left in scope with no convergence-history entry
+written — per the [convergence-history write triggers](#convergence-history-across---all-invocations),
+only `survivors == 0` or an explicit exclusion writes an entry. The file is
+simply re-attempted from Basic on the next `--all` invocation, the same as any
+other never-converged file today.
+
 ## Parallelism
 
 With `--all`, run files in parallel via git worktrees (each shard gets its own

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -375,6 +375,35 @@ only `survivors == 0` or an explicit exclusion writes an entry. The file is
 simply re-attempted from Basic on the next `--all` invocation, the same as any
 other never-converged file today.
 
+### CompileError trap during escalation
+
+A file that hits the known Standard-level `CompileError` trap during its
+escalation pass — the same "[Caching / key-building classes under
+`mutation-level: Standard`](../skills/mutation-testing/references/languages/csharp-stryker-net.md#probe-file-selection--c-specific-traps)"
+plume documented in `csharp-stryker-net.md` (`LinqMutation`/`StringMutation`
+operators generating calls to methods that don't exist, producing 1000+
+`CompileError` mutants) — drops back to Basic-only results and logs an
+`EXCLUDED` line, not a retry loop:
+
+```
+EXCLUDED <file> — Standard-level CompileError trap: LinqMutation/StringMutation
+  operators produced non-compiling mutants; retaining Basic-level results
+```
+
+### Concurrency cross-reference
+
+The Stryker.NET wrapper's `--stryker-concurrency` flag (env:
+`STRYKER_MUTANT_CONCURRENCY`) defaults Stryker's own mutant-testing-process
+count to `cores − 2` (`max(1, cpu_count - 2)`) — see
+[`csharp-stryker-net.md`](../skills/mutation-testing/references/languages/csharp-stryker-net.md#concurrency-default).
+This is a **different dial** from mutation-kill's own `--concurrency` flag
+(worktree fan-out, default 2, documented above): despite the shared "cores − 2"
+heuristic, tuning one has no effect on the other — `--stryker-concurrency`
+sets how many mutants Stryker itself tests in parallel per invocation;
+mutation-kill's `--concurrency` sets how many files run concurrently, each in
+its own git worktree. `--stryker-concurrency` is unrelated and unchanged by
+this document's `--concurrency` default.
+
 ## Parallelism
 
 With `--all`, run files in parallel via git worktrees (each shard gets its own

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -138,6 +138,39 @@ The language-agnostic probe rule (≥ 50 mutants, highest existing mutation scor
 - **gRPC / Protobuf service implementations.** Stryker.NET's `ObjectInitializer` mutations target the auto-generated Protobuf message types. Because those types are code-generated, the mutations produce constructor / initializer forms that do not compile, yielding hundreds to thousands of `CompileError` mutants — no signal, only cost. Avoid these files as probes; scope them out of full runs unless you have a specific reason.
 - **Caching / key-building classes under `mutation-level: Standard`.** The `Standard` mutation level enables `LinqMutation` and `StringMutation` operators that generate calls to methods that **do not exist** — for example `StringBuilder.Prepend` (the method is `Insert(0, …)`) and `IDictionary.Sum` (there is no `Sum` extension in the target namespace). These produce 1000+ `CompileError` mutants on files that build hash keys or aggregate LINQ. Drop such files to `mutation-level: Basic` (or exclude them) before probing.
 
+### Tiered mutation-level: Basic baseline, Standard escalation
+
+Pairs with the mutation-kill agent's [tiered mutation-level](../../../../agents/mutation-kill.md#tiered-mutation-level-strykernet-only) rule: the baseline `--all` scan runs at `Basic`; only files with survivors remaining after Basic converges get a Standard-level pass scoped to that one file.
+
+**Basic baseline (whole scan):**
+
+```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+dotnet stryker \
+  --config-file stryker-config.shard-<name>.json \
+  --mutation-level Basic \
+  --coverage-analysis perTest \
+  --reporter json \
+  -O StrykerOutput/baseline
+```
+
+**Standard escalation (single file, after Basic converges with survivors remaining):**
+
+```bash
+export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
+dotnet build <solution> -c Debug --nologo
+dotnet stryker \
+  --config-file stryker-config.shard-<name>.json \
+  --mutation-level Standard \
+  --mutate "**/CacheKeyBuilder.cs" \
+  --coverage-analysis perTest \
+  --reporter json \
+  -O StrykerOutput/escalation-CacheKeyBuilder
+```
+
+If the Standard escalation run hits the caching/key-building `CompileError` trap above, drop back to the Basic-level results and exclude the file from further Standard-level attempts rather than retrying.
+
 ## Run (scoped)
 
 Large C# repos take 60–90 min for a whole-project run. Always scope runs; if the repo has pre-generated shard configs, use them.

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -341,6 +341,31 @@ def test_tiered_mutation_level_basic_baseline_and_standard_escalation(
     assert re.search(r"re-attempted.*(from )?Basic", flat, re.IGNORECASE)
 
 
+def test_tiered_mutation_level_compile_error_trap_and_concurrency_crossref(
+    text: str, flat: str
+) -> None:
+    """Slice 4, Step 4.2 (#683)."""
+    # Cross-references the existing CompileError trap; drop-to-Basic-only +
+    # EXCLUDED log, not a retry loop.
+    assert re.search(r"CompileError", text)
+    assert re.search(
+        r"drops? back to Basic.only.*EXCLUDED|EXCLUDED.*drops? back to Basic.only",
+        flat,
+        re.IGNORECASE,
+    )
+    assert re.search(r"not a retry", flat, re.IGNORECASE)
+    # Cross-references the wrapper's --stryker-concurrency cores-2 default,
+    # naming it distinctly from mutation-kill's own --concurrency.
+    assert re.search(r"--stryker-concurrency", text)
+    assert re.search(r"cores.{0,10}2|cpu_count.{0,10}2", flat, re.IGNORECASE)
+    assert re.search(r"--concurrency", text)
+    assert re.search(
+        r"different dial|worktree fan.?out|unrelated and unchanged",
+        flat,
+        re.IGNORECASE,
+    )
+
+
 def test_registered_in_agent_registry() -> None:
     registry_text = REGISTRY.read_text(encoding="utf-8")
     assert "agents/mutation-kill.md" in registry_text

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -305,6 +305,42 @@ def test_convergence_history_staleness_check_and_glob_shrinking_read_path(
     assert re.search(r"complementary", flat, re.IGNORECASE)
 
 
+def test_tiered_mutation_level_basic_baseline_and_standard_escalation(
+    text: str, flat: str
+) -> None:
+    """Slice 4, Step 4.1 (#683)."""
+    # Baseline --all scan runs at mutation-level Basic.
+    assert re.search(r"mutation-level Basic", text)
+    # Fully-Basic-converged files skip the Standard pass.
+    assert re.search(
+        r"survivors *== *0.*(done|no Standard)|"
+        r"(done|no Standard).*survivors *== *0",
+        flat,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"no Standard.?level pass|does not receive a Standard", text, re.IGNORECASE
+    )
+    # Escalation condition: Basic rounds stop (no-improvement/--max-rounds)
+    # with survivors remaining.
+    assert re.search(r"no-improvement|--max-rounds", text)
+    assert re.search(
+        r"ESCALATING <file> — Standard pass: N survivors remaining after Basic",
+        text,
+    )
+    # One additional Standard-level pass scoped to that file only.
+    assert re.search(r"mutation-level Standard", text)
+    assert re.search(
+        r"scoped.*(via --mutate)?.*to (just )?that file", flat, re.IGNORECASE
+    )
+    # A Standard pass that itself still ends with survivors gets no
+    # convergence-history entry and is re-attempted from Basic next --all.
+    assert re.search(
+        r"no *(\*\*)?convergence.history(\*\*)? entry", flat, re.IGNORECASE
+    )
+    assert re.search(r"re-attempted.*(from )?Basic", flat, re.IGNORECASE)
+
+
 def test_registered_in_agent_registry() -> None:
     registry_text = REGISTRY.read_text(encoding="utf-8")
     assert "agents/mutation-kill.md" in registry_text

--- a/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
+++ b/tests/skills/mutation_kill_slice_loop_refinements_tests.bats
@@ -59,3 +59,18 @@ CSHARP="$BATS_TEST_DIRNAME/../../plugins/dev-team/skills/mutation-testing/refere
   echo "$section" | grep -q -- "!"
   echo "$section" | grep -qi "re-checked\|drop out\|permanent"
 }
+
+# --- Slice 4 · tiered mutation-level example commands (#683) ----------------
+
+@test "csharp-stryker-net.md shows both a Basic baseline and a Standard escalation example command" {
+  run cat "$CSHARP"
+  [ "$status" -eq 0 ]
+  content="$output"
+
+  # Basic baseline command.
+  echo "$content" | grep -q -- "--mutation-level Basic"
+
+  # Standard escalation command, scoped via --mutate to one file.
+  echo "$content" | grep -q -- "--mutation-level Standard"
+  echo "$content" | grep -q -- "--mutate"
+}


### PR DESCRIPTION
## Summary

- Adds a "Tiered mutation-level (Stryker.NET only)" section to `mutation-kill.md`: the baseline `--all` scan runs at `--mutation-level Basic`; a file whose Basic-level rounds converge (`survivors == 0`) skips the Standard pass entirely, and a file whose Basic-level rounds stop with survivors remaining logs `ESCALATING <file> — Standard pass: N survivors remaining after Basic` and gets one additional Standard-level pass scoped to that file.
- Documents the interaction with the existing Standard-level `CompileError` trap (caching/key-building classes producing 1000+ non-compiling mutants): a file that hits it during escalation drops back to Basic-only results with an `EXCLUDED` log line, not a retry loop. A Standard pass that itself doesn't converge writes no convergence-history entry and is simply re-attempted from Basic on the next `--all` invocation.
- Cross-references the Stryker.NET wrapper's `--stryker-concurrency` (cores-2 default) against mutation-kill's own `--concurrency` (worktree fan-out) so operators don't conflate the two dials.
- Adds Basic-baseline and Standard-escalation example `dotnet stryker` commands to `csharp-stryker-net.md`.
- Final slice of the mutation-kill-slice-loop-refinements plan (#667) — this PR also finalizes the shared plan file's Build Progress and Pre-PR Quality Gate checklists now that all four slices (#680, #681, #682, #683) are complete.

Closes #683

## Quality Gate

- [x] Tests: 826 passed, 2 skipped (`pytest tests/`)
- [x] bats: no new failures (`tests/skills/*.bats` — 330 passed; the 21 pre-existing failures are unrelated to this change, confirmed identical on `origin/main`)
- [x] Lint: `ruff check` clean
- [x] Cross-reference check: `scripts/check_md_references.py` clean
- [x] Plan completion gate: `scripts/progress_guardian.py --pre-pr` passes
- [x] Code review: no actionable findings (doc-only diff; secret scan, Semgrep, terminology-consistency final pass all clean)
- [x] `mutation-kill.md` stays under its 500-line gate (457/500)

## Test Plan

- [x] `pytest tests/agents/test_mutation_kill_agent.py -v` — new tiered-mutation-level assertions pass
- [x] `bats tests/skills/mutation_kill_slice_loop_refinements_tests.bats` — new Basic/Standard example-command assertions pass
- [x] `python3 scripts/check_md_references.py` — no broken cross-references