### PR TITLE
fix(skills): add diagnose-before-retry rule to /build

### DIFF
--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -24,6 +24,7 @@ You have been invoked with the `/build` command.
 4. **Verification evidence required.** Paste fresh test output before claiming a step is done.
 5. **Review checkpoints (granularity scales with complexity).** Run inline review (spec-compliance first, then quality agents) per step for `complex` steps; batch `standard`/`trivial` steps into one review at the slice boundary. Record each checkpoint's find/fix/no-op outcome to `metrics/review-value.jsonl`. The final `/code-review` is the backstop.
 6. **Be concise.** Report step status and verification evidence, no narration.
+7. **Diagnose before retry.** When any bash command run during the build fails (a script, a test run, a build-tooling invocation), read the exit code and error text and state a one-line cause hypothesis before correcting and re-issuing it. Never re-run a failed command unmodified. If the shallow diagnosis reveals a real defect rather than a shell-level mistake (bad path, typo, missing arg), escalate to Systematic Debugging per the Escalation section below.
 
 ## Parse Arguments
 
@@ -184,7 +185,7 @@ Invoke the [Feedback & Learning](../feedback-learning/SKILL.md) skill at task co
 
 ## Escalation
 
-A failure is a debugging task first, not a hand-back. Before escalating any test or review failure, run a [Systematic Debugging](../systematic-debugging/SKILL.md) pass — reproduce, find the root cause, state it in one sentence — and escalate **with that diagnosis**, never just an attempt count.
+A failure is a debugging task first, not a hand-back. Before escalating any test, review, or bash/command failure, run a [Systematic Debugging](../systematic-debugging/SKILL.md) pass — reproduce, find the root cause, state it in one sentence — and escalate **with that diagnosis**, never just an attempt count.
 
 Stop and ask the user when:
 


### PR DESCRIPTION
## Summary

Session telemetry (issue #707 backlog) shows failed bash commands get
reissued unmodified rather than diagnosed first — `retried_bash_commands`
at 0.508/session. Neither existing debugging skill covers the gap:
`systematic-debugging` is a heavyweight four-phase bug protocol scoped to
bugs/test failures; `ci-debugging` is scoped narrowly to CI/pipeline log
failures. `/build` is the plugin's highest bash-density skill and already
has a partial diagnose-before-escalate pattern in its Escalation section,
making it the natural single owner for this instruction (per the issue's
Ambiguity Log).

- Adds orchestrator constraint #7 to `plugins/dev-team/skills/build/SKILL.md`:
  on any failed bash command, read the exit code/error and state a
  one-line cause hypothesis before correcting and re-issuing it — never
  retry unmodified.
- Broadens the `## Escalation` section's lead sentence to explicitly cover
  bash/command failures (previously only "test or review failure"), so the
  existing Systematic Debugging hand-off already documented there also
  applies when a shallow diagnosis reveals a real defect.
- Prose-only change; no new file, hook, or code, consistent with the
  escalation script's assigned lever (`instruction-rule`).
- Rebuilt the knowledge index (no diff — frontmatter/description
  unchanged).

## Test plan

- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` (no diff)
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_knowledge_index.py tests/repo/test_registry_sync.py` — 18 passed
- [x] `python3 scripts/check_registry_sync.py` — in sync
- [x] Manually verified pre-existing `claude_setup_review.py` findings (unresolved `knowledge/*.md` links in plugin CLAUDE.md) and `token_efficiency_review.py` LLM-quality warnings are present on `main` too / are non-deterministic nested-LLM noise, unrelated to this diff

Closes #710