### PR TITLE
feat(hooks): pin context-window detection to specific 1M model versions

### DIFF
--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -29,10 +29,15 @@ Env:
                                      override that always wins over
                                      auto-detection. When unset, the window is
                                      auto-detected from the transcript's most
-                                     recent `message.model` (Haiku family ->
-                                     200000; Opus/Sonnet/Fable families ->
-                                     1000000; unrecognized or undetectable
-                                     model -> 200000).
+                                     recent `message.model` by family/version
+                                     substring: Haiku family -> 200000;
+                                     current 1M families (Fable, Mythos,
+                                     Opus 4.6/4.7/4.8, Sonnet 5, Sonnet 4.6)
+                                     -> 1000000; unrecognized or undetectable
+                                     model -> 200000 (conservative fallback —
+                                     window is a fixed per-model property, and
+                                     an unrecognized model is never assumed to
+                                     be a large-window one).
     DEV_TEAM_CONTEXT_ABS_CEILING=N   absolute token cap on the threshold;
                                      defaults to 150000 (Anthropic's
                                      server-side compaction default). The
@@ -63,6 +68,12 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Tuple
 
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]  # noqa: E402
+
 
 # Recovery skills that must never be gated — blocking them would deadlock a
 # session that has climbed over the ceiling.
@@ -82,25 +93,8 @@ _GATED_TOOLS = frozenset({"Agent", "Skill"})
 
 
 # ---------------------------------------------------------------------------
-# stdin + env parsing
+# env parsing
 # ---------------------------------------------------------------------------
-
-
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> Optional[dict]:
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -121,6 +115,16 @@ def _positive_int_env(name: str, default: int) -> int:
 # model -> context window auto-detection
 # ---------------------------------------------------------------------------
 
+# Window is a fixed per-model property, not a family-wide one: only the
+# specific model ids known today to ship a 1M window are listed. A future
+# model that merely shares a family name (e.g. a hypothetical small-window
+# "sonnet-6") must NOT be assumed 1M just because "sonnet" matches — that is
+# why this list is version-pinned rather than a bare family regex. Unknown
+# models fall back to the 200K default: over-nudging a 1M session is a minor
+# false-alarm; under-nudging a 200K session risks running well past the real
+# ceiling. See ADR 0011's dated amendment for the rationale change from a
+# pure env-var default to this per-model map.
+#
 # Family match order matters: Haiku is checked first so a hypothetical
 # "haiku-opus" alias (or similar) can't fall through to the 1M branch.
 _HAIKU_WINDOW = 200_000
@@ -128,14 +132,19 @@ _LARGE_WINDOW = 1_000_000
 _DEFAULT_WINDOW = 200_000
 
 _HAIKU_RE = re.compile(r"haiku", re.IGNORECASE)
-_LARGE_WINDOW_RE = re.compile(r"opus|sonnet|fable", re.IGNORECASE)
+_LARGE_WINDOW_RE = re.compile(
+    r"fable|mythos|opus-4-6|opus-4-7|opus-4-8|sonnet-5|sonnet-4-6",
+    re.IGNORECASE,
+)
 
 
 def _window_for_model(model: str) -> int:
-    """Map a model name to its context window via family substring match.
+    """Map a model name to its context window via family/version substring.
 
-    Haiku family -> 200K; Opus/Sonnet/Fable families -> 1M; anything else
-    (unrecognized model name) -> the 200K default.
+    Haiku family -> 200K. Current 1M-window models -> 1M: Fable (any
+    version), Mythos (any version), Opus 4.6/4.7/4.8, Sonnet 5, Sonnet 4.6.
+    Anything else (unrecognized model, or a same-family model outside the
+    pinned versions above) -> the 200K conservative default.
     """
     if _HAIKU_RE.search(model):
         return _HAIKU_WINDOW
@@ -460,8 +469,7 @@ def _resolve_verdict(payload: dict) -> Tuple[int, Optional[str], bool]:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json()
     if payload is None:
         # Empty or malformed stdin → silent-pass, same as the .sh.
         return 0

--- a/plugins/dev-team/hooks/lib/stdin_json.py
+++ b/plugins/dev-team/hooks/lib/stdin_json.py
@@ -4,7 +4,9 @@ Every Claude Code hook receives its payload as JSON on stdin. Seven hooks
 (pre_commit_review.py, pre_commit_knowledge_index.py, knowledge_index.py,
 mutation_testing_smoke_gate.py, codegraph_nudge.py, codegraph_bootstrap.py,
 bash_retry_guard.py) each carried an identical copy of this read/parse/
-validate step (#732). This module is the shared extraction.
+validate step (#732). This module is the shared extraction. Also adopted by
+context_ceiling_guard.py (#779), replacing its own local copy of the same
+read/parse/validate step.
 
 Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 """

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -1,8 +1,8 @@
 """Unit tests for the Python port of hooks/context-ceiling-guard.sh (#595).
 
-Mirrors tests/hooks/context_ceiling_guard.bats one-for-one via subprocess
-dispatch + covers the internal helpers as white-box units. Byte-parity with
-the .sh is enforced separately by the parity harness.
+Originally mirrored tests/hooks/context_ceiling_guard.bats one-for-one via
+subprocess dispatch; the .bats file was retired under the bash-removal epic
+(ADR 0015) and this suite is now the sole source of truth.
 """
 
 from __future__ import annotations
