### PR TITLE
fix(hooks): require a logged reason for --no-verify/-n commit bypass

### DIFF
--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -66,7 +66,7 @@ File scope is resolved with this priority: `--path` → `--since` → `--all` �
 Auto-scope (the default) runs `git diff --name-only` plus `git diff --cached --name-only`. If either shows changes, only those files are reviewed. If the working tree is clean, the full repository is reviewed.
 
 | File count (full-repo mode) | Behavior |
-|-----------------------------|----------|
+| ----------------------------- | ---------- |
 | ≤ 200 | Proceed |
 | 201–500 | Warn, proceed |
 | > 500 | Warn and request confirmation |
@@ -90,7 +90,7 @@ The orchestrator probes for enhanced analysis tools (RoslynMCP, code knowledge g
 Deterministic checks run before any AI agent is invoked. Cheaper checks block expensive ones.
 
 | # | Gate | Tool | Stops on |
-|---|------|------|----------|
+| --- | ------ | ------ | ---------- |
 | 1 | Lint | `npx eslint` (or project's lint) | errors |
 | 2 | Type check | `npx tsc --noEmit` (if `tsconfig.json` exists) | errors |
 | 3 | Secret scan | grep for common secret patterns | any match |
@@ -127,7 +127,7 @@ Each enabled agent is spawned as a sub-agent via the Agent tool, all in a single
 - Receives the minimum context its `Context needs` field requires
 
 | `Context needs` | Input | When to use |
-|-----------------|-------|-------------|
+| ----------------- | ------- | ------------- |
 | `diff-only` | Git diff output only | Pattern-matching agents (naming, FP) |
 | `full-file` | Complete file contents | Agents needing function-level context |
 | `project-structure` | Full files + directory tree | Agents reasoning about architecture |
@@ -137,7 +137,7 @@ When the target is the full repository (`--all`, `--path`, or clean auto-scope),
 **Model routing** is orchestrator-controlled, not agent-controlled:
 
 | Tier | Model | Assigned to |
-|------|-------|-------------|
+| ------ | ------- | ------------- |
 | small | Haiku | naming, complexity, claude-setup, token-efficiency, performance |
 | mid | Sonnet | spec-compliance, test, structure, js-fp, concurrency, a11y, svelte, doc, refactoring, progress-guardian, data-flow-tracer |
 | frontier | Opus | security, domain, arch |
@@ -151,7 +151,7 @@ Each agent returns a JSON result: `{agentName, status, modelTier, issues[], summ
 **5b. Health scoring** per [`knowledge/review-rubric.md`](../knowledge/review-rubric.md):
 
 | Score | Condition |
-|-------|-----------|
+| ------- | ----------- |
 | 🟢 HEALTHY | 0 fail AND ≤ 2 warn |
 | 🟠 NEEDS ATTENTION | 1–2 fail OR 3+ warn |
 | 🔴 CRITICAL | 3+ fail OR any `security-review` fail |
@@ -159,7 +159,7 @@ Each agent returns a JSON result: `{agentName, status, modelTier, issues[], summ
 **Actionability classification** determines what the fix loop touches:
 
 | Severity | Confidence | Actionable | Behavior |
-|----------|------------|------------|----------|
+| ---------- | ------------ | ------------ | ---------- |
 | error / warning | high / medium | Yes | Auto-apply in fix loop |
 | error / warning | none | No | Report only — human judgment |
 | suggestion | any | No | Report only — do not trigger loop |
@@ -190,7 +190,7 @@ while actionable_issues > 0 and iteration ≤ 5:
 **Exit conditions**:
 
 | Condition | Outcome |
-|-----------|---------|
+| ----------- | --------- |
 | Zero actionable issues | Converged → generate report |
 | Iteration limit (5) reached | Escalate remaining issues to human |
 | Same issues persist after fix attempt | Not converging → exit and escalate |
@@ -221,19 +221,34 @@ git diff --cached --name-only | sort | shasum -a 256 | cut -d' ' -f1 > .review-p
 
 The pre-commit hook reads this file to verify the staged files match what was actually reviewed. If the review failed, `.review-passed` is **not** written, and commits are blocked until the review is re-run and passes.
 
+### Reasoned bypass (`--no-verify` / `-n`)
+
+`git commit --no-verify` (or its short form `-n`) is git's standard escape
+hatch and still works — but the pre-commit review gate hook
+(`hooks/pre_commit_review.py`) now requires a non-empty `GATE_BYPASS_REASON`
+environment variable before it lets the bypass through. Without one, the
+commit is blocked (exit 2) with a message naming the required variable. With
+one, the hook allows the commit and appends an accountability line —
+timestamp, branch, which flag triggered it, the reason, staged file count,
+and plugin version — to `metrics/gate-bypass-audit.jsonl`, unconditionally
+(this log is not gated by `DEV_TEAM_TELEMETRY`). This closes the previously
+frictionless, unlogged bypass path that correlated with materially higher
+rework (#709).
+
 ## Artifacts
 
 | Artifact | When | Purpose |
-|----------|------|---------|
+| ---------- | ------ | --------- |
 | Stdout report (markdown or JSON) | Every run | Human or CI consumption |
 | `corrections/*.json` | When unfixed actionable or suggestion issues remain | Feeds `/apply-fixes` |
 | `.review-passed` | Auto-scoped clean/warn runs | Gates the pre-commit hook |
 | `metrics/override-audit.jsonl` | `--force --reason ...` | Audit trail for skipped gates |
+| `metrics/gate-bypass-audit.jsonl` | `git commit --no-verify`/`-n` with `GATE_BYPASS_REASON` set | Audit trail for reasoned pre-commit-gate bypasses |
 
 ## Customization points
 
 | File | Location | Effect |
-|------|----------|--------|
+| ------ | ---------- | -------- |
 | `review-config.json` | Project root | Disables specific agents per project |
 | `REVIEW-CONTEXT.md` | Project root | Injects institutional knowledge into every agent's prompt |
 | `ACCEPTED-RISKS.md` | Project root | Suppresses known findings with audit trail and expiry |

--- a/plugins/dev-team/hooks/lib/pre_commit_detect.py
+++ b/plugins/dev-team/hooks/lib/pre_commit_detect.py
@@ -1,18 +1,33 @@
 """pre_commit_detect — shared `git commit` detection for PreToolUse:Bash hooks.
 
 Python port of hooks/lib/pre-commit-detect.sh (#576 / #572 Cluster B).
+Extended under #709 to recognize bare `-n` as a bypass flag identically to
+`--no-verify` (parity fix — `hooks/telemetry.py`'s bypass detection already
+matched bare `-n`; this detector did not).
 
 Imported by the Python siblings of the two callers:
   - hooks/pre_commit_review.py
   - hooks/pre_commit_knowledge_index.py
 
-Exposes one function:
+Exposes:
+
+  is_git_commit_command(cmd: str) -> bool
+    True when `cmd` is a `git commit` invocation, regardless of any
+    bypass flag. Callers that need to distinguish "gate-worthy commit"
+    from "bypassed commit" should also consult `has_bypass_flag`.
+
+  has_bypass_flag(cmd: str) -> bool
+    True when `cmd` carries `--no-verify` or a bare `-n` argument — git's
+    two spellings of "skip hooks". Substring/word-bounded match; does not
+    require `cmd` to be a `git commit` invocation.
+
+  bypass_flag_name(cmd: str) -> Optional[str]
+    "--no-verify" or "-n" (whichever matched; `--no-verify` preferred when
+    both are present), or None when `cmd` carries no bypass flag.
 
   is_git_commit_invocation(cmd: str) -> bool
-
-  True when `cmd` is a `git commit` we should gate on, False otherwise.
-  Treats `--no-verify` as the documented bypass — the standard git escape
-  hatch keeps working.
+    True when `cmd` is a `git commit` we should gate on (no bypass flag).
+    Kept for backward compatibility with existing callers/tests.
 
 Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 """
@@ -20,6 +35,7 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 from __future__ import annotations
 
 import re
+from typing import Optional
 
 
 # Word-bounded `git commit` at the start of the (leading-whitespace-tolerant)
@@ -32,16 +48,49 @@ _GIT_COMMIT_RE = re.compile(r"^\s*git\s+commit\b")
 # the same. Byte-parity is the migration contract.
 _NO_VERIFY_RE = re.compile(r"--no-verify")
 
+# git's short-form bypass flag. Word-bounded (whitespace or string edges) so
+# it doesn't false-positive inside `-nx` or `--number`. Mirrors
+# `hooks/telemetry.py`'s `_NO_VERIFY_RE` pattern.
+_BARE_N_RE = re.compile(r"(?:^|\s)-n(?:\s|$)")
+
+
+def is_git_commit_command(cmd: str) -> bool:
+    """Return True iff `cmd` is a `git commit` invocation (bypass or not)."""
+    if not cmd:
+        return False
+    return bool(_GIT_COMMIT_RE.search(cmd))
+
+
+def has_bypass_flag(cmd: str) -> bool:
+    """Return True iff `cmd` carries `--no-verify` or a bare `-n` flag."""
+    if not cmd:
+        return False
+    return bool(_NO_VERIFY_RE.search(cmd)) or bool(_BARE_N_RE.search(cmd))
+
+
+def bypass_flag_name(cmd: str) -> Optional[str]:
+    """Return which bypass flag matched (`--no-verify` preferred), or None."""
+    if not cmd:
+        return None
+    if _NO_VERIFY_RE.search(cmd):
+        return "--no-verify"
+    if _BARE_N_RE.search(cmd):
+        return "-n"
+    return None
+
 
 def is_git_commit_invocation(cmd: str) -> bool:
     """Return True iff `cmd` is a gate-worthy `git commit` invocation."""
-    if not cmd:
+    if not is_git_commit_command(cmd):
         return False
-    if not _GIT_COMMIT_RE.search(cmd):
-        return False
-    if _NO_VERIFY_RE.search(cmd):
+    if has_bypass_flag(cmd):
         return False
     return True
 
 
-__all__ = ("is_git_commit_invocation",)
+__all__ = (
+    "is_git_commit_command",
+    "has_bypass_flag",
+    "bypass_flag_name",
+    "is_git_commit_invocation",
+)

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -2,6 +2,10 @@
 """pre_commit_review — Claude Code PreToolUse:Bash hook (Python port).
 
 Python port of hooks/pre-commit-review.sh (#583 / #572 Cluster B).
+Extended under #709 to require and durably log a reason when the
+`--no-verify`/`-n` bypass is used, closing the frictionless-bypass gap
+identified by the gate-correlation evidence (bypassed commits correlate
+with materially higher rework).
 
 Blocks `git commit` (exit 2) unless a `.review-passed` file exists in
 cwd with a hash matching the currently staged content. The /code-review
@@ -9,7 +13,13 @@ command auto-scopes to uncommitted changes and writes this file when
 review passes.
 
 Non-commit Bash commands pass through immediately (exit 0).
-`git commit --no-verify` is allowed through (standard bypass).
+`git commit --no-verify` (or bare `-n`) is still allowed through — but
+only when the process environment carries a non-empty `GATE_BYPASS_REASON`.
+When present, the bypass is appended as one line to
+`metrics/gate-bypass-audit.jsonl` (unconditional — not gated by
+`DEV_TEAM_TELEMETRY`) and the commit proceeds. When absent, the commit is
+blocked with a message naming `GATE_BYPASS_REASON` as the required
+mechanism.
 
 Contract (docs/python-hook-contract.md):
     Input : JSON on stdin (Claude Code PreToolUse:Bash payload)
@@ -25,6 +35,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -34,12 +45,22 @@ _LIB_DIR = _HOOK_DIR / "lib"
 
 sys.path.insert(0, str(_LIB_DIR))
 try:
-    from pre_commit_detect import is_git_commit_invocation  # type: ignore[import-not-found]
+    from pre_commit_detect import (  # type: ignore[import-not-found]
+        bypass_flag_name,
+        has_bypass_flag,
+        is_git_commit_command,
+    )
     from review_gate_hash import review_gate_hash  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
 
-    def is_git_commit_invocation(_: str) -> bool:  # type: ignore[misc]
+    def is_git_commit_command(_: str) -> bool:  # type: ignore[misc]
         return False
+
+    def has_bypass_flag(_: str) -> bool:  # type: ignore[misc]
+        return False
+
+    def bypass_flag_name(_: str) -> Optional[str]:  # type: ignore[misc]
+        return None
 
     def review_gate_hash(cwd=None) -> str:  # type: ignore[misc]
         return ""
@@ -52,6 +73,16 @@ _BLOCK_MESSAGE = (
     "If review passes, the commit will be allowed on the next attempt.\n"
     "\n"
     "To bypass: use git commit --no-verify\n"
+)
+
+_BYPASS_BLOCK_MESSAGE = (
+    "BLOCKED: git commit --no-verify (or -n) requires a reason.\n"
+    "\n"
+    "Set GATE_BYPASS_REASON to a non-empty explanation and retry, e.g.:\n"
+    '  GATE_BYPASS_REASON="hotfix, review to follow" git commit --no-verify -m ...\n'
+    "\n"
+    "The bypass is logged to metrics/gate-bypass-audit.jsonl once a reason\n"
+    "is supplied.\n"
 )
 
 
@@ -84,6 +115,54 @@ def _staged_names() -> List[str]:
     return [line for line in completed.stdout.splitlines() if line]
 
 
+def _current_branch() -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def _plugin_version() -> str:
+    manifest = _HOOK_DIR / ".." / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text())
+        version = data.get("version")
+        if isinstance(version, str) and version:
+            return version
+    except (OSError, ValueError):
+        pass
+    return "unknown"
+
+
+def _record_bypass_audit(flag: str, reason: str, staged_count: int) -> None:
+    """Append one accountability line to metrics/gate-bypass-audit.jsonl.
+
+    Unconditional (not gated by DEV_TEAM_TELEMETRY) — mirrors the existing
+    metrics/override-audit.jsonl precedent for a bypass a human/agent
+    actively chose, not passive usage telemetry.
+    """
+    log = Path("metrics") / "gate-bypass-audit.jsonl"
+    entry = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "branch": _current_branch(),
+        "triggeredBy": flag,
+        "reason": reason,
+        "stagedFileCount": staged_count,
+        "pluginVersion": _plugin_version(),
+    }
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
 def main() -> int:
     payload = _read_stdin_json()
     if payload is None:
@@ -94,12 +173,23 @@ def main() -> int:
         return 0
     command = str(tool_input.get("command") or "")
 
-    if not is_git_commit_invocation(command):
+    if not is_git_commit_command(command):
         return 0
 
+    staged = _staged_names()
     # Nothing staged → nothing to gate.
-    if not _staged_names():
+    if not staged:
         return 0
+
+    if has_bypass_flag(command):
+        reason = os.environ.get("GATE_BYPASS_REASON", "").strip()
+        if reason:
+            _record_bypass_audit(
+                bypass_flag_name(command) or "--no-verify", reason, len(staged)
+            )
+            return 0
+        sys.stdout.write(_BYPASS_BLOCK_MESSAGE)
+        return 2
 
     current_hash = review_gate_hash()
 

--- a/plugins/dev-team/tests/hooks/test_pre_commit_detect.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_detect.py
@@ -62,3 +62,50 @@ def test_no_verify_bypass_substring_matches_sh() -> None:
     assert detect.is_git_commit_invocation("git commit --no-verify") is False
     # Substring match — matches the .sh's plain grep behavior.
     assert detect.is_git_commit_invocation("git commit --no-verifying") is False
+
+
+# --- #709: bare `-n` parity with `--no-verify` -----------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git commit -n -m x",
+        "git commit -m x -n",
+        "  git commit  -n  -m x",
+        "git commit -n",
+    ],
+)
+def test_bare_n_is_a_bypass_like_no_verify(cmd: str) -> None:
+    assert detect.is_git_commit_invocation(cmd) is False
+    assert detect.has_bypass_flag(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git commit -m x",
+        "git commit -na -m x",  # not a bare -n token
+        "git commit --amend -na",
+    ],
+)
+def test_non_bare_n_is_not_a_bypass(cmd: str) -> None:
+    assert detect.has_bypass_flag(cmd) is False
+
+
+def test_is_git_commit_command_ignores_bypass_flags() -> None:
+    """Unlike is_git_commit_invocation, is_git_commit_command answers
+    "is this a git commit at all" regardless of any bypass flag — callers
+    that need to react to bypassed commits (rather than silently ignore
+    them) use this plus has_bypass_flag."""
+    assert detect.is_git_commit_command("git commit --no-verify -m x") is True
+    assert detect.is_git_commit_command("git commit -n -m x") is True
+    assert detect.is_git_commit_command("git status") is False
+
+
+def test_bypass_flag_name() -> None:
+    assert detect.bypass_flag_name("git commit -m x") is None
+    assert detect.bypass_flag_name("git commit -n -m x") == "-n"
+    assert detect.bypass_flag_name("git commit --no-verify -m x") == "--no-verify"
+    # Both present — --no-verify preferred.
+    assert detect.bypass_flag_name("git commit --no-verify -n -m x") == "--no-verify"

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -27,7 +27,9 @@ if str(_TESTS_LIB) not in sys.path:
 from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
 
 
-def _run(payload: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    payload: dict, cwd: Path, extra_env: dict = None
+) -> subprocess.CompletedProcess[str]:
     proc_env = {
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "HOME": os.environ.get("HOME", "/tmp"),
@@ -36,6 +38,8 @@ def _run(payload: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
         "GIT_CONFIG_GLOBAL": "/dev/null",
         "GIT_CONFIG_SYSTEM": "/dev/null",
     }
+    if extra_env:
+        proc_env.update(extra_env)
     return subprocess.run(
         ["python3", str(_HOOK)],
         input=json.dumps(payload),
@@ -84,12 +88,68 @@ def test_non_commit_silent(repo: Path) -> None:
     assert r.stdout == ""
 
 
-def test_no_verify_bypass(repo: Path) -> None:
+def test_no_verify_bypass_without_reason_blocks(repo: Path) -> None:
+    """#709: the --no-verify escape hatch now requires a logged reason."""
     r = _run(
         {"tool_name": "Bash", "tool_input": {"command": "git commit --no-verify -m x"}},
         cwd=repo,
     )
+    assert r.returncode == 2
+    assert "GATE_BYPASS_REASON" in r.stdout
+    assert not (repo / "metrics" / "gate-bypass-audit.jsonl").exists()
+
+
+def test_no_verify_bypass_with_reason_allows_and_audits(repo: Path) -> None:
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit --no-verify -m x"}},
+        cwd=repo,
+        extra_env={"GATE_BYPASS_REASON": "hotfix, review to follow"},
+    )
     assert r.returncode == 0
+    audit = repo / "metrics" / "gate-bypass-audit.jsonl"
+    assert audit.exists()
+    lines = audit.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["triggeredBy"] == "--no-verify"
+    assert entry["reason"] == "hotfix, review to follow"
+    assert entry["stagedFileCount"] == 1
+    assert "timestamp" in entry
+    assert "branch" in entry
+    assert "pluginVersion" in entry
+
+
+def test_no_verify_bypass_empty_reason_blocks(repo: Path) -> None:
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit --no-verify -m x"}},
+        cwd=repo,
+        extra_env={"GATE_BYPASS_REASON": "   "},
+    )
+    assert r.returncode == 2
+    assert "GATE_BYPASS_REASON" in r.stdout
+
+
+def test_bare_n_bypass_without_reason_blocks(repo: Path) -> None:
+    """#709 AC4: bare -n is treated identically to --no-verify."""
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -n -m x"}},
+        cwd=repo,
+    )
+    assert r.returncode == 2
+    assert "GATE_BYPASS_REASON" in r.stdout
+
+
+def test_bare_n_bypass_with_reason_allows_and_audits(repo: Path) -> None:
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -n -m x"}},
+        cwd=repo,
+        extra_env={"GATE_BYPASS_REASON": "emergency rollback"},
+    )
+    assert r.returncode == 0
+    audit = repo / "metrics" / "gate-bypass-audit.jsonl"
+    entry = json.loads(audit.read_text().splitlines()[0])
+    assert entry["triggeredBy"] == "-n"
+    assert entry["reason"] == "emergency rollback"
 
 
 def test_commit_with_nothing_staged_silent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- The pre-commit review gate hook (`plugins/dev-team/hooks/pre_commit_review.py`) is already a blocking `PreToolUse:Bash` hook — the real gap this issue's evidence points to is the fully frictionless, unlogged `git commit --no-verify` / `-n` escape hatch, which correlates with materially higher rework (`memory/gate-correlation.json`).
