### PR TITLE
refactor(mutation-adapters): dedupe first-changed-source-file lookup

### DIFF
--- a/plugins/dev-team/hooks/mutation_adapters/lib.py
+++ b/plugins/dev-team/hooks/mutation_adapters/lib.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +325,39 @@ def detect_adapter(command: str) -> str:
                 return "mutmut"
         return "none"
     return "none"
+
+
+# ---------------------------------------------------------------------------
+# First changed source file — shared by pitest / stryker-net / mutmut adapters
+#
+# Each adapter needs "the first non-test source file touched by this change"
+# to scope its mutation run (target class, --mutate pattern, --paths-to-mutate).
+# The traversal (git diff --name-only HEAD, falling back to --cached) is
+# identical across adapters; only the extension set and test-name exclusion
+# differ, so those are supplied as a single predicate.
+# ---------------------------------------------------------------------------
+
+
+def first_changed_file(is_source_predicate: Callable[[str], bool]) -> str:
+    """Return the first changed file for which `is_source_predicate` is True.
+
+    Checks `git diff --name-only HEAD` first, then falls back to
+    `git diff --cached --name-only` (mirrors the bash adapters' behaviour of
+    preferring unstaged/working-tree changes over already-staged ones).
+    Returns "" when git is unavailable or no line satisfies the predicate.
+    """
+    for cmd in (
+        ["git", "diff", "--name-only", "HEAD"],
+        ["git", "diff", "--cached", "--name-only"],
+    ):
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        except (FileNotFoundError, OSError):
+            return ""
+        for line in proc.stdout.splitlines():
+            if is_source_predicate(line):
+                return line
+    return ""
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/hooks/mutation_adapters/mutmut.py
+++ b/plugins/dev-team/hooks/mutation_adapters/mutmut.py
@@ -56,22 +56,17 @@ def _derive_python_source(test_file: str) -> str:
     return test_file
 
 
+def _is_python_source(line: str) -> bool:
+    """True for a non-test Python source path."""
+    if not line.endswith(".py"):
+        return False
+    if line.startswith("test_") or "_test.py" in line or "/test_" in line:
+        return False
+    return True
+
+
 def _changed_python_source() -> str:
-    for cmd in (
-        ["git", "diff", "--name-only", "HEAD"],
-        ["git", "diff", "--cached", "--name-only"],
-    ):
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        except (FileNotFoundError, OSError):
-            return ""
-        for line in proc.stdout.splitlines():
-            if not line.endswith(".py"):
-                continue
-            if line.startswith("test_") or "_test.py" in line or "/test_" in line:
-                continue
-            return line
-    return ""
+    return lib.first_changed_file(_is_python_source)
 
 
 def _mutmut_argv() -> List[str]:

--- a/plugins/dev-team/hooks/mutation_adapters/pitest.py
+++ b/plugins/dev-team/hooks/mutation_adapters/pitest.py
@@ -95,23 +95,18 @@ def _is_gradle() -> bool:
     )
 
 
+def _is_pitest_source(line: str) -> bool:
+    """True for a non-test Java/Kotlin/Groovy/Scala source path."""
+    if not re.search(r"\.(java|kt|groovy|scala)$", line):
+        return False
+    if "Test" in line or "Spec" in line:
+        return False
+    return True
+
+
 def _changed_source_file() -> str:
     """Return the first non-test Java/Kotlin/Groovy/Scala file from git diff."""
-    for cmd in (
-        ["git", "diff", "--name-only", "HEAD"],
-        ["git", "diff", "--cached", "--name-only"],
-    ):
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        except (FileNotFoundError, OSError):
-            return ""
-        for line in proc.stdout.splitlines():
-            if not re.search(r"\.(java|kt|groovy|scala)$", line):
-                continue
-            if "Test" in line or "Spec" in line:
-                continue
-            return line
-    return ""
+    return lib.first_changed_file(_is_pitest_source)
 
 
 def _extract_test_class(command: str) -> str:

--- a/plugins/dev-team/hooks/mutation_adapters/stryker_net.py
+++ b/plugins/dev-team/hooks/mutation_adapters/stryker_net.py
@@ -82,23 +82,18 @@ def _shard_for_file(changed_file: str) -> Optional[Path]:
     return None
 
 
+def _is_cs_source(line: str) -> bool:
+    """True for a non-test C# source path."""
+    if not line.endswith(".cs"):
+        return False
+    if "Test" in line or "Spec" in line:
+        return False
+    return True
+
+
 def _changed_cs_file() -> str:
     """Return the newest non-test C# file changed in HEAD (or cached), or ''."""
-    for cmd in (
-        ["git", "diff", "--name-only", "HEAD"],
-        ["git", "diff", "--cached", "--name-only"],
-    ):
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        except (FileNotFoundError, OSError):
-            return ""
-        for line in proc.stdout.splitlines():
-            if not line.endswith(".cs"):
-                continue
-            if "Test" in line or "Spec" in line:
-                continue
-            return line
-    return ""
+    return lib.first_changed_file(_is_cs_source)
 
 
 def stryker_net_run(output_file: Path) -> int:

