### PR TITLE
refactor: dedupe stdin-JSON-read hooks and review issue-dict builders

### DIFF
--- a/plugins/dev-team/hooks/bash_retry_guard.py
+++ b/plugins/dev-team/hooks/bash_retry_guard.py
@@ -31,6 +31,18 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
+
+
 # Verify-family commands — the verify-guard hook handles retry-nudging for
 # these; this hook must not double-warn. The pattern MUST match the .sh's
 # ERE byte-for-byte.
@@ -114,22 +126,8 @@ def _write_state(path: Path, state: Dict[str, Any]) -> None:
         pass
 
 
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
-
-
 def main() -> int:
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         return 0
 

--- a/plugins/dev-team/hooks/codegraph_bootstrap.py
+++ b/plugins/dev-team/hooks/codegraph_bootstrap.py
@@ -24,13 +24,24 @@ Stdlib-only. Python 3.8+.
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
 
 
 # Single-line messages — kept in sync with the .sh sibling and the bats.
@@ -46,24 +57,10 @@ _INSTALL_MSG = (
 )
 
 
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        # Empty stdin is a valid input — silent no-op like the .sh's
-        # `echo "$input" | jq -e .` on empty input (jq exits non-zero).
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
-
-
 def main() -> int:
-    payload = _read_stdin_json()
+    # Empty stdin is a valid input — silent no-op like the .sh's
+    # `echo "$input" | jq -e .` on empty input (jq exits non-zero).
+    payload = read_stdin_json()
     # Fail-open on malformed / empty input.
     if payload is None:
         return 0

--- a/plugins/dev-team/hooks/codegraph_nudge.py
+++ b/plugins/dev-team/hooks/codegraph_nudge.py
@@ -28,25 +28,23 @@ from pathlib import Path
 from typing import Optional
 
 
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
+
+
 WARN_MSG = (
     "[codegraph-nudge] CodeGraph is initialized in this project. Prefer "
     "codegraph_context or codegraph_explore for multi-file exploration; "
     "Grep/Glob/Read for confirming a specific detail."
 )
-
-
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def _codegraph_used_this_turn(cwd: Path, transcript_path: str) -> bool:
@@ -122,7 +120,7 @@ def _careful_active(hook_dir: Path) -> bool:
 
 
 def main() -> int:
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         return 0
 

--- a/plugins/dev-team/hooks/knowledge_index.py
+++ b/plugins/dev-team/hooks/knowledge_index.py
@@ -22,12 +22,10 @@ Stdlib-only. Python 3.8+.
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 
 _HOOK_DIR = Path(__file__).resolve().parent
@@ -37,6 +35,7 @@ _LIB_DIR = _HOOK_DIR / "lib"
 sys.path.insert(0, str(_LIB_DIR))
 try:
     from knowledge_index_paths import is_corpus_path  # type: ignore[import-not-found]
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
     # Fail-open: if the shared lib is missing (should never happen in a
     # correctly installed plugin), treat every path as non-corpus and
@@ -44,23 +43,12 @@ except ImportError:  # pragma: no cover
     def is_corpus_path(_: str) -> bool:  # type: ignore[misc]
         return False
 
-
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
+    def read_stdin_json():  # type: ignore[misc]
         return None
-    if not raw.strip():
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def main() -> int:
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         # Malformed/empty input — fail-open.
         return 0

--- a/plugins/dev-team/hooks/lib/stdin_json.py
+++ b/plugins/dev-team/hooks/lib/stdin_json.py
@@ -1,0 +1,38 @@
+"""stdin_json — single source of truth for the stdin-JSON-read helper.
+
+Every Claude Code hook receives its payload as JSON on stdin. Seven hooks
+(pre_commit_review.py, pre_commit_knowledge_index.py, knowledge_index.py,
+mutation_testing_smoke_gate.py, codegraph_nudge.py, codegraph_bootstrap.py,
+bash_retry_guard.py) each carried an identical copy of this read/parse/
+validate step (#732). This module is the shared extraction.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional
+
+
+def read_stdin_json() -> Optional[dict]:
+    """Read stdin, parse as JSON, return the dict on success.
+
+    Returns None on:
+      - an OSError while reading stdin
+      - empty/whitespace-only input
+      - malformed JSON
+      - valid JSON that is not a dict (e.g. a list or scalar)
+    """
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
+++ b/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
@@ -32,6 +32,18 @@ from pathlib import Path
 from typing import Optional
 
 
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+try:
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Trigger detection
 # ---------------------------------------------------------------------------
@@ -177,20 +189,6 @@ def count_mutants_by_status(report: dict, status: str) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _read_stdin_json() -> Optional[dict]:
-    """Read stdin as JSON; None on empty or malformed input."""
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        return None
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-
-
 def main() -> int:
     # -------------------------------------------------------------------
     # Dependency guards — a missing dep must NOT become a de facto gate.
@@ -209,7 +207,7 @@ def main() -> int:
     # -------------------------------------------------------------------
     # Parse PreToolUse payload
     # -------------------------------------------------------------------
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         # Empty or malformed stdin — nothing to check, silent-pass.
         return 0

--- a/plugins/dev-team/hooks/pre_commit_knowledge_index.py
+++ b/plugins/dev-team/hooks/pre_commit_knowledge_index.py
@@ -28,7 +28,6 @@ Stdlib-only. Python 3.8+.
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
@@ -43,6 +42,7 @@ sys.path.insert(0, str(_LIB_DIR))
 try:
     from knowledge_index_paths import is_corpus_path  # type: ignore[import-not-found]
     from pre_commit_detect import is_git_commit_invocation  # type: ignore[import-not-found]
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
     # Fail-open on missing shared libs.
     def is_corpus_path(_: str) -> bool:  # type: ignore[misc]
@@ -50,6 +50,9 @@ except ImportError:  # pragma: no cover
 
     def is_git_commit_invocation(_: str) -> bool:  # type: ignore[misc]
         return False
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
 
 
 _REMEDIATION = """knowledge/index.json is stale; the auto-rebuild ran but you must stage the result.
