### PR TITLE
feat(hooks): graduated bands keyed to multiples of the effective ceiling

### DIFF
--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -361,6 +361,57 @@ def _resolve_bound(pct_threshold_tokens: int, abs_ceiling: int) -> str:
     return "percentage" if pct_threshold_tokens <= abs_ceiling else "absolute"
 
 
+# Graduated bands (#781): keyed to multiples of the *effective* ceiling
+# (tokens), not raw window percentage — a band escalation always means
+# "occupancy climbed further past the same computed threshold", regardless
+# of which bound (percentage or absolute) produced that threshold.
+#   [1x,   1.25x) -> band 0, nudge
+#   [1.25x, 1.5x) -> band 1, run /context-summarization now
+#   [1.5x,   inf) -> band 2, full summary + fresh conversation (top band)
+# Integer math (eff * 5 // 4, eff * 3 // 2) avoids float imprecision.
+_BAND_NUDGE, _BAND_RUN_NOW, _BAND_FULL_SUMMARY = 0, 1, 2
+
+# Dedupe-key scale factor (#781): pct_bucket (occupancy % of window // 5)
+# tops out at 20 (100% // 5). 100 keeps `band * _BAND_SCALE` strictly above
+# any possible pct_bucket for every band >= 1, so a band transition always
+# wins the `max()` and forces a re-fire regardless of the coarser bucket.
+_BAND_SCALE = 100
+
+_BAND_ACTIONS = {
+    _BAND_NUDGE: (
+        "nudge",
+        "Consider running /context-summarization (write a memory/ progress "
+        "file, continue in a fresh context) and defer non-essential "
+        "agents/skills.",
+    ),
+    _BAND_RUN_NOW: (
+        "run-now",
+        "Run /context-summarization now — write a memory/ progress file "
+        "and continue in a fresh context.",
+    ),
+    _BAND_FULL_SUMMARY: (
+        "full-summary",
+        "Write a full summary to memory/ and start a new conversation now "
+        "— context is well past the effective ceiling.",
+    ),
+}
+
+
+def _band_for_threshold_multiple(occ: int, threshold_tokens: int) -> int:
+    """Map occupancy, as a multiple of the effective ceiling, to a band
+    index. Only called once occupancy has already cleared the ceiling
+    (`occ >= threshold_tokens`), so `threshold_tokens <= 0` never occurs on
+    that path — the guard is defensive only, not a documented behavior.
+    """
+    if threshold_tokens <= 0:
+        return _BAND_NUDGE
+    if occ >= threshold_tokens * 3 // 2:  # 1.5x
+        return _BAND_FULL_SUMMARY
+    if occ >= threshold_tokens * 5 // 4:  # 1.25x
+        return _BAND_RUN_NOW
+    return _BAND_NUDGE
+
+
 def _format_message(
     occ: int,
     window: int,
@@ -369,22 +420,31 @@ def _format_message(
     provenance: str,
     label: str,
 ) -> str:
-    """Pinned message contract (#780): plain token counts (not percentages),
-    the binding bound (percentage vs absolute — never both), and the
-    window's provenance (override/detected/default) so occupancy, the
-    computed ceiling, and where the window came from are all inspectable
-    from the warning text alone."""
-    return (
+    """Pinned message contract (#780) plus graduated band escalation
+    (#781): plain token counts (not percentages), the binding bound
+    (percentage vs absolute — never both), the window's provenance
+    (override/detected/default), and a Context Summarization action band
+    keyed to how far occupancy has climbed past the effective ceiling. The
+    top band (full-summary) leads with the directive and drops the knob
+    footer — at 1.5x the ceiling, tuning knobs are no longer the point."""
+    band = _band_for_threshold_multiple(occ, threshold_tokens)
+    band_name, action = _BAND_ACTIONS[band]
+    diagnostic = (
         f"🪟 Context at {occ} of {window} tokens — over the effective "
         f"ceiling of {threshold_tokens} tokens ({bound} bound; "
-        f"window {provenance}) before {label}.\n"
-        "Run /context-summarization (write a memory/ progress file, "
-        "continue in a fresh context) and defer non-essential agents/skills.\n"
+        f"window {provenance}) before {label}."
+    )
+
+    if band == _BAND_FULL_SUMMARY:
+        return f"[{band_name}] {action}\n{diagnostic}"
+
+    knob_footer = (
         "Tune with DEV_TEAM_CONTEXT_WINDOW (overrides auto-detection) / "
         "DEV_TEAM_CONTEXT_CEILING_PCT / DEV_TEAM_CONTEXT_ABS_CEILING;\n"
         "DEV_TEAM_CONTEXT_STRICT=on hard-blocks; "
         "DEV_TEAM_CONTEXT_CEILING=off disables."
     )
+    return f"{diagnostic}\n[{band_name}] {action}\n{knob_footer}"
 
 
 def _build_label(tool_name: str, tool_input: dict) -> str:
@@ -463,10 +523,18 @@ def _resolve_verdict(payload: dict) -> Tuple[int, Optional[str], bool]:
     if os.environ.get("DEV_TEAM_CONTEXT_STRICT") == "on":
         return 2, f"{msg} [blocked: DEV_TEAM_CONTEXT_STRICT=on]", False
 
-    # Warn mode with per-session per-5%-bucket dedupe.
+    # Warn mode dedupe, re-keyed on band identity (#781): the dedupe key is
+    # max(band_index_scaled, pct_bucket). _BAND_SCALE (100) makes any band
+    # transition dominate the coarser 5%-of-window pct_bucket (whose max
+    # value is 20, well under 100), so an escalation always breaks through
+    # even when the pct_bucket hasn't moved — worked 1M-window case: fires
+    # at occ=150000 (band 0, pct_bucket 3, key 3), re-fires at occ=190000
+    # (band 1 starts at 187500, key 100 > 3), and again at occ=226000 (band
+    # 2 starts at 225000, key 200 > 100).
+    band = _band_for_threshold_multiple(occ, threshold_tokens)
     session = _sanitize_session(payload.get("session_id") or "")
     marker = _marker_path(session)
-    bucket = pct // 5
+    bucket = max(band * _BAND_SCALE, pct // 5)
     last_bucket = _read_last_bucket(marker)
     # Always write the marker (matches the .sh's `printf ... >"$marker"` that
     # runs before the bucket comparison).

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -680,3 +680,82 @@ def test_absolute_cap_fail_open_when_transcript_missing(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     assert result.stderr == b""
+
+
+# ---------------------------------------------------------------------------
+# Graduated bands keyed to multiples of the effective ceiling (#781)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "occ,threshold_tokens,expected_band",
+    [
+        (150_000, 150_000, hook._BAND_NUDGE),  # exactly 1x
+        (187_499, 150_000, hook._BAND_NUDGE),  # just under 1.25x
+        (187_500, 150_000, hook._BAND_RUN_NOW),  # exactly 1.25x
+        (224_999, 150_000, hook._BAND_RUN_NOW),  # just under 1.5x
+        (225_000, 150_000, hook._BAND_FULL_SUMMARY),  # exactly 1.5x
+        (500_000, 150_000, hook._BAND_FULL_SUMMARY),  # well past 1.5x
+    ],
+)
+def test_band_for_threshold_multiple(
+    occ: int, threshold_tokens: int, expected_band: int
+) -> None:
+    assert hook._band_for_threshold_multiple(occ, threshold_tokens) == expected_band
+
+
+def test_format_message_nudge_band_leads_with_diagnostic_and_keeps_footer():
+    msg = hook._format_message(150_000, 1_000_000, 150_000, "absolute", "detected", "x")
+    assert msg.startswith("🪟 Context at")
+    assert "[nudge]" in msg
+    assert "Tune with DEV_TEAM_CONTEXT_WINDOW" in msg
+
+
+def test_format_message_run_now_band_leads_with_diagnostic_and_keeps_footer():
+    msg = hook._format_message(190_000, 1_000_000, 150_000, "absolute", "detected", "x")
+    assert msg.startswith("🪟 Context at")
+    assert "[run-now]" in msg
+    assert "Run /context-summarization now" in msg
+    assert "Tune with DEV_TEAM_CONTEXT_WINDOW" in msg
+
+
+def test_format_message_full_summary_band_leads_with_directive_no_footer():
+    """Top band (#781): leads with the directive (before the diagnostic
+    line) and drops the knob footer entirely."""
+    msg = hook._format_message(226_000, 1_000_000, 150_000, "absolute", "detected", "x")
+    assert msg.startswith("[full-summary]")
+    directive_idx = msg.index("Write a full summary to memory/")
+    diagnostic_idx = msg.index("🪟 Context at")
+    assert directive_idx < diagnostic_idx
+    assert "Tune with DEV_TEAM_CONTEXT_WINDOW" not in msg
+
+
+def test_dedupe_rekeyed_on_band_identity_worked_1m_case(tmp_path: Path) -> None:
+    """Worked case from #781: on a 1M window with the 150K absolute cap
+    binding, band escalations always break through the coarser
+    5%-of-window pct_bucket — fires at 150000 (band 0), re-fires at 190000
+    (band 1, even though pct_bucket is unchanged), and again at 226000
+    (band 2)."""
+    tr = tmp_path / "t.jsonl"
+    env = _base_env(tmp_path)
+    env["DEV_TEAM_CONTEXT_WINDOW"] = "1000000"
+
+    _write_transcript(tr, 150_000)  # band 0 (nudge)
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[nudge]" in result.stderr
+
+    # Same band, pct_bucket unchanged (15% -> still bucket 3) -> suppressed.
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert result.stderr == b""
+
+    _write_transcript(tr, 190_000)  # band 1 (run-now) — pct_bucket still 3
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[run-now]" in result.stderr
+
+    _write_transcript(tr, 226_000)  # band 2 (full-summary)
+    result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+    assert result.returncode == 0
+    assert b"[full-summary]" in result.stderr


### PR DESCRIPTION
## Summary
- Adds three Context Summarization action bands at 1x/1.25x/1.5x of the effective ceiling: `nudge` → `run /context-summarization now` → `full summary + fresh conversation`.
- The top band (`full-summary`) leads the message with the directive (before the diagnostic line) and drops the tuning-knob footer entirely.
- Re-keys the per-session dedupe on band identity: `max(band_index * 100, pct_bucket)`. The scale factor guarantees any band transition dominates the coarser 5%-of-window `pct_bucket`, so an escalation always re-fires even when the bucket hasn't moved.

This is slice 3 of the approved plan, built on slice 2 (#780, merged). Slices 4-5 (#782-#783) build on this branch.

## Test plan
- [x] Worked 1M-window case from the issue: fires at 150000 (band 0), re-fires at 190000 (band 1) and 226000 (band 2) — none of which cross a `pct_bucket` boundary on their own
- [x] Exact-at-threshold and just-under tests per band (150000/187500/225000 boundaries; 187499/224999 just-under)
- [x] Top band leads with the directive (`msg.index()` ordering check) and omits the knob footer; bands 0/1 keep the footer
- [x] `pytest plugins/dev-team/tests/hooks/test_context_ceiling_guard.py` → 96 passed
- [x] `pytest plugins/dev-team/tests tests/repo tests/docs` → 1183 passed, 16 skipped
- [x] Manual smoke test confirms the top-band message format end-to-end

Closes #781

---
_Generated by [Claude Code](https://claude.ai/code/session_016HMTTHuMXB8AtkHnVkK8G7)_