### PR TITLE
feat(mutation-testing): first-class Stryker.NET slicing + slice-level parallelism

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -324,6 +324,123 @@ concurrency value higher than the container's actual allotment — pass an
 explicit `--stryker-concurrency` value (or set `STRYKER_MUTANT_CONCURRENCY`)
 rather than rely on the computed default in those environments.
 
+## Slice runner
+
+The plugin ships a third script, `csharp_stryker_net_slice_runner.py`, under
+`plugins/dev-team/skills/mutation-testing/scripts/`, layering first-class
+slicing and configurable slice-level parallelism (#561) on top of the
+wrapper documented above. It imports `csharp_stryker_net_wrapper.py`
+directly and reuses its `hide_sln`/`restore_sln`/`build_project`/
+`run_stryker` primitives — the slice runner does not duplicate the
+DOTNET_ROOT probe, the pre-build-before-hide ordering, or the signal-safe
+Stryker subprocess handling; it only adds the fleet-level orchestration
+around them.
+
+### Invocation
+
+```bash
+python3 scripts/csharp_stryker_net_slice_runner.py \
+  --slices-config mutation-slices.json \
+  --slice <name>       # a single configured slice by name
+  --slice all          # every configured slice, resuming past terminal ones
+  --sln Foo.sln \
+  --output-root StrykerOutput \
+  --total-workers auto
+```
+
+### `slices:` config block
+
+A top-level `slices` array in `mutation-slices.json` (JSON, not YAML — this
+plugin's shipped scripts are stdlib-only Python, and `json` is stdlib while
+YAML is not). Only `name` + `mutate` are required in this first cut; `kind`,
+`mutation-level`, and `exclude-converged` are accepted and passed through
+but reserved for #667's within-slice refinements — a typo in one of those
+field names still fails config validation, it just isn't acted on yet:
+
+```json
+{
+  "slices": [
+    {
+      "name": "validators",
+      "mutate": "**/Validators/**/*.cs",
+      "kind": "logic",
+      "mutation-level": "Basic",
+      "exclude-converged": true
+    },
+    {
+      "name": "services",
+      "mutate": "**/Services/**/*.cs"
+    }
+  ]
+}
+```
+
+Each generated per-slice `stryker-config.json` inherits
+`"coverage-analysis": "perTest"` by default (per #669's validated
+recommendation above); pass a `--base-config` pointing at an existing
+`stryker-config.json` whose `"coverage-analysis": "off"` should be
+preserved (e.g. xunit.v3/MTP projects) — an explicit value in the base
+config always wins over the per-slice default.
+
+### Output layout and the aggregate roll-up
+
+Each slice writes its own report to
+`<output-root>/slice-<name>/reports/mutation-report.json` (Stryker's native
+JSON-reporter shape). After every slice in the run completes, the runner
+reads each slice's report, sums per-status mutant counts, and writes one
+aggregate roll-up to `<output-root>/aggregate-mutation-report.json` — the
+stable, programmatic entry point for #667's glob-shrinking logic (or any
+other tooling) instead of scraping per-slice reports individually.
+
+### Resume by skipping terminal slices
+
+A slice is **terminal** when its `mutation-report.json` exists, parses as
+JSON, and has a non-empty `files` map — a partial file from a crashed mid-
+run either fails to parse or has no `files` entries, so it is never
+mistaken for a completed run. On `--slice all`, the runner skips every
+terminal slice and logs `SKIPPED <name> — terminal report exists (use
+--force to rerun)`; pass `--force` to rerun every selected slice
+unconditionally, including terminal ones.
+
+### Configurable slice-level parallelism
+
+- `--total-workers N|auto` — the overall worker ceiling. `auto` (the
+  default) computes `max(2, cores / 2)`.
+- `--parallel-slices N` / `--per-slice-concurrency N` — optional hints for
+  operators who want to fix one axis explicitly. When **both** are set, the
+  runner refuses (unless `--force`) when their product exceeds
+  `--total-workers`.
+- When **neither** is set, the default split allocates slices first (up to
+  the configured slice count), then divides the remainder as per-slice
+  concurrency — this favours cross-slice parallelism over deeper
+  within-slice parallelism, matching #667's per-slice-convergence work.
+- A `--total-workers` value over `cores − 1` is refused with an error
+  unless `--force` is passed, in which case it proceeds with a warning
+  instead — never silently oversubscribe the machine.
+
+### `.sln` hide/restore is a fleet-level ceremony, done once
+
+Only one Stryker instance can safely hide the shared `.sln` at a time — a
+per-slice hide/restore would race across parallel slices. The slice runner
+hides `.sln` **once**, before spawning any slice, and restores it **once**,
+after every slice in the fleet has finished (success, failure, or
+exception) — never per slice. Individual slice invocations run against the
+already-hidden `.sln` and never touch the hide/restore state themselves.
+
+### Rolled-up progress reporting
+
+The runner prints one rolled-up progress line per slice-state transition,
+e.g.:
+
+```
+slice 1/7 running, slice 2/7 running, slice 3/7 queued, slice 4/7 queued, ...
+slice 1/7 done, slice 2/7 running, slice 3/7 running, slice 4/7 queued, ...
+```
+
+Each slice's state is one of `queued`, `running`, `done`, or `failed`
+(non-zero Stryker exit code); the overall exit code is the worst
+(highest, non-zero-preferred) of all slice exit codes.
+
 ## Incremental runs with `--since`
 
 For fast iteration during Phase-4 test-fix work, add a `since` block to the dev shard config so Stryker only mutates source files that changed vs a reference (typically `main`):

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""csharp_stryker_net_slice_runner.py — first-class slicing + configurable
+slice-level parallelism for Stryker.NET (issue #561).
+
+Layers on top of ``csharp_stryker_net_wrapper.py``: the wrapper's
+``hide_sln``/``restore_sln``/``build_project`` functions are reused directly,
+but the hide/restore ceremony happens **once around the whole parallel
+fleet** — not per slice — because only one Stryker instance can safely hide
+the shared ``.sln`` at a time (see issue #561 §2.1).
+
+Public API (importable, pure functions first):
+
+    load_slices_config(path) -> list[dict]
+    resolve_slice_selection(configured, requested) -> list[dict]
+    slice_output_dir(output_root, name) -> Path
+    slice_report_path(output_root, name) -> Path
+    is_terminal_report(path) -> bool
+    partition_terminal_slices(slices, output_root, force) -> (to_run, skipped)
+    resolve_total_workers(value, cpu_count) -> int
+    total_worker_ceiling_check(total_workers, cores, force) -> (bool, Optional[str])
+    resolve_worker_allocation(total_workers, slice_count, parallel_slices, per_slice_concurrency, force) -> (int, int)
+    build_slice_stryker_config(base_config, slice_def) -> dict
+    write_slice_config(output_root, name, stryker_config) -> Path
+    summarize_native_report(native_report) -> dict
+    aggregate_slice_summaries(summaries) -> dict
+    format_progress_line(order, states) -> str
+
+Refs: #561, #667, #669.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# Reuse the shipped wrapper's hide/restore/build/run primitives so the
+# hide-once-around-the-fleet contract composes with the existing
+# pre-build-before-hide and signal-safe-run guarantees instead of
+# duplicating them.
+import csharp_stryker_net_wrapper as wrapper
+
+REQUIRED_SLICE_FIELDS = ("name", "mutate")
+# Reserved for #667's within-slice refinements — accepted but not yet acted
+# on by this runner. Listed here so a typo in a reserved field still fails
+# validation instead of silently doing nothing.
+RESERVED_SLICE_FIELDS = ("kind", "mutation-level", "exclude-converged")
+KNOWN_SLICE_FIELDS = REQUIRED_SLICE_FIELDS + RESERVED_SLICE_FIELDS
+
+
+# =============================================================================
+# Slice config loading + validation
+# =============================================================================
+def load_slices_config(path: Path) -> List[Dict[str, Any]]:
+    """Load and validate the ``slices:`` block from a JSON config file.
+
+    Only ``name`` + ``mutate`` are required per slice (#561's "first cut").
+    ``kind`` / ``mutation-level`` / ``exclude-converged`` are accepted and
+    passed through (reserved for #667) but not otherwise interpreted here.
+    Raises ValueError with an actionable message on any structural problem.
+    """
+    try:
+        data = json.loads(Path(path).read_text())
+    except FileNotFoundError:
+        raise ValueError(f"slices config not found: {path}")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"slices config is not valid JSON: {path} ({e})")
+
+    slices = data.get("slices")
+    if not isinstance(slices, list) or not slices:
+        raise ValueError(
+            f'slices config {path} must have a non-empty top-level "slices" array'
+        )
+
+    seen_names = set()
+    for i, s in enumerate(slices):
+        if not isinstance(s, dict):
+            raise ValueError(f"slices[{i}] must be an object")
+        missing = [f for f in REQUIRED_SLICE_FIELDS if f not in s]
+        if missing:
+            raise ValueError(
+                f"slices[{i}] is missing required field(s): {', '.join(missing)}"
+            )
+        if s["name"] in seen_names:
+            raise ValueError(f"duplicate slice name: {s['name']!r}")
+        seen_names.add(s["name"])
+    return slices
+
+
+def resolve_slice_selection(
+    configured: Sequence[Dict[str, Any]], requested: str
+) -> List[Dict[str, Any]]:
+    """Return the configured slice(s) matching ``--slice <requested>``.
+
+    ``requested == "all"`` returns every configured slice, in config order.
+    A named slice must match a configured ``name`` exactly, else ValueError.
+    """
+    if requested == "all":
+        return list(configured)
+    for s in configured:
+        if s["name"] == requested:
+            return [s]
+    known = ", ".join(s["name"] for s in configured)
+    raise ValueError(f"no slice named {requested!r} in config (known: {known})")
+
+
+# =============================================================================
+# Per-slice output layout
+# =============================================================================
+def slice_output_dir(output_root: Path, name: str) -> Path:
+    return Path(output_root) / f"slice-{name}"
+
+
+def slice_report_path(output_root: Path, name: str) -> Path:
+    return slice_output_dir(output_root, name) / "reports" / "mutation-report.json"
+
+
+def is_terminal_report(path: Path) -> bool:
+    """A report is terminal when it exists, parses as JSON, and has a
+    non-empty top-level ``files`` map — Stryker.NET's own JSON-reporter
+    shape. A partial file from a crashed run either doesn't parse or has no
+    ``files`` entries, so it is never mistaken for a completed run.
+    """
+    p = Path(path)
+    if not p.exists():
+        return False
+    try:
+        data = json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    files = data.get("files")
+    return isinstance(files, dict) and len(files) > 0
+
+
+def partition_terminal_slices(
+    slices: Sequence[Dict[str, Any]], output_root: Path, force: bool
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Split ``slices`` into (to_run, skipped). A slice is skipped when its
+    report is terminal AND ``--force`` was not passed — resume-by-default.
+    """
+    if force:
+        return list(slices), []
+    to_run: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+    for s in slices:
+        report = slice_report_path(output_root, s["name"])
+        if is_terminal_report(report):
+            skipped.append(s)
+        else:
+            to_run.append(s)
+    return to_run, skipped
+
+
+# =============================================================================
+# Total-worker budget + slice/concurrency split
+# =============================================================================
+def resolve_total_workers(value: Optional[str], cpu_count: Optional[int]) -> int:
+    """``None``/``"auto"`` -> ``max(2, cores / 2)``; otherwise the given int."""
+    if value is None or value == "auto":
+        cores = cpu_count or 2
+        return max(2, cores // 2)
+    return int(value)
+
+
+def total_worker_ceiling_check(
+    total_workers: int, cores: Optional[int], force: bool
+) -> Tuple[bool, Optional[str]]:
+    """Return ``(allowed, message)``. Refuses (``allowed=False``, an error
+    message) a total-worker count over ``cores - 1`` unless ``--force`` is
+    set, in which case it is allowed with a warning message instead.
+    """
+    ceiling = max(1, (cores or 2) - 1)
+    if total_workers <= ceiling:
+        return True, None
+    if force:
+        return True, (
+            f"warning: --total-workers {total_workers} exceeds the cores-1 "
+            f"ceiling ({ceiling}, cores={cores or 2}); proceeding due to --force\n"
+        )
+    return False, (
+        f"error: --total-workers {total_workers} exceeds the cores-1 ceiling "
+        f"({ceiling}, cores={cores or 2}); pass --force to override\n"
+    )
+
+
+def default_split(total_workers: int, slice_count: int) -> Tuple[int, int]:
+    """Allocate slices first (up to the configured slice count), then divide
+    the remainder as per-slice concurrency — favours cross-slice parallelism
+    over deeper within-slice parallelism (#561 §2 default-split rule).
+    """
+    parallel_slices = max(1, min(total_workers, slice_count))
+    per_slice_concurrency = max(1, total_workers // parallel_slices)
+    return parallel_slices, per_slice_concurrency
+
+
+def resolve_worker_allocation(
+    total_workers: int,
+    slice_count: int,
+    parallel_slices: Optional[int],
+    per_slice_concurrency: Optional[int],
+    force: bool,
+) -> Tuple[int, int, Optional[str]]:
+    """Return ``(parallel_slices, per_slice_concurrency, message)``.
+
+    When both axes are set explicitly, refuse (unless ``--force``) if their
+    product exceeds ``total_workers``. When only one axis is set, derive the
+    other from ``total_workers``. When neither is set, use the default split.
+    """
+    if parallel_slices is not None and per_slice_concurrency is not None:
+        product = parallel_slices * per_slice_concurrency
+        if product > total_workers:
+            msg_kind = "warning" if force else "error"
+            msg = (
+                f"{msg_kind}: --parallel-slices {parallel_slices} x "
+                f"--per-slice-concurrency {per_slice_concurrency} = {product} "
+                f"exceeds the total-worker ceiling ({total_workers})"
+                + (
+                    "; proceeding due to --force\n"
+                    if force
+                    else "; pass --force to override\n"
+                )
+            )
+            return parallel_slices, per_slice_concurrency, msg
+        return parallel_slices, per_slice_concurrency, None
+    if parallel_slices is not None:
+        per_slice_concurrency = max(1, total_workers // parallel_slices)
+        return parallel_slices, per_slice_concurrency, None
+    if per_slice_concurrency is not None:
+        parallel_slices = max(1, total_workers // per_slice_concurrency)
+        return parallel_slices, per_slice_concurrency, None
+    parallel_slices, per_slice_concurrency = default_split(total_workers, slice_count)
+    return parallel_slices, per_slice_concurrency, None
+
+
+# =============================================================================
+# Per-slice Stryker config generation
+# =============================================================================
+def build_slice_stryker_config(
+    base_config: Dict[str, Any], slice_def: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Merge ``base_config`` with the slice's ``mutate`` glob. Defaults
+    ``coverage-analysis`` to ``"perTest"`` per #669's validated
+    recommendation, unless the base config already sets it (escape hatch,
+    e.g. xunit.v3/MTP projects that must keep it ``"off"``).
+    """
+    cfg = dict(base_config)
+    mutate = slice_def["mutate"]
+    cfg["mutate"] = mutate if isinstance(mutate, list) else [mutate]
+    cfg.setdefault("coverage-analysis", "perTest")
+    return cfg
+
+
+def write_slice_config(
+    output_root: Path, name: str, stryker_config: Dict[str, Any]
+) -> Path:
+    out_dir = slice_output_dir(output_root, name)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "stryker-config.json"
+    path.write_text(json.dumps({"stryker-config": stryker_config}, indent=2))
+    return path
+
+
+# =============================================================================
+# Report summarizing + aggregate roll-up
+# =============================================================================
+def summarize_native_report(native: Dict[str, Any]) -> Dict[str, int]:
+    """Reduce a Stryker.NET native ``mutation-report.json`` (top-level
+    ``files`` map of file -> {"mutants": [...]}) to per-status counts.
+    """
+    counts: Dict[str, int] = {}
+    for file_entry in native.get("files", {}).values():
+        for mutant in file_entry.get("mutants", []):
+            status = mutant.get("status", "Unknown")
+            counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def aggregate_slice_summaries(
+    summaries: Dict[str, Dict[str, int]],
+) -> Dict[str, Any]:
+    """Roll up per-slice status counts into one aggregate document."""
+    totals: Dict[str, int] = {}
+    per_slice: Dict[str, Dict[str, int]] = {}
+    for name, counts in summaries.items():
+        per_slice[name] = counts
+        for status, n in counts.items():
+            totals[status] = totals.get(status, 0) + n
+    killed = totals.get("Killed", 0)
+    survived = totals.get("Survived", 0)
+    no_coverage = totals.get("NoCoverage", 0)
+    denom = killed + survived + no_coverage
+    honest_score = (killed / denom * 100.0) if denom else 0.0
+    return {
+        "schema_version": 1,
+        "tool": "stryker-net",
+        "slices": per_slice,
+        "totals": totals,
+        "honest_score": honest_score,
+    }
+
+
+def write_aggregate_report(output_root: Path, aggregate: Dict[str, Any]) -> Path:
+    path = Path(output_root) / "aggregate-mutation-report.json"
+    path.write_text(json.dumps(aggregate, indent=2))
+    return path
+
+
+# =============================================================================
+# Rolled-up progress reporting
+# =============================================================================
+def format_progress_line(order: Sequence[str], states: Dict[str, str]) -> str:
+    """Render a rolled-up progress line, e.g.:
+
+    ``slice 3/7 done, slice 4/7 running, slice 5/7 running, slice 6/7 queued``
+    """
+    total = len(order)
+    parts = []
+    for i, name in enumerate(order, start=1):
+        status = states.get(name, "queued")
+        parts.append(f"slice {i}/{total} {status}")
+    return ", ".join(parts)
+
+
+# =============================================================================
+# Single-slice run (fleet-level hide/restore already done by the caller)
+# =============================================================================
+def run_slice(
+    slice_def: Dict[str, Any],
+    *,
+    base_config: Dict[str, Any],
+    output_root: Path,
+    stryker_bin: str,
+    per_slice_concurrency: int,
+) -> int:
+    """Write the slice's config, invoke Stryker scoped to it, return the
+    Stryker exit code. Does NOT hide/restore ``.sln`` — the fleet caller
+    owns that ceremony once for the whole run.
+    """
+    name = slice_def["name"]
+    cfg = build_slice_stryker_config(base_config, slice_def)
+    config_path = write_slice_config(output_root, name, cfg)
+    out_dir = slice_output_dir(output_root, name)
+    logfile = out_dir / "wrapper.log"
+    stryker_args = [
+        "--config-file",
+        str(config_path),
+        "-c",
+        str(per_slice_concurrency),
+        "-O",
+        str(out_dir),
+    ]
+    return wrapper.run_stryker(
+        stryker_bin=stryker_bin, stryker_args=stryker_args, logfile=logfile
+    )
+
+
+# =============================================================================
+# Main
+# =============================================================================
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="csharp_stryker_net_slice_runner.py",
+        description=(
+            "First-class slicing + configurable slice-level parallelism for "
+            "Stryker.NET (#561)."
+        ),
+    )
+    p.add_argument(
+        "--slices-config",
+        default=os.environ.get("MUTATION_SLICES_CONFIG", "mutation-slices.json"),
+        help="Path to the slices config JSON (default: %(default)s)",
+    )
+    p.add_argument(
+        "--slice",
+        required=True,
+        help='Slice name, or "all" to run every configured slice.',
+    )
+    p.add_argument(
+        "--output-root",
+        default=os.environ.get("MUTATION_SLICE_OUTPUT_ROOT", "StrykerOutput"),
+        help="Root directory for per-slice output (default: %(default)s)",
+    )
+    p.add_argument(
+        "--sln", default=os.environ.get("SLN", "Foo.sln"), help="Solution file."
+    )
+    p.add_argument(
+        "--shim-project",
+        default=os.environ.get("SHIM_PROJECT", ""),
+        help="Optional shim test project to pre-build.",
+    )
+    p.add_argument(
+        "--stryker-bin",
+        default=os.environ.get("STRYKER_BIN", "dotnet-stryker"),
+        help="Stryker executable name (default: %(default)s)",
+    )
+    p.add_argument(
+        "--base-config",
+        default=os.environ.get("MUTATION_BASE_CONFIG", ""),
+        help="Path to a base stryker-config.json's inner config to merge "
+        "into each slice's generated config. Empty = start from {}.",
+    )
+    p.add_argument(
+        "--total-workers",
+        default=os.environ.get("MUTATION_TOTAL_WORKERS", "auto"),
+        help='Integer, or "auto" = max(2, cores / 2) (default: auto).',
+    )
+    p.add_argument("--parallel-slices", type=int, default=None)
+    p.add_argument("--per-slice-concurrency", type=int, default=None)
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Rerun terminal slices and override worker-ceiling refusals.",
+    )
+    return p.parse_args(list(argv))
+
+
+def _load_base_config(path: str) -> Dict[str, Any]:
+    if not path:
+        return {}
+    data = json.loads(Path(path).read_text())
+    return data.get("stryker-config", data)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = parse_args(argv)
+
+    try:
+        configured = load_slices_config(Path(args.slices_config))
+        selected = resolve_slice_selection(configured, args.slice)
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        return 2
+
+    output_root = Path(args.output_root)
+    to_run, skipped = partition_terminal_slices(selected, output_root, args.force)
+    for s in skipped:
+        print(f"SKIPPED {s['name']} — terminal report exists (use --force to rerun)")
+
+    if not to_run:
+        print("no slices to run (all terminal; pass --force to rerun)")
+        return 0
+
+    cores = os.cpu_count()
+    total_workers = resolve_total_workers(args.total_workers, cores)
+    allowed, msg = total_worker_ceiling_check(total_workers, cores, args.force)
+    if msg:
+        sys.stderr.write(msg)
+    if not allowed:
+        return 2
+
+    parallel_slices, per_slice_concurrency, split_msg = resolve_worker_allocation(
+        total_workers,
+        len(to_run),
+        args.parallel_slices,
+        args.per_slice_concurrency,
+        args.force,
+    )
+    if split_msg:
+        sys.stderr.write(split_msg)
+        if split_msg.startswith("error") and not args.force:
+            return 2
+
+    base_config = _load_base_config(args.base_config)
+
+    # ---- Fleet-level .sln hide/restore — ONCE, not per slice. ----
+    sln = Path(args.sln)
+    sln_hidden = Path(f"{args.sln}.stryker-hidden")
+    stale_err = wrapper.check_stale_hidden_sln(sln, sln_hidden)
+    if stale_err is not None:
+        sys.stderr.write(stale_err)
+        return wrapper.EXIT_STALE_HIDDEN_SLN
+
+    rc = wrapper.build_project(args.sln)
+    if rc != 0:
+        return rc
+    if args.shim_project:
+        rc = wrapper.build_project(args.shim_project)
+        if rc != 0:
+            return rc
+
+    wrapper.hide_sln(sln, sln_hidden)
+
+    order = [s["name"] for s in to_run]
+    states: Dict[str, str] = {name: "queued" for name in order}
+    exit_codes: Dict[str, int] = {}
+
+    try:
+        with ThreadPoolExecutor(max_workers=max(1, parallel_slices)) as pool:
+            futures = {}
+            for s in to_run:
+                states[s["name"]] = "running"
+                futures[
+                    pool.submit(
+                        run_slice,
+                        s,
+                        base_config=base_config,
+                        output_root=output_root,
+                        stryker_bin=args.stryker_bin,
+                        per_slice_concurrency=per_slice_concurrency,
+                    )
+                ] = s["name"]
+            print(format_progress_line(order, states))
+            for future in futures:
+                name = futures[future]
+                exit_codes[name] = future.result()
+                states[name] = "done" if exit_codes[name] == 0 else "failed"
+                print(format_progress_line(order, states))
+    finally:
+        wrapper.restore_sln(sln, sln_hidden)
+
+    # ---- Aggregate roll-up ----
+    summaries = {}
+    for s in to_run:
+        report = slice_report_path(output_root, s["name"])
+        if report.exists():
+            try:
+                summaries[s["name"]] = summarize_native_report(
+                    json.loads(report.read_text())
+                )
+            except (json.JSONDecodeError, OSError):
+                pass
+    if summaries:
+        aggregate = aggregate_slice_summaries(summaries)
+        write_aggregate_report(output_root, aggregate)
+
+    return max(exit_codes.values(), default=0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_csharp_stryker_net_slice_runner.py
+++ b/tests/scripts/test_csharp_stryker_net_slice_runner.py
@@ -1,0 +1,589 @@
+"""Pytest tests for csharp_stryker_net_slice_runner.py — first-class
+slicing + configurable slice-level parallelism for Stryker.NET (#561).
+
+Follows the same hermetic, monkeypatch-the-subprocess-boundary strategy as
+tests/scripts/test_csharp_stryker_net_wrapper.py: no real ``dotnet``/
+``dotnet-stryker`` invocation, no filesystem PATH shims.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+WRAPPER_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(WRAPPER_DIR))
+
+import csharp_stryker_net_slice_runner as runner  # noqa: E402
+import csharp_stryker_net_wrapper as wrapper  # noqa: E402
+
+
+# =============================================================================
+# load_slices_config — validation
+# =============================================================================
+class TestLoadSlicesConfig:
+    def test_loads_valid_config(self, tmp_path):
+        cfg = tmp_path / "mutation-slices.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "slices": [
+                        {"name": "validators", "mutate": "**/Validators/**/*.cs"},
+                        {"name": "services", "mutate": "**/Services/**/*.cs"},
+                    ]
+                }
+            )
+        )
+        slices = runner.load_slices_config(cfg)
+        assert [s["name"] for s in slices] == ["validators", "services"]
+
+    def test_accepts_reserved_667_fields(self, tmp_path):
+        cfg = tmp_path / "mutation-slices.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "slices": [
+                        {
+                            "name": "validators",
+                            "mutate": "**/Validators/**/*.cs",
+                            "kind": "logic",
+                            "mutation-level": "Basic",
+                            "exclude-converged": True,
+                        }
+                    ]
+                }
+            )
+        )
+        slices = runner.load_slices_config(cfg)
+        assert slices[0]["kind"] == "logic"
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            runner.load_slices_config(tmp_path / "nope.json")
+
+    def test_invalid_json_raises(self, tmp_path):
+        cfg = tmp_path / "bad.json"
+        cfg.write_text("{not json")
+        with pytest.raises(ValueError, match="not valid JSON"):
+            runner.load_slices_config(cfg)
+
+    def test_empty_slices_array_raises(self, tmp_path):
+        cfg = tmp_path / "empty.json"
+        cfg.write_text(json.dumps({"slices": []}))
+        with pytest.raises(ValueError, match="non-empty"):
+            runner.load_slices_config(cfg)
+
+    def test_missing_required_field_raises(self, tmp_path):
+        cfg = tmp_path / "missing.json"
+        cfg.write_text(json.dumps({"slices": [{"name": "validators"}]}))
+        with pytest.raises(ValueError, match="missing required field"):
+            runner.load_slices_config(cfg)
+
+    def test_duplicate_name_raises(self, tmp_path):
+        cfg = tmp_path / "dup.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "slices": [
+                        {"name": "a", "mutate": "**/A/**/*.cs"},
+                        {"name": "a", "mutate": "**/B/**/*.cs"},
+                    ]
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="duplicate slice name"):
+            runner.load_slices_config(cfg)
+
+
+# =============================================================================
+# resolve_slice_selection — --slice <name> / --slice all
+# =============================================================================
+class TestResolveSliceSelection:
+    def setup_method(self):
+        self.configured = [
+            {"name": "validators", "mutate": "**/Validators/**/*.cs"},
+            {"name": "services", "mutate": "**/Services/**/*.cs"},
+        ]
+
+    def test_all_returns_every_slice_in_order(self):
+        assert runner.resolve_slice_selection(self.configured, "all") == self.configured
+
+    def test_named_slice_returns_single_match(self):
+        result = runner.resolve_slice_selection(self.configured, "services")
+        assert len(result) == 1
+        assert result[0]["name"] == "services"
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="no slice named"):
+            runner.resolve_slice_selection(self.configured, "nope")
+
+
+# =============================================================================
+# Per-slice output layout + terminal-report detection (resume support)
+# =============================================================================
+class TestOutputLayout:
+    def test_slice_report_path_shape(self, tmp_path):
+        p = runner.slice_report_path(tmp_path, "validators")
+        assert p == tmp_path / "slice-validators" / "reports" / "mutation-report.json"
+
+
+class TestIsTerminalReport:
+    def test_missing_file_is_not_terminal(self, tmp_path):
+        assert runner.is_terminal_report(tmp_path / "nope.json") is False
+
+    def test_invalid_json_is_not_terminal(self, tmp_path):
+        p = tmp_path / "report.json"
+        p.write_text("{truncated")
+        assert runner.is_terminal_report(p) is False
+
+    def test_empty_files_map_is_not_terminal(self, tmp_path):
+        p = tmp_path / "report.json"
+        p.write_text(json.dumps({"files": {}}))
+        assert runner.is_terminal_report(p) is False
+
+    def test_populated_files_map_is_terminal(self, tmp_path):
+        p = tmp_path / "report.json"
+        p.write_text(
+            json.dumps({"files": {"src/Foo.cs": {"mutants": [{"status": "Killed"}]}}})
+        )
+        assert runner.is_terminal_report(p) is True
+
+    def test_non_dict_json_is_not_terminal(self, tmp_path):
+        p = tmp_path / "report.json"
+        p.write_text(json.dumps([1, 2, 3]))
+        assert runner.is_terminal_report(p) is False
+
+
+class TestPartitionTerminalSlices:
+    def test_skips_slices_with_terminal_report(self, tmp_path):
+        slices = [
+            {"name": "validators", "mutate": "x"},
+            {"name": "services", "mutate": "y"},
+        ]
+        report = runner.slice_report_path(tmp_path, "validators")
+        report.parent.mkdir(parents=True)
+        report.write_text(
+            json.dumps({"files": {"a.cs": {"mutants": [{"status": "Killed"}]}}})
+        )
+        to_run, skipped = runner.partition_terminal_slices(
+            slices, tmp_path, force=False
+        )
+        assert [s["name"] for s in to_run] == ["services"]
+        assert [s["name"] for s in skipped] == ["validators"]
+
+    def test_force_reruns_terminal_slices(self, tmp_path):
+        slices = [{"name": "validators", "mutate": "x"}]
+        report = runner.slice_report_path(tmp_path, "validators")
+        report.parent.mkdir(parents=True)
+        report.write_text(
+            json.dumps({"files": {"a.cs": {"mutants": [{"status": "Killed"}]}}})
+        )
+        to_run, skipped = runner.partition_terminal_slices(slices, tmp_path, force=True)
+        assert [s["name"] for s in to_run] == ["validators"]
+        assert skipped == []
+
+    def test_non_terminal_report_is_not_skipped(self, tmp_path):
+        slices = [{"name": "validators", "mutate": "x"}]
+        report = runner.slice_report_path(tmp_path, "validators")
+        report.parent.mkdir(parents=True)
+        report.write_text("{crashed mid-write")
+        to_run, skipped = runner.partition_terminal_slices(
+            slices, tmp_path, force=False
+        )
+        assert [s["name"] for s in to_run] == ["validators"]
+        assert skipped == []
+
+
+# =============================================================================
+# Total-worker resolution: --total-workers N|auto
+# =============================================================================
+class TestResolveTotalWorkers:
+    def test_auto_is_max_2_cores_div_2(self):
+        assert runner.resolve_total_workers("auto", 12) == 6
+        assert runner.resolve_total_workers(None, 12) == 6
+
+    def test_auto_floors_at_2_on_low_core_count(self):
+        assert runner.resolve_total_workers("auto", 2) == 2
+        assert runner.resolve_total_workers("auto", 1) == 2
+
+    def test_auto_falls_back_when_cpu_count_is_none(self):
+        assert runner.resolve_total_workers("auto", None) == 2
+
+    def test_explicit_integer_is_used_verbatim(self):
+        assert runner.resolve_total_workers("10", 12) == 10
+
+
+class TestTotalWorkerCeilingCheck:
+    def test_within_ceiling_is_allowed_silently(self):
+        allowed, msg = runner.total_worker_ceiling_check(6, 12, force=False)
+        assert allowed is True
+        assert msg is None
+
+    def test_over_ceiling_without_force_is_refused(self):
+        allowed, msg = runner.total_worker_ceiling_check(20, 12, force=False)
+        assert allowed is False
+        assert "exceeds" in msg
+        assert "--force" in msg
+
+    def test_over_ceiling_with_force_is_allowed_with_warning(self):
+        allowed, msg = runner.total_worker_ceiling_check(20, 12, force=True)
+        assert allowed is True
+        assert "warning" in msg
+        assert "--force" in msg
+
+
+# =============================================================================
+# Worker allocation: --parallel-slices / --per-slice-concurrency hints
+# =============================================================================
+class TestResolveWorkerAllocation:
+    def test_default_split_allocates_slices_first(self):
+        # 6 total workers, 7 slices -> min(6,7)=6 parallel slices, remainder 1 each.
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, None, None, force=False
+        )
+        assert parallel == 6
+        assert per_slice == 1
+        assert msg is None
+
+    def test_default_split_with_fewer_slices_than_workers(self):
+        # 6 total workers, 2 slices -> 2 parallel slices, 3 per-slice each.
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 2, None, None, force=False
+        )
+        assert parallel == 2
+        assert per_slice == 3
+
+    def test_explicit_parallel_slices_only_derives_per_slice(self):
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, 3, None, force=False
+        )
+        assert parallel == 3
+        assert per_slice == 2
+
+    def test_explicit_per_slice_only_derives_parallel(self):
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, None, 2, force=False
+        )
+        assert parallel == 3
+        assert per_slice == 2
+
+    def test_both_explicit_within_ceiling_is_allowed(self):
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, 3, 2, force=False
+        )
+        assert (parallel, per_slice) == (3, 2)
+        assert msg is None
+
+    def test_both_explicit_over_ceiling_without_force_errors(self):
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, 6, 5, force=False
+        )
+        assert (parallel, per_slice) == (6, 5)
+        assert "exceeds" in msg
+        assert "error" in msg
+
+    def test_both_explicit_over_ceiling_with_force_warns(self):
+        parallel, per_slice, msg = runner.resolve_worker_allocation(
+            6, 7, 6, 5, force=True
+        )
+        assert (parallel, per_slice) == (6, 5)
+        assert "warning" in msg
+
+
+# =============================================================================
+# Per-slice Stryker config generation
+# =============================================================================
+class TestBuildSliceStrykerConfig:
+    def test_defaults_coverage_analysis_to_per_test(self):
+        cfg = runner.build_slice_stryker_config(
+            {}, {"name": "x", "mutate": "**/X/**/*.cs"}
+        )
+        assert cfg["coverage-analysis"] == "perTest"
+        assert cfg["mutate"] == ["**/X/**/*.cs"]
+
+    def test_respects_existing_coverage_analysis_escape_hatch(self):
+        cfg = runner.build_slice_stryker_config(
+            {"coverage-analysis": "off"}, {"name": "x", "mutate": "**/X/**/*.cs"}
+        )
+        assert cfg["coverage-analysis"] == "off"
+
+    def test_wraps_string_mutate_glob_in_a_list(self):
+        cfg = runner.build_slice_stryker_config(
+            {}, {"name": "x", "mutate": "**/X/**/*.cs"}
+        )
+        assert isinstance(cfg["mutate"], list)
+
+    def test_preserves_base_config_keys(self):
+        cfg = runner.build_slice_stryker_config(
+            {"reporters": ["dots", "json"]}, {"name": "x", "mutate": "**/X/**/*.cs"}
+        )
+        assert cfg["reporters"] == ["dots", "json"]
+
+
+class TestWriteSliceConfig:
+    def test_writes_wrapped_stryker_config_shape(self, tmp_path):
+        path = runner.write_slice_config(tmp_path, "validators", {"mutate": ["x"]})
+        assert path == tmp_path / "slice-validators" / "stryker-config.json"
+        data = json.loads(path.read_text())
+        assert data == {"stryker-config": {"mutate": ["x"]}}
+
+
+# =============================================================================
+# Native report summarizing + aggregate roll-up
+# =============================================================================
+class TestSummarizeNativeReport:
+    def test_counts_mutants_by_status(self):
+        native = {
+            "files": {
+                "a.cs": {
+                    "mutants": [
+                        {"status": "Killed"},
+                        {"status": "Killed"},
+                        {"status": "Survived"},
+                    ]
+                },
+                "b.cs": {"mutants": [{"status": "NoCoverage"}]},
+            }
+        }
+        counts = runner.summarize_native_report(native)
+        assert counts == {"Killed": 2, "Survived": 1, "NoCoverage": 1}
+
+    def test_empty_report_yields_empty_counts(self):
+        assert runner.summarize_native_report({"files": {}}) == {}
+
+
+class TestAggregateSliceSummaries:
+    def test_sums_totals_across_slices(self):
+        summaries = {
+            "validators": {"Killed": 10, "Survived": 2},
+            "services": {"Killed": 5, "Survived": 1, "NoCoverage": 1},
+        }
+        agg = runner.aggregate_slice_summaries(summaries)
+        assert agg["totals"] == {"Killed": 15, "Survived": 3, "NoCoverage": 1}
+        assert agg["slices"] == summaries
+        assert agg["schema_version"] == 1
+        assert agg["tool"] == "stryker-net"
+
+    def test_computes_honest_score(self):
+        summaries = {"a": {"Killed": 8, "Survived": 2}}
+        agg = runner.aggregate_slice_summaries(summaries)
+        assert agg["honest_score"] == 80.0
+
+    def test_honest_score_is_zero_when_no_mutants(self):
+        agg = runner.aggregate_slice_summaries({})
+        assert agg["honest_score"] == 0.0
+
+
+class TestWriteAggregateReport:
+    def test_writes_to_output_root(self, tmp_path):
+        path = runner.write_aggregate_report(tmp_path, {"totals": {}})
+        assert path == tmp_path / "aggregate-mutation-report.json"
+        assert json.loads(path.read_text()) == {"totals": {}}
+
+
+# =============================================================================
+# Rolled-up progress reporting
+# =============================================================================
+class TestFormatProgressLine:
+    def test_renders_positional_status_per_slice(self):
+        order = ["a", "b", "c", "d"]
+        states = {"a": "done", "b": "done", "c": "running", "d": "queued"}
+        line = runner.format_progress_line(order, states)
+        assert line == (
+            "slice 1/4 done, slice 2/4 done, slice 3/4 running, slice 4/4 queued"
+        )
+
+    def test_defaults_to_queued_for_unknown_slice(self):
+        line = runner.format_progress_line(["a"], {})
+        assert line == "slice 1/1 queued"
+
+
+# =============================================================================
+# main() — end-to-end fleet orchestration
+# =============================================================================
+@pytest.fixture
+def hermetic(tmp_path, monkeypatch):
+    root = tmp_path
+    sln = root / "Foo.sln"
+    sln.write_text("solution stub")
+    monkeypatch.setenv("DOTNET_ROOT", str(root / "fake-dotnet-root"))
+    monkeypatch.chdir(root)
+
+    cfg = root / "mutation-slices.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "slices": [
+                    {"name": "validators", "mutate": "**/Validators/**/*.cs"},
+                    {"name": "services", "mutate": "**/Services/**/*.cs"},
+                ]
+            }
+        )
+    )
+
+    class Ctx:
+        pass
+
+    ctx = Ctx()
+    ctx.root = root
+    ctx.sln = sln
+    ctx.sln_hidden = Path(str(sln) + ".stryker-hidden")
+    ctx.slices_config = cfg
+    ctx.build_calls = []
+    ctx.stryker_calls = []
+    ctx.sln_present_during_stryker = []
+    return ctx
+
+
+def _install_fakes(monkeypatch, ctx, *, exit_code=0):
+    def fake_build(project, cwd=None):
+        ctx.build_calls.append(project)
+        return 0
+
+    def fake_run_stryker(stryker_bin, stryker_args, logfile):
+        ctx.sln_present_during_stryker.append(ctx.sln.exists())
+        ctx.stryker_calls.append(
+            {
+                "stryker_bin": stryker_bin,
+                "stryker_args": list(stryker_args),
+                "logfile": str(logfile),
+            }
+        )
+        # Simulate a completed report for aggregate roll-up.
+        logfile.parent.mkdir(parents=True, exist_ok=True)
+        report_dir = logfile.parent / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        (report_dir / "mutation-report.json").write_text(
+            json.dumps({"files": {"a.cs": {"mutants": [{"status": "Killed"}]}}})
+        )
+        return exit_code
+
+    monkeypatch.setattr(wrapper, "build_project", fake_build)
+    monkeypatch.setattr(wrapper, "run_stryker", fake_run_stryker)
+
+
+def run_slice_runner(hermetic, *extra_args):
+    args = [
+        "--slices-config",
+        str(hermetic.slices_config),
+        "--sln",
+        str(hermetic.sln),
+        "--output-root",
+        str(hermetic.root / "StrykerOutput"),
+        "--stryker-bin",
+        "fake-stryker-bin",
+        *extra_args,
+    ]
+    return runner.main(args)
+
+
+class TestMainSingleSlice:
+    def test_runs_named_slice_and_restores_sln(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_slice_runner(hermetic, "--slice", "validators")
+        assert rc == 0
+        assert hermetic.sln.exists()
+        assert not hermetic.sln_hidden.exists()
+        assert len(hermetic.stryker_calls) == 1
+
+    def test_hides_sln_before_stryker_and_restores_after(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        run_slice_runner(hermetic, "--slice", "validators")
+        assert hermetic.sln_present_during_stryker == [False]
+
+    def test_unknown_slice_name_errors(self, hermetic, monkeypatch, capsys):
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_slice_runner(hermetic, "--slice", "nope")
+        assert rc == 2
+        assert "no slice named" in capsys.readouterr().err
+        assert hermetic.build_calls == []
+
+    def test_writes_per_slice_report_path(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        run_slice_runner(hermetic, "--slice", "validators")
+        report = (
+            hermetic.root
+            / "StrykerOutput"
+            / "slice-validators"
+            / "reports"
+            / "mutation-report.json"
+        )
+        assert report.exists()
+
+
+class TestMainAllSlices:
+    def test_runs_all_slices_hiding_sln_once(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        assert rc == 0
+        assert len(hermetic.stryker_calls) == 2
+        assert hermetic.sln.exists()
+        assert not hermetic.sln_hidden.exists()
+
+    def test_aggregate_report_written(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        agg_path = hermetic.root / "StrykerOutput" / "aggregate-mutation-report.json"
+        assert agg_path.exists()
+        agg = json.loads(agg_path.read_text())
+        assert agg["totals"] == {"Killed": 2}
+        assert set(agg["slices"].keys()) == {"validators", "services"}
+
+    def test_resume_skips_terminal_slices(self, hermetic, monkeypatch, capsys):
+        _install_fakes(monkeypatch, hermetic)
+        run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        hermetic.stryker_calls.clear()
+        hermetic.build_calls.clear()
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        assert rc == 0
+        assert hermetic.stryker_calls == []
+        out = capsys.readouterr().out
+        assert "SKIPPED validators" in out
+        assert "SKIPPED services" in out
+
+    def test_force_reruns_terminal_slices(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        hermetic.stryker_calls.clear()
+        rc = run_slice_runner(
+            hermetic, "--slice", "all", "--total-workers", "2", "--force"
+        )
+        assert rc == 0
+        assert len(hermetic.stryker_calls) == 2
+
+    def test_refuses_over_ceiling_without_force(self, hermetic, monkeypatch, capsys):
+        _install_fakes(monkeypatch, hermetic)
+        monkeypatch.setattr(os, "cpu_count", lambda: 4)
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "20")
+        assert rc == 2
+        assert "exceeds" in capsys.readouterr().err
+        assert hermetic.stryker_calls == []
+
+    def test_allows_over_ceiling_with_force(self, hermetic, monkeypatch):
+        _install_fakes(monkeypatch, hermetic)
+        monkeypatch.setattr(os, "cpu_count", lambda: 4)
+        rc = run_slice_runner(
+            hermetic, "--slice", "all", "--total-workers", "20", "--force"
+        )
+        assert rc == 0
+        assert len(hermetic.stryker_calls) == 2
+
+    def test_stryker_nonzero_exit_propagates_and_still_restores_sln(
+        self, hermetic, monkeypatch
+    ):
+        _install_fakes(monkeypatch, hermetic, exit_code=1)
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+        assert rc == 1
+        assert hermetic.sln.exists()
+        assert not hermetic.sln_hidden.exists()

--- a/tests/skills/test_mutation_slicing_parallelism.py
+++ b/tests/skills/test_mutation_slicing_parallelism.py
@@ -1,0 +1,95 @@
+"""Doc-shape contract for issue #561 (first-class slicing + configurable
+slice-level parallelism for Stryker.NET).
+
+Pattern mirrors tests/skills/test_mutation_kill_slice_loop_refinements.py —
+grep guards against csharp-stryker-net.md's new "Slice runner" section. The
+prose (and the shipped script it documents) are the deliverable; these
+guards regress when the contract drifts.
+"""
+
+from __future__ import annotations
+
+from skill_doc_helpers import PLUGIN_ROOT, grep, section
+
+CSHARP = (
+    PLUGIN_ROOT
+    / "skills"
+    / "mutation-testing"
+    / "references"
+    / "languages"
+    / "csharp-stryker-net.md"
+)
+
+
+def _text() -> str:
+    return CSHARP.read_text()
+
+
+def _slice_runner_section() -> str:
+    return section(
+        _text(),
+        r"^## Slice runner",
+        boundary_pattern=r"^## ",
+        include_start_line=True,
+    )
+
+
+def test_documents_the_shipped_slice_runner_script():
+    s = _slice_runner_section()
+    assert grep(r"csharp_stryker_net_slice_runner\.py", s)
+
+
+def test_documents_slice_cli_flags():
+    s = _slice_runner_section()
+    assert grep(r"--slice\s+<name>", s)
+    assert grep(r"--slice\s+all", s)
+
+
+def test_documents_slices_config_block_with_required_and_reserved_fields():
+    s = _slice_runner_section()
+    assert grep(r"\bname\b", s)
+    assert grep(r"\bmutate\b", s)
+    # Reserved fields for #667 — accepted, not yet acted on.
+    assert grep(r"\bkind\b", s)
+    assert grep(r"mutation-level", s)
+    assert grep(r"exclude-converged", s)
+    assert grep(r"#667", s)
+
+
+def test_documents_per_slice_output_and_aggregate_rollup():
+    s = _slice_runner_section()
+    assert grep(r"slice-<name>", s)
+    assert grep(r"mutation-report\.json", s)
+    assert grep(r"aggregate", s, ignore_case=True)
+
+
+def test_documents_resume_and_force_override():
+    s = _slice_runner_section()
+    assert grep(r"--force", s)
+    assert grep(r"resum", s, ignore_case=True)
+
+
+def test_documents_total_workers_flag_and_auto_formula():
+    s = _slice_runner_section()
+    assert grep(r"--total-workers", s)
+    assert grep(r"auto", s, ignore_case=True)
+    assert grep(r"max\(2,\s*cores\s*/\s*2\)", s) or grep(r"max\(2, cores", s)
+
+
+def test_documents_parallel_slices_and_per_slice_concurrency_hints():
+    s = _slice_runner_section()
+    assert grep(r"--parallel-slices", s)
+    assert grep(r"--per-slice-concurrency", s)
+    assert grep(r"cores\s*-\s*1|cores\s*−\s*1", s)
+
+
+def test_documents_sln_hide_restore_once_per_fleet_not_per_slice():
+    s = _slice_runner_section()
+    assert grep(r"\.sln", s)
+    assert grep(r"once", s, ignore_case=True)
+    assert grep(r"fleet", s, ignore_case=True)
+
+
+def test_documents_rolled_up_progress_reporting():
+    s = _slice_runner_section()
+    assert grep(r"slice \d/\d", s) or grep(r"queued|running|done", s)


### PR DESCRIPTION
## Summary

- Ships `csharp_stryker_net_slice_runner.py` — `--slice <name>` / `--slice all` against a JSON `slices:` config (only `name` + `mutate` required; `kind`/`mutation-level`/`exclude-converged` reserved for #667, accepted and validated but not yet acted on).
- Per-slice output at `<output-root>/slice-<name>/reports/mutation-report.json`, plus an aggregate roll-up at `<output-root>/aggregate-mutation-report.json`.
- Resume: skips slices with a terminal report; `--force` reruns everything.
- `--total-workers N|auto` (`auto` = `max(2, cores/2)`), with optional `--parallel-slices`/`--per-slice-concurrency` hints; refuses to oversubscribe past `cores-1` (or the product of the two hints past `--total-workers`) without `--force`.
- `.sln` hide/restore happens **once** around the whole parallel fleet (reusing `csharp_stryker_net_wrapper.py`'s hide/restore/build/run primitives), not per slice — avoids the shared-resource race the issue calls out.
- Documents the new script in `csharp-stryker-net.md`'s new "Slice runner" section.

Builds on #667 (schema fields reserved) and #669 (`coverage-analysis: perTest` default), both closed.

## Test plan

- [x] `python3 -m pytest tests/scripts/test_csharp_stryker_net_slice_runner.py tests/skills/test_mutation_slicing_parallelism.py` — new tests, all passing
- [x] `python3 -m pytest tests/ plugins/dev-team/tests/` — full suite green (1962 passed, 18 skipped)
- [x] `bash scripts/ci-local.sh` — all local CI checks passed

Closes #561