### PR TITLE
fix: harden cloud plugin freshness (scope-aware update, drift advisory, snippet auto-update)

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -61,9 +61,13 @@ fi
 if command -v claude >/dev/null 2>&1; then
   claude plugin marketplace add    bdfinst/agentic-dev-team >/dev/null 2>&1 || true
   claude plugin marketplace update bfinster                 >/dev/null 2>&1 || true
-  claude plugin install dev-team@bfinster                   >/dev/null 2>&1 || true
-  claude plugin update  dev-team@bfinster                   >/dev/null 2>&1 || true
+  # Install at user scope (the CLI default); update is pinned to it because
+  # `claude plugin update` needs an explicit --scope or it assumes user.
+  claude plugin install              dev-team@bfinster >/dev/null 2>&1 || true
+  claude plugin update  --scope user dev-team@bfinster >/dev/null 2>&1 || true
   python3 plugins/dev-team/skills/upgrade/scripts/enable_autoupdate.py --enable || true
+  # Report version drift (pending-restart update or a blocked refresh); silent when current.
+  python3 plugins/dev-team/skills/upgrade/scripts/check_version_drift.py || true
 else
   echo "cloud setup: claude CLI not found — skipping plugin install (run skills from files)."
 fi

--- a/.claude/install-dev-team.sh
+++ b/.claude/install-dev-team.sh
@@ -43,10 +43,17 @@ _tmo() {
 }
 _tmo claude plugin marketplace add    bdfinst/agentic-dev-team >/dev/null 2>&1 || true
 _tmo claude plugin marketplace update bfinster                 >/dev/null 2>&1 || true
-_tmo claude plugin install dev-team@bfinster                   >/dev/null 2>&1 || true
-_tmo claude plugin update  dev-team@bfinster                   >/dev/null 2>&1 || true
+# We install at user scope (the CLI default), so update/enable are pinned to it —
+# `claude plugin update` needs an explicit --scope or it assumes user and fails
+# noisily against a different scope (see the /upgrade skill).
+_tmo claude plugin install               dev-team@bfinster >/dev/null 2>&1 || true
+_tmo claude plugin update  --scope user  dev-team@bfinster >/dev/null 2>&1 || true
 # Enable auto-update via the plugin's own script (single source of truth, shared
 # with /upgrade). No consent prompt: running this cloud-gated hook is the opt-in.
 _root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
-python3 "$_root/plugins/dev-team/skills/upgrade/scripts/enable_autoupdate.py" --enable >/dev/null 2>&1 || true
+_scripts="$_root/plugins/dev-team/skills/upgrade/scripts"
+python3 "$_scripts/enable_autoupdate.py" --enable >/dev/null 2>&1 || true
+# Surface version drift (an update that lands next launch, or a blocked refresh)
+# as a SessionStart advisory; prints nothing when already current.
+python3 "$_scripts/check_version_drift.py" --session-start 2>/dev/null || true
 exit 0

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -51,18 +51,21 @@ if [ -f "$BOOTSTRAP" ]; then
 fi
 echo "[setup] no $BOOTSTRAP — installing/refreshing dev-team inline for this session."
 if command -v claude >/dev/null 2>&1; then
