### PR TITLE
feat: eval-gate feedback-learning mutations with change contracts

### DIFF
--- a/plugins/dev-team/hooks/eval_compliance_check.py
+++ b/plugins/dev-team/hooks/eval_compliance_check.py
@@ -18,10 +18,11 @@ Refs: #572 (bash → Python migration epic).
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 
 
 def _read_stdin() -> str:
@@ -68,7 +69,53 @@ def _grep_matches(content: str, pattern: str) -> bool:
     return re.search(pattern, content) is not None
 
 
-def _agent_checks(content: str, agent_name: str, file_path: str) -> str:
+def _project_root(payload: dict) -> Path:
+    """Resolve the project root the same way for every hook that needs one
+    (docs/python-hook-contract.md § Environment variables): prefer
+    ``CLAUDE_PROJECT_DIR``, fall back to the stdin payload's ``cwd``, then
+    ``Path.cwd()``. Never raises."""
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_root:
+        return Path(env_root)
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        return Path(cwd)
+    return Path.cwd()
+
+
+def _fixtured_agents(project_root: Path) -> Set[str]:
+    """Scan ``evals/expected/*.json`` for ``applicableAgents`` (#860).
+
+    Returns the empty set when ``evals/expected/`` does not exist — the
+    normal shape for a cache-only plugin install (no ``evals/`` dir ships)
+    — so the EVAL REQUIRED advisory below silently degrades to nothing
+    rather than erroring."""
+    expected_dir = project_root / "evals" / "expected"
+    if not expected_dir.is_dir():
+        return set()
+
+    agents: Set[str] = set()
+    for fixture_file in expected_dir.glob("*.json"):
+        try:
+            data = json.loads(fixture_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        applicable = data.get("applicableAgents")
+        if isinstance(applicable, list):
+            for entry in applicable:
+                if isinstance(entry, str):
+                    agents.add(entry)
+    return agents
+
+
+def _agent_checks(
+    content: str,
+    agent_name: str,
+    file_path: str,
+    eval_required: bool = False,
+) -> str:
     """Return the full stdout block for an agent-file update.
 
     Order of checks matches the .sh; the FAILS and WARNS strings accumulate
@@ -172,6 +219,12 @@ def _agent_checks(content: str, agent_name: str, file_path: str) -> str:
     parts.append("\n")
     parts.append(f"  Agent file changed: {agent_name}\n")
     parts.append(f"  ACTION REQUIRED: Run /agent-audit {file_path}\n")
+    if eval_required:
+        parts.append(
+            f"  EVAL REQUIRED: this agent has eval fixtures — run "
+            f"/agent-eval --agent {agent_name} and record the result "
+            f"before adopting this change.\n"
+        )
     parts.append(
         "  DOC SYNC REQUIRED: Update .claude/CLAUDE.md and "
         "docs/agent_info.md to reflect any changes.\n"
@@ -316,7 +369,12 @@ def main() -> int:
 
     if file_type == "agent":
         agent_name = Path(file_path).stem
-        sys.stdout.write(_agent_checks(content, agent_name, file_path))
+        fixtured = _fixtured_agents(_project_root(payload))
+        sys.stdout.write(
+            _agent_checks(
+                content, agent_name, file_path, eval_required=agent_name in fixtured
+            )
+        )
     elif file_type == "skill":
         skill_name = Path(file_path).stem
         block = _skill_checks(content, skill_name)

--- a/plugins/dev-team/hooks/lib/config_changelog_schema.py
+++ b/plugins/dev-team/hooks/lib/config_changelog_schema.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Change-contract schema validator for metrics/config-changelog.jsonl (#860).
+
+`feedback-learning` (plugins/dev-team/skills/feedback-learning/SKILL.md §
+Audit Trail) extends the config-changelog entry schema with nine change-
+contract fields whenever a change touches a review agent that has eval
+fixtures (`evals/expected/*.json` `applicableAgents`): `component`,
+`failure_mode_targeted`, `predicted_improvement`, `eval_pre`, `eval_post`,
+`eval_verdict`, `adoption_status`, `override_rationale` (required iff
+`adoption_status == "overridden"`), `rollback_pointer`.
+
+Entries that do NOT touch a fixtured agent (or predate the contract
+entirely) are unaffected — the log is append-only and backward-compatible:
+this validator only enforces the contract on *gated* entries (those whose
+`component` names a fixtured agent), never on legacy rows.
+
+Stdlib-only (ADR 0014/0015). Not wired into any hook's exit code — this is
+a standalone validator consumed by tests and, optionally, by a human/CI
+audit script. It intentionally does not decide *whether* to gate; callers
+pass in the fixtured-agent set (e.g. from
+`hooks/eval_compliance_check.py::_fixtured_agents`).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional, Set
+
+GATED_REQUIRED_FIELDS = (
+    "component",
+    "failure_mode_targeted",
+    "predicted_improvement",
+    "eval_pre",
+    "eval_post",
+    "eval_verdict",
+    "adoption_status",
+    "rollback_pointer",
+)
+
+VALID_ADOPTION_STATUSES = {
+    "pending-eval",
+    "adopted",
+    "rejected",
+    "rolled-back",
+    "overridden",
+}
+
+VALID_EVAL_VERDICTS = {"improved", "unchanged", "regressed", "not-applicable"}
+
+_AGENT_FILE_RE = re.compile(r"agents/([A-Za-z0-9_-]+)\.md")
+_AGENT_OVERRIDE_RE = re.compile(r"Agent Overrides\s*>\s*([A-Za-z0-9_-]+)")
+
+
+def extract_agent_name(component: str) -> Optional[str]:
+    """Pull the review-agent stem out of a `component` value.
+
+    Matches both direct plugin-repo edits (``agents/security-review.md``)
+    and project-side overrides (``CLAUDE.md > Agent Overrides >
+    security-review``) — the gate covers both per the spec's Ambiguity Log."""
+    if not component:
+        return None
+    match = _AGENT_FILE_RE.search(component)
+    if match:
+        return match.group(1)
+    match = _AGENT_OVERRIDE_RE.search(component)
+    if match:
+        return match.group(1)
+    return None
+
+
+def is_gated_entry(entry: dict, fixtured_agents: Iterable[str]) -> bool:
+    """True when `entry` touches a review agent that has eval fixtures."""
+    component = entry.get("component")
+    if not isinstance(component, str) or not component:
+        return False
+    agent_name = extract_agent_name(component)
+    return agent_name is not None and agent_name in set(fixtured_agents)
+
+
+def validate_entry(entry: dict, fixtured_agents: Iterable[str]) -> List[str]:
+    """Validate one config-changelog entry against the change-contract schema.
+
+    Returns a list of human-readable errors (empty = valid). Entries that
+    are not gated (no `component`, or a `component` naming an agent with
+    no fixtures) always validate — this keeps every pre-existing entry in
+    `metrics/config-changelog.jsonl` valid, per the append-only /
+    backward-compatible constraint."""
+    errors: List[str] = []
+    fixtured: Set[str] = set(fixtured_agents)
+
+    if not is_gated_entry(entry, fixtured):
+        return errors
+
+    for field in GATED_REQUIRED_FIELDS:
+        value = entry.get(field)
+        if value in (None, "", {}, []):
+            errors.append(f"missing or empty required field: {field}")
+
+    adoption_status = entry.get("adoption_status")
+    if adoption_status is not None and adoption_status not in VALID_ADOPTION_STATUSES:
+        errors.append(f"invalid adoption_status: {adoption_status!r}")
+
+    eval_verdict = entry.get("eval_verdict")
+    if eval_verdict is not None and eval_verdict not in VALID_EVAL_VERDICTS:
+        errors.append(f"invalid eval_verdict: {eval_verdict!r}")
+
+    if adoption_status == "overridden":
+        rationale = entry.get("override_rationale")
+        if not rationale:
+            errors.append(
+                "adoption_status is 'overridden' but override_rationale "
+                "is missing or empty"
+            )
+
+    return errors

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2970,9 +2970,33 @@
       "summary": "Preference and convention changes: apply after diff preview",
       "anchor": "approval-rules"
     },
