### PR TITLE
fix(skills): add pre-switch verification to branch-workflow

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1702,6 +1702,10 @@
       "summary": "After confirming the base branch, present exactly four choices:",
       "anchor": "3-present-options"
     },
+    "3a. Pre-Switch Verification (Option 1 only)": {
+      "summary": "Before performing the checkout/merge that Option 1 (\"Merge locally\") requires, verify the working tree is safe to switch:",
+      "anchor": "3a-pre-switch-verification-option-1-only"
+    },
     "4. Merge Strategy (for options 1 and 2)": {
       "summary": "| Situation | Strategy | Why |",
       "anchor": "4-merge-strategy-for-options-1-and-2"

--- a/plugins/dev-team/skills/branch-workflow/SKILL.md
+++ b/plugins/dev-team/skills/branch-workflow/SKILL.md
@@ -12,21 +12,26 @@ user-invocable: true
 The three-phase workflow ends at the Phase 3 human gate. This skill formalizes what happens after approval: PR creation, merge decision, and branch cleanup. Without this, branches linger and merge conflicts accumulate.
 
 ## Constraints
+
 - Do not push to main/master directly — always use a PR
 - Do not force-push unless the human explicitly requests it
 - Do not delete branches that have unmerged work
 - Do not merge without a passing CI check (if CI is configured)
+- Do not switch branches (checkout, worktree enter) without first checking working-tree state and confirming with the human if dirty
 
 ## Workflow
 
 ### 1. Pre-PR Checklist
+
 Before creating the PR, verify:
+
 - [ ] All tests pass (fresh run, not cached)
 - [ ] `/code-review` passed or warnings are documented
 - [ ] Documentation is current (tech-writer verified in Phase 3)
 - [ ] Branch is rebased on latest main (resolve conflicts if needed)
 
 ### 2. Create the PR
+
 - Title: concise, under 70 characters, describes the change
 - Body: Summary (what and why), test plan, link to design doc if one exists
 - Labels: add relevant labels (bug, feature, refactor, docs)
@@ -41,10 +46,22 @@ After confirming the base branch, present exactly four choices:
 3. **Keep as-is** — Preserve branch and worktree for later handling
 4. **Discard** — Permanently delete branch and all commits. **Requires the human to type "discard" to confirm.** Never discard without typed confirmation.
 
+### 3a. Pre-Switch Verification (Option 1 only)
+
+Before performing the checkout/merge that Option 1 ("Merge locally") requires, verify the working tree is safe to switch:
+
+1. Run a working-tree status check (`git status --short`, or the worktree-tool equivalent) covering the feature branch's tree. This surfaces both tracked changes (modified/staged) and untracked files — not just tracked ones.
+2. Show the result to the human.
+3. If the tree is clean, proceed with the switch.
+4. If the tree is **not** clean (any modified, staged, or untracked files), stop. Do not switch branches silently. Require the human to explicitly say how to proceed — commit, stash, or abort — before running the checkout. This follows the same explicit-confirmation pattern as Option 4's typed "discard," not a bare warning that can be clicked through.
+5. Re-check that the target/base branch still matches what was confirmed in step 3's "After confirming the base branch..." — this does not re-ask for that confirmation, only verifies it hasn't drifted since.
+
+This step applies only to the branch/worktree switch Option 1 performs. It does not replace or duplicate the Pre-PR Checklist's "Branch is rebased on latest main" item (§1) — that is a rebase-currency check performed earlier, not a dirty-tree check performed at the moment of switching. It also does not modify Post-Merge Verification & Cleanup (§5), which handles branch/worktree deletion after the merge, not the switch before it.
+
 ### 4. Merge Strategy (for options 1 and 2)
 
 | Situation | Strategy | Why |
-|-----------|----------|-----|
+| ----------- | ---------- | ----- |
 | Single logical change, clean history | Squash merge | One commit tells the story |
 | Multiple logical changes that should stay separate | Merge commit | Preserves the history of each change |
 | Long-lived branch with many commits | Squash merge | Reduces noise in main history |
@@ -53,13 +70,16 @@ After confirming the base branch, present exactly four choices:
 Default: **squash merge** unless the human specifies otherwise.
 
 ### 5. Post-Merge Verification & Cleanup
+
 - Run tests on the merged result — **do not skip this**. Broken code must never reach base branches.
 - Delete the feature branch (remote and local) — only for options 1 and 4
 - Remove worktree if applicable (options 1 and 4 only; keep for option 2)
 
 ## Integration
+
 - Triggered after Phase 3 human gate approval
 - PR creation follows the git commit conventions in the project
 
 ## Output
+
 A merged PR with clean branch history, closed issues, and deleted feature branch.


### PR DESCRIPTION
## Summary
- Adds a `### 3a. Pre-Switch Verification` step to `branch-workflow/SKILL.md`, run immediately before Option 1 ("Merge locally") performs its checkout/merge.
- The step runs a working-tree status check (`git status --short`, covering both tracked and untracked changes), shows it to the human, and — if the tree is dirty — requires explicit human confirmation (commit/stash/abort) before proceeding, reusing the same explicit-confirmation pattern as Option 4's typed "discard".
- Adds a matching constraint bullet: "Do not switch branches (checkout, worktree enter) without first checking working-tree state and confirming with the human if dirty."
- Regenerated `plugins/dev-team/knowledge/index.json` via `build_knowledge_index.py` since skill markdown changed.
- Scoped strictly to Option 1's switch — does not touch the Pre-PR Checklist's rebase-currency check (§1) or Post-Merge Verification & Cleanup (§5, targeted separately by #716).

Closes #714

## Test plan
- [x] `python3 -m pytest tests/ plugins/dev-team/tests/ -k "branch_workflow or skills_index or knowledge_index or registry_sync or agent_audit"` — 111 passed
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` re-run and diff committed