### PR TITLE
fix(build): mandate /verify before a runtime-surface slice is done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ metrics/session-digest.jsonl
 metrics/telemetry.jsonl
 # Per-checkpoint review-value meter (runtime data; counts-only — #348)
 metrics/review-value.jsonl
+# Per-slice /verify evidence log (runtime data; counts-only — #727)
+metrics/verify-log.jsonl
 
 # Effort-band model routing (per-user, never checked in)
 # - ladder: optional ordered model list (.claude/model-ladder.json), hand-written by users behind restricted endpoints

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1838,6 +1838,10 @@
       "summary": "Work the plan **wave by wave** (the plan's `## Parallelization` section, derived by `scripts/plan_waves.py`).",
       "anchor": "4-implement-each-step"
     },
+    "4.9. Verify runtime behavior before the slice is done (issue #727)": {
+      "summary": "A \"done\" step that only passed its own tests is not the same as a feature that works — a red suite catches structural regressions, not \"it fails the first time someone actually runs it.\" Once a slice's steps are all `[x]` (sub-step 5) and…",
+      "anchor": "49-verify-runtime-behavior-before-the-slice-is-done-issue-727"
+    },
     "5. Run full test suite": {
       "summary": "After all steps are complete, run the full test suite.",
       "anchor": "5-run-full-test-suite"
@@ -3899,6 +3903,10 @@
     "Review Value Entry (#348)": {
       "summary": "`/build` appends one entry per **inline review checkpoint** to",
       "anchor": "review-value-entry-348"
+    },
+    "Verify Log Entry (#727)": {
+      "summary": "`/build` appends one entry per **slice with a runtime surface** to",
+      "anchor": "verify-log-entry-727"
     },
     "When to Log": {
       "summary": "| Event | Action |",

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   the plan", "start building", or after /plan has been approved.
 argument-hint: "[--plan <path>] [--yes]"
 user-invocable: true
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, Skill(verify *)
 ---
 
 # Build
@@ -158,6 +158,22 @@ Within the RED/GREEN/REFACTOR mini-cycle below, repeated Write/Edit calls can ra
 
    `outcome` is `no-op` when the checkpoint passed clean (found nothing), `fixed` when it found and auto-fixed actionable issues, `escalated` when the loop didn't converge. This is the sensor that tells a build where review caught a real defect from one where every loop passed no-op — it turns the pipeline's "value untested" into "value measured" and feeds the plan/step tiering decisions. Disable with `DEV_TEAM_REVIEW_VALUE=off`.
 
+### 4.9. Verify runtime behavior before the slice is done (issue #727)
+
+A "done" step that only passed its own tests is not the same as a feature that works — a red suite catches structural regressions, not "it fails the first time someone actually runs it." Once a slice's steps are all `[x]` (sub-step 5) and its review checkpoint(s) have run (sub-steps 4/6), decide whether the slice has a runtime surface to exercise **before the slice may be marked `[x]` complete**:
+
+1. **Classify the slice's changed files**, per `knowledge/test-file-indicators.md`. If every changed file is a test file, or the rest are docs/config only (no source or runtime file changed), there is nothing for `/verify` to drive — record `outcome: "skipped"` with a `reason` (below) and continue.
+2. **Otherwise, invoke `/verify`** scoped to the slice's changed runtime files before the slice's checkbox is flipped to `[x]`. This generalizes the UI-only `/browse` smoke test (sub-step 4's UI bullet) into a universal completion criterion: APIs, CLIs, bots, and background jobs get the same "did this actually run" check UI changes already get.
+3. **Not bypassable by `--yes`, `DEV_TEAM_AUTO_APPROVE=1`, or no-TTY.** Contrast with the approval gates in Steps 2–3: those bypass a human judgment call when no human is present. This gate needs no human judgment — the agent runs `/verify` itself — so non-interactive mode never skips it. There is no override flag for this step.
+4. **A `/verify` failure is a failing test.** Per Step 5's "Quality ownership" language: do not mark the slice `[x]` or the plan `implemented`. Enter [Systematic Debugging](../systematic-debugging/SKILL.md), find the root cause, fix it, and re-run `/verify` before proceeding — never silently override.
+5. **Record the outcome.** Append exactly one JSON line per slice with a runtime surface to `metrics/verify-log.jsonl`, schema modeled on `metrics/review-value.jsonl` (sub-step 7):
+
+   ```json
+   {"timestamp":"<ISO8601>","plan":"<plan-file>","slice":"<N>","branch":"<branch>","files":["<changed runtime file>","..."],"outcome":"ran|skipped|failed-then-fixed","reason":"<set when outcome is skipped>"}
+   ```
+
+   `outcome` is `ran` (`/verify` executed and passed), `skipped` (no runtime surface in the diff — `reason` states why, e.g. `"tests-only"` or `"docs-only"`), or `failed-then-fixed` (`/verify` failed at least once before the fix landed). `python3 scripts/progress_guardian.py --pre-pr` reads this log: a branch with runtime-surface changes and no matching entry fails the pre-PR gate the same way an incomplete step or a missing commit does.
+
 ### 5. Run full test suite
 
 After all steps are complete, run the full test suite. Paste the output as final verification evidence.
@@ -201,8 +217,9 @@ Stop and ask the user when:
 
 - `/specs` produces the intent, architecture, and acceptance-criteria artifacts that inform the plan
 - `/plan` decomposes the feature into slices, authors each slice's Gherkin, and produces the plan this command executes
+- `/verify` exercises each runtime-surface slice end-to-end before it may be marked done (sub-step 4.9, issue #727)
 - `/code-review` runs the full review suite after implementation
 - `farley-score` scores the branch's tests (Farley Score) as the final pre-PR quality signal
 - `/pr` creates the pull request after a successful build
 - `/continue` can resume a partially completed build across sessions
-- `python3 scripts/progress_guardian.py --plan <plan-file>` validates step completion and commit discipline at each step boundary
+- `python3 scripts/progress_guardian.py --plan <plan-file>` validates step completion and commit discipline at each step boundary; `--pre-pr` also fails closed when runtime-surface changes have no matching `metrics/verify-log.jsonl` entry (issue #727)

--- a/plugins/dev-team/skills/performance-metrics/SKILL.md
+++ b/plugins/dev-team/skills/performance-metrics/SKILL.md
@@ -156,12 +156,47 @@ consistent with the cost meter's privacy boundary. Disable with
 `DEV_TEAM_REVIEW_VALUE=off`. Report it with `/cost-report` (its "review value"
 section).
 
+### Verify Log Entry (#727)
+
+`/build` appends one entry per **slice with a runtime surface** to
+`metrics/verify-log.jsonl` (sub-step 4.9) — evidence that `/verify` actually
+exercised the change end-to-end before the slice was marked done, or was
+explicitly skipped because the diff had no runtime surface to drive. This is
+the sensor that closes the gap the #727 investigation found: a "done" feature
+that fails the first time it's really run means `/verify` was either skipped
+or never mandated in the first place.
+
+```json
+{
+  "timestamp": "2026-07-02T14:30:00Z",
+  "plan": "plans/add-auth.md",
+  "slice": "2",
+  "branch": "feat/add-auth",
+  "files": ["src/api/auth.py"],
+  "outcome": "ran",
+  "reason": null
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `branch` | string | Current branch name — `scripts/progress_guardian.py --pre-pr` matches on this |
+| `files` | string[] | The slice's changed runtime files that `/verify` was scoped to |
+| `outcome` | string | `ran` (`/verify` executed and passed), `skipped` (no runtime surface — see `reason`), or `failed-then-fixed` (`/verify` failed at least once before the fix landed) |
+| `reason` | string \| null | Required when `outcome` is `skipped` (e.g. `"tests-only"`, `"docs-only"`); `null` otherwise |
+
+**Not disableable.** Unlike Review Value logging (`DEV_TEAM_REVIEW_VALUE=off`),
+there is no env var to turn this off — `scripts/progress_guardian.py --pre-pr`
+fails closed on a branch with runtime-surface changes and no matching entry,
+and that gate is a correctness control, not a metrics-collection nicety.
+
 ## When to Log
 
 | Event | Action |
 | --- | --- |
 | Task completed | Log full task completion entry |
 | `/build` inline review checkpoint | Append a Review Value entry to `metrics/review-value.jsonl` (#348) |
+| `/build` slice with a runtime surface | Append a Verify Log entry to `metrics/verify-log.jsonl` (#727) |
 | Configuration change | Log in `metrics/config-changelog.jsonl` (see Feedback & Learning skill) |
 | Hallucination detected | Flag in task entry + log separately if correction applied |
 | Context summarization triggered | Increment counter in current task entry |

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 import sys
@@ -450,6 +451,165 @@ def check_pre_pr(steps: List[Step]) -> List[dict]:
     return errors
 
 
+VERIFY_LOG_PATH = "metrics/verify-log.jsonl"
+
+# Test-file indicators — kept in sync with knowledge/test-file-indicators.md
+# so this Python check and the /build skill's prose classification agree on
+# what counts as "a test" (see issue #727).
+_TEST_NAME_RE = re.compile(r"\.(test|spec)\.[^./]+$")
+_TEST_DIR_FRAGMENTS = ("__tests__/",)
+_STEP_DEFINITION_RE = re.compile(
+    r"(\.steps\.[^./]+$|StepDefinitions\.[^./]+$|Steps\.[^./]+$)", re.IGNORECASE
+)
+_TEST_CLASS_NAME_RE = re.compile(r"(Test|Tests|TestCase|Spec)\.java$")
+_TEST_ATTRIBUTE_RE = re.compile(
+    r"\[Fact\]|\[Theory\]|\[TestCase\]|\[TestMethod\]|\[TestClass\]|"
+    r"(?<!Parameterized)(?<!Factory)\[Test\]|@Test\b|@ParameterizedTest|@TestFactory"
+)
+
+# Docs/config files never carry a runtime surface — no source ever executes
+# from them, so a diff touching only these (plus tests) has nothing for
+# /verify to drive.
+_DOC_CONFIG_SUFFIXES = {
+    ".md",
+    ".mdx",
+    ".txt",
+    ".rst",
+    ".adoc",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".editorconfig",
+}
+_DOC_CONFIG_BASENAMES = {
+    "LICENSE",
+    "LICENSE.txt",
+    ".gitignore",
+    ".gitattributes",
+    "CODEOWNERS",
+}
+
+
+def _is_test_file(path: str, repo_root: str) -> bool:
+    """True when `path` looks like a test per knowledge/test-file-indicators.md."""
+    if path.endswith(".feature"):
+        return True
+    if _TEST_NAME_RE.search(path):
+        return True
+    if any(frag in path for frag in _TEST_DIR_FRAGMENTS):
+        return True
+    if _STEP_DEFINITION_RE.search(path):
+        return True
+    if _TEST_CLASS_NAME_RE.search(path):
+        return True
+    suffix = Path(path).suffix.lower()
+    if suffix in (".cs", ".java"):
+        # Attribute-based test detection needs the file's content — best
+        # effort only, and only when the file still exists on disk.
+        try:
+            content = (Path(repo_root) / path).read_text(
+                encoding="utf-8", errors="replace"
+            )
+        except OSError:
+            return False
+        if _TEST_ATTRIBUTE_RE.search(content):
+            return True
+    return False
+
+
+def _is_doc_or_config_file(path: str) -> bool:
+    if path.startswith("metrics/") and path.endswith(".jsonl"):
+        return True
+    if Path(path).name in _DOC_CONFIG_BASENAMES:
+        return True
+    return Path(path).suffix.lower() in _DOC_CONFIG_SUFFIXES
+
+
+def has_runtime_surface(changed_files: List[str], repo_root: str) -> bool:
+    """True when at least one changed file is neither a test file nor a
+    docs/config file — i.e. there is something for /verify to exercise.
+    """
+    return any(
+        not _is_test_file(f, repo_root) and not _is_doc_or_config_file(f)
+        for f in changed_files
+    )
+
+
+def _collect_branch_changed_files(repo_root: str) -> List[str]:
+    """All files changed on this branch: the committed diff since the
+    branch base, plus any currently uncommitted (staged/unstaged) files.
+    Mirrors check_scope's branch-scope resolution (issue #727).
+    """
+    base_ref = _branch_base_sha(repo_root)
+    if not base_ref:
+        base_ref = run_git(["rev-list", "--max-parents=0", "HEAD"], repo_root).strip()
+
+    diff_output = (
+        run_git(["diff", "--name-only", base_ref + "..HEAD"], repo_root)
+        if base_ref
+        else ""
+    )
+    changed_files = (
+        set(diff_output.strip().splitlines()) if diff_output.strip() else set()
+    )
+
+    status_output = run_git(["status", "--porcelain"], repo_root)
+    for line in status_output.strip().splitlines():
+        if line.strip():
+            parts = line.strip().split(None, 1)
+            if len(parts) == 2:
+                changed_files.add(parts[1].strip())
+
+    return sorted(changed_files)
+
+
+def check_verify_log(repo_root: str, changed_files: List[str]) -> List[dict]:
+    """Pre-PR gate (issue #727): if the branch touches any runtime-surface
+    file (not exclusively tests/docs/config), require at least one entry
+    in metrics/verify-log.jsonl for the current branch — evidence that
+    `/verify` ran (or was explicitly skipped with a reason) before the
+    slice was marked done. Fails closed, the same way an incomplete step
+    or a missing commit does.
+    """
+    if not changed_files or not has_runtime_surface(changed_files, repo_root):
+        return []
+
+    branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root).strip()
+    log_path = Path(repo_root) / VERIFY_LOG_PATH
+
+    entries: List[dict] = []
+    if log_path.exists():
+        for raw_line in log_path.read_text(encoding="utf-8").splitlines():
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            try:
+                entries.append(json.loads(raw_line))
+            except ValueError:
+                continue
+
+    if any(entry.get("branch") == branch for entry in entries):
+        return []
+
+    return [
+        _make_error(
+            message=(
+                "Pre-PR gate: this branch touches runtime-surface file(s) but no "
+                f"entry in {VERIFY_LOG_PATH} matches branch '{branch}'. `/verify` "
+                "(or an explicit skip-with-reason) is required before a PR can be "
+                "opened."
+            ),
+            suggested_fix=(
+                "Run /verify against the branch's changed runtime files (or record "
+                "a skipped:<reason> entry if the diff genuinely has no runtime "
+                f"surface to drive), then append the outcome to {VERIFY_LOG_PATH}."
+            ),
+        )
+    ]
+
+
 def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     """Detect files in the branch diff that aren't declared in the plan.
 
@@ -490,13 +650,19 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
             if len(parts) == 2:
                 changed_files.add(parts[1].strip())
 
-    # Exclude the plan file itself from scope check
+    # Exclude the plan file itself from scope check, along with append-only
+    # metrics artifacts (e.g. review-value.jsonl, verify-log.jsonl) — these
+    # are pipeline instrumentation the plan never declares by name, not
+    # plan-scoped work product (issue #727).
     plan_name = plan_path.name
     plan_rel = str(plan_path)
     changed_files = {
         f
         for f in changed_files
-        if f != plan_name and f != plan_rel and not f.endswith(plan_name)
+        if f != plan_name
+        and f != plan_rel
+        and not f.endswith(plan_name)
+        and not (f.startswith("metrics/") and f.endswith(".jsonl"))
     }
 
     if not changed_files:
@@ -644,6 +810,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         if args.pre_pr:
             pre_pr_issues = check_pre_pr(steps)
             errors.extend(pre_pr_issues)
+
+            # 6. Verify-log gate (issue #727): runtime-surface changes need
+            # evidence /verify ran before the PR can be opened.
+            verify_changed_files = _collect_branch_changed_files(repo_root)
+            verify_issues = check_verify_log(repo_root, verify_changed_files)
+            errors.extend(verify_issues)
 
     result = build_result(errors, warnings)
     return main_exit(result)

--- a/tests/scripts/test_progress_guardian.py
+++ b/tests/scripts/test_progress_guardian.py
@@ -562,6 +562,7 @@ def test_4_4_realistic_plan_with_all_three_525_patterns_passes_the_pre_pr_gate(
         "- [ ] A2: bar\n"
         "- [ ] A3: baz\n"
     )
+    _write_verify_log(work, branch="feature")
 
     result = run_pg(plan, "--pre-pr", "--skip-llm")
     assert result.returncode == 0
@@ -588,7 +589,9 @@ def test_5_1_directory_declaration_satisfies_commit_discipline(tmp_path: Path) -
     _git(tmp_path, "add", "new_feature/SKILL.md")
     _git(tmp_path, "commit", "-q", "-m", "feat: add new-feature skill")
     plan = tmp_path / "plan.md"
-    plan.write_text("- [x] Slice 1: add new-feature skill\n\n**Files:** `new_feature/`\n")
+    plan.write_text(
+        "- [x] Slice 1: add new-feature skill\n\n**Files:** `new_feature/`\n"
+    )
 
     result = run_pg(plan, "--skip-llm")
     assert result.returncode == 0
@@ -690,3 +693,142 @@ def test_5_4_non_path_backtick_token_not_mis_captured_as_declared_path(
     ]
     assert len(errs) == 1, data
     assert "whose subject contains" in errs[0]["message"], errs[0]
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — issue #727: pre-PR gate requires evidence of /verify for
+# runtime-surface changes (metrics/verify-log.jsonl)
+# ---------------------------------------------------------------------------
+
+
+def _write_verify_log(repo: Path, branch: str, outcome: str = "ran") -> None:
+    metrics_dir = repo / "metrics"
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": "2026-07-02T00:00:00Z",
+        "plan": "plans/plan.md",
+        "slice": "1",
+        "branch": branch,
+        "files": ["a.py"],
+        "outcome": outcome,
+    }
+    log_path = metrics_dir / "verify-log.jsonl"
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+    # Commit it so it doesn't trip the uncommitted-changes check — the
+    # scenario under test is "does a committed verify-log entry satisfy
+    # the gate", isolated from check_uncommitted (issue #727).
+    _git(repo, "add", "metrics/verify-log.jsonl")
+    _git(repo, "commit", "-q", "-m", "chore: record verify-log entry")
+
+
+def _current_branch(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def test_6a_pre_pr_with_runtime_file_and_no_verify_log_exits_1(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] do thing\n\n**Files:** `a.py`\n")
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert any("verify-log" in i["message"] for i in data["issues"]), data
+
+
+def test_6b_pre_pr_with_runtime_file_and_matching_verify_log_entry_exits_0(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] do thing\n\n**Files:** `a.py`\n")
+    _write_verify_log(tmp_path, branch=_current_branch(tmp_path))
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data
+
+
+def test_6c_pre_pr_with_verify_log_for_a_different_branch_still_fails(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] do thing\n\n**Files:** `a.py`\n")
+    _write_verify_log(tmp_path, branch="some-other-branch")
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert any("verify-log" in i["message"] for i in data["issues"]), data
+
+
+def test_6d_pre_pr_with_test_only_changes_skips_the_verify_log_check(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.test.js").write_text("test('x', () => {})\n")
+    _git(tmp_path, "add", "a.test.js")
+    _git(tmp_path, "commit", "-q", "-m", "test: add test")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] add test\n\n**Files:** `a.test.js`\n")
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data
+
+
+def test_6e_pre_pr_with_docs_only_changes_skips_the_verify_log_check(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "notes.md").write_text("# Notes\n")
+    _git(tmp_path, "add", "notes.md")
+    _git(tmp_path, "commit", "-q", "-m", "docs: add notes")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] add notes\n\n**Files:** `notes.md`\n")
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data
+
+
+def test_6f_non_pre_pr_run_does_not_enforce_the_verify_log_check(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] do thing\n\n**Files:** `a.py`\n")
+
+    result = run_pg(plan, "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["issues"] == [], data


### PR DESCRIPTION
## Summary

A feature reported complete failed the first time it was actually exercised for real (issue #727, tier-2 finding from #707's session-review). Investigation confirmed `/verify` — Claude Code's built-in "exercise the change end-to-end" skill — is never invoked anywhere in the dev-team completion pipeline: `/build` only runs an end-to-end check for UI changes (via `/browse`), and `/pr`'s quality gate is tests + typecheck + lint + `/code-review`, with no runtime exercise step for APIs, CLIs, bots, or background jobs.

This generalizes the existing UI-only `/browse` pattern into a universal completion criterion.

## Changes

- **`plugins/dev-team/skills/build/SKILL.md`** — new step 4.9: before a slice with a runtime-surface change (classified per `knowledge/test-file-indicators.md`) may be marked `[x]`, `/verify` must run against its changed files (or the skip is recorded with a reason for tests/docs-only diffs). Explicitly **not bypassable** via `--yes`, `DEV_TEAM_AUTO_APPROVE=1`, or no-TTY — unlike the human-judgment gates in steps 2–3, this needs no human, so non-interactive mode never skips it. A `/verify` failure routes to Systematic Debugging like any other failing test. Added `Skill(verify *)` to the skill's `allowed-tools` so it can actually invoke it.
- **`plugins/dev-team/skills/performance-metrics/SKILL.md`** — documents the new `metrics/verify-log.jsonl` schema (`ran` / `skipped` / `failed-then-fixed`), mirroring the existing `review-value.jsonl` entry.
- **`scripts/progress_guardian.py`** — hook-enforced backstop: `--pre-pr` now fails closed when the branch diff touches a runtime-surface file (not exclusively tests/docs/config) but `metrics/verify-log.jsonl` has no entry for the current branch, the same way it already fails closed on incomplete steps or missing commits. Also stops `check_scope` from flagging append-only `metrics/*.jsonl` files as scope creep.
- **`.gitignore`** — ignores `metrics/verify-log.jsonl` for this repo's own dogfooding, consistent with `metrics/review-value.jsonl`.
- **`plugins/dev-team/knowledge/index.json`** — regenerated after the skill markdown edits.

`/pr` needed no changes — its existing pre-flight `progress_guardian.py --pre-pr` call surfaces the new failure automatically (AC6).

## Test plan

- [x] `tests/scripts/test_progress_guardian.py` — new tests for the verify-log gate (missing entry fails, matching-branch entry passes, entry for a different branch still fails, test-only/docs-only diffs skip the check, non-`--pre-pr` runs don't enforce it) plus updated fixtures for existing passing scenarios
- [x] `python3 -m pytest tests/scripts/ tests/repo/ -q` — 1901+ passed
- [x] `python3 scripts/check_registry_sync.py` — in sync
- [x] `bash scripts/ci-local.sh` — all checks pass except a pre-existing, unrelated `eslint` environment failure (missing `@eslint/js` module), reproduced identically on `main` with this branch's diff stashed out

Closes #727