### PR TITLE
docs: add end-to-end workflow recommendations report and refresh experiments FAQ

### DIFF
--- a/docs/experiments/FAQ.md
+++ b/docs/experiments/FAQ.md
@@ -2,18 +2,25 @@
 
 Questions and answers about the TDD experiment findings. See the reports for
 detail: [`01-final-results.md`](01-final-results.md) (three-arm study, which
-subsumes the earlier two-arm TDD-vs-test-after cut of the same data), and the
-unified follow-up design [`02-experiment-prompt-when-tdd-pays.md`](agentic-workflow-evidence/02-experiment-prompt-when-tdd-pays.md).
+subsumes the earlier two-arm TDD-vs-test-after cut of the same data),
+[`02-final-results.md`](02-final-results.md) (the follow-up that isolated
+refactoring as TDD's load-bearing mechanism), and
+[`05-final-results.md`](05-final-results.md) (the terminal workflow-matrix
+result). [`README.md`](README.md) tells the full five-experiment story.
 
 ---
 
 ## Q1. How do the findings align with the claim that a main goal of TDD is design discovery — "by writing tests one after the other, you are gradually discovering the design that you feel is optimal"?
 
-**Short answer:** the findings don't support that claim and lean mildly against
-it — but the experiment is a *weak test* of it, and the way it fails is itself
-informative.
+**Short answer:** the findings don't support the *test-ordering* half of that
+claim — writing tests one-by-one bought no measurable design advantage in any
+experiment — but they strongly support its *refactoring* half. The design
+benefit the claim describes is real, and it comes from the deliberate
+refactor-after-green step, not from the RED-GREEN cadence. Experiment 01
+suggested this; Experiment 02 confirmed it by isolation; Experiment 05's
+winning workflows both have per-batch refactoring as their shared trait.
 
-### What the claim predicts vs. what we saw
+### What the claim predicts vs. what Experiment 01 saw
 If writing tests one-by-one gradually surfaces the optimal design, test-first
 should produce the **best-structured** code. The review-grade lens — the only axis
 that actually measures design (SRP, complexity, coupling, duplication) — found the
@@ -35,8 +42,8 @@ The mechanism is visible: TDD's design discovery is supposed to happen in
 **REFACTOR**, and the agent's strict RED-GREEN-REFACTOR **stopped at GREEN** — it
 made tests pass and moved on. No refactor → no emergent design.
 
-### Why the experiment can't really adjudicate the claim
-The claim is about a *developer gradually discovering* design. The experiment
+### Why Experiment 01 alone couldn't adjudicate the claim
+The claim is about a *developer gradually discovering* design. Experiment 01
 removed the conditions that benefit lives in:
 
 - **It's an autonomous LLM, not a human.** An agent tends to pattern-match a whole
@@ -44,27 +51,56 @@ removed the conditions that benefit lives in:
   different shape" insight the claim describes isn't guaranteed to engage.
 - **Requirements were clear and frozen.** Design discovery matters most when the
   design space is open; with a fully-specified spec the optimal shape is largely
-  determined — little to discover. (Same scope caveat as the TDD-vs-non-TDD report.)
+  determined — little to discover.
 - **Tasks were small/well-understood**, constraining the design space; the payoff
   for emergent design grows with novelty and size.
 - **Design was measured by proxy** (review agents), not the developer's *felt*
   sense of "optimal," which is what the claim is actually about.
 
-### The interesting reconciliation
-Design quality **did** improve — but with the **build-pipeline**, which adds an
-explicit review/refactor step, not from test ordering. That supports the *spirit*
-of the claim (iterating on and critiquing structure yields better design) while
-showing the trigger was the deliberate "examine and improve the structure" act,
-not the RED-GREEN cadence alone. For an autonomous agent, the design benefit came
-from an **enforced refactor/review loop**, not from writing tests one-by-one.
+The human-developer and "felt sense of optimal" caveats still stand — no
+experiment in this line tests the claim for a human. The other conditions were
+addressed by the follow-ups below: open-design tasks with a deliberate trap,
+vague-spec conditions, and changeability measured by a withheld change chain.
 
-That gap is exactly what **Epic P1** (GitHub #362) targets — wiring
-`refactor-opportunity-review`/`complexity-review` into the REFACTOR step. Honest
-read: test-first *as run here* did not deliver design discovery, the experiment
-cannot refute the claim for a human on open-ended design, and it points at both
-*why* (the refactor/insight step was missing) and *how* to make TDD produce it.
+### What the follow-up experiments settled
 
-An experiment designed to actually test this claim — crossing requirement clarity
-with workflow (a refactor-enforced arm) on open-design tasks, graded by a withheld
-change chain measuring *changeability* — is specified in
-[`02-experiment-prompt-when-tdd-pays.md`](agentic-workflow-evidence/02-experiment-prompt-when-tdd-pays.md).
+**Experiment 02 ran the test this FAQ originally called for and confirmed the
+mechanism by isolation.** On open-design tasks graded by a 3-change chain,
+TDD-with-refactor produced the most changeable code (664 mean lines changed
+vs. 700–770 for every other arm) — and removing *just* the refactor step
+(`tdd-no-refactor`) erased the advantage entirely (701 lines, indistinguishable
+from test-after's 700). Test-first ordering by itself bought nothing; the
+discipline of refactoring after green is what mattered. See
+[`02-final-results.md`](02-final-results.md).
+
+**Experiment 05 closed the arc.** Across the full workflow matrix (test
+ordering × batch size × authorship), the two statistically separated winners on
+quality-per-dollar — Code-First Small Batches (Single Agent) and Classic TDD —
+share one trait: they refactor after every green increment in small batches.
+Test ordering did not separate them; every arm that deferred refactoring to a
+single end-of-build pass cost 2–4.5× more with worse changeability. See
+[`05-final-results.md`](05-final-results.md).
+
+### The reconciliation
+Design quality **does** improve — but the trigger is the deliberate "examine and
+improve the structure" act, not the RED-GREEN cadence alone. That supports the
+*spirit* of the claim (iterating on and critiquing structure yields better
+design) while relocating the credit: for an autonomous agent, the design benefit
+comes from an **enforced refactor/review loop**, not from writing tests
+one-by-one.
+
+That gap has since been closed in the plugin itself. Epic P1 (GitHub #362,
+"Make review actually improve the code") wired
+`refactor-opportunity-review`/`complexity-review` into the TDD skill's REFACTOR
+step (P1-S1, PR #378), and the regression check in
+[`complexity-refactor-regression.md`](../complexity-refactor-regression.md)
+confirms mean `complexity-review` findings dropped below the pre-wiring
+baseline (~5.3) — the refactor-step mechanism identified in these experiments
+is doing real work inside the actual `/build` workflow, not just the experiment
+harness.
+
+Honest read: test-first *as run in Experiment 01* did not deliver design
+discovery; the follow-ups showed why (the refactor step was missing), proved
+the mechanism by isolating it (Experiment 02), and validated the fix in
+production (Epic P1). The claim remains untested for a human developer on
+open-ended design.

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -4,6 +4,9 @@ Five experiments, run in sequence, each answering the question the previous one
 left open. This page tells that story end to end; each experiment's own report
 has the full methodology and data. **[`05-final-results.md`](05-final-results.md)
 is the terminal result** — the answer this whole line of work was building toward.
+For the practical takeaways — end-to-end workflow guidance from requirements
+definition through review, synthesized across all five experiments — see
+**[`RECOMMENDATIONS.md`](RECOMMENDATIONS.md)**.
 
 All experiments hold the model fixed at `claude-sonnet-4-6` and grade against
 hidden acceptance tests injected only at grading time, so no arm can see (or
@@ -237,6 +240,9 @@ not funded).
 
 ## Supporting documents
 
+- [`RECOMMENDATIONS.md`](RECOMMENDATIONS.md) — the practical synthesis:
+  end-to-end workflow guidance (requirements → workflow choice → build cadence
+  → review) with each recommendation tied to the experiment that resolved it.
 - [`FAQ.md`](FAQ.md) — targeted Q&A against specific claims about TDD (e.g.,
   "TDD gradually discovers optimal design"), cross-referencing 01 and 02.
 - [`04-power-analysis.md`](04-power-analysis.md) —

--- a/docs/experiments/RECOMMENDATIONS.md
+++ b/docs/experiments/RECOMMENDATIONS.md
@@ -1,0 +1,180 @@
+# Recommendations — The End-to-End Agentic Workflow
+
+Evidence-backed guidance for running an agentic development workflow from
+requirements definition through shipped code, synthesizing the best results
+from the full experiment line (Experiments 01–05 plus the production
+validation in
+[`complexity-refactor-regression.md`](../complexity-refactor-regression.md)).
+Each recommendation cites the experiment that resolved it; the narrative arc
+behind them is in [`README.md`](README.md), and the terminal statistical
+result is [`05-final-results.md`](05-final-results.md).
+
+**The workflow in one paragraph:** invest in requirements clarity *before* any
+code is written — no downstream workflow recovers information the spec never
+stated. Then build with **Code-First Small Batches (Single Agent)**: one agent
+writes the code for one behavior, then its test, then refactors while the
+suite stays green, and repeats. Keep refactoring on every small batch — never
+deferred to the end — and never let a refactor step change a test. Skip
+independent coder/tester splits and all-at-once batching; they cost 2–4.5×
+more for the same or worse outcomes. Reserve the full plan/review pipeline for
+large, multi-file work, where its overhead becomes a minor surcharge and its
+enforced review loop is the one lever that measurably improves structure.
+
+---
+
+## 1. Define the requirements first — clarity is irreducible
+
+**Recommendation:** state every business rule explicitly before implementation
+begins. Resolve ambiguities with a human conversation (design interrogation,
+spec review), not by hoping a disciplined workflow will surface them.
+
+**Evidence:**
+
+- **No workflow compensates for a vague spec.** Under vague requirements, no
+  arm recovered information the spec never stated — one task's vague spec
+  omitted per-channel retry semantics, and *every* workflow scored 0% on the
+  acceptance tests probing that omitted decision. This is a communication
+  problem, not a methodology problem
+  ([`02-final-results.md`](02-final-results.md)).
+- **Spec-synthesis pipelines don't fix it either.** The hypothesis that the
+  full `/specs`→`/plan`→`/build` pipeline's explicit acceptance-criteria
+  synthesis would surface unstated edge cases better than TDD's failing-test
+  discipline was rejected: run to completion, the ship arm scored 25% pooled
+  EDGE pass under vague specs vs. Classic TDD's 33% — matching or trailing on
+  every task (Experiment 03, reported in
+  [`02-final-results.md`](02-final-results.md)).
+- The expected clarity×workflow interaction never materialized — workflow
+  choice mattered the same amount whether the spec was clear or vague. Fixing
+  the spec is a separate, prior investment that no downstream choice
+  substitutes for (Experiment 02).
+
+**In practice:** treat the spec the way Experiments 04 and 05 did — they fixed
+spec clarity to "clear" because vague specs irreducibly cap what any workflow
+can achieve. Aim for the corpus standard: zero judgment calls left to the
+implementing agent.
+
+## 2. Size the task before choosing orchestration
+
+**Recommendation:** match the machinery to the work. For small, well-specified
+tasks, dispatch a single agent directly. Reserve the full plan/build/review
+pipeline for large, multi-file work.
+
+**Evidence:**
+
+- The pipeline's cost premium over the cheapest hand-driven arm **shrinks as
+  tasks grow** — 4.74× on small katas, 2.57× on medium features, 1.33× on
+  large multi-file packages. Its fixed planning/review overhead is a large
+  multiplier on a one-function change and a minor surcharge on a real feature
+  ([`01-final-results.md`](01-final-results.md)).
+- On the large tier, the pipeline produced the **cleanest code** by the
+  review-agent lens (67 weighted findings vs. 91 test-after, 108 test-first) —
+  directional at n=6, but the only quality signal in the whole line that
+  separated the arms (Experiment 01).
+
+## 3. Build with code-first small batches, one agent
+
+**Recommendation:** default to **Code-First Small Batches (Single Agent)**
+(harness arm `continuous-single`): for each behavior, write the code, then the
+test covering it, keep the suite green, refactor, move to the next behavior.
+**Classic TDD** (`tdd-refactor`) is a sound second choice for teams that
+prefer test-first discipline — it costs ~60% more per unit of work for
+statistically indistinguishable maintainability.
+
+**Evidence:**
+
+- In the full workflow matrix (test ordering × batch size × authorship),
+  Code-First Small Batches (Single Agent) is the clear winner on
+  quality-per-dollar ($0.99/cell, quality 0.961, efficiency 0.968), with
+  Classic TDD a clear second ($1.59/cell, efficiency 0.608). Both are
+  statistically separated from every other arm and from each other; the
+  remaining five arms are ¼–⅕ as cost-efficient
+  ([`05-final-results.md`](05-final-results.md)).
+- **Test-first ordering by itself buys nothing.** It never separated from
+  test-after on quality in Experiment 01, and removing just the refactor step
+  from TDD erased its changeability advantage entirely — 701 mean lines
+  changed vs. test-after's 700 (Experiment 02). The ordering is a preference;
+  the refactoring is the mechanism.
+
+**Avoid:**
+
+- **Big batches.** Writing the entire implementation and then the entire test
+  suite (or all tests first, then all code) costs 2–4.5× more per cell and
+  produces measurably worse changeability (blast radius ~50 vs. ~40 LOC per
+  follow-up change) (Experiment 05).
+- **Split authorship.** An independent tester agent context-isolated from the
+  coder costs ~3× the single-agent equivalent everywhere it was tried, with no
+  consistent quality gain — its marginally higher mutation scores never offset
+  the coordination tax (Experiments 04 and 05).
+
+## 4. Refactor on every small batch — never only at the end
+
+**Recommendation:** refactor immediately after each green increment, as part
+of the loop. Do not accumulate a refactoring debt to pay in one end-of-build
+pass, and never skip the step.
+
+**Evidence:**
+
+- **Refactoring is the load-bearing mechanism** of every workflow that won.
+  TDD-with-refactor produced the most changeable code across a 3-change chain
+  (664 mean lines vs. 700–770 for all other arms), and deleting just the
+  refactor step erased the advantage (Experiment 02).
+- **Per-batch beats end-of-build.** Both Experiment 05 winners refactor after
+  every green; every arm that deferred refactoring to a single final pass
+  landed in the inferior cluster. Experiment 04 found the same ordering among
+  cadences (continuous 138.5 cumulative blast vs. one-shot 155.0).
+- **Don't misread Experiment 04's "no refactoring scored best" row.** That
+  result is an artifact of its metric — cumulative blast charged the
+  refactor's own churn against the refactoring arms, and a 3-change horizon is
+  too short for the payoff to surface (documented in that report's
+  limitations). Experiment 05 treated "does refactoring help" as settled and
+  made it mandatory in every arm ([`04-final-results.md`](04-final-results.md),
+  [`05-final-results.md`](05-final-results.md)).
+- **This works in production, not just the harness.** Wiring
+  `refactor-opportunity-review`/`complexity-review` into the TDD skill's
+  REFACTOR step (Epic P1, PR #378) dropped mean complexity findings below the
+  pre-wiring baseline of ~5.3
+  ([`complexity-refactor-regression.md`](../complexity-refactor-regression.md)).
+
+**Invariant:** a refactor step must never change test behavior. Refactoring is
+behavior-preserving by definition; tests are frozen during it. This is
+enforceable mechanically and held perfectly in both campaigns — zero
+violations across Experiment 04's 364 cells and Experiment 05's 672 rows.
+
+## 5. Use review agents — not coverage — as the design signal
+
+**Recommendation:** gate structural quality with an enforced review/refactor
+loop. Do not use coverage or mutation score to choose between workflows.
+
+**Evidence:**
+
+- **Coverage and mutation are blind to workflow choice.** Every arm saturates
+  near 100% coverage / 1.0 mutation on small and medium tasks; even the large
+  tier showed the arms landing on top of each other (Experiment 01).
+- **Higher mutation scores did not mean better workflows.** The losing
+  big-batch and split arms posted *higher* mutation scores (0.93–0.98) than
+  the two winners (0.80–0.86) — thoroughness bought at 2–4× the cost with
+  worse changeability is a bad trade (Experiment 05).
+- The review-agent lens (SRP, complexity, coupling, duplication) was the one
+  axis that separated arms on quality (Experiment 01), and its enforced use in
+  the REFACTOR step is validated in production
+  ([`complexity-refactor-regression.md`](../complexity-refactor-regression.md)).
+
+---
+
+## Scope and caveats
+
+These recommendations rest on the experiment line's stated limits — apply
+judgment where your work falls outside them:
+
+- **Corpus:** small-to-medium, fully-specified, mostly single-module tasks
+  with a 3-change follow-up chain. A larger-corpus follow-up (multi-file
+  tasks, 8-change chain, held-out changeability probe) is scoped but not
+  funded ([`05-final-results.md`](05-final-results.md), Future work).
+- **Model:** all results at `claude-sonnet-4-6`, held fixed. A different
+  model's aptitude for incremental vs. big-batch work could shift rankings.
+- **Maintainability proxy:** Experiment 05's maintainability half is blast
+  radius (production-code churn per change), not static complexity metrics,
+  which were unavailable in that run.
+- **Human developers untested.** The design-discovery claim for a *human*
+  writing tests one-by-one on open-ended work is outside what this line can
+  adjudicate (see [`FAQ.md`](FAQ.md)).


### PR DESCRIPTION
## Summary

Two documentation additions to `docs/experiments/`, both synthesizing the now-complete experiment line (01–05):

- **New `RECOMMENDATIONS.md`** — end-to-end workflow guidance from requirements definition through review, encompassing the best results resolved across all five experiments. Covers: requirements clarity as an irreducible prerequisite (exp 02/03), sizing the task before choosing orchestration (exp 01), Code-First Small Batches (Single Agent) as the default build workflow with Classic TDD second (exp 05), per-batch refactoring cadence with the tests-frozen invariant (exp 02/04/05 plus the Epic P1 production validation), and review agents rather than coverage/mutation as the design signal (exp 01/05). Each recommendation cites the experiment that resolved it; a closing section restates the line's scope limits. Linked from the experiments README intro and supporting-documents list.

- **FAQ refresh** — the FAQ predated the completion of experiments 02–05 and Epic P1, so it framed the refactoring-mechanism question as open and the REFACTOR-step wiring as future work. It now cites the completed results (exp 02 confirmed refactoring as the mechanism by isolation; exp 05's winners share per-batch refactoring) and links the complexity regression check that validated the wiring, while keeping the still-valid caveats (human developers untested, design measured by proxy).

## Notes

- Docs-only diff (`docs/experiments/RECOMMENDATIONS.md`, `FAQ.md`, `README.md`); no code, agents, skills, or hooks touched — qualifies for auto-merge per the repo working rules.
- Branch restarted from `main` after PR #817 merged, per the merged-PR follow-up convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftou3rzKBfJgHu9kwdeHcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftou3rzKBfJgHu9kwdeHcn)_