### PR TITLE
fix: recognize directory-style Files: declarations in progress_guardian

### DIFF
--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -34,9 +34,44 @@ STEP_PATTERN = re.compile(r"^-\s+\[( |x|X)\]\s+(?:Step\s+[\d.]+:\s+)?(.+)$")
 # Matches backtick-quoted paths in plan text (declared file references)
 BACKTICK_PATH_RE = re.compile(r"`([^`\s]+\.[a-zA-Z0-9_]+)`")
 
+# Matches backtick-quoted directory declarations (trailing '/'), e.g.
+# `plugins/dev-team/skills/new-feature/`. Kept separate from
+# BACKTICK_PATH_RE so extension-less, non-path backtick tokens (e.g.
+# `runHook()`, `SomeClass`) are never mistaken for declared paths — see
+# issue #713.
+BACKTICK_DIR_RE = re.compile(r"`([^`\s]+/)`")
+
 # Matches a slice's `**Files:** ...` declaration line. Captures the
-# remainder of the line so BACKTICK_PATH_RE can extract the paths from it.
+# remainder of the line so BACKTICK_PATH_RE/BACKTICK_DIR_RE can extract
+# the paths from it.
 SLICE_FILES_RE = re.compile(r"^\*\*Files:\*\*\s*(.+)$")
+
+
+def _extract_declared_paths(text: str) -> List[str]:
+    """Return backtick-quoted file paths and directory paths declared in
+    text: exact file paths (ending in a dot-extension) plus directory
+    declarations (ending in '/'). A directory declaration means "this
+    slice touches things under here" — matched with startswith, not
+    equality, by callers. Bare backtick-quoted tokens with no extension
+    and no trailing slash (e.g. `` `runHook()` ``) are not paths and are
+    intentionally excluded (see issue #713).
+    """
+    return BACKTICK_PATH_RE.findall(text) + BACKTICK_DIR_RE.findall(text)
+
+
+def _is_path_declared(file_path: str, declared_paths) -> bool:
+    """True if file_path exactly matches a declared file, or falls under
+    a declared directory (trailing '/') prefix. Single source of truth
+    shared by check_commit_discipline and check_scope so the two checks
+    cannot drift on what counts as "declared" (see issue #525/#713).
+    """
+    for declared in declared_paths:
+        if declared.endswith("/"):
+            if file_path.startswith(declared):
+                return True
+        elif file_path == declared:
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -218,7 +253,7 @@ def _parse_slice_files(plan_text: str, slice_header: str) -> List[str]:
             break
         fm = SLICE_FILES_RE.match(line)
         if fm:
-            return BACKTICK_PATH_RE.findall(fm.group(1))
+            return _extract_declared_paths(fm.group(1))
 
     # Fall back to inline layout: `**Files:**` line near a `- [x] <header>`.
     in_block = False
@@ -239,7 +274,7 @@ def _parse_slice_files(plan_text: str, slice_header: str) -> List[str]:
             break
         fm = SLICE_FILES_RE.match(line)
         if fm:
-            return BACKTICK_PATH_RE.findall(fm.group(1))
+            return _extract_declared_paths(fm.group(1))
     return []
 
 
