### PR TITLE
fix(install): retire Git Bash hard-requirement on Windows

### DIFF
--- a/plugins/dev-team/install.py
+++ b/plugins/dev-team/install.py
@@ -70,22 +70,23 @@ def _detect_windows_uname() -> str:
 
 
 def check_platform(result: Result) -> None:
-    """On Windows the plugin's hooks and helper scripts still target
-    Git Bash for shell scripts and native Python 3 for Python scripts.
-    Native cmd.exe / PowerShell cannot run the .sh hooks that remain
-    until #572 completes. This check ONLY fires on Windows so it's a
-    no-op on macOS and Linux (matching the .sh exactly)."""
+    """Report the Windows shell environment, informationally only.
+
+    Per ADR 0015 (docs/adr/0015-bash-removal-complete.md), every shipped
+    hook and helper script under plugins/dev-team/ is now Python 3.8+
+    stdlib-only — Windows CI is fully bash-free and nothing in the
+    runtime requires Git Bash on Windows anymore. Native Windows without
+    Git Bash is a legitimate install path, so this check never fails; it
+    only surfaces which shell Claude Code is running under. It's a no-op
+    on macOS and Linux."""
     if os.environ.get("OS", "") != "Windows_NT":
         return
     uname = _detect_windows_uname()
     if uname.startswith(("MINGW", "MSYS", "CYGWIN")):
         print(f"[ok]   Git Bash ({uname})")
-        result.pass_ += 1
-        return
-    print("[FAIL] Windows without Git Bash — this plugin's hooks and helper")
-    print("       scripts need a POSIX bash. Install Git for Windows (Git Bash)")
-    print("       from https://git-scm.com/download/win and run Claude Code from it.")
-    result.fail += 1
+    else:
+        print("[ok]   native Windows (no Git Bash required — plugin is Python-only)")
+    result.pass_ += 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_install.py
+++ b/tests/scripts/test_install.py
@@ -6,7 +6,8 @@ Covers:
   - one optional missing → exit 0 with warn line + "X optional dependency missing"
   - trampoline .sh finds python3 → delegates to install.py byte-identically
   - trampoline .sh cannot find python3 → exit 1 with a clear pointer
-  - Windows-path detection: OS=Windows_NT + non-MSYS uname → [FAIL]
+  - Windows-path detection: OS=Windows_NT + non-MSYS uname → informational
+    [ok], never a hard failure (ADR 0015 retired the Git Bash requirement)
 """
 
 from __future__ import annotations
@@ -129,19 +130,26 @@ def test_trampoline_fails_when_no_python3(tmp_path: Path) -> None:
     assert "required" in r.stdout
 
 
-def test_windows_without_git_bash_fails(tmp_path: Path) -> None:
-    """OS=Windows_NT + non-MSYS uname → platform check FAIL branch."""
+def test_windows_without_git_bash_does_not_hard_fail(tmp_path: Path) -> None:
+    """OS=Windows_NT + non-MSYS uname must NOT hard-fail (ADR 0015).
+
+    ADR 0015 (docs/adr/0015-bash-removal-complete.md) retired the Git Bash
+    requirement: "Windows CI is now fully bash-free... nothing in the
+    plugins/dev-team/ runtime requires Git Bash on Windows anymore."
+    Native Windows without Git Bash is a legitimate install path.
+    """
     path = _shim_dir(tmp_path, ["claude", "jq", "gh", "python3"])
     r = _run_py(
         path_override=path,
         extra_env={"OS": "Windows_NT"},
     )
-    # On this macOS host, platform.uname().system returns "Darwin" —
-    # which does NOT start with MINGW/MSYS/CYGWIN, so the [FAIL] branch
-    # fires. This exercises the exact code path Windows-without-Git-Bash
-    # would hit.
-    assert r.returncode == 1
-    assert "Windows without Git Bash" in r.stdout
+    # On this macOS host, platform.uname().system returns "Darwin" — which
+    # does NOT start with MINGW/MSYS/CYGWIN, exercising the exact code path
+    # Windows-without-Git-Bash would hit. It must no longer be a [FAIL].
+    assert r.returncode == 0
+    assert "Windows without Git Bash" not in r.stdout
+    assert "[FAIL]" not in r.stdout
+    assert "[ok]   native Windows" in r.stdout
 
 
 def test_output_has_required_and_optional_sections(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`check_platform()` in `plugins/dev-team/install.py` still hard-failed native Windows installs that lack Git Bash, contradicting [ADR 0015](docs/adr/0015-bash-removal-complete.md)'s stated end state: every shipped hook and helper script under `plugins/dev-team/` is now Python 3.8+ stdlib-only, and Windows CI is fully bash-free. Nothing in the runtime requires Git Bash on Windows anymore, so a native Windows install without it is a legitimate path — not a hard failure.

- Downgrade `check_platform()` so it never registers a failure; it now reports `[ok]` for either Git Bash or native Windows (informational only).
- Update the docstring/comments that asserted the retired pre-ADR-0015 Git Bash rationale.
- Update `tests/scripts/test_install.py`'s `test_windows_without_git_bash_fails` (renamed to `test_windows_without_git_bash_does_not_hard_fail`) to assert the corrected behavior — confirmed it FAILED against the pre-fix code before applying the fix (TDD).

Part of #732

## Test plan

- [x] `python3 -m pytest tests/scripts/test_install.py -q` — 8 passed (new/updated test confirmed failing pre-fix, passing post-fix)
- [x] `python3 -m pytest plugins/dev-team/tests tests/scripts -q` — 853 passed, 18 skipped