### PR TITLE
fix(hooks): replace third-party PyYAML with a minimal stdlib parser

### DIFF
--- a/plugins/dev-team/hooks/lib/build_skills_index.py
+++ b/plugins/dev-team/hooks/lib/build_skills_index.py
@@ -26,7 +26,8 @@ import os
 import sys
 from pathlib import Path
 
-import yaml
+from minimal_yaml import FrontmatterError as _NoMarkersError
+from minimal_yaml import YamlError, extract_frontmatter_block, parse_yaml
 
 PLUGIN_DIR = Path(__file__).resolve().parents[2]  # lib -> hooks -> dev-team
 SKILLS_DIR = Path(os.environ.get("SKILLS_INDEX_SKILLS_DIR", PLUGIN_DIR / "skills"))
@@ -67,14 +68,13 @@ class FrontmatterError(ValueError):
 def _frontmatter(path: Path) -> dict:
     """Parse the YAML frontmatter block of a SKILL.md (between the first `---`s)."""
     text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        raise FrontmatterError(f"{path}: no `---` frontmatter block")
-    end = text.find("\n---", 3)
-    if end == -1:
-        raise FrontmatterError(f"{path}: unterminated frontmatter block")
     try:
-        data = yaml.safe_load(text[3:end])
-    except yaml.YAMLError as e:
+        block = extract_frontmatter_block(text)
+    except _NoMarkersError as e:
+        raise FrontmatterError(f"{path}: {e}") from e
+    try:
+        data = parse_yaml(block)
+    except YamlError as e:
         # Almost always an unquoted scalar with a bare `: ` (e.g. a description
         # like "...agent: this skill..."). Use a `>-` block scalar to fix it.
         raise FrontmatterError(f"{path}: invalid frontmatter YAML: {e}") from e
@@ -90,7 +90,7 @@ def _cell(text: str) -> str:
 
 def _load_categories():
     """Ordered [(category_name, [skill, ...]), ...] from skill_categories.yaml."""
-    data = yaml.safe_load(CATEGORIES_FILE.read_text(encoding="utf-8")) or {}
+    data = parse_yaml(CATEGORIES_FILE.read_text(encoding="utf-8")) or {}
     return [
         (c["name"], list(c.get("skills") or [])) for c in (data.get("categories") or [])
     ]

