### PR TITLE
fix(model-routing-check): invoke resolver with python3, not bash

### DIFF
--- a/plugins/dev-team/skills/model-routing-check/SKILL.md
+++ b/plugins/dev-team/skills/model-routing-check/SKILL.md
@@ -79,7 +79,7 @@ echo "Model Routing Check"
 echo "==================="
 echo
 echo "Effective band → model map:"
-bash "$RESOLVER" --dump-map
+python3 "$RESOLVER" --dump-map
 echo
 
 # Ladder section

--- a/tests/commands/test_model_routing_check.py
+++ b/tests/commands/test_model_routing_check.py
@@ -165,6 +165,46 @@ def test_clean_prints_all_three_band_model_pairs(case: dict) -> None:
     assert "high" in result.stdout and "claude-opus-4-8" in result.stdout
 
 
+def test_band_model_map_section_is_exact_three_lines_no_garbage(
+    case: dict,
+) -> None:
+    """Regression test for #718: the exec block ran the Python resolver
+    through `bash` instead of `python3`, silently corrupting this section
+    with bash's line-by-line misinterpretation of Python syntax while the
+    command still exited 0. Anchor on the exact section contents so a
+    reintroduced `bash "$RESOLVER"` invocation fails this test."""
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    lines = result.stdout.splitlines()
+    start = lines.index("Effective band → model map:") + 1
+    end = start
+    while end < len(lines) and lines[end].strip() != "":
+        end += 1
+    section = lines[start:end]
+    assert section == [
+        "  low     → claude-haiku-4-5-20251001",
+        "  medium  → claude-sonnet-4-6",
+        "  high    → claude-opus-4-8",
+    ], f"band->model map section corrupted: {section!r}"
+
+
+def test_clean_run_produces_no_stderr(case: dict) -> None:
+    """Regression test for #718: bash-interpreting the Python resolver
+    file emits `command not found` / syntax errors. Both stdout and
+    stderr are captured together elsewhere in this suite; here they are
+    kept separate so stray interpreter errors can't hide as stdout."""
+    env = dict(case["env"])
+    result = subprocess.run(
+        ["bash", str(case["exec_script"])],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == "", result.stderr
+
+
 def test_clean_prints_starter_ladder_seeded_from_defaults(case: dict) -> None:
     result = _run(case)
     assert result.returncode == 0, result.stdout


### PR DESCRIPTION
## Summary

`/model-routing-check`'s exec block resolved the effective band → model map by shelling out with `bash "$RESOLVER" --dump-map`, where `$RESOLVER` defaults to `hooks/lib/model_resolve.py` — a Python file, not a shell script. Running Python source through `bash` doesn't fail cleanly: it silently corrupts the "Effective band → model map" section with bash's line-by-line misinterpretation of Python syntax (stray `command not found`, and on machines where a same-named binary is on `PATH` — e.g. ImageMagick's `import` colliding with Python's `import` keyword — pages of unrelated output). Because the block has `set -uo pipefail` but no `-e`, execution continues past the corrupted section and the remaining sections print fine, so the command exits 0 and looks like it "mostly works" while silently reporting a broken band→model map.

This regressed in `d6af7e26` (the `.sh` → `.py` rename of the `RESOLVER` default path), which wasn't paired with a `bash` → `python3` invocation change.

## Fix

One-line change: `bash "$RESOLVER" --dump-map` → `python3 "$RESOLVER" --dump-map`. `hooks/lib/model_resolve.py`'s resolution algorithm is untouched, as is `hooks/agent_model_resolve.py` (the real PreToolUse dispatch hook, which imports the resolver as a Python module directly and was never exposed to this defect).

## Tests

`tests/commands/test_model_routing_check.py` gains two regression tests that fail against the pre-fix exec block:
- an exact-match assertion on the band→model section (the existing loose substring checks matched somewhere in the corrupted output and didn't catch this)
- an assertion that stderr is empty on a clean run

Verified both new tests fail against the pre-fix `bash "$RESOLVER"` invocation and pass after the fix. Full suite: `python3 -m pytest tests plugins/dev-team/tests` — 1425 + 539 passed (2 + 16 skipped), 0 failures.

Closes #718