### PR TITLE
docs: add Monitor timeout_ms guidance to ci-debugging skill

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1974,6 +1974,10 @@
       "summary": "Before fixing, reproduce the failure locally:",
       "anchor": "4-reproduce-locally"
     },
+    "Monitoring long-running jobs": {
+      "summary": "Before calling `Monitor` on a job whose completion time matters:",
+      "anchor": "monitoring-long-running-jobs"
+    },
     "5. Fix and verify": {
       "summary": "Fix the root cause.",
       "anchor": "5-fix-and-verify"

--- a/plugins/dev-team/skills/ci-debugging/SKILL.md
+++ b/plugins/dev-team/skills/ci-debugging/SKILL.md
@@ -23,6 +23,7 @@ CI failures are diagnosed systematically, not by guessing. This skill prevents t
 ### 1. Read the failure
 
 Read the full CI log output. Identify:
+
 - **What failed**: test, lint, typecheck, build, deploy, or infrastructure
 - **When it started failing**: this commit, recent merge, or intermittent
 - **Error message**: exact error text, not a summary
@@ -32,10 +33,12 @@ Read the full CI log output. Identify:
 Before touching any code, state a hypothesis: "I believe X is failing because Y, and I can verify by Z."
 
 Good hypotheses are specific and falsifiable:
+
 - "The test fails because the database migration added a NOT NULL column and the test fixture doesn't set it"
 - "The build fails because Node 20 dropped support for this API and CI upgraded last week"
 
 Bad hypotheses:
+
 - "Something is wrong with the tests"
 - "CI is flaky"
 
@@ -44,7 +47,7 @@ Bad hypotheses:
 Compare local vs CI environments using this checklist:
 
 | Factor | Check |
-|--------|-------|
+| -------- | ------- |
 | **Runtime version** | Node, Python, Go, JDK, Ruby, .NET — exact version match? |
 | **OS and architecture** | macOS vs Linux, x86 vs ARM? |
 | **Dependency resolution** | Lockfile committed? Registry differences? Private packages accessible? |
@@ -59,9 +62,19 @@ Compare local vs CI environments using this checklist:
 ### 4. Reproduce locally
 
 Before fixing, reproduce the failure locally:
+
 1. Match the CI environment as closely as possible (same Node version, same env vars)
 2. Run the exact failing command from the CI log
 3. If it passes locally, the delta from step 3 is the cause
+
+### Monitoring long-running jobs
+
+Before calling `Monitor` on a job whose completion time matters:
+
+1. Check whether a duration signal exists (prior run duration from CI history/logs, a known job-type baseline, or an explicit estimate the user gave).
+2. If a signal exists, set `timeout_ms` to a safety margin over that estimate (e.g., double it), capped at the tool's documented max (3,600,000 ms / 1 hour).
+3. If no signal exists, don't guess — set `persistent: true` and pair it with a command that exits on the job's own terminal state (success/failure/timeout), never an unbounded `tail -f`/`while true` with no exit condition, so the monitor self-terminates instead of requiring a manual `TaskStop`.
+4. Never silently re-arm after a timeout without noting the estimate was wrong; if a re-arm is needed, widen the estimate or switch to `persistent: true` rather than repeating the same timeout.
 
 ### 5. Fix and verify
 
@@ -70,12 +83,13 @@ Fix the root cause. Verify the fix locally. Push and confirm CI passes.
 ## Anti-Patterns
 
 | Anti-pattern | Why it's wrong | What to do instead |
-|-------------|---------------|-------------------|
+| ------------- | --------------- | ------------------- |
 | Retry the build | Masks the root cause, wastes CI minutes | Read the logs, form a hypothesis |
 | Add retry/sleep to test | Hides race conditions, makes tests slow | Fix the shared state or ordering issue |
 | Skip the failing test | Reduces coverage, hides regressions | Fix the test or the code |
 | Push a speculative fix | Pollutes git history, might not work | Reproduce locally first |
 | Blame "flaky CI" | Normalizes unreliable pipelines | Every failure has a cause — find it |
+| Re-arming a timed-out Monitor call | Wastes a round-trip and leaves a gap in coverage | Estimate `timeout_ms` from a duration signal, or use `persistent: true` (see Monitoring long-running jobs) |
 
 ## Integration
 


### PR DESCRIPTION
## Summary

- Adds a `### Monitoring long-running jobs` subsection to `plugins/dev-team/skills/ci-debugging/SKILL.md`: estimate `timeout_ms` from a duration signal when one exists (double the estimate, capped at the tool's 1-hour max), otherwise fall back to `persistent: true` paired with a self-terminating command (never an unbounded `tail -f`/`while true`).
- Adds an `## Anti-Patterns` table row cross-referencing the re-arm failure mode observed in the flagged session.
- Rebuilt `plugins/dev-team/knowledge/index.json` via `build_knowledge_index.py` to include the new subsection anchor.

Fixes the harness-guidance gap from issue #721: an agent picked a `Monitor` `timeout_ms` shorter than the job's actual runtime, was killed mid-watch, and had to re-arm — wasting a round-trip and leaving a coverage gap.

Prose-only change: no hook, script, or settings.json modified. Only `ci-debugging/SKILL.md` was touched (single-home decision per the issue's spec — `build/SKILL.md` doesn't invoke `Monitor`).

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_knowledge_index.py plugins/dev-team/tests/hooks/test_knowledge_index_paths.py plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py plugins/dev-team/tests/hooks/test_skills_index.py -q` — all pass
- [x] Full `bash scripts/ci-local.sh` pytest suite (1865 passed, 16 skipped) — the only failing check (`eslint`) is a pre-existing environment issue (missing `@eslint/js` module), reproduced identically on `main` before this change, unrelated to this markdown-only diff.

Closes #721