--- a/plugins/dev-team/tests/hooks/test_mutation_adapters_changed_file.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_adapters_changed_file.py
@@ -1,0 +1,134 @@
+"""Unit tests for the shared `lib.first_changed_file` helper and its three
+adapter callers (pitest, stryker_net, mutmut) — dedup of the "find first
+changed non-test source file via git diff" logic that used to be copy-pasted
+three times with only the extension set and test-name predicate varying.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[4] / "plugins" / "dev-team" / "hooks")
+)
+
+from mutation_adapters import lib, mutmut, pitest, stryker_net  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# lib.first_changed_file — the shared helper
+# ---------------------------------------------------------------------------
+
+
+def test_first_changed_file_returns_first_predicate_match(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):  # noqa: ARG001
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="FooTest.java\nFoo.java\n", stderr=""
+        )
+
+    monkeypatch.setattr(lib.subprocess, "run", fake_run)
+    result = lib.first_changed_file(lambda line: line == "Foo.java")
+    assert result == "Foo.java"
+
+
+def test_first_changed_file_falls_back_to_cached_diff(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, capture_output, text, check):  # noqa: ARG001
+        calls.append(cmd)
+        if "--cached" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="Bar.py\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(lib.subprocess, "run", fake_run)
+    result = lib.first_changed_file(lambda line: line.endswith(".py"))
+    assert result == "Bar.py"
+    assert len(calls) == 2
+
+
+def test_first_changed_file_returns_empty_when_no_match(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):  # noqa: ARG001
+        return subprocess.CompletedProcess(cmd, 0, stdout="README.md\n", stderr="")
+
+    monkeypatch.setattr(lib.subprocess, "run", fake_run)
+    assert lib.first_changed_file(lambda line: line.endswith(".py")) == ""
+
+
+def test_first_changed_file_returns_empty_when_git_missing(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):  # noqa: ARG001
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(lib.subprocess, "run", fake_run)
+    assert lib.first_changed_file(lambda line: True) == ""
+
+
+# ---------------------------------------------------------------------------
+# pitest — extension set .java/.kt/.groovy/.scala, excludes Test/Spec
+# ---------------------------------------------------------------------------
+
+
+def test_pitest_changed_source_file_delegates_to_shared_helper(monkeypatch):
+    captured = {}
+
+    def fake_first_changed_file(predicate):
+        captured["predicate"] = predicate
+        return "src/main/java/com/example/Calculator.java"
+
+    monkeypatch.setattr(pitest.lib, "first_changed_file", fake_first_changed_file)
+    result = pitest._changed_source_file()
+
+    assert result == "src/main/java/com/example/Calculator.java"
+    predicate = captured["predicate"]
+    assert predicate("src/main/java/com/example/Calculator.java") is True
+    assert predicate("src/main/java/com/example/CalculatorTest.java") is False
+    assert predicate("src/main/java/com/example/CalculatorSpec.kt") is False
+    assert predicate("README.md") is False
+
+
+# ---------------------------------------------------------------------------
+# stryker_net — extension .cs, excludes Test/Spec
+# ---------------------------------------------------------------------------
+
+
+def test_stryker_net_changed_cs_file_delegates_to_shared_helper(monkeypatch):
+    captured = {}
+
+    def fake_first_changed_file(predicate):
+        captured["predicate"] = predicate
+        return "src/Foo.Bar/Calculator.cs"
+
+    monkeypatch.setattr(stryker_net.lib, "first_changed_file", fake_first_changed_file)
+    result = stryker_net._changed_cs_file()
+
+    assert result == "src/Foo.Bar/Calculator.cs"
+    predicate = captured["predicate"]
+    assert predicate("src/Foo.Bar/Calculator.cs") is True
+    assert predicate("src/Foo.Bar/CalculatorTest.cs") is False
+    assert predicate("src/Foo.Bar/CalculatorSpec.cs") is False
+    assert predicate("README.md") is False
+
+
+# ---------------------------------------------------------------------------
+# mutmut — extension .py, excludes test_*.py / *_test.py / dir "test_"
+# ---------------------------------------------------------------------------
+
+
+def test_mutmut_changed_python_source_delegates_to_shared_helper(monkeypatch):
+    captured = {}
+
+    def fake_first_changed_file(predicate):
+        captured["predicate"] = predicate
+        return "src/calculator.py"
+
+    monkeypatch.setattr(mutmut.lib, "first_changed_file", fake_first_changed_file)
+    result = mutmut._changed_python_source()
+
+    assert result == "src/calculator.py"
+    predicate = captured["predicate"]
+    assert predicate("src/calculator.py") is True
+    assert predicate("test_calculator.py") is False
+    assert predicate("calculator_test.py") is False
+    assert predicate("tests/test_calculator.py") is False
+    assert predicate("README.md") is False


### PR DESCRIPTION
## Summary
- `pitest.py`, `stryker_net.py`, and `mutmut.py` each reimplemented the same "find the first changed non-test source file via git diff" logic, differing only in extension set and test-name predicate.
- Extracted `lib.first_changed_file(is_source_predicate)` in `mutation_adapters/lib.py` and updated all three adapters to call it with their own predicate (`_is_pitest_source`, `_is_cs_source`, `_is_python_source`).
- No behavior change: same git-diff traversal order (HEAD diff, then cached diff fallback), same first-match semantics.

## Test plan
- [x] Added `plugins/dev-team/tests/hooks/test_mutation_adapters_changed_file.py` — confirmed it FAILS before the fix (no `lib.first_changed_file`, adapters didn't delegate to it), then PASSES after the refactor.
- [x] `python3 -m pytest plugins/dev-team/tests -q` — 546 passed, 16 skipped.
- [x] `bash scripts/ci-local.sh` — all local CI checks passed (1872 passed, 16 skipped; eslint, shellcheck, etc. all green).

Part of #732