### PR TITLE
fix: point install link and SARIF informationUri at bdfinst/agentic-dev-team

### DIFF
--- a/plugins/dev-team/tools/entropy-check.py
+++ b/plugins/dev-team/tools/entropy-check.py
@@ -173,7 +173,7 @@ def sarif_from_findings(findings: list[Finding]) -> dict:
                     "driver": {
                         "name": "entropy-check",
                         "version": "1.0.0",
-                        "informationUri": "https://github.com/bdfinst/dev-team",
+                        "informationUri": "https://github.com/bdfinst/agentic-dev-team",
                         "rules": [
                             {"id": rid, "shortDescription": {"text": text}}
                             for rid, text in rules.items()

--- a/plugins/dev-team/tools/model-hash-verify.py
+++ b/plugins/dev-team/tools/model-hash-verify.py
@@ -156,7 +156,7 @@ def sarif_from_findings(findings: list[Finding]) -> dict:
                     "driver": {
                         "name": "model-hash-verify",
                         "version": "1.0.0",
-                        "informationUri": "https://github.com/bdfinst/dev-team",
+                        "informationUri": "https://github.com/bdfinst/agentic-dev-team",
                         "rules": [
                             {"id": rid, "shortDescription": {"text": text}}
                             for rid, text in rules.items()

--- a/plugins/security-assessment/README.md
+++ b/plugins/security-assessment/README.md
@@ -72,11 +72,11 @@ Re-runnable on all platforms — each step skips tools that are already present.
 
 ```bash
 # From the marketplace
-claude plugin marketplace add https://github.com/bdfinst/dev-team
+claude plugin marketplace add https://github.com/bdfinst/agentic-dev-team
 claude plugin install security-assessment@bfinster
 
 # From a local clone
-claude plugin install --scope project /path/to/dev-team/plugins/security-assessment
+claude plugin install --scope project /path/to/agentic-dev-team/plugins/security-assessment
 ```
 
 ### Verify

--- a/plugins/security-assessment/harness/tools/base64-decode-scan.py
+++ b/plugins/security-assessment/harness/tools/base64-decode-scan.py
@@ -225,7 +225,7 @@ def build_sarif(findings: list[dict]) -> dict:
                     "driver": {
                         "name": "base64-decode-scan",
                         "version": "1.0.0",
-                        "informationUri": "https://github.com/bdfinst/dev-team",
+                        "informationUri": "https://github.com/bdfinst/agentic-dev-team",
                         "rules": [
                             {
                                 "id": "secrets.base64-encoded-credential",

--- a/plugins/security-assessment/harness/tools/shared-cred-hash-match.py
+++ b/plugins/security-assessment/harness/tools/shared-cred-hash-match.py
@@ -107,7 +107,7 @@ def sarif_from_findings(
                 "driver": {
                     "name": "shared-cred-hash-match",
                     "version": "1.0.0",
-                    "informationUri": "https://github.com/bdfinst/dev-team",
+                    "informationUri": "https://github.com/bdfinst/agentic-dev-team",
                     "rules": rules,
                 }
             },


### PR DESCRIPTION
Fixes #805.

The security-assessment README told users to run
`claude plugin marketplace add https://github.com/bdfinst/dev-team`, which points at a repo that isn't this project. Beyond the line reported in the issue, the same wrong URL was embedded as the SARIF `informationUri` in four tool scripts, and the README's local-clone example used the same wrong directory name.

## Changes

- `plugins/security-assessment/README.md` — marketplace install URL and local-clone path now use `agentic-dev-team`
- `plugins/dev-team/tools/model-hash-verify.py`, `plugins/dev-team/tools/entropy-check.py`, `plugins/security-assessment/harness/tools/base64-decode-scan.py`, `plugins/security-assessment/harness/tools/shared-cred-hash-match.py` — SARIF `informationUri` corrected

String-only changes; the full local CI mirror (18 checks, 2204 pytest tests) passed on pre-push. Touches `.py` files, so this PR requires explicit human merge (no auto-merge armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)