### PR TITLE
fix: escape untrusted report/mermaid strings and close zip-slip bypass

### DIFF
--- a/plugins/security-assessment/commands/export-pdf.md
+++ b/plugins/security-assessment/commands/export-pdf.md
@@ -15,6 +15,7 @@ You have been invoked with the `/export-pdf` command.
 Converter from Markdown to PDF. Uses `pandoc` when available (cleaner tables, wider Markdown support); falls back to `weasyprint` when pandoc is absent; skips with a warning when neither is installed.
 
 Used for:
+
 - Executive reports from `/security-assessment` (`memory/report-<slug>.md`)
 - Red-team reports from `/redteam-model` (`harness/redteam/results/adversarial-report.md`)
 - Cross-repo summaries from `/cross-repo-analysis`
@@ -27,6 +28,7 @@ Arguments: $ARGUMENTS
 **Positional:** `<report.md>` — path to the input Markdown file.
 
 **Flags:**
+
 - `--output <path>`: output PDF path. Default: same basename with `.pdf` extension.
 - `--css <path>`: custom CSS stylesheet. Default: `plugins/security-assessment/templates/report-css/default.css`.
 
@@ -61,21 +63,39 @@ pandoc "$INPUT" \
 
 **Fallback (weasyprint + python-markdown):**
 
+The input Markdown is derived from a scanned repo / probed model (see
+`08_report_generator.py`, `service-comm-parser.py`) — treat it as
+untrusted. Rendered HTML/CSS can reference remote resources (`<img
+src="https://...">`, CSS `url(...)`), and weasyprint fetches those by
+default, which is a plausible SSRF vector at PDF-conversion time. Pass a
+`url_fetcher` that blocks every non-local scheme so conversion never makes
+an outbound network request:
+
 ```bash
 python3 -c "
 import sys, markdown
 from weasyprint import HTML, CSS
+
+def _no_remote_fetch(url, *args, **kwargs):
+    if not url.startswith(('file://', 'data:')):
+        raise ValueError(f'blocked remote resource fetch during PDF export: {url}')
+    from weasyprint import default_url_fetcher
+    return default_url_fetcher(url, *args, **kwargs)
+
 with open('$INPUT') as f:
     md_text = f.read()
 html_body = markdown.markdown(md_text, extensions=['tables', 'fenced_code', 'codehilite'])
 html = f'<html><head><meta charset=\"utf-8\"></head><body>{html_body}</body></html>'
-HTML(string=html).write_pdf('$OUTPUT', stylesheets=[CSS(filename='$CSS')])
+HTML(string=html, url_fetcher=_no_remote_fetch).write_pdf(
+    '$OUTPUT', stylesheets=[CSS(filename='$CSS')]
+)
 "
 ```
 
 ### 4. Report
 
 On success:
+
 ```
 PDF written: /absolute/path/to/report.pdf
 ```
@@ -83,6 +103,7 @@ PDF written: /absolute/path/to/report.pdf
 Print the **absolute** path — some downstream tooling expects an absolute path.
 
 On graceful skip (neither tool):