@@ -59,20 +62,6 @@ _REMEDIATION = """knowledge/index.json is stale; the auto-rebuild ran but you mu
 
 Diff (expected vs working tree):
 """
-
-
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def _staged_files() -> List[str]:
@@ -91,7 +80,7 @@ def _staged_files() -> List[str]:
 
 
 def main() -> int:
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         return 0
 

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -51,6 +51,7 @@ try:
         is_git_commit_command,
     )
     from review_gate_hash import review_gate_hash  # type: ignore[import-not-found]
+    from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
 
     def is_git_commit_command(_: str) -> bool:  # type: ignore[misc]
@@ -64,6 +65,9 @@ except ImportError:  # pragma: no cover
 
     def review_gate_hash(cwd=None) -> str:  # type: ignore[misc]
         return ""
+
+    def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
+        return None
 
 
 _BLOCK_MESSAGE = (
@@ -84,20 +88,6 @@ _BYPASS_BLOCK_MESSAGE = (
     "The bypass is logged to metrics/gate-bypass-audit.jsonl once a reason\n"
     "is supplied.\n"
 )
-
-
-def _read_stdin_json() -> Optional[dict]:
-    try:
-        raw = sys.stdin.read()
-    except OSError:
-        return None
-    if not raw.strip():
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def _staged_names() -> List[str]:
@@ -164,7 +154,7 @@ def _record_bypass_audit(flag: str, reason: str, staged_count: int) -> None:
 
 
 def main() -> int:
-    payload = _read_stdin_json()
+    payload = read_stdin_json()
     if payload is None:
         return 0
 

--- a/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_knowledge_index.py
@@ -87,6 +87,7 @@ def repo(tmp_path: Path) -> Path:
         "build_knowledge_index.py",
         "knowledge_index_paths.py",
         "pre_commit_detect.py",
+        "stdin_json.py",
     ):
         (plugin / "hooks" / "lib" / name).write_text((src_lib / name).read_text())
     # Copy the hook itself too so it can find its siblings on sys.path.