- The hook now requires a non-empty `GATE_BYPASS_REASON` env var before letting `--no-verify`/`-n` through. Without one: blocked (exit 2) with a message naming the required variable. With one: allowed, and one accountability line (timestamp, branch, which flag triggered it, reason, staged file count, plugin version) is appended to `metrics/gate-bypass-audit.jsonl` — unconditional, mirroring the existing `metrics/override-audit.jsonl` precedent, not gated by `DEV_TEAM_TELEMETRY`.
- Fixed a detector parity gap in `plugins/dev-team/hooks/lib/pre_commit_detect.py`: bare `-n` is now recognized as a bypass flag identically to `--no-verify` (the telemetry beacon already treated it this way; the gating detector did not).
- The existing `.review-passed` hash-matching gate path is unchanged.
- Documented the reasoned-bypass requirement in `plugins/dev-team/docs/code-review-process.md`.

## Test plan

- [x] New/updated pytest cases in `plugins/dev-team/tests/hooks/test_pre_commit_detect.py` (bare `-n` parity, `bypass_flag_name`, `is_git_commit_command`) and `test_pre_commit_review.py` (bypass blocked without reason, allowed + audited with reason, empty-reason blocked, `-n` parity) — all passing.
- [x] Full `python3 -m pytest plugins/dev-team/tests` — 1878 passed, 16 skipped.
- [x] `bash scripts/ci-local.sh` — all local CI checks passed.
- [x] No `/agent-eval` fixture needed — this changes hook behavior, not a review-agent detection rule (per the issue's own spec, AC9).

Closes #709