### PR TITLE
ci: alert on obsolete GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     name: Deploy docs site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -32,7 +32,7 @@ jobs:
     name: Docs nav integrity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -58,7 +58,7 @@ jobs:
     name: Docs link check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check documentation links
         uses: lycheeverse/lychee-action@v2


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for the `github-actions` ecosystem (weekly, grouped into one PR) so a pinned action falling behind opens a PR instead of drifting silently — this is the alert mechanism.
- Bump `docs.yml` and `link-check.yml` off `actions/checkout@v4` onto `@v7`, matching every other workflow in the repo (found via a manual audit while wiring this up).

## Test plan
- [x] `scripts/ci-local.sh` (pre-push mirror) passes locally
- [x] YAML validated (`dependabot.yml`, `docs.yml`, `link-check.yml`)
- [ ] Confirm Dependabot opens its first grouped PR on the next weekly run