--- a/plugins/dev-team/tests/hooks/test_stdin_json.py
+++ b/plugins/dev-team/tests/hooks/test_stdin_json.py
@@ -1,0 +1,64 @@
+"""Unit tests for hooks/lib/stdin_json.py — shared stdin-JSON-read helper (#732).
+
+Extracted from the identical `_read_stdin_json()` copy-pasted across 7 hooks
+(pre_commit_review.py, pre_commit_knowledge_index.py, knowledge_index.py,
+mutation_testing_smoke_gate.py, codegraph_nudge.py, codegraph_bootstrap.py,
+bash_retry_guard.py). Behavior: read stdin, parse JSON, return the dict on
+success — None on empty input, malformed JSON, a non-dict JSON value
+(e.g. a list or scalar), or an OSError while reading.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+_HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_HOOKS_LIB) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB))
+
+import stdin_json  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _set_stdin(monkeypatch, text: str) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(text))
+
+
+def test_valid_json_object_returns_dict(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, '{"tool_name": "Edit", "cwd": "/tmp"}')
+    assert stdin_json.read_stdin_json() == {"tool_name": "Edit", "cwd": "/tmp"}
+
+
+def test_empty_stdin_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, "")
+    assert stdin_json.read_stdin_json() is None
+
+
+def test_whitespace_only_stdin_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, "   \n\t")
+    assert stdin_json.read_stdin_json() is None
+
+
+def test_malformed_json_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, "{not valid json")
+    assert stdin_json.read_stdin_json() is None
+
+
+def test_non_dict_json_array_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, "[1, 2, 3]")
+    assert stdin_json.read_stdin_json() is None
+
+
+def test_non_dict_json_scalar_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _set_stdin(monkeypatch, "42")
+    assert stdin_json.read_stdin_json() is None
+
+
+def test_stdin_read_oserror_returns_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    class _BoomStdin:
+        def read(self) -> str:
+            raise OSError("broken pipe")
+
+    monkeypatch.setattr(sys, "stdin", _BoomStdin())
+    assert stdin_json.read_stdin_json() is None

--- a/scripts/claude_setup_review.py
+++ b/scripts/claude_setup_review.py
@@ -28,6 +28,9 @@ from typing import List, Optional
 
 import yaml  # PyYAML — required dev dep
 
+sys.path.insert(0, str(Path(__file__).parent))
+from lib.review_result import make_issue
+
 # ---------------------------------------------------------------------------
 # Module-level constants (REFACTOR: extracted here for easy maintenance)
 # ---------------------------------------------------------------------------
@@ -55,32 +58,6 @@ PATH_REF_RE = re.compile(
 # ---------------------------------------------------------------------------
 
 
-def _make_error(
-    message: str, file: str = "", line: int = 0, suggested_fix: str = ""
-) -> dict:
-    return {
-        "severity": "error",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": suggested_fix,
-    }
-
-
-def _make_warning(
-    message: str, file: str = "", line: int = 0, suggested_fix: str = ""
-) -> dict:
-    return {
-        "severity": "warning",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": suggested_fix,
-    }
-
-
 def _parse_frontmatter(text: str) -> Optional[dict]:
     """Extract YAML frontmatter from markdown. Returns dict or None."""
     if not text.startswith("---"):
@@ -104,7 +81,8 @@ def check_claude_md_exists(root: Path) -> List[dict]:
     claude_md = root / "CLAUDE.md"
     if not claude_md.exists():
         return [
-            _make_error(
+            make_issue(
+                "error",
                 message=f"CLAUDE.md not found at {root}",
                 file=str(claude_md),
             )
@@ -127,7 +105,8 @@ def check_frontmatter(agents_dir: Path) -> List[dict]:
 
         if fm is None:
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=f"Could not parse YAML frontmatter in {agent_file.name}",
                     file=rel,
                 )
@@ -138,7 +117,8 @@ def check_frontmatter(agents_dir: Path) -> List[dict]:
         for field in REQUIRED_FIELDS:
             if field not in fm or fm[field] is None or str(fm[field]).strip() == "":
                 errors.append(
-                    _make_error(
+                    make_issue(
+                        "error",
                         message=f"Missing required frontmatter field '{field}' in {agent_file.name}",
                         file=rel,
                         suggested_fix=f"Add '{field}: <value>' to the frontmatter.",
@@ -150,7 +130,8 @@ def check_frontmatter(agents_dir: Path) -> List[dict]:
             effort_val = str(fm["effort"])
             if effort_val not in VALID_EFFORT:
                 errors.append(
-                    _make_error(
+                    make_issue(
+                        "error",
                         message=(
                             f"Invalid effort value '{effort_val}' in {agent_file.name}. "
                             f"Must be one of: {', '.join(VALID_EFFORT)}"
@@ -164,7 +145,8 @@ def check_frontmatter(agents_dir: Path) -> List[dict]:
         for field in UNSUPPORTED_FIELDS:
             if field in fm:
                 warnings.append(
-                    _make_warning(
+                    make_issue(
+                        "warning",
                         message=(
                             f"Plugin-unsupported field '{field}' in {agent_file.name}. "
                             f"This field is ignored for plugin agents."
@@ -194,7 +176,8 @@ def check_naming(agents_dir: Path) -> List[dict]:
         # Kebab-case filename check
         if not KEBAB_RE.match(fname):
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=(
                         f"Agent filename '{fname}' is not kebab-case. "
                         f"Filenames must match ^[a-z0-9]+(-[a-z0-9]+)*\\.md$"
@@ -214,7 +197,8 @@ def check_naming(agents_dir: Path) -> List[dict]:
             stem = agent_file.stem  # filename without .md
             if declared_name != stem:
                 errors.append(
-                    _make_error(
+                    make_issue(
+                        "error",
                         message=(
                             f"Agent name field '{declared_name}' does not match "
                             f"filename stem '{stem}' in {fname}"
@@ -248,7 +232,8 @@ def check_path_references(root: Path) -> List[dict]:
             resolved = root / ref_path
             if not resolved.exists():
                 errors.append(
-                    _make_error(
+                    make_issue(
+                        "error",
                         message=f"Unresolvable path reference '{ref_path}' in CLAUDE.md",
                         file=str(claude_md),
                         line=lineno,
@@ -281,7 +266,8 @@ def check_duplicate_names(agents_dir: Path) -> List[dict]:
     for name, files in name_to_files.items():
         if len(files) > 1:
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=(
                         f"Duplicate agent name '{name}' declared in multiple files: "
                         + ", ".join(files)
@@ -321,19 +307,22 @@ def check_llm(root: Path, skip_llm: bool, errors: List[dict]) -> List[dict]:
         )
         if result.returncode != 0 or not result.stdout.strip():
             return [
-                _make_warning(
+                make_issue(
+                    "warning",
                     message="LLM quality check unavailable (claude returned non-zero or empty output)",
                 )
             ]
         # LLM findings are always warnings
         return [
-            _make_warning(
+            make_issue(
+                "warning",
                 message=f"LLM quality review: {result.stdout.strip()[:500]}",
             )
         ]
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return [
-            _make_warning(
+            make_issue(
+                "warning",
                 message="LLM quality check unavailable (claude not on PATH or timed out)",
             )
         ]

--- a/scripts/lib/review_result.py
+++ b/scripts/lib/review_result.py
@@ -44,6 +44,35 @@ def main_exit(result: dict) -> int:
     return 0
 
 
+def make_issue(
+    severity: str,
+    confidence: str = "high",
+    file: str = "",
+    line: int = 0,
+    message: str = "",
+    suggested_fix: str = "",
+    rule_id: str = "",
+) -> dict:
+    """Return a canonical issue dict — the shared shape every review script
+    (progress_guardian, claude_setup_review, test_modernization_review,
+    token_efficiency_review) independently duplicated before #732.
+
+    `rule_id` is included only when truthy, matching the pre-dedup
+    token_efficiency_review._issue behavior.
+    """
+    issue: dict = {
+        "severity": severity,
+        "confidence": confidence,
+        "file": file,
+        "line": line,
+        "message": message,
+        "suggestedFix": suggested_fix,
+    }
+    if rule_id:
+        issue["rule_id"] = rule_id
+    return issue
+
+
 def skipped_llm_warning(message: str = "LLM check skipped (--skip-llm)") -> dict:
     """Return a single warning finding for use when --skip-llm suppresses the LLM call."""
     return {

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.review_result import build_result, main_exit, skipped_llm_warning
+from lib.review_result import build_result, main_exit, make_issue, skipped_llm_warning
 
 # ---------------------------------------------------------------------------
 # Module constants (REFACTOR: extracted for easy maintenance)
@@ -89,38 +89,6 @@ class Step:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_error(
-    message: str,
-    file: str = "",
-    line: int = 0,
-    suggested_fix: str = "",
-) -> dict:
-    return {
-        "severity": "error",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": suggested_fix,
-    }
-
-
-def _make_warning(
-    message: str,
-    file: str = "",
-    line: int = 0,
-    suggested_fix: str = "",
-) -> dict:
-    return {
-        "severity": "warning",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": suggested_fix,
-    }
 
 
 def run_git(args: List[str], cwd: str) -> str:
@@ -213,7 +181,8 @@ def parse_plan(path: Path) -> tuple[List[Step], List[dict]]:
 
     if not steps:
         return [], [
-            _make_error(
+            make_issue(
+                "error",
                 message=f"No checkbox steps found in plan file: {path.name}",
                 file=str(path),
                 suggested_fix="Add steps with '- [ ] Step N.M: description' format.",
@@ -335,7 +304,8 @@ def check_commit_discipline(
     if not log_subjects_out.strip():
         # Zero commits on this branch — emit a warning, not a hard error.
         return [
-            _make_warning(
+            make_issue(
+                "warning",
                 message="No commits found on this branch — cannot verify commit discipline.",
                 suggested_fix="Commit work before marking steps done.",
             )
@@ -363,7 +333,8 @@ def check_commit_discipline(
             if any(_is_path_declared(bf, declared) for bf in branch_files):
                 continue
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=(
                         f"Done step '{step.header}' has no matching commit in git log. "
                         f"Expected a commit on this branch that touched one of: "
@@ -380,7 +351,8 @@ def check_commit_discipline(
         header_lower = step.header.lower()
         if not any(header_lower in subject for subject in commit_subjects):
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=(
                         f"Done step '{step.header}' has no matching commit in git log. "
                         f"Expected a commit whose subject contains: '{step.header}'"
@@ -423,7 +395,8 @@ def check_uncommitted(
 
     if non_excluded_lines:
         return [
-            _make_error(
+            make_issue(
+                "error",
                 message=(
                     "Uncommitted changes detected. All work must be committed "
                     "before plan steps can be considered complete."
@@ -440,7 +413,8 @@ def check_pre_pr(steps: List[Step]) -> List[dict]:
     for step in steps:
         if not step.done:
             errors.append(
-                _make_error(
+                make_issue(
+                    "error",
                     message=(
                         f"Pre-PR gate: step '{step.header}' is not done ([ ] unchecked). "
                         f"All plan steps must be complete before opening a PR."
@@ -594,7 +568,8 @@ def check_verify_log(repo_root: str, changed_files: List[str]) -> List[dict]:
         return []
 
     return [
-        _make_error(
+        make_issue(
+            "error",
             message=(
                 "Pre-PR gate: this branch touches runtime-surface file(s) but no "
                 f"entry in {VERIFY_LOG_PATH} matches branch '{branch}'. `/verify` "
@@ -709,7 +684,8 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
         )
         if result.returncode != 0 or not result.stdout.strip():
             return [
-                _make_warning(
+                make_issue(
+                    "warning",
                     message=(
                         f"LLM scope check unavailable: {len(out_of_plan)} file(s) not in plan "
                         f"({file_list}) — manual scope review recommended."
@@ -717,7 +693,8 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
                 )
             ]
         return [
-            _make_warning(
+            make_issue(
+                "warning",
                 message=(
                     f"Scope check (LLM): {len(out_of_plan)} out-of-plan file(s): "
                     f"{file_list}. LLM assessment: {result.stdout.strip()[:300]}"
@@ -726,7 +703,8 @@ def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
         ]
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return [
-            _make_warning(
+            make_issue(
+                "warning",
                 message=(
                     f"LLM scope check unavailable (claude not on PATH or timed out): "
                     f"{len(out_of_plan)} file(s) not declared in plan — manual review needed."
@@ -760,7 +738,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     plan_path = Path(args.plan).resolve()
     if not plan_path.exists():
         result = build_result(
-            errors=[_make_error(f"Plan file not found: {args.plan}", file=args.plan)],
+            errors=[
+                make_issue(
+                    "error",
+                    message=f"Plan file not found: {args.plan}",
+                    file=args.plan,
+                )
+            ],
             warnings=[],
         )
         return main_exit(result)

--- a/scripts/test_modernization_review.py
+++ b/scripts/test_modernization_review.py
@@ -23,34 +23,7 @@ from pathlib import Path
 from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.review_result import build_result, main_exit
-
-
-# ---------------------------------------------------------------------------
-# Issue helpers
-# ---------------------------------------------------------------------------
-
-
-def _error(file: str, line: int, message: str, fix: str = "") -> dict:
-    return {
-        "severity": "error",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": fix,
-    }
-
-
-def _warning(file: str, line: int, message: str, fix: str = "") -> dict:
-    return {
-        "severity": "warning",
-        "confidence": "high",
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": fix,
-    }
+from lib.review_result import build_result, main_exit, make_issue
 
 
 # ---------------------------------------------------------------------------
@@ -119,10 +92,11 @@ def validate_phase_2(paths: dict) -> tuple:
             bindings = json.loads(bindings_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             errors.append(
-                _error(
-                    str(bindings_path),
-                    0,
-                    f"gherkin-bindings.json is not valid JSON: {bindings_path}",
+                make_issue(
+                    "error",
+                    file=str(bindings_path),
+                    line=0,
+                    message=f"gherkin-bindings.json is not valid JSON: {bindings_path}",
                 )
             )
             return errors, warnings
@@ -133,11 +107,12 @@ def validate_phase_2(paths: dict) -> tuple:
     for title in scenario_titles:
         if title.lower() not in bindings_keys_lower:
             errors.append(
-                _error(
-                    str(paths["bindings_json"]),
-                    0,
-                    f"Scenario '{title}' found in .feature file but missing from gherkin-bindings.json",
-                    "Add an entry for this scenario to gherkin-bindings.json",
+                make_issue(
+                    "error",
+                    file=str(paths["bindings_json"]),
+                    line=0,
+                    message=f"Scenario '{title}' found in .feature file but missing from gherkin-bindings.json",
+                    suggested_fix="Add an entry for this scenario to gherkin-bindings.json",
                 )
             )
 
@@ -145,11 +120,12 @@ def validate_phase_2(paths: dict) -> tuple:
     for key in bindings:
         if key.lower() not in scenario_titles_lower:
             warnings.append(
-                _warning(
-                    str(paths["bindings_json"]),
-                    0,
-                    f"Binding key '{key}' in gherkin-bindings.json does not match any Scenario in .feature files",
-                    "Remove orphaned binding or add matching Scenario to a .feature file",
+                make_issue(
+                    "warning",
+                    file=str(paths["bindings_json"]),
+                    line=0,
+                    message=f"Binding key '{key}' in gherkin-bindings.json does not match any Scenario in .feature files",
+                    suggested_fix="Remove orphaned binding or add matching Scenario to a .feature file",
                 )
             )
 
@@ -179,15 +155,23 @@ def validate_phase_3(paths: dict) -> tuple:
         entries = json.loads(disabled_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         errors.append(
-            _error(
-                str(disabled_path), 0, f"disabled-tests.json is not valid JSON: {exc}"
+            make_issue(
+                "error",
+                file=str(disabled_path),
+                line=0,
+                message=f"disabled-tests.json is not valid JSON: {exc}",
             )
         )
         return errors, warnings
 
     if not isinstance(entries, list):
         errors.append(
-            _error(str(disabled_path), 0, "disabled-tests.json must be a JSON array")
+            make_issue(
+                "error",
+                file=str(disabled_path),
+                line=0,
+                message="disabled-tests.json must be a JSON array",
+            )
         )
         return errors, warnings
 
@@ -195,20 +179,22 @@ def validate_phase_3(paths: dict) -> tuple:
         test_name = entry.get("test", f"entry[{i}]")
         if "reason" not in entry:
             errors.append(
-                _error(
-                    str(disabled_path),
-                    0,
-                    f"Entry '{test_name}' missing required field 'reason'",
-                    "Add a 'reason' field drawn from the cannot-fail taxonomy",
+                make_issue(
+                    "error",
+                    file=str(disabled_path),
+                    line=0,
+                    message=f"Entry '{test_name}' missing required field 'reason'",
+                    suggested_fix="Add a 'reason' field drawn from the cannot-fail taxonomy",
                 )
             )
         if "skip_tag" not in entry:
             errors.append(
-                _error(
-                    str(disabled_path),
-                    0,
-                    f"Entry '{test_name}' missing required field 'skip_tag'",
-                    "Add a 'skip_tag' field (e.g. '@skip-foo')",
+                make_issue(
+                    "error",
+                    file=str(disabled_path),
+                    line=0,
+                    message=f"Entry '{test_name}' missing required field 'skip_tag'",
+                    suggested_fix="Add a 'skip_tag' field (e.g. '@skip-foo')",
                 )
             )
 
@@ -248,11 +234,12 @@ def validate_phase_4(paths: dict) -> tuple:
     # Need phase-3 for baseline
     if not phase3_path.exists():
         errors.append(
-            _error(
-                str(phase3_path),
-                0,
-                f"phase-3.md not found at {phase3_path} — cannot establish baseline for phase-4 comparison",
-                "Ensure phase 3 was completed and phase-3.md contains a Coverage line",
+            make_issue(
+                "error",
+                file=str(phase3_path),
+                line=0,
+                message=f"phase-3.md not found at {phase3_path} — cannot establish baseline for phase-4 comparison",
+                suggested_fix="Ensure phase 3 was completed and phase-3.md contains a Coverage line",
             )
         )
         return errors, warnings
@@ -261,11 +248,12 @@ def validate_phase_4(paths: dict) -> tuple:
     baseline = parse_coverage_number(baseline_text)
     if baseline is None:
         errors.append(
-            _error(
-                str(phase3_path),
-                0,
-                "Could not parse coverage baseline from phase-3.md",
-                "Add a line like 'Coverage: 80%' to phase-3.md",
+            make_issue(
+                "error",
+                file=str(phase3_path),
+                line=0,
+                message="Could not parse coverage baseline from phase-3.md",
+                suggested_fix="Add a line like 'Coverage: 80%' to phase-3.md",
             )
         )
         return errors, warnings
@@ -274,11 +262,12 @@ def validate_phase_4(paths: dict) -> tuple:
     current = parse_coverage_number(current_text)
     if current is None:
         errors.append(
-            _error(
-                str(phase4_path),
-                0,
-                "Could not parse current coverage from phase-4.md",
-                "Add a line like 'Coverage: 82%' to phase-4.md",
+            make_issue(
+                "error",
+                file=str(phase4_path),
+                line=0,
+                message="Could not parse current coverage from phase-4.md",
+                suggested_fix="Add a line like 'Coverage: 82%' to phase-4.md",
             )
         )
         return errors, warnings
@@ -286,12 +275,13 @@ def validate_phase_4(paths: dict) -> tuple:
     if current < baseline:
         delta = baseline - current
         errors.append(
-            _error(
-                str(phase4_path),
-                0,
-                f"Coverage regression: phase-4 reports {current}% but phase-3 baseline was {baseline}% "
+            make_issue(
+                "error",
+                file=str(phase4_path),
+                line=0,
+                message=f"Coverage regression: phase-4 reports {current}% but phase-3 baseline was {baseline}% "
                 f"(delta: -{delta:.1f}%)",
-                "Add tests to recover the coverage regression before advancing",
+                suggested_fix="Add tests to recover the coverage regression before advancing",
             )
         )
 
@@ -348,11 +338,12 @@ def validate_phase_5(paths: dict) -> tuple:
         mv_match = measured_re.search(block_body)
         if not mv_match:
             errors.append(
-                _error(
-                    str(phase5_path),
-                    0,
-                    f"Quality target '{target_name}' missing required field 'measured_value'",
-                    "Add 'measured_value: <N>' to the target block",
+                make_issue(
+                    "error",
+                    file=str(phase5_path),
+                    line=0,
+                    message=f"Quality target '{target_name}' missing required field 'measured_value'",
+                    suggested_fix="Add 'measured_value: <N>' to the target block",
                 )
             )
             continue
@@ -368,12 +359,13 @@ def validate_phase_5(paths: dict) -> tuple:
                 na_match = next_action_re.search(block_body)
                 if not na_match:
                     errors.append(
-                        _error(
-                            str(phase5_path),
-                            0,
-                            f"Quality target '{target_name}' has measured_value {measured} below "
+                        make_issue(
+                            "error",
+                            file=str(phase5_path),
+                            line=0,
+                            message=f"Quality target '{target_name}' has measured_value {measured} below "
                             f"threshold {threshold} but is missing 'next_action'",
-                            "Add 'next_action: <description>' to explain how the gap will be closed",
+                            suggested_fix="Add 'next_action: <description>' to explain how the gap will be closed",
                         )
                     )
 
@@ -450,11 +442,12 @@ def main() -> int:
     if not phase_md.exists():
         result = build_result(
             errors=[
-                _error(
-                    str(phase_md),
-                    0,
-                    f"phase artifact not found at {phase_md}",
-                    f"Run phase {args.phase} of /test-modernize to create this file",
+                make_issue(
+                    "error",
+                    file=str(phase_md),
+                    line=0,
+                    message=f"phase artifact not found at {phase_md}",
+                    suggested_fix=f"Run phase {args.phase} of /test-modernize to create this file",
                 )
             ],
             warnings=[],

--- a/scripts/token_efficiency_review.py
+++ b/scripts/token_efficiency_review.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.review_result import build_result, main_exit, skipped_llm_warning
+from lib.review_result import build_result, main_exit, make_issue, skipped_llm_warning
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -33,34 +33,6 @@ from lib.review_result import build_result, main_exit, skipped_llm_warning
 CLAUDE_MD_CHAR_LIMIT: int = 5000
 CLAUDE_MD_RULE_LIMIT: int = 200
 FILE_LINE_LIMIT: int = 500
-
-
-# ---------------------------------------------------------------------------
-# Issue helpers
-# ---------------------------------------------------------------------------
-
-
-def _issue(
-    severity: str,
-    confidence: str,
-    file: str,
-    line: int,
-    message: str,
-    suggested_fix: str = "",
-    rule_id: str = "",
-) -> dict:
-    """Return a canonical issue dict with all required fields."""
-    issue: dict = {
-        "severity": severity,
-        "confidence": confidence,
-        "file": file,
-        "line": line,
-        "message": message,
-        "suggestedFix": suggested_fix,
-    }
-    if rule_id:
-        issue["rule_id"] = rule_id
-    return issue
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +77,7 @@ def check_claude_md(path: Path) -> List[dict]:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         issues.append(
-            _issue(
+            make_issue(
                 "error",
                 "high",
                 str(path),
@@ -120,7 +92,7 @@ def check_claude_md(path: Path) -> List[dict]:
     char_count = len(text)
     if char_count > CLAUDE_MD_CHAR_LIMIT:
         issues.append(
-            _issue(
+            make_issue(
                 "error",
                 "high",
                 str(path),
@@ -139,7 +111,7 @@ def check_claude_md(path: Path) -> List[dict]:
     rule_count = _count_top_level_bullets(body)
     if rule_count > CLAUDE_MD_RULE_LIMIT:
         issues.append(
-            _issue(
+            make_issue(
                 "error",
                 "high",
                 str(path),
@@ -172,7 +144,7 @@ def check_line_counts(files: List[Path]) -> List[dict]:
         line_count = len(lines)
         if line_count > FILE_LINE_LIMIT:
             issues.append(
-                _issue(
+                make_issue(
                     "warning",
                     "high",
                     str(path),
@@ -258,7 +230,7 @@ def run_llm_review(path: Path) -> List[dict]:
         )
         if result.returncode != 0 or not result.stdout.strip():
             issues.append(
-                _issue(
+                make_issue(
                     "warning",
                     "high",
                     str(path),
@@ -282,7 +254,7 @@ def run_llm_review(path: Path) -> List[dict]:
             if not isinstance(f, dict):
                 continue
             issues.append(
-                _issue(
+                make_issue(
                     "warning",  # LLM findings are always warning severity
                     "medium",
                     str(path),
@@ -294,7 +266,7 @@ def run_llm_review(path: Path) -> List[dict]:
             )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         issues.append(
-            _issue(
+            make_issue(
                 "warning",
                 "high",
                 str(path),

--- a/tests/scripts/test_review_result.py
+++ b/tests/scripts/test_review_result.py
@@ -36,6 +36,75 @@ WARN = [
 NONE: list = []
 
 
+def _call_make_issue(**kwargs) -> subprocess.CompletedProcess:
+    code = f"""
+import sys, json
+sys.path.insert(0, {str(SCRIPTS_DIR)!r})
+from lib.review_result import make_issue
+
+kwargs = json.loads(sys.argv[1])
+print(json.dumps(make_issue(**kwargs)))
+"""
+    return subprocess.run(
+        [sys.executable, "-c", code, json.dumps(kwargs)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_make_issue_returns_canonical_shape_with_default_confidence() -> None:
+    result = _call_make_issue(
+        severity="error", file="a.py", line=3, message="bad thing"
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data == {
+        "severity": "error",
+        "confidence": "high",
+        "file": "a.py",
+        "line": 3,
+        "message": "bad thing",
+        "suggestedFix": "",
+    }
+
+
+def test_make_issue_accepts_suggested_fix_and_confidence_override() -> None:
+    result = _call_make_issue(
+        severity="warning",
+        confidence="medium",
+        file="b.py",
+        line=0,
+        message="meh",
+        suggested_fix="do the thing",
+    )
+    data = json.loads(result.stdout)
+    assert data == {
+        "severity": "warning",
+        "confidence": "medium",
+        "file": "b.py",
+        "line": 0,
+        "message": "meh",
+        "suggestedFix": "do the thing",
+    }
+
+
+def test_make_issue_only_includes_rule_id_when_provided() -> None:
+    without = json.loads(_call_make_issue(severity="error", message="x").stdout)
+    assert "rule_id" not in without
+
+    with_rule = json.loads(
+        _call_make_issue(severity="error", message="x", rule_id="my-rule").stdout
+    )
+    assert with_rule["rule_id"] == "my-rule"
+
+
+def test_make_issue_defaults_file_and_line_when_omitted() -> None:
+    data = json.loads(_call_make_issue(severity="error", message="x").stdout)
+    assert data["file"] == ""
+    assert data["line"] == 0
+
+
 def _call_helper(errors: list, warnings: list) -> subprocess.CompletedProcess:
     code = f"""
 import sys, json