@@ -26,14 +26,16 @@ _HOOK_PY = _HOOKS_DIR / "context_ceiling_guard.py"
 
 
 def _write_transcript(
-    path: Path, total: int, model: str = "claude-legacy-test-model"
+    path: Path, total: int, model: str = "claude-haiku-4-5"
 ) -> None:
     """Write a transcript whose latest usage line totals `total` prompt tokens.
 
-    `model` defaults to a name that matches neither the Haiku nor the
-    Opus/Sonnet/Fable family regex, so window auto-detection falls back to
-    the 200K default and existing ceiling-percentage fixtures are unaffected
-    by #785's detection feature.
+    `model` defaults to a Haiku id (200K window) rather than an unrecognized
+    placeholder — fixture re-baseline rule (#779): tests that aren't
+    specifically about window-family detection use a real, detectably-200K
+    model id AND pin `DEV_TEAM_CONTEXT_WINDOW=200000` explicitly (belt and
+    suspenders against a future default-window change); tests that ARE about
+    window detection pass an explicit `model=` and never pin the window.
     """
     line = {
         "message": {
@@ -85,7 +87,9 @@ def _base_env(tmp_path: Path) -> dict:
 def test_silent_below_the_ceiling(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 50_000)  # 50000/200000 = 25%
-    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path))
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
     assert result.stdout == b""
     assert result.stderr == b""
@@ -94,9 +98,11 @@ def test_silent_below_the_ceiling(tmp_path: Path) -> None:
 def test_warns_exit_0_on_agent_load_over_the_ceiling(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 100_000)  # 50%
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     result = _run(
         _mkinput("Agent", {"subagent_type": "dev-team:doc-review"}, tr),
-        _base_env(tmp_path),
+        env,
     )
     assert result.returncode == 0
     assert b"50%" in result.stderr
@@ -109,6 +115,7 @@ def test_blocks_exit_2_over_the_ceiling_under_strict_mode(
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 100_000)
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_STRICT"] = "on"
     result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
     assert result.returncode == 2
