### PR TITLE
refactor(hooks): dedupe model-band helpers into model_resolve

### DIFF
--- a/plugins/dev-team/docs/model-routing.md
+++ b/plugins/dev-team/docs/model-routing.md
@@ -204,8 +204,9 @@ truth. If a fourth band is ever warranted (e.g. a common 4+ model ladder), add
 it in lockstep:
 
 1. Extend `ALLOWED_BANDS` in `tests/agents/agent_effort_frontmatter_tests.bats`
-   and the weight table in `hooks/lib/model_resolve.py` (`_band_weight`) and
-   `hooks/agent_model_resolve.py` (`_normalize_band`).
+   and the weight table in `hooks/lib/model_resolve.py` (`_band_weight` and
+   `normalize_band` — `hooks/agent_model_resolve.py` calls the latter
+   directly rather than keeping its own copy).
 2. Add the band key to `knowledge/model-routing.json`.
 3. Update the band → model dump in `_dump_map`, this file, and the spec.
 

--- a/plugins/dev-team/hooks/agent_model_resolve.py
+++ b/plugins/dev-team/hooks/agent_model_resolve.py
@@ -55,7 +55,6 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 _HOOK_DIR = Path(__file__).resolve().parent
 _LIB_DIR = _HOOK_DIR / "lib"
@@ -165,35 +164,16 @@ def _read_effort(agent_file: Path) -> str:
     return ""
 
 
-def _normalize_band(token: str) -> str:
-    if token in ("low", "haiku"):
-        return "low"
-    if token in ("medium", "sonnet"):
-        return "medium"
-    if token in ("high", "opus"):
-        return "high"
-    return ""
-
-
-def _load_json(path: Path) -> Optional[object]:
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError, ValueError):
-        return None
-
-
-def _ladder_is_valid() -> bool:
-    data = _load_json(_ladder_json())
-    if not isinstance(data, list) or len(data) == 0:
-        return False
-    return all(isinstance(x, str) for x in data)
-
-
 def _snapshot_in_ladder(snap: str) -> bool:
-    if not _ladder_is_valid():
+    """True iff `snap` is a model ID present in the ladder file.
+
+    Delegates band-normalization/JSON-loading/ladder-validity to
+    hooks/lib/model_resolve.py (#732) rather than keeping local, driftable
+    copies of those helpers.
+    """
+    if not model_resolve.ladder_is_valid(_ladder_json()):
         return False
-    data = _load_json(_ladder_json())
+    data = model_resolve.load_json(_ladder_json())
     assert isinstance(data, list)
     return snap in data
 
@@ -314,6 +294,12 @@ def main() -> int:
     if tool_name != "Agent":
         return 0
 
+    if not _MODEL_RESOLVE_AVAILABLE:  # pragma: no cover
+        # Sibling hooks/lib/model_resolve.py should always ship alongside
+        # this file; if it's somehow missing, fail open rather than raise.
+        _emit_pass_through()
+        return 0
+
     tool_input = (
         payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
     )
@@ -337,10 +323,10 @@ def main() -> int:
     reason = ""
     explicit_snapshot = ""
     if effort:
-        band = _normalize_band(effort)
+        band = model_resolve.normalize_band(effort)
         reason = "effort"
     elif requested_model:
-        band = _normalize_band(requested_model)
+        band = model_resolve.normalize_band(requested_model)
         if band:
             reason = "legacy-tier"
         else:
@@ -352,7 +338,7 @@ def main() -> int:
         # Explicit out-of-ladder snapshot → session fallback.
         if (
             explicit_snapshot
-            and _ladder_is_valid()
+            and model_resolve.ladder_is_valid(_ladder_json())
             and not _snapshot_in_ladder(explicit_snapshot)
             and session
         ):
@@ -371,7 +357,7 @@ def main() -> int:
     routing = _routing_json()
     default_snapshot = ""
     if routing.is_file():
-        data = _load_json(routing)
+        data = model_resolve.load_json(routing)
         if isinstance(data, dict):
             v = data.get(band)
             if isinstance(v, str):

--- a/plugins/dev-team/hooks/lib/model_resolve.py
+++ b/plugins/dev-team/hooks/lib/model_resolve.py
@@ -86,10 +86,14 @@ def _resolve_paths() -> Tuple[Path, Path]:
 
 
 # ---------------------------------------------------------------------------
-# _normalize_band — map a band or legacy tier to a canonical band.
+# normalize_band — map a band or legacy tier to a canonical band.
 # Returns "" for an unrecognized token (matches the .sh's echo "").
+#
+# Public (#732): also called directly by hooks/agent_model_resolve.py, which
+# used to keep its own copy of this function. Promoted so there is exactly
+# one implementation to keep in sync.
 # ---------------------------------------------------------------------------
