### PR TITLE
feat: add boundary-events telemetry channel and intervention events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ metrics/telemetry.jsonl
 metrics/review-value.jsonl
 # Per-slice /verify evidence log (runtime data; counts-only — #727)
 metrics/verify-log.jsonl
+# Boundary-level policy-gateway event log (runtime data; rule-IDs-only — #859)
+metrics/boundary-events.jsonl
 
 # Effort-band model routing (per-user, never checked in)
 # - ladder: optional ordered model list (.claude/model-ladder.json), hand-written by users behind restricted endpoints

--- a/plugins/dev-team/hooks/bash_retry_guard.py
+++ b/plugins/dev-team/hooks/bash_retry_guard.py
@@ -38,10 +38,25 @@ _LIB_DIR = _HOOK_DIR / "lib"
 sys.path.insert(0, str(_LIB_DIR))
 try:
     from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+    from boundary_events import (  # type: ignore[import-not-found]
+        emit_boundary_event as _emit_boundary_event,
+    )
 except ImportError:  # pragma: no cover
 
     def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
         return None
+
+    def _emit_boundary_event(*_args, **_kwargs) -> None:  # type: ignore[misc]
+        return None
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 # Verify-family commands — the verify-guard hook handles retry-nudging for
@@ -184,6 +199,7 @@ def main() -> int:
         print(f"bash-retry-guard: This command has run {count} consecutive times.")
         print("  If it keeps failing, investigate the root cause rather than retrying.")
         print("  Set DEV_TEAM_BASH_RETRY_THRESHOLD=0 to disable this warning.")
+        emit_boundary_event(cwd, "bash_retry_guard", "Bash", "warn", "bash-retry-threshold", session_id)
 
     return 0
 

--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -83,6 +83,16 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 from stdin_json import read_stdin_json  # type: ignore[import-not-found]  # noqa: E402
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 # Recovery skills that must never be gated — blocking them would deadlock a
@@ -561,6 +571,14 @@ def main() -> int:
         # The .sh uses `printf '%s\n' "$msg" >&2` — write to stderr with a
         # trailing newline.
         sys.stderr.write(message + "\n")
+    if exit_code == 2 or message is not None:
+        cwd = payload.get("cwd") or "."
+        session_id = payload.get("session_id")
+        tool = payload.get("tool_name") or "unknown"
+        decision = "block" if exit_code == 2 else "warn"
+        emit_boundary_event(
+            cwd, "context_ceiling_guard", tool, decision, "context-ceiling", session_id
+        )
     return exit_code
 
 

--- a/plugins/dev-team/hooks/contract_version_guard.py
+++ b/plugins/dev-team/hooks/contract_version_guard.py
@@ -35,6 +35,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 # Matches the .sh's SCRIPT_DIR / REPO_ROOT resolution.
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parents[2]
@@ -284,6 +299,7 @@ def main() -> int:
 
     file_path = tool_input.get("file_path") or tool_input.get("path") or ""
     tool_name = payload.get("tool_name") or ""
+    session_id = payload.get("session_id")
 
     if not isinstance(file_path, str) or not file_path:
         return 0
@@ -321,6 +337,10 @@ def main() -> int:
             new_version = _extract_version(new_content)
             if not new_version:
                 sys.stderr.write(_msg_initial_add() + "\n")
+                emit_boundary_event(
+                    _REPO_ROOT, "contract_version_guard", tool_name, "block",
+                    "contract-version-missing", session_id,
+                )
                 return 2
         return 0
 
@@ -336,6 +356,10 @@ def main() -> int:
 
     if not new_version:
         sys.stderr.write(_msg_removed_version() + "\n")
+        emit_boundary_event(
+            _REPO_ROOT, "contract_version_guard", tool_name, "block",
+            "contract-version-removed", session_id,
+        )
         return 2
 
     head_body = _body_digest(head_content)
@@ -347,6 +371,10 @@ def main() -> int:
 
     if head_version == new_version:
         sys.stderr.write(_msg_missing_bump(head_version, new_version) + "\n")
+        emit_boundary_event(
+            _REPO_ROOT, "contract_version_guard", tool_name, "block",
+            "contract-version-missing-bump", session_id,
+        )
         return 2
 
     return 0

--- a/plugins/dev-team/hooks/destructive_guard.py
+++ b/plugins/dev-team/hooks/destructive_guard.py
@@ -25,8 +25,22 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-
 _SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 _COMMANDS_FILE = _SCRIPT_DIR / "destructive-commands.json"
 _CAREFUL_FILE = _SCRIPT_DIR / "careful-state.json"
 
@@ -173,6 +187,9 @@ def main() -> int:
     if not command:
         return 0
 