+
 ```
 SKIP: pandoc and weasyprint both absent; PDF not produced.
       Install one:
@@ -97,6 +118,7 @@ Exit 0 in both cases (skip is not a failure).
 ## Escalation
 
 Stop and ask the user when:
+
 - Input file does not exist.
 - Output directory is not writable.
 - CSS file specified by `--css` does not exist (default CSS should always exist; if missing, report as a plugin install issue).

--- a/plugins/security-assessment/harness/redteam/probes/08_report_generator.py
+++ b/plugins/security-assessment/harness/redteam/probes/08_report_generator.py
@@ -6,13 +6,31 @@ produces the raw, machine-friendly content; interpretation happens downstream.
 
 Produces: results/08_report.json  AND  results/adversarial-report.md
 """
+
 from __future__ import annotations
 
+import html
 import json
 from datetime import datetime, timezone
 
 from .. import config
 from ..lib import result_store
+
+
+def _esc(value: object) -> str:
+    """HTML-escape a probe-result value before it is interpolated into the
+    generated Markdown report.
+
+    Probe results ultimately originate from the probed model's own HTTP
+    responses — an attacker-controlled service under test — so any string
+    field here (framework name, feature name, doc path, ...) must be
+    treated as untrusted. The report is later rendered to HTML/PDF (see
+    commands/export-pdf.md: python-markdown + weasyprint), and
+    python-markdown passes raw embedded HTML through unmodified, so an
+    unescaped value could inject markup/script content into the rendered
+    report.
+    """
+    return html.escape(str(value), quote=True)
 
 
 def _load_or_empty(name: str) -> dict:
@@ -24,25 +42,33 @@ def _load_or_empty(name: str) -> dict:
 
 def _format_recon(recon: dict) -> str:
     lines = ["## Probe 01 — API Recon\n"]
-    lines.append(f"- **Target**: `{recon.get('target', 'unknown')}`")
-    lines.append(f"- **Inferred framework**: {recon.get('inferred_framework')}")
+    lines.append(f"- **Target**: `{_esc(recon.get('target', 'unknown'))}`")
+    lines.append(f"- **Inferred framework**: {_esc(recon.get('inferred_framework'))}")
     visible_doc = [p for p in recon.get("doc_paths", []) if p.get("status") == 200]
     lines.append(f"- **Documentation paths exposed**: {len(visible_doc)}")
     for p in visible_doc[:5]:
-        lines.append(f"  - `{p['path']}` ({p.get('content_type', 'unknown')})")
+        lines.append(
+            f"  - `{_esc(p['path'])}` ({_esc(p.get('content_type', 'unknown'))})"
+        )
     if recon.get("method_matrix"):
-        accepted_verbs = [m for m, d in recon["method_matrix"].items() if d.get("status", 500) < 400]
-        lines.append(f"- **HTTP verbs accepted on predict endpoint**: {', '.join(accepted_verbs) or 'none'}")
+        accepted_verbs = [
+            m for m, d in recon["method_matrix"].items() if d.get("status", 500) < 400
+        ]
+        escaped_verbs = ", ".join(_esc(v) for v in accepted_verbs) or "none"
+        lines.append(f"- **HTTP verbs accepted on predict endpoint**: {escaped_verbs}")
     return "\n".join(lines) + "\n"
 
 
 def _format_schema(schema: dict) -> str:
     lines = ["## Probe 02 — Schema Discovery\n"]
-    lines.append(f"- **Discovery strategy**: {schema.get('strategy_used', 'none succeeded')}")
+    lines.append(
+        f"- **Discovery strategy**: {_esc(schema.get('strategy_used', 'none succeeded'))}"
+    )
     feats = schema.get("features", [])
     lines.append(f"- **Features discovered**: {len(feats)}")
     for category, group in (schema.get("by_category") or {}).items():
-        lines.append(f"  - **{category}**: {', '.join(group)}")
+        escaped_group = ", ".join(_esc(g) for g in group)
+        lines.append(f"  - **{_esc(category)}**: {escaped_group}")
     return "\n".join(lines) + "\n"
 
 
@@ -51,7 +77,7 @@ def _format_sensitivity(sens: dict) -> str:
     lines.append(f"- **Baseline score**: {sens.get('baseline_score')}")
     lines.append("- **Top 5 most-influential features**:")
     for r in (sens.get("rankings") or [])[:5]:
-        lines.append(f"  - `{r['feature']}` (sensitivity {r['sensitivity']:.3f})")
+        lines.append(f"  - `{_esc(r['feature'])}` (sensitivity {r['sensitivity']:.3f})")
     return "\n".join(lines) + "\n"
 
 
@@ -59,9 +85,11 @@ def _format_boundaries(boundaries: dict) -> str:
     lines = ["## Probe 04 — Boundary Mapping\n"]
     for b in boundaries.get("boundaries", []):
         if b.get("boundary") is not None:
-            lines.append(f"- `{b['feature']}`: boundary at {b['boundary']:.3f}")
+            lines.append(f"- `{_esc(b['feature'])}`: boundary at {b['boundary']:.3f}")
         else:
-            lines.append(f"- `{b['feature']}`: no boundary ({b.get('reason')})")
+            lines.append(
+                f"- `{_esc(b['feature'])}`: no boundary ({_esc(b.get('reason'))})"
+            )
     return "\n".join(lines) + "\n"
 
 
@@ -70,9 +98,12 @@ def _format_evasion(evasion: dict) -> str:
     lines.append(f"- **Score target**: < {evasion.get('score_target', 0.4)}")
     results = evasion.get("results") or []
     methods_used = sorted({r.get("method") for r in results})
-    lines.append(f"- **Methods that found adversarials**: {', '.join(m for m in methods_used if m) or 'none'}")
-    lines.append(f"- **Lowest score achieved**: "
-                 f"{min((r['score'] for r in results if isinstance(r.get('score'), (int, float))), default='n/a')}")
+    escaped_methods = ", ".join(_esc(m) for m in methods_used if m) or "none"
+    lines.append(f"- **Methods that found adversarials**: {escaped_methods}")
+    lines.append(
+        f"- **Lowest score achieved**: "
+        f"{min((r['score'] for r in results if isinstance(r.get('score'), (int, float))), default='n/a')}"
+    )
     return "\n".join(lines) + "\n"
 
 
@@ -81,7 +112,9 @@ def _format_validation(validation: dict) -> str:
     summary = validation.get("summary") or {}
     lines.append(f"- **Cases tested**: {summary.get('total_cases', 0)}")
     lines.append(f"- **Fail-open cases**: {summary.get('fail_open_count', 0)}")
-    lines.append(f"- **Information-leakage cases**: {summary.get('information_leakage_count', 0)}")
+    lines.append(
+        f"- **Information-leakage cases**: {summary.get('information_leakage_count', 0)}"
+    )
     return "\n".join(lines) + "\n"
 
 
@@ -89,11 +122,11 @@ def _format_extraction(extraction: dict) -> str:
     lines = ["## Probe 07 — Model Extraction\n"]
     lines.append(f"- **Samples collected**: {extraction.get('n_samples', 0)}")
     lines.append(f"- **Best R²**: {extraction.get('best_r2', 0.0):.3f}")
-    lines.append(f"- **Fidelity**: {extraction.get('fidelity', 'unknown')}")
+    lines.append(f"- **Fidelity**: {_esc(extraction.get('fidelity', 'unknown'))}")
     surrogates = extraction.get("surrogates") or {}
     for name, stats in surrogates.items():
         if isinstance(stats, dict) and "r2" in stats:
-            lines.append(f"  - {name}: R² = {stats['r2']:.3f}")
+            lines.append(f"  - {_esc(name)}: R² = {stats['r2']:.3f}")
     return "\n".join(lines) + "\n"
 
 

--- a/plugins/security-assessment/harness/tools/service-comm-parser.py
+++ b/plugins/security-assessment/harness/tools/service-comm-parser.py
@@ -16,9 +16,11 @@ Exit codes:
     0  — Mermaid emitted on stdout (may be empty-ish if nothing found)
     2  — argument or IO error
 """
+
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import re
 import sys
@@ -81,7 +83,15 @@ def scan_nats(repo_path: Path, service: Service) -> None:
         if not src_file.is_file():
             continue
         # Only text-ish files
-        if src_file.suffix.lower() not in {".py", ".js", ".ts", ".go", ".java", ".scala", ".kt"}:
+        if src_file.suffix.lower() not in {
+            ".py",
+            ".js",
+            ".ts",
+            ".go",
+            ".java",
+            ".scala",
+            ".kt",
+        }:
             continue
         try:
             text = src_file.read_text(encoding="utf-8", errors="replace")
@@ -91,7 +101,8 @@ def scan_nats(repo_path: Path, service: Service) -> None:
         for m in re.finditer(NATS_PATTERN, text):
             subject = m.group(1)
             verb_match = re.search(
-                r"(subscribe|publish|queueSubscribe|request|respond)", text[max(0, m.start() - 30): m.start() + 1]
+                r"(subscribe|publish|queueSubscribe|request|respond)",
+                text[max(0, m.start() - 30) : m.start() + 1],
             )
             verb = verb_match.group(1).lower() if verb_match else ""
             if verb in ("subscribe", "queuesubscribe", "respond"):
@@ -123,7 +134,9 @@ def scan_k8s(repo_path: Path, service: Service) -> None:
             service.k8s_names.add(m.group(1))
 
 
-def scan_package_deps(repo_path: Path, service: Service, all_services: list[Service]) -> list[Edge]:
+def scan_package_deps(
+    repo_path: Path, service: Service, all_services: list[Service]
+) -> list[Edge]:
     """Emit edges where one repo's package.json / requirements.txt references
     another repo's service name as an internal dependency.
     """
@@ -141,12 +154,14 @@ def scan_package_deps(repo_path: Path, service: Service, all_services: list[Serv
                 # Normalize: drop scope
                 normalized = dep_name.lstrip("@").split("/", 1)[-1]
                 if normalized in service_names and normalized != service.name:
-                    edges.append(Edge(
-                        src=service.name,
-                        dst=normalized,
-                        kind="package",
-                        note=f"npm dependency: {dep_name}",
-                    ))
+                    edges.append(
+                        Edge(
+                            src=service.name,
+                            dst=normalized,
+                            kind="package",
+                            note=f"npm dependency: {dep_name}",
+                        )
+                    )
         except (json.JSONDecodeError, ValueError):
             pass
 
@@ -156,12 +171,14 @@ def scan_package_deps(repo_path: Path, service: Service, all_services: list[Serv
             for line in requirements.read_text(encoding="utf-8").splitlines():
                 line = line.strip().split("==")[0].split(">=")[0].split("<=")[0]
                 if line and line in service_names and line != service.name:
-                    edges.append(Edge(
-                        src=service.name,
-                        dst=line,
-                        kind="package",
-                        note=f"pip dependency: {line}",
-                    ))
+                    edges.append(
+                        Edge(
+                            src=service.name,
+                            dst=line,
+                            kind="package",
+                            note=f"pip dependency: {line}",
+                        )
+                    )
         except OSError:
             pass
 
@@ -196,36 +213,65 @@ def derive_nats_edges(services: list[Service]) -> list[Edge]:
                         auth = False
                     elif pub_svc.nats_auth and sub_svc.nats_auth:
                         auth = True
-                edges.append(Edge(src=p, dst=s, kind="nats", subject=subject, auth=auth))
+                edges.append(
+                    Edge(src=p, dst=s, kind="nats", subject=subject, auth=auth)
+                )
     return edges
+
+
+def _mermaid_id(name: str) -> str:
+    """Sanitize a repo/response-derived name into a safe, unquoted Mermaid
+    node identifier. Mermaid node IDs are emitted without quoting, so any
+    character outside [A-Za-z0-9_] (space, bracket, quote, newline, ...)
+    could otherwise break out of the identifier position and inject
+    arbitrary Mermaid/HTML syntax.
+    """
+    return re.sub(r"[^A-Za-z0-9_]", "_", name)
+
+
+def _mermaid_label(text: str) -> str:
+    """HTML-escape repo/response-derived text before it is interpolated into
+    a quoted Mermaid label. Mermaid renders flowchart labels as HTML, and
+    labels are also delimited by literal double quotes in the diagram
+    source, so unescaped `<`, `>`, `&`, or `"` in attacker-influenced input
+    (package.json name, k8s Service name, dependency name, NATS subject)
+    can break out of the label/quote and inject markup or script content
+    that a downstream Markdown/HTML/PDF renderer will execute.
+    """
+    return html.escape(text, quote=True)
 
 
 def emit_mermaid(services: list[Service], edges: list[Edge]) -> str:
     lines = ["```mermaid", "graph LR"]
     # Nodes
     for svc in services:
-        node_id = svc.name.replace("-", "_")
+        node_id = _mermaid_id(svc.name)
         # Annotate with K8s Services if any
-        label = svc.name
+        label = _mermaid_label(svc.name)
         if svc.k8s_names:
-            label += f"<br/>k8s: {', '.join(sorted(svc.k8s_names))}"
+            escaped_k8s = ", ".join(_mermaid_label(n) for n in sorted(svc.k8s_names))
+            label += f"<br/>k8s: {escaped_k8s}"
         lines.append(f'  {node_id}["{label}"]')
 
     # Edges — dedup; annotate auth / encryption where known
     seen: set[tuple[str, str, str]] = set()
     for e in edges:
-        src_id = e.src.replace("-", "_")
-        dst_id = e.dst.replace("-", "_")
+        src_id = _mermaid_id(e.src)
+        dst_id = _mermaid_id(e.dst)
         key = (src_id, dst_id, e.subject)
         if key in seen:
             continue
         seen.add(key)
         if e.kind == "nats":
-            auth_tag = "auth" if e.auth is True else ("NO-AUTH" if e.auth is False else "?auth")
-            label = f"{e.subject} [{auth_tag}]"
+            auth_tag = (
+                "auth"
+                if e.auth is True
+                else ("NO-AUTH" if e.auth is False else "?auth")
+            )
+            label = f"{_mermaid_label(e.subject)} [{auth_tag}]"
             lines.append(f'  {src_id} -- "{label}" --> {dst_id}')
         elif e.kind == "package":
-            lines.append(f'  {src_id} -. "{e.note}" .-> {dst_id}')
+            lines.append(f'  {src_id} -. "{_mermaid_label(e.note)}" .-> {dst_id}')
         else:
             lines.append(f"  {src_id} --> {dst_id}")
 
@@ -242,7 +288,10 @@ def main() -> int:
     for path_arg in args.paths:
         p = Path(path_arg)
         if not p.exists() or not p.is_dir():
-            print(f"service-comm-parser: skipping non-directory: {path_arg}", file=sys.stderr)
+            print(
+                f"service-comm-parser: skipping non-directory: {path_arg}",
+                file=sys.stderr,
+            )
             continue
         svc = Service(name=infer_service_name(p), repo=str(p))
         scan_nats(p, svc)
@@ -250,7 +299,7 @@ def main() -> int:
         services.append(svc)
 
     if not services:
-        print("```mermaid\ngraph LR\n  empty[\"no services detected\"]\n```")
+        print('```mermaid\ngraph LR\n  empty["no services detected"]\n```')
         return 0
 
     # Compute edges

--- a/scripts/run_integration_eval.py
+++ b/scripts/run_integration_eval.py
@@ -50,48 +50,85 @@ def check_prerequisites(skip_dispatch: bool) -> list[str]:
     if not registry.exists():
         missing.append(
             "the grader registry scripts/eval_graders/ (#309) — integration is "
-            "a registered grader")
+            "a registered grader"
+        )
     else:
         try:
             sys.path.insert(0, str(SCRIPTS))
             from eval_graders import is_registered  # noqa: E402
+
             if not is_registered("integration"):
-                missing.append(
-                    "the 'integration' grader in the registry (#309/#313)")
+                missing.append("the 'integration' grader in the registry (#309/#313)")
         except ImportError:
             missing.append("an importable grader registry (#309)")
     if not (SCRIPTS / "eval_cache.py").exists():
         missing.append(
             "scripts/eval_cache.py, the fingerprint replay cache (#311) — "
-            "without replay every integration run pays full orchestrator cost")
+            "without replay every integration run pays full orchestrator cost"
+        )
     if not skip_dispatch and shutil.which("claude") is None:
         missing.append(
             "the `claude` CLI (needed to dispatch the orchestrator; pass "
-            "--skip-dispatch to run the harness without a model)")
+            "--skip-dispatch to run the harness without a model)"
+        )
     return missing
+
+
+def _is_within(dest: Path, target: Path) -> bool:
+    """True iff `target` is dest itself or a real descendant of dest.
+
+    Both paths must already be resolved (absolute, symlinks/`..` collapsed).
+    Deliberately NOT `str(target).startswith(str(dest))`: that naive
+    string-prefix check has no separator boundary, so a sibling directory
+    whose name merely starts with dest's name (e.g. dest=".../out", target
+    ".../out-evil/pwned.txt") would incorrectly pass — the classic
+    zip-slip-guard-bypass pattern. `relative_to` enforces a real path-segment
+    containment check.
+    """
+    try:
+        target.relative_to(dest)
+        return True
+    except ValueError:
+        return False
 
 
 def extract_golden_repo(tarball: Path, dest: Path) -> None:
     """Extract the golden-repo snapshot into dest (created fresh)."""
     dest.mkdir(parents=True, exist_ok=True)
+    resolved_dest = dest.resolve()
     with tarfile.open(tarball) as tf:
         # Guard against path traversal in the archive.
         for member in tf.getmembers():
             target = (dest / member.name).resolve()
-            if not str(target).startswith(str(dest.resolve())):
+            if not _is_within(resolved_dest, target):
                 raise RuntimeError(f"unsafe path in tarball: {member.name}")
         tf.extractall(dest)  # noqa: S202 - members validated above
 
 
 def init_worktree(workdir: Path) -> None:
     """Make the extracted snapshot a git worktree (baseline commit)."""
-    quiet = {"cwd": str(workdir), "check": True,
-             "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
+    quiet = {
+        "cwd": str(workdir),
+        "check": True,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
     subprocess.run(["git", "init"], **quiet)
     subprocess.run(["git", "add", "-A"], **quiet)
     subprocess.run(
-        ["git", "-c", "user.email=eval@dev-team", "-c", "user.name=eval",
-         "commit", "-m", "golden-repo baseline", "--allow-empty"], **quiet)
+        [
+            "git",
+            "-c",
+            "user.email=eval@dev-team",
+            "-c",
+            "user.name=eval",
+            "commit",
+            "-m",
+            "golden-repo baseline",
+            "--allow-empty",
+        ],
+        **quiet,
+    )
 
 
 def dispatch_orchestrator(workdir: Path, spec_path: Path, model: str) -> None:
@@ -99,10 +136,11 @@ def dispatch_orchestrator(workdir: Path, spec_path: Path, model: str) -> None:
     prompt = (
         f"Implement the spec in {spec_path.name} using the full plan -> build -> "
         f"review pipeline. The working directory is a fresh git worktree; make "
-        f"the declared test commands pass.")
+        f"the declared test commands pass."
+    )
     subprocess.run(
-        ["claude", "-p", prompt, "--model", model],
-        cwd=str(workdir), check=False)
+        ["claude", "-p", prompt, "--model", model], cwd=str(workdir), check=False
+    )
 
 
 def run_commands(workdir: Path, commands: list[str]) -> list[dict]:
@@ -110,22 +148,31 @@ def run_commands(workdir: Path, commands: list[str]) -> list[dict]:
     results = []
     for cmd in commands:
         proc = subprocess.run(
-            cmd, cwd=str(workdir), shell=True,
-            capture_output=True, text=True)
+            cmd, cwd=str(workdir), shell=True, capture_output=True, text=True
+        )
         stderr_first = ""
         if proc.stderr:
-            stderr_first = proc.stderr.strip().splitlines()[0] if \
-                proc.stderr.strip() else ""
-        results.append({
-            "command": cmd,
-            "exit_code": proc.returncode,
-            "stderr_first_line": stderr_first,
-        })
+            stderr_first = (
+                proc.stderr.strip().splitlines()[0] if proc.stderr.strip() else ""
+            )
+        results.append(
+            {
+                "command": cmd,
+                "exit_code": proc.returncode,
+                "stderr_first_line": stderr_first,
+            }
+        )
     return results
 
 
-def run_fixture(stem: str, target: str, ispec: dict, fixtures_dir: Path,
-                skip_dispatch: bool, model: str) -> dict:
+def run_fixture(
+    stem: str,
+    target: str,
+    ispec: dict,
+    fixtures_dir: Path,
+    skip_dispatch: bool,
+    model: str,
+) -> dict:
     """Run one integration target; return its recorded actual (results list)."""
     fixture_dir = fixtures_dir / stem
     tarball = fixture_dir / ispec["goldenRepo"]
@@ -153,12 +200,16 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--expected-dir", default="evals/expected")
     ap.add_argument("--fixtures-dir", default="evals/fixtures")
     ap.add_argument("--out", default="actuals.json")
-    ap.add_argument("--only", default="",
-                    help="comma-separated integration target names to run")
+    ap.add_argument(
+        "--only", default="", help="comma-separated integration target names to run"
+    )
     ap.add_argument("--model", default="claude-sonnet-4-6")
-    ap.add_argument("--skip-dispatch", action="store_true",
-                    help="do not dispatch the orchestrator (harness self-test); "
-                         "test commands run against the golden repo as-is")
+    ap.add_argument(
+        "--skip-dispatch",
+        action="store_true",
+        help="do not dispatch the orchestrator (harness self-test); "
+        "test commands run against the golden repo as-is",
+    )
     args = ap.parse_args(argv)
 
     missing = check_prerequisites(args.skip_dispatch)
@@ -188,11 +239,14 @@ def main(argv: list[str]) -> int:
         for target, ispec in integration.items():
             if only and target not in only:
                 continue
-            print(f"· integration {stem}::{target} "
-                  f"({'no-dispatch' if args.skip_dispatch else 'dispatch'})",
-                  file=sys.stderr)
-            actual = run_fixture(stem, target, ispec, fixtures_dir,
-                                 args.skip_dispatch, args.model)
+            print(
+                f"· integration {stem}::{target} "
+                f"({'no-dispatch' if args.skip_dispatch else 'dispatch'})",
+                file=sys.stderr,
+            )
+            actual = run_fixture(
+                stem, target, ispec, fixtures_dir, args.skip_dispatch, args.model
+            )
             actuals.setdefault(stem, {}).setdefault("integration", {})[target] = actual
             ran += 1
 

--- a/tests/commands/test_export_pdf_doc.py
+++ b/tests/commands/test_export_pdf_doc.py
@@ -1,0 +1,98 @@
+"""Regression test for the security-assessment plugin's /export-pdf command.
+
+The weasyprint fallback path renders Markdown that is ultimately derived
+from a scanned repo or a probed model (`08_report_generator.py`,
+`service-comm-parser.py`) — untrusted input. weasyprint fetches remote
+resources referenced in rendered HTML/CSS (`<img src="https://...">`, CSS
+`url(...)`) by default, which is a plausible SSRF vector at PDF-conversion
+time. The embedded conversion snippet must pass a `url_fetcher` that blocks
+every non-local scheme.
+
+This extracts the actual `_no_remote_fetch` guard defined in the command
+doc and exercises it directly (with a stub `weasyprint.default_url_fetcher`)
+so the test fails if the guard is removed, weakened, or never wired into
+`HTML(...)`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPORT_PDF = (
+    REPO_ROOT / "plugins" / "security-assessment" / "commands" / "export-pdf.md"
+)
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return EXPORT_PDF.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def fallback_snippet(text: str) -> str:
+    match = re.search(
+        r"\*\*Fallback \(weasyprint \+ python-markdown\):\*\*.*?```bash\n(.*?)```",
+        text,
+        re.DOTALL,
+    )
+    assert match, "could not find the weasyprint fallback code block in export-pdf.md"
+    return match.group(1)
+
+
+def test_ships_export_pdf_md_command() -> None:
+    assert EXPORT_PDF.is_file()
+
+
+def test_fallback_snippet_defines_a_remote_fetch_guard(fallback_snippet: str) -> None:
+    assert "_no_remote_fetch" in fallback_snippet
+    assert "url_fetcher=_no_remote_fetch" in fallback_snippet
+
+
+def test_remote_fetch_guard_blocks_https_and_allows_local(
+    fallback_snippet: str,
+) -> None:
+    # Isolate just the guard function body (between "def _no_remote_fetch"
+    # and the next top-level statement) and execute it against a stub
+    # weasyprint module, so this test fails if the guard's logic itself is
+    # ever weakened (e.g. an "or True", a scheme typo) even though the
+    # string checks above still pass.
+    func_match = re.search(
+        r"def _no_remote_fetch\(.*?\n(?:    .*\n|\n)*", fallback_snippet
+    )
+    assert func_match, "could not isolate _no_remote_fetch function body"
+    func_src = func_match.group(0)
+
+    calls: list[str] = []
+
+    def _stub_default_url_fetcher(url, *args, **kwargs):
+        calls.append(url)
+        return {"string": "<html></html>"}
+
+    stub_weasyprint = types.ModuleType("weasyprint")
+    stub_weasyprint.default_url_fetcher = _stub_default_url_fetcher
+    sys.modules["weasyprint"] = stub_weasyprint
+    try:
+        namespace: dict = {}
+        exec(func_src, namespace)  # noqa: S102 - exercising extracted doc code
+        guard = namespace["_no_remote_fetch"]
+
+        for blocked in (
+            "https://evil.example.com/x.png",
+            "http://169.254.169.254/latest/meta-data/",
+        ):
+            with pytest.raises(ValueError):
+                guard(blocked)
+
+        # Local/inline schemes must still be allowed through to the real
+        # fetcher (this is a *safety* guard, not a functionality regression).
+        guard("file:///tmp/report.css")
+        guard("data:image/png;base64,AAAA")
+        assert calls == ["file:///tmp/report.css", "data:image/png;base64,AAAA"]
+    finally:
+        del sys.modules["weasyprint"]