--- a/plugins/dev-team/hooks/lib/minimal_yaml.py
+++ b/plugins/dev-team/hooks/lib/minimal_yaml.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""minimal_yaml.py — stdlib-only parser for the small YAML subset this plugin
+actually consumes (ADR 0014 / ADR 0015: no third-party imports in shipped
+`plugins/dev-team/` code).
+
+Three shipped scripts used to `import yaml` (PyYAML, a third-party package)
+to read two shapes of content:
+
+1. SKILL.md **frontmatter** blocks — flat `key: value` pairs, occasional
+   folded block scalars (`key: >-` followed by indented prose), booleans,
+   and simple block sequences (`- item`).
+2. Small **config YAML** files (skill_categories.yaml, scorecard.yaml,
+   security-review-rule-map.yaml) — nested block mappings/sequences, inline
+   flow collections (`{ mvp: true }`, `[".py", ".js"]`, including ones that
+   wrap across two physical lines), quoted and bare scalars, ints/floats/
+   bools.
+
+Neither shape needs anchors, tags, multi-document streams, complex keys, or
+any of the sharper edges of full YAML. This module implements just the
+subset above with a small recursive-descent, indentation-based parser —
+no third-party dependency, so a plain `python3` install (exactly what the
+ADRs promise is sufficient) can run every shipped script that reads YAML.
+
+Public API:
+    parse_yaml(text) -> dict | list | scalar | None
+    extract_frontmatter_block(text) -> str   (raises FrontmatterError)
+    YamlError                                 (raised on unsupported/invalid input)
+    FrontmatterError                          (raised when --- markers are missing)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Optional, Tuple
+
+_BLOCK_SCALAR_INDICATORS = (">-", ">+", ">", "|-", "|+", "|")
+_INT_RE = re.compile(r"^-?\d+$")
+_FLOAT_RE = re.compile(r"^-?\d+\.\d+([eE][+-]?\d+)?$|^-?\d+[eE][+-]?\d+$")
+
+
+class YamlError(ValueError):
+    """Input is outside the supported minimal-YAML subset, or malformed."""
+
+
+class FrontmatterError(ValueError):
+    """A document is missing a well-formed `---`-delimited frontmatter block."""
+
+
+def extract_frontmatter_block(text: str) -> str:
+    """Return the raw text between the first pair of `---` markers.
+
+    Raises FrontmatterError if the document doesn't start with `---` or the
+    block is unterminated.
+    """
+    if not text.startswith("---"):
+        raise FrontmatterError("no `---` frontmatter block")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise FrontmatterError("unterminated frontmatter block")
+    return text[3:end]
+
+
+def parse_yaml(text: str) -> Any:
+    """Parse a minimal YAML subset. See module docstring for the supported shape."""
+    lines = text.splitlines()
+    value, _ = _parse_node(lines, 0, 0)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Comment stripping / quote-aware scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_comment(line: str) -> str:
+    """Remove a trailing `# ...` comment (quote-aware, requires the `#` be at
+    start-of-line or preceded by whitespace, matching YAML's own rule)."""
+    in_single = in_double = False
+    for i, ch in enumerate(line):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            if i == 0 or line[i - 1] in (" ", "\t"):
+                return line[:i]
+    return line
+
+
+def _bracket_delta(s: str) -> int:
+    """Net change in flow-collection nesting depth contributed by `s`,
+    ignoring bracket characters inside quotes."""
+    depth = 0
+    in_single = in_double = False
+    for ch in s:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if ch in "[{":
+                depth += 1
+            elif ch in "]}":
+                depth -= 1
+    return depth
+
+
+def _split_key_value(content: str) -> Optional[Tuple[str, str]]:
+    """Split a `key: value` (or `key:`) line at the first unquoted colon that
+    is followed by whitespace or end-of-string. Returns None if `content`
+    isn't a mapping-key line at all."""
+    in_single = in_double = False
+    for i, ch in enumerate(content):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == ":" and not in_single and not in_double:
+            if i + 1 == len(content) or content[i + 1] in (" ", "\t"):
+                return content[:i].strip(), content[i + 1 :].strip()
+    return None
+
+
+def _parse_key(key: str) -> str:
+    key = key.strip()
+    if len(key) >= 2 and key[0] in "\"'" and key[-1] == key[0]:
+        return _parse_quoted(key)
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Scalars (bare, quoted, flow collections)
+# ---------------------------------------------------------------------------
+
+
+def _parse_quoted(text: str) -> str:
+    quote = text[0]
+    if len(text) < 2 or text[-1] != quote:
+        raise YamlError(f"unterminated quoted scalar: {text!r}")
+    body = text[1:-1]
+    if quote == '"':
+        return (
+            body.replace('\\"', '"')
+            .replace("\\n", "\n")
+            .replace("\\t", "\t")
+            .replace("\\\\", "\\")
+        )
+    return body.replace("''", "'")
+
+
+def _split_top_level(s: str, sep: str) -> List[str]:
+    """Split `s` on `sep` only at flow-collection depth 0 and outside quotes."""
+    parts: List[str] = []
+    depth = 0
+    in_single = in_double = False
+    start = 0
+    for i, ch in enumerate(s):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if ch in "[{":
+                depth += 1
+            elif ch in "]}":
+                depth -= 1
+            elif ch == sep and depth == 0:
+                parts.append(s[start:i])
+                start = i + 1
+    parts.append(s[start:])
+    return parts
+
+
+def _parse_flow(text: str) -> Any:
+    if text.startswith("["):
+        if not text.endswith("]"):
+            raise YamlError(f"unterminated flow sequence: {text!r}")
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_scalar(p.strip()) for p in _split_top_level(inner, ",")]
+    if text.startswith("{"):
+        if not text.endswith("}"):
+            raise YamlError(f"unterminated flow mapping: {text!r}")
+        inner = text[1:-1].strip()
+        if not inner:
+            return {}
+        result = {}
+        for part in _split_top_level(inner, ","):
+            kv = _split_key_value(part.strip())
+            if kv is None:
+                raise YamlError(f"malformed flow-mapping entry: {part!r}")
+            k, v = kv
+            result[_parse_key(k)] = _parse_scalar(v)
+        return result
+    raise YamlError(f"not a flow collection: {text!r}")
+
+
+def _parse_scalar(text: str) -> Any:
+    text = text.strip()
+    if text == "":
+        return None
+    if text[0] in "\"'":
+        return _parse_quoted(text)
+    if text[0] in "[{":
+        return _parse_flow(text)
+    if text in ("true", "True", "TRUE"):
+        return True
+    if text in ("false", "False", "FALSE"):
+        return False
+    if text in ("null", "Null", "NULL", "~"):
+        return None
+    if _INT_RE.match(text):
+        return int(text)
+    if _FLOAT_RE.match(text):
+        return float(text)
+    if ": " in text or text.endswith(":"):
+        # A plain (unquoted) scalar containing ": " is ambiguous with a nested
+        # mapping key in real YAML and is rejected there too — almost always
+        # an unescaped colon in prose (fix: quote it or use a `>-` block
+        # scalar), not something to silently accept as a string.
+        raise YamlError(
+            f"unquoted scalar contains ': ' (quote it or use '>-'): {text!r}"
+        )
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Line reader: comment-stripped, multi-line-flow-merged "structural" lines
+# ---------------------------------------------------------------------------
+
+
+def _next_line(lines: List[str], i: int) -> Optional[Tuple[int, str, int]]:
+    """Return (indent, content, next_i) for the next non-blank structural
+    line at or after index i, merging continuation lines of an unbalanced
+    flow collection. Returns None at end of input."""
+    n = len(lines)
+    while i < n:
+        stripped = _strip_comment(lines[i]).rstrip()
+        if stripped.strip() == "":
+            i += 1
+            continue
+        indent = len(stripped) - len(stripped.lstrip(" "))
+        content = stripped.strip()
+        depth = _bracket_delta(content)
+        j = i + 1
+        while depth > 0 and j < n:
+            piece_raw = _strip_comment(lines[j]).rstrip()
+            piece = piece_raw.strip()
+            if piece == "":
+                j += 1
+                continue
+            content += " " + piece
+            depth += _bracket_delta(piece)
+            j += 1
+        return indent, content, j
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Block scalars (`>-`, `|`, ...)
+# ---------------------------------------------------------------------------
+
+
+def _read_block_scalar(
+    lines: List[str], i: int, parent_indent: int, indicator: str
+) -> Tuple[str, int]:
+    style = indicator[0]
+    n = len(lines)
+    body: List[str] = []
+    content_indent: Optional[int] = None
+    while i < n:
+        raw = lines[i]
+        if raw.strip() == "":
+            if content_indent is None:
+                i += 1
+                continue
+            body.append("")
+            i += 1
+            continue
+        cur_indent = len(raw) - len(raw.lstrip(" "))
+        if cur_indent <= parent_indent:
+            break
+        if content_indent is None:
+            content_indent = cur_indent
+        elif cur_indent < content_indent:
+            break
+        body.append(raw[content_indent:].rstrip())
+        i += 1
+    while body and body[-1] == "":
+        body.pop()
+    if style == ">":
+        text = " ".join(body)
+    else:
+        text = "\n".join(body)
+    return text, i
+
+
+# ---------------------------------------------------------------------------
+# Recursive descent: mappings / sequences
+# ---------------------------------------------------------------------------
+
+
+def _consume_value(
+    lines: List[str], i: int, indent: int, val_text: str
+) -> Tuple[Any, int]:
+    """Resolve the value portion of a `key: val_text` (or `- val_text`)
+    entry, consuming further block-scalar or nested-block lines as needed."""
+    if val_text == "":
+        nxt = _next_line(lines, i)
+        if nxt is not None and nxt[0] > indent:
+            return _parse_node(lines, i, nxt[0])
+        return None, i
+    if val_text in _BLOCK_SCALAR_INDICATORS:
+        return _read_block_scalar(lines, i, indent, val_text)
+    return _parse_scalar(val_text), i
+
+
+def _parse_node(lines: List[str], i: int, indent: int) -> Tuple[Any, int]:
+    nxt = _next_line(lines, i)
+    if nxt is None:
+        return None, i
+    li, content, _j = nxt
+    if li != indent:
+        return None, i
+    if content == "-" or content.startswith("- "):
+        return _parse_sequence(lines, i, indent)
+    return _parse_mapping(lines, i, indent)
+
+
+def _parse_mapping(lines: List[str], i: int, indent: int) -> Tuple[dict, int]:
+    result: dict = {}
+    while True:
+        nxt = _next_line(lines, i)
+        if nxt is None:
+            break
+        li, content, j = nxt
+        if li < indent:
+            break
+        if li > indent:
+            raise YamlError(f"unexpected indentation before: {content!r}")
+        kv = _split_key_value(content)
+        if kv is None:
+            raise YamlError(f"expected 'key: value' mapping entry, got: {content!r}")
+        key, val = kv
+        i = j
+        value, i = _consume_value(lines, i, indent, val)
+        result[_parse_key(key)] = value
+    return result, i
+
+
+def _parse_sequence(lines: List[str], i: int, indent: int) -> Tuple[list, int]:
+    result: list = []
+    while True:
+        nxt = _next_line(lines, i)
+        if nxt is None:
+            break
+        li, content, j = nxt
+        if li < indent:
+            break
+        if li > indent:
+            raise YamlError(f"unexpected indentation in sequence before: {content!r}")
+        if not (content == "-" or content.startswith("- ")):
+            break
+        i = j
+        remainder = "" if content == "-" else content[2:]
+        if remainder == "":
+            nxt2 = _next_line(lines, i)
+            if nxt2 is not None and nxt2[0] > indent:
+                child, i = _parse_node(lines, i, nxt2[0])
+                result.append(child)
+            else:
+                result.append(None)
+            continue
+        kv = _split_key_value(remainder)
+        if kv is None:
+            result.append(_parse_scalar(remainder))
+            continue
+        # "- key: value" — an inline mapping starts at the column right
+        # after "- "; further keys of the same mapping are indented to
+        # align there.
+        after_dash = content[1:]
+        leading_spaces = len(after_dash) - len(after_dash.lstrip(" "))
+        content_col = indent + 1 + leading_spaces
+        key, val = kv
+        value, i = _consume_value(lines, i, content_col, val)
+        item = {_parse_key(key): value}
+        while True:
+            nxt2 = _next_line(lines, i)
+            if nxt2 is None:
+                break
+            li2, content2, j2 = nxt2
+            if li2 != content_col:
+                break
+            kv2 = _split_key_value(content2)
+            if kv2 is None:
+                break
+            key2, val2 = kv2
+            i = j2
+            value2, i = _consume_value(lines, i, content_col, val2)
+            item[_parse_key(key2)] = value2
+        result.append(item)
+    return result, i

