### PR TITLE
perf(hooks): bound cost-meter, guard-state, and pending-review reads

### DIFF
--- a/plugins/dev-team/hooks/bash_retry_guard.py
+++ b/plugins/dev-team/hooks/bash_retry_guard.py
@@ -26,6 +26,7 @@ import os
 import re
 import sys
 import tempfile
+import time
 import zlib
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -57,6 +58,11 @@ _VERIFY_RE = re.compile(
 _READ_ONLY_FIRST_TOKENS = {"ls", "pwd", "echo", "cat", "head", "tail", "grep"}
 
 _STATE_DIRNAME = "dev-team-bash-retry"
+
+# Same TTL-purge-on-write pattern as tdd_guard.py / mutation_adapters/lib.py
+# (#732) — one state file is written per session with no expiry otherwise,
+# so long-lived hosts accumulate a file per session forever.
+_STATE_TTL_SECONDS = 14400  # 4 hours
 
 
 def _cksum(text: str) -> str:
@@ -98,10 +104,23 @@ def _state_key(session_id: str, cwd: str) -> str:
     return _cksum(cwd or os.getcwd())
 
 
+def _purge_stale(state_dir: Path) -> None:
+    if not state_dir.is_dir():
+        return
+    now = time.time()
+    for path in state_dir.glob("*.json"):
+        try:
+            if now - path.stat().st_mtime > _STATE_TTL_SECONDS:
+                path.unlink()
+        except OSError:
+            pass
+
+
 def _state_file(state_key: str) -> Path:
     tmp = Path(os.environ.get("TMPDIR", tempfile.gettempdir()))
     state_dir = tmp / _STATE_DIRNAME
     state_dir.mkdir(parents=True, exist_ok=True)
+    _purge_stale(state_dir)
     return state_dir / f"{state_key}.json"
 
 

--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -67,13 +67,107 @@ The transcript schema is read defensively (usage may sit on the record or under
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import sys
+import time
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 # hooks/lib/cost_meter.py -> plugin root is three parents up.
 _PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_PRICING = _PLUGIN_ROOT / "knowledge/model-pricing.json"
+
+# ---------------------------------------------------------------------------
+# Incremental `record` state — a byte offset + running aggregates, keyed by
+# transcript path, so a Stop/SubagentStop hook fire only tails bytes appended
+# since the last fire instead of re-parsing the whole transcript (#732).
+# Same TTL-purge-on-write pattern as tdd_guard.py / mutation_adapters/lib.py.
+# ---------------------------------------------------------------------------
+
+_STATE_TTL_SECONDS = 14400  # 4 hours
+
+
+def _state_dir() -> Path:
+    return Path(os.environ.get("TMPDIR", "/tmp")) / "dev-team-cost-meter"
+
+
+def _state_file(transcript_path: Path) -> Path:
+    digest = hashlib.sha256(
+        str(Path(transcript_path).resolve()).encode("utf-8")
+    ).hexdigest()[:12]
+    return _state_dir() / f"session-{digest}.json"
+
+
+def _purge_stale(state_dir: Path) -> None:
+    if not state_dir.is_dir():
+        return
+    now = time.time()
+    for path in state_dir.glob("session-*.json"):
+        try:
+            if now - path.stat().st_mtime > _STATE_TTL_SECONDS:
+                path.unlink()
+        except OSError:
+            pass
+
+
+def _read_new_lines(path: Path, offset: int) -> Tuple[int, List[str]]:
+    """Tail `path` from `offset`, returning (new_offset, complete_lines).
+
+    Reads in binary mode and stops at the last full line so a line still
+    being written doesn't get parsed half-formed; the trailing partial bytes
+    are left unconsumed (picked up on the next fire once complete).
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(offset)
+            chunk = fh.read()
+    except OSError:
+        return offset, []
+    if not chunk:
+        return offset, []
+    if chunk.endswith(b"\n"):
+        consumed = chunk
+    else:
+        last_newline = chunk.rfind(b"\n")
+        consumed = chunk[: last_newline + 1] if last_newline != -1 else b""
+    if not consumed:
+        return offset, []
+    new_offset = offset + len(consumed)
+    lines = consumed.decode("utf-8", errors="replace").splitlines()
+    return new_offset, lines
+
+
+def _load_state(state_file: Path) -> Optional[dict]:
+    if not state_file.is_file():
+        return None
+    try:
+        data = json.loads(state_file.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_state(
+    state_file: Path,
+    offset: int,
+    by_model: dict,
+    by_thread: dict,
+    totals: dict,
+    unpriced_models: set,
+) -> None:
+    payload = {
+        "offset": offset,
+        "by_model": by_model,
+        "by_thread": by_thread,
+        "totals": totals,
+        "unpriced_models": sorted(unpriced_models),
+    }
+    try:
+        state_file.write_text(json.dumps(payload))
+    except OSError:
+        pass
 
 
 def _load_pricing(path: Path) -> dict:
@@ -93,7 +187,10 @@ def _rate(pricing: dict, model: str) -> dict | None:
 
 def _dig(rec: dict, *keys: str):
     """Return the first present key on rec or rec['message']."""
-    for src in (rec, rec.get("message", {}) if isinstance(rec.get("message"), dict) else {}):
+    for src in (
+        rec,
+        rec.get("message", {}) if isinstance(rec.get("message"), dict) else {},
+    ):
         for k in keys:
             if k in src and src[k] is not None:
                 return src[k]
@@ -114,27 +211,34 @@ def _cost(usage: dict, rate: dict, pricing: dict) -> float:
     )
 
 
-_TOKEN_FIELDS = ("input_tokens", "output_tokens",
-                 "cache_creation_input_tokens", "cache_read_input_tokens")
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
 
 
 def _new_bucket() -> dict:
     return {f: 0 for f in _TOKEN_FIELDS} | {"cost_usd": 0.0, "messages": 0}
 
 
-def parse_transcript(path: Path, pricing: dict) -> dict:
-    """Aggregate transcript usage by model and by thread (main vs subagent).
+def _accumulate_lines(
+    lines,
+    pricing: dict,
+    by_model: dict,
+    by_thread: dict,
+    totals: dict,
+    unpriced_models: set,
+) -> None:
+    """Fold `lines` (raw JSONL transcript records) into the given aggregates.
 
-    Only dimensions the harness actually records are attributed (#170): the
-    model (`message.model`) and the main/subagent split (native top-level
-    `isSidechain`), plus the session total.
+    Mutates `by_model`, `by_thread`, `totals`, and `unpriced_models` in place
+    so callers can seed them from a persisted running state and only pass in
+    the newly-appended lines (#732) — or seed them empty and pass the whole
+    transcript for a one-shot full parse.
     """
-    by_model: dict[str, dict] = {}
-    by_thread: dict[str, dict] = {}
-    totals = _new_bucket()
-    unpriced_models: set[str] = set()
-
-    for line in path.read_text().splitlines():
+    for line in lines:
         line = line.strip()
         if not line:
             continue
@@ -168,8 +272,40 @@ def parse_transcript(path: Path, pricing: dict) -> dict:
         totals["cost_usd"] = round(totals["cost_usd"] + cost, 6)
         totals["messages"] += 1
 
-    return {"by_model": by_model, "by_thread": by_thread,
-            "totals": totals, "unpriced_models": sorted(unpriced_models)}
+
+def parse_transcript(path: Path, pricing: dict) -> dict:
+    """Aggregate transcript usage by model and by thread (main vs subagent).
+
+    Only dimensions the harness actually records are attributed (#170): the
+    model (`message.model`) and the main/subagent split (native top-level
+    `isSidechain`), plus the session total.
+
+    Full one-shot parse — used by `report`/`regression`/`pace`, which run
+    on-demand rather than once per hook fire. `record` (the Stop-hook hot
+    path) uses the incremental `_read_new_lines` + `_accumulate_lines` path
+    in `cmd_record` instead so it doesn't re-parse the whole transcript on
+    every turn (#732).
+    """
+    by_model: dict[str, dict] = {}
+    by_thread: dict[str, dict] = {}
+    totals = _new_bucket()
+    unpriced_models: set[str] = set()
+
+    _accumulate_lines(
+        path.read_text().splitlines(),
+        pricing,
+        by_model,
+        by_thread,
+        totals,
+        unpriced_models,
+    )
+
+    return {
+        "by_model": by_model,
+        "by_thread": by_thread,
+        "totals": totals,
+        "unpriced_models": sorted(unpriced_models),
+    }
 
 
 def _print_dimension(title: str, bucket: dict) -> None:
@@ -178,8 +314,10 @@ def _print_dimension(title: str, bucket: dict) -> None:
     print(f"\n{title:<28} {'IN':>10} {'OUT':>10} {'COST $':>10}")
     print("-" * 60)
     for key, b in sorted(bucket.items(), key=lambda kv: -kv[1]["cost_usd"]):
-        print(f"{key:<28} {b['input_tokens']:>10} {b['output_tokens']:>10} "
-              f"{b['cost_usd']:>10.4f}")
+        print(
+            f"{key:<28} {b['input_tokens']:>10} {b['output_tokens']:>10} "
+            f"{b['cost_usd']:>10.4f}"
+        )
 
 
 def _print_report(summary: dict) -> None:
@@ -188,11 +326,15 @@ def _print_report(summary: dict) -> None:
     _print_dimension("MODEL", summary["by_model"])
     _print_dimension("THREAD (main/subagent)", summary["by_thread"])
     print("-" * 60)
-    print(f"{'TOTAL':<28} {t['input_tokens']:>10} {t['output_tokens']:>10} "
-          f"{t['cost_usd']:>10.4f}")
+    print(
+        f"{'TOTAL':<28} {t['input_tokens']:>10} {t['output_tokens']:>10} "
+        f"{t['cost_usd']:>10.4f}"
+    )
     if summary["unpriced_models"]:
-        print(f"\n⚠ no pricing for: {', '.join(summary['unpriced_models'])} "
-              f"(add to knowledge/model-pricing.json)")
+        print(
+            f"\n⚠ no pricing for: {', '.join(summary['unpriced_models'])} "
+            f"(add to knowledge/model-pricing.json)"
+        )
 
 
 def cmd_report(args, pricing) -> int:
@@ -208,13 +350,63 @@ def cmd_record(args, pricing) -> int:
     tpath = Path(args.transcript)
     if not tpath.is_file():
         return 0  # fail-open: hook must never break the session
-    summary = parse_transcript(tpath, pricing)
+
+    # Incremental read (#732): persist a byte offset + the running aggregates
+    # in a tmp-state file keyed by the transcript path, so this Stop-hook fire
+    # only tails bytes appended since the last fire instead of re-parsing the
+    # whole transcript every time (O(new content), not O(turns) per fire).
+    state_dir = _state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    _purge_stale(state_dir)
+    state_file = _state_file(tpath)
+
+    state = _load_state(state_file)
+    size = tpath.stat().st_size
+
+    prior_offset = state.get("offset") if state else None
+    if (
+        state is not None
+        and isinstance(prior_offset, int)
+        and 0 <= prior_offset <= size
+    ):
+        offset = prior_offset
+        by_model = state.get("by_model") or {}
+        by_thread = state.get("by_thread") or {}
+        totals = state.get("totals") or _new_bucket()
+        for f in _TOKEN_FIELDS:
+            totals.setdefault(f, 0)
+        totals.setdefault("cost_usd", 0.0)
+        totals.setdefault("messages", 0)
+        unpriced_models = set(state.get("unpriced_models") or [])
+    else:
+        # First fire, or the transcript shrank (rotated/truncated) since the
+        # last fire — start fresh rather than seek past a stale offset.
+        offset = 0
+        by_model, by_thread, totals, unpriced_models = {}, {}, _new_bucket(), set()
+
+    new_offset, new_lines = _read_new_lines(tpath, offset)
+    _accumulate_lines(new_lines, pricing, by_model, by_thread, totals, unpriced_models)
+
+    _save_state(state_file, new_offset, by_model, by_thread, totals, unpriced_models)
+
+    summary = {
+        "by_model": by_model,
+        "by_thread": by_thread,
+        "totals": totals,
+        "unpriced_models": sorted(unpriced_models),
+    }
+
     from datetime import datetime, timezone
+
     def _slim(bucket: dict) -> dict:
-        return {k: {"cost_usd": b["cost_usd"],
-                    "input_tokens": b["input_tokens"],
-                    "output_tokens": b["output_tokens"]}
-                for k, b in bucket.items()}
+        return {
+            k: {
+                "cost_usd": b["cost_usd"],
+                "input_tokens": b["input_tokens"],
+                "output_tokens": b["output_tokens"],
+            }
+            for k, b in bucket.items()
+        }
 
     line = {
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -257,8 +449,10 @@ def cmd_regression(args, pricing) -> int:
     mean = sum(prior) / len(prior)
     limit = mean * (1 + args.tolerance)
     win_label = f"window {len(prior)}" if window > 0 else f"prior {len(prior)}"
-    print(f"latest=${latest:.4f}  rolling-mean({win_label})=${mean:.4f}  "
-          f"limit(+{int(args.tolerance*100)}%)=${limit:.4f}")
+    print(
+        f"latest=${latest:.4f}  rolling-mean({win_label})=${mean:.4f}  "
+        f"limit(+{int(args.tolerance * 100)}%)=${limit:.4f}"
+    )
     if mean > 0 and latest > limit:
         print(f"COST REGRESSION: latest ${latest:.4f} exceeds limit ${limit:.4f}")
         return 1
@@ -268,6 +462,7 @@ def cmd_regression(args, pricing) -> int:
 
 def _parse_ts(s: str):
     from datetime import datetime, timezone
+
     try:
         return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
     except (ValueError, TypeError):
@@ -278,6 +473,7 @@ def cmd_pace(args, pricing) -> int:
     """Account-level pace: cumulative spend over a rolling window, projected
     against a budget for a billing period; flags when pace would exhaust it."""
     from datetime import datetime, timezone, timedelta
+
     log = Path(args.log)
     if not log.is_file():
         print("no metrics log yet; nothing to pace")
@@ -310,20 +506,28 @@ def cmd_pace(args, pricing) -> int:
     elapsed_days = max((now - earliest).total_seconds() / 86400.0, 1e-9)
     daily_rate = spend / elapsed_days
     projected = daily_rate * args.period_days
-    print(f"  daily rate:         ${daily_rate:.4f}/day "
-          f"(over {elapsed_days:.2f} active day(s))")
+    print(
+        f"  daily rate:         ${daily_rate:.4f}/day "
+        f"(over {elapsed_days:.2f} active day(s))"
+    )
     print(f"  projected / {args.period_days}d:   ${projected:.4f}")
 
     if args.budget is not None and args.budget > 0:
         pct = projected / args.budget * 100
-        print(f"  budget / {args.period_days}d:       ${args.budget:.2f} "
-              f"({pct:.0f}% of budget at current pace)")
+        print(
+            f"  budget / {args.period_days}d:       ${args.budget:.2f} "
+            f"({pct:.0f}% of budget at current pace)"
+        )
         if projected > args.budget:
-            print(f"\n⚠ PACE EXCEEDS BUDGET: at ${daily_rate:.4f}/day you would "
-                  f"spend ${projected:.2f} over {args.period_days} days, past the "
-                  f"${args.budget:.2f} budget.")
-            print("  Consider dropping Opus→Sonnet for the remainder of the "
-                  "window (see .claude/model-overrides.json / /harness-audit).")
+            print(
+                f"\n⚠ PACE EXCEEDS BUDGET: at ${daily_rate:.4f}/day you would "
+                f"spend ${projected:.2f} over {args.period_days} days, past the "
+                f"${args.budget:.2f} budget."
+            )
+            print(
+                "  Consider dropping Opus→Sonnet for the remainder of the "
+                "window (see .claude/model-overrides.json / /harness-audit)."
+            )
     return 0
 
 
@@ -332,27 +536,50 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--pricing", default=str(_DEFAULT_PRICING))
     sub = ap.add_subparsers(dest="cmd", required=True)
 
-    p = sub.add_parser("report"); p.add_argument("--transcript", required=True)
+    p = sub.add_parser("report")
+    p.add_argument("--transcript", required=True)
     p.add_argument("--json", action="store_true")
-    p = sub.add_parser("record"); p.add_argument("--transcript", required=True)
+    p = sub.add_parser("record")
+    p.add_argument("--transcript", required=True)
     p.add_argument("--log", default="metrics/cost-metering.jsonl")
-    p = sub.add_parser("regression"); p.add_argument("--log", default="metrics/cost-metering.jsonl")
+    p = sub.add_parser("regression")
+    p.add_argument("--log", default="metrics/cost-metering.jsonl")
     p.add_argument("--tolerance", type=float, default=0.5)
-    p.add_argument("--window", type=int, default=0,
-                   help="baseline = mean of the N most recent prior sessions "
-                        "(0 = all-time mean)")
-    p = sub.add_parser("pace"); p.add_argument("--log", default="metrics/cost-metering.jsonl")
-    p.add_argument("--budget", type=float, default=None,
-                   help="account budget for one billing period (dollars)")
-    p.add_argument("--period-days", type=int, default=30,
-                   help="length of the billing period to project against")
-    p.add_argument("--window-days", type=int, default=7,
-                   help="rolling lookback used to estimate the current daily rate")
+    p.add_argument(
+        "--window",
+        type=int,
+        default=0,
+        help="baseline = mean of the N most recent prior sessions (0 = all-time mean)",
+    )
+    p = sub.add_parser("pace")
+    p.add_argument("--log", default="metrics/cost-metering.jsonl")
+    p.add_argument(
+        "--budget",
+        type=float,
+        default=None,
+        help="account budget for one billing period (dollars)",
+    )
+    p.add_argument(
+        "--period-days",
+        type=int,
+        default=30,
+        help="length of the billing period to project against",
+    )
+    p.add_argument(
+        "--window-days",
+        type=int,
+        default=7,
+        help="rolling lookback used to estimate the current daily rate",
+    )
 
     args = ap.parse_args(argv)
     pricing = _load_pricing(Path(args.pricing))
-    return {"report": cmd_report, "record": cmd_record,
-            "regression": cmd_regression, "pace": cmd_pace}[args.cmd](args, pricing)
+    return {
+        "report": cmd_report,
+        "record": cmd_record,
+        "regression": cmd_regression,
+        "pace": cmd_pace,
+    }[args.cmd](args, pricing)
 
 
 if __name__ == "__main__":

--- a/plugins/dev-team/hooks/lib/verify_guard_state.py
+++ b/plugins/dev-team/hooks/lib/verify_guard_state.py
@@ -25,9 +25,15 @@ import json
 import os
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 _STATE_DIRNAME = "dev-team-verify-guard"
+
+# Same TTL-purge-on-write pattern as tdd_guard.py / mutation_adapters/lib.py
+# (#732) — one state file is written per session with no expiry otherwise,
+# so long-lived hosts accumulate a file per session forever.
+_STATE_TTL_SECONDS = 14400  # 4 hours
 
 
 def cksum(text: str) -> str:
@@ -78,11 +84,31 @@ def read_state(path: Path) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def purge_stale(directory: Path) -> None:
+    """Delete `*.json` state files in `directory` untouched past the TTL.
+
+    Both verify_guard.py and verify_guard_edit_marker.py write through
+    `write_state`, so calling this there is the single choke point that
+    keeps the shared state dir from accumulating one file per session
+    forever (#732).
+    """
+    if not directory.is_dir():
+        return
+    now = time.time()
+    for path in directory.glob("*.json"):
+        try:
+            if now - path.stat().st_mtime > _STATE_TTL_SECONDS:
+                path.unlink()
+        except OSError:
+            pass
+
+
 def write_state(path: Path, data: dict) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
         return
+    purge_stale(path.parent)
     try:
         path.write_text(json.dumps(data, separators=(",", ":")) + "\n")
     except OSError:

--- a/plugins/dev-team/hooks/session_model_banner.py
+++ b/plugins/dev-team/hooks/session_model_banner.py
@@ -201,6 +201,19 @@ def _render_banner(session_model: str, session_known: bool, reused: bool) -> str
 
 
 def _notify_pending_findings(cwd: str) -> Optional[str]:
+    """Count still-pending entries in the pending-review queue, rotating out
+    disposed ones so the file stays bounded (#732).
+
+    A finding gains exactly one disposition (`reviewed_at` on approval,
+    `rejected_at` on rejection — see feedback-learning/SKILL.md); once either
+    is present, its audit trail lives in metrics/config-changelog.jsonl (on
+    approval) and the entry itself has no further use here. Rewriting the
+    queue to drop disposed entries every SessionStart keeps it bounded to the
+    outstanding backlog instead of growing without limit across the life of
+    a project. Lines that fail to parse can't be classified either way, so
+    they are left untouched — /session-review handles malformed-line
+    reporting on its own.
+    """
     queue_env = os.environ.get("PENDING_REVIEW_FILE")
     queue = (
         Path(queue_env) if queue_env else Path(cwd) / "metrics" / "pending-review.jsonl"
@@ -212,17 +225,39 @@ def _notify_pending_findings(cwd: str) -> Optional[str]:
             lines = fh.readlines()
     except OSError:
         return None
+
+    kept_lines: List[str] = []
+    dropped_any = False
     count = 0
-    for line in lines:
-        line = line.strip()
+    for raw_line in lines:
+        line = raw_line.strip()
         if not line:
+            dropped_any = True
             continue
         try:
             entry = json.loads(line)
         except (json.JSONDecodeError, ValueError):
+            # Can't classify — keep it as-is rather than silently losing it.
+            kept_lines.append(line)
             continue
-        if isinstance(entry, dict) and "reviewed_at" not in entry:
+        if isinstance(entry, dict) and (
+            "reviewed_at" in entry or "rejected_at" in entry
+        ):
+            # Disposed — rotate it out of the queue.
+            dropped_any = True
+            continue
+        if isinstance(entry, dict):
             count += 1
+        kept_lines.append(line)
+
+    if dropped_any:
+        try:
+            queue.write_text(
+                "".join(f"{line}\n" for line in kept_lines), encoding="utf-8"
+            )
+        except OSError:
+            pass
+
     if count <= 0:
         return None
     return (

--- a/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
+++ b/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
@@ -19,6 +19,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -221,6 +222,31 @@ def test_missing_session_id_falls_back_to_cwd_hash(tmp_path: Path) -> None:
 
 
 # --- whitespace normalization ---------------------------------------------
+
+
+def test_purges_stale_state_files_older_than_ttl(tmp_path: Path) -> None:
+    """State files never got a TTL purge (unlike tdd_guard.py/
+    mutation_adapters/lib.py's `_purge_stale`) — old per-session state files
+    accumulated in $TMPDIR/dev-team-bash-retry forever."""
+    state_dir = tmp_path / "dev-team-bash-retry"
+    state_dir.mkdir(parents=True)
+
+    stale = state_dir / "old-session.json"
+    stale.write_text('{"hash":"deadbeef","count":1}')
+    old_time = time.time() - (241 * 60)  # just over a 4h TTL
+    os.utime(stale, (old_time, old_time))
+
+    fresh = state_dir / "recent-session.json"
+    fresh.write_text('{"hash":"cafef00d","count":1}')
+
+    _run(
+        {"session_id": "sess-purge", "tool_input": {"command": "curl example.com"}},
+        env={},
+        tmpdir=tmp_path,
+    )
+
+    assert not stale.exists(), "stale state file should be purged on write"
+    assert fresh.exists(), "recently-touched state file should survive purge"
 
 
 def test_whitespace_variations_hash_identically(tmp_path: Path) -> None:

--- a/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
+++ b/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
@@ -1,0 +1,217 @@
+"""Unit tests for hooks/lib/cost_meter.py's `record` path (issue #732 Fix A).
+
+`cmd_record` is invoked once per Stop/SubagentStop hook fire over the life of
+a session. Before this fix it called `parse_transcript()`, which re-reads and
+re-parses the *entire* transcript file from byte 0 on every single fire —
+O(turns) work repeated O(turns) times over a long session.
+
+This suite proves the fix: `cmd_record` now persists a byte offset (plus the
+running per-model/per-thread aggregates) in a tmp-state file keyed by the
+transcript path, and only tails bytes appended since the last fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"))
+
+import cost_meter  # noqa: E402
+
+
+_PRICING = {
+    "cache_write_multiplier": 1.25,
+    "cache_read_multiplier": 0.1,
+    "models": {
+        "claude-x": {"input": 3.0, "output": 15.0},
+    },
+    "aliases": {},
+}
+
+
+def _usage_line(
+    model: str, input_tokens: int, output_tokens: int, sidechain: bool = False
+) -> str:
+    rec = {
+        "message": {
+            "model": model,
+            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+        },
+    }
+    if sidechain:
+        rec["isSidechain"] = True
+    return json.dumps(rec) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# _read_new_lines — the bounded tail-read primitive
+# ---------------------------------------------------------------------------
+
+
+def test_read_new_lines_returns_nothing_past_eof(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text("line-one\nline-two\n")
+    offset = p.stat().st_size
+    new_offset, lines = cost_meter._read_new_lines(p, offset)
+    assert lines == []
+    assert new_offset == offset
+
+
+def test_read_new_lines_only_returns_content_after_offset(tmp_path):
+    """Proves the read is bounded to new bytes, not a full re-read from 0."""
+    p = tmp_path / "t.jsonl"
+    p.write_text("line-one\nline-two\n")
+    offset = p.stat().st_size
+    with p.open("a") as fh:
+        fh.write("line-three\n")
+    new_offset, lines = cost_meter._read_new_lines(p, offset)
+    # If this had re-read from byte 0, line-one/line-two would show up too.
+    assert lines == ["line-three"]
+    assert new_offset == p.stat().st_size
+
+
+def test_read_new_lines_keeps_partial_trailing_line_unconsumed(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text("complete\n")
+    with p.open("a") as fh:
+        fh.write("partial-no-newline-yet")
+    new_offset, lines = cost_meter._read_new_lines(p, 0)
+    assert lines == ["complete"]
+    assert new_offset == len("complete\n".encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# cmd_record — persists offset + aggregates, only tails new content
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermetic_cost_meter(tmp_path, monkeypatch):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    yield tmp_path
+
+
+def test_cmd_record_persists_byte_offset_state(hermetic_cost_meter):
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(_usage_line("claude-x", 100, 50))
+
+    args = SimpleNamespace(transcript=str(transcript), log=str(log))
+    cost_meter.cmd_record(args, _PRICING)
+
+    state_file = cost_meter._state_file(transcript)
+    assert state_file.is_file()
+    state = json.loads(state_file.read_text())
+    assert state["offset"] == transcript.stat().st_size
+
+
+def test_cmd_record_second_fire_only_tails_new_content(
+    hermetic_cost_meter, monkeypatch
+):
+    """The core bounded-read contract: on the 2nd fire, `_read_new_lines` must
+    be called with the offset left off at, never 0 — i.e. it must not re-scan
+    content already accounted for."""
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(_usage_line("claude-x", 100, 50))
+
+    args = SimpleNamespace(transcript=str(transcript), log=str(log))
+    cost_meter.cmd_record(args, _PRICING)
+    offset_after_first = transcript.stat().st_size
+
+    with transcript.open("a") as fh:
+        fh.write(_usage_line("claude-x", 200, 75))
+
+    seen_offsets = []
+    real_read_new_lines = cost_meter._read_new_lines
+
+    def _spy(path, offset):
+        seen_offsets.append(offset)
+        return real_read_new_lines(path, offset)
+
+    monkeypatch.setattr(cost_meter, "_read_new_lines", _spy)
+    cost_meter.cmd_record(args, _PRICING)
+
+    assert seen_offsets == [offset_after_first]
+
+
+def test_cmd_record_across_two_fires_matches_full_reparse(hermetic_cost_meter):
+    """Correctness: cumulative totals recorded incrementally must equal a
+    from-scratch full parse of the final transcript."""
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(_usage_line("claude-x", 100, 50))
+
+    args = SimpleNamespace(transcript=str(transcript), log=str(log))
+    cost_meter.cmd_record(args, _PRICING)
+
+    with transcript.open("a") as fh:
+        fh.write(_usage_line("claude-x", 200, 75, sidechain=True))
+        fh.write(_usage_line("claude-x", 10, 5))
+
+    cost_meter.cmd_record(args, _PRICING)
+
+    logged_lines = log.read_text().splitlines()
+    assert len(logged_lines) == 2
+    last = json.loads(logged_lines[-1])
+
+    expected = cost_meter.parse_transcript(transcript, _PRICING)
+    assert last["total"]["input_tokens"] == expected["totals"]["input_tokens"]
+    assert last["total"]["output_tokens"] == expected["totals"]["output_tokens"]
+    assert last["total"]["cost_usd"] == expected["totals"]["cost_usd"]
+
+
+def test_cmd_record_resets_when_transcript_shrinks(hermetic_cost_meter):
+    """A truncated/rotated transcript (offset > new size) must reset from
+    scratch rather than seek past EOF."""
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(_usage_line("claude-x", 100, 50) * 5)
+
+    args = SimpleNamespace(transcript=str(transcript), log=str(log))
+    cost_meter.cmd_record(args, _PRICING)
+
+    # Simulate rotation: transcript replaced by a smaller fresh file.
+    transcript.write_text(_usage_line("claude-x", 10, 5))
+    cost_meter.cmd_record(args, _PRICING)
+
+    logged_lines = log.read_text().splitlines()
+    last = json.loads(logged_lines[-1])
+    assert last["total"]["input_tokens"] == 10
+    assert last["total"]["output_tokens"] == 5
+
+
+# ---------------------------------------------------------------------------
+# _purge_stale — TTL purge for the new cost-meter state dir
+# ---------------------------------------------------------------------------
+
+
+def test_purge_stale_removes_old_state_but_keeps_fresh(hermetic_cost_meter):
+    tmp_path = hermetic_cost_meter
+    state_dir = cost_meter._state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    stale = state_dir / "session-aaaaaaaaaaaa.json"
+    stale.write_text("{}")
+    old_time = time.time() - cost_meter._STATE_TTL_SECONDS - 60
+    os.utime(stale, (old_time, old_time))
+
+    fresh = state_dir / "session-bbbbbbbbbbbb.json"
+    fresh.write_text("{}")
+
+    cost_meter._purge_stale(state_dir)
+
+    assert not stale.exists()
+    assert fresh.exists()

--- a/plugins/dev-team/tests/hooks/test_session_model_banner.py
+++ b/plugins/dev-team/tests/hooks/test_session_model_banner.py
@@ -1,0 +1,132 @@
+"""Unit tests for hooks/session_model_banner.py's pending-review queue notice
+(issue #732 Fix C).
+
+`_notify_pending_findings` used to read the *entire* unbounded
+`metrics/pending-review.jsonl` on every SessionStart with no cap or rotation
+on the underlying queue file — so a queue that accumulates disposed
+(reviewed/rejected) findings over months of sessions gets slower to scan on
+every single session start, forever.
+
+This suite proves the fix: disposed entries (those carrying `reviewed_at` or
+`rejected_at`) are rotated out of the queue file each time it's scanned, so
+the file stays bounded to the outstanding backlog instead of growing without
+limit.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).resolve().parents[2] / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import session_model_banner as hook  # noqa: E402
+
+
+def _entry(**kwargs) -> str:
+    base = {
+        "queued_at": "2026-06-01T12:00:00Z",
+        "source": "session-learning-trigger",
+        "session_id": "abc-123",
+        "findings": [{"lever": "instruction-rule"}],
+    }
+    base.update(kwargs)
+    return json.dumps(base)
+
+
+def test_returns_none_when_queue_file_absent(tmp_path):
+    assert hook._notify_pending_findings(str(tmp_path)) is None
+
+
+def test_returns_none_when_no_unreviewed_entries(tmp_path):
+    metrics = tmp_path / "metrics"
+    metrics.mkdir()
+    queue = metrics / "pending-review.jsonl"
+    queue.write_text(_entry(reviewed_at="2026-06-02T09:00:00Z") + "\n")
+
+    assert hook._notify_pending_findings(str(tmp_path)) is None
+
+
+def test_counts_unreviewed_entries(tmp_path):
+    metrics = tmp_path / "metrics"
+    metrics.mkdir()
+    queue = metrics / "pending-review.jsonl"
+    queue.write_text(_entry(session_id="a") + "\n" + _entry(session_id="b") + "\n")
+
+    notice = hook._notify_pending_findings(str(tmp_path))
+    assert notice is not None
+    assert "2 queued finding(s)" in notice
+
+
+def test_rotates_out_disposed_entries(tmp_path):
+    """Reviewed/rejected entries must be dropped from the queue file so it
+    doesn't grow without bound; still-pending entries are preserved."""
+    metrics = tmp_path / "metrics"
+    metrics.mkdir()
+    queue = metrics / "pending-review.jsonl"
+    queue.write_text(
+        _entry(session_id="reviewed", reviewed_at="2026-06-02T09:00:00Z")
+        + "\n"
+        + _entry(session_id="rejected", rejected_at="2026-06-02T09:00:00Z")
+        + "\n"
+        + _entry(session_id="pending")
+        + "\n"
+    )
+
+    notice = hook._notify_pending_findings(str(tmp_path))
+    assert notice is not None
+    assert "1 queued finding(s)" in notice
+
+    remaining = [json.loads(l) for l in queue.read_text().splitlines() if l.strip()]
+    assert len(remaining) == 1
+    assert remaining[0]["session_id"] == "pending"
+
+
+def test_rotation_keeps_file_bounded_across_repeated_session_starts(tmp_path):
+    """After rotation, re-scanning the queue must not keep re-processing the
+    already-disposed history — the file itself shrinks."""
+    metrics = tmp_path / "metrics"
+    metrics.mkdir()
+    queue = metrics / "pending-review.jsonl"
+    disposed = "\n".join(
+        _entry(session_id=f"done-{i}", reviewed_at="2026-06-02T09:00:00Z")
+        for i in range(50)
+    )
+    queue.write_text(disposed + "\n" + _entry(session_id="still-pending") + "\n")
+
+    size_before = queue.stat().st_size
+    hook._notify_pending_findings(str(tmp_path))
+    size_after = queue.stat().st_size
+
+    assert size_after < size_before
+    remaining = [json.loads(l) for l in queue.read_text().splitlines() if l.strip()]
+    assert len(remaining) == 1
+    assert remaining[0]["session_id"] == "still-pending"
+
+
+def test_malformed_lines_are_preserved_not_silently_dropped(tmp_path):
+    """Lines that fail to parse can't be classified as disposed or pending —
+    rotation must not destroy them; leave them for /session-review's own
+    malformed-line handling."""
+    metrics = tmp_path / "metrics"
+    metrics.mkdir()
+    queue = metrics / "pending-review.jsonl"
+    queue.write_text("not-json-at-all\n" + _entry(session_id="pending") + "\n")
+
+    hook._notify_pending_findings(str(tmp_path))
+
+    remaining = queue.read_text().splitlines()
+    assert "not-json-at-all" in remaining
+
+
+def test_respects_pending_review_file_env_override(tmp_path, monkeypatch):
+    custom = tmp_path / "custom-queue.jsonl"
+    custom.write_text(_entry() + "\n")
+    monkeypatch.setenv("PENDING_REVIEW_FILE", str(custom))
+
+    notice = hook._notify_pending_findings(str(tmp_path))
+    assert notice is not None
+    assert "1 queued finding(s)" in notice

--- a/plugins/dev-team/tests/hooks/test_verify_guard_state.py
+++ b/plugins/dev-team/tests/hooks/test_verify_guard_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from pathlib import Path
 
 _HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"
@@ -55,3 +56,47 @@ def test_read_state_malformed_json_returns_empty_dict(tmp_path: Path) -> None:
 def test_cksum_deterministic_for_same_input() -> None:
     assert vgs.cksum("npm test") == vgs.cksum("npm test")
     assert vgs.cksum("npm test") != vgs.cksum("pytest -q")
+
+
+# ---------------------------------------------------------------------------
+# purge_stale — TTL purge on write (#732)
+#
+# verify_guard.py / verify_guard_edit_marker.py each write one state file per
+# session with no expiry, unlike tdd_guard.py / mutation_adapters/lib.py's
+# `_purge_stale`. Both hooks write through `write_state`, so the purge lives
+# there as the single choke point.
+# ---------------------------------------------------------------------------
+
+
+def test_purge_stale_removes_old_files_but_keeps_fresh(tmp_path: Path) -> None:
+    state_dir = tmp_path / "dev-team-verify-guard"
+    state_dir.mkdir(parents=True)
+
+    stale = state_dir / "old-session.json"
+    stale.write_text("{}")
+    old_time = time.time() - vgs._STATE_TTL_SECONDS - 60
+    os.utime(stale, (old_time, old_time))
+
+    fresh = state_dir / "recent-session.json"
+    fresh.write_text("{}")
+
+    vgs.purge_stale(state_dir)
+
+    assert not stale.exists()
+    assert fresh.exists()
+
+
+def test_write_state_purges_stale_sibling_state_files(tmp_path: Path) -> None:
+    """The TTL purge fires on every write_state call, not just on request."""
+    state_dir = tmp_path / "dev-team-verify-guard"
+    state_dir.mkdir(parents=True)
+
+    stale = state_dir / "old-session.json"
+    stale.write_text('{"hash":"x","count":1}')
+    old_time = time.time() - vgs._STATE_TTL_SECONDS - 60
+    os.utime(stale, (old_time, old_time))
+
+    vgs.write_state(state_dir / "new-session.json", {"hash": "y", "count": 1})
+
+    assert not stale.exists()
+    assert (state_dir / "new-session.json").exists()


### PR DESCRIPTION
## Summary

Three Medium-severity performance/hygiene fixes in `plugins/dev-team/hooks/`:

- **cost_meter.py** (`hooks/lib/cost_meter.py`): the Stop/SubagentStop `record` path re-read and re-parsed the *entire* session transcript on every hook fire — O(turns) work repeated O(turns) times over a long session, unlike sibling hooks (`context_ceiling_guard.py`, `codegraph_turn_mark.py`) which tail a bounded window. Now persists a byte offset + running per-model/per-thread aggregates in a tmp-state file keyed by the transcript path, so each fire only tails bytes appended since the last one. `report`/`regression`/`pace` keep the full one-shot parse since they run on-demand, not once per turn.
- **bash_retry_guard.py** / **verify_guard.py**: each writes one tmp-state file per session with no TTL purge, unlike `tdd_guard.py` / `mutation_adapters/lib.py`'s existing `_purge_stale`. Added the same TTL-purge-on-write pattern (4h TTL) to both.
- **session_model_banner.py**: `_notify_pending_findings` read the entire unbounded `pending-review.jsonl` on every SessionStart with no cap or rotation. Now rotates disposed entries (`reviewed_at`/`rejected_at` present) out of the queue file on each scan, keeping it bounded to the outstanding backlog. Unparseable lines are left untouched rather than silently dropped.

## Test plan

- [x] TDD: each fix has a new/adjusted pytest that fails against the pre-fix code and passes after
- [x] `python3 -m pytest plugins/dev-team/tests/ -q` — 567 passed
- [x] `python3 -m pytest tests/ -q` (repo-root suite) — 1423 passed
- [x] `bash scripts/ci-local.sh` — all checks pass except `eslint`, which fails identically on a clean checkout of this worktree with no `npm install` run (missing `node_modules`/`@eslint/js`) — unrelated to this Python-only diff; CI's own `npm ci` step covers this.

Part of #732