### PR TITLE
docs: recover from Edit stale-old_string via re-Read

### DIFF
--- a/plugins/dev-team/agents/software-engineer.md
+++ b/plugins/dev-team/agents/software-engineer.md
@@ -17,6 +17,10 @@ You are a pragmatic, test-first engineer who builds in small, verifiable increme
 - For structured deliverables (test output, build results), paste the raw output without commentary.
 - Status updates: one paragraph max.
 
+## Tool Discipline
+
+- If an `Edit` call fails with a stale `old_string` (the text is no longer found verbatim), do not retry with a guessed variant — re-`Read` the file first, then retry the `Edit` against its current contents. A `PostToolUse` hook that rewrites files (e.g., a formatter) may have changed the file since your last Write/Edit.
+
 ## Technical Responsibilities
 
 - Full-stack development capabilities

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -133,6 +133,8 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_jobs.py --wave-width <W> [--jobs N] 
 
 For each step within a slice, dispatch implementation following the implementer template (`${CLAUDE_PLUGIN_ROOT}/prompts/implementer.md`). Pass the implementer its step **and the slice's Gherkin scenario(s)** — the scenarios are the behavioral contract the step's test must satisfy.
 
+Within the RED/GREEN/REFACTOR mini-cycle below, repeated Write/Edit calls can race a `PostToolUse` hook that rewrites files (e.g., a formatter): an `Edit` failing on a stale `old_string` is expected to self-correct by re-`Read`ing the file before the next `Edit` attempt, not to escalate immediately.
+
 1. **RED** — Write the failing test described in the step, covering the slice scenario it traces to. Run the test suite. **Hard gate: the new test must fail.** Paste the failing output. If the test passes without new code, the behavior already exists — pick a different test. Do NOT proceed to GREEN without pasted failing output.
 2. **GREEN** — Write the minimum implementation to make the failing test pass. Do not add behavior beyond what the test requires. Run the test suite. **Hard gate: all tests must pass.** Paste the passing output. Do NOT proceed without pasted passing output.
 3. **REFACTOR** — Clean up structure, naming, duplication without changing behavior. Run tests again — they must still pass. If tests break, undo and try a smaller change.


### PR DESCRIPTION
## Summary
- Add a `Tool Discipline` rule to `software-engineer.md`: on an `Edit` failure due to a stale `old_string`, re-`Read` the file before retrying — a `PostToolUse` hook that rewrites files (e.g., a formatter) may have changed it since the last Write/Edit.
- Cross-reference the same recovery pattern in `build/SKILL.md` Step 4, at the RED/GREEN/REFACTOR mini-cycle where repeated Write/Edit calls occur.
- Documentation-only; no code, script, or hook behavior changes.

## Test plan
- [x] `python3 -m pytest tests/repo/test_knowledge_index_current.py tests/repo/test_skills_registry_knowledge.py -q` — passes
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — no diff (index already current)
- [x] Verified terminology consistency ("stale `old_string`", "re-`Read` before the next `Edit`") across both files, and neither names a specific formatter as definitive cause

Closes #726