### PR TITLE
docs: document frontmatter extension keys, drop stale skip-guard, clarify ADR 0015 scope

### DIFF
--- a/docs/adr/0015-bash-removal-complete.md
+++ b/docs/adr/0015-bash-removal-complete.md
@@ -39,5 +39,5 @@ The parity harness's job is now over — the `.sh` implementations it dispatched
 ## Non-goals
 
 - **Not migrating the ~130 content-guard bats to pytest** in this PR. That's a separate, orthogonal effort (test tooling only, no plugin runtime change).
-- **Not touching `plugins/security-assessment/` scripts** — different plugin, different owner, out of scope for #572.
+- **Not touching `plugins/security-assessment/` scripts** — different plugin, different owner, out of scope for #572. Concretely, this is why `plugins/dev-team/hooks/*.py` and `plugins/security-assessment/hooks/*.sh` use different hook file-naming conventions today: the divergence is this ADR's stated scope boundary, not an inconsistency to fix.
 - **Not migrating repo-root `scripts/*.sh`** (`ci-local.sh`, `dev-setup.sh`, `cost-regression-check.sh`, `assemble-docs.sh`, `run-full-eval.sh`, ...). These orchestrate developer tooling AROUND the plugin, not the plugin itself, and are not shipped downstream. Convert opportunistically when touched.

--- a/plugins/dev-team/docs/agent_info.md
+++ b/plugins/dev-team/docs/agent_info.md
@@ -96,6 +96,13 @@ Every agent file follows this structure:
 
 The `## Skills` section is the bridge between agents and skills. The agent defines *when and why* to invoke a skill; the skill defines *how* to execute it.
 
+## Non-standard frontmatter keys
+
+Two frontmatter keys appear alongside the standard `name`/`description`/`tools`/`effort`/`model` fields and are easy to mistake for schema drift when auditing agent files. Both are intentional internal tooling metadata:
+
+- **`cites:`** — a list of canonical skill/knowledge-file sources an agent's normative rules (MUST/SHOULD/SHALL thresholds) derive from, e.g. `cites: [owasp-detection, accepted-risks-schema]`. `scripts/citation_lint.py` reads this list and flags a warning when a stated numeric threshold doesn't appear in any cited source — catching silent drift when a canonical file changes but a reviewer agent's inline rule doesn't. See the script's module docstring for the full contract. Used by 22 agents today; see `tests/repo/test_citation_lint_corpus.py` for the regression guard over the real corpus.
+- **`enforcement: script`** — marks an agent whose behavior is deterministically implemented by a script rather than driven by free-form LLM reasoning from the persona prose alone. Agents carrying this key also carry a `> **Implemented by:** scripts/<name>.py` blockquote near the top of the file pointing at that implementation (e.g. `orchestrator.md` → `scripts/orchestrator.py`, `codebase-recon.md` → `scripts/codebase_recon.py`). Used by 5 agents today (`orchestrator`, `codebase-recon`, `claude-setup-review`, `progress-guardian`, `token-efficiency-review`).
+
 ## Add a Team Agent
 
 1. Create `agents/{role-name}.md` using the template above

