### PR TITLE
feat(telemetry): attribute user-correction turns to active skill/agent

### DIFF
--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -172,6 +172,8 @@ def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
     tool_errors = Counter()        # by tool name
     tool_calls = Counter()         # by tool name (for ratios)
     correction_turns = 0
+    correction_by_skill = Counter()   # #711: correction attribution
+    correction_by_agent = Counter()
 
     # utilization
     skills_invoked = Counter()
@@ -179,6 +181,12 @@ def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
 
     # map tool_use id -> tool name, to attribute tool_result errors back
     pending_tool: dict[str, str] = {}
+    # #711: most-recently-invoked Skill/Agent on the main thread, sticky until
+    # superseded — used to attribute a correction turn to the artifact active
+    # when it happened. No "skill ended" event exists in the transcript
+    # format, so "most recent invocation" is the only signal available.
+    active_skill: str | None = None
+    active_agent: str | None = None
 
     for rec in _iter_records(paths):
         sid = rec.get("sessionId") or rec.get("session_id")
@@ -243,10 +251,12 @@ def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
                         s = inp.get("skill") or inp.get("name")
                         if isinstance(s, str) and s:
                             skills_invoked[_strip_ns(s)] += 1
+                            active_skill = _strip_ns(s)
                     elif name in ("Agent", "Task"):
                         a = inp.get("subagent_type")
                         if isinstance(a, str) and a:
                             agents_invoked[_strip_ns(a)] += 1
+                            active_agent = _strip_ns(a)
                     if name in _EDIT_TOOLS and inp.get("file_path"):
                         edits_per_file[os.path.basename(str(inp["file_path"]))] += 1
                     if name == "Bash" and isinstance(inp.get("command"), str):
@@ -282,6 +292,8 @@ def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
                                       for b in content)):
                 if _CORRECTION_RE.search(utext.lower()):
                     correction_turns += 1
+                    correction_by_skill[active_skill or "unattributed"] += 1
+                    correction_by_agent[active_agent or "unattributed"] += 1
 
     # repeated edits / retried bash (>1 occurrence)
     repeated_file_edits = {f: n for f, n in edits_per_file.items() if n > 1}
@@ -327,6 +339,8 @@ def extract(paths: list[Path], pricing: dict, registry: dict) -> dict:
             "tool_calls": total_calls,
             "tool_error_rate": round(total_errors / total_calls, 4) if total_calls else 0.0,
             "user_correction_turns": correction_turns,