+    "Evaluate — the eval gate (#860)": {
+      "summary": "A change that mutates a review agent's effective behavior — a direct edit to",
+      "anchor": "evaluate-the-eval-gate-860"
+    },
+    "1. Determine whether the change is gated": {
+      "summary": "Scan `evals/expected/*.json` for `applicableAgents` arrays.",
+      "anchor": "1-determine-whether-the-change-is-gated"
+    },
+    "2. Get the pre-score": {
+      "summary": "Read `evals/baseline.json`, filtered to pairs whose agent is the touched",
+      "anchor": "2-get-the-pre-score"
+    },
+    "3. Pause for approval, then dispatch the targeted eval": {
+      "summary": "Before dispatching *any* live `/agent-eval` run (pre-run or post-run), show",
+      "anchor": "3-pause-for-approval-then-dispatch-the-targeted-eval"
+    },
+    "4. Compare and decide adoption": {
+      "summary": "| `eval_post` vs `eval_pre` | `eval_verdict` | Default `adoption_status` |",
+      "anchor": "4-compare-and-decide-adoption"
+    },
     "Audit Trail": {
       "summary": "All changes are logged in `metrics/config-changelog.jsonl` (one JSON object per line, append-only).",
       "anchor": "audit-trail"
+    },
+    "Change-contract schema extension (#860)": {
+      "summary": "The nine fields below are **required only for entries that gate through",
+      "anchor": "change-contract-schema-extension-860"
     },
     "Rollback": {
       "summary": "1.",
@@ -3260,29 +3284,33 @@
       "summary": "Read metrics JSONL files from `metrics/`.",
       "anchor": "1-check-for-metrics-data"
     },