@@ -321,8 +356,10 @@ def check_commit_discipline(
     for step in done_steps:
         declared = _parse_slice_files(plan_text, step.header) if plan_text else []
         if declared:
-            # File-path path: pass when any declared path was touched on this branch.
-            if any(p in branch_files for p in declared):
+            # File-path path: pass when any declared file was touched on
+            # this branch, or any branch file falls under a declared
+            # directory (see issue #713).
+            if any(_is_path_declared(bf, declared) for bf in branch_files):
                 continue
             errors.append(
                 _make_error(
@@ -424,7 +461,7 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     LLM unavailability always produces a warning, never an error.
     """
     text = plan_path.read_text(encoding="utf-8")
-    declared_paths = set(BACKTICK_PATH_RE.findall(text))
+    declared_paths = set(_extract_declared_paths(text))
 
     # Single source of truth for base-ref resolution — shared with
     # check_commit_discipline so the two checks cannot drift on what
@@ -465,9 +502,14 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     if not changed_files:
         return []
 
-    # If no declared paths, any changed file is potentially out-of-plan
+    # If no declared paths, any changed file is potentially out-of-plan.
+    # Otherwise a file is "declared" (not out-of-plan) if it exactly
+    # matches a declared file or falls under a declared directory prefix
+    # (see issue #713).
     out_of_plan = (
-        changed_files if not declared_paths else (changed_files - declared_paths)
+        changed_files
+        if not declared_paths
+        else {f for f in changed_files if not _is_path_declared(f, declared_paths)}
     )
 
     if not out_of_plan:

--- a/tests/scripts/test_progress_guardian.py
+++ b/tests/scripts/test_progress_guardian.py
@@ -567,3 +567,126 @@ def test_4_4_realistic_plan_with_all_three_525_patterns_passes_the_pre_pr_gate(
     assert result.returncode == 0
     data = json.loads(result.stdout)
     assert data["issues"] == [], data
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — Issue #713: directory-style `**Files:**` declarations
+# Bug: BACKTICK_PATH_RE only captures backtick-quoted paths that end in a
+# dot-extension, so a `**Files:** `some/dir/`` declaration (a common way to
+# scope a slice that adds several new files under one folder) is invisible
+# to _parse_slice_files and check_scope's declared_paths, silently falling
+# through to the pre-#525 substring fallback / flagging every file as
+# out-of-plan.
+# ---------------------------------------------------------------------------
+
+
+def test_5_1_directory_declaration_satisfies_commit_discipline(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "new_feature").mkdir()
+    (tmp_path / "new_feature" / "SKILL.md").write_text("skill\n")
+    _git(tmp_path, "add", "new_feature/SKILL.md")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] Slice 1: add new-feature skill\n\n**Files:** `new_feature/`\n")
+
+    result = run_pg(plan, "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data
+
+
+def test_5_2_directory_declaration_still_catches_real_gaps(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "unrelated.py").write_text("code\n")
+    _git(tmp_path, "add", "unrelated.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add unrelated file")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] add new-feature skill\n\n**Files:** `new_feature/`\n")
+
+    result = run_pg(plan, "--skip-llm")
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    errs = [
+        i
+        for i in data["issues"]
+        if i["severity"] == "error" and "'add new-feature skill'" in i["message"]
+    ]
+    assert len(errs) == 1, data
+
+
+def test_5_3a_check_scope_does_not_flag_file_under_declared_directory(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "initial")
+    plan = tmp_path / "plan.md"
+    make_plan(
+        plan,
+        "- [x] Slice 1: add new-feature skill\n\n**Files:** `new_feature/`",
+    )
+    _git(tmp_path, "add", "plan.md")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill")
+    (tmp_path / "new_feature").mkdir()
+    (tmp_path / "new_feature" / "SKILL.md").write_text("skill\n")
+    _git(tmp_path, "add", "new_feature/SKILL.md")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill impl")
+
+    result = run_pg(plan, "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data
+
+
+def test_5_3b_check_scope_still_flags_file_outside_declared_directory(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "initial")
+    plan = tmp_path / "plan.md"
+    make_plan(
+        plan,
+        "- [x] Slice 1: add new-feature skill\n\n**Files:** `new_feature/`",
+    )
+    _git(tmp_path, "add", "plan.md")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill")
+    (tmp_path / "new_feature").mkdir()
+    (tmp_path / "new_feature" / "SKILL.md").write_text("skill\n")
+    _git(tmp_path, "add", "new_feature/SKILL.md")
+    (tmp_path / "extra.py").write_text("extra\n")
+    _git(tmp_path, "add", "extra.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill plus extra")
+
+    result = run_pg(plan, "--skip-llm")
+    assert result.returncode == 2
+    data = json.loads(result.stdout)
+    assert any(i.get("rule_id") == "llm-skipped" for i in data["issues"]), data
+
+
+def test_5_4_non_path_backtick_token_not_mis_captured_as_declared_path(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "unrelated.py").write_text("code\n")
+    _git(tmp_path, "add", "unrelated.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: unrelated change")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] wire up the hook\n\n**Files:** `runHook()`\n")
+
+    result = run_pg(plan, "--skip-llm")
+    # `runHook()` has no extension and no trailing slash -> not captured as
+    # a declared path, so the slice falls back to substring matching on
+    # "wire up the hook" (which isn't in any commit subject) -> exit 1 with
+    # the substring-fallback message, proving the token was never absorbed
+    # into declared_paths.
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    errs = [
+        i
+        for i in data["issues"]
+        if i["severity"] == "error" and "'wire up the hook'" in i["message"]
+    ]
+    assert len(errs) == 1, data
+    assert "whose subject contains" in errs[0]["message"], errs[0]


### PR DESCRIPTION
## Summary

`scripts/progress_guardian.py`'s `BACKTICK_PATH_RE` only captured backtick-quoted paths ending in a dot extension, so a `**Files:**` line declaring a *directory* (e.g. `` `plugins/dev-team/skills/new-feature/` ``) — a common way to scope a slice that adds several new files under one folder — was invisible to `_parse_slice_files` and `check_scope`'s `declared_paths`. That silently:

- fell `check_commit_discipline` through to the pre-#525 substring fallback for that slice, and
- caused `check_scope` to flag every file under the declared directory as scope creep.

This is a gate false-positive reported in #713 (part of the #707 session-review backlog).

## Fix

- Added `BACKTICK_DIR_RE` to capture trailing-slash directory declarations, kept separate from the extension-based `BACKTICK_PATH_RE` so bare non-path backtick tokens (e.g. `` `runHook()` ``) are never mistakenly captured.
- Added `_extract_declared_paths()` (both regexes) and `_is_path_declared()` (exact-match or directory-prefix match) as the single source of truth, used by both `check_commit_discipline` and `check_scope` so the two checks can't drift on what counts as "declared".
- `_parse_slice_files` now returns directory tokens alongside file tokens (same signature/return type).

No changes to exit codes, JSON shape, or `plugins/dev-team/agents/progress-guardian.md`.

## Test plan

- [x] New tests in `tests/scripts/test_progress_guardian.py` (TDD — written first, confirmed failing before the fix):
  - `test_5_1_directory_declaration_satisfies_commit_discipline` (AC1)
  - `test_5_2_directory_declaration_still_catches_real_gaps` (AC2 — no over-matching)
  - `test_5_3a/b_check_scope_...` (AC3 — directory recognized, true out-of-plan still caught)
  - `test_5_4_non_path_backtick_token_not_mis_captured_as_declared_path` (AC4)
- [x] All 27 tests in `tests/scripts/test_progress_guardian.py` pass (22 pre-existing + 5 new)
- [x] `bash scripts/ci-local.sh` — full local gate green (1870 passed, 16 skipped; eslint required a one-time `npm ci` in this fresh worktree, unrelated to this change)

Closes #713