### PR TITLE
fix: harden code-review against EISDIR on --path dirs and json non-determinism

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2109,11 +2109,11 @@
       "anchor": "7-generate-report"
     },
     "8. Save correction prompts for remaining issues": {
-      "summary": "For issues NOT auto-fixed (confidence: none, auto-fix failed, or suggestions), generate one correction prompt per issue using the Correction prompt schema in [`output-format.md`](output-format.md#correction-prompt-json).",
+      "summary": "**Skip this entire step if `--json` was set.** Step 7 already stopped the run for `--json` mode; corrections are never written to disk in `--json` mode.",
       "anchor": "8-save-correction-prompts-for-remaining-issues"
     },
     "9. Write pre-commit gate file": {
-      "summary": "If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit.",
+      "summary": "**Skip this entire step if `--json` was set** (same reason as step 8).",
       "anchor": "9-write-pre-commit-gate-file"
     }
   },

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -92,6 +92,8 @@ Priority order:
 3. `--all` — all source files
 4. **Auto-scope** (no flags): run `git diff --name-only` + `git diff --cached --name-only`, combine and dedupe. If non-empty, review those files. If empty, review the full repository.
 
+**Never `Read` a directory path directly to enumerate its contents** — `Read` on a directory throws `EISDIR` (the same hazard step 3 avoids for agent-roster enumeration). This applies to `--path <dir>`, `--all`, and the full-repository fallback alike: always list files with `Glob` (e.g. `Glob("<dir>/**/*")`), never a bare `Read` on the directory itself.
+
 **Scope validation** (full-repo paths only):
 
 | File count | Action |
@@ -275,15 +277,19 @@ Track each iteration for the report — template in [`output-format.md`](output-
 
 Read `knowledge/review-template.md` for the structure.
 
-If `--json`, emit the aggregated JSON object per the schema in [`output-format.md`](output-format.md#aggregated-json-result---json-flag) to **stdout** (no file is written) and stop.
+**If `--json`: the JSON object is the ONLY output for this run — non-negotiable, not model discretion.** Emit the aggregated JSON object per the schema in [`output-format.md`](output-format.md#aggregated-json-result---json-flag) to **stdout**, write no file, and **stop: do not proceed to step 8 or step 9 in this run, regardless of how many issues were found or whether any are actionable.** There is no fallback to prose, and no `corrections/`/`.review-passed` persistence, in `--json` mode — ever. (`/pr`'s `--json` call already only reads this JSON object's `overall`/`status` field, so this loses nothing a caller depends on.)
 
-Otherwise emit the prose summary using the Code Review Summary template in [`output-format.md`](output-format.md#code-review-summary-report-step-7-prose-mode). Append the iteration table.
+Otherwise (no `--json`): emit the prose summary using the Code Review Summary template in [`output-format.md`](output-format.md#code-review-summary-report-step-7-prose-mode). Append the iteration table, then continue to step 8.
 
 ### 8. Save correction prompts for remaining issues
+
+**Skip this entire step if `--json` was set.** Step 7 already stopped the run for `--json` mode; corrections are never written to disk in `--json` mode.
 
 For issues NOT auto-fixed (confidence: none, auto-fix failed, or suggestions), generate one correction prompt per issue using the Correction prompt schema in [`output-format.md`](output-format.md#correction-prompt-json). Save to `./corrections/` **in the target repository's working directory** (the cwd `/code-review` was invoked in). Write all output artifacts only to these repo-relative paths — never prepend a scratchpad, sandbox, or session root, and never join two absolute paths. These can be addressed manually or via `/apply-fixes`.
 
 ### 9. Write pre-commit gate file
+
+**Skip this entire step if `--json` was set** (same reason as step 8).
 
 If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit. Use the **shared gate-hash helper** so the writer and the pre-commit hook compute the hash identically — it hashes the staged **content** (the cached patch), not just the file paths (#193), so any edit after review invalidates the gate:
 

--- a/plugins/dev-team/skills/code-review/output-format.md
+++ b/plugins/dev-team/skills/code-review/output-format.md
@@ -74,6 +74,13 @@ distinct `file:line`, so a finding surfaced by several agents appears once:
   attribution lives here; never join multiple values into `severity` or an
   `agent` scalar.
 
+**`--json` output contract.** When `--json` is set, the object above is the
+run's *only* output: printed to stdout, and no `corrections/*.json` files or
+`.review-passed` gate file are written — regardless of scope (`--path`,
+`--since`, `--all`, auto-scope) or how many issues were found. This holds
+whether `--json` was reached directly or via `/pr`'s call into `/code-review
+--json` (see SKILL.md steps 7–9).
+
 ## Correction prompt JSON
 
 ```json


### PR DESCRIPTION
## Summary

Hardens the code-review skill's `--json` output contract and fixes a critical directory enumeration hazard. When `--json` is set, the JSON object is now the *only* output — no corrections files or gate files are written, and steps 8–9 are skipped entirely. Additionally, clarifies that directory paths must never be read directly to enumerate contents; `Glob` must be used instead to avoid `EISDIR` errors.

## Changes

- **Step 7 (Generate report):** Rewrote to make `--json` mode non-negotiable. The JSON object is printed to stdout, no file is written, and execution stops before steps 8–9 — regardless of scope or issue count. Removed any fallback to prose or persistence in `--json` mode.
- **Step 8 (Save correction prompts):** Added explicit skip condition for `--json` mode. Corrections are never written to disk when `--json` is set.
- **Step 9 (Write pre-commit gate file):** Added explicit skip condition for `--json` mode for the same reason.
- **Scope section (SKILL.md):** Added new guidance prohibiting bare `Read` on directory paths. All directory enumeration must use `Glob` (e.g., `Glob("<dir>/**/*")`) to avoid `EISDIR` errors — applies to `--path <dir>`, `--all`, and full-repository fallback alike.
- **output-format.md:** Documented the `--json` output contract: JSON object only, no corrections or gate files, regardless of scope or findings.
- **knowledge/index.json:** Updated step summaries to reflect the `--json` skip conditions.

## Implementation Details

- The `--json` contract is now explicit and non-discretionary — callers like `/pr` depend only on the `overall`/`status` field, so skipping steps 8–9 loses nothing.
- Directory enumeration hazard mirrors the agent-roster enumeration safeguard already in place; this extends that pattern to all file-listing operations in the skill.

https://claude.ai/code/session_01Pd7L1zpEBQiPksUT5a4VJg