-def _normalize_band(token: str) -> str:
+def normalize_band(token: str) -> str:
     if token in ("low", "haiku"):
         return "low"
     if token in ("medium", "sonnet"):
@@ -107,24 +111,34 @@ def _band_weight(band: str) -> float:
 
 
 # ---------------------------------------------------------------------------
-# _load_json — read a JSON file if present; return None on any failure.
+# load_json — read a JSON file if present; return None on any failure.
+#
+# Public (#732): also called directly by hooks/agent_model_resolve.py. The
+# exception tuple deliberately includes `ValueError` in addition to
+# `json.JSONDecodeError` (a `ValueError` subclass) so a mis-encoded file
+# (e.g. `UnicodeDecodeError`, also a `ValueError` subclass) degrades to None
+# rather than raising — this hook's fail-open posture requires it, and it
+# was the one behavior agent_model_resolve.py's now-removed local copy had
+# that this shared version previously lacked.
 # ---------------------------------------------------------------------------
-def _load_json(path: Path) -> Optional[object]:
+def load_json(path: Path) -> Optional[object]:
     try:
         with path.open("r", encoding="utf-8") as fh:
             return json.load(fh)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, ValueError):
         return None
 
 
 # ---------------------------------------------------------------------------
-# _ladder_is_valid — true iff the ladder file exists and is a non-empty JSON
+# ladder_is_valid — true iff the ladder file exists and is a non-empty JSON
 # array of strings. Anything else degrades to the default map.
+#
+# Public (#732): also called directly by hooks/agent_model_resolve.py.
 # ---------------------------------------------------------------------------
-def _ladder_is_valid(ladder_path: Path) -> bool:
+def ladder_is_valid(ladder_path: Path) -> bool:
     if not ladder_path.exists():
         return False
-    data = _load_json(ladder_path)
+    data = load_json(ladder_path)
     if not isinstance(data, list):
         return False
     if len(data) == 0:
@@ -137,7 +151,7 @@ def _ladder_is_valid(ladder_path: Path) -> bool:
 # Returns "" when the band key is absent (matches jq's // empty behavior).
 # ---------------------------------------------------------------------------
 def _default_for_band(routing_path: Path, band: str) -> str:
-    data = _load_json(routing_path)
+    data = load_json(routing_path)
     if not isinstance(data, dict):
         return ""
     value = data.get(band)