+    cwd = payload.get("cwd") or "."
+    session_id = payload.get("session_id")
+
     lower_command = command.lower()
 
     (
@@ -207,11 +224,13 @@ def main() -> int:
         _emit(f"Command: {command}")
         _emit("Careful mode is active. This command has been blocked.")
         _emit("Use /careful off to disable careful mode, or confirm with the user.")
+        emit_boundary_event(cwd, "destructive_guard", "Bash", "block", match, session_id)
         return 2
 
     _emit(f"CAUTION: Destructive command detected ({match}).")
     _emit(f"Command: {command}")
     _emit("This action is hard to reverse. Confirm with the user before proceeding.")
+    emit_boundary_event(cwd, "destructive_guard", "Bash", "warn", match, session_id)
     return 0
 
 

--- a/plugins/dev-team/hooks/lib/boundary_events.py
+++ b/plugins/dev-team/hooks/lib/boundary_events.py
@@ -1,0 +1,93 @@
+"""boundary_events.py — shared boundary-level telemetry emit helper (#859).
+
+Records the decision process of the plugin's guard hooks (policy-gateway
+events, per *Code as Agent Harness* §3.5.1): which hook, on which tool,
+decided what, because of which rule. Complements `telemetry.py`
+(command/skill/gate invocation counts) and `cost_meter.py` (per-agent
+token/cost) as the third, boundary-level channel.
+
+ALWAYS-ON: unlike `telemetry.py`, this stream is not gated by
+`DEV_TEAM_TELEMETRY` consent — it is a local-only, rule-IDs-only safety /
+accountability record (Ambiguity Log, issue #859). Never write free text:
+command text, prompt text, file paths, or reasons must never appear in a
+`matched_rule` value — only rule IDs from closed vocabularies.
+
+Fail-open: every exception is swallowed. A full disk, read-only
+`metrics/`, or malformed state must never change the calling hook's
+stdout, stderr, or exit code.
+
+Stdlib only. Python 3.8+. See ADR 0014 / ADR 0015.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_LOG_NAME = "boundary-events.jsonl"
+
+
+def _isoformat_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_plugin_version() -> str:
+    # hooks/lib/boundary_events.py -> hooks/lib -> hooks -> plugin root
+    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        version = data.get("version")
+        if isinstance(version, str) and version:
+            return version
+    except (OSError, ValueError):
+        pass
+    return "unknown"
+
+
+def emit_boundary_event(
+    cwd,
+    hook: str,
+    tool: str,
+    decision: str,
+    matched_rule: str,
+    session_id: Optional[str] = None,
+) -> None:
+    """Append one compact JSON line to `<cwd>/metrics/boundary-events.jsonl`.
+
+    Fail-open: any error (bad `cwd`, unwritable `metrics/`, disk full,
+    etc.) is swallowed silently — this must never affect the caller's
+    exit code, stdout, or stderr.
+
+    Args:
+        cwd: Directory whose `metrics/` subdirectory receives the event.
+            Accepts `str` or `Path`.
+        hook: Emitting hook's module name (e.g. "destructive_guard").
+        tool: Hooked tool / event name (e.g. "Bash", "UserPromptSubmit").
+        decision: One of "block", "warn", "bypass", "intervention".
+        matched_rule: A rule ID from a closed vocabulary — never free
+            text (no command text, prompt text, file paths, or reasons).
+        session_id: Optional opaque session ID from the hook payload,
+            enabling per-session joins with session-digest.jsonl.
+    """
+    try:
+        base = Path(cwd) if cwd else Path.cwd()
+        log = base / "metrics" / _LOG_NAME
+        log.parent.mkdir(parents=True, exist_ok=True)
+
+        payload = {
+            "ts": _isoformat_utc(),
+            "hook": hook,
+            "tool": tool,
+            "decision": decision,
+            "matched_rule": matched_rule,
+            "plugin_version": _load_plugin_version(),
+        }
+        if session_id:
+            payload["session_id"] = session_id
+
+        with open(log, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    except Exception:  # noqa: BLE001 — fail-open by design, see module docstring
+        pass

--- a/plugins/dev-team/hooks/mutation_gate.py
+++ b/plugins/dev-team/hooks/mutation_gate.py
@@ -25,9 +25,20 @@ from pathlib import Path
 _HOOK_DIR = Path(__file__).resolve().parent
 # Add the plugin hooks dir to sys.path so the mutation_adapters package resolves.
 sys.path.insert(0, str(_HOOK_DIR))
+sys.path.insert(0, str(_HOOK_DIR / "lib"))
 
 from mutation_adapters import lib as adapter_lib  # noqa: E402
 from mutation_adapters import mutmut, pitest, stryker, stryker_net  # noqa: E402
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 _JQ_MISSING_MESSAGE = (
@@ -167,6 +178,10 @@ def main() -> int:
         if isinstance(data, list) and data:
             reason = adapter_lib.format_blocking_reason(zero_kills_file, command)
             _emit_block_pretty(reason)
+            emit_boundary_event(
+                payload.get("cwd") or ".", "mutation_gate", "Bash", "block",
+                "mutation-gate-zero-kills", payload.get("session_id"),
+            )
 
     return 0
 

--- a/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
+++ b/plugins/dev-team/hooks/mutation_testing_smoke_gate.py
@@ -38,10 +38,25 @@ _LIB_DIR = _HOOK_DIR / "lib"
 sys.path.insert(0, str(_LIB_DIR))
 try:
     from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+    from boundary_events import (  # type: ignore[import-not-found]
+        emit_boundary_event as _emit_boundary_event,
+    )
 except ImportError:  # pragma: no cover
 
     def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
         return None
+
+    def _emit_boundary_event(*_args, **_kwargs) -> None:  # type: ignore[misc]
+        return None
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -251,14 +266,24 @@ def main() -> int:
         / "mutation-report.json"
     )
 
+    session_id = payload.get("session_id")
+
     if not report_path.is_file():
         print_block_message(f"no smoke report at {report_path}")
+        emit_boundary_event(
+            payload_cwd, "mutation_testing_smoke_gate", "Bash", "block",
+            "mutation-smoke-report-missing", session_id,
+        )
         return 2
 
     try:
         report_text = report_path.read_text(encoding="utf-8")
     except OSError:
         print_block_message(f"no smoke report at {report_path}")
+        emit_boundary_event(
+            payload_cwd, "mutation_testing_smoke_gate", "Bash", "block",
+            "mutation-smoke-report-missing", session_id,
+        )
         return 2
 
     try:
@@ -292,11 +317,19 @@ def main() -> int:
             f"killed=0 survived={survived} — mutation-switch not observing mutations at runtime "
             "(see #554, #557 and SKILL.md Step 1c diagnostic checklist)"
         )
+        emit_boundary_event(
+            payload_cwd, "mutation_testing_smoke_gate", "Bash", "block",
+            "mutation-smoke-switch-not-observed", session_id,
+        )
         return 2
 
     # Killed==0 && Survived==0 → empty mutants[] or only NoCoverage/CompileError.
     print_block_message(
         "no scored mutants in smoke report — pick a different probe file with real test coverage"
+    )
+    emit_boundary_event(
+        payload_cwd, "mutation_testing_smoke_gate", "Bash", "block",
+        "mutation-smoke-no-scored-mutants", session_id,
     )
     return 2
 

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -52,6 +52,9 @@ try:
     )
     from review_gate_hash import review_gate_hash  # type: ignore[import-not-found]
     from stdin_json import read_stdin_json  # type: ignore[import-not-found]
+    from boundary_events import (  # type: ignore[import-not-found]
+        emit_boundary_event as _emit_boundary_event,
+    )
 except ImportError:  # pragma: no cover
 
     def is_git_commit_command(_: str) -> bool:  # type: ignore[misc]
@@ -68,6 +71,18 @@ except ImportError:  # pragma: no cover
 
     def read_stdin_json() -> Optional[dict]:  # type: ignore[misc]
         return None
+
+    def _emit_boundary_event(*_args, **_kwargs) -> None:  # type: ignore[misc]
+        return None
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 _BLOCK_MESSAGE = (
@@ -163,6 +178,9 @@ def main() -> int:
         return 0
     command = str(tool_input.get("command") or "")
 
+    cwd = payload.get("cwd") or "."
+    session_id = payload.get("session_id")
+
     if not is_git_commit_command(command):
         return 0
 
@@ -172,10 +190,12 @@ def main() -> int:
         return 0
 
     if has_bypass_flag(command):
+        flag = bypass_flag_name(command) or "--no-verify"
         reason = os.environ.get("GATE_BYPASS_REASON", "").strip()
         if reason:
-            _record_bypass_audit(
-                bypass_flag_name(command) or "--no-verify", reason, len(staged)
+            _record_bypass_audit(flag, reason, len(staged))
+            emit_boundary_event(
+                cwd, "pre_commit_review", "Bash", "bypass", flag, session_id
             )
             return 0
         sys.stdout.write(_BYPASS_BLOCK_MESSAGE)
@@ -201,6 +221,9 @@ def main() -> int:
     # writes to stdout, not stderr, so Claude sees it in the tool-call
     # feedback stream).
     sys.stdout.write(_BLOCK_MESSAGE)
+    emit_boundary_event(
+        cwd, "pre_commit_review", "Bash", "block", "pre-commit-review", session_id
+    )
     return 2
 
 

--- a/plugins/dev-team/hooks/pre_tool_guard.py
+++ b/plugins/dev-team/hooks/pre_tool_guard.py
@@ -19,6 +19,21 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 
 _DEFAULT_BLOCKED = [
     ".env",
@@ -120,12 +135,16 @@ def evaluate(
     file_path: str,
     guards_path: Path,
     freeze_path: Path,
+    cwd: str = ".",
+    session_id: Optional[str] = None,
 ) -> tuple:
     """Return (exit_code, [stdout_lines]) for a single file_path decision.
 
     - exit_code 0 with `[warning]` lines means "allow with warning".
     - exit_code 0 with `[]` means "silent pass".
     - exit_code 2 with `[block message]` means "block".
+
+    Emits a boundary event (#859) for every warn/block decision.
     """
     if not file_path:
         return 0, []
@@ -146,6 +165,7 @@ def evaluate(
         )
         if not matched:
             allowed_display = "\n".join(allowed)
+            emit_boundary_event(cwd, "pre_tool_guard", "Write", "block", "freeze-scope-lock", session_id)
             return 2, [
                 "BLOCKED: Freeze mode is active. Only files matching the allowed patterns can be edited.",
                 f"File: {file_path}",
@@ -158,6 +178,7 @@ def evaluate(
     if _matches_any(lower_filename, blocked_patterns) or _matches_any(
         lower_path, blocked_patterns
     ):
+        emit_boundary_event(cwd, "pre_tool_guard", "Write", "block", "sensitive-path", session_id)
         return 2, [
             f"BLOCKED: Write to '{file_path}' is not allowed.",
             "This path matches a sensitive-file pattern in .claude/hooks/guards.json.",
@@ -165,6 +186,7 @@ def evaluate(
         ]
 
     if _matches_any(lower_path, warn_patterns):
+        emit_boundary_event(cwd, "pre_tool_guard", "Write", "warn", "protected-config", session_id)
         return 0, [
             f"WARNING: '{file_path}' is a protected configuration file.",
             "Verify this change is intentional before writing.",
@@ -178,11 +200,19 @@ def main() -> int:
     file_path = _extract_file_path(raw)
     if not file_path:
         return 0
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        payload = {}
+    cwd = (payload.get("cwd") if isinstance(payload, dict) else None) or "."
+    session_id = payload.get("session_id") if isinstance(payload, dict) else None
     script_dir = Path(__file__).resolve().parent
     exit_code, lines = evaluate(
         file_path,
         script_dir / "guards.json",
         script_dir / "freeze-state.json",
+        cwd,
+        session_id,
     )
     for line in lines:
         print(line)

--- a/plugins/dev-team/hooks/refactor_test_freeze_guard.py
+++ b/plugins/dev-team/hooks/refactor_test_freeze_guard.py
@@ -26,6 +26,16 @@ sys.path.insert(0, str(_LIB_DIR))
 
 from stdin_json import read_stdin_json  # noqa: E402
 from test_file_classify import is_test_file, read_build_phase  # noqa: E402
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 AUDIT_RELPATH = Path("metrics") / "refactor-freeze.jsonl"
 
@@ -108,6 +118,12 @@ def main() -> int:
         payload = read_stdin_json()
         file_path = _extract_file_path(payload)
         exit_code, lines = evaluate(file_path, project_dir)
+        if exit_code == 2:
+            session_id = payload.get("session_id") if isinstance(payload, dict) else None
+            emit_boundary_event(
+                project_dir, "refactor_test_freeze_guard", "Write", "block",
+                "refactor-test-freeze", session_id,
+            )
     except Exception as exc:  # fail open — a broken guard never blocks work
         audit(project_dir, "freeze", "fail-open", reason="internal error: {}".format(exc))
         return 0

--- a/plugins/dev-team/hooks/tdd_guard.py
+++ b/plugins/dev-team/hooks/tdd_guard.py
@@ -21,6 +21,21 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple
 
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 
 _SOURCE_SUFFIXES = {
     ".ts",
@@ -161,6 +176,12 @@ def main() -> int:
     file_path = _extract_file_path(raw)
     if not file_path:
         return 0
+    try:
+        _payload = json.loads(raw)
+    except (TypeError, ValueError):
+        _payload = {}
+    cwd = (_payload.get("cwd") if isinstance(_payload, dict) else None) or "."
+    session_id = _payload.get("session_id") if isinstance(_payload, dict) else None
     if not Path(file_path).is_file():
         return 0
     if not _is_source_file(file_path):
@@ -191,6 +212,7 @@ def main() -> int:
     print(f"  File: {basename}")
     print("  Write a failing test FIRST, then implement. RED before GREEN.")
     print("  If this is a refactor with passing tests, run the test suite to confirm.")
+    emit_boundary_event(cwd, "tdd_guard", "Write", "warn", "tdd-red-before-green", session_id)
     return 0
 
 

--- a/plugins/dev-team/hooks/telemetry.py
+++ b/plugins/dev-team/hooks/telemetry.py
@@ -39,10 +39,34 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 
 _SLASH_CMD_RE = re.compile(r"^/([a-zA-Z][a-zA-Z0-9_-]*)")
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_:-]*$")
 _NO_VERIFY_RE = re.compile(r"(?:^|\s)-n(?:\s|$)")
+
+# Human-intervention keyword grammar (#859, Ambiguity Log): anchored
+# whole-prompt match — same grammar-match-only posture as _SLASH_CMD_RE —
+# substring matching would flood the stream with false positives on
+# ordinary prose ("stop" mid-sentence must NOT match). An optional
+# `:`-suffixed payload following the keyword is captured by the prompt
+# but deliberately discarded — never logged.
+_INTERVENTION_RE = re.compile(r"^\s*(override|pause|stop)\b", re.IGNORECASE)
 
 
 def _isoformat_utc() -> str:
@@ -180,14 +204,33 @@ def main() -> int:
     if not cwd.is_dir():
         cwd = Path.cwd()
 
+    event_name = payload.get("hook_event_name") or ""
+    session_id = payload.get("session_id")
+
+    # Boundary events (#859) are ALWAYS-ON — unlike telemetry.jsonl below,
+    # they are not gated by DEV_TEAM_TELEMETRY consent (Ambiguity Log:
+    # safety/accountability channel must have no observability holes; no
+    # free text is ever recorded, only the matched keyword).
+    if event_name == "UserPromptSubmit":
+        prompt = payload.get("prompt") or ""
+        if isinstance(prompt, str):
+            intervention = _INTERVENTION_RE.match(prompt)
+            if intervention:
+                emit_boundary_event(
+                    cwd,
+                    "telemetry",
+                    "UserPromptSubmit",
+                    "intervention",
+                    intervention.group(1).lower(),
+                    session_id,
+                )
+
     if not _consent_enabled(cwd):
         return 0
 
     hook_dir = Path(__file__).resolve().parent
     version = _load_plugin_version(hook_dir)
     log = cwd / "metrics" / "telemetry.jsonl"
-
-    event_name = payload.get("hook_event_name") or ""
 
     if event_name == "UserPromptSubmit":
         prompt = payload.get("prompt") or ""

--- a/plugins/dev-team/hooks/verify_guard.py
+++ b/plugins/dev-team/hooks/verify_guard.py
@@ -45,6 +45,16 @@ from verify_guard_state import (  # noqa: E402  (import after sys.path setup)
     state_key,
     write_state,
 )
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
 
 
 # Verify-class command detector — mirrors `session_extract.py::_VERIFY_RE`.
@@ -134,6 +144,9 @@ def main() -> int:
             "re-running the same command."
         )
         print("  To suppress this warning, set DEV_TEAM_VERIFY_THRESHOLD=0.")
+        emit_boundary_event(
+            cwd, "verify_guard", "Bash", "warn", "verify-repeat-threshold", session_id
+        )
         return 0
 
     print(
@@ -157,6 +170,9 @@ def main() -> int:
         "again."
     )
     print("  To suppress this block, set DEV_TEAM_VERIFY_THRESHOLD=0.")
+    emit_boundary_event(
+        cwd, "verify_guard", "Bash", "block", "verify-repeat-threshold", session_id
+    )
     return 2
 
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1053,6 +1053,80 @@
       "anchor": "decision-log-entry"
     }
   },
+  "plugins/dev-team/knowledge/telemetry-schema.md": {
+    "`boundary-events.jsonl`": {
+      "summary": "**Added by #859.** The boundary-level (policy-gateway) channel: every guard",
+      "anchor": "boundary-eventsjsonl"
+    },
+    "`telemetry.jsonl`": {
+      "summary": "Opt-in usage beacon: which slash commands / skills get invoked, and whether",
+      "anchor": "telemetryjsonl"
+    },
+    "`cost-metering.jsonl`": {
+      "summary": "Per-session token/cost summary, incrementally accumulated from the",
+      "anchor": "cost-meteringjsonl"
+    },
+    "`artifact-usage.json`": {
+      "summary": "Not JSONL — a single JSON object keyed by skill/agent name, upserted on",
+      "anchor": "artifact-usagejson"
+    },
+    "`gate-bypass-audit.jsonl`": {
+      "summary": "Accountability record for `git commit --no-verify`/`-n` bypasses of the",
+      "anchor": "gate-bypass-auditjsonl"
+    },
+    "`gate-bypass.jsonl`": {
+      "summary": "Accountability record for `MUTATION_SMOKE_GATE_SKIP=1` bypasses of the",
+      "anchor": "gate-bypassjsonl"
+    },
+    "`config-changelog.jsonl`": {
+      "summary": "Audit trail for `/feedback-learning` config changes and human-oversight",
+      "anchor": "config-changelogjsonl"
+    },
+    "`session-digest.jsonl`": {
+      "summary": "Trend digest from `/session-review` (backed by `scripts/session_extract.py`):",
+      "anchor": "session-digestjsonl"
+    },
+    "`review-value.jsonl`": {
+      "summary": "Whether a `/build` inline review checkpoint actually changed anything —",
+      "anchor": "review-valuejsonl"
+    },
+    "`verify-log.jsonl`": {
+      "summary": "Evidence that `/verify` actually ran (or was legitimately skipped) before a",
+      "anchor": "verify-logjsonl"
+    },
+    "`override-audit.jsonl`": {
+      "summary": "Audit trail for `/code-review --force --reason \"<text>\"`, which skips all",
+      "anchor": "override-auditjsonl"
+    },
+    "`eval-variance.jsonl`": {
+      "summary": "Multi-trial pass@k stability trend for `/agent-eval` fixtures.",
+      "anchor": "eval-variancejsonl"
+    },
+    "`refactor-freeze.jsonl`": {
+      "summary": "Audit log for the tests-frozen-during-REFACTOR invariant (`#813`) — both the",
+      "anchor": "refactor-freezejsonl"
+    },
+    "`contract-version-guard-audit.jsonl`": {
+      "summary": "Audit log for release-please's bypass of the security-primitives-contract",
+      "anchor": "contract-version-guard-auditjsonl"
+    },
+    "`learning-loop-state.json`": {
+      "summary": "Not JSONL — a single current-value JSON file: a counter gating when",
+      "anchor": "learning-loop-statejson"
+    },
+    "`pending-review.jsonl`": {
+      "summary": "Queued findings from the background session-analysis dispatch, before",
+      "anchor": "pending-reviewjsonl"
+    },
+    "`metrics/{date}-task-log.jsonl` (e.g. `2026-02-20-task-log.jsonl`)": {
+      "summary": "Self-reported per-task completion log, one file per calendar date.",
+      "anchor": "metricsdate-task-logjsonl-eg-2026-02-20-task-logjsonl"
+    },
+    "Adding a new stream": {
+      "summary": "1.",
+      "anchor": "adding-a-new-stream"
+    }
+  },
   "plugins/dev-team/knowledge/test-automation-maturity.md": {
     "Maturity scale (diagnose from evidence, lowest rung first)": {
       "summary": "| Rung | Signal in the suite | Risk |",
@@ -4437,7 +4511,7 @@
       "anchor": "0-queued-findings-surface-pending-review-queue-before-fresh-analysis"
     },
     "`pending-review.jsonl` Schema": {
-      "summary": "Each line is a JSON object:",
+      "summary": "Full field reference: `${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md`",
       "anchor": "pending-reviewjsonl-schema"
     },
     "1. Cross-machine Telemetry — validate config, then sync (#178)": {

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -1,0 +1,366 @@
+# Telemetry Schema Reference
+
+Every `metrics/*.jsonl` and `metrics/*.json` file the dev-team plugin writes,
+in one place, so `session-analysis`, `/session-review`, `/harness-audit`,
+`/cost-report`, and future cross-machine aggregation (#178) compose against
+stable, named schemas instead of reverse-engineering emitters.
+
+**Privacy stance (non-negotiable, all streams):** rule IDs, counts, hashes,
+and enums only — never command text, prompt text, file contents, or free-text
+reasons beyond what a stream explicitly documents below as human-authored
+(e.g. `config-changelog.jsonl`'s `description`, which is a deliberate,
+human/agent-reviewed audit note, not incidental free text). Where a stream
+predates this doc and already carries a `reason` field with freeform text
+(e.g. `refactor-freeze.jsonl`'s internal-error diagnostics), that is existing,
+unchanged precedent — not a new exception.
+
+Each section below names: fields, types, emitter, consent gating, and
+consumers. A companion test
+(`tests/hooks/test_boundary_events.py::test_schema_doc_covers_all_metrics_paths`)
+cross-checks every `metrics/*.jsonl` / `metrics/*.json` path string referenced
+in shipped code against this doc's coverage and fails on omission.
+
+---
+
+## `boundary-events.jsonl`
+
+**Added by #859.** The boundary-level (policy-gateway) channel: every guard
+hook's block/warn/bypass decision, plus human-intervention keywords.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `ts` | string | ISO-8601 UTC `%Y-%m-%dT%H:%M:%SZ` |
+| `hook` | string | Emitting hook's module name, e.g. `destructive_guard`, `verify_guard`, `pre_commit_review`, `telemetry` |
+| `tool` | string | Hooked tool/event: `Bash`, `Write`, `Edit`, `Skill`, `Agent`, `UserPromptSubmit` |
+| `decision` | string enum | `block` \| `warn` \| `bypass` \| `intervention` |
+| `matched_rule` | string | Rule ID from a closed vocabulary (pattern ID, hook-defined constant, bypass flag name, or intervention keyword) — never free text |
+| `plugin_version` | string | From `.claude-plugin/plugin.json` |
+| `session_id` | string, optional | Opaque per-session ID, when present in the hook payload — enables joins with `session-digest.jsonl` |
+
+- **Emitter:** `hooks/lib/boundary_events.py::emit_boundary_event()`, called from `destructive_guard.py`, `verify_guard.py`, `pre_commit_review.py`, `telemetry.py` (intervention keywords), and the mechanically-adopted guards (`pre_tool_guard.py`, `context_ceiling_guard.py`, `bash_retry_guard.py`, `refactor_test_freeze_guard.py`, `contract_version_guard.py`, `mutation_testing_smoke_gate.py`, `mutation_gate.py`, `tdd_guard.py`).
+- **Consent:** ALWAYS-ON — not gated by `DEV_TEAM_TELEMETRY`. Local-only, rule-IDs-only safety/accountability channel; no observability holes by design.
+- **Fail-open:** every exception in the emit helper is swallowed — never changes the calling hook's exit code, stdout, or stderr.
+- **Consumers:** `skills/session-review/SKILL.md`, `skills/harness-audit/SKILL.md`, `agents/session-analysis.md`, `skills/cost-report/`, future `agent-telemetry` cross-machine aggregation (#178).
+
+---
+
+## `telemetry.jsonl`
+
+Opt-in usage beacon: which slash commands / skills get invoked, and whether
+the pre-commit review gate fired or was bypassed.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `ts` | string | ISO-8601 UTC |
+| `event` | string enum | `command` \| `skill` \| `gate` |
+| `name` | string | Grammar-matched slash-command name, skill name, or `pre-commit-review` |
+| `outcome` | string | `invoked` \| `fired` \| `bypassed` |
+| `plugin_version` | string | From `.claude-plugin/plugin.json` |
+
+- **Emitter:** `hooks/telemetry.py::_emit()`.
+- **Consent:** opt-in — `DEV_TEAM_TELEMETRY=on` env var, or `<cwd>/.claude/telemetry.json` `{"enabled": true}`. Off by default; nothing recorded, nothing leaves the machine.
+- **Consumers:** `skills/telemetry/SKILL.md`, `scripts/session_extract.py`.
+
+---
+
+## `cost-metering.jsonl`
+
+Per-session token/cost summary, incrementally accumulated from the
+transcript on each `Stop` hook fire.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `transcript` | string | Transcript file basename (not full path) |
+| `total` | object | Aggregated token counts + `cost_usd` + `messages` across the session |
+| `by_model` | object | Per-model slim breakdown: `cost_usd`, `input_tokens`, `output_tokens` |
+| `by_thread` | object | Per-thread slim breakdown, same shape as `by_model` |
+
+- **Emitter:** `hooks/cost_meter.py` (wrapper) → `hooks/lib/cost_meter.py::cmd_record()`.
+- **Consent:** unconditional (local-only cost accounting).
+- **Consumers:** `skills/cost-report/SKILL.md`, `skills/harness-audit/SKILL.md`, `cmd_regression`/`cmd_pace` in the same library.
+
+---
+
+## `artifact-usage.json`
+
+Not JSONL — a single JSON object keyed by skill/agent name, upserted on
+every invocation.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `<skill_name>.use_count` | integer | Cumulative invocation count |
+| `<skill_name>.last_used_at` | string | ISO-8601 UTC of the most recent invocation |
+| `<skill_name>.lifecycle` | string | `active` (set on creation; other lifecycle states are assigned externally by `/artifact-lifecycle`) |
+
+- **Emitter:** `hooks/telemetry.py::_upsert_artifact_usage()` (atomic rewrite via tempfile + `os.replace`).
+- **Consent:** follows `telemetry.jsonl`'s opt-in gate, with an independent explicit-off switch: `.claude/telemetry.json` `{"enabled": false}` disables usage tracking specifically.
+- **Consumers:** `skills/artifact-lifecycle/SKILL.md`.
+
+---
+
+## `gate-bypass-audit.jsonl`
+
+Accountability record for `git commit --no-verify`/`-n` bypasses of the
+pre-commit review gate.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `branch` | string | Current git branch |
+| `triggeredBy` | string | Bypass flag name (`--no-verify` or `-n`) |
+| `reason` | string | Value of `GATE_BYPASS_REASON` — human/agent-authored, required to be non-empty |
+| `stagedFileCount` | integer | Count of staged files at bypass time |
+| `pluginVersion` | string | From `.claude-plugin/plugin.json` |
+
+- **Emitter:** `hooks/pre_commit_review.py::_record_bypass_audit()`.
+- **Consent:** unconditional — accountability record for an actively-chosen bypass, not passive usage telemetry.
+- **Consumers:** `skills/code-review/SKILL.md`, `docs/code-review-process.md`.
+
+---
+
+## `gate-bypass.jsonl`
+
+Accountability record for `MUTATION_SMOKE_GATE_SKIP=1` bypasses of the
+mutation-testing smoke gate. Distinct stream from `gate-bypass-audit.jsonl`
+above (different gate, different hook).
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC (`Z`-suffixed) |
+| `hook` | string | Always `mutation-testing-smoke-gate` |
+| `command_hash` | string | First 16 hex chars of `sha256(raw_command)` — the raw command is never logged |
+| `cwd` | string | Payload cwd |
+
+- **Emitter:** `hooks/mutation_testing_smoke_gate.py::log_bypass_audit()`.
+- **Consent:** unconditional.
+- **Consumers:** `skills/mutation-testing/SKILL.md`.
+
+---
+
+## `config-changelog.jsonl`
+
+Audit trail for `/feedback-learning` config changes and human-oversight
+protocol events (approval / override / pause / stop).
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `type` | string enum | `amend` \| `approval` \| `override` \| `pause` \| `stop` (feedback-learning change types, or oversight event types) |
+| `trigger` | string | `user` (who/what triggered the change) |
+| `description` | string | Human/agent-authored summary of what happened and why (deliberate audit note, not incidental free text) |
+| `file_modified` | string, optional | Config file touched (feedback-learning changes) |
+| `section_modified` | string, optional | Section within the file |
+| `previous_value` / `new_value` | string, optional | Before/after values |
+| `approved_by` | string, optional | Who approved the change |
+
+- **Emitter:** `/feedback-learning` skill (model-authored append) and `/human-oversight-protocol` skill.
+- **Consent:** unconditional (append-only governance record).
+- **Consumers:** `skills/feedback-learning/SKILL.md`, `skills/human-oversight-protocol/SKILL.md`, `skills/governance-compliance/SKILL.md`.
+
+---
+
+## `session-digest.jsonl`
+
+Trend digest from `/session-review` (backed by `scripts/session_extract.py`):
+aggregate counts only, no file names, prompts, command strings, or code.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `recorded_at` | string | UTC ISO-8601 of the run |
+| `sessions`, `transcripts` | integer | How many sessions/transcripts the digest covered |
+| `tokens` | object | Input/output/cache token totals |
+| `cost_usd`, `cache_hit_ratio` | number | Session cost and cache-read efficiency |
+| `rework` | object | `failed_edits`, `repeated_file_edits`, `retried_bash_commands`, `repeated_verify_runs`, `permission_denials`, `compaction_events` |
+| `accuracy` | object | `tool_calls`, `tool_error_rate`, `user_correction_turns` |
+| `utilization` | object | `skills_invoked`, `agents_invoked`, `never_observed_skills`, `never_observed_agents` |
+
+- **Emitter:** `/session-review` skill via `scripts/session_extract.py`.
+- **Consent:** unconditional (aggregate counts only, no file/prompt/command content).
+- **Consumers:** `skills/harness-audit/SKILL.md` (joins with self-reported task logs), `agents/session-analysis.md`.
+
+---
+
+## `review-value.jsonl`
+
+Whether a `/build` inline review checkpoint actually changed anything —
+counts and outcomes only, never code or file content.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `plan` | string | Plan file path |
+| `slice` | string | Slice number |
+| `step` | string | Step number (`N.M`) or `all` |
+| `checkpoint` | string enum | `step` \| `slice` |
+| `complexity` | string enum | `standard` \| `complex` |
+| `agents_run` | array of string | Review agents dispatched |
+| `issues_found`, `issues_fixed`, `fix_iterations` | integer | Counts |
+| `outcome` | string enum | `no-op` \| `fixed` \| `escalated` |
+
+- **Emitter:** `/build` skill (model-authored append, sub-step 7). Disable with `DEV_TEAM_REVIEW_VALUE=off`.
+- **Consent:** unconditional when enabled (no code/file content recorded).
+- **Consumers:** `skills/cost-report/SKILL.md`, `skills/harness-audit/SKILL.md`.
+
+---
+
+## `verify-log.jsonl`
+
+Evidence that `/verify` actually ran (or was legitimately skipped) before a
+`/build` slice with a runtime surface was marked complete. Schema modeled on
+`review-value.jsonl`.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `plan` | string | Plan file path |
+| `slice` | string | Slice number |
+| `branch` | string | Current git branch |
+| `files` | array of string | Changed runtime files in scope |
+| `outcome` | string enum | `ran` \| `skipped` \| `failed-then-fixed` |
+| `reason` | string, optional | Set when `outcome` is `skipped` (e.g. `"tests-only"`, `"docs-only"`) |
+
+- **Emitter:** `/build` skill (model-authored append, sub-step 4.9).
+- **Consent:** unconditional.
+- **Consumers:** `scripts/progress_guardian.py --pre-pr` (fails closed on a runtime-surface change with no matching entry), `skills/performance-metrics/SKILL.md`.
+
+---
+
+## `override-audit.jsonl`
+
+Audit trail for `/code-review --force --reason "<text>"`, which skips all
+gates and the documentation-only short-circuit.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 |
+| `branch` | string | Current git branch |
+| `triggeredBy` | string | Always `--force` |
+| `reason` | string | Value of `--reason` (required, human/agent-authored) |
+| `targetFiles` | array of string | Files the forced review targeted |
+| `gatesSkipped` | array of string | e.g. `["lint", "type-check", "secret-scan", "semgrep", "pipeline-red"]` |
+
+- **Emitter:** `/code-review` skill (model-authored append, step 2).
+- **Consent:** unconditional.
+- **Consumers:** `skills/code-review/SKILL.md`, `docs/code-review-process.md`.
+
+---
+
+## `eval-variance.jsonl`
+
+Multi-trial pass@k stability trend for `/agent-eval` fixtures.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `recorded_at` | string | ISO-8601 UTC |
+| `schema` | string | `eval-variance/v1` |
+| `trials` | integer | Number of trials in this run |
+| `pairs_evaluated` | integer | Fixture/agent pairs evaluated |
+| `flaky_count` | integer | Pairs that neither always passed nor always failed |
+| `mean_pass_at_k` | number | Mean pass@k across evaluated agents |
+
+- **Emitter:** `scripts/eval_variance.py --append`.
+- **Consent:** unconditional (eval infra, not user-session telemetry).
+- **Consumers:** `skills/agent-eval/SKILL.md`.
+
+---
+
+## `refactor-freeze.jsonl`
+
+Audit log for the tests-frozen-during-REFACTOR invariant (`#813`) — both the
+enforcement decision and any fail-open diagnostic.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 |
+| `hook` | string | `freeze` or `revert` |
+| `event` | string enum | `block` \| `fail-open` \| `revert` \| `remove` |
+| `file` | string, optional | File path involved |
+| `step` | string, optional | Plan step label |
+| `reason` | string, optional | Fail-open diagnostic (existing precedent — internal-error text, not a rule ID; unchanged by #859) |
+
+- **Emitter:** `hooks/refactor_test_freeze_guard.py::audit()`, `hooks/refactor_test_revert_guard.py` (via the same `audit()` import).
+- **Consent:** unconditional (fails open, audits itself).
+- **Consumers:** none automated yet; inspected manually when the freeze invariant is investigated.
+
+---
+
+## `contract-version-guard-audit.jsonl`
+
+Audit log for release-please's bypass of the security-primitives-contract
+version-bump requirement.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `ts` | string | ISO-8601 UTC |
+| `bypass` | boolean | Always `true` |
+| `reason` | string | Always `release-please-actor` |
+| `github_actor` | string | `$GITHUB_ACTOR` env value |
+| `git_email` | string | `$GIT_AUTHOR_EMAIL` env value |
+
+- **Emitter:** `hooks/contract_version_guard.py::_log_bypass()`.
+- **Consent:** unconditional.
+- **Consumers:** none automated yet; CI-only diagnostic trail.
+
+---
+
+## `learning-loop-state.json`
+
+Not JSONL — a single current-value JSON file: a counter gating when
+`session_learning_trigger.py` dispatches background session analysis.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `counter` | integer | Turns since the last dispatch |
+
+- **Emitter:** `hooks/session_learning_trigger.py::_write_state()`.
+- **Consent:** unconditional (internal scheduling state, no content).
+- **Consumers:** `hooks/session_learning_trigger.py` itself (read on next fire).
+
+---
+
+## `pending-review.jsonl`
+
+Queued findings from the background session-analysis dispatch, before
+`/session-review` consumes them.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `queued_at` | string | ISO-8601 UTC |
+| `source` | string | Always `session-learning-trigger` |
+| `session_id` | string, optional | Session ID when available |
+| `findings` | array of object | Each: `lever`, `evidence`, `target_artifact`, `proposed_change`, `route` |
+
+- **Emitter:** background `claude --print` run dispatched by `hooks/session_learning_trigger.py::_dispatch_background_analysis()`, writing via `session-analysis` agent output.
+- **Consent:** unconditional (dispatch happens automatically; content is model-authored analysis, not raw session data).
+- **Consumers:** `/session-review` skill.
+
+---
+
+## `metrics/{date}-task-log.jsonl` (e.g. `2026-02-20-task-log.jsonl`)
+
+Self-reported per-task completion log, one file per calendar date.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 |
+| (task-specific fields) | — | Tokens, cost, agents used, rework cycles, hallucination events — see `skills/performance-metrics/SKILL.md` for the full field list |
+
+- **Emitter:** `/performance-metrics` skill (model-authored append at task completion).
+- **Consent:** unconditional (self-reported, no raw content).
+- **Consumers:** `skills/harness-audit/SKILL.md` (self-reported half of the harness-audit join, alongside `session-digest.jsonl`'s real-session half), `skills/governance-compliance/SKILL.md`.
+
+---
+
+## Adding a new stream
+
+1. Name it `metrics/<name>.jsonl` (or `.json` for a single-current-value
+   file) — one stream per concern, matching existing precedent.
+2. Append-only, compact JSON (`separators=(",", ":")`) + trailing newline for
+   JSONL streams.
+3. Rule IDs / counts / enums only — never command text, prompt text, file
+   contents, or incidental free text.
+4. Add a section to this file with the same shape as the ones above
+   (fields/types, emitter, consent gating, consumers) in the same PR that
+   introduces the emitter — the coverage test in
+   `tests/hooks/test_boundary_events.py` enforces this.

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -42,7 +42,10 @@ Arguments: $ARGUMENTS
 
 ### 1. Check for metrics data
 
-Read metrics JSONL files from `metrics/`. Three complementary streams exist:
+Read metrics JSONL files from `metrics/`. Full field reference for every
+stream below: `${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md` — read it
+instead of re-deriving a schema from the emitter. Four complementary streams
+exist:
 
 - `metrics/*-task-log.jsonl` — **self-reported** task logs (whatever the model
   chose to record about itself).
@@ -58,6 +61,13 @@ Read metrics JSONL files from `metrics/`. Three complementary streams exist:
   (absent or `last_used_at` > 30 days ago). Cross-reference with
   `never_observed_*` in `session-digest.jsonl` for corroboration. See
   `knowledge/artifact-lifecycle.md` for the lifecycle threshold definitions.
+- `metrics/boundary-events.jsonl` — **boundary-level (policy-gateway) events**
+  (#859): every guard hook's `block`/`warn`/`bypass` decision plus
+  `intervention` keywords, each with the emitting `hook` and a `matched_rule`
+  rule ID. Where `session-digest.jsonl`'s `rework` counts show outcomes
+  without causes, join on `session_id` (when present on both streams) to
+  attribute friction to a specific hook/rule instead of reasoning from counts
+  alone.
 
 If no metrics data exists or insufficient data is available (fewer than 10 review runs logged), report:
 

--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -17,6 +17,12 @@ Role: orchestrator. Mines ground-truth session transcripts and routes
 suggestions into existing machinery — it **suggests, never auto-applies**, and
 preserves every human gate.
 
+Every `metrics/*.jsonl`/`.json` schema referenced below (including
+`pending-review.jsonl` and the boundary-level `boundary-events.jsonl` block/
+warn/bypass/intervention causes, #859) is documented in full at
+`${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md` — read it before
+reasoning about a stream's fields ad hoc.
+
 You have been invoked with the `/session-review` command.
 
 ## Orchestrator constraints
@@ -68,7 +74,8 @@ findings that are waiting for review.
 
 ### `pending-review.jsonl` Schema
 
-Each line is a JSON object:
+Full field reference: `${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md`
+(`pending-review.jsonl` section). Summary — each line is a JSON object:
 
 ```json
 {

--- a/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
+++ b/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
@@ -38,6 +38,9 @@ def _run(payload: dict, env: dict, tmpdir: Path) -> subprocess.CompletedProcess[
         "GIT_CONFIG_SYSTEM": "/dev/null",
         **env,
     }
+    # Boundary events (#859) resolve metrics/ from payload["cwd"] — default
+    # it to the isolated `tmpdir` so tests never write into the real repo.
+    payload = {"cwd": str(tmpdir), **payload}
     return subprocess.run(
         ["python3", str(_HOOK)],
         input=json.dumps(payload),

--- a/plugins/dev-team/tests/hooks/test_boundary_events.py
+++ b/plugins/dev-team/tests/hooks/test_boundary_events.py
@@ -1,0 +1,491 @@
+"""Unit + end-to-end tests for hooks/lib/boundary_events.py (#859).
+
+Covers:
+  - the emit helper itself: append, dir creation, compact single-line JSON,
+    fail-open on OSError / arbitrary exceptions.
+  - one block, one warn, one bypass, and one intervention emission, driven
+    end-to-end through the real hooks (destructive_guard.py, verify_guard.py,
+    pre_commit_review.py, telemetry.py).
+  - fail-open: with the emit helper monkeypatched to raise, each hook's
+    exit code / stdout / stderr are unaffected.
+  - append-only valid JSONL across two consecutive emissions.
+  - the "never free text" privacy boundary: sentinel strings fed through
+    commands/prompts never appear anywhere in boundary-events.jsonl, and
+    every emitted event has exactly the documented schema keys with
+    `decision` inside the enum.
+  - knowledge/telemetry-schema.md documents every `metrics/*.jsonl`/`.json`
+    path referenced in shipped code (coverage cross-check).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PLUGIN_DIR = _REPO_ROOT / "plugins" / "dev-team"
+_HOOKS_DIR = _PLUGIN_DIR / "hooks"
+_LIB_DIR = _HOOKS_DIR / "lib"
+_TESTS_LIB = _PLUGIN_DIR / "tests" / "lib"
+
+for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import boundary_events  # type: ignore[import-not-found]  # noqa: E402
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
+
+_DECISION_ENUM = {"block", "warn", "bypass", "intervention"}
+_SCHEMA_FIELDS = {"ts", "hook", "tool", "decision", "matched_rule", "plugin_version"}
+_OPTIONAL_FIELDS = {"session_id"}
+
+
+def _read_jsonl(path: Path) -> list:
+    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    return [json.loads(ln) for ln in lines]
+
+
+# ---------------------------------------------------------------------------
+# emit_boundary_event() — the helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_emit_appends_one_compact_jsonl_line(tmp_path: Path) -> None:
+    boundary_events.emit_boundary_event(
+        tmp_path, "destructive_guard", "Bash", "warn", "file_destruction:rm-rf"
+    )
+    log = tmp_path / "metrics" / "boundary-events.jsonl"
+    assert log.is_file()
+    raw = log.read_text(encoding="utf-8")
+    lines = raw.splitlines()
+    assert len(lines) == 1
+    assert raw.endswith("\n")
+    # Compact separators: no space after ',' or ':'.
+    assert ", " not in lines[0]
+    assert '": ' not in lines[0]
+    event = json.loads(lines[0])
+    assert event["hook"] == "destructive_guard"
+    assert event["tool"] == "Bash"
+    assert event["decision"] == "warn"
+    assert event["matched_rule"] == "file_destruction:rm-rf"
+    assert "ts" in event and "plugin_version" in event
+
+
+def test_emit_creates_metrics_dir_when_absent(tmp_path: Path) -> None:
+    assert not (tmp_path / "metrics").exists()
+    boundary_events.emit_boundary_event(tmp_path, "verify_guard", "Bash", "block", "x")
+    assert (tmp_path / "metrics").is_dir()
+
+
+def test_emit_appends_not_overwrites_across_two_calls(tmp_path: Path) -> None:
+    boundary_events.emit_boundary_event(tmp_path, "h1", "Bash", "warn", "r1")
+    boundary_events.emit_boundary_event(tmp_path, "h2", "Bash", "block", "r2")
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    assert len(events) == 2
+    assert events[0]["hook"] == "h1"
+    assert events[1]["hook"] == "h2"
+
+
+def test_emit_includes_session_id_when_given(tmp_path: Path) -> None:
+    boundary_events.emit_boundary_event(
+        tmp_path, "verify_guard", "Bash", "block", "verify-repeat-threshold", "sess-1"
+    )
+    event = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")[0]
+    assert event["session_id"] == "sess-1"
+
+
+def test_emit_omits_session_id_when_absent(tmp_path: Path) -> None:
+    boundary_events.emit_boundary_event(tmp_path, "verify_guard", "Bash", "block", "r")
+    event = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")[0]
+    assert "session_id" not in event
+
+
+def test_emit_fails_open_on_unwritable_metrics_dir(tmp_path: Path) -> None:
+    """A metrics/ that can't be created (e.g. a file occupying its path)
+    must not raise — the caller's exit code must never be affected."""
+    (tmp_path / "metrics").write_text("not a directory")
+    # Must not raise.
+    boundary_events.emit_boundary_event(tmp_path, "h", "Bash", "warn", "r")
+
+
+def test_emit_fails_open_on_arbitrary_exception(tmp_path: Path, monkeypatch) -> None:
+    def _boom(*_a, **_k):
+        raise RuntimeError("disk is on fire")
+
+    monkeypatch.setattr(boundary_events, "_isoformat_utc", _boom)
+    # Must not raise.
+    boundary_events.emit_boundary_event(tmp_path, "h", "Bash", "warn", "r")
+    assert not (tmp_path / "metrics" / "boundary-events.jsonl").exists()
+
+
+def test_emit_swallows_bad_cwd_type(monkeypatch) -> None:
+    """An unusable `cwd` (e.g. None with no real cwd fallback failing) must
+    still not raise — fail-open covers the whole call, not just I/O."""
+    boundary_events.emit_boundary_event(None, "h", "Bash", "warn", "r")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: one block, one warn, one bypass, one intervention through the
+# real hooks.
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(hook_name: str, payload: dict, env_extra: dict | None = None):
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C.UTF-8",
+    }
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / hook_name)],
+        input=json.dumps(payload).encode(),
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_destructive_guard_warn_emits_boundary_event(tmp_path: Path) -> None:
+    result = _run_hook(
+        "destructive_guard.py",
+        {"tool_input": {"command": "kill -9 1234"}, "cwd": str(tmp_path)},
+    )
+    assert result.returncode == 0
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    assert len(events) == 1
+    event = events[0]
+    assert event["hook"] == "destructive_guard"
+    assert event["tool"] == "Bash"
+    assert event["decision"] == "warn"
+    assert "Process destruction" in event["matched_rule"]
+
+
+def test_destructive_guard_block_emits_boundary_event(tmp_path: Path) -> None:
+    careful_state = _HOOKS_DIR / "careful-state.json"
+    original = careful_state.read_text() if careful_state.is_file() else None
+    try:
+        careful_state.write_text(json.dumps({"active": True}), encoding="utf-8")
+        result = _run_hook(
+            "destructive_guard.py",
+            {"tool_input": {"command": "rm -rf /"}, "cwd": str(tmp_path)},
+        )
+        assert result.returncode == 2
+        events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+        assert len(events) == 1
+        assert events[0]["decision"] == "block"
+        assert events[0]["hook"] == "destructive_guard"
+    finally:
+        if original is None:
+            careful_state.unlink(missing_ok=True)
+        else:
+            careful_state.write_text(original, encoding="utf-8")
+
+
+def test_verify_guard_block_emits_boundary_event(tmp_path: Path) -> None:
+    env = {"TMPDIR": str(tmp_path)}
+    payload = {
+        "session_id": "boundary-verify-1",
+        "cwd": str(tmp_path),
+        "tool_input": {"command": "npm test"},
+    }
+    for _ in range(3):
+        result = _run_hook("verify_guard.py", payload, env)
+    assert result.returncode == 2
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    block_events = [e for e in events if e["decision"] == "block"]
+    assert len(block_events) == 1
+    assert block_events[0]["hook"] == "verify_guard"
+    assert block_events[0]["matched_rule"] == "verify-repeat-threshold"
+    assert block_events[0]["session_id"] == "boundary-verify-1"
+
+
+def _init_git_repo(root: Path) -> dict:
+    env = hermetic_git_env(home=root)
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+    )
+    subprocess.run(["git", "init", "--quiet", "-b", "main"], cwd=root, env=env, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, env=env, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, env=env, check=True)
+    (root / "file.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "-A"], cwd=root, env=env, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "init"], cwd=root, env=env, check=True
+    )
+    (root / "file.txt").write_text("hello again\n")
+    subprocess.run(["git", "add", "-A"], cwd=root, env=env, check=True)
+    return env
+
+
+def test_pre_commit_review_block_emits_boundary_event(tmp_path: Path) -> None:
+    env = _init_git_repo(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / "pre_commit_review.py")],
+        input=json.dumps(
+            {
+                "tool_input": {"command": 'git commit -m "wip"'},
+                "cwd": str(tmp_path),
+            }
+        ).encode(),
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    assert len(events) == 1
+    assert events[0]["hook"] == "pre_commit_review"
+    assert events[0]["decision"] == "block"
+    assert events[0]["matched_rule"] == "pre-commit-review"
+
+
+def test_pre_commit_review_bypass_emits_boundary_event(tmp_path: Path) -> None:
+    env = _init_git_repo(tmp_path)
+    env["GATE_BYPASS_REASON"] = "hotfix, review to follow"
+    result = subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / "pre_commit_review.py")],
+        input=json.dumps(
+            {
+                "tool_input": {"command": 'git commit --no-verify -m "wip"'},
+                "cwd": str(tmp_path),
+            }
+        ).encode(),
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    assert len(events) == 1
+    assert events[0]["hook"] == "pre_commit_review"
+    assert events[0]["decision"] == "bypass"
+    assert events[0]["matched_rule"] == "--no-verify"
+    # The existing gate-bypass-audit.jsonl accountability record is untouched.
+    audit = _read_jsonl(tmp_path / "metrics" / "gate-bypass-audit.jsonl")
+    assert len(audit) == 1
+    assert audit[0]["reason"] == "hotfix, review to follow"
+
+
+def test_intervention_keyword_emits_event(tmp_path: Path) -> None:
+    for prompt, keyword in (("override", "override"), ("pause", "pause"), ("stop", "stop")):
+        result = _run_hook(
+            "telemetry.py",
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": prompt,
+                "cwd": str(tmp_path),
+                "session_id": "s-intervention",
+            },
+        )
+        assert result.returncode == 0
+        events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+        assert events[-1]["decision"] == "intervention"
+        assert events[-1]["matched_rule"] == keyword
+        assert events[-1]["hook"] == "telemetry"
+        assert events[-1]["tool"] == "UserPromptSubmit"
+
+
+def test_intervention_with_payload_records_only_keyword(tmp_path: Path) -> None:
+    """`override: some secret reason` must record only `override`, never
+    the payload after the colon."""
+    result = _run_hook(
+        "telemetry.py",
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "override: SENTINEL-PAYLOAD-TEXT",
+            "cwd": str(tmp_path),
+        },
+    )
+    assert result.returncode == 0
+    events = _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl")
+    assert len(events) == 1
+    assert events[0]["matched_rule"] == "override"
+    raw = (tmp_path / "metrics" / "boundary-events.jsonl").read_text()
+    assert "SENTINEL-PAYLOAD-TEXT" not in raw
+
+
+def test_non_intervention_prompt_emits_nothing(tmp_path: Path) -> None:
+    """The word 'stop' mid-sentence (not anchored at the start) must not
+    fire an intervention event — grammar-anchored, not substring match."""
+    result = _run_hook(
+        "telemetry.py",
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "please don't stop working on this",
+            "cwd": str(tmp_path),
+        },
+    )
+    assert result.returncode == 0
+    assert not (tmp_path / "metrics" / "boundary-events.jsonl").exists()
+
+
+def test_ordinary_prompt_emits_nothing(tmp_path: Path) -> None:
+    result = _run_hook(
+        "telemetry.py",
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "please implement feature X",
+            "cwd": str(tmp_path),
+        },
+    )
+    assert result.returncode == 0
+    assert not (tmp_path / "metrics" / "boundary-events.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: telemetry failure must never change the hooked tool call's
+# exit code / stdout / stderr.
+# ---------------------------------------------------------------------------
+
+
+def test_destructive_guard_behavior_unaffected_when_metrics_unwritable(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "metrics").write_text("occupied by a file, not a directory")
+    result = _run_hook(
+        "destructive_guard.py",
+        {"tool_input": {"command": "kill -9 1234"}, "cwd": str(tmp_path)},
+    )
+    assert result.returncode == 0
+    assert b"CAUTION: Destructive command detected (Process destruction: kill -9)." in (
+        result.stdout
+    )
+
+
+def test_emit_helper_monkeypatched_to_raise_does_not_change_hook_behavior(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Each hook wraps the shared helper in a local safety net (#859): even
+    if the underlying `boundary_events.emit_boundary_event` itself is
+    broken/monkeypatched to raise, the hook's own `emit_boundary_event`
+    (the module-level wrapper every call site uses) swallows it — main()'s
+    exit code and stdout are unaffected."""
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    import destructive_guard  # type: ignore[import-not-found]  # noqa: E402
+    import io
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("telemetry exploded")
+
+    # Patch the underlying (imported-as-_emit_boundary_event) implementation
+    # that destructive_guard's local emit_boundary_event() wrapper delegates
+    # to — this simulates the shared helper itself misbehaving.
+    monkeypatch.setattr(destructive_guard, "_emit_boundary_event", _boom)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps({"tool_input": {"command": "kill -9 1"}, "cwd": str(tmp_path)})
+        ),
+    )
+    result = destructive_guard.main()
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "CAUTION: Destructive command detected (Process destruction: kill -9)." in out
+
+
+# ---------------------------------------------------------------------------
+# Privacy: no free text anywhere in the stream.
+# ---------------------------------------------------------------------------
+
+
+def test_no_free_text_leaks_into_boundary_events(tmp_path: Path) -> None:
+    sentinel = "SENTINEL-DO-NOT-LOG-THIS-COMMAND-TEXT"
+    # destructive_guard: pattern match still fires on the destructive
+    # substring even embedded in a sentinel-laden command.
+    _run_hook(
+        "destructive_guard.py",
+        {
+            "tool_input": {"command": f"kill -9 1234 # {sentinel}"},
+            "cwd": str(tmp_path),
+        },
+    )
+    _run_hook(
+        "telemetry.py",
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": f"override: {sentinel}",
+            "cwd": str(tmp_path),
+        },
+    )
+    raw = (tmp_path / "metrics" / "boundary-events.jsonl").read_text(encoding="utf-8")
+    assert sentinel not in raw
+    for event in _read_jsonl(tmp_path / "metrics" / "boundary-events.jsonl"):
+        keys = set(event.keys())
+        assert keys <= (_SCHEMA_FIELDS | _OPTIONAL_FIELDS)
+        assert _SCHEMA_FIELDS <= keys
+        assert event["decision"] in _DECISION_ENUM
+
+
+# ---------------------------------------------------------------------------
+# Schema doc completeness (#859 acceptance criterion).
+# ---------------------------------------------------------------------------
+
+
+def test_schema_doc_covers_all_metrics_paths() -> None:
+    """Every `metrics/*.jsonl` / `metrics/*.json` path string referenced in
+    shipped plugin code (hooks/skills/agents/knowledge) must have a
+    corresponding section in knowledge/telemetry-schema.md."""
+    schema_doc = _PLUGIN_DIR / "knowledge" / "telemetry-schema.md"
+    schema_text = schema_doc.read_text(encoding="utf-8")
+
+    pattern = re.compile(r"metrics/([A-Za-z0-9_.{}-]+\.(?:jsonl|json))")
+    found: set[str] = set()
+    search_dirs = ["hooks", "skills", "agents", "knowledge"]
+    for sub in search_dirs:
+        root = _PLUGIN_DIR / sub
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.is_dir() or "__pycache__" in path.parts:
+                continue
+            if path.suffix not in (".py", ".md", ".json"):
+                continue
+            if path == schema_doc:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for match in pattern.finditer(text):
+                found.add(match.group(1))
+
+    # Dated task-log files (metrics/2026-02-20-task-log.jsonl, etc.) are one
+    # family — normalize any concrete date-stamped name to the documented
+    # placeholder form.
+    normalized = set()
+    date_stamped = re.compile(r"^\d{4}-\d{2}-\d{2}-task-log\.jsonl$")
+    for name in found:
+        if date_stamped.match(name):
+            normalized.add("{date}-task-log.jsonl")
+        else:
+            normalized.add(name)
+
+    missing = [name for name in sorted(normalized) if name not in schema_text]
+    assert not missing, (
+        "knowledge/telemetry-schema.md is missing coverage for: "
+        f"{missing} — add a section documenting each stream's schema."
+    )
+
+
+def test_schema_doc_documents_boundary_events_fields() -> None:
+    schema_doc = _PLUGIN_DIR / "knowledge" / "telemetry-schema.md"
+    text = schema_doc.read_text(encoding="utf-8")
+    assert "boundary-events.jsonl" in text
+    for field in _SCHEMA_FIELDS | _OPTIONAL_FIELDS:
+        assert field in text, f"telemetry-schema.md missing field `{field}`"
+    for decision in _DECISION_ENUM:
+        assert decision in text

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -10,9 +10,16 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
+
+# Boundary events (#859) are ALWAYS-ON and resolve their metrics/ dir from
+# the hook payload's "cwd" (falling back to the process's actual OS cwd when
+# absent) — isolate every subprocess run to a scratch dir so tests never
+# write metrics/boundary-events.jsonl into the real repo checkout.
+_BOUNDARY_EVENTS_SCRATCH_CWD = tempfile.mkdtemp(prefix="dev-team-context-ceiling-test-")
 
 
 _HOOKS_DIR = Path(__file__).resolve().parents[2] / "hooks"
@@ -90,6 +97,7 @@ def _mkinput(tool_name: str, tool_input: dict, transcript: Path) -> str:
             "session_id": "s1",
             "transcript_path": str(transcript),
             "tool_input": tool_input,
+            "cwd": _BOUNDARY_EVENTS_SCRATCH_CWD,
         }
     )
 

--- a/plugins/dev-team/tests/hooks/test_contract_version_guard.py
+++ b/plugins/dev-team/tests/hooks/test_contract_version_guard.py
@@ -183,6 +183,22 @@ def _run_hook_from(
     target_py = target_hooks / "contract_version_guard.py"
     if not target_py.exists():
         target_py.write_bytes((_HOOKS_DIR / "contract_version_guard.py").read_bytes())
+    target_lib = target_hooks / "lib"
+    target_lib.mkdir(parents=True, exist_ok=True)
+    target_boundary_events = target_lib / "boundary_events.py"
+    if not target_boundary_events.exists():
+        target_boundary_events.write_bytes(
+            (_HOOKS_DIR / "lib" / "boundary_events.py").read_bytes()
+        )
+    # The plugin manifest path is resolved relative to hooks/lib/, i.e.
+    # hooks/../.claude-plugin/plugin.json — create a minimal one so
+    # emit_boundary_event's version lookup doesn't hit a missing-file path
+    # (harmless either way since it's fail-open, but keeps behavior tidy).
+    manifest_dir = repo_root / "plugins" / "dev-team" / ".claude-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "plugin.json"
+    if not manifest_path.exists():
+        manifest_path.write_text('{"version": "0.0.0-test"}')
     env = {
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "HOME": str(repo_root),

--- a/plugins/dev-team/tests/hooks/test_destructive_guard.py
+++ b/plugins/dev-team/tests/hooks/test_destructive_guard.py
@@ -13,11 +13,24 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
+
 _HOOKS_DIR = Path(__file__).resolve().parents[2] / "hooks"
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
 import destructive_guard  # type: ignore[import-not-found]  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_boundary_events(monkeypatch):
+    """This suite calls destructive_guard.main() in-process with no `cwd`
+    in the payload — without this, emit_boundary_event (#859) would resolve
+    metrics/ against the test process's real OS cwd (the repo checkout).
+    Boundary-event emission itself is covered end-to-end in
+    tests/hooks/test_boundary_events.py.
+    """
+    monkeypatch.setattr(destructive_guard, "emit_boundary_event", lambda *a, **k: None)
 
 
 def _feed(monkeypatch, payload: dict) -> None:

--- a/plugins/dev-team/tests/hooks/test_pre_tool_guard.py
+++ b/plugins/dev-team/tests/hooks/test_pre_tool_guard.py
@@ -19,6 +19,16 @@ sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
 import pre_tool_guard  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _no_boundary_events(monkeypatch):
+    """evaluate() defaults cwd="." — without this, emit_boundary_event
+    (#859) would resolve metrics/ against the test process's real OS cwd.
+    Boundary-event emission itself is covered end-to-end in
+    tests/hooks/test_boundary_events.py.
+    """
+    monkeypatch.setattr(pre_tool_guard, "emit_boundary_event", lambda *a, **k: None)
+
+
 # ---------------------------------------------------------------------------
 # _extract_file_path
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/tests/hooks/test_tdd_guard.py
+++ b/plugins/dev-team/tests/hooks/test_tdd_guard.py
@@ -16,6 +16,16 @@ sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
 import tdd_guard  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _no_boundary_events(monkeypatch):
+    """main() defaults cwd="." when the test payload omits it — without
+    this, emit_boundary_event (#859) would resolve metrics/ against the
+    test process's real OS cwd. Boundary-event emission itself is covered
+    end-to-end in tests/hooks/test_boundary_events.py.
+    """
+    monkeypatch.setattr(tdd_guard, "emit_boundary_event", lambda *a, **k: None)
+
+
 # ---------------------------------------------------------------------------
 # _extract_file_path — walks 4 candidate keys
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_destructive_guard.py
+++ b/tests/hooks/test_destructive_guard.py
@@ -19,6 +19,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,12 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "destructive_guard.py"
 _CAREFUL_STATE = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "careful-state.json"
+
+# Boundary events (#859) resolve metrics/ from payload["cwd"] (falling back
+# to the process's actual OS cwd when absent) — isolate every subprocess run
+# to a scratch dir so tests never write metrics/boundary-events.jsonl into
+# the real repo checkout.
+_BOUNDARY_EVENTS_SCRATCH_CWD = tempfile.mkdtemp(prefix="dev-team-destructive-guard-test-")
 
 
 @pytest.fixture(autouse=True)
@@ -40,6 +47,7 @@ def _run(payload: dict) -> subprocess.CompletedProcess:
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "LANG": "C.UTF-8",
     }
+    payload = {"cwd": _BOUNDARY_EVENTS_SCRATCH_CWD, **payload}
     return subprocess.run(
         [sys.executable, str(_HOOK_PY)],
         input=json.dumps(payload).encode(),

--- a/tests/hooks/test_verify_guard.py
+++ b/tests/hooks/test_verify_guard.py
@@ -30,6 +30,9 @@ def _run(payload: dict, *, tmp: Path, threshold: str | None = None):
     }
     if threshold is not None:
         env["DEV_TEAM_VERIFY_THRESHOLD"] = threshold
+    # Boundary events (#859) resolve metrics/ from payload["cwd"] — default
+    # it to the isolated `tmp` dir so tests never write into the real repo.
+    payload = {"cwd": str(tmp), **payload}
     return subprocess.run(
         [sys.executable, str(_HOOK_PY)],
         input=json.dumps(payload).encode(),
@@ -46,6 +49,7 @@ def _run_edit_marker(payload: dict, *, tmp: Path):
         "LANG": "C.UTF-8",
         "TMPDIR": str(tmp),
     }
+    payload = {"cwd": str(tmp), **payload}
     return subprocess.run(
         [sys.executable, str(_EDIT_MARKER_PY)],
         input=json.dumps(payload).encode(),


### PR DESCRIPTION
## Summary

Implements #859: the boundary-level (policy-gateway) telemetry channel recommended by the *Code as Agent Harness* paper (§3.5.1, §5.2.1), complementing the existing eval-score and trajectory-level (cost/session-digest) channels.

- **New `hooks/lib/boundary_events.py`**: shared `emit_boundary_event(cwd, hook, tool, decision, matched_rule, session_id=None)` helper. Appends one compact JSON line to `metrics/boundary-events.jsonl`; creates `metrics/` if absent; fail-open (swallows every exception) so a broken helper can never affect a hook's exit code/stdout/stderr. Stdlib only, Python 3.8+.
- **Wired into the three acceptance-tested core guards**: `destructive_guard.py` (warn/block), `verify_guard.py` (warn/block), `pre_commit_review.py` (block/bypass — the existing `gate-bypass-audit.jsonl` accountability record is untouched).
- **`telemetry.py`**: new `UserPromptSubmit` intervention-keyword detection (`override`/`pause`/`stop`, anchored whole-prompt grammar match, payload after `:` discarded, never logged). This sub-stream is **always-on** (not gated by `DEV_TEAM_TELEMETRY` consent) per the issue's Ambiguity Log.
- **Mechanically adopted** into the remaining decision-making guards named in the architecture spec: `pre_tool_guard.py`, `context_ceiling_guard.py`, `bash_retry_guard.py`, `refactor_test_freeze_guard.py`, `contract_version_guard.py`, `mutation_testing_smoke_gate.py`, `mutation_gate.py`, `tdd_guard.py`. Each hook wraps the shared helper in a local safety-net wrapper (`emit_boundary_event` delegating to `_emit_boundary_event` in a try/except) so even a misbehaving helper can't leak into the hook's behavior — verified by a dedicated test.
- **`refactor_test_revert_guard.py`** intentionally excluded — see the ambiguity comment on the issue (it never blocks/warns/bypasses; it silently reverts/removes files and always exits 0, which doesn't fit the `block|warn|bypass|intervention` enum without stretching it).
- **New `knowledge/telemetry-schema.md`**: documents every `metrics/*.jsonl`/`.json` schema shipped by the plugin (17 streams), each with fields/types/emitter/consent-gating/consumers. `session-review` and `harness-audit` skill docs now reference it via `${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md` instead of describing schemas ad hoc.
- **New `tests/hooks/test_boundary_events.py`**: helper unit tests (append, dir creation, compact JSONL, fail-open on OSError/arbitrary exception), one block/warn/bypass/intervention emission driven end-to-end through the real hooks, a fail-open behavioral-parity test, the "never free text" privacy boundary (sentinel strings never leak; every event's keys match the documented schema; `decision` stays in-enum), append-only JSONL across two emissions, and a coverage cross-check between every `metrics/` path referenced in shipped code and the schema doc's sections.
- Existing hook test fixtures (`tests/hooks/`, `plugins/dev-team/tests/hooks/`) were updated to isolate the now-always-on `boundary-events.jsonl` stream to a scratch/tmp directory so tests never write into the real repo checkout (this stream, unlike `telemetry.jsonl`, is unconditional).
- `metrics/boundary-events.jsonl` added to `.gitignore`.
- `knowledge/index.json` regenerated to include the new schema doc.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/ -q` — 760 passed
- [x] `python3 -m pytest tests/hooks/ -q` — 65 passed
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py -q` (the repo's actual CI-equivalent invocation from `scripts/ci-local.sh`) — same 18 pre-existing environment-gap failures as on `main` (missing `jsonschema`/`pytest-asyncio` in this sandbox), zero new failures
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 scripts/check-python-only.py` — clean
- [x] `python3 plugins/dev-team/hooks/lib/build_skills_index.py --check` — clean
- [x] `bash scripts/assemble-docs.sh && python3 scripts/check_nav_integrity.py` — OK
- [x] Confirmed no `metrics/*` files leak into the real repo checkout as a side effect of running the test suite

Closes #859

https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_