### PR TITLE
fix(tests): extend hermetic-adoption gate to plugins/dev-team/tests/**/*.py

### DIFF
--- a/plugins/dev-team/tests/hooks/test_contract_version_guard.py
+++ b/plugins/dev-team/tests/hooks/test_contract_version_guard.py
@@ -20,7 +20,12 @@ _HOOKS_DIR = Path(__file__).resolve().parents[2] / "hooks"
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
 import contract_version_guard as hook  # type: ignore[import-not-found]  # noqa: E402
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -128,28 +133,38 @@ def _init_hermetic_repo(root: Path, contract_content: str) -> None:
     plugins/dev-team/knowledge/security-primitives-contract.md relative to
     repo root.
     """
+    env = hermetic_git_env(home=root)
     subprocess.run(
         ["git", "init", "--quiet", "-b", "main"],
         cwd=root,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "t@t"],
         cwd=root,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
-        ["git", "config", "user.name", "t"], cwd=root, check=True, capture_output=True
+        ["git", "config", "user.name", "t"],
+        cwd=root,
+        env=env,
+        check=True,
+        capture_output=True,
     )
     contract_dir = root / "plugins" / "dev-team" / "knowledge"
     contract_dir.mkdir(parents=True, exist_ok=True)
     (contract_dir / "security-primitives-contract.md").write_text(contract_content)
-    subprocess.run(["git", "add", "-A"], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "-A"], cwd=root, env=env, check=True, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "--quiet", "-m", "init"],
         cwd=root,
+        env=env,
         check=True,
         capture_output=True,
     )
@@ -290,29 +305,36 @@ def test_non_contract_file_pass(tmp_path: Path) -> None:
 
 def test_initial_add_without_version_blocks(tmp_path: Path) -> None:
     # Hermetic repo does NOT commit the contract → HEAD_CONTENT is empty.
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(
         ["git", "init", "--quiet", "-b", "main"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "t@t"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "t"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     (tmp_path / "sentinel").write_text("")
-    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "-A"], cwd=tmp_path, env=env, check=True, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "--quiet", "-m", "init"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
@@ -331,29 +353,36 @@ def test_initial_add_without_version_blocks(tmp_path: Path) -> None:
 
 
 def test_initial_add_with_version_passes(tmp_path: Path) -> None:
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(
         ["git", "init", "--quiet", "-b", "main"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "t@t"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "t"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )
     (tmp_path / "sentinel").write_text("")
-    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "-A"], cwd=tmp_path, env=env, check=True, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "--quiet", "-m", "init"],
         cwd=tmp_path,
+        env=env,
         check=True,
         capture_output=True,
     )

--- a/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
@@ -20,6 +20,12 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_knowledge_index.py"
 
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
+
 
 def _run(
     payload: dict, cwd: Path, extra_env: dict = None
@@ -53,11 +59,7 @@ def _run(
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     """A tiny hermetic git repo with a plugin corpus tree + fresh index."""
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
     subprocess.run(
         ["git", "config", "user.email", "t@t.dev"], cwd=tmp_path, env=env, check=True
@@ -124,11 +126,7 @@ def test_no_verify_bypass(repo: Path) -> None:
     (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
         "# Foo\n## Section A\nEdited body.\n"
     )
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     subprocess.run(
         ["git", "add", "plugins/dev-team/knowledge/foo.md"],
         cwd=repo,
@@ -146,11 +144,7 @@ def test_no_verify_bypass(repo: Path) -> None:
 
 
 def test_commit_with_only_non_corpus_staged_is_allowed(repo: Path) -> None:
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     (repo / "plugins" / "dev-team" / "agents" / "some-agent.md").write_text(
         "# Some Agent\n## New\nBody.\n"
     )
@@ -167,11 +161,7 @@ def test_commit_with_only_non_corpus_staged_is_allowed(repo: Path) -> None:
 
 
 def test_commit_with_corpus_and_matching_index_passes(repo: Path) -> None:
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
         "# Foo\n## Section A\nFirst sentence of A.\n## New Section\nBody of new section.\n"
     )
@@ -201,11 +191,7 @@ def test_commit_with_corpus_and_matching_index_passes(repo: Path) -> None:
 
 
 def test_commit_with_stale_index_blocks_with_remediation(repo: Path) -> None:
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
         "# Foo\n## Section A\nFirst sentence of A.\n## New Section\nBody of new section.\n"
     )
@@ -226,11 +212,7 @@ def test_commit_with_stale_index_blocks_with_remediation(repo: Path) -> None:
 
 
 def test_commit_blocks_when_working_tree_drifts_past_staged_pair(repo: Path) -> None:
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     (repo / "plugins" / "dev-team" / "knowledge" / "foo.md").write_text(
         "# Foo\n## Section A\nFirst sentence of A.\n## First\nBody of first.\n"
     )

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -20,6 +20,12 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "pre_commit_review.py"
 
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
+
 
 def _run(payload: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
     proc_env = {
@@ -44,11 +50,7 @@ def _run(payload: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     """A minimal hermetic git repo with one staged file."""
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
     subprocess.run(
         ["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True
@@ -92,11 +94,7 @@ def test_no_verify_bypass(repo: Path) -> None:
 
 def test_commit_with_nothing_staged_silent(tmp_path: Path) -> None:
     """No staged files → nothing to gate."""
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
     subprocess.run(
         ["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True
@@ -156,11 +154,7 @@ def test_stale_gate_file_blocks(repo: Path) -> None:
     (repo / ".review-passed").write_text(h)
     # Edit the staged file's content.
     (repo / "a.ts").write_text("v2-unreviewed\n")
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     subprocess.run(["git", "add", "a.ts"], cwd=repo, env=env, check=True)
     r = _run(
         {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
@@ -175,11 +169,7 @@ def test_extra_staged_file_after_review_blocks(repo: Path) -> None:
     h = _current_hash(repo)
     (repo / ".review-passed").write_text(h)
     (repo / "b.ts").write_text("new\n")
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=repo)
     subprocess.run(["git", "add", "b.ts"], cwd=repo, env=env, check=True)
     r = _run(
         {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo

--- a/plugins/dev-team/tests/hooks/test_review_gate_hash.py
+++ b/plugins/dev-team/tests/hooks/test_review_gate_hash.py
@@ -8,7 +8,6 @@ implementations against each other were removed alongside it.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -20,15 +19,16 @@ _HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
 if str(_HOOKS_LIB) not in sys.path:
     sys.path.insert(0, str(_HOOKS_LIB))
 
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
 import review_gate_hash as gate  # type: ignore[import-not-found]  # noqa: E402
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
 
 
 def _init_repo(tmp_path: Path) -> Path:
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
-    }
+    env = hermetic_git_env(home=tmp_path)
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
     subprocess.run(
         ["git", "config", "user.email", "t@t.dev"], cwd=tmp_path, env=env, check=True
@@ -59,7 +59,9 @@ def test_empty_staged_area_produces_stable_hash(tmp_path: Path) -> None:
 def test_single_staged_file_produces_hex_hash(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     (tmp_path / "a.ts").write_text("hello\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h = gate.review_gate_hash(cwd=tmp_path)
     assert len(h) == 64
     int(h, 16)  # hex
@@ -69,10 +71,14 @@ def test_changed_content_changes_hash(tmp_path: Path) -> None:
     """The whole point of #193 — content edits must alter the hash."""
     _init_repo(tmp_path)
     (tmp_path / "a.ts").write_text("v1\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h1 = gate.review_gate_hash(cwd=tmp_path)
     (tmp_path / "a.ts").write_text("v2\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h2 = gate.review_gate_hash(cwd=tmp_path)
     assert h1 != h2
 
@@ -80,10 +86,14 @@ def test_changed_content_changes_hash(tmp_path: Path) -> None:
 def test_extra_staged_file_changes_hash(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     (tmp_path / "a.ts").write_text("hi\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h1 = gate.review_gate_hash(cwd=tmp_path)
     (tmp_path / "b.ts").write_text("new\n")
-    subprocess.run(["git", "add", "b.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "b.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h2 = gate.review_gate_hash(cwd=tmp_path)
     assert h1 != h2
 
@@ -91,7 +101,9 @@ def test_extra_staged_file_changes_hash(tmp_path: Path) -> None:
 def test_deterministic_across_repeated_calls(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     (tmp_path / "a.ts").write_text("stable\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     hashes = {gate.review_gate_hash(cwd=tmp_path) for _ in range(5)}
     assert len(hashes) == 1
 
@@ -100,7 +112,9 @@ def test_hash_is_64_hex_chars(tmp_path: Path) -> None:
     """sha256 hex-encoded → 64 chars."""
     _init_repo(tmp_path)
     (tmp_path / "a.ts").write_text("x\n")
-    subprocess.run(["git", "add", "a.ts"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "a.ts"], cwd=tmp_path, env=hermetic_git_env(home=tmp_path), check=True
+    )
     h = gate.review_gate_hash(cwd=tmp_path)
     assert len(h) == 64
     int(h, 16)  # raises if not hex

--- a/plugins/dev-team/tests/lib/hermetic.py
+++ b/plugins/dev-team/tests/lib/hermetic.py
@@ -1,0 +1,43 @@
+"""Shared hermetic-env helper for plugins/dev-team/tests/ pytest fixtures.
+
+Issue #715: pytest fixtures under plugins/dev-team/tests/ that shell out to
+mutating `git` subprocesses (init, add, commit, ...) must not inherit the
+five git-exported env vars a pre-push hook's own git invocation sets
+(GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE, GIT_PREFIX, GIT_REFLOG_ACTION) —
+otherwise the fixture's "git init"/"git commit" can be redirected into the
+*parent* worktree/index instead of the fixture's own tmp_path, corrupting
+real refs. This mirrors tests/repo/conftest.py's `hermetic_env` fixture
+(issue #546) as a plain importable function so tests outside tests/repo/
+(which has no conftest.py of its own) get the same guarantee.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+_DANGEROUS_GIT_VARS = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_REFLOG_ACTION",
+)
+
+
+def hermetic_git_env(home: Optional[Path] = None) -> Dict[str, str]:
+    """Return an environment safe to pass to subprocess git mutations.
+
+    Strips the five dangerous git-exported vars so a fixture's own `git`
+    subprocess calls can never be redirected into the parent worktree, and
+    redirects global/system git config to /dev/null so the real user's
+    ~/.gitconfig can't bleed into the test. Pass `home` (typically the
+    fixture's `tmp_path`) to also isolate HOME for tests that care.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _DANGEROUS_GIT_VARS}
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    if home is not None:
+        env["HOME"] = str(home)
+    return env

--- a/plugins/dev-team/tests/lib/test_hermetic.py
+++ b/plugins/dev-team/tests/lib/test_hermetic.py
@@ -1,0 +1,55 @@
+"""Unit tests for tests/lib/hermetic.py's hermetic_git_env() (issue #715)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import hermetic  # type: ignore[import-not-found]  # noqa: E402
+
+_DANGEROUS = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_REFLOG_ACTION",
+)
+
+
+def test_strips_dangerous_git_vars_even_when_ambient(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("GIT_DIR", str(tmp_path / "decoy.git"))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "decoy-index"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "decoy-wt"))
+    monkeypatch.setenv("GIT_PREFIX", "subdir/")
+    monkeypatch.setenv("GIT_REFLOG_ACTION", "push")
+
+    env = hermetic.hermetic_git_env()
+
+    for var in _DANGEROUS:
+        assert var not in env
+
+
+def test_redirects_git_config_to_dev_null() -> None:
+    env = hermetic.hermetic_git_env()
+    assert env["GIT_CONFIG_GLOBAL"] == "/dev/null"
+    assert env["GIT_CONFIG_SYSTEM"] == "/dev/null"
+
+
+def test_home_override_when_provided(tmp_path: Path) -> None:
+    env = hermetic.hermetic_git_env(home=tmp_path)
+    assert env["HOME"] == str(tmp_path)
+
+
+def test_home_left_as_ambient_when_not_provided(monkeypatch) -> None:
+    monkeypatch.setenv("HOME", "/original/home")
+    env = hermetic.hermetic_git_env()
+    assert env["HOME"] == "/original/home"
+
+
+def test_preserves_path_for_git_lookup() -> None:
+    env = hermetic.hermetic_git_env()
+    assert "PATH" in env

--- a/tests/repo/test_hermetic_adoption.py
+++ b/tests/repo/test_hermetic_adoption.py
@@ -7,13 +7,21 @@ worktree's refs.
 Ported from tests/repo/hermetic_adoption_tests.bats (issue #671). bats-core
 itself (and tests/lib/hermetic.bash with it) is now fully retired (#677,
 closing epic #668) — there are no *.bats files left under tests/ for this
-sensor to scan, so it now passes vacuously. Left in place rather than
-deleted: it costs nothing to run and re-arms automatically if a *.bats file
-ever reappears.
+sensor to scan, so that half now passes vacuously. Left in place rather
+than deleted: it costs nothing to run and re-arms automatically if a
+*.bats file ever reappears.
+
+Issue #715 — the bats-only, repo-root-`tests/`-only enumeration above was
+blind to plugins/dev-team/tests/**/*.py, where four pytest files shelled
+out to mutating `git` subprocess calls without scrubbing the same five
+dangerous env vars. This module now also scans that pytest tree for
+subprocess-based git mutation that doesn't route through the shared
+plugins/dev-team/tests/lib/hermetic.hermetic_git_env() helper.
 """
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -67,5 +75,127 @@ def test_every_fixture_bats_file_that_runs_git_ops_loads_hermetic() -> None:
         "The following bats files do fixture git operations but do not "
         "source tests/lib/hermetic.bash + wire "
         "hermetic_setup/hermetic_teardown. See issue #546 for why this "
+        f"matters.\n" + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python-fixture equivalent (issue #715)
+# ---------------------------------------------------------------------------
+
+# Roots of pytest trees, outside tests/, that are known to shell out to
+# mutating git subprocesses directly (not via tests/repo/conftest.py's
+# hermetic_env fixture, which this scan does not need to duplicate). Add a
+# new root here if another such tree is confirmed.
+_PY_SCAN_ROOTS = ("plugins/dev-team/tests",)
+
+# Same rationale as _WHITELIST above, for the Python-side scan.
+_PY_WHITELIST: set[str] = set()
+
+# The helper itself and its own unit test never need to be flagged: the
+# helper defines hermetic_git_env() but doesn't call subprocess with git
+# args, and its test only calls the helper, not subprocess.
+_PY_SELF_EXEMPT = {
+    "plugins/dev-team/tests/lib/hermetic.py",
+    "plugins/dev-team/tests/lib/test_hermetic.py",
+}
+
+_PY_SUBPROCESS_FUNCS = {"run", "call", "check_call", "check_output", "Popen"}
+
+# Kept in lockstep with _MUTATING_GIT_RE's verb list above.
+_PY_MUTATING_VERBS = {
+    "init",
+    "commit",
+    "push",
+    "update-ref",
+    "checkout",
+    "branch",
+    "tag",
+    "add",
+    "clone",
+    "fetch",
+    "pull",
+    "merge",
+    "rebase",
+    "reset",
+    "apply",
+    "cherry-pick",
+    "revert",
+    "worktree",
+    "stash",
+}
+
+
+def _iter_git_mutating_calls(tree: ast.AST):
+    """Yield subprocess.* Call nodes whose first arg is a git-mutating argv."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            fname = func.attr
+        elif isinstance(func, ast.Name):
+            fname = func.id
+        else:
+            continue
+        if fname not in _PY_SUBPROCESS_FUNCS:
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if not isinstance(first, (ast.List, ast.Tuple)):
+            continue
+        argv = [
+            elt.value
+            for elt in first.elts
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+        ]
+        if len(argv) < 2 or argv[0] != "git" or argv[1] not in _PY_MUTATING_VERBS:
+            continue
+        yield node
+
+
+def _needs_hermetic_py(text: str) -> bool:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return False
+    return any(True for _ in _iter_git_mutating_calls(tree))
+
+
+def _is_hermetic_py(text: str) -> bool:
+    """Best-effort static check (regex/AST, not full data-flow — #715 spec's
+    documented tradeoff): the file must use the shared helper, AND every
+    flagged git-mutating call site must pass an env= kwarg at all."""
+    if "hermetic_git_env(" not in text:
+        return False
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return False
+    for node in _iter_git_mutating_calls(tree):
+        if not any(kw.arg == "env" for kw in node.keywords):
+            return False
+    return True
+
+
+def test_every_python_fixture_that_runs_git_ops_uses_hermetic_env() -> None:
+    offenders = []
+    for root in _PY_SCAN_ROOTS:
+        for f in sorted((REPO_ROOT / root).rglob("*.py")):
+            rel = f.relative_to(REPO_ROOT).as_posix()
+            if rel in _PY_WHITELIST or rel in _PY_SELF_EXEMPT:
+                continue
+            text = f.read_text()
+            if not _needs_hermetic_py(text):
+                continue
+            if not _is_hermetic_py(text):
+                offenders.append(rel)
+
+    assert not offenders, (
+        "The following pytest files shell out to mutating git subprocess "
+        "calls but do not route every call through "
+        "plugins/dev-team/tests/lib/hermetic.hermetic_git_env() (env= on "
+        "every git-mutating call site). See issue #715 / #546 for why this "
         f"matters.\n" + "\n".join(f"  {o}" for o in offenders)
     )


### PR DESCRIPTION
## Summary

The hermetic-adoption gate (`tests/repo/test_hermetic_adoption.py`, issue #546) enumerated `tests/**/*.bats` only — a scope that predates the bash-removal migration (epic #572/#668) and never followed pytest fixture authorship. It was blind to four pytest files under `plugins/dev-team/tests/hooks/` that shell out to mutating `git` subprocess calls without scrubbing the five dangerous git-exported env vars (`GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_PREFIX`, `GIT_REFLOG_ACTION`), risking corruption of the parent worktree's refs.

- Added an AST-based Python-fixture scan (`test_every_python_fixture_that_runs_git_ops_uses_hermetic_env`) alongside the existing bats scan, scoped to `plugins/dev-team/tests/**/*.py`, with its own whitelist mechanism mirroring the bats side.
- Added a shared `hermetic_git_env()` helper at `plugins/dev-team/tests/lib/hermetic.py` (mirrors `tests/repo/conftest.py`'s existing `hermetic_env` fixture, but as a plain importable function for trees without their own conftest).
- Remediated the four offending files to route every git-mutating `subprocess.*` call through the helper: `test_review_gate_hash.py`, `test_pre_commit_review.py`, `test_pre_commit_knowledge_index.py`, `test_contract_version_guard.py`.
- Verified the new gate actually catches the pre-fix state (reverting the four files locally reproduces a failure naming all four) before confirming it passes clean post-fix.
- Stays wired into `chk_hook_units` (already runs `pytest plugins/dev-team/tests tests/repo ...`), so enforcement posture (blocking in both pre-push and CI) is unchanged.

## Test plan

- [x] `python3 -m pytest tests/repo/test_hermetic_adoption.py -q` — both bats and new Python scan pass
- [x] Reverted the four remediated files locally and re-ran the gate — it failed and named exactly those four files
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py -q` — 1871 passed, 16 skipped (pre-existing)
- [x] `bash scripts/ci-local.sh --only=chk_hook_units,chk_python_only,chk_md_references,chk_skills_index` — all passed

Closes #715