### PR TITLE
docs: document proxy connection-refused retry/surface policy

### DIFF
--- a/plugins/dev-team/CLAUDE.md
+++ b/plugins/dev-team/CLAUDE.md
@@ -44,7 +44,7 @@ Teams can create `REVIEW-CONTEXT.md` in the project root with domain knowledge c
 
 ## Skills Registry
 
-See [knowledge/skills-registry.md](knowledge/skills-registry.md) for the full command reference. All review skills run under orchestrator direction with model assignment flowing through the Resolution Procedure (`agents/orchestrator.md`).
+See [knowledge/skills-registry.md](knowledge/skills-registry.md) for the full command reference. All review skills run under orchestrator direction via the Resolution Procedure (`agents/orchestrator.md`).
 
 ## Request Processing Flow
 
@@ -53,6 +53,8 @@ See [knowledge/request-processing-flow.md](knowledge/request-processing-flow.md)
 ## Model Routing
 
 Each agent declares an effort band (`effort: low|medium|high`). Resolution enforced by `hooks/agent_model_resolve.py` via `knowledge/model-routing.json` (or `.claude/model-ladder.json`). See `agents/orchestrator.md` → Resolution Procedure and `/model-routing-check`.
+
+Restricted-endpoint (proxy) failures: [proxy-connectivity.md](knowledge/proxy-connectivity.md).
 
 ## Context Management
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -773,6 +773,16 @@
       "anchor": "a10-ssrf"
     }
   },
+  "plugins/dev-team/knowledge/proxy-connectivity.md": {
+    "Root cause": {
+      "summary": "Sessions that route Anthropic API traffic (or Bash-invoked tools like `curl`,",
+      "anchor": "root-cause"
+    },
+    "Connection refused": {
+      "summary": "**Signature:** `ECONNREFUSED` / \"Connection refused\" / any TCP-level",
+      "anchor": "connection-refused"
+    }
+  },
   "plugins/dev-team/knowledge/release-strategies.md": {
     "Decouple deployment from release": {
       "summary": "| Technique | What it does | Use when |",

--- a/plugins/dev-team/knowledge/proxy-connectivity.md
+++ b/plugins/dev-team/knowledge/proxy-connectivity.md
@@ -1,0 +1,62 @@
+# Proxy Connectivity
+
+## Root cause
+
+Sessions that route Anthropic API traffic (or Bash-invoked tools like `curl`,
+`dotnet restore`, `npm install`) through a corporate proxy can hit two
+structurally different failure modes, both stemming from transient
+corporate-proxy unavailability:
+
+- **Connection refused** (this doc) — a transport-layer rejection. Nothing
+  accepted the TCP connection at all.
+- **Rate limited** (tracked separately in
+  [issue #723](https://github.com/bdfinst/agentic-dev-team/issues/723)) — the
+  proxy accepted the connection and the application layer returned an
+  HTTP-level 429/503.
+
+These require different responses (see below), so this file keeps them in
+separate subsections rather than merging them into shared prose.
+
+This mirrors the failure-mode taxonomy this repo already documents for
+reviewed code under test — see the "Failure modes" bullet in
+[`component-test-patterns.md`](component-test-patterns.md) (API Consumer
+patterns) and the Polly-based resilience-policy coverage in
+[`references/csharp-http-client-testing.md`](references/csharp-http-client-testing.md).
+This doc applies that same taxonomy one level up, to the agent's own
+session-level network behavior.
+
+## Connection refused
+
+**Signature:** `ECONNREFUSED` / "Connection refused" / any TCP-level
+rejection — distinct from an HTTP-level 429/503 + `Retry-After`, which
+requires the proxy to have accepted the connection in the first place. A
+refused connection means nothing is listening/accepting on the other end:
+commonly a proxy or network outage, a VPN drop, or a misconfigured proxy
+address — not something the application layer can throttle its way out of.
+
+**Policy:**
+
+1. Retry a small, bounded number of times with backoff. Reuse the existing
+   `DEV_TEAM_BASH_RETRY_THRESHOLD` default of `3` (see
+   `hooks/bash_retry_guard.py`) as the reference retry count, for consistency
+   with the one retry-count precedent already shipped in this plugin.
+2. If the connection is still refused after those attempts, **stop** —
+   do not keep retrying silently. Surface a concise diagnostic to the user
+   that states:
+   - what failed (the host/endpoint being reached, if known),
+   - how many attempts were made,
+   - that repeated refusal may indicate a proxy or network outage rather
+     than a code problem, and remediation is likely outside the agent's
+     control (e.g. check VPN/network status, confirm the proxy address,
+     or contact whoever operates the proxy).
+
+A rate limit is expected to clear on its own and warrants standard
+exponential backoff (see #723); a refused connection may not clear on its
+own, so spinning on it indefinitely stalls the session for no benefit.
+
+**Non-goal:** this is documentation of expected agent behavior, not a new
+hook. Reliably detecting "connection refused" from heterogeneous tool
+stdout (curl, dotnet, npm, git, MCP clients each format it differently) is
+not a safe, generically-matchable pattern for a `PreToolUse`/`PostToolUse`
+hook without a high false-positive/false-negative rate, so this stays prose
+guidance rather than mechanical enforcement.


### PR DESCRIPTION
## Summary

- 21 connection-refused proxy errors occurred in one flagged session with no documented convention for how the agent should respond, risking silent spinning or a stalled session.
- Adds `plugins/dev-team/knowledge/proxy-connectivity.md`, distinguishing **connection refused** (transport-layer rejection — bounded retry with backoff using the existing `DEV_TEAM_BASH_RETRY_THRESHOLD` default of 3, then stop and surface a concise diagnostic to the user) from **rate limited** (HTTP-layer 429/503 — standard exponential backoff, tracked separately in #723), sharing one root-cause intro without merging the two response policies.
- Links the new doc from `CLAUDE.md`'s `## Model Routing` section (trimmed a nearby sentence to stay under the enforced 5000-char budget).
- Documentation only — no hook or shipped script changes, per the issue's own non-goal (detecting "connection refused" reliably across heterogeneous tool stdout isn't a safe, generically-matchable hook pattern).

## Test plan

- [x] `pytest tests/repo/test_claude_md_size.py` — CLAUDE.md stays under the 5000-char budget
- [x] `pytest tests/repo/test_knowledge_index_current.py tests/repo/test_knowledge_index_shape.py` — knowledge index regenerated and current
- [x] `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/skills` — 1051+ passed, 0 failed

Closes #724