--- a/tests/repo/test_integration_tier.py
+++ b/tests/repo/test_integration_tier.py
@@ -25,6 +25,36 @@ GRADE = REPO_ROOT / "scripts" / "eval_grade.py"
 RUNNER = REPO_ROOT / "scripts" / "run_integration_eval.py"
 
 
+def _load_runner_module():
+    """Import scripts/run_integration_eval.py by path so its functions
+    (extract_golden_repo) can be unit-tested directly, in-process, without
+    forking a subprocess for every case."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("run_integration_eval", RUNNER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+runner_module = _load_runner_module()
+
+
+def _tarball_with_member(
+    tar_path: Path, member_name: str, content: bytes = b"pwned"
+) -> None:
+    """Build a tarball containing a single member whose name is a raw,
+    attacker-chosen string (bypassing tarfile.add()'s own name normalization,
+    the same way a hand-crafted malicious archive would)."""
+    import io
+
+    info = tarfile.TarInfo(name=member_name)
+    info.size = len(content)
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.addfile(info, io.BytesIO(content))
+
+
 EXPECTED_DEMO = """{
   "fixture": "demo",
   "applicableSkills": ["orchestrator"],
@@ -303,3 +333,88 @@ def test_runner_missing_claude_errors_naming_component(case: Path) -> None:
     assert res.returncode == 2, out
     assert "claude" in out
     assert "prerequisites missing" in out
+
+
+# --- extract_golden_repo zip-slip guard --------------------------------------
+#
+# extract_golden_repo()'s path-traversal guard previously used a naive
+# `str(target).startswith(str(dest.resolve()))` string-prefix check with no
+# separator boundary — the classic zip-slip-guard-bypass pattern flagged by
+# semgrep's trailofbits.python.tarfile-extractall-traversal rule. A sibling
+# directory whose name happens to share dest's name as a string prefix (e.g.
+# dest="out", sibling="out-evil") passes the naive check even though it is
+# not actually inside dest.
+#
+# test_prefix_sibling_bypass_is_rejected_by_is_within unit-tests the
+# containment predicate (_is_within) directly rather than only going
+# through a full extract_golden_repo() -> tarfile.extractall() round-trip:
+# Python 3.12+'s own tarfile.extractall() added its own PEP 706 traversal
+# filter, which independently rejects some crafted members and can mask a
+# still-buggy prefix check on newer interpreters, giving a false-negative
+# "the code is already fixed" reading. Testing the predicate in isolation
+# exercises exactly the logic this repo owns and is responsible for.
+
+
+def test_prefix_sibling_bypass_is_rejected_by_is_within() -> None:
+    # The specific naive-startswith bypass: dest is named "out"; the crafted
+    # target resolves one level up into a *sibling* directory "out-evil"
+    # whose name has "out" as a string prefix. The old
+    # `str(target).startswith(str(dest))` check incorrectly treated this as
+    # "inside dest".
+    dest = Path("/tmp/case/out")
+    sibling_escape = Path("/tmp/case/out-evil/pwned.txt")
+    assert runner_module._is_within(dest, sibling_escape) is False
+
+
+def test_dotdot_traversal_is_rejected_by_is_within() -> None:
+    dest = Path("/tmp/case/out")
+    assert runner_module._is_within(dest, Path("/etc/passwd")) is False
+
+
+def test_legitimate_nested_target_is_accepted_by_is_within() -> None:
+    dest = Path("/tmp/case/out")
+    assert runner_module._is_within(dest, dest / "src" / "app" / "main.py") is True
+    assert runner_module._is_within(dest, dest) is True
+
+
+def test_extract_golden_repo_rejects_dotdot_traversal(tmp_path: Path) -> None:
+    dest = tmp_path / "work" / "extracted"
+    tarball = tmp_path / "golden.tar.gz"
+    _tarball_with_member(tarball, "../../../../../../etc/passwd")
+
+    with pytest.raises(Exception):
+        runner_module.extract_golden_repo(tarball, dest)
+
+    assert not (Path("/etc/passwd_pwned")).exists()  # sanity: no stray writes
+    assert not any(dest.rglob("passwd"))
+
+
+def test_extract_golden_repo_rejects_prefix_sibling_bypass(tmp_path: Path) -> None:
+    # Regression for the specific naive-startswith bypass: dest is named
+    # "out"; a crafted member escapes one level up into a *sibling*
+    # directory "out-evil" whose name has "out" as a string prefix. The old
+    # `str(target).startswith(str(dest.resolve()))` check incorrectly
+    # treated this as "inside dest" and let extractall() write outside it.
+    dest = tmp_path / "out"
+    sibling_escape = tmp_path / "out-evil" / "pwned.txt"
+    tarball = tmp_path / "golden.tar.gz"
+    _tarball_with_member(tarball, "../out-evil/pwned.txt")
+
+    with pytest.raises(Exception):
+        runner_module.extract_golden_repo(tarball, dest)
+
+    assert not sibling_escape.exists(), (
+        f"zip-slip guard bypass: file escaped into sibling directory {sibling_escape}"
+    )
+
+
+def test_extract_golden_repo_allows_legitimate_nested_paths(tmp_path: Path) -> None:
+    dest = tmp_path / "out"
+    tarball = tmp_path / "golden.tar.gz"
+    _tarball_with_member(tarball, "src/app/main.py", content=b"print('hi')\n")
+
+    runner_module.extract_golden_repo(tarball, dest)
+
+    extracted = dest / "src" / "app" / "main.py"
+    assert extracted.is_file()
+    assert extracted.read_bytes() == b"print('hi')\n"

--- a/tests/security-assessment/harness/test_report_generator_escaping.py
+++ b/tests/security-assessment/harness/test_report_generator_escaping.py
@@ -1,0 +1,96 @@
+"""Regression test for HTML/Markdown injection in
+probes/08_report_generator.py.
+
+`_format_*()` interpolate fields from probe result dicts — which ultimately
+originate from the probed model's own HTTP responses (an attacker-controlled
+service under test) — directly into the generated `adversarial-report.md`.
+That Markdown is later rendered to HTML/PDF (see
+plugins/security-assessment/commands/export-pdf.md, python-markdown +
+weasyprint), and python-markdown passes raw embedded HTML through
+unmodified. A malicious model response value (e.g. an inferred-framework
+string, a feature name, a doc path) can therefore inject arbitrary HTML/
+script markup into the rendered report — a plausible HTML injection -> SSRF
+vector, since weasyprint fetches remote resources referenced in rendered
+HTML/CSS by default.
+
+This test proves a crafted probed-model response value can no longer break
+out of the Markdown/HTML context unescaped.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HARNESS = REPO_ROOT / "plugins" / "security-assessment" / "harness"
+
+os.environ.setdefault("TARGET_URL", "http://127.0.0.1:8000")
+sys.path.insert(0, str(HARNESS))
+
+from redteam import orchestrator  # noqa: E402  (path set above)
+
+report_generator = orchestrator._import_agent("08_report_generator.py")
+
+PAYLOAD = '"><script>alert(document.cookie)</script>'
+
+
+def _assert_escaped(rendered: str) -> None:
+    assert "<script>alert(document.cookie)</script>" not in rendered
+    assert "&lt;script&gt;alert(document.cookie)&lt;/script&gt;" in rendered
+
+
+def test_recon_target_and_framework_are_escaped():
+    recon = {
+        "target": PAYLOAD,
+        "inferred_framework": PAYLOAD,
+        "doc_paths": [{"status": 200, "path": PAYLOAD, "content_type": PAYLOAD}],
+        "method_matrix": {PAYLOAD: {"status": 200}},
+    }
+    _assert_escaped(report_generator._format_recon(recon))
+
+
+def test_schema_categories_and_features_are_escaped():
+    schema = {
+        "strategy_used": PAYLOAD,
+        "features": [PAYLOAD],
+        "by_category": {PAYLOAD: [PAYLOAD]},
+    }
+    _assert_escaped(report_generator._format_schema(schema))
+
+
+def test_sensitivity_feature_names_are_escaped():
+    sens = {
+        "baseline_score": 0.5,
+        "rankings": [{"feature": PAYLOAD, "sensitivity": 0.123}],
+    }
+    _assert_escaped(report_generator._format_sensitivity(sens))
+
+
+def test_boundaries_feature_and_reason_are_escaped():
+    boundaries = {
+        "boundaries": [
+            {"feature": PAYLOAD, "boundary": None, "reason": PAYLOAD},
+        ]
+    }
+    _assert_escaped(report_generator._format_boundaries(boundaries))
+
+
+def test_evasion_methods_are_escaped():
+    evasion = {
+        "score_target": 0.4,
+        "results": [{"method": PAYLOAD, "score": 0.1}],
+    }
+    _assert_escaped(report_generator._format_evasion(evasion))
+
+
+def test_extraction_surrogate_names_and_fidelity_are_escaped():
+    extraction = {
+        "n_samples": 10,
+        "best_r2": 0.9,
+        "fidelity": PAYLOAD,
+        "surrogates": {PAYLOAD: {"r2": 0.5}},
+    }
+    _assert_escaped(report_generator._format_extraction(extraction))

--- a/tests/security-assessment/harness/test_service_comm_parser_escaping.py
+++ b/tests/security-assessment/harness/test_service_comm_parser_escaping.py
@@ -1,0 +1,118 @@
+"""Regression test for HTML/Mermaid injection in service-comm-parser.py.
+
+`emit_mermaid()` builds a Mermaid `graph LR` block by interpolating
+repo-derived strings (package.json `name`, Kubernetes Service names, NATS
+subjects, npm/pip dependency names) directly into Mermaid node labels and
+edge labels. Those labels are quoted with literal `"` in the Mermaid source
+and rendered as HTML by Mermaid/downstream Markdown->HTML->PDF pipelines
+(see plugins/security-assessment/commands/export-pdf.md), so an attacker who
+controls one of those repo-derived strings (e.g. a malicious package.json
+`name` field in a scanned repo) could break out of the label/quote context
+and inject arbitrary HTML/script markup, or Mermaid syntax, into the
+downstream report — a plausible HTML injection -> SSRF vector once the
+report is rendered to HTML/PDF (weasyprint fetches remote resources
+referenced in rendered HTML/CSS by default).
+
+This test proves a crafted repo-derived string can no longer break out of
+the Mermaid label/HTML context unescaped.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "security-assessment"
+    / "harness"
+    / "tools"
+    / "service-comm-parser.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("service_comm_parser", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Register before exec: @dataclass looks up cls.__module__ in
+    # sys.modules while the module body is executing.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+scp = _load_module()
+
+MALICIOUS_NAME = '"><img src=x onerror=alert(document.domain)>'
+
+
+def test_malicious_service_name_is_escaped_in_node_label():
+    svc = scp.Service(name=MALICIOUS_NAME, repo="/tmp/evil-repo")
+    out = scp.emit_mermaid([svc], [])
+
+    # The raw payload must never appear verbatim in the emitted diagram —
+    # i.e. no literal `<` / `>` / `"` markup delimiters from the payload,
+    # only their HTML-escaped, inert text form.
+    assert MALICIOUS_NAME not in out
+    assert "<img src=x onerror=alert(document.domain)>" not in out
+
+    # It must appear HTML-escaped instead.
+    assert "&quot;&gt;&lt;img src=x onerror=alert(document.domain)&gt;" in out
+
+
+def test_malicious_k8s_service_name_is_escaped():
+    svc = scp.Service(name="checkout", repo="/tmp/checkout")
+    svc.k8s_names.add('"><script>alert(1)</script>')
+    out = scp.emit_mermaid([svc], [])
+
+    assert "<script>alert(1)</script>" not in out
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+
+
+def test_malicious_nats_subject_is_escaped_in_edge_label():
+    pub = scp.Service(name="svc-a", repo="/tmp/a")
+    sub = scp.Service(name="svc-b", repo="/tmp/b")
+    subject = '"><svg onload=alert(1)>'
+    pub.publishes.add(subject)
+    sub.subscribes.add(subject)
+
+    edges = scp.derive_nats_edges([pub, sub])
+    out = scp.emit_mermaid([pub, sub], edges)
+
+    assert "<svg onload=alert(1)>" not in out
+    assert "&lt;svg onload=alert(1)&gt;" in out
+
+
+def test_malicious_dependency_name_is_escaped_in_edge_note():
+    all_services = [
+        scp.Service(name="svc-a", repo="/tmp/a"),
+        scp.Service(name="svc-b", repo="/tmp/b"),
+    ]
+    edge = scp.Edge(
+        src="svc-a",
+        dst="svc-b",
+        kind="package",
+        note='npm dependency: "><iframe src=javascript:alert(1)>',
+    )
+    out = scp.emit_mermaid(all_services, [edge])
+
+    assert "<iframe src=javascript:alert(1)>" not in out
+    assert "&lt;iframe src=javascript:alert(1)&gt;" in out
+
+
+def test_malicious_name_cannot_break_out_of_unquoted_node_id():
+    # Node IDs are emitted unquoted (`node_id["label"]`), so a raw name
+    # containing spaces/brackets/quotes could otherwise inject arbitrary
+    # Mermaid syntax at the node-id position, not just inside the label.
+    svc = scp.Service(name='a"] --> evil["pwned', repo="/tmp/evil")
+    out = scp.emit_mermaid([svc], [])
+    for line in out.splitlines():
+        if line.startswith("  ") and "[" in line and "```" not in line:
+            node_id = line.strip().split("[", 1)[0]
+            assert all(c.isalnum() or c == "_" for c in node_id), (
+                f"unsafe mermaid node id: {node_id!r}"
+            )


### PR DESCRIPTION
## Summary

Fixes two High-severity findings:

**(A) HTML/Mermaid injection -> plausible SSRF in security-assessment's own report pipeline**
- `plugins/security-assessment/harness/tools/service-comm-parser.py`: `emit_mermaid()` interpolated repo-derived strings (package.json `name`, k8s Service names, NATS subjects, npm/pip dependency names) directly into Mermaid node labels/edge labels. Added `_mermaid_label()` (HTML-escape via `html.escape(..., quote=True)`) and `_mermaid_id()` (sanitize unquoted Mermaid node identifiers to `[A-Za-z0-9_]`).
- `plugins/security-assessment/harness/redteam/probes/08_report_generator.py`: `_format_*()` interpolated probed-model response fields directly into `adversarial-report.md`. Added a shared `_esc()` helper and applied it to every untrusted field.
- `plugins/security-assessment/commands/export-pdf.md`: the weasyprint fallback snippet now passes a `url_fetcher` that blocks every non-`file://`/`data:` scheme, so PDF conversion of an untrusted report can no longer make outbound requests (SSRF-by-default otherwise).

**(B) Zip-slip guard bypass in the eval harness**
- `scripts/run_integration_eval.py`: `extract_golden_repo()`'s traversal guard used a naive `str(target).startswith(str(dest.resolve()))` check with no separator boundary — a sibling directory whose name merely starts with dest's name (e.g. `.../out` vs `.../out-evil/pwned.txt`) incorrectly passed. Flagged by semgrep's `trailofbits.python.tarfile-extractall-traversal` rule. Replaced with a real containment check (`Path.relative_to()` in try/except), factored into a testable `_is_within()` predicate.

## Tests

- `tests/security-assessment/harness/test_service_comm_parser_escaping.py` — 5 new tests proving a crafted repo-derived string (malicious service/k8s/NATS-subject/dependency names) can no longer break out of the Mermaid label/HTML context unescaped, confirmed RED against the unfixed code before applying the fix.
- `tests/security-assessment/harness/test_report_generator_escaping.py` — 6 new tests proving crafted probed-model response fields are escaped in every `_format_*()` report section, confirmed RED against the unfixed code.
- `tests/commands/test_export_pdf_doc.py` — extracts and executes the `_no_remote_fetch` guard defined in the command doc against a stub `weasyprint` module; proves it blocks `https://`/`http://` and allows `file://`/`data:`.
- `tests/repo/test_integration_tier.py` — new `_is_within()` unit tests plus end-to-end `extract_golden_repo()` tests with a hand-crafted malicious tarball (`../out-evil/pwned.txt`, `../../../../../../etc/passwd`); the sibling-prefix-bypass test is unit-tested against the isolated predicate specifically because Python 3.12+'s own `tarfile.extractall()` traversal filter can otherwise mask a still-buggy prefix check on newer interpreters.

All new/changed tests pass locally; full `pytest` suite (1874 passed, 16 skipped) and `scripts/ci-local.sh` pass except a pre-existing, unrelated `eslint` environment failure (missing `node_modules`/`@eslint/js`, reproduced identically on unmodified `main`).

## Test plan
- [x] `python3 -m pytest tests/security-assessment/harness/test_service_comm_parser_escaping.py tests/security-assessment/harness/test_report_generator_escaping.py tests/commands/test_export_pdf_doc.py tests/repo/test_integration_tier.py -q`
- [x] `python3 tests/security-assessment/harness/smoke_test.py`
- [x] `bash tests/security-assessment/scripts/run-all.sh`
- [x] Full local pytest suite (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 1874 passed
- [x] `bash scripts/ci-local.sh` — all checks pass except pre-existing unrelated `eslint` env issue

Part of #732