-    "2. Analyze review agent effectiveness": {
+    "2. Check for a stale baseline (re-baseline detection, #860)": {
+      "summary": "Report-only — this step never edits `evals/baseline.json` or re-runs evals",
+      "anchor": "2-check-for-a-stale-baseline-re-baseline-detection-860"
+    },
+    "3. Analyze review agent effectiveness": {
       "summary": "For each review agent in the registry (`knowledge/agent-registry.md`):",
-      "anchor": "2-analyze-review-agent-effectiveness"
+      "anchor": "3-analyze-review-agent-effectiveness"
     },
-    "3. Analyze review-value fix rates": {
+    "4. Analyze review-value fix rates": {
       "summary": "Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `performance-metrics`).",
-      "anchor": "3-analyze-review-value-fix-rates"
+      "anchor": "4-analyze-review-value-fix-rates"
     },
-    "4. Analyze model routing": {
+    "5. Analyze model routing": {
       "summary": "For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):",
-      "anchor": "4-analyze-model-routing"
+      "anchor": "5-analyze-model-routing"
     },
-    "5. Analyze orchestration complexity": {
+    "6. Analyze orchestration complexity": {
       "summary": "Review the current pipeline for components that may be unnecessary overhead:",
-      "anchor": "5-analyze-orchestration-complexity"
+      "anchor": "6-analyze-orchestration-complexity"
     },
-    "6. Produce report": {
+    "7. Produce report": {
       "summary": "Write the report to the output path using this structure:",
-      "anchor": "6-produce-report"
+      "anchor": "7-produce-report"
     },
-    "7. Present results": {
+    "8. Present results": {
       "summary": "Display a summary of the report and the file path.",
-      "anchor": "7-present-results"
+      "anchor": "8-present-results"
     },
     "Error Handling": {
       "summary": "Missing metrics files: Report what's missing, suggest how to generate data",

--- a/plugins/dev-team/skills/feedback-learning/SKILL.md
+++ b/plugins/dev-team/skills/feedback-learning/SKILL.md
@@ -64,14 +64,95 @@ These instructions are loaded into every session and take precedence over the pl
 2. **Classify**: Determine change type using the resolution table above
 3. **Preview**: Show the user the proposed edit as a diff before applying
 4. **Apply**: Write the change to the target file
-5. **Log**: Record the change in the audit trail
-6. **Verify**: Read back the modified section to confirm correctness
+5. **Evaluate**: Eval-gate the change if it touches a fixtured review agent (see below)
+6. **Log**: Record the change in the audit trail
+7. **Verify**: Read back the modified section to confirm correctness
 
 ### Approval rules
 
 - Preference and convention changes: apply after diff preview
 - New sections or structural edits to CLAUDE.md: require explicit approval
 - Rollbacks: apply after confirming which change to reverse
+
+## Evaluate — the eval gate (#860)
+
+A change that mutates a review agent's effective behavior — a direct edit to
+`plugins/dev-team/agents/*.md` (when developing this repo) or a project-side
+`CLAUDE.md > Agent Overrides > <agent>` / `REVIEW-CONTEXT.md` entry — is a
+harness edit, not a preference tweak. The paper this closes a gap against
+(*Code as Agent Harness*, §3.5.2–3.5.3) warns that a self-improving loop
+optimizing against "the diff looked reasonable" is optimizing against a weak
+verifier and can learn the wrong thing. `/agent-eval --agent <name>` is the
+falsifier; this step wires it into the mutation path.
+
+This gate sits between **Apply** and **Log**. It never blocks the edit
+itself — the file is already written by the time this step runs. What it
+gates is **adoption**: whether the changelog entry for this change can reach
+`adoption_status: "adopted"`.
+
+### 1. Determine whether the change is gated
+
+Scan `evals/expected/*.json` for `applicableAgents` arrays. If the changed
+agent's name (the `component` field — see Audit Trail below) appears in any
+of them, the change is **gated**. Two graceful-degradation cases, neither of
+which blocks:
+
+- **No `evals/` directory at all** (the normal cache-only plugin-install
+  case — most users have the plugin as a read-only cache with no `evals/`
+  shipped). Write `eval_verdict: "not-applicable"` and tell the operator:
+  "This install has no `evals/` directory — eval-gating requires the plugin
+  repo. Run `/agent-eval --agent <name>` from a clone of
+  `bdfinst/agentic-dev-team` if you want a falsifier for this change."
+- **`evals/` exists but the agent has no fixtures.** Write
+  `eval_verdict: "not-applicable"` and name the fixture gap in both the
+  changelog entry and the chat reply (never silent — this is the
+  documented fallback, not an error).
+
+If ungated (the change doesn't touch a review agent, or touches one with no
+fixtures), skip straight to **Log** with `adoption_status: "adopted"` (or
+`not-applicable`'s equivalent — see schema below) — no eval run, no cost.
+
+### 2. Get the pre-score
+
+Read `evals/baseline.json`, filtered to pairs whose agent is the touched
+one. If baseline entries exist for this agent, that is `eval_pre` —
+`{"passed": <n>, "total": <n>, "source": "baseline"}` — no live run, no
+cost. Only when the agent has **zero** baseline entries, dispatch a fresh
+`/agent-eval --agent <name>` first to establish `eval_pre` (`source` becomes
+the resulting transcript path instead of `"baseline"`).
+
+### 3. Pause for approval, then dispatch the targeted eval
+
+Before dispatching *any* live `/agent-eval` run (pre-run or post-run), show
+the operator the cost estimate and wait for approval — consistent with the
+opt-in live-eval posture (#134). Once approved, dispatch:
+
+```
+/agent-eval --agent <name>
+```
+
+Always targeted, always cache-on. **Never** dispatch the full unfiltered
+`/agent-eval` suite from this gate — that is a distinct, much more expensive
+operation the operator runs deliberately, not something a single config
+mutation should trigger.
+
+Write the changelog entry with `adoption_status: "pending-eval"` *before*
+this run starts (see schema below), then finalize it once the run completes.
+
+### 4. Compare and decide adoption
+
+| `eval_post` vs `eval_pre` | `eval_verdict` | Default `adoption_status` |
+| --- | --- | --- |
+| Post ≥ pre, no new pair regresses | `improved` or `unchanged` | `adopted` |
+| Post < pre (any pair that was passing now fails) | `regressed` | `rejected` or `rolled-back` |
+
+**Regression is always a human decision, never an automatic rollback.** The
+default proposal to the human is `rejected`/`rolled-back`; the human may
+instead choose `overridden`, which requires a non-empty
+`override_rationale` (who decided, and why the regression is acceptable).
+Auto-rollback never fires without that logged human choice — this matches
+the plugin's Human-in-the-Loop principle and `/harness-audit`'s
+"do not auto-edit" posture.
 
 ## Audit Trail
 
@@ -102,6 +183,54 @@ All changes are logged in `metrics/config-changelog.jsonl` (one JSON object per 
 | `previous_value` | Yes | Content before (empty string if new) |
 | `new_value` | Yes | Content after (empty string if removed) |
 | `approved_by` | Yes | `user` or `auto` |
+
+### Change-contract schema extension (#860)
+
+The nine fields below are **required only for entries that gate through
+Evaluate above** — i.e. `component` names a review agent that has eval
+fixtures. Older entries and entries for ungated changes remain valid as-is;
+this is a backward-compatible, append-only extension, never a retroactive
+rewrite of prior lines. A reference validator lives at
+`plugins/dev-team/hooks/lib/config_changelog_schema.py`
+(`validate_entry(entry, fixtured_agents)`).
+
+| Field | Required (gated only) | Type | Meaning |
+| --- | --- | --- | --- |
+| `component` | Yes | string | Artifact whose behavior changes (e.g. `agents/security-review.md` or `CLAUDE.md > Agent Overrides > security-review`) |
+| `failure_mode_targeted` | Yes | string | The observed failure the change intends to fix |
+| `predicted_improvement` | Yes | string | Falsifiable prediction (e.g. "sec-xss-vulnerable stops flapping; no other pair regresses") |
+| `eval_pre` | Yes | object | `{passed, total, source}` — `source` is `"baseline"` (`evals/baseline.json`) or a transcript path |
+| `eval_post` | Yes | object | `{passed, total, transcript}` — transcript under `.claude/evals/transcripts/` |
+| `eval_verdict` | Yes | string | `improved` \| `unchanged` \| `regressed` \| `not-applicable` (no fixtures) |
+| `adoption_status` | Yes | string | `pending-eval` \| `adopted` \| `rejected` \| `rolled-back` \| `overridden` |
+| `override_rationale` | Iff `adoption_status: "overridden"` | string | Names the human and the reason the regression was accepted |
+| `rollback_pointer` | Yes | string | How to undo: the entry's own `previous_value` + `file_modified`/`section_modified` (existing rollback mechanics), or a git ref for direct agent-file edits |
+
+Example gated entry (written once, after the eval completes — the
+`pending-eval` interim state is a separate appended line, not an in-place
+mutation):
+
+```json
+{
+  "timestamp": "2026-07-06T00:00:00Z",
+  "type": "amend",
+  "trigger": "system",
+  "description": "Tightened XSS detection regex",
+  "file_modified": "agents/security-review.md",
+  "section_modified": "## Detect",
+  "previous_value": "old regex",
+  "new_value": "new regex",
+  "approved_by": "user",
+  "component": "agents/security-review.md",
+  "failure_mode_targeted": "sec-xss-vulnerable flapping",
+  "predicted_improvement": "sec-xss-vulnerable stops flapping; no other pair regresses",
+  "eval_pre": { "passed": 20, "total": 21, "source": "baseline" },
+  "eval_post": { "passed": 21, "total": 21, "transcript": ".claude/evals/transcripts/x.json" },
+  "eval_verdict": "improved",
+  "adoption_status": "adopted",
+  "rollback_pointer": "previous_value above"
+}
+```
 
 ## Rollback
 

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -65,7 +65,33 @@ If no metrics data exists or insufficient data is available (fewer than 10 revie
 
 List what data is missing and exit.
 
-### 2. Analyze review agent effectiveness
+### 2. Check for a stale baseline (re-baseline detection, #860)
+
+Report-only — this step never edits `evals/baseline.json` or re-runs evals
+itself; it only decides whether the report needs a **Re-baseline Required**
+section.
+
+1. Read `evals/baseline.json`. If the file is absent, skip this step
+   entirely (nothing to compare).
+2. Read its `model` field (written by `scripts/eval_variance.py
+   --write-baseline --model <name>`, per the change-contract flow in
+   `skills/feedback-learning/SKILL.md`). **Absent field = pre-migration
+   baseline — do not prompt.** This is deliberate: a baseline recorded
+   before the `model` field existed carries no false signal either way.
+3. Read the current session's model from `metrics/session-digest.jsonl`
+   (the most recent record's model field) or session metadata.
+4. Compare. **On mismatch**, the report (Step 7) gains a **Re-baseline
+   Required** section instructing the operator to re-run the eval suite and
+   re-write the baseline (`/agent-eval` full suite + `eval_variance.py
+   --write-baseline --model <current-model>`) before trusting any pre/post
+   comparison elsewhere in this report or in a feedback-learning change
+   contract. Flag explicitly that scaffolding kept alive by old-model scores
+   (e.g. a removal candidate from Step 3 that "still fails" on the old
+   model) may now be re-evaluable and possibly removable.
+5. **On match** (or the field absent), no section is added — this is silent
+   success, not a finding.
+
+### 3. Analyze review agent effectiveness
 
 For each review agent in the registry (`knowledge/agent-registry.md`):
 
@@ -74,7 +100,7 @@ For each review agent in the registry (`knowledge/agent-registry.md`):
 3. **False positive rate**: If correction data exists (from `/apply-fixes`), check how often findings were dismissed vs. applied. Agents with >50% dismissed findings have a high false positive rate.
 4. **Finding severity distribution**: Is the agent producing mostly minor findings? If >80% of findings are minor severity, consider whether the agent justifies its token cost.
 
-### 3. Analyze review-value fix rates
+### 4. Analyze review-value fix rates
 
 Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `performance-metrics`). If the file is absent, note it and continue — this section is skippable.
 
@@ -108,7 +134,7 @@ For each drop candidate emit a recommendation in this form:
 
 Do not modify any skill or agent file. The report is the only artifact.
 
-### 4. Analyze model routing
+### 5. Analyze model routing
 
 For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):
 
@@ -116,7 +142,7 @@ For each agent listed in `knowledge/agent-registry.md` (with model tier from its
 2. **Under-tiered agents**: Agents on haiku that frequently miss issues caught by human review may need a higher tier.
 3. **Cost distribution**: Which agents consume the most tokens? Are the most expensive agents also the most valuable?
 
-### 5. Analyze orchestration complexity
+### 6. Analyze orchestration complexity
 
 Review the current pipeline for components that may be unnecessary overhead:
 
@@ -124,7 +150,7 @@ Review the current pipeline for components that may be unnecessary overhead:
 2. **Review checkpoint frequency**: Are inline reviews running on every step? If most steps are trivial, the complexity classification (see `skills/plan/SKILL.md` § Complexity Classification) should be catching this.
 3. **Unused skills**: Skills loaded but never applied in logged sessions.
 
-### 6. Produce report
+### 7. Produce report
 
 Write the report to the output path using this structure:
 
@@ -134,6 +160,22 @@ Write the report to the output path using this structure:
 **Date**: <date>
 **Metrics period**: <earliest to latest logged review>
 **Review runs analyzed**: <count>
+
+## Re-baseline Required
+
+> Only present when Step 2 detects a model mismatch between
+> `evals/baseline.json`'s `model` field and the current session's model.
+> Omit this section entirely on a match or an absent/pre-migration field.
+
+- **Baseline model**: <model recorded in evals/baseline.json>
+- **Current session model**: <current model>
+- **Action**: Re-run the eval suite and re-write the baseline
+  (`/agent-eval` full suite, then `eval_variance.py --write-baseline
+  --model <current-model>`) before trusting any pre/post comparison in this
+  report or in a feedback-learning change contract.
+- **Possibly stale scaffolding**: <any removal candidate below whose
+  "zero fail" or "high false positive" verdict was measured on the old
+  model — flag for re-evaluation, not automatic removal>
 
 ## Review Agent Effectiveness
 
@@ -185,13 +227,14 @@ Write the report to the output path using this structure:
 - Orchestration simplifications: <count>
 - Review-value drop candidates: <count>
 - Review-value high-value checkpoints: <count>
+- Re-baseline required: <yes/no>
 
 ## Next Steps
 
 <Actionable recommendations prioritized by impact>
 ```
 
-### 7. Present results
+### 8. Present results
 
 Display a summary of the report and the file path. Do not repeat the full report in chat — the file is the artifact.
 

--- a/plugins/dev-team/tests/hooks/test_eval_compliance_check.py
+++ b/plugins/dev-team/tests/hooks/test_eval_compliance_check.py
@@ -1,0 +1,157 @@
+"""Unit tests for hooks/eval_compliance_check.py EVAL REQUIRED advisory (#860).
+
+Verifies the eval-gate escalation described in
+plugins/dev-team/skills/feedback-learning/SKILL.md § Evaluate: editing a
+review agent listed in any evals/expected/*.json `applicableAgents` emits an
+`EVAL REQUIRED` advisory naming `/agent-eval --agent <name>`; editing an
+unfixtured agent, or running where evals/expected/ does not exist (the
+cache-only plugin-install case), emits no such line. The hook always stays
+advisory and exits 0 (docs/python-hook-contract.md).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "eval_compliance_check.py"
+
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
+import eval_compliance_check as ecc  # noqa: E402
+
+_AGENT_BODY = """---
+name: security-review
+role: worker
+model tier: mid
+context needs: diff-only
+---
+
+# Security Review
+
+## Detect
+Checks for XSS.
+
+## Skip
+Skip generated files.
+
+Output JSON with status/issues/summary.
+Severity: error, warning, suggestion.
+"""
+
+
+def _run(payload: dict, env_extra: dict) -> subprocess.CompletedProcess:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    env.update(env_extra)
+    return subprocess.run(
+        ["python3", str(_HOOK)],
+        input=json.dumps(payload),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    agents_dir = tmp_path / "plugins" / "dev-team" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "security-review.md").write_text(_AGENT_BODY, encoding="utf-8")
+    (agents_dir / "naming-review.md").write_text(_AGENT_BODY, encoding="utf-8")
+    return tmp_path
+
+
+def _fixture_evals(project_root: Path) -> None:
+    expected_dir = project_root / "evals" / "expected"
+    expected_dir.mkdir(parents=True)
+    (expected_dir / "sec-xss.json").write_text(
+        json.dumps({"applicableAgents": ["security-review"]}), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _fixtured_agents
+# ---------------------------------------------------------------------------
+
+
+def test_fixtured_agents_empty_when_no_evals_dir(tmp_path: Path):
+    assert ecc._fixtured_agents(tmp_path) == set()
+
+
+def test_fixtured_agents_collects_applicable_agents(tmp_path: Path):
+    _fixture_evals(tmp_path)
+    assert ecc._fixtured_agents(tmp_path) == {"security-review"}
+
+
+def test_fixtured_agents_skips_malformed_json(tmp_path: Path):
+    expected_dir = tmp_path / "evals" / "expected"
+    expected_dir.mkdir(parents=True)
+    (expected_dir / "broken.json").write_text("not json", encoding="utf-8")
+    assert ecc._fixtured_agents(tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# main() end-to-end via subprocess
+# ---------------------------------------------------------------------------
+
+
+def test_eval_required_fires_for_fixtured_agent(project: Path):
+    _fixture_evals(project)
+    file_path = str(project / "plugins" / "dev-team" / "agents" / "security-review.md")
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path},
+        "cwd": str(project),
+    }
+    result = _run(payload, {"CLAUDE_PROJECT_DIR": str(project)})
+    assert result.returncode == 0
+    assert "EVAL REQUIRED" in result.stdout
+    assert "/agent-eval --agent security-review" in result.stdout
+
+
+def test_eval_required_absent_for_unfixtured_agent(project: Path):
+    _fixture_evals(project)
+    file_path = str(project / "plugins" / "dev-team" / "agents" / "naming-review.md")
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path},
+        "cwd": str(project),
+    }
+    result = _run(payload, {"CLAUDE_PROJECT_DIR": str(project)})
+    assert result.returncode == 0
+    assert "EVAL REQUIRED" not in result.stdout
+
+
+def test_eval_required_absent_when_evals_dir_missing(project: Path):
+    # No evals/expected/ at all — the cache-only plugin-install case.
+    file_path = str(project / "plugins" / "dev-team" / "agents" / "security-review.md")
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path},
+        "cwd": str(project),
+    }
+    result = _run(payload, {"CLAUDE_PROJECT_DIR": str(project)})
+    assert result.returncode == 0
+    assert "EVAL REQUIRED" not in result.stdout
+
+
+def test_hook_exits_zero_even_with_eval_required(project: Path):
+    _fixture_evals(project)
+    file_path = str(project / "plugins" / "dev-team" / "agents" / "security-review.md")
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path},
+        "cwd": str(project),
+    }
+    result = _run(payload, {"CLAUDE_PROJECT_DIR": str(project)})
+    assert result.returncode == 0

--- a/plugins/dev-team/tests/lib/test_config_changelog_schema.py
+++ b/plugins/dev-team/tests/lib/test_config_changelog_schema.py
@@ -1,0 +1,173 @@
+"""Unit tests for hooks/lib/config_changelog_schema.py (#860).
+
+Covers the acceptance criteria from feat: eval-gate feedback-learning
+mutations with change contracts:
+
+- fixtured-agent-change-cannot-adopt-without-eval-result
+- changelog-entry-carries-full-change-contract
+- unfixtured-agent-change-follows-documented-fallback
+- regression-blocks-adoption-absent-logged-override
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"))
+
+import config_changelog_schema as schema  # noqa: E402
+
+FIXTURED = {"security-review", "arch-review"}
+
+_FULL_GATED_ENTRY = {
+    "timestamp": "2026-07-06T00:00:00Z",
+    "type": "amend",
+    "trigger": "system",
+    "description": "Tightened XSS detection regex",
+    "file_modified": "agents/security-review.md",
+    "section_modified": "## Detect",
+    "previous_value": "old regex",
+    "new_value": "new regex",
+    "approved_by": "user",
+    "component": "agents/security-review.md",
+    "failure_mode_targeted": "sec-xss-vulnerable flapping",
+    "predicted_improvement": "sec-xss-vulnerable stops flapping; no other pair regresses",
+    "eval_pre": {"passed": 20, "total": 21, "source": "baseline"},
+    "eval_post": {"passed": 21, "total": 21, "transcript": ".claude/evals/transcripts/x.json"},
+    "eval_verdict": "improved",
+    "adoption_status": "adopted",
+    "rollback_pointer": "previous_value above",
+}
+
+
+# ---------------------------------------------------------------------------
+# extract_agent_name
+# ---------------------------------------------------------------------------
+
+
+def test_extract_agent_name_from_agent_file_path():
+    assert schema.extract_agent_name("agents/security-review.md") == "security-review"
+
+
+def test_extract_agent_name_from_agent_override_component():
+    assert (
+        schema.extract_agent_name("CLAUDE.md > Agent Overrides > security-review")
+        == "security-review"
+    )
+
+
+def test_extract_agent_name_none_when_no_match():
+    assert schema.extract_agent_name("CLAUDE.md > Some Other Section") is None
+    assert schema.extract_agent_name("") is None
+
+
+# ---------------------------------------------------------------------------
+# is_gated_entry
+# ---------------------------------------------------------------------------
+
+
+def test_is_gated_entry_true_for_fixtured_agent():
+    assert schema.is_gated_entry({"component": "agents/security-review.md"}, FIXTURED)
+
+
+def test_is_gated_entry_false_for_unfixtured_agent():
+    assert not schema.is_gated_entry({"component": "agents/naming-review.md"}, FIXTURED)
+
+
+def test_is_gated_entry_false_when_component_missing():
+    assert not schema.is_gated_entry({"description": "no component field"}, FIXTURED)
+
+
+# ---------------------------------------------------------------------------
+# validate_entry — legacy / non-fixtured entries always pass
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_entry_without_component_is_valid():
+    legacy_entry = {
+        "timestamp": "2026-02-20T14:30:00Z",
+        "type": "amend",
+        "trigger": "user",
+        "description": "Updated software engineer to prefer functional patterns",
+        "file_modified": "CLAUDE.md",
+        "section_modified": "Agent Overrides > Software Engineer",
+        "previous_value": "",
+        "new_value": "- Prefer functional programming patterns over OOP",
+        "approved_by": "user",
+    }
+    assert schema.validate_entry(legacy_entry, FIXTURED) == []
+
+
+def test_unfixtured_agent_change_is_valid_without_contract_fields():
+    entry = {
+        "component": "agents/naming-review.md",
+        "description": "tweak naming rule",
+    }
+    assert schema.validate_entry(entry, FIXTURED) == []
+
+
+# ---------------------------------------------------------------------------
+# validate_entry — gated entries require the full contract
+# ---------------------------------------------------------------------------
+
+
+def test_full_gated_entry_is_valid():
+    assert schema.validate_entry(_FULL_GATED_ENTRY, FIXTURED) == []
+
+
+def test_gated_entry_missing_eval_verdict_is_rejected():
+    entry = dict(_FULL_GATED_ENTRY)
+    del entry["eval_verdict"]
+    errors = schema.validate_entry(entry, FIXTURED)
+    assert any("eval_verdict" in e for e in errors)
+
+
+def test_gated_entry_missing_rollback_pointer_is_rejected():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["rollback_pointer"] = ""
+    errors = schema.validate_entry(entry, FIXTURED)
+    assert any("rollback_pointer" in e for e in errors)
+
+
+def test_gated_entry_invalid_adoption_status_is_rejected():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["adoption_status"] = "not-a-real-status"
+    errors = schema.validate_entry(entry, FIXTURED)
+    assert any("adoption_status" in e for e in errors)
+
+
+def test_gated_entry_invalid_eval_verdict_is_rejected():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["eval_verdict"] = "great"
+    errors = schema.validate_entry(entry, FIXTURED)
+    assert any("eval_verdict" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# regression / override handling
+# ---------------------------------------------------------------------------
+
+
+def test_regressed_entry_rejected_without_override_is_valid_shape():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["eval_verdict"] = "regressed"
+    entry["adoption_status"] = "rejected"
+    assert schema.validate_entry(entry, FIXTURED) == []
+
+
+def test_overridden_entry_requires_rationale():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["eval_verdict"] = "regressed"
+    entry["adoption_status"] = "overridden"
+    errors = schema.validate_entry(entry, FIXTURED)
+    assert any("override_rationale" in e for e in errors)
+
+
+def test_overridden_entry_with_rationale_is_valid():
+    entry = dict(_FULL_GATED_ENTRY)
+    entry["eval_verdict"] = "regressed"
+    entry["adoption_status"] = "overridden"
+    entry["override_rationale"] = "bryan.finster@gmail.com: accepted minor tradeoff for perf"
+    assert schema.validate_entry(entry, FIXTURED) == []

--- a/scripts/eval_variance.py
+++ b/scripts/eval_variance.py
@@ -119,19 +119,31 @@ def _assemble(passes: dict, trials: dict, flap_threshold: float) -> dict:
 
 
 def write_baseline(report: dict, target_path, demote_below: float,
-                   min_trials: int, harvest_id: str | None = None) -> tuple[list, list]:
+                   min_trials: int, harvest_id: str | None = None,
+                   model: str | None = None) -> tuple[list, list]:
     """Trust-gated baseline write (#230). A pair is **added** only when it passed
     every trial (pass@k == 1.0); **removed** only when it failed consistently
     (pass@k <= demote_below) over >= min_trials AND is not flaky. A flaky pair is
     never removed — it is quarantined instead (write_quarantine). So a single
     noisy trial (trials < min_trials) can add but never delete. Returns
-    (added, removed) relative to the prior baseline."""
+    (added, removed) relative to the prior baseline.
+
+    `model` (#860) stamps the base model that produced this measured baseline
+    into the record, so `/harness-audit` can detect a stale baseline (scored
+    on a model that has since been upgraded) and prompt a re-baseline. When
+    omitted, a pre-existing `model` field is carried forward unchanged (a
+    baseline write that only tops up pairs shouldn't silently blank the
+    field); when there is no prior value either, the field is left unset —
+    the pre-migration case `/harness-audit` treats as "no prompt"."""
     from datetime import datetime, timezone
     target = Path(target_path)
     existing: set = set()
+    existing_model: str | None = None
     if target.exists():
         try:
-            existing = set(json.loads(target.read_text()).get("passing", []))
+            existing_data = json.loads(target.read_text())
+            existing = set(existing_data.get("passing", []))
+            existing_model = existing_data.get("model")
         except (OSError, json.JSONDecodeError):
             existing = set()
     by_pair = report["by_pair"]
@@ -152,6 +164,9 @@ def write_baseline(report: dict, target_path, demote_below: float,
         "trials": report.get("trials", 0),
         "passing": sorted(merged),
     }
+    resolved_model = model or existing_model
+    if resolved_model:
+        record["model"] = resolved_model  # re-baseline detection input (#860)
     if harvest_id:
         record["harvest_id"] = harvest_id  # provenance: which harvest measured this (#232)
     target.write_text(json.dumps(record, indent=2) + "\n")
@@ -229,6 +244,10 @@ def main(argv=None) -> int:
                     help="write the flaky-pair quarantine the grader excludes (#231)")
     ap.add_argument("--harvest-id",
                     help="stamp this harvest id into the written artifacts (#232 provenance)")
+    ap.add_argument("--model",
+                    help="base model that produced this measured baseline; stamped into "
+                         "the --write-baseline record's `model` field so /harness-audit "
+                         "can detect a stale baseline after a model upgrade (#860)")
     args = ap.parse_args(argv)
 
     if args.trials_root:
@@ -261,7 +280,7 @@ def main(argv=None) -> int:
     if args.write_baseline:
         added, removed = write_baseline(report, args.write_baseline,
                                         args.demote_below, args.min_trials,
-                                        args.harvest_id)
+                                        args.harvest_id, args.model)
         print(f"Baseline (trust-gated) → {args.write_baseline}: "
               f"+{len(added)} / -{len(removed)} "
               f"(min_trials={args.min_trials}, demote_below={args.demote_below}); "

--- a/tests/repo/test_eval_variance.py
+++ b/tests/repo/test_eval_variance.py
@@ -83,6 +83,77 @@ def test_variance_per_agent_stability_summary(case: Path) -> None:
     assert data["by_agent"]["b"]["flaky_fixtures"] == 1
 
 
+def test_write_baseline_stamps_model_field(case: Path) -> None:
+    """#860 — /harness-audit re-baseline detection reads `model` off the
+    baseline; --write-baseline must stamp it when --model is passed."""
+    baseline = case / "baseline.json"
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(VARIANCE),
+            "--trials-dir",
+            str(case / "trials"),
+            "--expected-dir",
+            str(case / "expected"),
+            "--write-baseline",
+            str(baseline),
+            "--model",
+            "claude-sonnet-5",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    data = json.loads(baseline.read_text())
+    assert data["model"] == "claude-sonnet-5"
+
+
+def test_write_baseline_omits_model_when_never_provided(case: Path) -> None:
+    """Pre-migration baselines (no --model ever passed) get no `model` field —
+    /harness-audit treats an absent field as "no re-baseline prompt"."""
+    baseline = case / "baseline.json"
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(VARIANCE),
+            "--trials-dir",
+            str(case / "trials"),
+            "--expected-dir",
+            str(case / "expected"),
+            "--write-baseline",
+            str(baseline),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    data = json.loads(baseline.read_text())
+    assert "model" not in data
+
+
+def test_write_baseline_carries_forward_prior_model_when_omitted(case: Path) -> None:
+    """A top-up run that doesn't pass --model must not blank a prior value."""
+    baseline = case / "baseline.json"
+    baseline.write_text(json.dumps({"passing": [], "model": "claude-opus-4"}))
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(VARIANCE),
+            "--trials-dir",
+            str(case / "trials"),
+            "--expected-dir",
+            str(case / "expected"),
+            "--write-baseline",
+            str(baseline),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    data = json.loads(baseline.read_text())
+    assert data["model"] == "claude-opus-4"
+
+
 def test_variance_append_writes_a_metrics_only_trend_record(case: Path) -> None:
     trend = case / "trend.jsonl"
     res = subprocess.run(


### PR DESCRIPTION
## Summary

Closes #860. Implements the human-approved spec (Intent/Architecture/Acceptance Criteria/Ambiguity Log, Verdict: PASS) closing the weak-verifier self-improvement gap identified against *Code as Agent Harness* (arXiv 2605.18747): a `feedback-learning` change to a review agent could previously look plausible in a diff, get logged, and silently degrade detection accuracy, with no behavioral falsifier in the loop.

- **`plugins/dev-team/skills/feedback-learning/SKILL.md`**: Processing Flow gains an **Evaluate** gate between Apply and Log. A change touching a review agent listed in any `evals/expected/*.json` `applicableAgents` requires a targeted `/agent-eval --agent <name>` run (cache-on, never the full suite) before the changelog entry reaches `adoption_status: "adopted"`. Pre-score comes from `evals/baseline.json` (fresh) or a one-off pre-run only when the agent has no baseline entries. Cost estimate shown and operator approval required before any live dispatch (consistent with #134's opt-in posture); a cache-only install (no `evals/` dir) degrades to instructing the operator to run the eval from the plugin repo. Regression is a human decision, never auto-rollback — default outcome `rejected`/`rolled-back`, `overridden` requires a logged `override_rationale`. No fixtures for the touched agent → `eval_verdict: "not-applicable"`, documented, never silent. The Audit Trail section documents the nine-field change-contract schema extension to `metrics/config-changelog.jsonl` (`component`, `failure_mode_targeted`, `predicted_improvement`, `eval_pre`, `eval_post`, `eval_verdict`, `adoption_status`, `override_rationale`, `rollback_pointer`) — required only for gated entries, append-only, backward-compatible with every pre-existing entry.
- **`plugins/dev-team/hooks/eval_compliance_check.py`**: adds one advisory line — `EVAL REQUIRED: ... run /agent-eval --agent <name> ...` — when the edited agent's stem appears in any `evals/expected/*.json` `applicableAgents`. Fixture lookup is a filesystem scan (stdlib `json`/`pathlib`), degrading silently to no extra line when `evals/expected/` doesn't exist. The hook remains advisory and exits 0 always — enforcement lives in the skill's `adoption_status`, not the hook exit code (per `docs/python-hook-contract.md`).
- **`plugins/dev-team/hooks/lib/config_changelog_schema.py`** (new): stdlib-only reference validator (`validate_entry`, `is_gated_entry`, `extract_agent_name`) for the change-contract schema — used by the new pytest suite and available for a future CI/audit hook.
- **`scripts/eval_variance.py`**: `write_baseline()` and the `--write-baseline` CLI gain a `--model` flag that stamps a `model` field into `evals/baseline.json`, carrying forward the prior value when omitted (so a top-up run never blanks it) and leaving it unset for pre-migration baselines.
- **`plugins/dev-team/skills/harness-audit/SKILL.md`**: new Step 2, "Check for a stale baseline (re-baseline detection)" — compares `evals/baseline.json`'s `model` field against the current session's model; on mismatch, the report gains a **Re-baseline Required** section (report-only, no auto-edit). Absent `model` field (pre-migration) never prompts. Existing steps 2–7 renumbered to 3–8.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_eval_compliance_check.py` — 7 new tests covering `_fixtured_agents` and the end-to-end EVAL REQUIRED advisory (fixtured agent fires, unfixtured agent doesn't, missing `evals/` dir doesn't, hook always exits 0).
- [x] `python3 -m pytest plugins/dev-team/tests/lib/test_config_changelog_schema.py` — 16 new tests covering the change-contract schema validator (legacy entries always valid, gated entries require all 8 always-required fields, invalid `adoption_status`/`eval_verdict` rejected, `overridden` requires `override_rationale`).
- [x] `python3 -m pytest tests/repo/test_eval_variance.py` — 3 new tests for the `--model` baseline-stamping behavior (stamps, omits when never provided, carries forward prior value on a top-up run). All 7 tests in the file pass.
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands` — 1404 passed, 16 skipped, 1 pre-existing unrelated failure (`test_mypy_adapter.py::test_emitted_findings_validate_against_unified_finding_v1`, `ModuleNotFoundError: No module named 'jsonschema'` — reproduced identically on `origin/main` before this branch's changes, not touched by this PR).
- [x] `python3 scripts/check_md_references.py` — clean.
- [x] `python3 plugins/dev-team/hooks/lib/build_skills_index.py --check` — clean.
- [x] `plugins/dev-team/knowledge/index.json` regenerated (`build_knowledge_index.py write`) to pick up the SKILL.md step renumbering/additions; `test_knowledge_index_current` / `test_knowledge_index_no_leak` / `test_recommendations_docs_sweep` all pass against the regenerated index.

Closes #860


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_