### PR TITLE
feat: graduate context ceiling warning to summarization action bands

### DIFF
--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -227,20 +227,54 @@ def _write_bucket(marker: Path, bucket: int) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _band_for_pct(pct: int) -> Tuple[str, str]:
+    """Map occupancy percent to a Context Summarization action band.
+
+    Mirrors the action-band table in
+    skills/context-summarization/SKILL.md (`## When to Summarize`):
+    30-40% prepare, 40-50% summarize + fresh context, 50-65% summarize
+    everything but the current task, 65%+ full summary to memory/. The
+    guard only ever fires at or above the configured ceiling (default
+    40%), so the "<30%" band is unreachable at default settings but is
+    included for completeness when DEV_TEAM_CONTEXT_CEILING_PCT is
+    lowered below 30.
+    """
+    if pct >= 65:
+        return (
+            "65%+",
+            "write a full summary to memory/ and start a new conversation",
+        )
+    if pct >= 50:
+        return ("50-65%", "summarize everything except the current task")
+    if pct >= 40:
+        return (
+            "40-50%",
+            "write a summary to memory/ and start a fresh context window",
+        )
+    if pct >= 30:
+        return (
+            "30-40%",
+            "prepare: identify summarization candidates",
+        )
+    return ("<30%", "no action needed yet")
+
+
 def _format_message(
     pct: int,
     window: int,
     ceiling: int,
     label: str,
 ) -> str:
-    """Byte-identical to the .sh's heredoc when interpolated with the same
-    values. Preserving the exact wording keeps `bats` and `pytest` fixtures
-    interchangeable during the parallel-ship window."""
+    """Graduated warning message (#787): names the Context Summarization
+    action band (see `_band_for_pct`) that applies at the current
+    occupancy, escalating the wording as occupancy climbs further past
+    the ceiling instead of repeating one fixed message."""
+    band_name, action = _band_for_pct(pct)
     return (
         f"🪟 Context at {pct}% of the {window}-token window "
         f"(≥ {ceiling}% ceiling) before {label}.\n"
-        "Per the Context Loading Protocol, summarize before loading more: "
-        "run /context-summarization\n"
+        f"Per the Context Loading Protocol [{band_name} band]: {action}. "
+        "Run /context-summarization\n"
         "(write a memory/ progress file, continue in a fresh context) "
         "and defer non-essential agents/skills.\n"
         "Tune with DEV_TEAM_CONTEXT_WINDOW (set 1000000 on a 1M-context "

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -348,3 +348,77 @@ def test_measure_occupancy_uses_last_usage_line_only(tmp_path: Path) -> None:
 
 def test_measure_occupancy_missing_file(tmp_path: Path) -> None:
     assert hook._measure_occupancy(tmp_path / "nope.jsonl") is None
+
+
+# ---------------------------------------------------------------------------
+# Graduated warning bands (#787)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pct,expected_band,expected_action_snippet",
+    [
+        (25, "<30%", "no action needed yet"),
+        (35, "30-40%", "prepare"),
+        (45, "40-50%", "fresh context window"),
+        (55, "50-65%", "everything except the current task"),
+        (70, "65%+", "full summary to memory/"),
+        (100, "65%+", "full summary to memory/"),
+    ],
+)
+def test_band_for_pct(pct, expected_band, expected_action_snippet):
+    band, action = hook._band_for_pct(pct)
+    assert band == expected_band
+    assert expected_action_snippet in action
+
+
+def test_format_message_names_the_band_action_at_boundaries():
+    msg_40 = hook._format_message(40, 200_000, 40, "loading agent 'x'")
+    assert "[40-50% band]" in msg_40
+    assert "fresh context window" in msg_40
+
+    msg_50 = hook._format_message(50, 200_000, 40, "loading agent 'x'")
+    assert "[50-65% band]" in msg_50
+    assert "everything except the current task" in msg_50
+
+    msg_65 = hook._format_message(65, 200_000, 40, "loading agent 'x'")
+    assert "[65%+ band]" in msg_65
+    assert "full summary to memory/" in msg_65
+    assert "new conversation" in msg_65
+
+
+def test_warn_message_escalates_band_as_occupancy_climbs(tmp_path: Path) -> None:
+    """End-to-end: crossing 40%, 50%, and 65% each names the matching
+    Context Summarization action band, not one fixed message."""
+    tr = tmp_path / "t.jsonl"
+    env = _base_env(tmp_path)
+
+    _write_transcript(tr, 90_000)  # 45% -> 40-50% band
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[40-50% band]" in result.stderr
+    assert b"fresh context window" in result.stderr
+
+    _write_transcript(tr, 110_000)  # 55% -> 50-65% band, new bucket
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[50-65% band]" in result.stderr
+    assert b"everything except the current task" in result.stderr
+
+    _write_transcript(tr, 140_000)  # 70% -> 65%+ band, new bucket
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[65%+ band]" in result.stderr
+    assert b"full summary to memory/" in result.stderr
+    assert b"new conversation" in result.stderr
+
+
+def test_prepare_band_fires_when_ceiling_lowered_below_40(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    _write_transcript(tr, 70_000)  # 35%
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "30"
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[30-40% band]" in result.stderr
+    assert b"prepare" in result.stderr


### PR DESCRIPTION
## Summary
- Added `_band_for_pct(pct)` mapping occupancy to the four Context Summarization action bands from `context-summarization/SKILL.md`'s "When to Summarize" table (30-40% prepare, 40-50% summarize + fresh context, 50-65% summarize-except-current-task, 65%+ full summary to memory/)
- Updated `_format_message` to name the band and its action in the warning text, keeping the existing `/context-summarization` pointer, tuning-knob footer, and per-session 5%-bucket dedupe logic untouched

This PR depends on #785 (window auto-detection) and #786 (absolute cap) and may need a rebase once those merge.

## Test plan
- [x] Unit tests for `_band_for_pct` at each boundary
- [x] `_format_message` band-naming at boundaries
- [x] End-to-end test escalating through 45%/55%/70% occupancy confirming distinct band messages
- [x] Full `plugins/dev-team/tests/hooks/` suite (643 tests) passes

Closes #787

---
_Generated by [Claude Code](https://claude.ai/code/session_016HMTTHuMXB8AtkHnVkK8G7)_