### PR TITLE
ci: lint every PR commit and issue titles against commitlint

### DIFF
--- a/.github/workflows/issue-title-lint.yml
+++ b/.github/workflows/issue-title-lint.yml
@@ -1,0 +1,91 @@
+name: Issue title lint
+
+# Specs become epic issues and plan slices become sub-issues; downstream those
+# titles seed branch names, PR titles, and (via the landed commits) release
+# versions. So issue titles must follow the SAME Conventional Commits ruleset as
+# commits (commitlint.config.js). GitHub has no "required check" for issues, so
+# this is a visible backstop: it labels a non-conforming title and comments the
+# fix once, then clears the label when the title is corrected. The primary,
+# proactive enforcement is in the issue-creating skills (issues-from-plan,
+# issues-from-assessment), which lint titles before `gh issue create`.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-title-lint-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-issue-title:
+    name: Issue title lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          # Single source of truth for the Node version — read from .nvmrc.
+          node-version-file: .nvmrc
+      - run: npm ci
+        env:
+          HUSKY: 0
+      - name: Lint issue title against commitlint.config.js
+        id: lint
+        env:
+          # Pass via env, never interpolate untrusted issue input into the shell.
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          set +e
+          report="$(printf '%s' "$ISSUE_TITLE" | npx commitlint --verbose 2>&1)"
+          rc=$?
+          printf '%s\n' "$report"
+          {
+            echo "rc=$rc"
+            echo "report<<COMMITLINT_EOF"
+            printf '%s\n' "$report"
+            echo "COMMITLINT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Flag or clear the issue based on the result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUM: ${{ github.event.issue.number }}
+          RC: ${{ steps.lint.outputs.rc }}
+          REPORT: ${{ steps.lint.outputs.report }}
+        run: |
+          label="needs-conventional-title"
+          # Ensure the label exists (idempotent); ignore "already exists".
+          gh label create "$label" --color FBCA04 \
+            --description "Issue title does not follow Conventional Commits" --force >/dev/null 2>&1 || true
+
+          if [ "$RC" = "0" ]; then
+            # Passing: clear the flag if it was set. No comment on success.
+            gh issue edit "$NUM" --remove-label "$label" >/dev/null 2>&1 || true
+            exit 0
+          fi
+
+          # Failing: comment only on the first detection (label not already
+          # present) so successive bad edits don't spam the thread. Build the
+          # body with tilde code fences (not backticks) so the shell never reads
+          # the markdown as command substitution.
+          had_label="$(gh issue view "$NUM" --json labels --jq '.labels[].name' 2>/dev/null | grep -Fxq "$label" && echo yes || echo no)"
+          gh issue edit "$NUM" --add-label "$label" >/dev/null 2>&1 || true
+          if [ "$had_label" = "no" ]; then
+            {
+              echo "⚠️ **This issue title is not a Conventional Commit.**"
+              echo
+              echo "Specs become epics and plan slices become sub-issues, and these titles seed branch names, PR titles, and release versions — so they must follow the same commitlint ruleset as commits (for example: feat:, fix:, docs:, chore:)."
+              echo
+              echo "~~~"
+              printf '%s\n' "$REPORT"
+              echo "~~~"
+              echo
+              echo "Edit the title to fix; this check re-runs on every edit and clears the label once it passes."
+            } > issue-title-comment.md
+            gh issue comment "$NUM" --body-file issue-title-comment.md
+          fi

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,11 +1,13 @@
 name: PR title lint
 
-# release-please derives the version bump from the commit subject on main.
-# Because this repo squash-merges, that subject is the PR *title* — which the
-# .husky/commit-msg commitlint hook never sees (it only lints local commit
-# messages). Lint the PR title here with the SAME commitlint ruleset so a
-# non-conventional title fails at PR time instead of silently dropping a release.
-# (PR #350 shipped a feat under a non-conventional title and skipped v7.1.0.)
+# release-please derives each version bump from the commit subjects on main.
+# This repo REBASE-merges, so every PR commit lands on main verbatim and
+# release-please reads each one — the PR title itself never lands. So the real
+# guarantee is linting every commit in the PR range against the SAME commitlint
+# ruleset the .husky/commit-msg hook uses (that local hook only sees locally
+# authored commits and is bypassable with --no-verify). The PR title is linted
+# too, as hygiene and in case the merge strategy ever changes.
+# (PR #350 shipped a feat under a non-conventional subject and skipped v7.1.0.)
 
 on:
   # `synchronize` (a push to the PR) is required: branch protection evaluates the
@@ -26,11 +28,17 @@ jobs:
   lint-pr-title:
     # The job name IS the status-check context branch protection matches on.
     # It must equal the required check configured in the ruleset ("PR title lint"),
-    # not the workflow name — otherwise the requirement is never satisfied.
+    # not the workflow name — otherwise the requirement is never satisfied. It now
+    # lints commits too, but the name stays stable so the required check keeps
+    # binding.
     name: PR title lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so `commitlint --from BASE --to HEAD` can walk every
+          # commit in the PR range (default depth 1 has only the tip).
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           # Single source of truth for the Node version — read from .nvmrc.
@@ -38,6 +46,13 @@ jobs:
       - run: npm ci
         env:
           HUSKY: 0
+      - name: Lint every commit in the PR range against commitlint.config.js
+        # This is the load-bearing check: rebase-merge lands each of these commits
+        # on main verbatim, so each subject must be a Conventional Commit.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
       - name: Lint PR title against commitlint.config.js
         env:
           # Pass via env, never interpolate untrusted PR input into the shell.


### PR DESCRIPTION
Enforces Conventional Commits on the two title surfaces that today can slip non-conventional text onto `main` when **developing this repo**. Repo-local CI only — no shipped plugin behavior changes.

## 1. Commit titles — lint the whole PR range (the real guarantee)

This repo **rebase-merges**, so every PR commit lands on `main` verbatim and release-please reads each subject — the PR *title* never lands. CI only linted the title. Now the required `PR title lint` job also runs:
```
npx commitlint --from <base.sha> --to <head.sha> --verbose
```
over the full PR commit range (added `fetch-depth: 0`). The title lint stays as hygiene. Also corrected the stale "this repo squash-merges" comment. Job name unchanged so the required-check binding holds.

## 2. Issue titles — new `issue-title-lint.yml`

Specs become epics and plan slices become sub-issues, seeding branch/PR/release names. On `issues: [opened, edited]` this lints the title with the same `commitlint.config.js`, labels non-conforming titles `needs-conventional-title`, comments the fix **once**, and clears the label when corrected. Advisory — GitHub has no required check for issues.

## Scope

Per the reviewer's direction, these govern **developing this plugin**, not people using the plugin on their own projects — so the earlier proactive edits to the shipped `issues-from-plan` / `issues-from-assessment` skills were dropped; enforcement lives entirely in this repo's CI.

Validated with `actionlint` (clean) + YAML parse. Human merge (CI config).