### PR TITLE
feat: plan-as-contract fields — invariants, rollback points, declared file scope per slice

### DIFF
--- a/plugins/dev-team/agents/progress-guardian.md
+++ b/plugins/dev-team/agents/progress-guardian.md
@@ -55,6 +55,7 @@ Pre-PR gate (`--pre-pr` flag):
 
 - Any `[ ]` unchecked step blocks the PR
 - Uncommitted changes block the PR
+- Declared-scope adherence (issue #865): out-of-scope edits against a slice's declared `**Files:**` are a **named warning**, never a gate failure — freeze (opt-in via plan metadata) is the actual enforcement mechanism
 
 ## Verify by dispatch (read-only)
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1994,6 +1994,10 @@
       "summary": "A \"done\" step that only passed its own tests is not the same as a feature that works — a red suite catches structural regressions, not \"it fails the first time someone actually runs it.\" Once a slice's steps are all `[x]` (sub-step 5) and…",
       "anchor": "49-verify-runtime-behavior-before-the-slice-is-done-issue-727"
     },
+    "4.10. Run slice invariants (issue #865)": {
+      "summary": "When the slice declares `**Invariants:**`, run them **after** the slice's own suite is green (sub-step 5) and its review checkpoint(s) have run (sub-steps 4/6) — invariants check what must stay green *beyond* the slice's new acceptance…",
+      "anchor": "410-run-slice-invariants-issue-865"
+    },
     "5. Run full test suite": {
       "summary": "After all steps are complete, run the full test suite.",
       "anchor": "5-run-full-test-suite"

--- a/plugins/dev-team/scripts/build_rollback_point.py
+++ b/plugins/dev-team/scripts/build_rollback_point.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""build_rollback_point.py — resolve + record slice rollback points (#865).
+
+A plan's optional slice-level `**Rollback point:**` field is symbolic — a
+concrete SHA cannot be known when the plan is written. Values are one of
+`slice-start` (default meaning: HEAD at slice dispatch), `wave-start`,
+`plan-start`, or an explicit git ref. `/build` resolves the symbolic value
+to a concrete SHA at slice dispatch and records it in the slice's build
+bookkeeping so a dead-end escalation (issue #864) can name the exact revert
+boundary: "revert to <sha> (<symbolic>)".
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+_SYMBOLIC_VALUES = ("slice-start", "wave-start", "plan-start")
+
+
+def resolve_rollback_point(
+    symbolic: str,
+    *,
+    repo_root: str,
+    slice_start: Optional[str] = None,
+    wave_start: Optional[str] = None,
+    plan_start: Optional[str] = None,
+) -> str:
+    """Resolve a symbolic rollback value (or an explicit ref) to a concrete
+    commit SHA. Raises `ValueError` if the ref cannot be resolved, and
+    `ValueError` if a symbolic value is requested but its anchor ref wasn't
+    supplied (the caller — `/build` — always has these three at dispatch
+    time)."""
+    mapping = {
+        "slice-start": slice_start,
+        "wave-start": wave_start,
+        "plan-start": plan_start,
+    }
+    if symbolic in mapping:
+        ref = mapping[symbolic]
+        if not ref:
+            raise ValueError(
+                f"rollback point '{symbolic}' requires its anchor ref to be supplied"
+            )
+    else:
+        ref = symbolic  # explicit ref, e.g. a SHA or tag
+
+    result = subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"could not resolve ref {ref!r}: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _load(path: Path) -> Dict[str, dict]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def record_rollback_point(path: Path, slice_id: str, symbolic: str, sha: str) -> None:
+    """Persist `{slice_id: {"symbolic", "sha", "recorded_at"}}` to `path`,
+    merging with any existing entries for other slices."""
+    data = _load(path)
+    data[slice_id] = {
+        "symbolic": symbolic,
+        "sha": sha,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def get_rollback_point(path: Path, slice_id: str) -> Optional[dict]:
+    """Retrieve the recorded rollback point for `slice_id`, or `None`."""
+    return _load(path).get(slice_id)
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="build_rollback_point.py",
+        description="Resolve and record a slice's rollback point (issue #865).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    resolve_p = sub.add_parser("resolve", help="Resolve a symbolic value to a SHA.")
+    resolve_p.add_argument("--symbolic", required=True)
+    resolve_p.add_argument("--repo", default=".")
+    resolve_p.add_argument("--slice-start")
+    resolve_p.add_argument("--wave-start")
+    resolve_p.add_argument("--plan-start")
+
+    record_p = sub.add_parser("record", help="Record a resolved rollback point.")
+    record_p.add_argument("--path", type=Path, required=True)
+    record_p.add_argument("--slice", required=True)
+    record_p.add_argument("--symbolic", required=True)
+    record_p.add_argument("--sha", required=True)
+
+    get_p = sub.add_parser("get", help="Retrieve a recorded rollback point.")
+    get_p.add_argument("--path", type=Path, required=True)
+    get_p.add_argument("--slice", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "resolve":
+        try:
+            sha = resolve_rollback_point(
+                args.symbolic,
+                repo_root=args.repo,
+                slice_start=args.slice_start,
+                wave_start=args.wave_start,
+                plan_start=args.plan_start,
+            )
+        except ValueError as exc:
+            sys.stderr.write(f"build-rollback-point: {exc}\n")
+            return 2
+        print(sha)
+        return 0
+
+    if args.command == "record":
+        record_rollback_point(args.path, args.slice, args.symbolic, args.sha)
+        print(f"Recorded rollback point for slice {args.slice}: {args.sha}")
+        return 0
+
+    if args.command == "get":
+        entry = get_rollback_point(args.path, args.slice)
+        if entry is None:
+            sys.stderr.write(
+                f"build-rollback-point: no rollback point recorded for slice {args.slice}\n"
+            )
+            return 1
+        print(json.dumps(entry))
+        return 0
+
+    return 2  # pragma: no cover — argparse enforces a valid subcommand
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/scripts/build_slice_scope.py
+++ b/plugins/dev-team/scripts/build_slice_scope.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""build_slice_scope.py — freeze-scope wiring for `/build` (issue #865).
+
+Auto-freeze is OPT-IN VIA PLAN METADATA: a top-level `**Scope enforcement:**
+freeze` line in the plan enables it. Declared per-slice `**Files:**` alone
+only feeds `plan_waves.py`'s scope-mismatch warnings (see `plan_waves.py`) —
+it never freezes anything by itself.
+
+When engaged, `/build` calls this script at slice dispatch to write
+`hooks/freeze-state.json` (the same contract `/freeze` writes and
+`hooks/pre_tool_guard.py` already enforces) with `allowed_patterns` equal to
+the slice's declared paths **plus a fixed bookkeeping allowlist** (the plan
+file itself, `memory/**`, `metrics/**`) — without which `/build` could not
+update its own Build Progress checkboxes or `memory/build-phase.json`. At
+slice completion, `/build` calls this script again to clear the state.
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "lib"))
+
+import plan_parse  # noqa: E402
+
+_SCOPE_ENFORCEMENT_RE = re.compile(
+    r"^\*\*Scope enforcement:?\*\*\s*:?\s*(.+)$", re.IGNORECASE | re.MULTILINE
+)
+_TOKEN_SPLIT_RE = re.compile(r"[,\s]+")
+
+FREEZE_STATE_FILENAME = "freeze-state.json"
+
+
+def scope_enforcement_enabled(plan_text: str) -> bool:
+    """True when the plan's top-level `**Scope enforcement:** freeze` line
+    is present (case-insensitive). Any other value (or its absence) means
+    declared Files feeds mismatch warnings only — no auto-freeze."""
+    match = _SCOPE_ENFORCEMENT_RE.search(plan_text)
+    if not match:
+        return False
+    return match.group(1).strip().lower().startswith("freeze")
+
+
+def declared_files_for_slice(plan_text: str, slice_id: str) -> List[str]:
+    """Return the tokenized slice-level `**Files:**` declaration for
+    `slice_id`, or `[]` when the slice declares none."""
+    rows = plan_parse.parse_slices(plan_text.splitlines())
+    for sid, _deps, files_raw in rows:
+        if sid == slice_id:
+            return [f for f in _TOKEN_SPLIT_RE.split(files_raw) if f]
+    return []
+
+
+def bookkeeping_allowlist(plan_path: Path) -> List[str]:
+    """The fixed allowlist every freeze must include so `/build` never
+    self-blocks its own progress writes: the plan file itself, plus
+    `memory/**` and `metrics/**`."""
+    return [plan_path.name, "memory/**", "metrics/**"]
+
+
+def build_allowed_patterns(plan_path: Path, plan_text: str, slice_id: str) -> List[str]:
+    declared = declared_files_for_slice(plan_text, slice_id)
+    return declared + bookkeeping_allowlist(plan_path)
+
+
+def write_freeze_state(hooks_dir: Path, allowed_patterns: List[str]) -> Path:
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    state_path = hooks_dir / FREEZE_STATE_FILENAME
+    payload = {
+        "active": True,
+        "allowed_patterns": allowed_patterns,
+        "frozen_at": datetime.now(timezone.utc).isoformat(),
+    }
+    state_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return state_path
+
+
+def clear_freeze_state(hooks_dir: Path) -> Path:
+    """Remove the freeze-state file — mirrors `/unfreeze`'s `rm -f`."""
+    state_path = hooks_dir / FREEZE_STATE_FILENAME
+    if state_path.exists():
+        state_path.unlink()
+    return state_path
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="build_slice_scope.py",
+        description="Engage/clear /build's per-slice freeze scope lock (issue #865).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enabled_p = sub.add_parser(
+        "enabled", help="Exit 0 if the plan opts into freeze scope enforcement."
+    )
+    enabled_p.add_argument("plan", type=Path)
+
+    engage_p = sub.add_parser(
+        "engage", help="Write freeze-state.json scoped to a slice's declared Files."
+    )
+    engage_p.add_argument("plan", type=Path)
+    engage_p.add_argument("--slice", required=True)
+    engage_p.add_argument("--hooks-dir", type=Path, default=Path("hooks"))
+
+    clear_p = sub.add_parser("clear", help="Clear freeze-state.json.")
+    clear_p.add_argument("--hooks-dir", type=Path, default=Path("hooks"))
+
+    args = parser.parse_args(argv)
+
+    if args.command == "enabled":
+        plan_text = args.plan.read_text(encoding="utf-8")
+        if scope_enforcement_enabled(plan_text):
+            print("enabled")
+            return 0
+        print("disabled")
+        return 1
+
+    if args.command == "engage":
+        plan_text = args.plan.read_text(encoding="utf-8")
+        allowed = build_allowed_patterns(args.plan, plan_text, args.slice)
+        state_path = write_freeze_state(args.hooks_dir, allowed)
+        print(f"Freeze engaged for slice {args.slice}: {state_path}")
+        print(f"Allowed patterns: {', '.join(allowed)}")
+        return 0
+
+    if args.command == "clear":
+        state_path = clear_freeze_state(args.hooks_dir)
+        print(f"Freeze cleared: {state_path}")
+        return 0
+
+    return 2  # pragma: no cover — argparse enforces a valid subcommand
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/scripts/lib/plan_parse.py
+++ b/plugins/dev-team/scripts/lib/plan_parse.py
@@ -22,21 +22,61 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional, TextIO, Tuple
+from typing import Dict, Iterable, List, Optional, TextIO, Tuple
 
 
 _SLICE_RE = re.compile(r"^#+\s+[Ss]lice\s+([^:]+)")
 _SLICE_HEADING_RE = re.compile(r"^#{1,3}\s+[Ss]lice\s+([^:]+):\s*(.*)$")
 _HEADING_RE = re.compile(r"^#{1,3}\s")
 _STEP_RE = re.compile(r"^#{4,}\s")
-_DEPENDS_RE = re.compile(r"[Dd]epends-[Oo]n\**\s*:\s*(.*)")
-_FILES_RE = re.compile(r"[Ff]iles\**\s*:\s*(.*)")
-_MARKDOWN_NOISE_RE = re.compile(r"[*`]")
+# `\**\s*:\s*\**\s*` handles bold markup on *both* sides of the colon —
+# `**Depends-on:**` puts the closing `**` right after the colon, not before
+# it, so without the trailing `\**\s*` the leaked marker lands inside the
+# captured value (see #865 AC9: a value may legitimately end in its own
+# `**` glob suffix like `src/auth/**`, so blanket-stripping every asterisk
+# in `_clean_value` is no longer safe — the regex must consume the label's
+# own bold markers instead).
+_DEPENDS_RE = re.compile(r"[Dd]epends-[Oo]n\**\s*:\s*\**\s*(.*)")
+_FILES_RE = re.compile(r"[Ff]iles\**\s*:\s*\**\s*(.*)")
+_INVARIANTS_RE = re.compile(r"[Ii]nvariants\**\s*:\s*\**\s*(.*)")
+_ROLLBACK_RE = re.compile(r"[Rr]ollback[ _-][Pp]oint\**\s*:\s*\**\s*(.*)")
+_BACKTICK_TOKEN_RE = re.compile(r"`([^`]+)`")
+_TOKEN_SPLIT_RE = re.compile(r"[,\s]+")
 
 
 def _clean_value(raw: str) -> str:
-    """Strip `**` / backticks and surrounding whitespace from a field value."""
-    return _MARKDOWN_NOISE_RE.sub("", raw).strip()
+    """Strip backticks and bold-wrapping `**` / surrounding whitespace from a
+    field value.
+
+    Backticks are removed unconditionally (inline-code delimiters are never
+    semantically meaningful). Bold markers are trickier since #865: a `Files`
+    or `Invariants` value may legitimately end in a recursive glob like
+    `src/auth/**`, so a lone trailing `**` must survive — only a **paired**
+    `**...**` wrapping the *entire* value (both ends) is markdown bold and
+    gets stripped.
+    """
+    value = raw.replace("`", "").strip()
+    if value.startswith("**") and value.endswith("**") and len(value) > 3:
+        value = value[2:-2].strip()
+    return value
+
+
+def _parse_invariant_commands(raw: str) -> List[str]:
+    """Split an `**Invariants:**` value into individual shell commands.
+
+    Each command is expected to be its own backtick-quoted token
+    (`` `npm test` ``, `` `python3 scripts/foo.py` ``) so commas or spaces
+    *inside* a command (e.g. `--grep "session"`) don't get misread as
+    separators. Falls back to a plain comma split when no backtick tokens
+    are present (no commands to run — an empty raw value — yields `[]`).
+    """
+    tokens = _BACKTICK_TOKEN_RE.findall(raw)
+    if tokens:
+        return [t.strip() for t in tokens if t.strip()]
+    cleaned = _clean_value(raw)
+    if not cleaned:
+        return []
+    return [c.strip() for c in cleaned.split(",") if c.strip()]
 
 
 def _slice_id(header_line: str) -> str:
@@ -106,6 +146,121 @@ def parse_slices(lines: Iterable[str]) -> List[Tuple[str, str, str]]:
 
     flush()
     return rows
+
+
+def parse_slice_optional_fields(lines: Iterable[str]) -> Dict[str, Dict[str, object]]:
+    """Return `{slice_id: {"invariants": [...], "rollback_point": str}}`.
+
+    Collects the two new (#865) optional slice-level fields — `**Invariants:**`
+    and `**Rollback point:**` — using the same slice-level-only grammar as
+    `parse_slices` (fields before the slice's first `#### Step` heading).
+    A slice missing either field simply has an empty list / empty string in
+    its entry; this is purely additive and never raises.
+    """
+    result: Dict[str, Dict[str, object]] = {}
+
+    current_id: str = ""
+    invariants: List[str] = []
+    rollback: str = ""
+    in_step: bool = False
+
+    def flush() -> None:
+        if current_id:
+            result[current_id] = {
+                "invariants": invariants,
+                "rollback_point": rollback,
+            }
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        if _SLICE_RE.match(line):
+            flush()
+            current_id = _slice_id(line)
+            invariants = []
+            rollback = ""
+            in_step = False
+            continue
+
+        if _STEP_RE.match(line):
+            in_step = True
+            continue
+
+        if not current_id or in_step:
+            continue
+
+        lowered = line.lower()
+
+        if not invariants and "invariants" in lowered:
+            match = _INVARIANTS_RE.search(line)
+            if match is not None:
+                invariants = _parse_invariant_commands(match.group(1))
+                continue
+
+        if not rollback and "rollback" in lowered:
+            match = _ROLLBACK_RE.search(line)
+            if match is not None:
+                rollback = _clean_value(match.group(1))
+
+    flush()
+    return result
+
+
+def parse_step_files(lines: Iterable[str]) -> Dict[str, List[str]]:
+    """Return `{slice_id: [raw per-step Files values...]}` — the *inferred*
+    write set (#865). Each entry is the list of raw `**Files**:` line values
+    found under that slice's `#### Step` headings, in source order and
+    un-tokenized (callers split on `[,\\s]+` same as slice-level `files`).
+
+    This is deliberately the mirror image of `parse_slices`, which stops
+    collecting `Files` the moment a step heading is seen — here we only
+    collect *after* a step heading, so the two never double-count the same
+    line.
+    """
+    result: Dict[str, List[str]] = {}
+
+    current_id: str = ""
+    in_step: bool = False
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        if _SLICE_RE.match(line):
+            current_id = _slice_id(line)
+            in_step = False
+            continue
+
+        if _STEP_RE.match(line):
+            in_step = True
+            continue
+
+        if not current_id or not in_step:
+            continue
+
+        if "files" in line.lower():
+            match = _FILES_RE.search(line)
+            if match is not None:
+                value = match.group(1).strip()
+                if value:
+                    result.setdefault(current_id, []).append(value)
+
+    return result
+
+
+def step_files_union(lines: Iterable[str]) -> Dict[str, List[str]]:
+    """Return `{slice_id: sorted [tokenized inferred files]}` — the union of
+    per-step `**Files**:` tokens for each slice, deduplicated and sorted.
+    Convenience wrapper around `parse_step_files` for callers (`plan_waves.py`)
+    that want the tokenized set directly rather than raw per-line values.
+    """
+    raw = parse_step_files(lines)
+    unioned: Dict[str, List[str]] = {}
+    for slice_id, values in raw.items():
+        tokens: set = set()
+        for value in values:
+            tokens.update(t for t in _TOKEN_SPLIT_RE.split(_clean_value(value)) if t)
+        unioned[slice_id] = sorted(tokens)
+    return unioned
 
 
 class _SliceSection:

--- a/plugins/dev-team/scripts/plan_waves.py
+++ b/plugins/dev-team/scripts/plan_waves.py
@@ -22,6 +22,7 @@ Uses `scripts/lib/plan_parse.py` for the parser stage.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -43,15 +44,66 @@ def _die(message: str) -> None:
     sys.exit(2)
 
 
+def _is_glob(pattern: str) -> bool:
+    return any(ch in pattern for ch in "*?[")
+
+
+def _file_covered(file_path: str, patterns: List[str]) -> bool:
+    """True when `file_path` exactly matches a declared pattern, or a
+    declared glob pattern (fnmatch, stdlib — #865 AC9) matches it."""
+    for pattern in patterns:
+        if pattern == file_path:
+            return True
+        if _is_glob(pattern) and fnmatch.fnmatch(file_path, pattern):
+            return True
+    return False
+
+
+def _pattern_covers_any(pattern: str, files: List[str]) -> bool:
+    """True when a declared `pattern` is satisfied by at least one inferred
+    file — an exact-match hit, or (for a glob pattern) any fnmatch hit."""
+    for file_path in files:
+        if pattern == file_path:
+            return True
+        if _is_glob(pattern) and fnmatch.fnmatch(file_path, pattern):
+            return True
+    return False
+
+
+def _scope_mismatch(sid: str, declared: List[str], inferred: List[str]) -> Dict:
+    """Return a `scope_mismatches` entry for `sid`, or `None` when the
+    declared and inferred sets reconcile (#865 AC3). `under_declared` is the
+    dangerous direction: a step plans to touch a file the slice never
+    declared. `over_declared` is a declared path/pattern nothing inferred
+    actually touches."""
+    under_declared = sorted(f for f in inferred if not _file_covered(f, declared))
+    over_declared = sorted(p for p in declared if not _pattern_covers_any(p, inferred))
+    if not under_declared and not over_declared:
+        return None
+    return {
+        "slice": sid,
+        "declared": sorted(declared),
+        "inferred": sorted(inferred),
+        "under_declared": under_declared,
+        "over_declared": over_declared,
+    }
+
+
 def compute_waves(plan_path: Path) -> dict:
     """Return the plan-waves/v1 JSON payload for `plan_path`."""
-    rows = plan_parse.parse_slices(plan_path.read_text().splitlines())
+    plan_lines = plan_path.read_text().splitlines()
+    rows = plan_parse.parse_slices(plan_lines)
+    inferred_by_slice = plan_parse.step_files_union(plan_lines)
 
     slices: Dict[str, dict] = {}
     order: List[str] = []
     for sid, deps_raw, files_raw in rows:
         files = [f for f in _TOKEN_SPLIT_RE.split(files_raw) if f]
-        slices[sid] = {"deps_raw": deps_raw, "files": files}
+        slices[sid] = {
+            "deps_raw": deps_raw,
+            "files": files,
+            "inferred_files": inferred_by_slice.get(sid, []),
+        }
         order.append(sid)
 
     if not slices:
@@ -89,17 +141,36 @@ def compute_waves(plan_path: Path) -> dict:
 
     wave_of = {s: i for i, wave in enumerate(waves, 1) for s in wave}
 
+    # Conservative same-wave collision detection (#865): compare the union of
+    # each slice's declared + inferred files, not declared alone, so a step
+    # that plans to touch a file its slice never declared still trips a
+    # collision against another slice's overlapping write.
+    combined_files = {
+        sid: set(slices[sid]["files"]) | set(slices[sid]["inferred_files"])
+        for sid in order
+    }
+
     collisions: List[dict] = []
     for i, wave in enumerate(waves, 1):
         for a in range(len(wave)):
             for b in range(a + 1, len(wave)):
-                shared = sorted(
-                    set(slices[wave[a]]["files"]) & set(slices[wave[b]]["files"])
-                )
+                shared = sorted(combined_files[wave[a]] & combined_files[wave[b]])
                 for f in shared:
                     collisions.append(
                         {"wave": i, "slices": [wave[a], wave[b]], "file": f}
                     )
+
+    # Declared-vs-inferred scope mismatches (#865 AC3) — only for slices that
+    # declare slice-level Files; a slice with no declaration has nothing to
+    # reconcile against.
+    scope_mismatches: List[dict] = []
+    for sid in order:
+        declared = slices[sid]["files"]
+        if not declared:
+            continue
+        entry = _scope_mismatch(sid, declared, slices[sid]["inferred_files"])
+        if entry is not None:
+            scope_mismatches.append(entry)
 
     return {
         "schema": "plan-waves/v1",
@@ -113,6 +184,7 @@ def compute_waves(plan_path: Path) -> dict:
             for sid in order
         },
         "collisions": collisions,
+        "scope_mismatches": scope_mismatches,
     }
 
 

--- a/plugins/dev-team/scripts/run_invariants.py
+++ b/plugins/dev-team/scripts/run_invariants.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""run_invariants.py — run a slice's `**Invariants:**` commands (issue #865).
+
+Invariants are checks that must stay green *beyond* a slice's own new
+acceptance tests — "don't break X" as a runnable gate term instead of tribal
+knowledge. `/build`'s slice review checkpoint runs each command from the
+repo root after the slice's own suite is green; a non-zero exit fails the
+slice gate exactly like a red test (fix or escalate — never step over).
+
+Each command is run in its own subshell via `shell=True` (same trust model
+as the plan's own test commands — the plan author owns portability). Runs
+stop at the first failure so the failing command is unambiguous.
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "lib"))
+
+import plan_parse  # noqa: E402
+
+
+class InvariantResult(NamedTuple):
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_invariants(commands: List[str], repo_root: str) -> List[InvariantResult]:
+    """Run each command from `repo_root`, stopping at the first failure.
+    Returns the results for every command actually run (in order)."""
+    results: List[InvariantResult] = []
+    for command in commands:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        results.append(
+            InvariantResult(command, proc.returncode, proc.stdout, proc.stderr)
+        )
+        if proc.returncode != 0:
+            break
+    return results
+
+
+def invariants_for_slice(plan_path: Path, slice_id: str) -> List[str]:
+    """Return the parsed Invariants commands declared for `slice_id`, or
+    `[]` when the slice declares none."""
+    fields = plan_parse.parse_slice_optional_fields(
+        plan_path.read_text(encoding="utf-8").splitlines()
+    )
+    entry = fields.get(slice_id)
+    if not entry:
+        return []
+    return list(entry.get("invariants") or [])
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_invariants.py",
+        description="Run a slice's declared Invariants commands (issue #865).",
+    )
+    parser.add_argument("--repo", default=".", help="Repo root to run commands from.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--plan", type=Path, help="Plan file — used with --slice to look up commands."
+    )
+    group.add_argument(
+        "command",
+        nargs="*",
+        default=[],
+        help="Explicit invariant command(s) to run.",
+    )
+    parser.add_argument("--slice", help="Slice id (required with --plan).")
+    args = parser.parse_args(argv)
+
+    if args.plan is not None:
+        if not args.slice:
+            parser.error("--slice is required when --plan is given")
+        commands = invariants_for_slice(args.plan, args.slice)
+    else:
+        commands = [c for c in args.command if c]
+
+    if not commands:
+        print("No invariants declared — nothing to run.")
+        return 0
+
+    results = run_invariants(commands, args.repo)
+    for result in results:
+        status = "PASS" if result.returncode == 0 else "FAIL"
+        print(f"[{status}] {result.command}")
+        if result.returncode != 0:
+            if result.stdout.strip():
+                print(result.stdout)
+            if result.stderr.strip():
+                print(result.stderr, file=sys.stderr)
+
+    failed = [r for r in results if r.returncode != 0]
+    if failed:
+        sys.stderr.write(
+            f"run-invariants: invariant failed: {failed[0].command!r} "
+            f"(exit {failed[0].returncode})\n"
+        )
+        return failed[0].returncode or 1
+
+    print(f"All {len(results)} invariant(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -133,6 +133,11 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_jobs.py --wave-width <W> [--jobs N] 
    - A **failing slice** → exit non-zero naming it, list which same-wave slices succeeded and where their (preserved) worktrees are, print the resume command, and start no next-wave slice. Resume rebuilds only the incomplete slice.
    - A **reconcile conflict** (two same-wave diffs touch one file) → exit non-zero naming the file, pick no side, start no next-wave slice.
 
+**Slice dispatch bookkeeping (issue #865).** Before a slice's first step begins:
+
+1. **Freeze scope (opt-in only).** Check whether the plan opts into scope enforcement: `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py enabled <plan-file>` (exit 0 = engaged). Declaring slice-level `**Files:**` alone never freezes anything — only a `**Scope enforcement:** freeze` metadata line does (Ambiguity Log Q1). When engaged **and** the dispatching slice declares `**Files:**`, run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py engage <plan-file> --slice <id> --hooks-dir <worktree>/hooks` — this writes `hooks/freeze-state.json` with `allowed_patterns` set to the slice's declared paths plus the fixed bookkeeping allowlist (the plan file, `memory/**`, `metrics/**`), so `hooks/pre_tool_guard.py` blocks any Write/Edit outside that scope without also blocking `/build`'s own progress writes. Clear it at slice completion (sub-step 5 below): `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py clear --hooks-dir <worktree>/hooks`.
+2. **Rollback point.** When the slice declares `**Rollback point:**`, resolve the symbolic value to a concrete SHA and record it: `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_rollback_point.py resolve --symbolic <value> --repo <worktree> --slice-start <HEAD-at-dispatch> --wave-start <wave-start-ref> --plan-start <plan-start-ref>`, then `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_rollback_point.py record --path memory/build-rollback.json --slice <id> --symbolic <value> --sha <resolved-sha>`. This is the boundary a dead-end escalation (issue #864) names verbatim: "revert to `<sha>` (`<symbolic>`)" — retrieve it with the script's `get` subcommand. A slice without `Rollback point` records nothing.
+
 For each step within a slice, dispatch implementation following the implementer template (`${CLAUDE_PLUGIN_ROOT}/prompts/implementer.md`). Pass the implementer its step **and the slice's Gherkin scenario(s)** — the scenarios are the behavioral contract the step's test must satisfy.
 
 Within the per-behavior mini-cycle below, repeated Write/Edit calls can race a `PostToolUse` hook that rewrites files (e.g., a formatter): an `Edit` failing on a stale `old_string` is expected to self-correct by re-`Read`ing the file before the next `Edit` attempt, not to escalate immediately.
@@ -171,6 +176,7 @@ Work each step **one behavior at a time** — never all the code then all the te
    - When every step under a slice is `[x]`, check off the parent `- [ ] Slice N: <title>`.
    - After all slices are `[x]`, change `**Status**: approved` to `**Status**: in-progress`.
    - This disk write is the durable commit. If a `/clear` occurs, `/continue` reads `## Build Progress` to determine the resume point without needing conversation history.
+   - **Clear freeze scope (issue #865).** When every step under the slice is `[x]` and freeze was engaged for it (dispatch bookkeeping above), run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py clear --hooks-dir <worktree>/hooks` before starting the next slice. A slice that never engaged freeze has nothing to clear.
 6. **Slice review checkpoint (batched).** When every step under the current slice is `[x]` **and** the slice had any deferred `standard` (or unspecified) steps, run **one** review pass over the slice's accumulated changed files: the static self-heal pass first (`references/static-self-heal.md`), then `/review-agent spec-compliance-review`, then the quality review agents relevant to what changed. Apply the same review-fix loop (up to 5 iterations; escalate if it doesn't converge). `trivial`-only and all-`complex` slices have nothing to batch — skip this pass. Then **record the checkpoint outcome** (sub-step 7).
 7. **Record review value (#348).** For **each** checkpoint that runs (per-step `complex` in sub-step 4, and per-slice in sub-step 6), append one JSON line to `metrics/review-value.jsonl` capturing whether review actually changed anything — counts and outcomes only, never code or file content (consistent with the cost meter's privacy boundary). Schema in `performance-metrics`:
 
@@ -195,6 +201,16 @@ A "done" step that only passed its own tests is not the same as a feature that w
    ```
 
    `outcome` is `ran` (`/verify` executed and passed), `skipped` (no runtime surface in the diff — `reason` states why, e.g. `"tests-only"` or `"docs-only"`), or `failed-then-fixed` (`/verify` failed at least once before the fix landed). `python3 scripts/progress_guardian.py --pre-pr` reads this log: a branch with runtime-surface changes and no matching entry fails the pre-PR gate the same way an incomplete step or a missing commit does.
+
+### 4.10. Run slice invariants (issue #865)
+
+When the slice declares `**Invariants:**`, run them **after** the slice's own suite is green (sub-step 5) and its review checkpoint(s) have run (sub-steps 4/6) — invariants check what must stay green *beyond* the slice's new acceptance tests, so they gate on top of everything else, not instead of it:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/run_invariants.py --plan <plan-file> --slice <id> --repo <worktree>
+```
+
+A non-zero exit **fails the slice gate exactly like a red test** — fix it or escalate (Escalation section below), never step over it, and never flip the slice checkbox to `[x]` until it's green. A slice with no `Invariants` line runs its gate unchanged (the script itself no-ops with "No invariants declared" — nothing to enforce). Invariant commands run as-is from the repo root; the plan author owns their portability, same trust model as the plan's own test commands.
 
 ### 5. Run full test suite
 
@@ -279,4 +295,5 @@ unresolved escalation.
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md` defines the structured evidence bundle assembled in Step 7.5 and surfaced in the Step 8 completion report
 - `/pr` creates the pull request after a successful build, assembling its own evidence bundle independently (no handoff file)
 - `/continue` can resume a partially completed build across sessions
-- `python3 scripts/progress_guardian.py --plan <plan-file>` validates step completion and commit discipline at each step boundary; `--pre-pr` also fails closed when runtime-surface changes have no matching `metrics/verify-log.jsonl` entry (issue #727)
+- `python3 scripts/progress_guardian.py --plan <plan-file>` validates step completion and commit discipline at each step boundary; `--pre-pr` also fails closed when runtime-surface changes have no matching `metrics/verify-log.jsonl` entry (issue #727), and warns (never fails) on out-of-scope edits against declared slice `Files` (issue #865)
+- `scripts/build_slice_scope.py`, `scripts/build_rollback_point.py`, and `scripts/run_invariants.py` implement the plan-as-contract fields (issue #865): opt-in freeze scope, rollback-point resolution/recording, and the slice invariants gate, respectively

--- a/plugins/dev-team/skills/freeze/SKILL.md
+++ b/plugins/dev-team/skills/freeze/SKILL.md
@@ -56,3 +56,4 @@ Display:
 - Freeze state persists across tool calls within a session.
 - If a session crashes while frozen, use `/unfreeze` in the next session to clear stale state.
 - Multiple patterns can be provided as comma-separated: `/freeze src/auth/**,src/middleware/**`
+- `/build` can also engage this same `freeze-state.json` contract automatically, per slice, when a plan opts into `**Scope enforcement:** freeze` and declares slice-level `**Files:**` (issue #865) — see `scripts/build_slice_scope.py` and the `build` skill's "Slice dispatch bookkeeping" section. That path is opt-in metadata, not a manual `/freeze` invocation, but writes/clears the identical file this command does.

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -97,6 +97,13 @@ Render the `## Parallelization` Mermaid DAG + wave table and the wave-grouped
 (cycle, missing `Depends-on`, or unknown reference) or reports a `collisions` entry,
 fix the plan and re-run before the human gate — those defeat safe concurrent build.
 
+**`scope_mismatches` (#865) is fix-or-acknowledge, not fix-before-gate.** For a slice
+declaring slice-level `**Files:**`, this JSON array compares it against the union of
+the slice's per-step `**Files**:` lines (`under_declared`/`over_declared`, `[]` when
+matching or undeclared). Unlike `collisions`, don't block on it — surface it at the
+human gate (step 6); if the author proceeds unreconciled, record it in `## Risks &
+Open Questions`.
+
 ### 5. Run plan review personas
 
 Before presenting to the user, dispatch the plan review personas in parallel as sub-agents. Each critically challenges the plan from a different perspective. **The reviewer set scales to plan complexity** — a one-function plan does not pay the same review ceremony as a complex feature (the fixed-overhead cost the TDD experiment surfaced; see `docs/experiments/01-final-results.md`).
@@ -146,6 +153,8 @@ Pass each reviewer the full plan content. Also pass the Parallelization Critic t
 ### 6. Present for approval
 
 **Gate check before presenting.** Verify the `## Skipped (low value)` section captures every `LOW_VALUE` finding — no slice or TDD step may carry one. If a `LOW_VALUE` finding leaked into a work stream, move it to the Skipped section before the plan reaches the human.
+
+**Surface any `scope_mismatches` (#865)** alongside the review summary, same visibility as `collisions` — never blocking. Unreconciled on approval → append it to `## Risks & Open Questions`.
 
 **First determine interactivity.** The run is **non-interactive** when any of these hold: `--yes` was passed, `DEV_TEAM_AUTO_APPROVE=1` is set in the environment, or stdin is not a usable TTY (`test -t 0` is false — the headless/CI/automation case). Otherwise it is **interactive**. This is the same non-interactive principle the GitHub-issue prompt below already follows; the approval gate now follows it too, so a headless `/plan`→`/build` run never hangs waiting for input.
 

--- a/plugins/dev-team/skills/plan/references/plan-template.md
+++ b/plugins/dev-team/skills/plan/references/plan-template.md
@@ -12,6 +12,12 @@ Use this structure when writing the plan file (step 3 of `SKILL.md`).
 <!-- Recorded once at plan creation (detected convention, operator answer, or
      headless default). Re-runs honor this line without re-prompting; editing
      it is the supported way to change the decision. -->
+**Scope enforcement**: <freeze | none> <!-- OPTIONAL. Omit or set `none` for
+     today's behavior. `freeze` opts every slice declaring `**Files:**` into
+     `/build` auto-freezing its worktree to the declared scope at dispatch
+     (see Slice 2's `**Files:**` line below) — declared Files alone, without
+     this line, only feeds `plan_waves.py`'s scope-mismatch warnings, never
+     freeze. -->
 
 ## Goal
 
@@ -69,6 +75,21 @@ Feature: <feature name>
 
 **Depends-on:** 1
 **Files:** `path/to/other.ts`
+**Invariants:** `<runnable shell command>`, `<another command>`
+**Rollback point:** slice-start
+<!-- All three of Files/Invariants/Rollback point are OPTIONAL — a slice
+     that omits them parses, reviews, and builds exactly as today.
+     - **Files**: declared write scope for the slice (glob patterns
+       accepted, e.g. `src/auth/**`). Feeds `plan_waves.py`'s
+       declared-vs-inferred scope-mismatch check; only auto-freezes when
+       the plan sets `**Scope enforcement:** freeze` above.
+     - **Invariants**: runnable shell commands (exit 0 = green) that must
+       stay green *beyond* this slice's own new acceptance tests — run by
+       `/build`'s slice gate after the slice's own suite passes.
+     - **Rollback point**: the commit boundary to revert to if the slice
+       dead-ends — `slice-start` (default: HEAD at slice dispatch),
+       `wave-start`, `plan-start`, or an explicit ref. `/build` resolves it
+       to a concrete SHA at dispatch and records it. -->
 
 **Behavior:**
 
@@ -100,8 +121,14 @@ graph TD
 | 2 | 2 |
 
 If `scripts/plan_waves.py` reports a cycle, a missing `Depends-on`, an unknown reference,
-or a **same-wave file collision** (two slices in one wave declaring the same file),
+or a **same-wave file collision** (two slices in one wave declaring the same file —
+now computed conservatively over each slice's declared **and** inferred files),
 fix the plan before the human gate — those break safe concurrent delivery.
+
+A `scope_mismatches` entry (a slice's declared `Files` disagreeing with the union
+of its steps' `**Files**:` lines) is **fix-or-acknowledge, not fix-before-gate**:
+shown as a warning at the human gate (step 6), and recorded in `## Risks & Open
+Questions` if the author proceeds without reconciling it.
 
 ## Complexity Classification
 

--- a/plugins/dev-team/tests/scripts/test_build_rollback_point.py
+++ b/plugins/dev-team/tests/scripts/test_build_rollback_point.py
@@ -1,0 +1,135 @@
+"""Unit tests for scripts/build_rollback_point.py (issue #865).
+
+Covers symbolic rollback-value resolution to a concrete SHA and
+record/retrieve bookkeeping so a dead-end escalation (issue #864) can name
+the exact revert boundary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import build_rollback_point  # noqa: E402
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(cwd: Path) -> None:
+    _git(cwd, "init", "-q")
+    _git(cwd, "config", "user.email", "test@test.com")
+    _git(cwd, "config", "user.name", "Test")
+
+
+# ---------------------------------------------------------------------------
+# resolve_rollback_point
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_slice_start_uses_supplied_anchor_ref(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "a.txt").write_text("one\n")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "commit", "-m", "first")
+    sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    resolved = build_rollback_point.resolve_rollback_point(
+        "slice-start", repo_root=str(tmp_path), slice_start=sha
+    )
+    assert resolved == sha
+
+
+def test_resolve_wave_start_and_plan_start_use_their_own_anchors(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "a.txt").write_text("one\n")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "commit", "-m", "first")
+    sha1 = _git(tmp_path, "rev-parse", "HEAD")
+    (tmp_path / "b.txt").write_text("two\n")
+    _git(tmp_path, "add", "b.txt")
+    _git(tmp_path, "commit", "-m", "second")
+    sha2 = _git(tmp_path, "rev-parse", "HEAD")
+
+    assert (
+        build_rollback_point.resolve_rollback_point(
+            "wave-start",
+            repo_root=str(tmp_path),
+            wave_start=sha1,
+            plan_start=sha2,
+        )
+        == sha1
+    )
+    assert (
+        build_rollback_point.resolve_rollback_point(
+            "plan-start",
+            repo_root=str(tmp_path),
+            wave_start=sha1,
+            plan_start=sha2,
+        )
+        == sha2
+    )
+
+
+def test_resolve_explicit_ref_is_passed_through_to_git(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "a.txt").write_text("one\n")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "commit", "-m", "first")
+    _git(tmp_path, "tag", "v1")
+    sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    resolved = build_rollback_point.resolve_rollback_point(
+        "v1", repo_root=str(tmp_path)
+    )
+    assert resolved == sha
+
+
+def test_resolve_symbolic_without_anchor_raises():
+    with pytest.raises(ValueError):
+        build_rollback_point.resolve_rollback_point("slice-start", repo_root=".")
+
+
+def test_resolve_unresolvable_ref_raises(tmp_path):
+    _init_repo(tmp_path)
+    with pytest.raises(ValueError):
+        build_rollback_point.resolve_rollback_point(
+            "no-such-ref", repo_root=str(tmp_path)
+        )
+
+
+# ---------------------------------------------------------------------------
+# record_rollback_point / get_rollback_point
+# ---------------------------------------------------------------------------
+
+
+def test_record_then_get_round_trips(tmp_path):
+    path = tmp_path / "build-rollback.json"
+    build_rollback_point.record_rollback_point(path, "1", "slice-start", "abc123")
+    entry = build_rollback_point.get_rollback_point(path, "1")
+    assert entry["symbolic"] == "slice-start"
+    assert entry["sha"] == "abc123"
+    assert "recorded_at" in entry
+
+
+def test_get_missing_slice_returns_none(tmp_path):
+    path = tmp_path / "build-rollback.json"
+    assert build_rollback_point.get_rollback_point(path, "nope") is None
+
+
+def test_record_merges_with_existing_entries_for_other_slices(tmp_path):
+    path = tmp_path / "build-rollback.json"
+    build_rollback_point.record_rollback_point(path, "1", "slice-start", "sha1")
+    build_rollback_point.record_rollback_point(path, "2", "wave-start", "sha2")
+    assert build_rollback_point.get_rollback_point(path, "1")["sha"] == "sha1"
+    assert build_rollback_point.get_rollback_point(path, "2")["sha"] == "sha2"

--- a/plugins/dev-team/tests/scripts/test_build_slice_scope.py
+++ b/plugins/dev-team/tests/scripts/test_build_slice_scope.py
@@ -1,0 +1,128 @@
+"""Unit tests for scripts/build_slice_scope.py (issue #865).
+
+Covers the freeze-scope wiring for `/build`: the `Scope enforcement: freeze`
+opt-in detection, the declared-Files + bookkeeping-allowlist computation,
+and the engage/clear freeze-state.json lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import build_slice_scope  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# scope_enforcement_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_scope_enforcement_disabled_by_default():
+    """A plan with declared Files but no Scope enforcement line does not
+    engage freeze (#865 Ambiguity Log Q1: opt-in only)."""
+    text = "# Plan\n\n### Slice 1: alpha\n**Files:** `a.ts`\n"
+    assert build_slice_scope.scope_enforcement_enabled(text) is False
+
+
+def test_scope_enforcement_enabled_via_metadata_line():
+    text = "# Plan\n\n**Scope enforcement:** freeze\n\n### Slice 1: alpha\n"
+    assert build_slice_scope.scope_enforcement_enabled(text) is True
+
+
+def test_scope_enforcement_case_insensitive():
+    text = "**scope enforcement:** FREEZE\n"
+    assert build_slice_scope.scope_enforcement_enabled(text) is True
+
+
+def test_scope_enforcement_other_value_is_disabled():
+    text = "**Scope enforcement:** none\n"
+    assert build_slice_scope.scope_enforcement_enabled(text) is False
+
+
+# ---------------------------------------------------------------------------
+# declared_files_for_slice / build_allowed_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_declared_files_for_slice_returns_tokenized_list():
+    text = "### Slice 1: alpha\n**Depends-on:** none\n**Files:** `a.ts`, `b.ts`\n"
+    assert build_slice_scope.declared_files_for_slice(text, "1") == ["a.ts", "b.ts"]
+
+
+def test_declared_files_for_slice_empty_when_undeclared():
+    text = "### Slice 1: alpha\n**Depends-on:** none\n"
+    assert build_slice_scope.declared_files_for_slice(text, "1") == []
+
+
+def test_build_allowed_patterns_includes_bookkeeping_allowlist(tmp_path):
+    plan_path = tmp_path / "myplan.md"
+    text = "### Slice 1: alpha\n**Depends-on:** none\n**Files:** `a.ts`\n"
+    patterns = build_slice_scope.build_allowed_patterns(plan_path, text, "1")
+    assert patterns == ["a.ts", "myplan.md", "memory/**", "metrics/**"]
+
+
+# ---------------------------------------------------------------------------
+# write_freeze_state / clear_freeze_state
+# ---------------------------------------------------------------------------
+
+
+def test_write_freeze_state_writes_expected_contract(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    path = build_slice_scope.write_freeze_state(hooks_dir, ["a.ts", "memory/**"])
+    data = json.loads(path.read_text())
+    assert data["active"] is True
+    assert data["allowed_patterns"] == ["a.ts", "memory/**"]
+    assert "frozen_at" in data
+
+
+def test_clear_freeze_state_removes_the_file(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    build_slice_scope.write_freeze_state(hooks_dir, ["a.ts"])
+    assert (hooks_dir / build_slice_scope.FREEZE_STATE_FILENAME).exists()
+    build_slice_scope.clear_freeze_state(hooks_dir)
+    assert not (hooks_dir / build_slice_scope.FREEZE_STATE_FILENAME).exists()
+
+
+def test_clear_freeze_state_is_a_no_op_when_absent(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    # Should not raise.
+    build_slice_scope.clear_freeze_state(hooks_dir)
+
+
+# ---------------------------------------------------------------------------
+# Integration with hooks/pre_tool_guard.py (issue #865 AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_engaged_freeze_blocks_writes_outside_declared_scope(tmp_path):
+    sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
+    import pre_tool_guard  # noqa: E402
+
+    hooks_dir = tmp_path / "hooks"
+    plan_path = tmp_path / "plan.md"
+    text = "### Slice 1: alpha\n**Depends-on:** none\n**Files:** `a.ts`\n"
+    allowed = build_slice_scope.build_allowed_patterns(plan_path, text, "1")
+    build_slice_scope.write_freeze_state(hooks_dir, allowed)
+
+    exit_code, lines = pre_tool_guard.evaluate(
+        "out-of-scope.ts", hooks_dir / "guards.json", hooks_dir / "freeze-state.json"
+    )
+    assert exit_code == 2
+    assert any("BLOCKED" in line for line in lines)
+
+    exit_code, lines = pre_tool_guard.evaluate(
+        "a.ts", hooks_dir / "guards.json", hooks_dir / "freeze-state.json"
+    )
+    assert exit_code == 0
+
+    # Bookkeeping allowlist entries are honored too.
+    exit_code, lines = pre_tool_guard.evaluate(
+        "memory/build-phase.json", hooks_dir / "guards.json", hooks_dir / "freeze-state.json"
+    )
+    assert exit_code == 0

--- a/plugins/dev-team/tests/scripts/test_plan_parse.py
+++ b/plugins/dev-team/tests/scripts/test_plan_parse.py
@@ -113,6 +113,91 @@ def test_no_slices_yields_empty():
 
 
 # ---------------------------------------------------------------------------
+# Behavioural tests — issue #865: plan-as-contract optional fields
+# ---------------------------------------------------------------------------
+
+
+def test_slice_with_no_optional_fields_parses_unchanged():
+    """A slice using none of the three new fields still parses via
+    parse_slices exactly as before, and parse_slice_optional_fields reports
+    empty invariants/rollback for it."""
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `one.ts`
+"""
+    assert _rows(md) == [("1", "none", "one.ts")]
+    fields = plan_parse.parse_slice_optional_fields(md.splitlines())
+    assert fields["1"] == {"invariants": [], "rollback_point": ""}
+
+
+def test_invariants_and_rollback_point_are_collected_per_slice():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `a.ts`
+**Invariants:** `npm test -- --grep "session"`, `python3 scripts/check_md_references.py`
+**Rollback point:** slice-start
+"""
+    fields = plan_parse.parse_slice_optional_fields(md.splitlines())
+    assert fields["1"]["invariants"] == [
+        'npm test -- --grep "session"',
+        "python3 scripts/check_md_references.py",
+    ]
+    assert fields["1"]["rollback_point"] == "slice-start"
+
+
+def test_rollback_point_accepts_explicit_ref():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Rollback point:** abc1234
+"""
+    fields = plan_parse.parse_slice_optional_fields(md.splitlines())
+    assert fields["1"]["rollback_point"] == "abc1234"
+
+
+def test_invariants_comma_split_fallback_when_no_backticks():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Invariants:** npm test, python3 scripts/check.py
+"""
+    fields = plan_parse.parse_slice_optional_fields(md.splitlines())
+    assert fields["1"]["invariants"] == ["npm test", "python3 scripts/check.py"]
+
+
+def test_optional_fields_are_slice_level_only_step_level_ignored():
+    md = """### Slice 1: First
+**Depends-on:** none
+#### Step 1.1: do it
+**Invariants:** `should-be-ignored`
+**Rollback point:** should-be-ignored
+"""
+    fields = plan_parse.parse_slice_optional_fields(md.splitlines())
+    assert fields["1"] == {"invariants": [], "rollback_point": ""}
+
+
+def test_step_files_union_collects_per_step_files_only():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `slice-level.ts`
+#### Step 1.1: do it
+**Files**: `a.ts`
+#### Step 1.2: do more
+**Files**: `b.ts`, `a.ts`
+"""
+    result = plan_parse.parse_step_files(md.splitlines())
+    assert result == {"1": ["`a.ts`", "`b.ts`, `a.ts`"]}
+    union = plan_parse.step_files_union(md.splitlines())
+    assert union == {"1": ["a.ts", "b.ts"]}
+
+
+def test_step_files_union_empty_when_no_step_files():
+    md = """### Slice 1: First
+**Depends-on:** none
+**Files:** `slice-level.ts`
+"""
+    assert plan_parse.step_files_union(md.splitlines()) == {}
+
+
+# ---------------------------------------------------------------------------
 # Byte-parity against the bash implementation
 # ---------------------------------------------------------------------------
 

--- a/plugins/dev-team/tests/scripts/test_plan_waves.py
+++ b/plugins/dev-team/tests/scripts/test_plan_waves.py
@@ -108,6 +108,124 @@ def test_compute_waves_rejects_empty_plan(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
+# scope_mismatches (issue #865)
+# ---------------------------------------------------------------------------
+
+
+def test_scope_mismatches_empty_when_no_slice_declares_files(tmp_path):
+    """Fieldless plan (AC1): scope_mismatches is always present, [] here."""
+    plan = tmp_path / "plan.md"
+    plan.write_text("### Slice A: alpha\n**Depends-on:** none\n")
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == []
+
+
+def test_scope_mismatches_empty_when_declared_matches_inferred(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `a.ts`, `b.ts`\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `a.ts`\n"
+        "#### Step A.2: do more\n"
+        "**Files**: `b.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == []
+
+
+def test_scope_mismatch_flags_under_declared_the_dangerous_direction(tmp_path):
+    """A step touches a file the slice never declared."""
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `a.ts`\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `a.ts`, `undeclared.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == [
+        {
+            "slice": "A",
+            "declared": ["a.ts"],
+            "inferred": ["a.ts", "undeclared.ts"],
+            "under_declared": ["undeclared.ts"],
+            "over_declared": [],
+        }
+    ]
+
+
+def test_scope_mismatch_flags_over_declared_nothing_touches_it(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `a.ts`, `never-touched.ts`\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `a.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == [
+        {
+            "slice": "A",
+            "declared": ["a.ts", "never-touched.ts"],
+            "inferred": ["a.ts"],
+            "under_declared": [],
+            "over_declared": ["never-touched.ts"],
+        }
+    ]
+
+
+def test_scope_mismatch_glob_pattern_covers_inferred_literal(tmp_path):
+    """AC9: a declared glob covers an inferred literal via fnmatch."""
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `src/auth/*`\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `src/auth/session.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == []
+
+
+def test_scope_mismatch_absent_for_slice_with_no_declared_files(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `anything.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["scope_mismatches"] == []
+
+
+def test_conservative_collision_uses_declared_plus_inferred_union(tmp_path):
+    """Same-wave collision detection is conservative (#865): a file only
+    referenced at step level (never declared) still trips a collision
+    against another slice's overlapping write."""
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice A: alpha\n"
+        "**Depends-on:** none\n"
+        "**Files:** `a.ts`\n"
+        "#### Step A.1: do it\n"
+        "**Files**: `shared.ts`\n"
+        "### Slice B: beta\n"
+        "**Depends-on:** none\n"
+        "**Files:** `shared.ts`\n"
+    )
+    payload = plan_waves.compute_waves(plan)
+    assert payload["collisions"] == [
+        {"wave": 1, "slices": ["A", "B"], "file": "shared.ts"}
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Byte-parity against plan-waves.sh
 # ---------------------------------------------------------------------------
 

--- a/plugins/dev-team/tests/scripts/test_run_invariants.py
+++ b/plugins/dev-team/tests/scripts/test_run_invariants.py
@@ -1,0 +1,89 @@
+"""Unit tests for scripts/run_invariants.py (issue #865).
+
+Covers running a slice's declared Invariants commands from the repo root
+after the slice's own suite is green: a non-zero exit fails the slice gate
+exactly like a red test, and the failing command is named.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import run_invariants  # noqa: E402
+
+
+def test_all_passing_invariants_returns_every_result():
+    results = run_invariants.run_invariants(["true", "true"], repo_root=".")
+    assert len(results) == 2
+    assert all(r.returncode == 0 for r in results)
+
+
+def test_stops_at_first_failure_and_names_it():
+    results = run_invariants.run_invariants(
+        ["true", "false", "true"], repo_root="."
+    )
+    # Stops after the failing command — the third command never runs.
+    assert [r.command for r in results] == ["true", "false"]
+    assert results[-1].returncode != 0
+
+
+def test_runs_from_the_given_repo_root(tmp_path):
+    (tmp_path / "marker.txt").write_text("present\n")
+    results = run_invariants.run_invariants(
+        ["test -f marker.txt"], repo_root=str(tmp_path)
+    )
+    assert results[0].returncode == 0
+
+
+def test_invariants_for_slice_extracts_declared_commands(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "### Slice 1: alpha\n"
+        "**Depends-on:** none\n"
+        "**Invariants:** `true`, `echo ok`\n"
+    )
+    commands = run_invariants.invariants_for_slice(plan, "1")
+    assert commands == ["true", "echo ok"]
+
+
+def test_invariants_for_slice_empty_when_undeclared(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text("### Slice 1: alpha\n**Depends-on:** none\n")
+    assert run_invariants.invariants_for_slice(plan, "1") == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_0_and_reports_no_invariants_when_none_declared(
+    capsys, tmp_path
+):
+    plan = tmp_path / "plan.md"
+    plan.write_text("### Slice 1: alpha\n**Depends-on:** none\n")
+    exit_code = run_invariants.main(["--plan", str(plan), "--slice", "1"])
+    assert exit_code == 0
+    assert "nothing to run" in capsys.readouterr().out
+
+
+def test_main_returns_nonzero_and_names_failing_command(capsys):
+    exit_code = run_invariants.main(["--", "true", "false"])
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "[FAIL] false" in captured.out
+    assert "false" in captured.err
+
+
+def test_main_requires_slice_with_plan(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text("### Slice 1: alpha\n**Depends-on:** none\n")
+    try:
+        run_invariants.main(["--plan", str(plan)])
+        assert False, "expected SystemExit from argparse.error"
+    except SystemExit as exc:
+        assert exc.code != 0

--- a/scripts/progress_guardian.py
+++ b/scripts/progress_guardian.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import re
 import subprocess
@@ -61,16 +62,22 @@ def _extract_declared_paths(text: str) -> List[str]:
 
 
 def _is_path_declared(file_path: str, declared_paths) -> bool:
-    """True if file_path exactly matches a declared file, or falls under
-    a declared directory (trailing '/') prefix. Single source of truth
-    shared by check_commit_discipline and check_scope so the two checks
-    cannot drift on what counts as "declared" (see issue #525/#713).
+    """True if file_path exactly matches a declared file, falls under
+    a declared directory (trailing '/') prefix, or matches a declared glob
+    pattern (fnmatch, stdlib — issue #865 AC9, e.g. `src/auth/**`). Single
+    source of truth shared by check_commit_discipline, check_scope, and
+    check_declared_scope_adherence so these checks cannot drift on what
+    counts as "declared" (see issue #525/#713/#865).
     """
     for declared in declared_paths:
         if declared.endswith("/"):
             if file_path.startswith(declared):
                 return True
         elif file_path == declared:
+            return True
+        elif any(ch in declared for ch in "*?[") and fnmatch.fnmatch(
+            file_path, declared
+        ):
             return True
     return False
 
@@ -585,6 +592,70 @@ def check_verify_log(repo_root: str, changed_files: List[str]) -> List[dict]:
     ]
 
 
+def _all_slice_headers(steps: List[Step]) -> List[str]:
+    """Return the subset of Build Progress checkbox headers that are slice
+    headers (`"Slice N: <title>"`), not step headers — the shape
+    `_parse_slice_files` expects (issue #865 AC8)."""
+    return [s.header for s in steps if s.header.startswith("Slice ")]
+
+
+def check_declared_scope_adherence(
+    steps: List[Step], plan_path: Path, repo_root: str, plan_text: str
+) -> List[dict]:
+    """Issue #865 AC8: compare the branch diff against the union of every
+    slice's declared `**Files:**` scope (fnmatch-aware, glob-capable).
+
+    This is a **named WARNING only** — never a pre-PR gate failure. When a
+    plan opts into `Scope enforcement: freeze` (see `build_slice_scope.py`),
+    freeze itself is the real enforcement mechanism (a blocked Write/Edit);
+    this check exists for the *unfrozen* case, where out-of-scope edits are
+    otherwise invisible until `/code-review` or a human catches them.
+
+    Deterministic — no LLM call, unlike `check_scope` (which reasons about
+    *all* backtick-quoted paths in the plan prose). A plan with no slice
+    declaring `**Files:**` has nothing to compare against and returns `[]`.
+    """
+    declared: List[str] = []
+    for header in _all_slice_headers(steps):
+        declared.extend(_parse_slice_files(plan_text, header))
+    if not declared:
+        return []
+
+    changed_files = _collect_branch_changed_files(repo_root)
+    plan_name = plan_path.name
+    changed_files = [
+        f
+        for f in changed_files
+        if f != plan_name
+        and not f.endswith(plan_name)
+        and not (f.startswith("metrics/") and f.endswith(".jsonl"))
+        and not f.startswith("memory/")
+    ]
+    if not changed_files:
+        return []
+
+    out_of_scope = sorted(f for f in changed_files if not _is_path_declared(f, declared))
+    if not out_of_scope:
+        return []
+
+    return [
+        make_issue(
+            "warning",
+            message=(
+                "Scope adherence: out-of-scope edit(s) without freeze: "
+                f"{', '.join(out_of_scope)} not covered by any slice's declared "
+                f"Files ({', '.join(sorted(set(declared)))})."
+            ),
+            suggested_fix=(
+                "Reconcile the plan's Files declarations, or engage scope "
+                "enforcement (`**Scope enforcement:** freeze`) so out-of-scope "
+                "writes are blocked rather than merely warned about."
+            ),
+            rule_id="declared-scope-warning",
+        )
+    ]
+
+
 def check_scope(plan_path: Path, repo_root: str, skip_llm: bool) -> List[dict]:
     """Detect files in the branch diff that aren't declared in the plan.
 
@@ -800,6 +871,15 @@ def main(argv: Optional[List[str]] = None) -> int:
             verify_changed_files = _collect_branch_changed_files(repo_root)
             verify_issues = check_verify_log(repo_root, verify_changed_files)
             errors.extend(verify_issues)
+
+            # 7. Declared-scope adherence (issue #865 AC8): named warning
+            # only, never a gate failure — freeze (when engaged) is the
+            # real enforcement mechanism.
+            warnings.extend(
+                check_declared_scope_adherence(
+                    steps, plan_path, repo_root, plan_text
+                )
+            )
 
     result = build_result(errors, warnings)
     return main_exit(result)

--- a/tests/scripts/test_progress_guardian.py
+++ b/tests/scripts/test_progress_guardian.py
@@ -817,6 +817,94 @@ def test_6e_pre_pr_with_docs_only_changes_skips_the_verify_log_check(
     assert data["issues"] == [], data
 
 
+def test_865_1_pre_pr_with_matching_declared_scope_emits_no_warning(
+    tmp_path: Path,
+) -> None:
+    """Issue #865 AC8: a branch that only touches declared Files gets no
+    scope-adherence warning."""
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] Slice 1: do thing\n\n**Files:** `a.py`\n")
+    _write_verify_log(tmp_path, branch=_current_branch(tmp_path))
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert not any(
+        i.get("rule_id") == "declared-scope-warning" for i in data["issues"]
+    ), data
+
+
+def test_865_2_pre_pr_with_out_of_scope_edit_emits_named_warning_not_a_gate_failure(
+    tmp_path: Path,
+) -> None:
+    """Out-of-scope edits without freeze are a NAMED WARNING, never a
+    pre-PR gate failure (#865 Ambiguity Log Q2)."""
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    (tmp_path / "extra.py").write_text("out of scope\n")
+    _git(tmp_path, "add", "a.py", "extra.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing plus extra")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] Slice 1: do thing\n\n**Files:** `a.py`\n")
+    _write_verify_log(tmp_path, branch=_current_branch(tmp_path))
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    # Not a gate failure — exit 2 (warn) or better, never 1 (fail) for this
+    # reason. (--skip-llm's existing check_scope may also warn; either way
+    # returncode must never be 1 here.)
+    assert result.returncode != 1
+    data = json.loads(result.stdout)
+    warning = next(
+        i for i in data["issues"] if i.get("rule_id") == "declared-scope-warning"
+    )
+    assert warning["severity"] == "warning"
+    assert "extra.py" in warning["message"]
+
+
+def test_865_3_pre_pr_with_no_slice_declaring_files_emits_no_warning(
+    tmp_path: Path,
+) -> None:
+    """A plan where no slice declares Files has nothing to compare against."""
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "a.py").write_text("branch work\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] Slice 1: do thing\n")
+    _write_verify_log(tmp_path, branch=_current_branch(tmp_path))
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    data = json.loads(result.stdout)
+    assert not any(
+        i.get("rule_id") == "declared-scope-warning" for i in data["issues"]
+    ), data
+
+
+def test_865_4_glob_pattern_in_files_covers_matching_file(tmp_path: Path) -> None:
+    """Issue #865 AC9: glob patterns (fnmatch) are accepted in Files."""
+    _init_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "chore: initial")
+    (tmp_path / "session.py").write_text("branch work\n")
+    _git(tmp_path, "add", "session.py")
+    _git(tmp_path, "commit", "-q", "-m", "feat: do thing")
+    plan = tmp_path / "plan.md"
+    plan.write_text("- [x] Slice 1: do thing\n\n**Files:** `*.py`\n")
+    _write_verify_log(tmp_path, branch=_current_branch(tmp_path))
+
+    result = run_pg(plan, "--pre-pr", "--skip-llm")
+    data = json.loads(result.stdout)
+    assert not any(
+        i.get("rule_id") == "declared-scope-warning" for i in data["issues"]
+    ), data
+
+
 def test_6f_non_pre_pr_run_does_not_enforce_the_verify_log_check(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Implements issue #865 (spec generated via `/specs`, Verdict: PASS) — three new optional per-slice fields that make `/plan`'s execution contract explicit:

- **`Files`** — redefined from collision-detection input to declared write scope for the slice (still accepts globs via `fnmatch`, e.g. `src/auth/**`).
- **`Invariants`** — runnable shell commands that must stay green *beyond* the slice's own new acceptance tests.
- **`Rollback point`** — a symbolic commit boundary (`slice-start` / `wave-start` / `plan-start` / explicit ref) `/build` resolves to a concrete SHA at slice dispatch and records, so a dead-end escalation (issue #864) can name the exact revert target.

All three fields are **optional** — a plan omitting them parses, reviews, and builds exactly as today (AC1).

### Components

1. `plugins/dev-team/skills/plan/SKILL.md` + `references/plan-template.md` — documents the three fields, the top-level opt-in `**Scope enforcement:** freeze` metadata line, and surfaces `plan_waves.py`'s new `scope_mismatches` warning at the human gate (fix-or-acknowledge, not fix-before-gate).
2. `plugins/dev-team/scripts/lib/plan_parse.py` — new accessors: `parse_slice_optional_fields` (Invariants/Rollback point), `parse_step_files` / `step_files_union` (the inferred per-step write set). Existing `(id, depends, files)` TSV contract from `parse_slices` is unchanged. Also fixes `_clean_value` so a legitimate trailing glob (`src/auth/**`) survives markdown-bold stripping instead of being eaten as if it were a `**bold**` marker.
3. `plugins/dev-team/scripts/plan_waves.py` — emits an additive `scope_mismatches` array (`{slice, declared, inferred, under_declared, over_declared}`), a **warning only** (exit code stays 0; only the existing hard errors exit 2). Same-wave collision detection is now conservative over the declared+inferred union. Schema id stays `plan-waves/v1`.
4. `plugins/dev-team/scripts/build_slice_scope.py` (new) — resolves the `Scope enforcement: freeze` opt-in and writes/clears `hooks/freeze-state.json` (the same contract `/freeze` writes and `hooks/pre_tool_guard.py` enforces) scoped to a slice's declared `Files` plus a fixed bookkeeping allowlist (plan file, `memory/**`, `metrics/**`).
5. `plugins/dev-team/scripts/build_rollback_point.py` (new) — resolves a symbolic rollback value to a SHA and records/retrieves it per slice.
6. `plugins/dev-team/scripts/run_invariants.py` (new) — runs a slice's declared Invariants commands from the repo root; a non-zero exit fails the slice gate like a red test.
7. `plugins/dev-team/skills/build/SKILL.md` — wires all of the above into slice dispatch (freeze engage + rollback resolve/record), the slice gate (invariants run after the slice's own suite is green), and slice completion (freeze clear).
8. `scripts/progress_guardian.py` — `--pre-pr` gains `check_declared_scope_adherence`: branch diff vs. the union of declared slice scopes, a **named warning**, never a gate failure (out-of-scope-without-freeze resolution). `_is_path_declared` gains `fnmatch` glob support, shared by all scope checks.

### Ambiguity Log (already resolved in the issue, not re-litigated)

- Auto-freeze is opt-in via plan metadata (`Scope enforcement: freeze`) — declared `Files` alone only enables mismatch warnings.
- Out-of-scope edits without freeze are a named warning, not a pre-PR gate failure.

## Test plan

- [x] `pytest plugins/dev-team/tests` (818 passed, 16 pre-existing skips) — new coverage in `test_plan_parse.py`, `test_plan_waves.py`, `test_build_slice_scope.py`, `test_build_rollback_point.py`, `test_run_invariants.py`.
- [x] `pytest tests` at repo root (1914 passed, 3 pre-existing skips) — extended `test_progress_guardian.py` for the new declared-scope-adherence warning + glob support; regenerated `plugins/dev-team/knowledge/index.json` via `hooks/lib/build_knowledge_index.py write` after the SKILL.md edits.
- [x] `python3 scripts/check_md_references.py` — clean, exit 0.
- [x] Verified byte-parity / no-break on existing `plan_parse.py` / `plan_waves.py` / `progress_guardian.py` tests (all still green — additive changes only).
- Pre-existing, unrelated failures confirmed identical on `origin/main` before this branch: `test_mypy_adapter.py` (missing `jsonschema`), `test_codebase_recon.py` / `test_orchestrator.py` (missing `jsonschema`/`pytest-asyncio`) — not touched by this change.

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_