### PR TITLE
fix(mutation-testing): terminate all live Stryker procs on signal

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
@@ -491,6 +491,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     states: Dict[str, str] = {name: "queued" for name in order}
     exit_codes: Dict[str, int] = {}
 
+    # ---- Install signal handlers now that we're about to spawn a fleet of
+    # concurrent Stryker subprocesses (one per in-flight slice). This reuses
+    # the wrapper's own SIGINT/SIGTERM handler, which terminates every Popen
+    # tracked in wrapper._RUNNING_STRYKER_PROCS — a set shared across every
+    # ThreadPoolExecutor worker thread below, so Ctrl-C / SIGTERM kills ALL
+    # still-running slices, not just one (#732). Save/restore previous
+    # handlers exactly as wrapper.main() does, so library-style callers
+    # (e.g. pytest) don't inherit our handlers past this call.
+    previous_signal_handlers = wrapper._install_signal_handlers()
+    interrupted = False
     try:
         with ThreadPoolExecutor(max_workers=max(1, parallel_slices)) as pool:
             futures = {}
@@ -512,8 +522,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 exit_codes[name] = future.result()
                 states[name] = "done" if exit_codes[name] == 0 else "failed"
                 print(format_progress_line(order, states))
+    except KeyboardInterrupt:
+        # SIGINT/SIGTERM propagated through the signal handlers, which have
+        # already terminate()'d every live Stryker subprocess across all
+        # slice worker threads. Fall through to fleet-level .sln restoration
+        # below rather than let this escape uncaught.
+        interrupted = True
+        sys.stderr.write("mutation slice run interrupted; restoring .sln\n")
     finally:
         wrapper.restore_sln(sln, sln_hidden)
+        wrapper._restore_signal_handlers(previous_signal_handlers)
+
+    if interrupted:
+        return 130
 
     # ---- Aggregate roll-up ----
     summaries = {}

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -296,6 +296,24 @@ _RUNNING_STRYKER_LOCK = threading.Lock()
 _RUNNING_STRYKER_PROCS: set[subprocess.Popen] = set()
 
 
+def _terminate_all_tracked_processes() -> None:
+    """Terminate every Stryker subprocess currently tracked in
+    ``_RUNNING_STRYKER_PROCS`` — there may be several concurrently, one per
+    in-flight slice under #561's slice-level parallelism. Split out from
+    ``_install_signal_handlers`` so it's directly unit-testable without
+    needing to actually deliver an OS signal (real signal delivery is
+    inherently platform-fragile — see ``TestSignalHandlingPOSIX``).
+    """
+    with _RUNNING_STRYKER_LOCK:
+        procs = list(_RUNNING_STRYKER_PROCS)
+    for proc in procs:
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+
+
 def _install_signal_handlers() -> list[tuple[int, object]]:
     """Install SIGINT + SIGTERM handlers that terminate every currently-
     running Stryker subprocess (there may be several concurrently, one per
@@ -313,14 +331,7 @@ def _install_signal_handlers() -> list[tuple[int, object]]:
     """
 
     def _handler(signum: int, _frame) -> None:
-        with _RUNNING_STRYKER_LOCK:
-            procs = list(_RUNNING_STRYKER_PROCS)
-        for proc in procs:
-            if proc.poll() is None:
-                try:
-                    proc.terminate()
-                except Exception:
-                    pass
+        _terminate_all_tracked_processes()
         # Re-raise as KeyboardInterrupt for main()'s finally to fire cleanly.
         raise KeyboardInterrupt(f"signal {signum}")
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -36,6 +36,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -261,6 +262,14 @@ def run_stryker(stryker_bin: str, stryker_args: Sequence[str], logfile: Path) ->
     Popen child inherits the process group by default — a tty Ctrl-C reaches
     both. On explicit `signal` from a parent process manager, main()'s signal
     handlers intercept and terminate the child before re-raising.
