### PR TITLE
docs: stop publishing CLAUDE.md to the MkDocs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,13 +112,11 @@ nav:
 
   - security-assessment Plugin:
       - Overview: plugins/security-assessment/README.md
-      - Architecture: plugins/security-assessment/CLAUDE.md
       - User Guide: plugins/security-assessment/docs/user-guide-security-assessment.md
       - Accepted Risks Format: plugins/security-assessment/docs/accepted-risks-format.md
       - Comparative Testing: plugins/security-assessment/docs/comparative-testing.md
 
   - marketplace-dev Plugin:
-      - Guide: plugins/marketplace-dev/CLAUDE.md
       - Agent-type Decision Rules: plugins/marketplace-dev/knowledge/agent-type-decision-rules.md
 
   - Guides:

--- a/scripts/assemble-docs.sh
+++ b/scripts/assemble-docs.sh
@@ -26,13 +26,12 @@ cp -r "${REPO_ROOT}/plugins/dev-team/docs"      "${OUT}/plugins/dev-team/docs"
 # security-assessment plugin docs
 mkdir -p "${OUT}/plugins/security-assessment"
 cp "${REPO_ROOT}/plugins/security-assessment/README.md"    "${OUT}/plugins/security-assessment/README.md"
-cp "${REPO_ROOT}/plugins/security-assessment/CLAUDE.md"    "${OUT}/plugins/security-assessment/CLAUDE.md"
 cp "${REPO_ROOT}/plugins/security-assessment/CHANGELOG.md" "${OUT}/plugins/security-assessment/CHANGELOG.md"
 cp -r "${REPO_ROOT}/plugins/security-assessment/docs"      "${OUT}/plugins/security-assessment/docs"
 
-# marketplace-dev plugin docs (CLAUDE.md is the guide; no README/docs tree)
+# marketplace-dev plugin docs (no README/docs tree; CLAUDE.md is an agent
+# instruction file and is intentionally NOT published to the docs site)
 mkdir -p "${OUT}/plugins/marketplace-dev/knowledge"
-cp "${REPO_ROOT}/plugins/marketplace-dev/CLAUDE.md"        "${OUT}/plugins/marketplace-dev/CLAUDE.md"
 cp "${REPO_ROOT}/plugins/marketplace-dev/CHANGELOG.md"     "${OUT}/plugins/marketplace-dev/CHANGELOG.md"
 cp "${REPO_ROOT}/plugins/marketplace-dev/knowledge/agent-type-decision-rules.md" \
    "${OUT}/plugins/marketplace-dev/knowledge/agent-type-decision-rules.md"


### PR DESCRIPTION
## What

Stop the docs build from publishing plugin `CLAUDE.md` files to the site:

- `scripts/assemble-docs.sh` — drop the copies of `security-assessment/CLAUDE.md` and `marketplace-dev/CLAUDE.md` into `_mkdocs_src/`.
- `mkdocs.yml` — remove the two nav entries that pointed at them (`security-assessment` "Architecture", `marketplace-dev` "Guide").

## Why

`CLAUDE.md` is an **agent instruction file**, not user-facing documentation. Publishing it exposed internal build/behavior instructions on the public docs site.

## Follow-up (not in this PR)

`marketplace-dev` used `CLAUDE.md` as its only published page, so its nav section now has just "Agent-type Decision Rules". If a public overview is wanted, it should get a proper `README.md` / docs page authored as user documentation — not a re-published instruction file. Happy to do that separately.

Requires human merge (touches `mkdocs.yml` + a script, not just `*.md`).