### PR TITLE
feat(hooks): pinned message contract with bound + window provenance

### DIFF
--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -42,10 +42,15 @@ Env:
                                      defaults to 150000 (Anthropic's
                                      server-side compaction default). The
                                      effective threshold is
-                                     min(ceiling_pct * window, abs_ceiling)
+                                     min(ceiling_pct * window // 100, abs_ceiling)
                                      — a no-op on a 200K window (40% = 80K
                                      < 150K) but caps a 1M window's 400K
-                                     percentage threshold down to 150K.
+                                     percentage threshold down to 150K. The
+                                     warning names which bound is binding
+                                     (percentage or absolute) and the window's
+                                     provenance (override, detected, or
+                                     default) so the operator can see why the
+                                     threshold landed where it did.
 
 Contract (docs/python-hook-contract.md):
     Input : PreToolUse JSON on stdin
@@ -153,14 +158,21 @@ def _window_for_model(model: str) -> int:
     return _DEFAULT_WINDOW
 
 
-def _detect_window(transcript_path: Path) -> int:
+def _detect_window(transcript_path: Path) -> Tuple[int, bool]:
     """Auto-detect the context window from the transcript's most recent
     `message.model`. Mirrors `_measure_occupancy`'s scan (last 400 lines,
     last matching row wins) so the detected model tracks the same session
     state as the occupancy measurement.
 
+    Returns (window, matched) — `matched` is True only when a model id was
+    found AND it matched a known family (Haiku or a pinned 1M version);
+    False when no model id was found, or the model id is unrecognized, in
+    which case `window` is the 200K conservative default either way. The
+    caller uses `matched` to report window provenance as "detected" vs
+    "default".
+
     Fail-open: any parse error, missing/malformed `model` field, or a
-    transcript with no model at all resolves to the 200K default — this
+    transcript with no model at all resolves to (200000, False) — this
     function never raises and never blocks.
     """
     lines = _tail_lines(transcript_path, 400)
@@ -182,8 +194,10 @@ def _detect_window(transcript_path: Path) -> int:
         if isinstance(model, str) and model:
             last_model = model
     if last_model is None:
-        return _DEFAULT_WINDOW
-    return _window_for_model(last_model)
+        return _DEFAULT_WINDOW, False
+    if _HAIKU_RE.search(last_model) or _LARGE_WINDOW_RE.search(last_model):
+        return _window_for_model(last_model), True
+    return _DEFAULT_WINDOW, False
 
 
 def _env_window_override() -> Optional[int]:
@@ -197,6 +211,20 @@ def _env_window_override() -> Optional[int]:
         return None
     value = int(raw)
     return value if value > 0 else None
+
+
+def _resolve_window(transcript_path: Path) -> Tuple[int, str]:
+    """Resolve the effective context window and its provenance tag.
+
+    Precedence: `DEV_TEAM_CONTEXT_WINDOW` env ("override") > detected from
+    the transcript model ("detected") > the 200K conservative default
+    ("default") when the model is missing/unrecognized.
+    """
+    override = _env_window_override()
+    if override is not None:
+        return override, "override"
+    window, matched = _detect_window(transcript_path)
+    return window, ("detected" if matched else "default")
 
 
 # ---------------------------------------------------------------------------
@@ -322,58 +350,38 @@ def _write_bucket(marker: Path, bucket: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _band_for_pct(pct: int) -> Tuple[str, str]:
-    """Map occupancy percent to a Context Summarization action band.
+def _resolve_bound(pct_threshold_tokens: int, abs_ceiling: int) -> str:
+    """Which of the two thresholds is binding for `min(pct, abs)` (#780).
 
-    Mirrors the action-band table in
-    skills/context-summarization/SKILL.md (`## When to Summarize`):
-    30-40% prepare, 40-50% summarize + fresh context, 50-65% summarize
-    everything but the current task, 65%+ full summary to memory/. The
-    guard only ever fires at or above the configured ceiling (default
-    40%), so the "<30%" band is unreachable at default settings but is
-    included for completeness when DEV_TEAM_CONTEXT_CEILING_PCT is
-    lowered below 30.
+    "percentage" when the percentage-of-window threshold is the smaller (or
+    equal — ties read as percentage, matching `min()`'s first-argument
+    preference), "absolute" when the absolute cap is strictly smaller. The
+    two framings never co-occur in the message — exactly one is reported.
     """
-    if pct >= 65:
-        return (
-            "65%+",
-            "write a full summary to memory/ and start a new conversation",
-        )
-    if pct >= 50:
-        return ("50-65%", "summarize everything except the current task")
-    if pct >= 40:
-        return (
-            "40-50%",
-            "write a summary to memory/ and start a fresh context window",
-        )
-    if pct >= 30:
-        return (
-            "30-40%",
-            "prepare: identify summarization candidates",
-        )
-    return ("<30%", "no action needed yet")
+    return "percentage" if pct_threshold_tokens <= abs_ceiling else "absolute"
 
 
 def _format_message(
-    pct: int,
+    occ: int,
     window: int,
-    ceiling: int,
+    threshold_tokens: int,
+    bound: str,
+    provenance: str,
     label: str,
 ) -> str:
-    """Graduated warning message (#787): names the Context Summarization
-    action band (see `_band_for_pct`) that applies at the current
-    occupancy, escalating the wording as occupancy climbs further past
-    the ceiling instead of repeating one fixed message."""
-    band_name, action = _band_for_pct(pct)
+    """Pinned message contract (#780): plain token counts (not percentages),
+    the binding bound (percentage vs absolute — never both), and the
+    window's provenance (override/detected/default) so occupancy, the
+    computed ceiling, and where the window came from are all inspectable
+    from the warning text alone."""
     return (
-        f"🪟 Context at {pct}% of the {window}-token window "
-        f"(≥ {ceiling}% ceiling) before {label}.\n"
-        f"Per the Context Loading Protocol [{band_name} band]: {action}. "
-        "Run /context-summarization\n"
-        "(write a memory/ progress file, continue in a fresh context) "
-        "and defer non-essential agents/skills.\n"
-        "Tune with DEV_TEAM_CONTEXT_WINDOW (overrides auto-detection) "
-        "/ DEV_TEAM_CONTEXT_CEILING_PCT;\n"
+        f"🪟 Context at {occ} of {window} tokens — over the effective "
+        f"ceiling of {threshold_tokens} tokens ({bound} bound; "
+        f"window {provenance}) before {label}.\n"
+        "Run /context-summarization (write a memory/ progress file, "
+        "continue in a fresh context) and defer non-essential agents/skills.\n"
+        "Tune with DEV_TEAM_CONTEXT_WINDOW (overrides auto-detection) / "
+        "DEV_TEAM_CONTEXT_CEILING_PCT / DEV_TEAM_CONTEXT_ABS_CEILING;\n"
         "DEV_TEAM_CONTEXT_STRICT=on hard-blocks; "
         "DEV_TEAM_CONTEXT_CEILING=off disables."
     )
@@ -431,25 +439,26 @@ def _resolve_verdict(payload: dict) -> Tuple[int, Optional[str], bool]:
     if occ is None:
         return 0, None, False
 
-    window = _env_window_override()
-    if window is None:
-        window = _detect_window(transcript_path)
+    window, provenance = _resolve_window(transcript_path)
     ceiling = _positive_int_env("DEV_TEAM_CONTEXT_CEILING_PCT", 40)
     abs_ceiling = _positive_int_env("DEV_TEAM_CONTEXT_ABS_CEILING", 150_000)
 
     # Effective threshold = min(ceiling_pct * window, absolute cap). On a
     # 200K window this is a no-op (40% = 80K < 150K); on a 1M window it caps
-    # the 400K percentage threshold down to 150K (#786).
+    # the 400K percentage threshold down to 150K (#786/#780).
     pct_threshold_tokens = (ceiling * window) // 100
     threshold_tokens = min(pct_threshold_tokens, abs_ceiling)
+    bound = _resolve_bound(pct_threshold_tokens, abs_ceiling)
 
     # Bash: `pct=$((occ * 100 / window))` — integer truncation. Match exactly.
+    # Still computed for the per-session dedupe bucket even though the
+    # message itself now reports plain token counts, not a percentage.
     pct = (occ * 100) // window
     if occ < threshold_tokens:
         return 0, None, False
 
     label = _build_label(tool_name, tool_input)
-    msg = _format_message(pct, window, ceiling, label)
+    msg = _format_message(occ, window, threshold_tokens, bound, provenance, label)
 
     if os.environ.get("DEV_TEAM_CONTEXT_STRICT") == "on":
         return 2, f"{msg} [blocked: DEV_TEAM_CONTEXT_STRICT=on]", False

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -105,7 +105,7 @@ def test_warns_exit_0_on_agent_load_over_the_ceiling(tmp_path: Path) -> None:
         env,
     )
     assert result.returncode == 0
-    assert b"50%" in result.stderr
+    assert b"100000 of 200000 tokens" in result.stderr
     assert b"context-summarization" in result.stderr
 
 
@@ -175,7 +175,8 @@ def test_context_ceiling_pct_lowers_the_trigger_point(tmp_path: Path) -> None:
     env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "25"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
-    assert b"30%" in result.stderr
+    assert b"60000 of 200000 tokens" in result.stderr
+    assert b"ceiling of 50000 tokens" in result.stderr
 
 
 def test_fail_open_when_the_transcript_is_missing(tmp_path: Path) -> None:
@@ -209,7 +210,7 @@ def test_warn_dedupes_within_5_pt_bucket_rewarns_on_higher(
 
     result1 = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result1.returncode == 0
-    assert b"50%" in result1.stderr
+    assert b"100000 of 200000 tokens" in result1.stderr
 
     # Same bucket → suppressed.
     result2 = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
@@ -220,7 +221,7 @@ def test_warn_dedupes_within_5_pt_bucket_rewarns_on_higher(
     _write_transcript(tr, 140_000)  # 70% → bucket 14
     result3 = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result3.returncode == 0
-    assert b"70%" in result3.stderr
+    assert b"140000 of 200000 tokens" in result3.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -253,8 +254,8 @@ def test_malformed_ceiling_pct_falls_back_to_40(tmp_path: Path) -> None:
     env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "not-a-number"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
-    # 50% ≥ 40 (default) → warning fires
-    assert b"50%" in result.stderr
+    # 100000/200000 = 50% ≥ 40% (default) → warning fires
+    assert b"100000 of 200000 tokens" in result.stderr
 
 
 def test_malformed_window_falls_back_to_200000(tmp_path: Path) -> None:
@@ -264,7 +265,7 @@ def test_malformed_window_falls_back_to_200000(tmp_path: Path) -> None:
     env["DEV_TEAM_CONTEXT_WINDOW"] = "bogus"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
-    assert b"50%" in result.stderr
+    assert b"100000 of 200000 tokens" in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -374,79 +375,47 @@ def test_measure_occupancy_missing_file(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Graduated warning bands (#787)
+# Pinned message contract + absolute-ceiling bound framing (#780)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "pct,expected_band,expected_action_snippet",
-    [
-        (25, "<30%", "no action needed yet"),
-        (35, "30-40%", "prepare"),
-        (45, "40-50%", "fresh context window"),
-        (55, "50-65%", "everything except the current task"),
-        (70, "65%+", "full summary to memory/"),
-        (100, "65%+", "full summary to memory/"),
-    ],
-)
-def test_band_for_pct(pct, expected_band, expected_action_snippet):
-    band, action = hook._band_for_pct(pct)
-    assert band == expected_band
-    assert expected_action_snippet in action
+def test_resolve_bound_percentage_when_pct_threshold_is_smaller_or_equal():
+    assert hook._resolve_bound(80_000, 150_000) == "percentage"
+    assert hook._resolve_bound(150_000, 150_000) == "percentage"  # tie
 
 
-def test_format_message_names_the_band_action_at_boundaries():
-    msg_40 = hook._format_message(40, 200_000, 40, "loading agent 'x'")
-    assert "[40-50% band]" in msg_40
-    assert "fresh context window" in msg_40
-
-    msg_50 = hook._format_message(50, 200_000, 40, "loading agent 'x'")
-    assert "[50-65% band]" in msg_50
-    assert "everything except the current task" in msg_50
-
-    msg_65 = hook._format_message(65, 200_000, 40, "loading agent 'x'")
-    assert "[65%+ band]" in msg_65
-    assert "full summary to memory/" in msg_65
-    assert "new conversation" in msg_65
+def test_resolve_bound_absolute_when_abs_ceiling_is_smaller():
+    assert hook._resolve_bound(400_000, 150_000) == "absolute"
 
 
-def test_warn_message_escalates_band_as_occupancy_climbs(tmp_path: Path) -> None:
-    """End-to-end: crossing 40%, 50%, and 65% each names the matching
-    Context Summarization action band, not one fixed message."""
-    tr = tmp_path / "t.jsonl"
-    env = _base_env(tmp_path)
-    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
-
-    _write_transcript(tr, 90_000)  # 45% -> 40-50% band
-    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
-    assert result.returncode == 0
-    assert b"[40-50% band]" in result.stderr
-    assert b"fresh context window" in result.stderr
-
-    _write_transcript(tr, 110_000)  # 55% -> 50-65% band, new bucket
-    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
-    assert result.returncode == 0
-    assert b"[50-65% band]" in result.stderr
-    assert b"everything except the current task" in result.stderr
-
-    _write_transcript(tr, 140_000)  # 70% -> 65%+ band, new bucket
-    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
-    assert result.returncode == 0
-    assert b"[65%+ band]" in result.stderr
-    assert b"full summary to memory/" in result.stderr
-    assert b"new conversation" in result.stderr
+def test_format_message_matches_the_pinned_contract():
+    msg = hook._format_message(
+        100_000, 200_000, 80_000, "percentage", "detected", "loading agent 'x'"
+    )
+    assert (
+        "🪟 Context at 100000 of 200000 tokens — over the effective "
+        "ceiling of 80000 tokens (percentage bound; window detected)" in msg
+    )
 
 
-def test_prepare_band_fires_when_ceiling_lowered_below_40(tmp_path: Path) -> None:
-    tr = tmp_path / "t.jsonl"
-    _write_transcript(tr, 70_000)  # 35%
-    env = _base_env(tmp_path)
-    env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
-    env["DEV_TEAM_CONTEXT_CEILING_PCT"] = "30"
-    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
-    assert result.returncode == 0
-    assert b"[30-40% band]" in result.stderr
-    assert b"prepare" in result.stderr
+def test_format_message_bound_framings_never_co_occur():
+    pct_msg = hook._format_message(
+        100_000, 200_000, 80_000, "percentage", "override", "x"
+    )
+    assert "percentage bound" in pct_msg
+    assert "absolute bound" not in pct_msg
+
+    abs_msg = hook._format_message(
+        200_000, 1_000_000, 150_000, "absolute", "detected", "x"
+    )
+    assert "absolute bound" in abs_msg
+    assert "percentage bound" not in abs_msg
+
+
+@pytest.mark.parametrize("provenance", ["override", "detected", "default"])
+def test_format_message_names_window_provenance(provenance: str) -> None:
+    msg = hook._format_message(100_000, 200_000, 80_000, "percentage", provenance, "x")
+    assert f"window {provenance}" in msg
 
 
 # ---------------------------------------------------------------------------
@@ -508,7 +477,7 @@ def test_detects_window_per_model_family_end_to_end(
     assert result.returncode == 0
     expected_pct = (100_000 * 100) // expected_pct_denominator
     if expected_pct >= 40:
-        assert f"{expected_pct}%".encode() in result.stderr
+        assert f"100000 of {expected_pct_denominator} tokens".encode() in result.stderr
     else:
         assert result.stderr == b""
 
@@ -523,7 +492,8 @@ def test_env_override_wins_over_detection(tmp_path: Path) -> None:
     env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
-    assert b"50%" in result.stderr
+    assert b"100000 of 200000 tokens" in result.stderr
+    assert b"window override" in result.stderr
 
 
 def test_unrecognized_model_falls_back_to_200000(tmp_path: Path) -> None:
@@ -531,7 +501,8 @@ def test_unrecognized_model_falls_back_to_200000(tmp_path: Path) -> None:
     _write_transcript(tr, 100_000, model="gpt-5-turbo")  # unrecognized family
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path))
     assert result.returncode == 0
-    assert b"50%" in result.stderr  # 100000/200000 default
+    assert b"100000 of 200000 tokens" in result.stderr  # 100000/200000 default
+    assert b"window default" in result.stderr
 
 
 def test_detect_window_fail_open_on_missing_model_field(tmp_path: Path) -> None:
@@ -550,28 +521,29 @@ def test_detect_window_fail_open_on_missing_model_field(tmp_path: Path) -> None:
         )
         + "\n"
     )
-    assert hook._detect_window(tr) == 200_000
+    assert hook._detect_window(tr) == (200_000, False)
     result = _run(
         _mkinput("Agent", {"subagent_type": "x"}, tr), _base_env(tmp_path)
     )
     assert result.returncode == 0
-    assert b"50%" in result.stderr
+    assert b"100000 of 200000 tokens" in result.stderr
+    assert b"window default" in result.stderr
 
 
 def test_detect_window_fail_open_on_malformed_transcript(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     tr.write_text("not json at all\n")
-    assert hook._detect_window(tr) == 200_000
+    assert hook._detect_window(tr) == (200_000, False)
 
 
 def test_detect_window_fail_open_on_missing_transcript(tmp_path: Path) -> None:
-    assert hook._detect_window(tmp_path / "nope.jsonl") == 200_000
+    assert hook._detect_window(tmp_path / "nope.jsonl") == (200_000, False)
 
 
 def test_detect_window_fail_open_on_non_string_model(tmp_path: Path) -> None:
     tr = tmp_path / "t.jsonl"
     tr.write_text(json.dumps({"message": {"model": 12345}}) + "\n")
-    assert hook._detect_window(tr) == 200_000
+    assert hook._detect_window(tr) == (200_000, False)
 
 
 def test_env_window_override_none_when_unset(monkeypatch) -> None:
@@ -609,7 +581,10 @@ def test_absolute_cap_fires_at_150k_on_a_1m_window(tmp_path: Path) -> None:
     env["DEV_TEAM_CONTEXT_WINDOW"] = "1000000"
     result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
     assert result.returncode == 0
-    assert result.stderr != b""
+    assert b"150000 of 1000000 tokens" in result.stderr
+    assert b"ceiling of 150000 tokens" in result.stderr
+    assert b"absolute bound" in result.stderr
+    assert b"percentage bound" not in result.stderr
 
 
 def test_absolute_cap_does_not_fire_just_under_150k_on_a_1m_window(
@@ -642,7 +617,8 @@ def test_absolute_cap_is_a_noop_on_a_200k_window(tmp_path: Path) -> None:
     env2["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
     result2 = _run(_mkinput("Agent", {"subagent_type": "y"}, tr2), env2)
     assert result2.returncode == 0
-    assert b"40%" in result2.stderr
+    assert b"80000 of 200000 tokens" in result2.stderr
+    assert b"percentage bound" in result2.stderr
 
 
 def test_dev_team_context_abs_ceiling_override_wins_over_default(


### PR DESCRIPTION
## Summary
- Replaces the percentage-based warning text with the pinned message contract: `🪟 Context at {occ} of {window} tokens — over the effective ceiling of {eff} tokens ({bound} bound; window {provenance})`.
- `{bound}` reports which threshold is binding — `percentage` or `absolute`, never both.
- `{provenance}` reports where the window came from — `override` (env var), `detected` (matched a known model family/version), or `default` (unrecognized model / no model info).
- Threshold computation is unchanged: `min(ceiling_pct * window // 100, abs_ceiling)`.
- Removes the old `_band_for_pct` percent-based action-band text — slice 3 (#781) reintroduces graduated bands keyed to multiples of the effective ceiling (in tokens) instead of raw window percentage.

This is slice 2 of the approved plan, built on slice 1 (#779, merged). Slices 3-5 (#781-#783) build on this branch.

## Test plan
- [x] Exact boundary tests: 150000 fires / 149999 silent on a 1M window; 80000 fires / 79999 silent on a 200K window
- [x] Bound framings never co-occur (percentage vs absolute)
- [x] Provenance tags (override/detected/default) substring-tested
- [x] `pytest plugins/dev-team/tests/hooks/test_context_ceiling_guard.py` → 86 passed
- [x] `pytest plugins/dev-team/tests tests/repo tests/docs` → 1173 passed, 16 skipped
- [x] Manual smoke test confirms exact message format end-to-end

Closes #780

---
_Generated by [Claude Code](https://claude.ai/code/session_016HMTTHuMXB8AtkHnVkK8G7)_