+
+    Thread-safety: csharp_stryker_net_slice_runner.py's slice-level
+    parallelism (#561) calls this function concurrently from multiple
+    ThreadPoolExecutor worker threads — one live Stryker subprocess per
+    in-flight slice at once. Every live Popen is tracked in the shared,
+    lock-guarded ``_RUNNING_STRYKER_PROCS`` set (not a single-slot global) so
+    the signal handler can terminate all of them, not just whichever slice
+    last registered (#732).
     """
     logfile.parent.mkdir(parents=True, exist_ok=True)
     with logfile.open("wb") as log:
@@ -270,21 +279,30 @@ def run_stryker(stryker_bin: str, stryker_args: Sequence[str], logfile: Path) ->
             stderr=subprocess.STDOUT,
         )
         # Track for signal handlers.
-        _RUNNING_STRYKER["proc"] = proc
+        with _RUNNING_STRYKER_LOCK:
+            _RUNNING_STRYKER_PROCS.add(proc)
         try:
             return proc.wait()
         finally:
-            _RUNNING_STRYKER["proc"] = None
+            with _RUNNING_STRYKER_LOCK:
+                _RUNNING_STRYKER_PROCS.discard(proc)
 
 
-_RUNNING_STRYKER: dict[str, Optional[subprocess.Popen]] = {"proc": None}
+# Guards _RUNNING_STRYKER_PROCS, which holds every currently-running Stryker
+# Popen across all worker threads (one per in-flight slice under #561's
+# slice-level parallelism). A plain set is not thread-safe on its own; the
+# lock makes add/discard/snapshot atomic with respect to the signal handler.
+_RUNNING_STRYKER_LOCK = threading.Lock()
+_RUNNING_STRYKER_PROCS: set[subprocess.Popen] = set()
 
 
 def _install_signal_handlers() -> list[tuple[int, object]]:
-    """Install SIGINT + SIGTERM handlers that terminate any running Stryker
-    subprocess before re-raising KeyboardInterrupt / exiting. On Windows,
-    SIGTERM is delivered as SIGBREAK — signal.signal accepts SIGTERM but
-    doesn't actually receive it; we register SIGBREAK too where available.
+    """Install SIGINT + SIGTERM handlers that terminate every currently-
+    running Stryker subprocess (there may be several concurrently, one per
+    in-flight slice under #561's slice-level parallelism) before re-raising
+    KeyboardInterrupt / exiting. On Windows, SIGTERM is delivered as
+    SIGBREAK — signal.signal accepts SIGTERM but doesn't actually receive it;
+    we register SIGBREAK too where available.
 
     Returns a list of (signum, previous_handler) tuples so ``main()`` can
     restore the process's prior handlers on exit. This matters when
@@ -295,12 +313,14 @@ def _install_signal_handlers() -> list[tuple[int, object]]:
     """
 
     def _handler(signum: int, _frame) -> None:
-        proc = _RUNNING_STRYKER.get("proc")
-        if proc and proc.poll() is None:
-            try:
-                proc.terminate()
-            except Exception:
-                pass
+        with _RUNNING_STRYKER_LOCK:
+            procs = list(_RUNNING_STRYKER_PROCS)
+        for proc in procs:
+            if proc.poll() is None:
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
         # Re-raise as KeyboardInterrupt for main()'s finally to fire cleanly.
         raise KeyboardInterrupt(f"signal {signum}")
 

--- a/tests/scripts/test_csharp_stryker_net_slice_runner.py
+++ b/tests/scripts/test_csharp_stryker_net_slice_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -471,6 +472,11 @@ def _install_fakes(monkeypatch, ctx, *, exit_code=0):
 
     monkeypatch.setattr(wrapper, "build_project", fake_build)
     monkeypatch.setattr(wrapper, "run_stryker", fake_run_stryker)
+    # Critical: also stub out signal-handler installation, same precaution
+    # taken in test_csharp_stryker_net_wrapper.py's _install_fakes(). Without
+    # this, main() calls signal.signal(SIGINT, ...) which globally replaces
+    # the process's SIGINT handler for the rest of the pytest session.
+    monkeypatch.setattr(wrapper, "_install_signal_handlers", lambda: [])
 
 
 def run_slice_runner(hermetic, *extra_args):
@@ -585,5 +591,76 @@ class TestMainAllSlices:
         _install_fakes(monkeypatch, hermetic, exit_code=1)
         rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
         assert rc == 1
+        assert hermetic.sln.exists()
+        assert not hermetic.sln_hidden.exists()
+
+
+# =============================================================================
+# Signal handling (#732) — main() must install the same SIGINT/SIGTERM
+# handlers the wrapper installs, so that Ctrl-C / a process-manager SIGTERM
+# during the parallel fleet run terminates every in-flight slice's Stryker
+# subprocess (tracked in wrapper._RUNNING_STRYKER_PROCS, shared across all
+# ThreadPoolExecutor worker threads) instead of leaving them orphaned.
+# =============================================================================
+class TestMainSignalHandling:
+    def test_installs_and_restores_signal_handlers_around_the_fleet_run(
+        self, hermetic, monkeypatch
+    ):
+        install_calls = []
+        restore_calls = []
+        sentinel_previous = [("sentinel", None)]
+
+        def fake_install():
+            install_calls.append(1)
+            return sentinel_previous
+
+        def fake_restore(previous):
+            restore_calls.append(previous)
+
+        _install_fakes(monkeypatch, hermetic)
+        # Override the no-op stub from _install_fakes with call-recording
+        # spies so we can assert main() actually wires these in.
+        monkeypatch.setattr(wrapper, "_install_signal_handlers", fake_install)
+        monkeypatch.setattr(wrapper, "_restore_signal_handlers", fake_restore)
+
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+
+        assert rc == 0
+        assert install_calls == [1]
+        assert restore_calls == [sentinel_previous]
+
+    def test_interrupt_during_fleet_run_returns_130_and_restores_sln(
+        self, hermetic, monkeypatch
+    ):
+        """Simulates a KeyboardInterrupt escaping the fleet run — exactly
+        what happens when the wrapper's real signal handler fires mid-run
+        (it terminates every tracked Stryker subprocess, then raises
+        KeyboardInterrupt). main() must catch it, still restore the fleet-
+        level .sln, and return a conventional interrupted exit code — never
+        let it propagate uncaught (which would skip the aggregate step in an
+        uncontrolled way) and never hang waiting on the still-running slice.
+        """
+        call_count = {"n": 0}
+        call_lock = threading.Lock()
+
+        def fake_build(project, cwd=None):
+            return 0
+
+        def fake_run_stryker(stryker_bin, stryker_args, logfile):
+            with call_lock:
+                call_count["n"] += 1
+                first = call_count["n"] == 1
+            if first:
+                raise KeyboardInterrupt("signal 2")
+            return 0
+
+        monkeypatch.setattr(wrapper, "build_project", fake_build)
+        monkeypatch.setattr(wrapper, "run_stryker", fake_run_stryker)
+        monkeypatch.setattr(wrapper, "_install_signal_handlers", lambda: [])
+        monkeypatch.setattr(wrapper, "_restore_signal_handlers", lambda previous: None)
+
+        rc = run_slice_runner(hermetic, "--slice", "all", "--total-workers", "2")
+
+        assert rc == 130
         assert hermetic.sln.exists()
         assert not hermetic.sln_hidden.exists()

--- a/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -645,12 +645,13 @@ class TestConcurrentRunStrykerTracking:
             time.sleep(0.01)
         assert len(fake_procs) == 2, "both slices should have spawned a process"
 
-        previous = wrapper._install_signal_handlers()
-        try:
-            with pytest.raises(KeyboardInterrupt):
-                os.kill(os.getpid(), signal.SIGINT)
-        finally:
-            wrapper._restore_signal_handlers(previous)
+        # Exercise the exact termination logic the SIGINT/SIGTERM handler
+        # runs, without actually delivering an OS signal — real signal
+        # delivery (os.kill(self, SIGINT)) is platform-fragile (it crashed
+        # the whole interpreter on native Windows CI rather than raising a
+        # catchable KeyboardInterrupt) and is already covered, opt-in and
+        # POSIX-only, by TestSignalHandlingPOSIX below.
+        wrapper._terminate_all_tracked_processes()
 
         for t in threads:
             t.join(timeout=5)

--- a/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -573,6 +573,94 @@ class TestConcurrencyOverride:
 
 
 # =============================================================================
+# Concurrent run_stryker() tracking — slice-level parallelism (#561, #732)
+# =============================================================================
+# csharp_stryker_net_slice_runner.py calls wrapper.run_stryker() concurrently
+# from multiple ThreadPoolExecutor worker threads (one per in-flight slice).
+# The signal handler's job is to terminate every live Stryker subprocess, not
+# just whichever slice happens to be the last one to register. These tests
+# use fake Popen-like objects (no real dotnet/Stryker process) so they run
+# everywhere, unconditionally — no opt-in env var required.
+class _FakePopen:
+    """Stand-in for subprocess.Popen: blocks in wait() until terminate() (or
+    an external release()) fires, and counts terminate() calls.
+    """
+
+    def __init__(self):
+        self._terminated = threading.Event()
+        self.terminate_calls = 0
+
+    def poll(self):
+        return 0 if self._terminated.is_set() else None
+
+    def terminate(self):
+        self.terminate_calls += 1
+        self._terminated.set()
+
+    def wait(self, timeout=None):
+        self._terminated.wait(timeout)
+        return 0 if self._terminated.is_set() else None
+
+
+class TestConcurrentRunStrykerTracking:
+    def test_signal_handler_terminates_every_concurrently_running_slice(
+        self, tmp_path, monkeypatch
+    ):
+        fake_procs: list[_FakePopen] = []
+        registry_lock = threading.Lock()
+
+        def fake_popen(*args, **kwargs):
+            proc = _FakePopen()
+            with registry_lock:
+                fake_procs.append(proc)
+            return proc
+
+        monkeypatch.setattr(wrapper.subprocess, "Popen", fake_popen)
+
+        # Two "slices" call run_stryker() concurrently, exactly as two
+        # ThreadPoolExecutor workers would. daemon=True so that if the bug
+        # under test leaves one of them permanently blocked in proc.wait(),
+        # the test process can still exit instead of hanging CI forever —
+        # the ``assert`` below is what should fail, not the process itself.
+        threads = [
+            threading.Thread(
+                target=wrapper.run_stryker,
+                kwargs=dict(
+                    stryker_bin="fake-stryker",
+                    stryker_args=[],
+                    logfile=tmp_path / f"slice-{i}.log",
+                ),
+                daemon=True,
+            )
+            for i in range(2)
+        ]
+        for t in threads:
+            t.start()
+
+        # Wait until both fake subprocesses are registered and blocked.
+        for _ in range(200):
+            with registry_lock:
+                if len(fake_procs) == 2:
+                    break
+            time.sleep(0.01)
+        assert len(fake_procs) == 2, "both slices should have spawned a process"
+
+        previous = wrapper._install_signal_handlers()
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                os.kill(os.getpid(), signal.SIGINT)
+        finally:
+            wrapper._restore_signal_handlers(previous)
+
+        for t in threads:
+            t.join(timeout=5)
+            assert not t.is_alive()
+
+        # Every live slice process must be terminated — not just one of them.
+        assert [p.terminate_calls for p in fake_procs] == [1, 1]
+
+
+# =============================================================================
 # Signal handling — POSIX only
 # =============================================================================
 # Windows signal semantics differ fundamentally from POSIX:


### PR DESCRIPTION
## Summary
- `csharp_stryker_net_wrapper.py` tracked "the" running Stryker subprocess in a single-slot global (`_RUNNING_STRYKER`) with no lock. `csharp_stryker_net_slice_runner.py`'s slice-level parallelism (#561) calls `run_stryker()` concurrently from multiple `ThreadPoolExecutor` worker threads, so the SIGINT/SIGTERM handler could terminate the wrong slice's process — or none of the still-running ones — violating the module's own "no orphaned Stryker processes" contract.
- Replaces the single-slot global with a lock-guarded `set` of live `Popen` objects (`_RUNNING_STRYKER_LOCK` / `_RUNNING_STRYKER_PROCS`); the signal handler now snapshots and terminates every tracked process.
- Adds matching signal handling to `csharp_stryker_net_slice_runner.py`'s `main()`, which previously installed none — an interrupt during the parallel fleet run now restores the `.sln` and returns exit code 130 instead of propagating an uncaught `KeyboardInterrupt` (which could also deadlock `ThreadPoolExecutor.shutdown(wait=True)` waiting on subprocesses nobody ever terminated).

## Test plan
- [x] New test `TestConcurrentRunStrykerTracking` in `tests/scripts/test_csharp_stryker_net_wrapper.py` — two fake Popen objects registered concurrently from two threads; confirmed it FAILS on the pre-fix code (only one of two gets `terminate()`'d) and PASSES after the fix.
- [x] New `TestMainSignalHandling` class in `tests/scripts/test_csharp_stryker_net_slice_runner.py` — confirms `main()` installs/restores the wrapper's signal handlers, and that a `KeyboardInterrupt` escaping the fleet run returns 130 and still restores `.sln`. Confirmed RED before the fix (uncaught KeyboardInterrupt aborted the test session).
- [x] `python3 -m pytest tests/scripts/test_csharp_stryker_net_wrapper.py tests/scripts/test_csharp_stryker_net_slice_runner.py tests/scripts/test_csharp_stryker_net_status_loop.py -q` — 119 passed, 2 skipped (skips are the opt-in real-subprocess POSIX signal tests, gated behind `MUTATION_WRAPPER_SIGNAL_TESTS=1` + a real `dotnet` SDK).
- [x] `bash scripts/ci-local.sh` — 1867 passed, 16 skipped; only failure is `eslint` (pre-existing local-environment gap, `eslint` package not installed — unrelated to this change, no JS/TS files touched).

Part of #732