--- a/plugins/dev-team/skills/agent-readiness/scanner.py
+++ b/plugins/dev-team/skills/agent-readiness/scanner.py
@@ -23,14 +23,17 @@ import json
 import sys
 from pathlib import Path
 
-import yaml
-
 HERE = Path(__file__).resolve().parent
+# skills/agent-readiness -> skills -> dev-team -> hooks/lib (stdlib-only YAML
+# subset parser; see ADR 0014/0015 — no third-party imports in shipped code).
+sys.path.insert(0, str(HERE.parents[1] / "hooks" / "lib"))
+from minimal_yaml import parse_yaml  # noqa: E402
 
 
 # --------------------------------------------------------------------------
 # Small filesystem helpers (all detection is file-presence/heuristic).
 # --------------------------------------------------------------------------
+
 
 def _exists(root: Path, *names: str) -> str | None:
     for n in names:
@@ -38,19 +41,27 @@ def _exists(root: Path, *names: str) -> str | None:
             return n
     return None
 
+
 def _glob_any(root: Path, *patterns: str) -> str | None:
     for p in patterns:
         for hit in root.glob(p):
             return str(hit.relative_to(root))
     return None
 
+
 def _ci_files(root: Path) -> list[Path]:
     out = []
-    for pat in (".github/workflows/*.yml", ".github/workflows/*.yaml",
-                "Jenkinsfile", ".gitlab-ci.yml", "azure-pipelines.yml",
-                ".azure-pipelines.yml"):
+    for pat in (
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        "Jenkinsfile",
+        ".gitlab-ci.yml",
+        "azure-pipelines.yml",
+        ".azure-pipelines.yml",
+    ):
         out.extend(root.glob(pat))
     return [p for p in out if p.is_file()]
+
 
 def _ci_mentions(root: Path, *needles: str) -> bool:
     for f in _ci_files(root):
@@ -62,6 +73,7 @@ def _ci_mentions(root: Path, *needles: str) -> bool:
             return True
     return False
 
+
 def _score(n: int, evidence: str) -> dict:
     return {"score": n, "max": 2, "evidence": evidence}
 
@@ -70,48 +82,76 @@ def _score(n: int, evidence: str) -> dict:
 # Analyzers — each returns {score, max, evidence}. MVP: file-presence only.
 # --------------------------------------------------------------------------
 
+
 def b2_reproducible_env(root: Path, cfg: dict) -> dict:
-    strong = _exists(root, ".devcontainer/devcontainer.json", "flake.nix",
-                     "docker-compose.yml", "docker-compose.yaml", "compose.yaml")
+    strong = _exists(
+        root,
+        ".devcontainer/devcontainer.json",
+        "flake.nix",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yaml",
+    )
     if strong:
         return _score(2, f"{strong} present (full reproducible environment)")
     if _exists(root, "Dockerfile"):
         return _score(1, "Dockerfile only (no devcontainer/compose/nix)")
     return _score(0, "no Dockerfile/devcontainer/compose/nix")
 