@@ -164,9 +178,9 @@ def resolve_band(
         routing_path = routing_path or r
         ladder_path = ladder_path or l
 
-    if _ladder_is_valid(ladder_path):
-        ladder = _load_json(ladder_path)
-        # _ladder_is_valid guarantees list[str] with len ≥ 1.
+    if ladder_is_valid(ladder_path):
+        ladder = load_json(ladder_path)
+        # ladder_is_valid guarantees list[str] with len ≥ 1.
         assert isinstance(ladder, list)
         n = len(ladder)
         weight = _band_weight(band)
@@ -231,7 +245,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         return EXIT_OK
 
     requested = args[0]
-    band = _normalize_band(requested)
+    band = normalize_band(requested)
     if not band:
         sys.stderr.write(
             f"Unknown effort band '{requested}'. Valid bands: low, medium, "

--- a/plugins/dev-team/tests/hooks/test_agent_model_resolve.py
+++ b/plugins/dev-team/tests/hooks/test_agent_model_resolve.py
@@ -1,0 +1,67 @@
+"""Unit tests for hooks/agent_model_resolve.py (#732 dedup fix).
+
+agent_model_resolve.py imports hooks/lib/model_resolve.py already — this
+suite guards against re-introducing local, drifted copies of
+normalize_band/load_json/ladder_is_valid instead of calling model_resolve's
+versions directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_HOOKS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
+sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_HOOKS_DIR / "lib"))
+
+import agent_model_resolve  # noqa: E402
+import model_resolve  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# No local duplicate helpers — must call model_resolve's public versions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["_normalize_band", "_load_json", "_ladder_is_valid"],
+)
+def test_no_local_duplicate_helper(name: str) -> None:
+    assert not hasattr(agent_model_resolve, name), (
+        f"agent_model_resolve.{name} should not exist — call "
+        f"model_resolve's public equivalent directly instead of keeping a "
+        f"local (and driftable) copy."
+    )
+
+
+def test_snapshot_in_ladder_uses_shared_ladder_validity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`_snapshot_in_ladder` must delegate ladder-validity to
+    model_resolve.ladder_is_valid so both hooks always agree, even on edge
+    cases like a mis-encoded ladder file (must degrade to False, not raise).
+    """
+    bad_ladder = tmp_path / "ladder.json"
+    bad_ladder.write_bytes(b"\xff\xfe\x00\x00invalid")
+    monkeypatch.setenv("MODEL_LADDER_JSON", str(bad_ladder))
+
+    assert model_resolve.ladder_is_valid(bad_ladder) is False
+    assert agent_model_resolve._snapshot_in_ladder("claude-opus-4-8") is False
+
+
+def test_snapshot_in_ladder_false_when_ladder_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MODEL_LADDER_JSON", str(tmp_path / "missing.json"))
+    assert agent_model_resolve._snapshot_in_ladder("claude-opus-4-8") is False
+
+
+def test_snapshot_in_ladder_true_when_present(tmp_path, monkeypatch) -> None:
+    ladder = tmp_path / "ladder.json"
+    ladder.write_text('["a", "b", "c"]', encoding="utf-8")
+    monkeypatch.setenv("MODEL_LADDER_JSON", str(ladder))
+    assert agent_model_resolve._snapshot_in_ladder("b") is True
+    assert agent_model_resolve._snapshot_in_ladder("z") is False

--- a/plugins/dev-team/tests/hooks/test_model_resolve.py
+++ b/plugins/dev-team/tests/hooks/test_model_resolve.py
@@ -561,7 +561,7 @@ def test_dump_map_format_matches_bash_printf(
 
 
 # ---------------------------------------------------------------------------
-# Internal helper coverage — _normalize_band / _band_weight / _round_half_up
+# Internal helper coverage — normalize_band / _band_weight / _round_half_up
 # ---------------------------------------------------------------------------
 
 
@@ -580,7 +580,48 @@ def test_dump_map_format_matches_bash_printf(
     ],
 )
 def test_normalize_band(token: str, expected: str) -> None:
-    assert model_resolve._normalize_band(token) == expected
+    # Public name (#732 dedup): agent_model_resolve.py calls this directly
+    # instead of keeping its own drifted copy.
+    assert model_resolve.normalize_band(token) == expected
+
+
+# ---------------------------------------------------------------------------
+# load_json — public so agent_model_resolve.py can call it directly (#732
+# dedup). Regression coverage for the exception tuple the two copies had
+# drifted on: agent_model_resolve.py's private copy additionally caught
+# `ValueError` (covering e.g. UnicodeDecodeError from a mis-encoded file),
+# which model_resolve.py's original did not. The shared implementation must
+# have the broader (safer) tuple so both callers behave identically.
+# ---------------------------------------------------------------------------
+
+
+def test_load_json_returns_none_for_invalid_utf8(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_bytes(b"\xff\xfe\x00\x00invalid")
+    assert model_resolve.load_json(bad) is None
+
+
+def test_load_json_returns_none_for_missing_file(tmp_path: Path) -> None:
+    assert model_resolve.load_json(tmp_path / "missing.json") is None
+
+
+def test_load_json_returns_none_for_malformed_json(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    assert model_resolve.load_json(bad) is None
+
+
+def test_load_json_returns_parsed_data(tmp_path: Path) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"low": "x"}), encoding="utf-8")
+    assert model_resolve.load_json(good) == {"low": "x"}
+
+
+def test_ladder_is_valid_public_name(tmp_path: Path) -> None:
+    ladder = tmp_path / "ladder.json"
+    ladder.write_text(json.dumps(["a", "b"]), encoding="utf-8")
+    assert model_resolve.ladder_is_valid(ladder) is True
+    assert model_resolve.ladder_is_valid(tmp_path / "missing.json") is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `hooks/agent_model_resolve.py` reimplemented `_normalize_band`, `_load_json`, and `_ladder_is_valid` instead of calling the versions already shipped in `hooks/lib/model_resolve.py`, and the copies had drifted (different caught-exception tuples).
- Promoted the three helpers to public names (`normalize_band`, `load_json`, `ladder_is_valid`) in `model_resolve.py`, widened `load_json`'s except tuple to also catch `ValueError` (a strict superset — closes the drift without narrowing existing fail-open behavior), and deleted the local duplicate copies in `agent_model_resolve.py` in favor of calling `model_resolve` directly.
- Added a regression test guarding against re-introducing local duplicates, plus tests demonstrating the exception-tuple drift bug (a mis-encoded ladder file used to raise `UnicodeDecodeError` out of `model_resolve.load_json` uncovered).

Part of #732

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_model_resolve.py plugins/dev-team/tests/hooks/test_agent_model_resolve.py -q` — new tests confirmed RED before the fix, GREEN after
- [x] `python3 -m pytest plugins/dev-team/tests -q` — full plugin suite (1876 passed, 16 skipped)
- [x] `bash scripts/ci-local.sh` — all Python/pytest gates pass; `eslint` fails only due to missing `node_modules` in this fresh worktree (pre-existing environment gap, unrelated to this Python-only change)