-  claude plugin marketplace add    "$MARKETPLACE_REPO" >/dev/null 2>&1 || true
-  claude plugin marketplace update "$MARKET"           >/dev/null 2>&1 || true
-  claude plugin install "$PLUGIN"                      >/dev/null 2>&1 || true
-  claude plugin update  "$PLUGIN"                      >/dev/null 2>&1 || true
+  claude plugin marketplace add    "$MARKETPLACE_REPO"    >/dev/null 2>&1 || true
+  claude plugin marketplace update "$MARKET"              >/dev/null 2>&1 || true
+  claude plugin install              "$PLUGIN"            >/dev/null 2>&1 || true
+  claude plugin update  --scope user "$PLUGIN"            >/dev/null 2>&1 || true
+  # Enable auto-update so later releases refresh at launch without a snapshot rebuild.
+  AU="$ROOT/plugins/dev-team/skills/upgrade/scripts/enable_autoupdate.py"
+  [ -f "$AU" ] && python3 "$AU" --enable >/dev/null 2>&1 || true
 fi
 exit 0
 ```
 
-> Pasting the body of [`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh)
-> instead does all of the above **and** enables marketplace auto-update (via the
-> plugin's own `skills/upgrade/scripts/enable_autoupdate.py`), so later releases
-> refresh at launch without a snapshot rebuild.
+> This snippet now enables marketplace auto-update itself (via the plugin's
+> `skills/upgrade/scripts/enable_autoupdate.py`). Pasting the body of
+> [`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) instead additionally
+> installs this repo's test/gate toolchain and reports version drift — see below.
 
 If you also want this repo's test/gate toolchain (`jq`, `shellcheck`,
 the Python dev deps, `gh`) in the same step, paste the body of
@@ -120,6 +123,13 @@ The fix has three layers, all wired into `.claude/cloud-setup.sh` and the
   within the existing snapshot**, so a routine release lands without a snapshot
   rebuild. `/upgrade` runs the very same script (its `--check`/`--enable` modes),
   so there is one implementation of the flag, not two.
+- **Drift advisory.** Both also run the plugin's
+  [`skills/upgrade/scripts/check_version_drift.py`](../plugins/dev-team/skills/upgrade/scripts/check_version_drift.py),
+  which compares the installed version against the refreshed catalog and surfaces
+  a "v{installed} → v{latest}; restart or run `/upgrade`" advisory. This is the
+  safety net for the one case the refresh can't fix silently: a **restrictive
+  network policy** that blocks the catalog/update fetch, or an update that only
+  applies on the next launch. It says nothing when already current.
 - **Manual escape hatch.** `/upgrade` updates on demand in any single session.
 
 Two things this does **not** do:

--- a/plugins/dev-team/skills/upgrade/scripts/check_version_drift.py
+++ b/plugins/dev-team/skills/upgrade/scripts/check_version_drift.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Report dev-team plugin version drift: installed version vs latest catalog.
+
+Read-only diagnostic. Prints a one-line advisory when the installed plugin
+version differs from the version the (refreshed) marketplace catalog offers.
+That mismatch is the signal auto-update alone cannot surface:
+
+* a refreshed catalog is ahead but the update lands only on the next launch, or
+* the refresh was blocked (e.g. by a restrictive network policy) so the session
+  is silently stale.
+
+Prints nothing when the versions match (or when either can't be resolved), so a
+caller can gate on empty output.
+
+Modes:
+  (default)         Print a plain advisory line, or nothing when current.
+  --session-start   Print a SessionStart hookSpecificOutput JSON wrapping the
+                    advisory, or nothing when current — for the cloud hook.
+
+Honors ``CLAUDE_CONFIG_DIR``. Stdlib only, Python 3.8+ (ADR 0014 / 0015).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Optional, Tuple
+
+PLUGIN = "dev-team"
+
+
+def config_dir() -> str:
+    """The Claude Code config dir — ``CLAUDE_CONFIG_DIR`` if set, else ~/.claude."""
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(
+        os.path.expanduser("~"), ".claude"
+    )
+
+
+def load(path: str):
+    """Parse a JSON file, or return None if missing or malformed."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def installed(cfg: str) -> Tuple[Optional[str], Optional[str]]:
+    """(version, marketplace) for the installed dev-team plugin, or (None, None)."""
+    plugins = (
+        load(os.path.join(cfg, "plugins", "installed_plugins.json")) or {}
+    ).get("plugins", {})
+    for pid, entries in plugins.items():
+        if pid.split("@", 1)[0] == PLUGIN and "@" in pid and entries:
+            return entries[0].get("version"), pid.split("@", 1)[1]
+    return None, None
+
+
+def latest(cfg: str, market: str) -> Optional[str]:
+    """The dev-team version the cached marketplace catalog offers, or None."""
+    reg = load(os.path.join(cfg, "plugins", "known_marketplaces.json")) or {}
+    loc = (reg.get(market) or {}).get("installLocation")
+    if not loc:
+        return None
+    catalog = load(os.path.join(loc, ".claude-plugin", "marketplace.json")) or {}
+    for p in catalog.get("plugins", []):
+        if p.get("name") == PLUGIN:
+            return p.get("version")
+    return None
+
+
+def advisory(cfg: str) -> str:
+    """The drift advisory line, or '' when current / indeterminate."""
+    inst, market = installed(cfg)
+    if not inst or not market:
+        return ""
+    newest = latest(cfg, market)
+    if not newest or newest == inst:
+        return ""
+    return (
+        f"dev-team plugin is v{inst}; v{newest} is available from '{market}'. "
+        "Restart Claude Code (or run /upgrade) to apply."
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Report dev-team version drift.")
+    parser.add_argument(
+        "--session-start",
+        action="store_true",
+        help="Emit a SessionStart hookSpecificOutput JSON instead of a plain line.",
+    )
+    args = parser.parse_args(argv)
+    msg = advisory(config_dir())
+    if not msg:
+        return 0
+    if args.session_start:
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": msg,
+                    }
+                }
+            )
+        )
+    else:
+        print(msg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dev-team/tests/scripts/test_check_version_drift.py
+++ b/plugins/dev-team/tests/scripts/test_check_version_drift.py
@@ -1,0 +1,102 @@
+"""Unit tests for skills/upgrade/scripts/check_version_drift.py.
+
+Covers the drift comparison (installed vs catalog), the silent-when-current and
+silent-when-indeterminate contracts, and the two output modes (plain line vs
+SessionStart hookSpecificOutput JSON).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(
+    0, str(_REPO_ROOT / "plugins" / "dev-team" / "skills" / "upgrade" / "scripts")
+)
+
+import check_version_drift  # noqa: E402
+
+
+def _seed(cfg: Path, *, installed="10.1.0", catalog="10.1.0", registry=True):
+    plugins = cfg / "plugins"
+    plugins.mkdir(parents=True, exist_ok=True)
+    if installed is not None:
+        (plugins / "installed_plugins.json").write_text(
+            json.dumps(
+                {"plugins": {"dev-team@bfinster": [{"scope": "user", "version": installed}]}}
+            )
+        )
+    market_dir = cfg / "marketplaces" / "bfinster"
+    if registry:
+        (plugins / "known_marketplaces.json").write_text(
+            json.dumps({"bfinster": {"installLocation": str(market_dir)}})
+        )
+    if catalog is not None:
+        cp = market_dir / ".claude-plugin"
+        cp.mkdir(parents=True, exist_ok=True)
+        (cp / "marketplace.json").write_text(
+            json.dumps({"plugins": [{"name": "dev-team", "version": catalog}]})
+        )
+
+
+@pytest.fixture()
+def cfg(tmp_path, monkeypatch):
+    d = tmp_path / "config"
+    d.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(d))
+    return d
+
+
+def test_silent_when_current(cfg):
+    _seed(cfg, installed="10.1.0", catalog="10.1.0")
+    assert check_version_drift.advisory(str(cfg)) == ""
+
+
+def test_advisory_when_catalog_ahead(cfg):
+    _seed(cfg, installed="9.9.0", catalog="10.1.0")
+    msg = check_version_drift.advisory(str(cfg))
+    assert "v9.9.0" in msg and "v10.1.0" in msg and "/upgrade" in msg
+
+
+def test_silent_when_not_installed(cfg):
+    _seed(cfg, installed=None)
+    assert check_version_drift.advisory(str(cfg)) == ""
+
+
+def test_silent_when_catalog_missing(cfg):
+    _seed(cfg, catalog=None)
+    assert check_version_drift.advisory(str(cfg)) == ""
+
+
+def test_silent_when_registry_missing(cfg):
+    _seed(cfg, registry=False, catalog=None)
+    assert check_version_drift.advisory(str(cfg)) == ""
+
+
+def test_main_plain_prints_line(cfg, capsys):
+    _seed(cfg, installed="9.9.0", catalog="10.1.0")
+    rc = check_version_drift.main([])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("dev-team plugin is v9.9.0")
+
+
+def test_main_session_start_emits_hook_json(cfg, capsys):
+    _seed(cfg, installed="9.9.0", catalog="10.1.0")
+    rc = check_version_drift.main(["--session-start"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    hso = payload["hookSpecificOutput"]
+    assert hso["hookEventName"] == "SessionStart"
+    assert "v10.1.0" in hso["additionalContext"]
+
+
+def test_main_session_start_silent_when_current(cfg, capsys):
+    _seed(cfg, installed="10.1.0", catalog="10.1.0")
+    rc = check_version_drift.main(["--session-start"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == ""


### PR DESCRIPTION
## Summary

Adds a new diagnostic script that detects and reports when the installed dev-team plugin version differs from the latest version available in the refreshed marketplace catalog. This surfaces update availability in cases where auto-update alone cannot — specifically when a catalog refresh is blocked by network policy or when an update lands only on the next session launch.

## Changes

- **New script:** `plugins/dev-team/skills/upgrade/scripts/check_version_drift.py`
  - Compares installed plugin version against the cached marketplace catalog
  - Outputs a plain advisory line by default, or SessionStart hookSpecificOutput JSON with `--session-start` flag
  - Silent when versions match or when either cannot be resolved (no noise on success)
  - Stdlib-only, Python 3.8+ (ADR 0014/0015 compliant)

- **New test suite:** `plugins/dev-team/tests/scripts/test_check_version_drift.py`
  - Covers drift detection (installed vs catalog comparison)
  - Validates silent-when-current and silent-when-indeterminate contracts
  - Tests both output modes (plain line and SessionStart JSON)

- **Integration into cloud setup:**
  - `.claude/install-dev-team.sh` and `.claude/cloud-setup.sh` now call `check_version_drift.py` after enabling auto-update
  - `.claude/install-dev-team.sh` emits SessionStart hook JSON for cloud environments
  - `.claude/cloud-setup.sh` emits plain advisory for local setups
  - Both scripts now explicitly pin plugin updates to `--scope user` (matching install scope)

- **Documentation:** Updated `docs/cloud-setup.md` to explain the drift advisory layer and its role in the three-layer update fix (auto-update flag, drift detection, manual `/upgrade` escape hatch)

## Implementation Details

- Reads from `CLAUDE_CONFIG_DIR` (or `~/.claude` by default) to locate installed plugin metadata and marketplace catalog
- Parses `installed_plugins.json` to extract installed version and marketplace name
- Looks up the marketplace in `known_marketplaces.json` to find the catalog location
- Compares against the dev-team entry in the marketplace's cached `marketplace.json`
- Returns empty string (silent) when versions match, either file is missing/malformed, or plugin is not installed — allowing callers to gate on output
- Honors the same config directory as the Claude Code CLI for consistency

https://claude.ai/code/session_01Pd7L1zpEBQiPksUT5a4VJg