### PR TITLE
fix(skills): extend quality-gate-pipeline with external UI citation guidance

### DIFF
--- a/plugins/dev-team/skills/quality-gate-pipeline/SKILL.md
+++ b/plugins/dev-team/skills/quality-gate-pipeline/SKILL.md
@@ -12,6 +12,7 @@ user-invocable: true
 Single quality gate that every agent passes through before output is accepted. Replaces three formerly separate skills (accuracy-validation, verification-before-completion, task-review-correction) with a unified pipeline of three phases that run in sequence.
 
 ## Constraints
+
 - Do not deliver output containing unverified claims; pause and verify first
 - Do not claim completion without fresh verification evidence from this session
 - Do not reference test results or tool output from earlier in the conversation — re-run and show current output
@@ -26,18 +27,22 @@ Single quality gate that every agent passes through before output is accepted. R
 Every agent runs this checklist mentally before presenting output.
 
 **Factual Accuracy**
+
 - [ ] All file paths referenced actually exist (verify with tool, don't assume)
 - [ ] All function/class/variable names match what's in the codebase
 - [ ] Version numbers, API signatures, and config values are verified, not recalled from training
 - [ ] No statistics or citations are fabricated
+- [ ] Claims about an external tool or product's UI (menu paths, button/control labels, screen layouts, settings locations) are backed by a citation the agent actually has — a fetched doc, a user-provided screenshot/description, or tool output — not recalled from training as if current and authoritative. When no citation exists, say so plainly (e.g. "I don't have a verified/current view of this menu — check the tool's current UI") rather than describing specifics; this is the same **Low** confidence fallback as any other recalled/guessed claim (see Confidence Assessment below).
 
 **Instruction Fidelity**
+
 - [ ] Output addresses what the user actually asked, not a reinterpretation
 - [ ] All acceptance criteria from the task are met
 - [ ] No scope creep beyond the request
 - [ ] Constraints from the agent persona are respected
 
 **Internal Consistency**
+
 - [ ] No contradictions within the output
 - [ ] Code samples compile/run conceptually (correct syntax, valid imports)
 - [ ] Referenced earlier decisions are accurately recalled (if unsure, re-read from memory/)
@@ -53,10 +58,12 @@ Every agent runs this checklist mentally before presenting output.
 **Hallucination Detection Signals**
 
 Strong signals (likely hallucination):
+
 - Referencing a file, function, or API that was never read in this session
 - Quoting specific numbers without a source
 - Describing behavior that contradicts tool observations
 - Generating imports for packages not in dependencies
+- Describing a specific control, menu path, or screen in an external tool/product without a citation the agent can point to
 
 When a signal fires: **Pause** → **Verify** (use tools) → **Correct** → **Log** (`hallucination_detected: true` in metrics)
 
@@ -65,6 +72,7 @@ When a signal fires: **Pause** → **Verify** (use tools) → **Correct** → **
 **Iron Law**: No completion claims without fresh verification evidence. Skipping any step is falsification, not verification.
 
 **The Gate Function**:
+
 1. **IDENTIFY** — What command proves your claim? (e.g., `npm test`, `cargo build`)
 2. **RUN** — Execute the command fresh and completely. Not from cache, not from memory.
 3. **READ** — Read the complete output and exit code. Don't skim.
@@ -72,6 +80,7 @@ When a signal fires: **Pause** → **Verify** (use tools) → **Correct** → **
 5. **ONLY THEN** — Make the claim, with supporting evidence pasted.
 
 **Required Evidence (all tasks)**:
+
 1. **Tests pass**: Run the **whole** test suite. Paste output with pass/fail counts.
 2. **Build succeeds**: If the project has a build step, run it. Paste output.
 3. **Lint clean**: If the project has a linter, run it. Paste output.
@@ -93,7 +102,7 @@ change. You own the quality state you can see, not just your delta.
 **Additional Evidence by task type**:
 
 | Task Type | Additional Evidence |
-|-----------|-------------------|
+| ----------- | ------------------- |
 | Bug fix | Red-green cycle: failing test → passing test |
 | New feature | Feature working via test output or demo command |
 | Refactor | Same test count, same pass count |
@@ -102,6 +111,7 @@ change. You own the quality state you can see, not just your delta.
 | Agent work | Inspect VCS diff independently — don't trust self-report |
 
 **Evidence Format**:
+
 ```
 ## Verification
 - Tests: `npm test` → 47 passed, 0 failed (output below)
@@ -110,6 +120,7 @@ change. You own the quality state you can see, not just your delta.
 ```
 
 **Red Flag Language** — stop and verify when you catch yourself saying:
+
 - "should work now" / "should be fixed" / "probably" / "I believe"
 - Expressing satisfaction before running verification
 - Preparing commits without verification output
@@ -128,11 +139,13 @@ Activated when output is returned for rework, during peer review, or when self-r
 | **Cosmetic** | Formatting, naming, style | Bundle with next change |
 
 **Correction Scope**:
+
 - **Isolated fix**: Self-contained; fix doesn't affect other outputs
 - **Cascading fix**: Implies other outputs may also be wrong; verify related work
 - **Rework**: Fundamental approach flawed; redo from requirements
 
 **Review Checklist**:
+
 1. Requirements compliance — all acceptance criteria addressed, no silent scope changes
 2. Correctness — intended result, edge cases handled, no regressions
 3. Completeness — all files touched, no TODOs remain, integration points addressed
@@ -140,6 +153,7 @@ Activated when output is returned for rework, during peer review, or when self-r
 5. Quality — appropriately simple, readable, sufficient documentation
 
 **Iteration Rules**:
+
 - Max 3 review-correction cycles before escalation
 - Each cycle must reduce total defect count
 - If defects increase or stay flat after 2 cycles, escalate to Orchestrator
@@ -150,7 +164,7 @@ Activated when output is returned for rework, during peer review, or when self-r
 ## When to Apply Each Phase
 
 | Situation | Phases to run |
-|-----------|--------------|
+| ----------- | -------------- |
 | Initial development, about to deliver | Phase 1 → Phase 2 |
 | Claiming task completion | Phase 2 (at minimum) |
 | Output returned for rework | Phase 3 → Phase 2 |


### PR DESCRIPTION
## Summary

Extends `plugins/dev-team/skills/quality-gate-pipeline/SKILL.md` per the spec in #728: agents were asserting specifics about a third-party tool's UI (menu paths, control labels, screen layouts) recalled from training rather than backed by a citation the agent actually has, misleading users.

- Phase 1 "Factual Accuracy" checklist gains a bullet requiring external tool/product UI claims to be backed by a citation (fetched doc, user-provided screenshot/description, or tool output), falling back to stating uncertainty when none exists.
- "Hallucination Detection Signals" → "Strong signals" gains an item for describing an external tool/product UI specific without a citation.
- Both cross-reference the existing Confidence Assessment **Low** row rather than introducing a parallel remediation mechanism.
- No new hook/script/schema/CLAUDE.md change — confined to this one skill file, per the issue's architecture spec.

## Test plan

- [x] `bash scripts/ci-local.sh` — full pytest suite passes (1865 passed, 16 skipped); the `eslint` check fails only because this fresh worktree has no `node_modules` installed (pre-existing environment gap, unrelated to this markdown-only change — confirmed by running `npx eslint` directly and seeing `ERR_MODULE_NOT_FOUND` for `@eslint/js`).
- [x] Frontmatter/structure of the edited SKILL.md verified unchanged (name/role/user-invocable intact) — satisfies AC6 (`/agent-audit` structural compliance).
- [x] Diff confined to the one skill file named in the issue's architecture spec; no new hook/script/CLAUDE.md changes.

Closes #728