-LOCK_FILES = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock",
-              "Pipfile.lock", "go.sum", "Cargo.lock", "composer.lock",
-              "uv.lock", "Gemfile.lock"]
+
+LOCK_FILES = [
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Pipfile.lock",
+    "go.sum",
+    "Cargo.lock",
+    "composer.lock",
+    "uv.lock",
+    "Gemfile.lock",
+]
+
 
 def b3_dependency_management(root: Path, cfg: dict) -> dict:
     found = [f for f in LOCK_FILES if (root / f).exists()]
     if not found:
         return _score(0, "no lock file found")
-    gi = (root / ".gitignore")
-    ignored = gi.exists() and any(f in gi.read_text(errors="ignore")
-                                  for f in found)
+    gi = root / ".gitignore"
+    ignored = gi.exists() and any(f in gi.read_text(errors="ignore") for f in found)
     if ignored:
         return _score(1, f"lock file(s) {found} present but matched in .gitignore")
     return _score(2, f"lock file(s) committed: {', '.join(found)}")
 
+
 def c1_formatting(root: Path, cfg: dict) -> dict:
-    cfgfile = (_glob_any(root, ".prettierrc*", ".editorconfig", "rustfmt.toml")
-               or _pyproject_has(root, "[tool.black]", "[tool.ruff.format]"))
+    cfgfile = _glob_any(
+        root, ".prettierrc*", ".editorconfig", "rustfmt.toml"
+    ) or _pyproject_has(root, "[tool.black]", "[tool.ruff.format]")
     if not cfgfile:
         return _score(0, "no formatter config")
     if _ci_mentions(root, "prettier", "format", "fmt", "ruff format"):
         return _score(2, f"formatter config ({cfgfile}) + CI format step")
     return _score(1, f"formatter config ({cfgfile}) but no CI enforcement found")
 
+
 def c2_linting(root: Path, cfg: dict) -> dict:
-    cfgfile = (_glob_any(root, ".eslintrc*", "eslint.config.*", "ruff.toml",
-                         ".pylintrc", "pylintrc", ".golangci.yml", ".golangci.yaml")
-               or _pyproject_has(root, "[tool.ruff]", "[tool.pylint]"))
+    cfgfile = _glob_any(
+        root,
+        ".eslintrc*",
+        "eslint.config.*",
+        "ruff.toml",
+        ".pylintrc",
+        "pylintrc",
+        ".golangci.yml",
+        ".golangci.yaml",
+    ) or _pyproject_has(root, "[tool.ruff]", "[tool.pylint]")
     if not cfgfile:
         return _score(0, "no linter config")
     if _ci_mentions(root, "lint", "eslint", "ruff check", "golangci"):
         return _score(2, f"linter config ({cfgfile}) + CI lint step")
     return _score(1, f"linter config ({cfgfile}) but no CI enforcement found")
+
 
 def c4_module_size(root: Path, cfg: dict) -> dict:
     exts = set(cfg.get("source_extensions", []))
@@ -132,10 +172,13 @@ def c4_module_size(root: Path, cfg: dict) -> dict:
     p90 = counts[min(len(counts) - 1, int(round(0.9 * (len(counts) - 1))))]
     th = cfg["thresholds"]
     if p90 <= th["file_size_p90_small"]:
-        return _score(2, f"p90 source file = {p90} lines (<= {th['file_size_p90_small']})")
+        return _score(
+            2, f"p90 source file = {p90} lines (<= {th['file_size_p90_small']})"
+        )
     if p90 <= th["file_size_p90_large"]:
         return _score(1, f"p90 source file = {p90} lines")
     return _score(0, f"p90 source file = {p90} lines (> {th['file_size_p90_large']})")
+
 
 def d1_readme(root: Path, cfg: dict) -> dict:
     readme = _exists(root, "README.md", "README.rst", "README")
@@ -144,59 +187,97 @@ def d1_readme(root: Path, cfg: dict) -> dict:
     text = (root / readme).read_text(errors="ignore")
     words = len(text.split())
     low = text.lower()
-    has_sections = all(k in low for k in ("setup",)) and \
-        any(k in low for k in ("build", "install")) and "test" in low
+    has_sections = (
+        all(k in low for k in ("setup",))
+        and any(k in low for k in ("build", "install"))
+        and "test" in low
+    )
     min_words = cfg["thresholds"]["readme_min_words"]
     if words >= min_words and has_sections:
         return _score(2, f"README {words} words with setup/build/test sections")
     if words > 0:
-        return _score(1, f"README present ({words} words) but thin or missing setup/build/test")
+        return _score(
+            1, f"README present ({words} words) but thin or missing setup/build/test"
+        )
     return _score(0, "README empty")
 
+
 def d2_ai_instructions(root: Path, cfg: dict) -> dict:
-    f = _exists(root, "CLAUDE.md", ".claude/CLAUDE.md", "AGENTS.md",
-                ".cursorrules", ".github/copilot-instructions.md",
-                "CODING_GUIDELINES.md")
+    f = _exists(
+        root,
+        "CLAUDE.md",
+        ".claude/CLAUDE.md",
+        "AGENTS.md",
+        ".cursorrules",
+        ".github/copilot-instructions.md",
+        "CODING_GUIDELINES.md",
+    )
     if not f:
-        return _score(0, "no AI-instructions file (CLAUDE.md/AGENTS.md/.cursorrules/...)")
+        return _score(
+            0, "no AI-instructions file (CLAUDE.md/AGENTS.md/.cursorrules/...)"
+        )
     words = len((root / f).read_text(errors="ignore").split())
     if words >= cfg["thresholds"]["ai_instructions_min_words"]:
         return _score(2, f"{f} present ({words} words, detailed)")
     return _score(1, f"{f} present but brief ({words} words)")
 
+
 def d3_architecture_docs(root: Path, cfg: dict) -> dict:
-    f = (_glob_any(root, "docs/adr/*", "docs/architecture*", "docs/design*",
-                   "ARCHITECTURE.md", "docs/decisions/*"))
+    f = _glob_any(
+        root,
+        "docs/adr/*",
+        "docs/architecture*",
+        "docs/design*",
+        "ARCHITECTURE.md",
+        "docs/decisions/*",
+    )
     if f:
         return _score(2, f"architecture docs present ({f})")
     return _score(0, "no architecture docs (docs/adr, ARCHITECTURE.md, ...)")
 