--- a/tests/repo/test_adr_0015_hook_naming_scope.py
+++ b/tests/repo/test_adr_0015_hook_naming_scope.py
@@ -1,0 +1,27 @@
+"""ADR 0015 must explicitly scope the hook file-naming convention (issue #732).
+
+`plugins/dev-team/hooks/*.py` and `plugins/security-assessment/hooks/*.sh`
+use different file extensions/conventions. ADR 0015 already excludes
+`plugins/security-assessment/` from the Python migration in its Non-goals,
+but doesn't call out the hook file-naming convention specifically, which
+invites a future reader to flag the divergence as an oversight. This guard
+requires an explicit, findable sentence tying the two together.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADR_0015 = REPO_ROOT / "docs" / "adr" / "0015-bash-removal-complete.md"
+
+
+def test_adr_0015_scopes_hook_naming_convention_to_dev_team_only() -> None:
+    text = ADR_0015.read_text(encoding="utf-8")
+    assert "file-naming convention" in text, (
+        f"{ADR_0015} should explicitly mention the hook file-naming "
+        "convention difference between plugins/dev-team (.py) and "
+        "plugins/security-assessment (.sh), so it isn't flagged as an "
+        "oversight in a future audit."
+    )
+    assert "security-assessment" in text

--- a/tests/repo/test_agent_frontmatter_docs.py
+++ b/tests/repo/test_agent_frontmatter_docs.py
@@ -1,0 +1,35 @@
+"""Non-standard agent frontmatter keys must be documented (issue #732).
+
+`cites:` (used by 22 agents) and `enforcement: script` (used by 5 agents) are
+intentional internal tooling metadata read by `scripts/citation_lint.py` and
+the "Implemented by:" agent convention respectively — not schema errors. This
+guard checks that a real doc explains both, so a future contributor auditing
+agent frontmatter doesn't mistake them for drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "plugins" / "dev-team" / "docs" / "agent_info.md"
+
+
+def test_agent_info_doc_explains_cites_frontmatter_key() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "`cites:`" in text, (
+        f"{DOC} should document the `cites:` frontmatter key used by "
+        "review agents to declare their canonical knowledge sources."
+    )
+    assert "citation_lint.py" in text, (
+        f"{DOC} should reference scripts/citation_lint.py, the tool that "
+        "consumes the `cites:` frontmatter key."
+    )
+
+
+def test_agent_info_doc_explains_enforcement_script_frontmatter_key() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "`enforcement: script`" in text, (
+        f"{DOC} should document the `enforcement: script` frontmatter key "
+        "used by deterministic-script-backed agents."
+    )

--- a/tests/repo/test_citation_lint_corpus.py
+++ b/tests/repo/test_citation_lint_corpus.py
@@ -23,8 +23,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LINT = REPO_ROOT / "scripts" / "citation_lint.py"
 PLUGIN_ROOT = REPO_ROOT / "plugins" / "dev-team"
@@ -39,11 +37,6 @@ CITED_CLEAN = [
     "test-review",
     "test-smell-review",
 ]
-
-
-def _require_lint() -> None:
-    if not LINT.is_file():
-        pytest.skip("citation_lint.py not present yet (PR #315 not merged)")
 
 
 def _run_lint() -> subprocess.CompletedProcess:
@@ -62,13 +55,11 @@ def _run_lint() -> subprocess.CompletedProcess:
 
 
 def test_lint_exits_0_on_the_real_plugin_corpus() -> None:
-    _require_lint()
     result = _run_lint()
     assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_every_reviewer_with_declared_cites_resolves_to_real_sources() -> None:
-    _require_lint()
     # Any 'unknown source' warning means a cites: entry points at a file that
     # does not exist - i.e. a knowledge file was renamed without updating the
     # citing agent. Hard fail (advisory exit code, but the warning text is
@@ -82,7 +73,6 @@ def test_every_reviewer_with_declared_cites_resolves_to_real_sources() -> None:
 
 
 def test_no_drift_on_backfilled_reviewers() -> None:
-    _require_lint()
     # Reviewers that have a cites: list AND zero threshold drift today. If any
     # of these later appear in the warning stream, a backfilled agent
     # silently regressed.

--- a/tests/repo/test_citation_lint_corpus_no_stale_skip_guard.py
+++ b/tests/repo/test_citation_lint_corpus_no_stale_skip_guard.py
@@ -1,0 +1,34 @@
+"""tests/repo/test_citation_lint_corpus.py must not carry a dead skip-guard
+for PR #315 (issue #732).
+
+PR #315 (the citation-lint tool itself) merged long ago, so
+`scripts/citation_lint.py` always exists in this repo. A `pytest.skip(...
+"not merged")` guard keyed on that PR is permanently dead code that misleads
+a reader into thinking the corpus test can legitimately be skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORPUS_TEST = REPO_ROOT / "tests" / "repo" / "test_citation_lint_corpus.py"
+LINT = REPO_ROOT / "scripts" / "citation_lint.py"
+
+
+def test_citation_lint_script_exists() -> None:
+    # Precondition for the assertion below: the skip-guard's premise (the
+    # script might not exist yet) is false and has been false for a long time.
+    assert LINT.is_file()
+
+
+def test_corpus_test_has_no_stale_pr_315_skip_guard() -> None:
+    text = CORPUS_TEST.read_text(encoding="utf-8")
+    assert "not merged" not in text, (
+        f"{CORPUS_TEST} still contains a skip-guard premised on PR #315 not "
+        "being merged; remove the dead guard now that citation_lint.py ships."
+    )
+    assert "pytest.skip" not in text, (
+        f"{CORPUS_TEST} should not skip — scripts/citation_lint.py always "
+        "exists in this repo."
+    )


### PR DESCRIPTION
## Summary
- Document the non-standard \`cites:\` and \`enforcement: script\` agent frontmatter keys in \`plugins/dev-team/docs/agent_info.md\` so contributors don't mistake them for schema errors.
- Remove \`tests/repo/test_citation_lint_corpus.py\`'s dead skip-guard for PR #315, which merged long ago.
- Clarify in \`docs/adr/0015-bash-removal-complete.md\`'s Non-goals section that \`plugins/security-assessment\`'s \`.sh\` hooks are intentionally out of scope for the Python migration, not an oversight.

## Test plan
- [x] New tests for all three changes (RED before, GREEN after)
- [x] Full \`bash scripts/ci-local.sh\` — all 17 checks pass

Part of #732