### PR DESCRIPTION
## Summary
- Extract the identical stdin-JSON-read/parse/validate helper copy-pasted across 7 hooks (`pre_commit_review.py`, `pre_commit_knowledge_index.py`, `knowledge_index.py`, `mutation_testing_smoke_gate.py`, `codegraph_nudge.py`, `codegraph_bootstrap.py`, `bash_retry_guard.py`) into a single `plugins/dev-team/hooks/lib/stdin_json.py::read_stdin_json()`; all 7 hooks now import and call it.
- Add `make_issue(...)` to `scripts/lib/review_result.py` matching the identical issue-dict shape independently duplicated by `progress_guardian.py` (`_make_error`/`_make_warning`), `claude_setup_review.py` (`_make_error`/`_make_warning`), `test_modernization_review.py` (`_error`/`_warning`), and `token_efficiency_review.py` (`_issue`); deleted the 4 local copies and updated every call site.
- Pure mechanical refactor — no behavior change. New unit tests added for both extracted helpers; all pre-existing tests for touched hooks/scripts pass unchanged.

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_stdin_json.py` (new, RED confirmed before extraction, GREEN after)
- [x] `python3 -m pytest tests/scripts/test_review_result.py` (new `make_issue` tests, RED confirmed before, GREEN after)
- [x] Full suites for all 7 touched hooks pass unchanged (204 tests)
- [x] Full suites for all 4 touched review scripts pass unchanged
- [x] `scripts/test_modernization_review.py` has no dedicated pytest coverage — manually smoke-tested every phase-2/3/4/5 branch (including the em-dash message call site) end-to-end to confirm identical output shape
- [x] `python3 -m pytest plugins/dev-team/tests -q` — 546 passed, 16 skipped
- [x] `python3 -m pytest tests -q` (repo root) — 1427 passed, 2 skipped
- [x] `bash scripts/ci-local.sh --changed-only` — all Python/hook suites pass (1876 passed); the only failing check is `eslint`, a pre-existing environment gap (missing `@eslint/js` in `node_modules`, unrelated to this all-Python diff)

Part of #732