+            "by_skill": dict(sorted(correction_by_skill.items())),
+            "by_agent": dict(sorted(correction_by_agent.items())),
         },
         "gate": {
             "commit_attempts": commit_attempts,
@@ -426,6 +440,7 @@ def sync_record(digest: dict, host: str, project: str,
     file names, paths, prompts, or code — same privacy boundary as the digest."""
     base = slim_record(digest)
     tok = digest.get("token", {})
+    acc = digest.get("accuracy", {})
     util = digest.get("utilization", {})
     by_model = {m: dict(sorted(v.items()))
                 for m, v in sorted(tok.get("by_model", {}).items())}
@@ -443,7 +458,14 @@ def sync_record(digest: dict, host: str, project: str,
         "by_model": by_model,
         "by_thread": tok.get("by_subagent", {}),
         "rework": base["rework"],
-        "accuracy": base["accuracy"],
+        # #711: by_skill/by_agent correction attribution comes from the FULL
+        # digest (not slim_record, which deliberately drops per-name maps) —
+        # same pattern already used above for by_thread.
+        "accuracy": {
+            **base["accuracy"],
+            "by_skill": dict(sorted(acc.get("by_skill", {}).items())),
+            "by_agent": dict(sorted(acc.get("by_agent", {}).items())),
+        },
         "gate": base["gate"],
         # Utilization carries the invoked NAME maps (registry ids, non-sensitive),
         # not slim counts, so a cross-host rollup can compute which skills/agents
@@ -538,6 +560,8 @@ def rollup(digests_root: Path, registry: dict) -> dict:
     tool_calls = 0
     err_weighted = 0.0
     corrections = 0
+    correction_by_skill = Counter()   # #711
+    correction_by_agent = Counter()
     skills_invoked = Counter()
     agents_invoked = Counter()
     by_host: dict[str, Counter] = defaultdict(Counter)
@@ -570,6 +594,10 @@ def rollup(digests_root: Path, registry: dict) -> dict:
         tool_calls += n
         err_weighted += (acc.get("tool_error_rate", 0.0) or 0.0) * n
         corrections += acc.get("user_correction_turns", 0) or 0
+        for name, k in (acc.get("by_skill", {}) or {}).items():
+            correction_by_skill[name] += k
+        for name, k in (acc.get("by_agent", {}) or {}).items():
+            correction_by_agent[name] += k
         u = r.get("utilization", {}) if isinstance(r.get("utilization"), dict) else {}
         for name, k in (u.get("skills_invoked", {}) or {}).items():
             skills_invoked[name] += k
@@ -597,6 +625,8 @@ def rollup(digests_root: Path, registry: dict) -> dict:
             "tool_calls": tool_calls,
             "tool_error_rate": round(err_weighted / tool_calls, 4) if tool_calls else 0.0,
             "user_correction_turns": corrections,
+            "by_skill": dict(sorted(correction_by_skill.items())),
+            "by_agent": dict(sorted(correction_by_agent.items())),
         },
         "utilization": {
             "skills_invoked": dict(sorted(skills_invoked.items())),

--- a/tests/repo/test_session_extract.py
+++ b/tests/repo/test_session_extract.py
@@ -70,6 +70,58 @@ def test_extract_accuracy_signals() -> None:
     assert accuracy["user_correction_turns"] == 1
 
 
+def test_extract_accuracy_correction_attribution_unattributed_without_tool_use() -> (
+    None
+):
+    # sample-transcript.jsonl's correction turn is preceded by no Skill/Agent
+    # tool_use block (only attributionSkill tags, which don't drive
+    # attribution per #182) -> attributed to "unattributed" (#711).
+    digest = _digest()
+    accuracy = digest["accuracy"]
+    assert accuracy["by_skill"] == {"unattributed": 1}
+    assert accuracy["by_agent"] == {"unattributed": 1}
+    # invariant (AC2): sum of by_skill/by_agent == the scalar
+    assert sum(accuracy["by_skill"].values()) == accuracy["user_correction_turns"]
+    assert sum(accuracy["by_agent"].values()) == accuracy["user_correction_turns"]
+
+
+def test_extract_accuracy_correction_attributed_to_most_recent_skill_and_agent(
+    tmp_path: Path,
+) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        '{"type":"assistant","sessionId":"s1","message":{"content":'
+        '[{"type":"tool_use","id":"u1","name":"Skill",'
+        '"input":{"skill":"dev-team:plan"}}]}}\n'
+        '{"type":"assistant","sessionId":"s1","message":{"content":'
+        '[{"type":"tool_use","id":"u2","name":"Agent",'
+        '"input":{"subagent_type":"dev-team:software-engineer","description":"x"}}]}}\n'
+        '{"type":"user","sessionId":"s1","message":{"content":'
+        '"No, actually revert that change"}}\n'
+        # a second correction with no intervening Skill/Agent invocation ->
+        # still attributed to the STICKY last-seen skill/agent, not reset.
+        '{"type":"user","sessionId":"s1","message":{"content":'
+        '"that is wrong, stop"}}\n'
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(EXTRACT),
+            "--transcript",
+            str(transcript),
+            "--plugin-root",
+            str(PLUGIN),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    accuracy = json.loads(result.stdout)["accuracy"]
+    assert accuracy["user_correction_turns"] == 2
+    assert accuracy["by_skill"] == {"plan": 2}
+    assert accuracy["by_agent"] == {"software-engineer": 2}
+
+
 def test_extract_utilization() -> None:
     digest = _digest()
     utilization = digest["utilization"]

--- a/tests/repo/test_session_extract_rollup.py
+++ b/tests/repo/test_session_extract_rollup.py
@@ -72,7 +72,8 @@ def _seed_digests(tmp_path: Path) -> Path:
         '{"schema":"session-sync/v1","host":"boxA","project":"alpha","session_id":"s1",'
         '"tokens":{"input_tokens":1000,"output_tokens":100,"cache_read_input_tokens":400},'
         '"cost_usd":0.5,"rework":{"failed_edits":1},'
-        '"accuracy":{"tool_calls":10,"tool_error_rate":0.1,"user_correction_turns":1},'
+        '"accuracy":{"tool_calls":10,"tool_error_rate":0.1,"user_correction_turns":1,'
+        '"by_skill":{"plan":1},"by_agent":{"unattributed":1}},'
         '"utilization":{"skills_invoked":{"plan":1},"agents_invoked":{}}}\n'
         '{"schema":"session-sync/v1","host":"boxA","project":"beta","session_id":"s2",'
         '"tokens":{"input_tokens":2000,"output_tokens":200},"cost_usd":1.0,'
@@ -84,7 +85,8 @@ def _seed_digests(tmp_path: Path) -> Path:
         '{"schema":"session-sync/v1","host":"boxB","project":"alpha","session_id":"s3",'
         '"tokens":{"input_tokens":500,"output_tokens":50},"cost_usd":0.25,'
         '"rework":{"failed_edits":2},'
-        '"accuracy":{"tool_calls":4,"tool_error_rate":0.25,"user_correction_turns":0},'
+        '"accuracy":{"tool_calls":4,"tool_error_rate":0.25,"user_correction_turns":1,'
+        '"by_skill":{"code-review":1},"by_agent":{"software-engineer":1}},'
         '"utilization":{"skills_invoked":{"plan":2},"agents_invoked":{}}}\n'
     )
     return tmp_path / "digests"
@@ -130,6 +132,21 @@ def test_rollup_utilization_unions_invocations_and_never_observed(
     # set
     assert "plan" not in data["utilization"]["never_observed_skills"]
     assert len(data["utilization"]["never_observed_skills"]) > 5
+
+
+def test_rollup_accuracy_sums_correction_by_skill_and_by_agent_across_hosts(
+    tmp_path: Path,
+) -> None:
+    # #711: rollup must sum the per-session correction-attribution maps, and
+    # the summed total must equal the scalar user_correction_turns rollup.
+    digests = _seed_digests(tmp_path)
+    data = _rollup(digests)
+    accuracy = data["accuracy"]
+    assert accuracy["user_correction_turns"] == 2
+    assert accuracy["by_skill"] == {"code-review": 1, "plan": 1}
+    assert accuracy["by_agent"] == {"software-engineer": 1, "unattributed": 1}
+    assert sum(accuracy["by_skill"].values()) == accuracy["user_correction_turns"]
+    assert sum(accuracy["by_agent"].values()) == accuracy["user_correction_turns"]
 
 
 def test_rollup_a_session_id_seen_twice_is_deduped(tmp_path: Path) -> None:

--- a/tests/repo/test_session_extract_sync.py
+++ b/tests/repo/test_session_extract_sync.py
@@ -150,6 +150,52 @@ def test_sync_privacy_basename_only_no_full_paths_or_content(
     assert '"project": "alpha"' in text or '"project":"alpha"' in text
 
 
+def test_sync_record_carries_correction_by_skill_and_by_agent(
+    tmp_path: Path,
+) -> None:
+    # #711: sync_record's accuracy block must carry the full by_skill/by_agent
+    # correction-attribution maps through from the digest, not just the
+    # slimmed scalar.
+    projects = tmp_path / "projects"
+    proj = projects / "projC"
+    proj.mkdir(parents=True)
+    (proj / "sess-corr.jsonl").write_text(
+        '{"type":"assistant","cwd":"/home/u/work/gamma","sessionId":"s-corr",'
+        '"timestamp":"2026-06-07T10:00:00Z","message":{"content":'
+        '[{"type":"tool_use","id":"u1","name":"Skill",'
+        '"input":{"skill":"dev-team:plan"}}]}}\n'
+        '{"type":"user","cwd":"/home/u/work/gamma","sessionId":"s-corr",'
+        '"message":{"content":"No, actually revert that change"}}\n'
+    )
+    out = tmp_path / "digests" / "testhost" / "session-digest.jsonl"
+    watermark = tmp_path / "watermark.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(EXTRACT),
+            "--sync-out",
+            str(out),
+            "--watermark",
+            str(watermark),
+            "--projects-root",
+            str(projects),
+            "--host",
+            "testhost",
+            "--plugin-root",
+            str(PLUGIN),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    records = _records(out)
+    assert len(records) == 1
+    accuracy = records[0]["accuracy"]
+    assert accuracy["user_correction_turns"] == 1
+    assert accuracy["by_skill"] == {"plan": 1}
+    assert accuracy["by_agent"] == {"unattributed": 1}
+
+
 def test_all_projects_non_sync_digest_aggregates_sessions_across_projects(
     scratch: Dict[str, Path],
 ) -> None:


### PR DESCRIPTION
## Summary

`session_extract.py`'s digest tracked `accuracy.user_correction_turns` as a session-wide scalar with no way to say which skill or agent was active when the correction happened, so `telemetry-escalation.json` marked it `matchable: false` and every remediation fell back to the shared `plugins/dev-team/CLAUDE.md` catch-all instead of a specific artifact.

This extends the extractor (phase 1 of the issue's spec) to correlate each correction turn with the most-recently-invoked `Skill`/`Agent` tool_use on the main thread (sticky, reusing the existing #182 tool_use walk), and threads the resulting `accuracy.by_skill` / `accuracy.by_agent` breakdown through `sync_record()` and `rollup()` so a future `/session-review` pass can name a concrete target instead of deferring to the shared instruction layer.

- `extract()`: tracks sticky `active_skill`/`active_agent`; each correction turn increments `by_skill[active_skill or "unattributed"]` and `by_agent[active_agent or "unattributed"]` alongside the existing scalar.
- `sync_record()`: carries the full `by_skill`/`by_agent` maps through from the digest (the slim record deliberately drops per-name maps, same pattern already used for `by_thread`).
- `rollup()`: sums the per-session maps across hosts into the cross-machine `accuracy.by_skill`/`accuracy.by_agent`.
- `slim_record()` (trend log) and `escalate()`'s lever logic are intentionally unchanged, per the issue's phase-1 scope.

## Test plan

- [x] New/updated tests in `tests/repo/test_session_extract.py`, `test_session_extract_sync.py`, `test_session_extract_rollup.py` cover: unattributed fallback, sticky attribution across multiple corrections, sync passthrough, and rollup summation (with the sum-equals-scalar invariant from the spec's AC2/AC4).
- [x] `python3 -m pytest tests/repo/test_session_extract*.py tests/repo/test_gate_correlation.py tests/repo/test_cost_regression_ci.py tests/repo/test_shipped_script_refs.py` — 46 passed.
- [x] `python3 -m py_compile scripts/session_extract.py`

Closes #711