### PR TITLE
feat(hooks): auto-detect context window from transcript model

### DIFF
--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -25,9 +25,14 @@ Env:
     DEV_TEAM_CONTEXT_CEILING=off     disable entirely (default on)
     DEV_TEAM_CONTEXT_STRICT=on       block over the ceiling (default: warn)
     DEV_TEAM_CONTEXT_CEILING_PCT=N   ceiling percent (default 40)
-    DEV_TEAM_CONTEXT_WINDOW=N        context window in tokens; defaults to
-                                     200000 (every current Claude model's
-                                     base window). Set 1000000 on 1M models.
+    DEV_TEAM_CONTEXT_WINDOW=N        context window in tokens; an explicit
+                                     override that always wins over
+                                     auto-detection. When unset, the window is
+                                     auto-detected from the transcript's most
+                                     recent `message.model` (Haiku family ->
+                                     200000; Opus/Sonnet/Fable families ->
+                                     1000000; unrecognized or undetectable
+                                     model -> 200000).
 
 Contract (docs/python-hook-contract.md):
     Input : PreToolUse JSON on stdin
@@ -102,6 +107,79 @@ def _positive_int_env(name: str, default: int) -> int:
         return default
     value = int(raw)
     return value if value > 0 else default
+
+
+# ---------------------------------------------------------------------------
+# model -> context window auto-detection
+# ---------------------------------------------------------------------------
+
+# Family match order matters: Haiku is checked first so a hypothetical
+# "haiku-opus" alias (or similar) can't fall through to the 1M branch.
+_HAIKU_WINDOW = 200_000
+_LARGE_WINDOW = 1_000_000
+_DEFAULT_WINDOW = 200_000
+
+_HAIKU_RE = re.compile(r"haiku", re.IGNORECASE)
+_LARGE_WINDOW_RE = re.compile(r"opus|sonnet|fable", re.IGNORECASE)
+
+
+def _window_for_model(model: str) -> int:
+    """Map a model name to its context window via family substring match.
+
+    Haiku family -> 200K; Opus/Sonnet/Fable families -> 1M; anything else
+    (unrecognized model name) -> the 200K default.
+    """
+    if _HAIKU_RE.search(model):
+        return _HAIKU_WINDOW
+    if _LARGE_WINDOW_RE.search(model):
+        return _LARGE_WINDOW
+    return _DEFAULT_WINDOW
+
+
+def _detect_window(transcript_path: Path) -> int:
+    """Auto-detect the context window from the transcript's most recent
+    `message.model`. Mirrors `_measure_occupancy`'s scan (last 400 lines,
+    last matching row wins) so the detected model tracks the same session
+    state as the occupancy measurement.
+
+    Fail-open: any parse error, missing/malformed `model` field, or a
+    transcript with no model at all resolves to the 200K default — this
+    function never raises and never blocks.
+    """
+    lines = _tail_lines(transcript_path, 400)
+    last_model: Optional[str] = None
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            row = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(row, dict):
+            continue
+        message = row.get("message")
+        if not isinstance(message, dict):
+            continue
+        model = message.get("model")
+        if isinstance(model, str) and model:
+            last_model = model
+    if last_model is None:
+        return _DEFAULT_WINDOW
+    return _window_for_model(last_model)
+
+
+def _env_window_override() -> Optional[int]:
+    """Explicit `DEV_TEAM_CONTEXT_WINDOW` override; `None` when unset or
+    invalid, in which case the caller falls through to auto-detection.
+    """
+    raw = os.environ.get("DEV_TEAM_CONTEXT_WINDOW")
+    if raw is None:
+        return None
+    if not re.fullmatch(r"[0-9]+", raw):
+        return None
+    value = int(raw)
+    return value if value > 0 else None
 
 
 # ---------------------------------------------------------------------------
@@ -277,8 +355,8 @@ def _format_message(
         "Run /context-summarization\n"
         "(write a memory/ progress file, continue in a fresh context) "
         "and defer non-essential agents/skills.\n"
-        "Tune with DEV_TEAM_CONTEXT_WINDOW (set 1000000 on a 1M-context "
-        "model) / DEV_TEAM_CONTEXT_CEILING_PCT;\n"
+        "Tune with DEV_TEAM_CONTEXT_WINDOW (overrides auto-detection) "
+        "/ DEV_TEAM_CONTEXT_CEILING_PCT;\n"
         "DEV_TEAM_CONTEXT_STRICT=on hard-blocks; "
         "DEV_TEAM_CONTEXT_CEILING=off disables."
     )
