### PR TITLE
fix: surface headless assumptions and escalations to the PR (#825)

### DIFF
--- a/plugins/dev-team/knowledge/adversarial-review-protocol.md
+++ b/plugins/dev-team/knowledge/adversarial-review-protocol.md
@@ -15,6 +15,10 @@ After the initial review pass, re-examine findings with the following questions.
 
 Repeat until the challenger finds no new issues, or a maximum of 3 rounds is reached. Each agent's own `## Self-Challenge` questions sharpen this loop for that agent's domain — run them as part of the same pass.
 
+The challenger verifies; it does not fill a quota. Zero new findings after an honest
+pass is a passing outcome — never manufacture a finding to prove the loop ran, and
+never upgrade a `suggestion` to justify the round.
+
 ## Output
 
 After the challenger pass, append to the `summary` field in your JSON output:

--- a/plugins/dev-team/knowledge/decision-defaults.md
+++ b/plugins/dev-team/knowledge/decision-defaults.md
@@ -12,6 +12,14 @@ exists to prevent. State your best answer for each axis and let the user overrid
 These are defaults, not laws — an explicit user instruction always wins. The point is
 to resolve the axis *before* building, not to relitigate it mid-stream.
 
+**Non-interactive runs.** When no human can answer the upfront batch (headless
+`/plan`/`/build`, `--yes`, `DEV_TEAM_AUTO_APPROVE=1`), surfacing degrades to
+recording: take the recommended default for every ambiguous axis, state each axis and
+stance in the plan (and, via `/pr`, the PR body) — and **never take a non-default
+stance on any axis without an explicit user instruction**. A non-default stance with
+nobody present to confirm it is a guess, not a decision; if the task appears to
+require one, that is an escalation, not an assumption.
+
 ## Destructive shape: replace vs. merge
 
 Trigger: a request writes config, settings, dotfiles, or installer output where prior

--- a/plugins/dev-team/prompts/implementer.md
+++ b/plugins/dev-team/prompts/implementer.md
@@ -42,6 +42,12 @@ Only when the build resolved the `tdd` cadence:
 
 Only after the suite is green — and on **every** green, never deferred to an end-of-build pass, never skipped, never conditional on how small the step is (`docs/experiments/RECOMMENDATIONS.md` Rec 4). Refactor the code for clarity. The full suite must still pass after every change.
 
+- **"Nothing to refactor" is a valid outcome.** The mandate is to run the check on
+  every green, not to produce a diff — record `refactor: no-op` with a one-line
+  reason rather than inventing a cleanup to satisfy the phase.
+- **Scope bound.** A refactor touches only code this step changed or code directly
+  extracted from it. Renames, reformatting, or cleanup reaching into files the step
+  did not otherwise change are `followUps`, not refactors.
 - **Never change a test file during REFACTOR.** Refactoring is behavior-preserving by definition; the tests are frozen for the phase (the invariant held at zero violations across both experiment campaigns). The `refactor_test_freeze_guard`/`refactor_test_revert_guard` hooks enforce this mechanically.
 - **If the guard fires** (a test genuinely needs to change): leave REFACTOR, return to the TEST phase, make the test change there, re-verify the full suite green with captured output, then re-enter REFACTOR.
 - If refactoring suggests a structural change beyond the step's scope, log it as a follow-up and stop. Do not expand scope mid-step.
@@ -62,6 +68,12 @@ Capture and return:
 
 - **One behavior per cycle; one agent does code, test, and refactor.** Do not split coder and tester across contexts, and do not batch behaviors (Rec 3).
 - **Do not work outside your assigned step.** If you find a bug or improvement opportunity in adjacent code, flag it to the orchestrator; do not fix it inline.
+- **Record assumptions; never resolve ambiguity silently.** When the plan
+  under-specifies a detail that does not rise to an escalation (exact wording of an
+  error message, an unspecified boundary condition, a choice between two equally
+  plan-consistent shapes), pick the smallest reversible option and record it in the
+  `assumptions` array of your output. An assumption that would change observable
+  behavior beyond the slice's Gherkin scenarios is not an assumption — escalate it.
 - **Do not skip a phase.** In `tdd`, a test that has never failed is not a test. In `code-first`, a behavior without its test in the same cycle is unfinished work.
 - **Do not silently revert unrelated changes** if you encounter merge conflicts in a worktree. Stop and escalate.
 - **Do not claim completion without verification evidence.** No "tests passed" without the captured output.
@@ -89,6 +101,9 @@ Capture and return:
   },
   "followUps": [
     { "type": "refactor | bug | adjacent-improvement", "description": "<short note>", "file": "<path>" }
+  ],
+  "assumptions": [
+    { "decision": "<what was under-specified and what you chose>", "basis": "<why this is the minimal/reversible reading of the plan>" }
   ],
   "escalation": {
     "reason": "<why escalating, if status=escalated|blocked>",

--- a/plugins/dev-team/prompts/quality-reviewer.md
+++ b/plugins/dev-team/prompts/quality-reviewer.md
@@ -73,6 +73,11 @@ Failures from `/browse` enter the same review-fix loop (max 2 iterations).
 - Do not run agents whose file scope does not match the diff.
 - Do not skip the fix loop on findings classified as actionable.
 - Do not auto-apply fixes for findings with `confidence: none` — these require human judgment.
+- Enumerate every auto-applied fix whose confidence was `medium` in the `summary`
+  field — medium is defined by the review agents as "direction clear but context may
+  differ" (e.g. a rename where domain terminology may vary), so in a non-interactive
+  run these acknowledged-uncertain changes must surface in the build output and PR
+  body rather than landing silently.
 - Be concise. The result is structured; no narration.
 
 ## Output format

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -155,7 +155,7 @@ Work each step **one behavior at a time** in the resolved cadence — never all 
 
 1. **First phase — IMPLEMENT (`code-first`, default) or RED (`tdd`).** Code-first: implement exactly one behavior from the step — no cleanup, no behavior beyond what the step requires. TDD: write the failing test covering the slice scenario the step traces to; run the suite. **Hard gate (`tdd` only): the new test must fail — paste the failing output.** If the test passes without new code, the behavior already exists — pick a different test. Do NOT proceed without pasted failing output.
 2. **Second phase — TEST (`code-first`) or GREEN (`tdd`).** Code-first: write the test covering the behavior's slice scenario, immediately after the code. TDD: write the minimum implementation to make the failing test pass. Either way, run the full test suite. **Hard gate: all tests must pass — paste the passing output.** Do NOT proceed to REFACTOR without pasted passing output.
-3. **REFACTOR (both cadences — every green, never skipped).** Clean up structure, naming, duplication without changing behavior. Runs in **every** per-behavior cycle: never deferred to an end-of-build pass, never made conditional on task size or complexity (`docs/experiments/RECOMMENDATIONS.md` Rec 4 — deleting just this step erased TDD's changeability advantage entirely). **Tests are frozen for the phase** — a refactor must never change a test (enforced by the freeze/revert guards; recovery: return to the TEST phase, change the test there, re-verify green, re-enter REFACTOR). Run tests again — they must still pass. If tests break, undo and try a smaller change.
+3. **REFACTOR (both cadences — every green, never skipped).** Clean up structure, naming, duplication without changing behavior. Runs in **every** per-behavior cycle: never deferred to an end-of-build pass, never made conditional on task size or complexity (`docs/experiments/RECOMMENDATIONS.md` Rec 4 — deleting just this step erased TDD's changeability advantage entirely). **Tests are frozen for the phase** — a refactor must never change a test (enforced by the freeze/revert guards; recovery: return to the TEST phase, change the test there, re-verify green, re-enter REFACTOR). Run tests again — they must still pass. If tests break, undo and try a smaller change. A no-op refactor (nothing worth changing, stated in one line) satisfies the phase — the mandate is the check on every green, not a diff — and any refactor made stays within the code the step touched; adjacent-file cleanups are follow-ups, not refactors.
 4. **Inline review checkpoint — granularity scales with complexity.** *Where* the checkpoint runs depends on the step's **Complexity** classification (review *depth* still scales too):
    - **trivial**: Skip inline review. The final `/code-review` (step 6) covers all modified files.
    - **standard**: **Defer** review to the slice boundary (sub-step 6) — do not review now. Track the step's changed files so the slice checkpoint reviews them in one batch. Per-step review on standard steps is N near-identical passes where one at slice end largely does the same work, and the final `/code-review` (step 6) remains the backstop. This is the batching win — fewer review dispatches per multi-step slice at bounded quality risk.
@@ -230,6 +230,17 @@ Stop and ask the user when:
 - A review checkpoint fails after 2 correction iterations *and* the root cause is understood but unresolvable within scope
 - You discover the plan is incomplete or contradictory
 - The `verify_guard.py` hook blocks a verify command (`[BLOCK]` on a test/lint/build re-run) — this is the deterministic signal that the same command has run repeatedly with no intervening code change, i.e. a stuck loop rather than a progressing per-behavior cycle. Run the Systematic Debugging pass above instead of retrying the command again, and escalate with the diagnosis if it's still unresolvable in scope.
+
+**Non-interactive runs: an escalation is a hard stop, not another auto-approval.**
+The approval gates in Steps 2–3 auto-proceed because they bypass a judgment call the
+human delegated by going non-interactive; an escalation exists because the agent hit
+something it cannot safely decide — that authority was never delegated. When any
+condition above fires and no user can answer (`--yes`, `DEV_TEAM_AUTO_APPROVE=1`, or
+no TTY): write the escalation (trigger, one-sentence root-cause diagnosis, options
+considered) to `memory/build-escalation-<plan-slug>.md`, leave the plan status
+unchanged, report the halt as the build result, and stop. Never resolve an escalation
+by picking an interpretation and continuing, and never proceed to `/pr` over an
+unresolved escalation.
 
 ## Integration
 

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -42,6 +42,11 @@ Search for specification artifacts produced by `/specs` — look for files match
 
 If no spec artifacts are found, ask the user: "No specification artifacts found for this task. Run `/specs` first to produce them, or continue planning without specs?"
 
+**Non-interactive** (per step 6's interactivity rule): do not prompt — log
+`No spec artifacts found — continuing without specs (non-interactive).`, proceed, and
+record the absence in the plan's `## Risks & Open Questions` so it reaches the PR's
+Decisions & Assumptions section.
+
 If the user chooses to continue without specs, proceed. Otherwise, stop and let them run `/specs` first.
 
 ### 2. Understand the task and cut the slices

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -93,6 +93,13 @@ Analyze the diff against the base branch (`git diff <base>...HEAD`) and commit h
 - **Title**: Short, imperative (<70 chars)
 - **Summary**: 1-3 bullet points of what changed and why
 - **Test plan**: How to verify the changes
+- **Decisions & assumptions**: Collect everything decided without a human in the
+  loop, from the run's artifacts: the plan's `## Approval` auto-approval record and
+  any auto-passed gate lines from the build output; the plan's stated stances on
+  `knowledge/decision-defaults.md` axes; the spec's `## Ambiguity Log` entries
+  classified `inferable`; `assumptions` entries from implementer step outputs;
+  auto-applied review fixes with `confidence: medium`; and deferred follow-ups.
+  Omit the section only when every gate had an interactive human approval.
 
 ### 4. Create the PR
 
@@ -112,6 +119,10 @@ Use the structured template:
 - [x] Type check: clean
 - [x] Lint: clean
 - [x] Code review: <status>
+
+## Decisions & Assumptions
+<!-- Everything decided without a human in the loop. An empty section means a fully human-gated run. -->
+- <axis or assumption> — <stance taken> — <one-line rationale / recommended-default basis>
 
 ## Test Plan
 - [ ] <verification step 1>


### PR DESCRIPTION
Adds explicit guidance for non-interactive builds and PR generation to ensure decisions made without human input are surfaced transparently rather than landing silently.

## Summary

This change documents how the dev-team plugin should behave when running without interactive approval (headless builds, `--yes` flag, or `DEV_TEAM_AUTO_APPROVE=1`). It establishes that:

1. **Escalations are hard stops in non-interactive mode** — they are not auto-approved like gates are, and must be recorded to a file rather than proceeding with a guess.
2. **All decisions made without human input must be recorded** — in the plan, build output, and PR body — so reviewers can see what was decided and on what basis.
3. **Assumptions and auto-applied fixes must be enumerated** — medium-confidence review fixes and under-specified plan details must surface explicitly rather than landing as silent changes.

## Key Changes

- **`implementer.md`**: Added two new refactor-phase rules:
  - "Nothing to refactor" is a valid outcome; record `refactor: no-op` with a one-line reason rather than inventing cleanup.
  - Refactor scope is bound to code the step changed or directly extracted from it; adjacent-file cleanups are follow-ups, not refactors.
  - Added a new rule requiring assumptions to be recorded when the plan under-specifies details that don't rise to escalation.
  - Added `assumptions` array to the implementer output schema.

- **`build/SKILL.md`**: 
  - Clarified that no-op refactors satisfy the phase mandate (the check on every green, not a diff).
  - Added explicit non-interactive escalation behavior: write escalations to `memory/build-escalation-<plan-slug>.md`, leave plan status unchanged, report halt as build result, and never resolve escalations by picking an interpretation.

- **`pr/SKILL.md`**: 
  - Added "Decisions & Assumptions" section to PR template to collect everything decided without human input: auto-approval records, decision-defaults stances, spec ambiguity log entries, implementer assumptions, medium-confidence review fixes, and deferred follow-ups.
  - Omit the section only when every gate had interactive human approval.

- **`decision-defaults.md`**: 
  - Added guidance for non-interactive runs: take the recommended default for every ambiguous axis, state each axis and stance in the plan and PR body, and never take a non-default stance without explicit user instruction.

- **`quality-reviewer.md`**: 
  - Added requirement to enumerate every auto-applied fix with `confidence: medium` in the summary, since these acknowledged-uncertain changes must surface in build output and PR body rather than landing silently.

- **`plan/SKILL.md`**: 
  - Added non-interactive behavior for missing spec artifacts: log the absence, proceed, and record it in plan's Risks & Open Questions so it reaches the PR's Decisions & Assumptions section.

- **`adversarial-review-protocol.md`**: 
  - Clarified that the challenger verifies; it does not fill a quota. Zero new findings is a passing outcome — never manufacture a finding to prove the loop ran.

## Rationale

These changes ensure that when the plugin runs without human oversight, all decisions are made transparently and recorded for human review in the PR. This prevents silent assumptions from landing in code and maintains the human-in-the-loop principle even in headless scenarios.

https://claude.ai/code/session_01Tu7JLq6qFudYuJqJKA9Gft