+
 def v2_precommit_hooks(root: Path, cfg: dict) -> dict:
-    f = _exists(root, ".pre-commit-config.yaml", ".husky", "lefthook.yml",
-                "lefthook.yaml") or _glob_any(root, ".lintstagedrc*")
+    f = _exists(
+        root, ".pre-commit-config.yaml", ".husky", "lefthook.yml", "lefthook.yaml"
+    ) or _glob_any(root, ".lintstagedrc*")
     if not f:
         return _score(0, "no pre-commit hook config")
     if _ci_mentions(root, "pre-commit") or f == ".pre-commit-config.yaml":
         return _score(2, f"pre-commit hooks configured ({f})")
     return _score(1, f"partial hook config ({f})")
 
+
 def v3_commit_conventions(root: Path, cfg: dict) -> dict:
     f = _glob_any(root, "commitlint.config.*", ".commitlintrc*")
     if f:
         enforced = _ci_mentions(root, "commitlint") or (root / ".husky").exists()
-        return _score(2 if enforced else 1,
-                      f"commit-convention tooling ({f})" +
-                      ("" if enforced else " but no CI/hook enforcement found"))
+        return _score(
+            2 if enforced else 1,
+            f"commit-convention tooling ({f})"
+            + ("" if enforced else " but no CI/hook enforcement found"),
+        )
     return _score(0, "no commit-convention tooling")
 
+
 def v4_dependency_scanning(root: Path, cfg: dict) -> dict:
-    found = [n for n in (".github/dependabot.yml", ".github/dependabot.yaml",
-                         ".snyk", "renovate.json", ".renovaterc",
-                         ".renovaterc.json") if (root / n).exists()]
+    found = [
+        n
+        for n in (
+            ".github/dependabot.yml",
+            ".github/dependabot.yaml",
+            ".snyk",
+            "renovate.json",
+            ".renovaterc",
+            ".renovaterc.json",
+        )
+        if (root / n).exists()
+    ]
     if not found:
         return _score(0, "no dependency-scanning config")
-    return _score(2 if len(found) >= 1 else 1,
-                  f"dependency scanning configured: {', '.join(found)}")
+    return _score(
+        2 if len(found) >= 1 else 1,
+        f"dependency scanning configured: {', '.join(found)}",
+    )
 
 
 def _pyproject_has(root: Path, *sections: str) -> str | None:
@@ -228,6 +309,7 @@ ANALYZERS = {
 # Scorer.
 # --------------------------------------------------------------------------
 
+
 def scan(root: Path, cfg: dict) -> dict:
     weights = cfg["weights"]
     categories = {}
@@ -237,8 +319,9 @@ def scan(root: Path, cfg: dict) -> dict:
         scored, raw, mx = {}, 0, 0
         for crit, meta in crits.items():
             if meta.get("manual_review"):
-                manual_flags.append({"criterion": crit,
-                                     "reason": "heuristic weak; needs human review"})
+                manual_flags.append(
+                    {"criterion": crit, "reason": "heuristic weak; needs human review"}
+                )
             if not meta.get("mvp"):
                 continue
             fn = ANALYZERS.get(crit)
@@ -249,13 +332,20 @@ def scan(root: Path, cfg: dict) -> dict:
             raw += res["score"]
             mx += res["max"]
         if mx == 0:
-            categories[cat] = {"weight": weights.get(cat, 0), "scored": False,
-                               "reason": "no MVP criteria (deferred — needs CI API)",
-                               "criteria": {}}
+            categories[cat] = {
+                "weight": weights.get(cat, 0),
+                "scored": False,
+                "reason": "no MVP criteria (deferred — needs CI API)",
+                "criteria": {},
+            }
         else:
             pct = round(raw / mx * 100, 1)
-            categories[cat] = {"weight": weights.get(cat, 0), "scored": True,
-                               "score_pct": pct, "criteria": scored}
+            categories[cat] = {
+                "weight": weights.get(cat, 0),
+                "scored": True,
+                "score_pct": pct,
+                "criteria": scored,
+            }
 
     # Renormalize weights across scored categories only.
     scored_w = sum(c["weight"] for c in categories.values() if c["scored"])
@@ -267,10 +357,15 @@ def scan(root: Path, cfg: dict) -> dict:
     overall = round(overall, 2)
 
     t = cfg["tiers"]
-    tier = ("Agent-Ready" if overall >= t["agent_ready"] else
-            "Agent-Assisted" if overall >= t["agent_assisted"] else
-            "Agent-Limited" if overall >= t["agent_limited"] else
-            "Agent-Hostile")
+    tier = (
+        "Agent-Ready"
+        if overall >= t["agent_ready"]
+        else "Agent-Assisted"
+        if overall >= t["agent_assisted"]
+        else "Agent-Limited"
+        if overall >= t["agent_limited"]
+        else "Agent-Hostile"
+    )
 
     return {
         "repository": root.name,
@@ -278,7 +373,7 @@ def scan(root: Path, cfg: dict) -> dict:
         "scope": "mvp-local-file-presence",
         "overall_score": overall,
         "overall_note": "renormalized over scored categories; deferred "
-                        "categories excluded (need CI-platform APIs)",
+        "categories excluded (need CI-platform APIs)",
         "tier": tier,
         "categories": categories,
         "manual_review_flags": manual_flags,
@@ -287,16 +382,16 @@ def scan(root: Path, cfg: dict) -> dict:
 
 def to_markdown(result: dict) -> str:
     lines = [f"# Agent-Readiness Report — {result['repository']}", ""]
-    lines.append(f"**Overall: {result['overall_score']} / 100 — "
-                 f"{result['tier']}**  ")
+    lines.append(f"**Overall: {result['overall_score']} / 100 — {result['tier']}**  ")
     lines.append(f"_{result['overall_note']}_")
     lines.append("")
     lines.append("| Category | Scored | % | Weighted |")
     lines.append("| --- | --- | --- | --- |")
     for cat, c in result["categories"].items():
         if c["scored"]:
-            lines.append(f"| {cat} | yes | {c['score_pct']}% | "
-                         f"{c.get('weighted_score', 0)} |")
+            lines.append(
+                f"| {cat} | yes | {c['score_pct']}% | {c.get('weighted_score', 0)} |"
+            )
         else:
             lines.append(f"| {cat} | deferred | — | — |")
     lines.append("")
@@ -326,7 +421,7 @@ def main(argv: list[str]) -> int:
     if not root.is_dir():
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 2
-    cfg = yaml.safe_load(Path(args.config).read_text())
+    cfg = parse_yaml(Path(args.config).read_text())
 
     result = scan(root, cfg)
     md = to_markdown(result)

--- a/plugins/dev-team/skills/static-analysis-integration/adapters/security-review-adapter.py
+++ b/plugins/dev-team/skills/static-analysis-integration/adapters/security-review-adapter.py
@@ -54,9 +54,11 @@ _PLUGIN_ROOT = os.path.abspath(os.path.join(_ADAPTER_DIR, "..", "..", ".."))
 _DEFAULT_MAPPING_ABS = os.path.join(
     _PLUGIN_ROOT, "knowledge", "security-review-rule-map.yaml"
 )
-_DEFAULT_MAPPING_REL = (
-    "plugins/dev-team/knowledge/security-review-rule-map.yaml"
-)
+_DEFAULT_MAPPING_REL = "plugins/dev-team/knowledge/security-review-rule-map.yaml"
+
+# Stdlib-only YAML subset parser (ADR 0014/0015 — no third-party imports in
+# shipped plugins/dev-team/ code); lives at plugins/dev-team/hooks/lib/.
+sys.path.insert(0, os.path.join(_PLUGIN_ROOT, "hooks", "lib"))
 
 
 def _fail_mapping(path: str) -> None:
@@ -66,23 +68,19 @@ def _fail_mapping(path: str) -> None:
 
 def _load_mapping(path: str) -> Dict[str, str]:
     """Load the YAML mapping. Hard-fails with a specific ERROR on any issue."""
-    try:
-        import yaml  # local import so --help works without pyyaml
-    except ImportError as exc:  # pragma: no cover
-        print(
-            f"ERROR: pyyaml not installed; install with 'pip install pyyaml' ({exc})",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    from minimal_yaml import YamlError, parse_yaml  # local import; cheap, stdlib-only
+
     try:
         with open(path, "r", encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+            data = parse_yaml(fh.read())
     except FileNotFoundError:
         _fail_mapping(path)
-    except yaml.YAMLError:
+    except YamlError:
         _fail_mapping(path)
-    if not isinstance(data, dict) or "mappings" not in data or not isinstance(
-        data.get("mappings"), dict
+    if (
+        not isinstance(data, dict)
+        or "mappings" not in data
+        or not isinstance(data.get("mappings"), dict)
     ):
         _fail_mapping(path)
     return {str(k): str(v) for k, v in data["mappings"].items()}
@@ -110,8 +108,7 @@ def resolve_rule_id(
         return mapping[category], None
     minted = _FALLBACK_NAMESPACE + category.lower()
     warning = (
-        f"WARN: category {category} not in mapping at {mapping_path}; "
-        f"minted {minted}"
+        f"WARN: category {category} not in mapping at {mapping_path}; minted {minted}"
     )
     return minted, warning
 
@@ -191,9 +188,7 @@ def main(argv=None) -> int:
                     file=sys.stderr,
                 )
                 return 1
-            rule_id, warning = resolve_rule_id(
-                issue["category"], mapping, args.mapping
-            )
+            rule_id, warning = resolve_rule_id(issue["category"], mapping, args.mapping)
             if warning:
                 print(warning, file=sys.stderr)
             finding = _build_finding(issue, rule_id)

--- a/plugins/dev-team/tests/hooks/test_minimal_yaml.py
+++ b/plugins/dev-team/tests/hooks/test_minimal_yaml.py
@@ -1,0 +1,361 @@
+"""Unit tests for hooks/lib/minimal_yaml.py (#732).
+
+This module replaces `import yaml` (third-party PyYAML) in three shipped
+scripts, per ADR 0014 / ADR 0015 (stdlib-only). Coverage here targets the
+exact shapes those three call sites parse:
+
+  - build_skills_index.py: SKILL.md frontmatter (name/description/
+    user-invocable, folded `>-` block scalars, block sequences with
+    trailing comments) + skill_categories.yaml (block sequence of
+    two-key mappings with a multi-line flow list value).
+  - agent-readiness/scanner.py: scorecard.yaml-shaped config (nested block
+    mappings, inline flow mappings/lists, multi-line flow collections,
+    quoted strings, ints/floats/bools).
+  - security-review-adapter.py: security-review-rule-map.yaml-shaped
+    mapping file (flat string->string `mappings`, plus a `classes` section
+    mixing block and inline-flow mapping values) and its malformed-input
+    failure mode.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"))
+
+import minimal_yaml  # noqa: E402,F401
+from minimal_yaml import (
+    FrontmatterError,
+    YamlError,
+    extract_frontmatter_block,
+    parse_yaml,
+)  # noqa: E402
+
+
+def test_yaml_import_is_not_used_by_this_module():
+    """The whole point: no third-party import anywhere in the module."""
+    src = (
+        _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib" / "minimal_yaml.py"
+    ).read_text(encoding="utf-8")
+    assert not any(
+        line.strip() in ("import yaml", "from yaml import *")
+        for line in src.splitlines()
+    )
+    assert not any(line.strip().startswith("from yaml ") for line in src.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# extract_frontmatter_block
+# ---------------------------------------------------------------------------
+
+
+def test_extract_frontmatter_block_returns_text_between_markers():
+    text = "---\nname: foo\n---\n\n# Body\n"
+    assert extract_frontmatter_block(text) == "\nname: foo"
+
+
+def test_extract_frontmatter_block_missing_leading_marker_raises():
+    with pytest.raises(FrontmatterError):
+        extract_frontmatter_block("name: foo\n---\n")
+
+
+def test_extract_frontmatter_block_unterminated_raises():
+    with pytest.raises(FrontmatterError):
+        extract_frontmatter_block("---\nname: foo\n")
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md frontmatter shapes (build_skills_index.py's _frontmatter)
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_simple_key_values():
+    block = extract_frontmatter_block(
+        "---\n"
+        "name: agent-audit\n"
+        "description: Audit code-review agents, skills, and hooks.\n"
+        "user-invocable: true\n"
+        "---\n"
+    )
+    data = parse_yaml(block)
+    assert data == {
+        "name": "agent-audit",
+        "description": "Audit code-review agents, skills, and hooks.",
+        "user-invocable": True,
+    }
+
+
+def test_frontmatter_folded_block_scalar_description():
+    block = extract_frontmatter_block(
+        "---\n"
+        "name: agent-readiness\n"
+        "description: >-\n"
+        "  Score how ready the current repository is for AI-assisted development against\n"
+        '  the Agent-Readiness Scorecard. Use when the user asks "how agent-ready is this\n'
+        '  repo".\n'
+        'argument-hint: "[repo-path] [--json <file>]"\n'
+        "user-invocable: true\n"
+        "---\n"
+    )
+    data = parse_yaml(block)
+    assert data["name"] == "agent-readiness"
+    assert data["description"] == (
+        "Score how ready the current repository is for AI-assisted development against "
+        'the Agent-Readiness Scorecard. Use when the user asks "how agent-ready is this '
+        'repo".'
+    )
+    assert data["argument-hint"] == "[repo-path] [--json <file>]"
+    assert data["user-invocable"] is True
+
+
+def test_frontmatter_block_scalar_ignores_hash_as_literal_not_comment():
+    """Inside a `>-` body, `#` is literal text, never a comment (matches the
+    real init-dev-team SKILL.md, which has 'C#' inside its description)."""
+    block = extract_frontmatter_block(
+        "---\n"
+        "name: init-dev-team\n"
+        "description: >-\n"
+        "  prompts for language selection (JS/TS, Java, C#) to install the matching\n"
+        "  tool.\n"
+        "---\n"
+    )
+    data = parse_yaml(block)
+    assert "C#)" in data["description"]
+
+
+def test_frontmatter_block_sequence_with_trailing_comment():
+    """Matches static-analysis-integration/SKILL.md's `maintainers:` list,
+    including a `# TODO: ...` trailing comment on one item."""
+    block = extract_frontmatter_block(
+        "---\n"
+        "name: static-analysis-integration\n"
+        "maintainers:\n"
+        "  - bdfinst\n"
+        "  - unassigned   # TODO: name a second maintainer; bus-factor minimum is 2.\n"
+        "required-primitives-contract: ^1.0.0\n"
+        "---\n"
+    )
+    data = parse_yaml(block)
+    assert data["maintainers"] == ["bdfinst", "unassigned"]
+    assert data["required-primitives-contract"] == "^1.0.0"
+
+
+def test_frontmatter_unescaped_colon_in_plain_scalar_raises_yamlerror():
+    """A bare (unquoted, non-`>-`) description containing ': ' is ambiguous
+    with a nested mapping key in real YAML and must be rejected loudly, not
+    silently accepted — matches tests/repo/test_skills_index_current.py's
+    test_unparseable_frontmatter_fails_the_build_loudly."""
+    block = extract_frontmatter_block(
+        "---\nname: bad\ndescription: refers to foo: bar inline\nuser-invocable: true\n---\n"
+    )
+    with pytest.raises(YamlError):
+        parse_yaml(block)
+
+
+def test_frontmatter_missing_description_key_is_just_absent():
+    block = extract_frontmatter_block("---\nname: foo\n---\n")
+    data = parse_yaml(block)
+    assert "description" not in data
+
+
+def test_frontmatter_malformed_yaml_raises_yamlerror():
+    block = extract_frontmatter_block("---\nname: foo: bar: baz\n  nested: oops\n---\n")
+    with pytest.raises(YamlError):
+        parse_yaml(block)
+
+
+# ---------------------------------------------------------------------------
+# skill_categories.yaml shape (build_skills_index.py's _load_categories)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_categories_shape_sequence_of_two_key_mappings_with_flow_list():
+    text = (
+        "categories:\n"
+        "  - name: Specs & Planning\n"
+        "    skills: [specs, plan, design-doc, design-interrogation, design-it-twice,\n"
+        "             api-design, gherkin-derive]\n"
+        "  - name: Build & Ship\n"
+        "    skills: [build, test-driven-development, continue]\n"
+    )
+    data = parse_yaml(text)
+    cats = data["categories"]
+    assert cats[0]["name"] == "Specs & Planning"
+    assert cats[0]["skills"] == [
+        "specs",
+        "plan",
+        "design-doc",
+        "design-interrogation",
+        "design-it-twice",
+        "api-design",
+        "gherkin-derive",
+    ]
+    assert cats[1] == {
+        "name": "Build & Ship",
+        "skills": ["build", "test-driven-development", "continue"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# scorecard.yaml shape (agent-readiness/scanner.py)
+# ---------------------------------------------------------------------------
+
+
+def test_scorecard_shape_nested_mappings_flow_collections_and_types():
+    text = (
+        'version: "1.0-mvp"\n'
+        "\n"
+        "weights:\n"
+        "  test_infrastructure: 0.25\n"
+        "  build_env: 0.20\n"
+        "\n"
+        "tiers:\n"
+        "  agent_ready: 75\n"
+        "  agent_assisted: 50\n"
+        "\n"
+        "criteria:\n"
+        "  build_env:\n"
+        "    B1_single_command_build: { mvp: false }\n"
+        "    B2_reproducible_env: { mvp: true }\n"
+        "  code_quality:\n"
+        "    C3_architecture: { mvp: false, manual_review: true }\n"
+        "\n"
+        "thresholds:\n"
+        "  file_size_p90_small: 300   # source-file p90 line count\n"
+        "  readme_min_words: 200\n"
+        "\n"
+        'source_extensions: [".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java",\n'
+        '                    ".cs", ".rb"]\n'
+        'exclude_dirs: [".git", "node_modules"]\n'
+    )
+    data = parse_yaml(text)
+    assert data["version"] == "1.0-mvp"
+    assert data["weights"] == {"test_infrastructure": 0.25, "build_env": 0.20}
+    assert data["tiers"] == {"agent_ready": 75, "agent_assisted": 50}
+    assert data["criteria"]["build_env"]["B1_single_command_build"] == {"mvp": False}
+    assert data["criteria"]["build_env"]["B2_reproducible_env"] == {"mvp": True}
+    assert data["criteria"]["code_quality"]["C3_architecture"] == {
+        "mvp": False,
+        "manual_review": True,
+    }
+    assert data["thresholds"]["file_size_p90_small"] == 300
+    assert data["thresholds"]["readme_min_words"] == 200
+    assert data["source_extensions"] == [
+        ".py",
+        ".js",
+        ".ts",
+        ".jsx",
+        ".tsx",
+        ".go",
+        ".rs",
+        ".java",
+        ".cs",
+        ".rb",
+    ]
+    assert data["exclude_dirs"] == [".git", "node_modules"]
+
+
+def test_scorecard_inline_test_config_shape():
+    """Matches tests/repo/test_agent_readiness.py's inline custom config —
+    single-line flow mappings, including one split across two lines."""
+    text = (
+        'version: "test"\n'
+        "weights: { documentation: 1.0 }\n"
+        "tiers: { agent_ready: 0, agent_assisted: 0, agent_limited: 0 }\n"
+        "criteria:\n"
+        "  documentation:\n"
+        "    D1_readme: { mvp: true }\n"
+        "thresholds: { readme_min_words: 200, ai_instructions_min_words: 100,\n"
+        "              file_size_p90_small: 300, file_size_p90_large: 500 }\n"
+        'source_extensions: [".py"]\n'
+        'exclude_dirs: [".git"]\n'
+    )
+    data = parse_yaml(text)
+    assert data["version"] == "test"
+    assert data["weights"] == {"documentation": 1.0}
+    assert data["tiers"] == {
+        "agent_ready": 0,
+        "agent_assisted": 0,
+        "agent_limited": 0,
+    }
+    assert data["criteria"]["documentation"]["D1_readme"] == {"mvp": True}
+    assert data["thresholds"] == {
+        "readme_min_words": 200,
+        "ai_instructions_min_words": 100,
+        "file_size_p90_small": 300,
+        "file_size_p90_large": 500,
+    }
+    assert data["source_extensions"] == [".py"]
+    assert data["exclude_dirs"] == [".git"]
+
+
+# ---------------------------------------------------------------------------
+# security-review-rule-map.yaml shape (security-review-adapter.py)
+# ---------------------------------------------------------------------------
+
+
+def test_rule_map_shape_flat_mappings_dict():
+    text = (
+        "version: 1.1.0\n"
+        "mappings:\n"
+        "  A02.weak-hashing-md5: semgrep.generic.weak-hash-md5\n"
+        "  A01.idor: security-review.a01.idor\n"
+        "\n"
+        "classes:\n"
+        "  A02.weak-hashing-md5:\n"
+        "    surface: rule\n"
+        "    fp_rate: 0.0\n"
+        "    fixtures: knowledge/rule-fixtures/A02.weak-hashing-md5\n"
+        "  A01.idor: { surface: prompt }\n"
+    )
+    data = parse_yaml(text)
+    assert data["mappings"] == {
+        "A02.weak-hashing-md5": "semgrep.generic.weak-hash-md5",
+        "A01.idor": "security-review.a01.idor",
+    }
+    assert data["classes"]["A02.weak-hashing-md5"] == {
+        "surface": "rule",
+        "fp_rate": 0.0,
+        "fixtures": "knowledge/rule-fixtures/A02.weak-hashing-md5",
+    }
+    assert data["classes"]["A01.idor"] == {"surface": "prompt"}
+
+
+def test_rule_map_malformed_mapping_raises_yamlerror():
+    """Matches evals/security-review-adapter/fixtures/malformed-mapping.yaml:
+    a scalar value ('this: is') followed by orphaned, more-indented content
+    is invalid and must hard-fail, not silently parse."""
+    text = "version: 1.0.0\nmappings: this: is\n  not valid\n  [yaml\n"
+    with pytest.raises(YamlError):
+        parse_yaml(text)
+
+
+# ---------------------------------------------------------------------------
+# Scalar type coercion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("false", False),
+        ("null", None),
+        ("~", None),
+        ("42", 42),
+        ("-3", -3),
+        ("0.25", 0.25),
+        ("2.0.0", "2.0.0"),  # not a valid int/float -> stays a plain string
+        ("^1.0.0", "^1.0.0"),
+        ('"quoted string"', "quoted string"),
+        ("'single quoted'", "single quoted"),
+        ("bare string", "bare string"),
+    ],
+)
+def test_parse_scalar_via_top_level_key(raw, expected):
+    data = parse_yaml(f"k: {raw}\n")
+    assert data["k"] == expected


### PR DESCRIPTION
## Summary
- `build_skills_index.py`, `agent-readiness/scanner.py`, and `static-analysis-integration/adapters/security-review-adapter.py` imported PyYAML directly, violating the stdlib-only mandate for shipped `plugins/dev-team/` code (ADR 0014/0015). On a plain `python3` install with no PyYAML, `build_skills_index.py` silently failed fail-open and `docs/skills.md` never regenerated — silent catalog drift.
- Adds `hooks/lib/minimal_yaml.py`, a stdlib-only parser covering the exact frontmatter/config shapes these three files consume, and rewires all three call sites off `import yaml`.

## Test plan
- [x] New `plugins/dev-team/tests/hooks/test_minimal_yaml.py` (27 tests) covering all real consumed shapes
- [x] `build_skills_index.py --check` produces byte-identical `docs/skills.md`
- [x] `tests/repo/test_agent_readiness.py` passes
- [x] Confirmed no `import yaml` remains under `plugins/dev-team/`

Part of #732