### PR TITLE
perf(ci): parallelize the pytest gate, ~139s → ~42s

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,6 +41,13 @@ pytest>=7.0
 # functions are not natively supported."
 pytest-asyncio>=0.23
 
+# Parallelizes the content-guard pytest run (chk_hook_units in scripts/ci-local.sh)
+# across cores. The suite is the local/CI wall-clock long pole; ci-local.sh runs it
+# with `-n auto --dist loadfile` when this is present and falls back to a serial run
+# when it is not. loadfile keeps each file's tests on one worker so order-dependent
+# git-subprocess suites stay deterministic.
+pytest-xdist>=3.0
+
 # Required by the Python static-analysis lane (dev-team plugin): /build's
 # self-heal pass and /code-review's static pre-pass dispatch ruff (lint +
 # autofix, native SARIF; SARIF needs >= 0.3.1) whenever Python files are in

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -224,10 +224,21 @@ chk_hook_units() {
   # Windows workflow (wrapper-windows.yml) because they are timing/signal
   # sensitive and not portable to this runner, matching the pre-existing
   # tests/hooks/ exclusion below.
+  # This suite is the wall-clock long pole. Parallelize it across cores when
+  # pytest-xdist is installed (declared in requirements-dev.txt); fall back to a
+  # serial run when it is absent so the gate never hard-depends on xdist.
+  # --dist loadfile keeps every test from one file on a single worker, preserving
+  # intra-file execution order — the git-subprocess suites (e.g. progress_guardian)
+  # are order-sensitive and race when their tests are split across workers.
+  parallel=()
+  if python3 -c 'import xdist' >/dev/null 2>&1; then
+    parallel=(-n auto --dist loadfile)
+  fi
   python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands \
     tests/docs tests/knowledge tests/bats tests/skills tests/scripts \
     --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py \
-    --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py
+    --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py \
+    ${parallel[@]+"${parallel[@]}"}
 }
 
 # Ordered list of "label::function". Order defines both the replay order and the

--- a/tests/repo/test_plan_template.py
+++ b/tests/repo/test_plan_template.py
@@ -10,8 +10,6 @@ Ported from tests/repo/plan-template-tests.bats (#673).
 from __future__ import annotations
 
 import re
-import subprocess
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -29,7 +27,6 @@ PLAN_TEMPLATE = (
 )
 BUILD_SKILL = REPO_ROOT / "plugins" / "dev-team" / "skills" / "build" / "SKILL.md"
 GUARDIAN = REPO_ROOT / "scripts" / "progress_guardian.py"
-GUARDIAN_TESTS = REPO_ROOT / "tests" / "scripts" / "test_progress_guardian.py"
 
 # ---------------------------------------------------------------------------
 # Slice 1 - /plan template + Step 4 prose
@@ -87,23 +84,6 @@ def test_526_2_1c_build_skill_still_contains_verify_acceptance_criteria_step() -
 # Slice 3 - belt-and-suspenders: the #525 guardian inner-skip is preserved so
 # legacy plans (that still carry the AC mirror) don't false-positive.
 # ---------------------------------------------------------------------------
-
-
-def test_526_3_1a_full_progress_guardian_pytest_suite_still_passes_end_to_end() -> None:
-    # Runs the guardian's own regression suite (ported from bats to pytest in
-    # #676). If either the removal of the /build AC-tick or any other
-    # post-#525 change accidentally regresses the guardian, this fails loudly
-    # with which of the 22 tests broke.
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", str(GUARDIAN_TESTS), "-q"],
-        cwd=str(REPO_ROOT),
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-    match = re.search(r"(\d+) passed", result.stdout)
-    assert match is not None, result.stdout
-    assert int(match.group(1)) >= 22
 
 
 def test_526_3_1b_guardian_parse_plan_carries_in_acceptance_inner_skip_state() -> None:


### PR DESCRIPTION
## Problem

`scripts/ci-local.sh` (the pre-push gate, mirrored by CI) was slow. Profiling every check shows one dominates the wall-clock:

| Check | Wall time |
|---|---|
| **`chk_hook_units` (pytest)** | **~139s** |
| `semgrep_fixtures` | ~18s |
| `sa_shell_suite` | ~10s |
| the other 15 checks | < 1s each |

Everything but pytest already runs in the parallel pool and is hidden. The pytest gate ran **2500+ tests single-process** on an otherwise-idle multi-core box, and one test alone took **24s**.

## Fix

- **Parallelize the pytest gate** with `pytest-xdist` (added to `requirements-dev.txt`). ci-local runs it `-n auto --dist loadfile` when xdist is present, serial fallback when not. `loadfile` keeps each file's tests on one worker so the order-sensitive git-subprocess suites (e.g. `progress_guardian`) stay deterministic — `--dist load` (per-test) reorders them across workers and makes them flake.
- **Delete `test_526_3_1a_..._end_to_end`.** It shelled out to re-run `tests/scripts/test_progress_guardian.py`, which the outer suite already runs directly — pure duplication, the single most expensive test (24s), and an xdist race against the direct run. Removed its orphaned `subprocess`/`sys`/`GUARDIAN_TESTS` imports.

## Result

`chk_hook_units` **~139s → ~42s** (2526 passed, 17 skipped), which drops the whole gate to roughly the same since pytest was the pole. CI's per-job pytest run benefits identically.

## Follow-up (not here)

Further speedup is available by making the `progress_guardian` suite per-test isolated so `--dist load` (better balancing than `loadfile`) can be used — that would push toward the ~15–18s semgrep floor. Left out to keep this change safe and reviewable.

Human merge (touches a script, a test, and a dev dep).