### PR TITLE
test: cover destructive_guard/js_fp_review hooks; tighten orchestrator fallback test

### DIFF
--- a/tests/hooks/test_destructive_guard.py
+++ b/tests/hooks/test_destructive_guard.py
@@ -1,0 +1,111 @@
+"""Pytest tests for hooks/destructive_guard.py.
+
+Drives main() via subprocess with representative PreToolUse JSON payloads,
+covering both the blocked path (careful mode active + a destructive
+command) and the pass-through path (non-destructive command, and the
+always-allowed safe-allowlist entries).
+
+`_careful_active()` reads a fixed path (hooks/careful-state.json) rather
+than an env-overridable location, so the blocked-path test writes that file
+directly — mirroring the precedent already established in
+plugins/dev-team/tests/hooks/test_codegraph_nudge.py's `clean_careful_state`
+fixture. A leaked file would silently flip every other test into block
+mode, so the fixture wipes it before AND after every test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "destructive_guard.py"
+_CAREFUL_STATE = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "careful-state.json"
+
+
+@pytest.fixture(autouse=True)
+def clean_careful_state():
+    _CAREFUL_STATE.unlink(missing_ok=True)
+    yield
+    _CAREFUL_STATE.unlink(missing_ok=True)
+
+
+def _run(payload: dict) -> subprocess.CompletedProcess:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C.UTF-8",
+    }
+    return subprocess.run(
+        [sys.executable, str(_HOOK_PY)],
+        input=json.dumps(payload).encode(),
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_destructive_command_blocked_when_careful_active() -> None:
+    """A destructive command with careful mode active must exit 2 and
+    print a BLOCKED decision."""
+    _CAREFUL_STATE.write_text(json.dumps({"active": True}), encoding="utf-8")
+
+    r = _run({"tool_input": {"command": "rm -rf /"}})
+
+    assert r.returncode == 2
+    assert b"BLOCKED" in r.stdout
+    assert b"Destructive command detected" in r.stdout
+
+
+def test_benign_command_passes_through() -> None:
+    """A non-destructive command must exit 0 with no output, careful mode
+    or not."""
+    r = _run({"tool_input": {"command": "ls -la"}})
+
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_safe_allowlisted_command_passes_through_even_when_careful() -> None:
+    """Safe-allowlist entries (e.g. `rm -rf node_modules`) short-circuit
+    before the destructive check, even with careful mode active."""
+    _CAREFUL_STATE.write_text(json.dumps({"active": True}), encoding="utf-8")
+
+    r = _run({"tool_input": {"command": "rm -rf node_modules"}})
+
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_destructive_command_warns_without_blocking_when_careful_inactive() -> None:
+    """Without careful mode, a destructive command still exits 0 (advisory
+    CAUTION only, not a block)."""
+    r = _run({"tool_input": {"command": "git push --force"}})
+
+    assert r.returncode == 0
+    assert b"CAUTION" in r.stdout
+
+
+def test_missing_command_silent() -> None:
+    r = _run({"tool_input": {}})
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_malformed_stdin_silent() -> None:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    r = subprocess.run(
+        [sys.executable, str(_HOOK_PY)],
+        input=b"{broken",
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert r.stdout == b""

--- a/tests/hooks/test_js_fp_review.py
+++ b/tests/hooks/test_js_fp_review.py
@@ -1,0 +1,96 @@
+"""Pytest tests for hooks/js_fp_review.py.
+
+Drives main() via subprocess with representative PostToolUse JSON
+payloads (Write/Edit on a JS/TS file). The hook is advisory-only — it
+never blocks (always exits 0) — so "should be blocked" here means the
+warning text is emitted on stdout for a mutation-pattern file, and
+"should pass through" means stdout is empty for a clean file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "js_fp_review.py"
+
+
+def _run(payload: dict) -> subprocess.CompletedProcess:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C.UTF-8",
+    }
+    return subprocess.run(
+        [sys.executable, str(_HOOK_PY)],
+        input=json.dumps(payload).encode(),
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_array_mutation_warns(tmp_path: Path) -> None:
+    """A file with an in-place array mutation must produce an advisory
+    warning on stdout, but the hook always exits 0 (advisory, non-blocking)."""
+    js_file = tmp_path / "widget.js"
+    js_file.write_text("function addItem(list, item) {\n  list.push(item);\n}\n")
+
+    r = _run({"tool_input": {"file_path": str(js_file)}})
+
+    assert r.returncode == 0
+    assert b"FP: Array mutation detected" in r.stdout
+    assert b"list.push" in r.stdout
+
+
+def test_clean_file_passes_through(tmp_path: Path) -> None:
+    """A file with no mutation patterns must produce no output."""
+    js_file = tmp_path / "widget.js"
+    js_file.write_text("function addItem(list, item) {\n  return [...list, item];\n}\n")
+
+    r = _run({"tool_input": {"file_path": str(js_file)}})
+
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_non_js_file_skipped(tmp_path: Path) -> None:
+    """Non JS/TS files are ignored entirely, even with mutation patterns."""
+    py_file = tmp_path / "widget.py"
+    py_file.write_text("list.push(item)\n")
+
+    r = _run({"tool_input": {"file_path": str(py_file)}})
+
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_missing_file_path_silent() -> None:
+    r = _run({"tool_input": {}})
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_nonexistent_file_silent(tmp_path: Path) -> None:
+    missing = tmp_path / "ghost.ts"
+    r = _run({"tool_input": {"file_path": str(missing)}})
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+def test_malformed_stdin_silent() -> None:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    r = subprocess.run(
+        [sys.executable, str(_HOOK_PY)],
+        input=b"{broken",
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert r.stdout == b""

--- a/tests/scripts/test_orchestrator.py
+++ b/tests/scripts/test_orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -77,9 +78,28 @@ async def test_classify_standard_calls_research_phase():
 
 @pytest.mark.asyncio
 async def test_classify_fallback_on_llm_unavailable():
-    """When claude is not on PATH, classify() must return standard (safe default)."""
+    """When `claude` is not on PATH, subprocess.run raises FileNotFoundError;
+    classify() must catch it and fall back to the exact safe default."""
+    with patch.object(orch.subprocess, "run", side_effect=FileNotFoundError):
+        result = await orch.classify("do something", skip_llm=False)
+    assert result == {"size": "standard"}
+
+
+@pytest.mark.skipif(
+    os.environ.get("ORCHESTRATOR_REAL_SUBPROCESS_TESTS") != "1",
+    reason=(
+        "shells out to the real `claude` CLI with a 30s timeout and its "
+        "outcome/latency/cost vary by host; opt in with "
+        "ORCHESTRATOR_REAL_SUBPROCESS_TESTS=1 on a host with `claude` on "
+        "PATH. Mirrors the opt-in pattern in "
+        "test_csharp_stryker_net_wrapper.py's TestSignalHandlingPOSIX."
+    ),
+)
+@pytest.mark.asyncio
+async def test_classify_real_subprocess_returns_valid_size():
+    """Real-subprocess probe: classify() against the actual `claude` CLI
+    must still return a dict with a valid 'size', whatever the classification."""
     result = await orch.classify("do something", skip_llm=False)
-    # claude may or may not be available; either way must return a dict with 'size'
     assert "size" in result
     assert result["size"] in ("trivial", "standard", "complex")
 


### PR DESCRIPTION
## Summary
- Add `tests/hooks/test_destructive_guard.py` and `tests/hooks/test_js_fp_review.py` — both hooks had zero test coverage despite being security-relevant (destructive-command blocking, JS mutation-pattern advisory). Each drives `main()` via subprocess with representative PreToolUse/PostToolUse payloads, covering both a blocked/warned case and a pass-through case.
- Tighten `test_classify_fallback_on_llm_unavailable` in `tests/scripts/test_orchestrator.py`: it previously shelled out to the real `claude` CLI (30s timeout) and accepted any of 3 outcomes, so it couldn't actually catch a broken fallback path and its result/latency/cost varied by host/CI. Now mocks `subprocess.run` to raise `FileNotFoundError` and asserts the exact `{"size": "standard"}` fallback. Kept a real-subprocess probe as an opt-in test gated behind `ORCHESTRATOR_REAL_SUBPROCESS_TESTS=1`, mirroring the existing opt-in pattern in `test_csharp_stryker_net_wrapper.py`'s `TestSignalHandlingPOSIX`.

Verified TDD-style: manually broke `classify()`'s except clause and confirmed the new mocked test fails (RED), then restored it and confirmed it passes (GREEN).

Part of #732

## Test plan
- [x] `python3 -m pytest tests/hooks/test_destructive_guard.py tests/hooks/test_js_fp_review.py tests/scripts/test_orchestrator.py -q` — all pass (1 opt-in test skipped by default)
- [x] `bash scripts/ci-local.sh` — all checks pass except `chk_eslint`, which fails identically on unmodified `main` in this sandbox (missing `node_modules`/`@eslint/js`, unrelated to this change)