@@ -336,7 +414,9 @@ def _resolve_verdict(payload: dict) -> Tuple[int, Optional[str], bool]:
     if occ is None:
         return 0, None, False
 
-    window = _positive_int_env("DEV_TEAM_CONTEXT_WINDOW", 200_000)
+    window = _env_window_override()
+    if window is None:
+        window = _detect_window(transcript_path)
     ceiling = _positive_int_env("DEV_TEAM_CONTEXT_CEILING_PCT", 40)
 
     # Bash: `pct=$((occ * 100 / window))` — integer truncation. Match exactly.

--- a/plugins/dev-team/skills/context-loading-protocol/SKILL.md
+++ b/plugins/dev-team/skills/context-loading-protocol/SKILL.md
@@ -25,8 +25,10 @@ This protocol is backed by a `PreToolUse` hook — `hooks/context_ceiling_guard.
 and, at/above the ceiling, nudges you to summarize (warn, default) or blocks the
 load (`DEV_TEAM_CONTEXT_STRICT=on`). Recovery skills (`/context-summarization`,
 `/context-loading-protocol`, `/continue`, `/review-summary`, `/session-review`) are
-never gated. The window cannot be auto-detected on a 1M-context model (the
-transcript omits the `[1m]` suffix) — set `DEV_TEAM_CONTEXT_WINDOW=1000000` there.
+never gated. The window auto-detects from the transcript's most recent
+`message.model` (Haiku family -> 200K; Opus/Sonnet/Fable families -> 1M;
+unrecognized/undetectable model -> 200K); set `DEV_TEAM_CONTEXT_WINDOW` to
+override detection explicitly.
 Knobs: `DEV_TEAM_CONTEXT_CEILING_PCT` (default 40), `DEV_TEAM_CONTEXT_CEILING=off`.
 The hook is a backstop measured from real usage; the budget estimate below is still
 the planning tool you apply *before* loading.

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -25,11 +25,19 @@ import context_ceiling_guard as hook  # type: ignore[import-not-found]  # noqa: 
 _HOOK_PY = _HOOKS_DIR / "context_ceiling_guard.py"
 
 
-def _write_transcript(path: Path, total: int) -> None:
-    """Write a transcript whose latest usage line totals `total` prompt tokens."""
+def _write_transcript(
+    path: Path, total: int, model: str = "claude-legacy-test-model"
+) -> None:
+    """Write a transcript whose latest usage line totals `total` prompt tokens.
+
+    `model` defaults to a name that matches neither the Haiku nor the
+    Opus/Sonnet/Fable family regex, so window auto-detection falls back to
+    the 200K default and existing ceiling-percentage fixtures are unaffected
+    by #785's detection feature.
+    """
     line = {
         "message": {
-            "model": "claude-opus-4-8",
+            "model": model,
             "usage": {
                 "input_tokens": 2,
                 "cache_read_input_tokens": total - 2,
@@ -422,3 +430,129 @@ def test_prepare_band_fires_when_ceiling_lowered_below_40(tmp_path: Path) -> Non
     assert result.returncode == 0
     assert b"[30-40% band]" in result.stderr
     assert b"prepare" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# #785: context window auto-detection from transcript model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-haiku-4-5", 200_000),
+        ("claude-3-5-haiku-20241022", 200_000),
+        ("claude-opus-4-8", 1_000_000),
+        ("claude-sonnet-5", 1_000_000),
+        ("claude-fable-1", 1_000_000),
+        ("some-unrecognized-model", 200_000),
+    ],
+)
+def test_window_for_model(model: str, expected: int) -> None:
+    assert hook._window_for_model(model) == expected
+
+
+@pytest.mark.parametrize(
+    "model,expected_pct_denominator",
+    [
+        ("claude-haiku-4-5", 200_000),
+        ("claude-3-5-haiku-20241022", 200_000),
+        ("claude-opus-4-8", 1_000_000),
+        ("claude-sonnet-5", 1_000_000),
+        ("claude-fable-1", 1_000_000),
+    ],
+)
+def test_detects_window_per_model_family_end_to_end(
+    tmp_path: Path, model: str, expected_pct_denominator: int
+) -> None:
+    """100_000 occupancy tokens against each family's detected window."""
+    tr = tmp_path / "t.jsonl"
+    _write_transcript(tr, 100_000, model=model)
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path))
+    assert result.returncode == 0
+    expected_pct = (100_000 * 100) // expected_pct_denominator
+    if expected_pct >= 40:
+        assert f"{expected_pct}%".encode() in result.stderr
+    else:
+        assert result.stderr == b""
+
+
+def test_env_override_wins_over_detection(tmp_path: Path) -> None:
+    """An Opus transcript would auto-detect to 1M (10%, below ceiling); the
+    explicit override forces 200K (50%, over ceiling) and the override wins.
+    """
+    tr = tmp_path / "t.jsonl"
+    _write_transcript(tr, 100_000, model="claude-opus-4-8")
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"50%" in result.stderr
+
+
+def test_unrecognized_model_falls_back_to_200000(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    _write_transcript(tr, 100_000, model="gpt-5-turbo")  # unrecognized family
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path))
+    assert result.returncode == 0
+    assert b"50%" in result.stderr  # 100000/200000 default
+
+
+def test_detect_window_fail_open_on_missing_model_field(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    tr.write_text(
+        json.dumps(
+            {
+                "message": {
+                    "usage": {
+                        "input_tokens": 2,
+                        "cache_read_input_tokens": 99_998,
+                        "cache_creation_input_tokens": 0,
+                    }
+                }
+            }
+        )
+        + "\n"
+    )
+    assert hook._detect_window(tr) == 200_000
+    result = _run(
+        _mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path)
+    )
+    assert result.returncode == 0
+    assert b"50%" in result.stderr
+
+
+def test_detect_window_fail_open_on_malformed_transcript(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    tr.write_text("not json at all\n")
+    assert hook._detect_window(tr) == 200_000
+
+
+def test_detect_window_fail_open_on_missing_transcript(tmp_path: Path) -> None:
+    assert hook._detect_window(tmp_path / "nope.jsonl") == 200_000
+
+
+def test_detect_window_fail_open_on_non_string_model(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    tr.write_text(json.dumps({"message": {"model": 12345}}) + "\n")
+    assert hook._detect_window(tr) == 200_000
+
+
+def test_env_window_override_none_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("DEV_TEAM_CONTEXT_WINDOW", raising=False)
+    assert hook._env_window_override() is None
+
+
+def test_env_window_override_none_when_malformed(monkeypatch) -> None:
+    monkeypatch.setenv("DEV_TEAM_CONTEXT_WINDOW", "bogus")
+    assert hook._env_window_override() is None
+
+
+def test_env_window_override_none_when_zero_or_negative(monkeypatch) -> None:
+    monkeypatch.setenv("DEV_TEAM_CONTEXT_WINDOW", "0")
+    assert hook._env_window_override() is None
+
+
+def test_env_window_override_returns_explicit_value(monkeypatch) -> None:
+    monkeypatch.setenv("DEV_TEAM_CONTEXT_WINDOW", "1000000")
+    assert hook._env_window_override() == 1_000_000


### PR DESCRIPTION
## Summary

- `context_ceiling_guard.py` previously assumed every model has a 200K context window (via `DEV_TEAM_CONTEXT_WINDOW`, default 200000). Every current frontier model (Fable 5, Opus 4.6-4.8, Sonnet 5) actually has a 1M token window; only Haiku models are 200K.
- Added a model-family → window-size map, detected from the transcript's most recent `message.model`: Haiku family → 200K, Opus/Sonnet/Fable families → 1M, unrecognized/undetectable model → 200K default.
- `DEV_TEAM_CONTEXT_WINDOW` remains an explicit override that always wins over auto-detection.
- All detection failures (missing `model` field, malformed transcript, missing transcript) stay fail-open — never throw, never block.
- Updated `skills/context-loading-protocol/SKILL.md`, which previously documented detection as impossible on 1M-context models.

## Test plan

- [x] Added pytest cases covering: window per model family (Haiku→200K, Opus/Sonnet/Fable→1M), `DEV_TEAM_CONTEXT_WINDOW` override winning over detection, unrecognized model names falling back to 200K, fail-open behavior (missing model field, malformed transcript, missing transcript).
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_context_ceiling_guard.py -q` → 57 passed
- [x] `python3 -m pytest plugins/dev-team/tests/ -q` → 674 passed, 16 skipped
- [x] `python3 -m pytest tests/repo/test_knowledge_index_current.py -q` → 1 passed (knowledge index unaffected)

Closes #785

---
_Generated by [Claude Code](https://claude.ai/code/session_016HMTTHuMXB8AtkHnVkK8G7)_