### PR TITLE
docs(skills): add fast feedback loop guidance to browser-testing

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1782,6 +1782,10 @@
       "summary": "| Category | Description |",
       "anchor": "playwright-patterns"
     },
+    "Fast Feedback Loop": {
+      "summary": "A verification pass is usually a *sequence* of related checks, not one isolated check — keep the loop cheap:",
+      "anchor": "fast-feedback-loop"
+    },
     "Visual Verification Guidelines": {
       "summary": "When interpreting screenshots, describe:",
       "anchor": "visual-verification-guidelines"

--- a/plugins/dev-team/skills/browser-testing/SKILL.md
+++ b/plugins/dev-team/skills/browser-testing/SKILL.md
@@ -17,6 +17,7 @@ This skill provides reusable patterns for browser-based testing and visual verif
 ## Prerequisites
 
 Playwright must be installed with at least the Chromium browser:
+
 ```bash
 npx playwright install chromium
 ```
@@ -24,7 +25,7 @@ npx playwright install chromium
 ## Playwright Patterns
 
 | Category | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | Navigation | `goto`, `waitForSelector`, `waitForNavigation` with network-idle |
 | Form Interaction | `fill`, `selectOption`, `check`, `setInputFiles`, submit |
 | Click Actions | Click by selector/text, double-click, right-click, hover |
@@ -36,6 +37,17 @@ npx playwright install chromium
 | CAPTCHA/Auth Handoff | Detect walls, report to user, resume from `storageState` |
 
 See `references/playwright-patterns.md` for full code examples, the script template, and the error handling table.
+
+## Fast Feedback Loop
+
+A verification pass is usually a *sequence* of related checks, not one isolated check — keep the loop cheap:
+
+- **Batch checks into one session.** Launch the browser once, run the full sequence of actions/waits/screenshots needed for the verification pass, then close — don't relaunch a fresh browser per individual check.
+- **Reserve `networkidle` for the first navigation.** After the initial `goto`, a re-check following a known, small change should wait on the specific signal that changed (`waitForSelector`, `waitForResponse`) rather than re-waiting on full network idle.
+- **Skip the reload when nothing routed.** If the change under verification didn't require a new route or a fresh document, act on the already-loaded page instead of calling `page.goto()` again or relaunching; use `page.reload()` only when a fresh document is genuinely required.
+- **Scope intermediate screenshots.** Prefer element/clip screenshots for the in-between checks in a sequence; reserve full-page screenshots for the final verification.
+
+The underlying principle — prefer the cheapest deterministic signal over a broad, expensive wait — is the same one that governs CI-gate test-suite design, but this section applies it to a single interactive verification session, not a project's test architecture.
 
 ## Visual Verification Guidelines
 

--- a/plugins/dev-team/skills/browser-testing/references/playwright-patterns.md
+++ b/plugins/dev-team/skills/browser-testing/references/playwright-patterns.md
@@ -99,6 +99,31 @@ await page.waitForResponse(resp =>
 await page.waitForTimeout(2000);
 ```
 
+#### Batched re-check session (fast feedback loop)
+
+For a QA pass with several related checks, reuse one browser/page instead of relaunching per check. Use `networkidle` only for the first navigation; wait on the specific signal that changed for each re-check after that.
+
+```javascript
+const browser = await chromium.launch({ headless: true });
+const page = await (await browser.newContext()).newPage();
+
+// First navigation: full network-idle wait
+await page.goto('http://localhost:3000/form', { waitUntil: 'networkidle' });
+await page.screenshot({ path: 'tmp/screenshots/01-initial.png', fullPage: true });
+
+// Re-check 1: same page, small change — wait on the specific signal, not networkidle
+await page.fill('input[name="email"]', 'user@example.com');
+await page.click('button[type="submit"]');
+await page.waitForSelector('.confirmation-banner');
+await page.locator('.confirmation-banner').screenshot({ path: 'tmp/screenshots/02-confirmation.png' });
+
+// Re-check 2: still no route change — no goto/reload needed
+await page.waitForResponse(resp => resp.url().includes('/api/status') && resp.status() === 200);
+await page.locator('.status-panel').screenshot({ path: 'tmp/screenshots/03-status.png' });
+
+await browser.close();
+```
+
 ### Extracting Information
 
 ```javascript
@@ -168,7 +193,7 @@ const { chromium } = require('playwright');
 ## Error Handling
 
 | Error | Cause | Resolution |
-|-------|-------|------------|
+| ------- | ------- | ------------ |
 | `TimeoutError: page.goto` | Server not running or URL wrong | Check if dev server is up; verify URL |
 | `TimeoutError: waiting for selector` | Element doesn't exist or is hidden | Inspect page HTML; check selector syntax |
 | `net::ERR_CONNECTION_REFUSED` | No server at the target port | Start the dev server first |
@@ -184,6 +209,7 @@ When automated browsing hits a CAPTCHA, MFA, or OAuth login wall:
 4. **Resume**: After manual completion, re-run `/browse` from the authenticated state
 
 For recurring auth needs, suggest the user:
+
 - Set up a test account with MFA disabled
 - Use session cookies via Playwright's `storageState`
 - Pre-authenticate and save state: `await context.storageState({ path: 'auth.json' })`


### PR DESCRIPTION
## Summary

The `browser-testing` skill's script template implies one browser relaunch and one full `networkidle` wait per check, even for a sequence of related checks within a single QA pass. This adds a "Fast Feedback Loop" section to `SKILL.md` (batch checks into one session, reserve `networkidle` for the first navigation, skip `goto`/reload for in-page re-checks, scope intermediate screenshots) and a matching batched-session example to `references/playwright-patterns.md`, so the concrete template reflects the guidance.

Per the issue's spec, `cd-test-architecture` is intentionally not added as a dependency (different altitude — CI-gate suite architecture vs. an interactive single-session verification loop); the one transferable principle is restated inline instead.

## Changes

- `plugins/dev-team/skills/browser-testing/SKILL.md`: new "Fast Feedback Loop" subsection between Playwright Patterns and Visual Verification Guidelines.
- `plugins/dev-team/skills/browser-testing/references/playwright-patterns.md`: new batched re-check session example under Waiting Strategies.
- `plugins/dev-team/knowledge/index.json`: regenerated via `build_knowledge_index.py`.

## Test plan

- [x] `python3 -m pytest tests/repo/test_knowledge_index_current.py -q` passes
- [x] `python3 -m pytest tests/agents/test_agent_audit_metadata.py tests/scripts/test_agent_audit_integration.py -q` passes
- [x] Manual review of both markdown files for AC1-AC7 in the issue's specification

Closes #725