### PR TITLE
feat: structured evidence bundles in /build output and /pr bodies

### DIFF
--- a/plugins/dev-team/knowledge/evidence-bundle.md
+++ b/plugins/dev-team/knowledge/evidence-bundle.md
@@ -1,0 +1,90 @@
+# Evidence Bundle
+
+A structured "what was checked, and what wasn't" statement carried by `/build`'s
+final output and `/pr`'s PR body. Verification here is a stack of scoped
+verifiers — unit suite, type check, lint, review agents, coverage delta,
+runtime `/verify`, Farley score — not one boolean. A green checkmark alone
+over-claims: it says checks passed but not what each one actually verified,
+what it structurally cannot verify for this diff, which regions remain
+untested, or what risk was consciously accepted. The bundle closes that gap.
+
+**Reporting only — no new checks.** The bundle is assembled entirely from data
+the pipeline already produces: quality-gate outputs, `metrics/review-value.jsonl`,
+`metrics/verify-log.jsonl`, coverage baseline/delta files, and gate-bypass audit
+lines already written to the build/PR output. Assembling it never re-runs a
+check, never invokes a tool "just to build the bundle."
+
+Reference form: `${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md`.
+
+## The four fixed sections
+
+Always present, in this order, with these exact headers. **Degradation rule**:
+when a section has no data, it states why (e.g. "not measured — no coverage
+tool detected") — it is never dropped. All four headers always appear even on
+a run with nothing to report in one of them.
+
+| Section | Content | Data source (already produced) |
+|---|---|---|
+| Checks run | One row per verifier: exact command executed + result summary | `/pr` Step 2 gate commands/output; `/build` Step 5 suite output, Step 6 review status, Step 7 Farley score |
+| Scope notes | What the executed suite does NOT verify for this diff | Review agents dispatched vs. skipped; gate steps reported "not applicable"; `metrics/verify-log.jsonl` `skipped` reasons; absent tools (coverage, mutation) |
+| Untested regions | Coverage-derived statement of what the diff leaves unexercised | `baseline-coverage.json` + `coverage-history.json` line/branch % and delta; diff-scoped uncovered files from a coverage report artifact when one exists; "not measured" when none exists |
+| Residual risks | Consciously accepted risk, derived-first | Deferred/escalated findings (`metrics/review-value.jsonl`), gate-bypass audit lines, structural-review waivers, negative coverage-delta warnings; author-judged prose may be appended but never substitutes for the derived rows |
+
+## Skeleton
+
+```markdown
+## Evidence Bundle
+
+**Checks run**
+- `<exact command>` — <result summary>
+- `<exact command>` — <result summary>
+(N checks total; showing top N — see full log at <pointer> if truncated)
+
+**Scope notes**
+- <what this suite does not cover for this diff, one line each>
+
+**Untested regions**
+- <line/branch % + delta, or diff-scoped uncovered files, or "not measured — <reason>">
+
+**Residual risks**
+- <deferred/escalated finding, waiver, or bypass line — or "None identified" only when every derived source is empty>
+```
+
+## Degradation examples
+
+- No coverage tool detected:
+  `Untested regions: not measured — no coverage tool detected in this repo.`
+  paired with a matching Scope note: `Scope notes: coverage delta unavailable — no coverage baseline exists for this repo.`
+- No deferred/escalated findings, no waivers, no bypass lines, no negative
+  coverage delta: `Residual risks: None identified — no deferred findings, waivers, or bypass lines this run.`
+- Non-interactive bypass recorded during the run: fold the audit line in verbatim,
+  e.g. `Residual risks: Acceptance-criteria gate auto-passed with 1 flagged criterion (non-interactive) — no human gate.`
+
+## Line budget
+
+Target **under ~40 lines** in a PR body. When a section's data would exceed
+that, collapse to counts plus a pointer to the full log rather than growing
+unbounded — e.g. `12 checks run, 12 passed (full command log in build output above)`
+instead of listing all 12 rows.
+
+## Assembly is per-command, not handed off
+
+`/build` assembles its bundle from its own run's Step 5/6/7 outputs at Step 8.
+`/pr` assembles its bundle from its own Step 2 quality-gate results plus
+on-disk pipeline data (metrics files, coverage files) at its own runtime —
+never from a handoff file written by `/build`. Running `/pr` standalone (no
+preceding `/build` in the session) still produces a complete bundle; sections
+degrade per the rule above wherever the on-disk data doesn't cover a source
+that only `/build`'s in-session steps would have (e.g. Farley score).
+
+## Boundaries
+
+- Does not persist to `metrics/` or `memory/` — every underlying datum already
+  persists in its own source file; a persisted bundle would duplicate that
+  audit trail.
+- `/code-review`'s own report keeps its existing contract
+  (`knowledge/review-template.md`); it is one **input** to the bundle's Checks
+  run section, not a carrier of the bundle itself.
+- Never displaces the PR body's closing keywords (`Closes #N` / `Part of #`)
+  or its other sections (`## Summary`, `## Quality Gate`, `## Decisions &
+  Assumptions`, `## Test Plan`) — it is added alongside them.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -581,6 +581,32 @@
       "anchor": "ubiquitous-language-drift"
     }
   },