@@ -119,6 +126,7 @@ def test_never_gates_a_recovery_skill_even_strict(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 180_000)  # 90%
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_STRICT"] = "on"
     result = _run(
         _mkinput("Skill", {"skill": "dev-team:context-summarization"}, tr),
@@ -131,7 +139,9 @@ def test_never_gates_a_recovery_skill_even_strict(tmp_path: Path) -> None:
 def test_ignores_tools_other_than_agent_or_skill(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 180_000)
-    result = _run(_mkinput("Read", {"file_path": "/x"}, tr), _base_env(tmp_path))
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+    result = _run(_mkinput("Read", {"file_path": "/x"}, tr), env)
     assert result.returncode == 0
     assert result.stderr == b""
 
@@ -140,6 +150,7 @@ def test_disabled_via_dev_team_context_ceiling_off(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 180_000)
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_CEILING"] = "off"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
@@ -160,6 +171,7 @@ def test_context_ceiling_pct_lowers_the_trigger_point(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 60_000)  # 30%
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "25"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
@@ -193,6 +205,7 @@ def test_warn_dedupes_within_5_pt_bucket_rewarns_on_higher(
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 100_000)  # 50% → bucket 10
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
 
     result1 = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result1.returncode == 0
@@ -226,6 +239,7 @@ def test_skill_recovery_stripped_plugin_prefix(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 180_000)
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_STRICT"] = "on"
     result = _run(_mkinput("Skill", {"skill": "any-plugin:continue"}, tr), env)
     assert result.returncode == 0
@@ -235,6 +249,7 @@ def test_malformed_ceiling_pct_falls_back_to_40(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 100_000)  # 50%
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "not-a-number"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
@@ -400,6 +415,7 @@ def test_warn_message_escalates_band_as_occupancy_climbs(tmp_path: Path) -> None
     Context Summarization action band, not one fixed message."""
     tr = tmp_path / "t.jsonl"
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
 
     _write_transcript(tr, 90_000)  # 45% -> 40-50% band
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
@@ -425,6 +441,7 @@ def test_prepare_band_fires_when_ceiling_lowered_below_40(tmp_path: Path) -> Non
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 70_000)  # 35%
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "30"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
@@ -443,9 +460,21 @@ def test_prepare_band_fires_when_ceiling_lowered_below_40(tmp_path: Path) -> Non
         ("claude-haiku-4-5", 200_000),
         ("claude-3-5-haiku-20241022", 200_000),
         ("claude-opus-4-8", 1_000_000),
+        ("claude-opus-4-7", 1_000_000),
+        ("claude-opus-4-6", 1_000_000),
         ("claude-sonnet-5", 1_000_000),
+        ("claude-sonnet-4-6", 1_000_000),
+        ("claude-fable-5", 1_000_000),
         ("claude-fable-1", 1_000_000),
+        ("claude-mythos-1", 1_000_000),
         ("some-unrecognized-model", 200_000),
+        # Window is a fixed per-model property, not a family-wide one: a
+        # same-family model outside the pinned 1M versions must NOT be
+        # assumed 1M (#779) — these fall to the 200K conservative default.
+        ("claude-opus-4-5", 200_000),
+        ("claude-3-opus-20240229", 200_000),
+        ("claude-sonnet-4-5", 200_000),
+        ("claude-3-5-sonnet-20241022", 200_000),
     ],
 )
 def test_window_for_model(model: str, expected: int) -> None:
@@ -458,8 +487,15 @@ def test_window_for_model(model: str, expected: int) -> None:
         ("claude-haiku-4-5", 200_000),
         ("claude-3-5-haiku-20241022", 200_000),
         ("claude-opus-4-8", 1_000_000),
+        ("claude-opus-4-7", 1_000_000),
+        ("claude-opus-4-6", 1_000_000),
         ("claude-sonnet-5", 1_000_000),
-        ("claude-fable-1", 1_000_000),
+        ("claude-sonnet-4-6", 1_000_000),
+        ("claude-fable-5", 1_000_000),
+        ("claude-mythos-1", 1_000_000),
+        # Same-family, non-pinned versions must NOT auto-detect as 1M.
+        ("claude-opus-4-5", 200_000),
+        ("claude-sonnet-4-5", 200_000),
     ],
 )
 def test_detects_window_per_model_family_end_to_end(
@@ -595,6 +631,7 @@ def test_absolute_cap_is_a_noop_on_a_200k_window(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     _write_transcript(tr, 79_999)  # just under the 40% pct threshold
     env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
     assert result.stderr == b""
@@ -602,6 +639,7 @@ def test_absolute_cap_is_a_noop_on_a_200k_window(tmp_path: Path) -> None:
     tr2 = tmp_path / "t2.jsonl"
     _write_transcript(tr2, 80_000)  # exactly the 40% pct threshold
     env2 = _base_env(tmp_path)
+    env2["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     result2 = _run(_mkinput("Agent", {"subagent_type": "y"}, tr2), env2)
     assert result2.returncode == 0
     assert b"40%" in result2.stderr


### PR DESCRIPTION
## Summary
- Tightens window auto-detection from a bare family regex (`opus|sonnet|fable`) to version-pinned 1M model ids: Fable (any version), Mythos (any version), Opus 4.6/4.7/4.8, Sonnet 5, Sonnet 4.6. Window is a fixed per-model property, not a family-wide one — a future same-family model with a smaller window must not be mis-detected as 1M.
- Swaps the hook's local stdin read/parse/validate for the shared `hooks/lib/stdin_json.py` helper (#732 convention).
- Re-baselines the test suite: default transcript fixture now uses a real Haiku id, and every non-window-behavior test pins `DEV_TEAM_CONTEXT_WINDOW=200000` explicitly.
- Precedence unchanged: `DEV_TEAM_CONTEXT_WINDOW` env > detected > default. Fail-open on missing/empty/non-string model ids (unchanged).

This is slice 1 of the approved plan; slices 2-5 (#780-#783) build on this branch.

## Test plan
- [x] `pytest plugins/dev-team/tests/hooks/test_context_ceiling_guard.py` → 88 passed (new negative cases confirm same-family/off-version models like `claude-opus-4-5`, `claude-sonnet-4-5` fall to 200K, not 1M)
- [x] `pytest plugins/dev-team/tests tests/repo tests/docs` → 1175 passed, 16 skipped
- [x] Knowledge index regenerated — no drift

Closes #779

---
_Generated by [Claude Code](https://claude.ai/code/session_016HMTTHuMXB8AtkHnVkK8G7)_