### PR TITLE
fix: guard claude-setup-review against Read-on-directory EISDIR

### DIFF
--- a/plugins/dev-team/agents/claude-setup-review.md
+++ b/plugins/dev-team/agents/claude-setup-review.md
@@ -30,6 +30,8 @@ Return `{"status": "skip", "issues": [], "summary": "Not a Claude Code project"}
 - No CLAUDE.md, `.claude/` directory, agent files, or `.clinerules` file exists
 - Target is clearly not a Claude Code-enabled project
 
+Check existence with `Glob` only — e.g. `Glob("CLAUDE.md")`, `Glob(".claude/**")`, `Glob("**/agents/*.md")`, `Glob(".clinerules")`. Never `Read` a directory path (the repo root, `.claude/`, `agents/`) to see what it contains — `Read` on a directory fails with `EISDIR`. `Read` only specific files `Glob` has confirmed exist.
+
 ## Detect — CLAUDE.md
 
 - Missing or malformed
@@ -59,7 +61,7 @@ Accuracy:
 
 ## Detect — Agent frontmatter schema
 
-Apply to every `.md` file found in `agents/` directories within the target. Check against the official Claude Code sub-agent specification.
+Apply to every `.md` file found in `agents/` directories within the target — enumerate them with `Glob("**/agents/*.md")`, never by `Read`ing the directory. Check against the official Claude Code sub-agent specification.
 
 ### Required fields
 


### PR DESCRIPTION
## Summary

Third occurrence of the `Read`-on-a-directory → `EISDIR` hazard class (#841: agent-roster enumeration, #857: `--path <dir>` resolution, both fixed). This time the offender was a spawned `claude-setup-review` sub-agent probing the repo root to evaluate its `## Skip` condition ("No CLAUDE.md, `.claude/` directory, agent files, or `.clinerules` file exists") — the agent spec said *what* to detect but never *how*, leaving the model to reach for `Read` on the bare directory.

## Changes

- **`agents/claude-setup-review.md` → `## Skip`:** existence checks must use `Glob` (`Glob("CLAUDE.md")`, `Glob(".claude/**")`, `Glob("**/agents/*.md")`, `Glob(".clinerules")`); never `Read` a directory path; `Read` only files `Glob` has confirmed exist.
- **`## Detect — Agent frontmatter schema`:** enumerate agent files via `Glob("**/agents/*.md")`, never by `Read`ing the directory.

## Verification

`bash scripts/ci-local.sh --changed-only` — all gates green (2599 passed, 17 skipped).

## Note

The issue also raises a non-blocking follow-up: with three independent occurrences of this class, a single shared directory-enumeration instruction (e.g. `knowledge/`) referenced by all existence-checking agents/skills may beat per-file fixes. Left out of scope here.

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)