+  "plugins/dev-team/knowledge/evidence-bundle.md": {
+    "The four fixed sections": {
+      "summary": "Always present, in this order, with these exact headers.",
+      "anchor": "the-four-fixed-sections"
+    },
+    "Skeleton": {
+      "summary": "No coverage tool detected:",
+      "anchor": "skeleton"
+    },
+    "Degradation examples": {
+      "summary": "No coverage tool detected:",
+      "anchor": "degradation-examples"
+    },
+    "Line budget": {
+      "summary": "Target **under ~40 lines** in a PR body.",
+      "anchor": "line-budget"
+    },
+    "Assembly is per-command, not handed off": {
+      "summary": "`/build` assembles its bundle from its own run's Step 5/6/7 outputs at Step 8.",
+      "anchor": "assembly-is-per-command-not-handed-off"
+    },
+    "Boundaries": {
+      "summary": "Does not persist to `metrics/` or `memory/` — every underlying datum already",
+      "anchor": "boundaries"
+    }
+  },
   "plugins/dev-team/knowledge/exploratory-testing-field-guide.md": {
     "1. Charter Quality (§2.3–2.4)": {
       "summary": "**Format**: `Explore [target] with [approach] to discover [concern]`",
@@ -1979,6 +2005,10 @@
     "7. Final test quality score (branch)": {
       "summary": "Produce a Farley Score for the tests written on this branch — the last quality signal before `/pr`.",
       "anchor": "7-final-test-quality-score-branch"
+    },
+    "7.5. Assemble the evidence bundle": {
+      "summary": "Before the completion report, assemble a structured evidence bundle per",
+      "anchor": "75-assemble-the-evidence-bundle"
     },
     "8. Update plan status": {
       "summary": "Use the Edit tool to change `**Status**: in-progress` to `**Status**: implemented` in the plan file.",

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -201,9 +201,31 @@ Produce a Farley Score for the tests written on this branch — the last quality
 3. If no test files changed on the branch, print one line — `No tests written on this branch — skipping Farley Score.` — and continue to Step 8.
 4. Otherwise invoke the `farley-score` skill scoped to those files. Present the suite-level Farley Score, rating, and distribution as the final pre-PR signal. This is **informational** — a low score does not block `/pr`, but surface it so the user can decide whether to revise before opening the PR.
 
+### 7.5. Assemble the evidence bundle
+
+Before the completion report, assemble a structured evidence bundle per
+`${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md` — **no new checks, no
+re-execution**; it renders data this run already produced:
+
+- **Checks run**: the Step 5 full-suite command + result, the Step 6
+  `/code-review` status, the Step 7 Farley Score command/output (or its
+  skip line when no tests changed).
+- **Scope notes**: review agents dispatched vs. skipped across the build's
+  checkpoints (sub-steps 4/6), and any gate reported "not applicable."
+- **Untested regions**: read `baseline-coverage.json` / `coverage-history.json`
+  if present (from `/coverage-baseline` / `/coverage-delta`); otherwise state
+  "not measured — no coverage tool detected."
+- **Residual risks**: derived-first from this run's `metrics/review-value.jsonl`
+  entries with `outcome: "escalated"`, any non-interactive gate-bypass audit
+  lines printed in Steps 2–3, and any `/verify` `failed-then-fixed` entries in
+  `metrics/verify-log.jsonl`. "None identified" only when all of those are empty.
+
+Follow the degradation rule: every one of the four section headers appears in
+the completion report even when a section has nothing to show — it states why.
+
 ### 8. Update plan status
 
-Use the Edit tool to change `**Status**: in-progress` to `**Status**: implemented` in the plan file. Briefly confirm completion, report the branch Farley Score, and direct the user to `/pr`.
+Use the Edit tool to change `**Status**: in-progress` to `**Status**: implemented` in the plan file. Briefly confirm completion, report the branch Farley Score, include the Step 7.5 evidence bundle in the completion report, and direct the user to `/pr`.
 
 ### 9. Learning loop
 
@@ -239,6 +261,7 @@ unresolved escalation.
 - `/verify` exercises each runtime-surface slice end-to-end before it may be marked done (sub-step 4.9, issue #727)
 - `/code-review` runs the full review suite after implementation
 - `farley-score` scores the branch's tests (Farley Score) as the final pre-PR quality signal
-- `/pr` creates the pull request after a successful build
+- `${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md` defines the structured evidence bundle assembled in Step 7.5 and surfaced in the Step 8 completion report
+- `/pr` creates the pull request after a successful build, assembling its own evidence bundle independently (no handoff file)
 - `/continue` can resume a partially completed build across sessions
 - `python3 scripts/progress_guardian.py --plan <plan-file>` validates step completion and commit discipline at each step boundary; `--pre-pr` also fails closed when runtime-surface changes have no matching `metrics/verify-log.jsonl` entry (issue #727)

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -100,6 +100,21 @@ Analyze the diff against the base branch (`git diff <base>...HEAD`) and commit h
   classified `inferable`; `assumptions` entries from implementer step outputs;
   auto-applied review fixes with `confidence: medium`; and deferred follow-ups.
   Omit the section only when every gate had an interactive human approval.
+- **Evidence bundle**: Assemble per `${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md`
+  from the Step 2 quality-gate results plus on-disk pipeline data — **no new
+  checks, no re-execution**:
+  - **Checks run**: the exact Step 2 commands (test/typecheck/lint/`/code-review
+    --json`) and their results.
+  - **Scope notes**: gates skipped as not-applicable in Step 2 (e.g. no
+    `tsconfig.json` → type check skipped), plus `--skip-review` if passed.
+  - **Untested regions**: read `baseline-coverage.json` / `coverage-history.json`
+    if present; otherwise "not measured — no coverage tool detected."
+  - **Residual risks**: derived-first from `metrics/review-value.jsonl` entries
+    with `outcome: "escalated"`, gate-bypass audit lines, and negative coverage
+    deltas; "None identified" only when all derived sources are empty.
+  - This command assembles from its own runtime's live data — it never reads a
+    handoff file from a prior `/build` run, so running `/pr` standalone still
+    produces a complete (possibly more-degraded) bundle.
 
 ### 4. Create the PR
 
@@ -127,6 +142,20 @@ Use the structured template:
 ## Test Plan
 - [ ] <verification step 1>
 - [ ] <verification step 2>
+
+## Evidence Bundle
+<!-- Per ${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md. All four headers always appear; a section with no data states why instead of being omitted. -->
+**Checks run**
+- `<command>` — <result>
+
+**Scope notes**
+- <what this gate does not cover for this diff>
+
+**Untested regions**
+- <coverage % + delta, or "not measured — <reason>">
+
+**Residual risks**
+- <deferred/escalated finding, waiver, or bypass line — or "None identified">
 ```
 
 ### 5. Enable auto-merge (default)


### PR DESCRIPTION
## Summary
- New `plugins/dev-team/knowledge/evidence-bundle.md`: defines the four fixed evidence-bundle sections (Checks run, Scope notes, Untested regions, Residual risks), their data sources, the degradation rule, and the ~40-line PR budget. Registered in `knowledge/index.json` (regenerated via `build_knowledge_index.py`).
- `plugins/dev-team/skills/build/SKILL.md`: new Step 7.5 assembles the bundle from Step 5 (suite run), Step 6 (`/code-review`), and Step 7 (Farley score) data — no new checks, no re-execution — and Step 8's completion report now surfaces it.
- `plugins/dev-team/skills/pr/SKILL.md`: Step 3 assembles the bundle from Step 2's quality-gate results plus on-disk metrics/coverage data; Step 4's PR-body template gains a `## Evidence Bundle` section alongside (not displacing) `## Summary`, `## Quality Gate`, `## Decisions & Assumptions`, `## Test Plan`, and the closing keywords.
- Each command assembles from its own live data at its own runtime — no handoff file between `/build` and `/pr`.

## Quality Gate
- [x] Tests: 787 passed, 16 skipped (1 pre-existing unrelated failure — see Residual risks)
- [x] Type check: not applicable (Markdown-only change)
- [x] Lint: not applicable (Markdown-only change)
- [x] Code review: not run this session (documentation/skill-content change, no source diff to dispatch review agents against)

## Decisions & Assumptions
- Ambiguity Log in issue #863 was fully resolved (Verdict: PASS, 0 open questions) — implemented exactly as specified, no re-litigation.
- `metrics/boundary-events.jsonl` appeared as an untracked file in the working tree before this branch was cut; left untouched and out of this PR's diff as unrelated.

## Test Plan
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — index regenerated; new file registered.
- [x] `python3 scripts/check_md_references.py` — 0 reference errors.
- [x] `python3 -m pytest plugins/dev-team/tests -q` — 787 passed, 16 skipped, 1 pre-existing failure (`test_mypy_adapter.py::test_emitted_findings_validate_against_unified_finding_v1`, missing `jsonschema` dev dependency — reproduces identically on `origin/main`, unrelated to this change).

## Evidence Bundle
<!-- Per plugins/dev-team/knowledge/evidence-bundle.md -->
**Checks run**
- `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — index regenerated cleanly (30-line diff, new file registered)
- `python3 scripts/check_md_references.py` — 0 reference errors, exit 0
- `python3 -m pytest plugins/dev-team/tests -q` — 787 passed, 16 skipped, 1 failed

**Scope notes**
- No source/runtime files changed — lint and type check are not applicable to this diff.
- No review agents dispatched — this session made no code change for `/code-review` to scope against, only skill/knowledge Markdown.

**Untested regions**
- Not measured — no coverage tool applies to a documentation/skill-content-only diff.

**Residual risks**
- Pre-existing failure in `test_mypy_adapter.py::test_emitted_findings_validate_against_unified_finding_v1` (missing `jsonschema` module, a declared-but-uninstalled dev dependency) — confirmed present before this branch was cut, unrelated to these changes.

Closes #863

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_