### PR TITLE
fix(docs): repoint docs site config to devteam.bryanfinster.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Every new or changed agent/skill/hook must pass `/agent-audit`.
 
 The docs use three diagram formats, each for a distinct purpose — match the convention when adding or editing a diagram:
 
-- **Mermaid** (` ```mermaid ` fences) — the default for flow, sequence, and architecture diagrams authored inline. It is text-based (diffs cleanly), renders on GitHub natively, and renders on the [docs site](https://docs.bryanfinster.com/) (Material loads Mermaid.js via the `pymdownx.superfences` custom fence in `mkdocs.yml`). Reuse the shared `%%{init ...}%%` theme block from an existing diagram (e.g. `plugins/dev-team/docs/model-routing.md`) so diagrams look consistent.
+- **Mermaid** (` ```mermaid ` fences) — the default for flow, sequence, and architecture diagrams authored inline. It is text-based (diffs cleanly), renders on GitHub natively, and renders on the [docs site](https://devteam.bryanfinster.com/) (Material loads Mermaid.js via the `pymdownx.superfences` custom fence in `mkdocs.yml`). Reuse the shared `%%{init ...}%%` theme block from an existing diagram (e.g. `plugins/dev-team/docs/model-routing.md`) so diagrams look consistent.
 - **SVG** (`plugins/dev-team/docs/diagrams/*.svg`) — reserved for the polished, hand-tuned architecture diagrams that are laid out deliberately and tuned for dark mode. Don't auto-convert these to Mermaid; edit the SVG.
 - **ASCII** (plain ` ``` ` fences) — only for directory/file trees and short inline command flows, never for boxes-and-arrows diagrams (use Mermaid for those).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docs checks](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/link-check.yml)
 [![Docs deploy](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/bdfinst/agentic-dev-team/actions/workflows/docs.yml)
 
-📖 **[Documentation](https://docs.bryanfinster.com/)**
+📖 **[Documentation](https://devteam.bryanfinster.com/)**
 
 Three Claude Code plugins for engineering workflows. Install one or all.
 
@@ -106,7 +106,7 @@ Developing, testing, or releasing the plugins? See **[CONTRIBUTING.md](CONTRIBUT
 
 ## Documentation
 
-The full documentation — architecture, model routing, eval system, telemetry, ADRs, and experiment reports — lives at **[docs.bryanfinster.com](https://docs.bryanfinster.com/)**, with search and complete navigation.
+The full documentation — architecture, model routing, eval system, telemetry, ADRs, and experiment reports — lives at **[devteam.bryanfinster.com](https://devteam.bryanfinster.com/)**, with search and complete navigation.
 
 Start here:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Agentic Dev Team
-site_url: https://docs.bryanfinster.com/
+site_url: https://devteam.bryanfinster.com/
 repo_url: https://github.com/bdfinst/agentic-dev-team
 repo_name: bdfinst/agentic-dev-team
 edit_uri: edit/main/

--- a/scripts/assemble-docs.sh
+++ b/scripts/assemble-docs.sh
@@ -39,4 +39,4 @@ cp "${REPO_ROOT}/plugins/marketplace-dev/knowledge/agent-type-decision-rules.md"
 
 # GitHub Pages custom domain — published to the gh-pages root so GitHub binds it.
 # Must match the host in mkdocs.yml site_url.
-printf 'docs.bryanfinster.com\n' > "${OUT}/CNAME"
+printf 'devteam.bryanfinster.com\n' > "${OUT}/CNAME"


### PR DESCRIPTION
## Summary
- The live GitHub Pages custom domain had drifted to `devteam.bryanfinster.com`, but `mkdocs.yml` and `scripts/assemble-docs.sh` (which regenerates the published `CNAME`) still pointed at `docs.bryanfinster.com` — the next docs deploy would have silently reverted the working custom domain.
- Updated `mkdocs.yml`'s `site_url` and the generated `CNAME` value to match the live domain.
- Updated the two documentation links in `README.md` and one in `CONTRIBUTING.md` to point at `devteam.bryanfinster.com`.

## Test plan
- [x] `scripts/ci-local.sh` (via pre-push hook) — all checks pass
- [ ] Confirm `devteam.bryanfinster.com` custom domain check goes green in GitHub Pages settings after this merges and the docs workflow redeploys