### PR TITLE
docs: align command taxonomy and developer-notes index with the graph-tools step

### DIFF
--- a/docs/command-graph-audit.md
+++ b/docs/command-graph-audit.md
@@ -109,7 +109,8 @@ user), `cost-report`, `agent-readiness` (scores *your* repo — contrast
 - **Project onboarding** — user-invoked *after adding the plugin to a repo*; they
   configure the target repo, not the plugin: `setup` (detect stack; generate
   CLAUDE.md, hooks, templates) and `project-init` (detect stack, inventory/install
-  static-analysis tools). See the open gap below — a command that needs a missing
+  static-analysis tools, offer opt-in graph-tools — CodeGraph and/or Graphify, see
+  `plugins/dev-team/knowledge/codegraph-vs-graphify.md`). See the open gap below — a command that needs a missing
   tool should prompt the user to run these.
 - **Harness plumbing** — context management, rarely typed directly:
   `context-loading-protocol`, `context-summarization`

--- a/plugins/dev-team/docs/developer-notes.md
+++ b/plugins/dev-team/docs/developer-notes.md
@@ -22,6 +22,7 @@ topic.
 | Eval upkeep | [`eval-maintenance.md`](eval-maintenance.md) | Grading rules, the calibration trap, and corpus discipline. |
 | Adapter & ruleset lifecycle | [`static-analysis-integration/maintenance.md`](../skills/static-analysis-integration/maintenance.md) | Ownership, drift detection, and deprecation for shipped adapters and rulesets. |
 | Adding agents, skills, or hooks | [root `CLAUDE.md`](../../../CLAUDE.md) § "Adding agents, skills, or hooks" | Where each artifact type lives and the structural audit to run afterwards. |
+| Code knowledge graphs | [`codegraph-vs-graphify.md`](../knowledge/codegraph-vs-graphify.md) | When to use CodeGraph vs Graphify, how `/project-init` installs each, and the CLAUDE.md-preservation guard. |
 | Script conventions | [ADR 0014](../../../docs/adr/0014-python-for-cross-os-scripts.md), [ADR 0015](../../../docs/adr/0015-bash-removal-complete.md) | Why every shipped script is Python 3.8+ stdlib-only, and the completed bash removal. |
 
 The rest of this page covers the one extension path that touches several of


### PR DESCRIPTION
## Summary

Final cleanup for the code-knowledge-graph epic. All four slices (#845, #846, #848, #849 — #847 superseded by graphify's native hooks) are implemented and merged; this PR lands the two doc updates from #849's task list that never made it in:

- `docs/command-graph-audit.md` — the `project-init` taxonomy entry now mentions the opt-in graph-tools step (Step 4c: CodeGraph and/or Graphify) so the taxonomy reflects reality.
- `plugins/dev-team/docs/developer-notes.md` — the doc index gains a row pointing to `knowledge/codegraph-vs-graphify.md` (when to use which, the `/project-init` install paths, and the CLAUDE.md-preservation guard).

Verified: full `scripts/ci-local.sh` suite passes (18 checks, registry sync gates included).

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)