### PR TITLE
feat: add validated-outcome weighting to feedback-learning lessons

### DIFF
--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -77,7 +77,7 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | Exploratory Testing | `skills/exploratory-testing/SKILL.md` | ~900 | QA Engineer, `/explore` command |
 | Farley Score | `skills/farley-score/SKILL.md` | 600 | QA Engineer, `/build` (final branch score), `/test-design` (all existing tests; reached by `/test-health` via `/test-design`) |
 | Feature File Validation | `skills/feature-file-validation/SKILL.md` | 700 | test-review, QA Engineer, spec-compliance-review |
-| Feedback & Learning | `skills/feedback-learning/SKILL.md` | 1,010 | Orchestrator |
+| Feedback & Learning | `skills/feedback-learning/SKILL.md` | 1,400 | Orchestrator |
 | Gherkin Derive | `skills/gherkin-derive/SKILL.md` | ~700 | `/test-improve` (Phase 2b, conditional), QA Engineer, standalone |
 | Gherkin Public | `skills/gherkin-public/SKILL.md` | ~700 | Standalone worker; QA Engineer, Product Manager |
 | Governance & Compliance | `skills/governance-compliance/SKILL.md` | 990 | QA Engineer, Technical Writer |

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3112,6 +3112,14 @@
       "summary": "All changes are logged in `metrics/config-changelog.jsonl` (one JSON object per line, append-only).",
       "anchor": "audit-trail"
     },
+    "The `evidence` field (validated-outcome weighting, #866)": {
+      "summary": "Every new `amend`/`learn`/`remember` entry names how its own effect can be",
+      "anchor": "the-evidence-field-validated-outcome-weighting-866"
+    },
+    "Validation verdicts and rollback proposals (#866)": {
+      "summary": "`/harness-audit` reads this changelog and appends new `type: \"validation\"`",
+      "anchor": "validation-verdicts-and-rollback-proposals-866"
+    },
     "Change-contract schema extension (#860)": {
       "summary": "The nine fields below are **required only for entries that gate through",
       "anchor": "change-contract-schema-extension-860"
@@ -3414,21 +3422,25 @@
       "summary": "Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `performance-metrics`).",
       "anchor": "4-analyze-review-value-fix-rates"
     },
-    "5. Analyze model routing": {
+    "5. Lesson Validation — validated-outcome weighting (#866)": {
+      "summary": "Close the loop on `/feedback-learning` lessons: does an adopted lesson",
+      "anchor": "5-lesson-validation-validated-outcome-weighting-866"
+    },
+    "6. Analyze model routing": {
       "summary": "For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):",
-      "anchor": "5-analyze-model-routing"
+      "anchor": "6-analyze-model-routing"
     },
-    "6. Analyze orchestration complexity": {
+    "7. Analyze orchestration complexity": {
       "summary": "Review the current pipeline for components that may be unnecessary overhead:",
-      "anchor": "6-analyze-orchestration-complexity"
+      "anchor": "7-analyze-orchestration-complexity"
     },
-    "7. Produce report": {
+    "8. Produce report": {
       "summary": "Write the report to the output path using this structure:",
-      "anchor": "7-produce-report"
+      "anchor": "8-produce-report"
     },
-    "8. Present results": {
+    "9. Present results": {
       "summary": "Display a summary of the report and the file path.",
-      "anchor": "8-present-results"
+      "anchor": "9-present-results"
     },
     "Error Handling": {
       "summary": "Missing metrics files: Report what's missing, suggest how to generate data",

--- a/plugins/dev-team/skills/feedback-learning/SKILL.md
+++ b/plugins/dev-team/skills/feedback-learning/SKILL.md
@@ -168,14 +168,19 @@ All changes are logged in `metrics/config-changelog.jsonl` (one JSON object per 
   "section_modified": "Agent Overrides > Software Engineer",
   "previous_value": "",
   "new_value": "- Prefer functional programming patterns over OOP",
-  "approved_by": "user"
+  "approved_by": "user",
+  "evidence": {
+    "metrics": ["rework"],
+    "direction": "decrease",
+    "window_sessions": 10
+  }
 }
 ```
 
 | Field | Required | Description |
 | --- | --- | --- |
 | `timestamp` | Yes | ISO 8601 |
-| `type` | Yes | `amend`, `learn`, `remember`, `forget`, `rollback` |
+| `type` | Yes | `amend`, `learn`, `remember`, `forget`, `rollback`, `validation` |
 | `trigger` | Yes | `user` or `system` (learning loop) |
 | `description` | Yes | Human-readable summary |
 | `file_modified` | Yes | Path of the file changed |
@@ -183,6 +188,77 @@ All changes are logged in `metrics/config-changelog.jsonl` (one JSON object per 
 | `previous_value` | Yes | Content before (empty string if new) |
 | `new_value` | Yes | Content after (empty string if removed) |
 | `approved_by` | Yes | `user` or `auto` |
+| `evidence` | Yes on `amend`/`learn`/`remember` entries (#866) | Either a structured object or the literal string `"unmeasurable"` — see below. Never silently absent. |
+
+### The `evidence` field (validated-outcome weighting, #866)
+
+Every new `amend`/`learn`/`remember` entry names how its own effect can be
+checked, so `/harness-audit` can later close the loop instead of letting
+lessons accumulate on the strength of the approval that admitted them alone.
+
+**Structured case** — the lesson is expected to move a metric in
+`metrics/session-digest.jsonl`:
+
+```json
+"evidence": {
+  "metrics": ["rework"],
+  "direction": "decrease",
+  "window_sessions": 10
+}
+```
+
+- `metrics`: one or more metric names resolvable in a `session-digest.jsonl`
+  record (e.g. `rework`, `accuracy`, `cost_usd`, or a dotted path such as
+  `rework.failed_edits`).
+- `direction`: `"increase"` or `"decrease"` — which way the metric should move
+  if the lesson helped.
+- `window_sessions`: integer N — how many digest records after adoption to
+  observe before judging. **Default: 10** (mirrors `/harness-audit`'s existing
+  "minimum 10 logged review runs" floor).
+
+**Unmeasurable case** — when no digest metric can plausibly reflect the
+lesson's effect (most prose `memory/` notes land here), write the literal
+string instead of an object:
+
+```json
+"evidence": "unmeasurable"
+```
+
+**Default when the author names no metric**: `evidence: rework` with
+`direction: "decrease"` and `window_sessions: 10` — most lessons aim to
+reduce rework, so this is the default rather than refusing to log the
+lesson. Authors can still explicitly set a different metric, direction, or
+`"unmeasurable"`.
+
+**Prose lessons (`memory/` notes) are in scope.** The `evidence` field
+attaches at this changelog layer regardless of which resolution-order
+destination the lesson was written to; a memory-note lesson typically carries
+`"unmeasurable"`. Anything not logged to `metrics/config-changelog.jsonl` is
+out of scope by construction.
+
+**Legacy entries** (written before this field existed) have no `evidence`
+key at all. `/harness-audit` surfaces them as a count — it never assigns
+them a verdict or proposes a rollback on evidence grounds.
+
+### Validation verdicts and rollback proposals (#866)
+
+`/harness-audit` reads this changelog and appends new `type: "validation"`
+entries recording a verdict (`validated` / `neutral` / `harmful` / `insufficient
+data`) for every matured, structured-evidence lesson — see
+[harness-audit](../harness-audit/SKILL.md) → Lesson Validation. These
+verdict entries are **new appended lines**, never edits to the original
+entry; the changelog stays append-only.
+
+A `harmful` verdict produces a **rollback proposal** in the harness-audit
+report (never an automatic rollback). To action one:
+
+1. Locate the original entry by the proposal's `references_timestamp`.
+2. Follow the existing [Rollback](#rollback) procedure below using that
+   entry's `file_modified` / `section_modified` / `previous_value`.
+3. Log the rollback as usual — a new `type: "rollback"` entry.
+
+A human always decides whether to apply a harmful-verdict rollback; the
+validation pass only ever proposes.
 
 ### Change-contract schema extension (#860)
 
@@ -331,3 +407,5 @@ content entries safely).
 - Never auto-apply without user preview for structural modifications
 - Behavioral tweaks (tone, preferences) can be auto-applied; structural changes (new sections, removed overrides) require approval
 - The changelog is append-only — never delete entries
+- Every new `amend`/`learn`/`remember` entry carries an `evidence` field — a structured object or `"unmeasurable"`, never silently absent (#866)
+- A `harmful` validation verdict from `/harness-audit` is a rollback *proposal* only — never auto-apply it without user confirmation

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   use /agent-readiness).
 argument-hint: "[--output <path>]"
 user-invocable: true
-allowed-tools: Read, Glob, Grep, Bash(date *), Write
+allowed-tools: Read, Glob, Grep, Bash(date *, python3 *, jq *), Write
 ---
 
 # Harness Audit
@@ -90,7 +90,7 @@ section.
    before the `model` field existed carries no false signal either way.
 3. Read the current session's model from `metrics/session-digest.jsonl`
    (the most recent record's model field) or session metadata.
-4. Compare. **On mismatch**, the report (Step 7) gains a **Re-baseline
+4. Compare. **On mismatch**, the report (Step 8) gains a **Re-baseline
    Required** section instructing the operator to re-run the eval suite and
    re-write the baseline (`/agent-eval` full suite + `eval_variance.py
    --write-baseline --model <current-model>`) before trusting any pre/post
@@ -144,7 +144,64 @@ For each drop candidate emit a recommendation in this form:
 
 Do not modify any skill or agent file. The report is the only artifact.
 
-### 5. Analyze model routing
+### 5. Lesson Validation — validated-outcome weighting (#866)
+
+Close the loop on `/feedback-learning` lessons: does an adopted lesson
+measurably help, or should it become a rollback candidate? This step is
+**report-only**, consistent with the orchestrator constraints above — it
+never edits an agent, skill, or CLAUDE.md file, and a `harmful` verdict is
+always a *proposal*, never an automatic rollback.
+
+Reads `metrics/config-changelog.jsonl` (written by `/feedback-learning`,
+schema in [feedback-learning](../feedback-learning/SKILL.md) → Audit Trail)
+and `metrics/session-digest.jsonl` (this command's existing Step 1 input).
+Both are metrics-only — no prompt or code content, consistent with the
+session-review privacy boundary.
+
+Run the deterministic helper (pure stdlib, zero model tokens for the
+computation):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/harness-audit/scripts/lesson_validate.py \
+  --changelog metrics/config-changelog.jsonl \
+  --digest metrics/session-digest.jsonl \
+  --apply -o memory/lesson-validation.json
+```
+
+- **`--apply`** appends new `type: "validation"` entries to
+  `metrics/config-changelog.jsonl` for every newly-judged lesson — this is an
+  **append-only** write (new lines only); it never rewrites or deletes an
+  existing line. Verify this yourself if in doubt: a byte-for-byte diff of the
+  file before and after the run must show only appended lines.
+- Every **adopted lesson with structured evidence** (`amend`/`learn`/`remember`
+  entries whose `evidence` field is an object, not the literal string
+  `"unmeasurable"` and not absent) whose observation window has elapsed gets a
+  verdict:
+  - **validated** — the watched metric moved in the expected `direction`.
+  - **neutral** — the window elapsed, adequate data exists, no meaningful
+    movement either way.
+  - **harmful** — the watched metric moved against the expected `direction`.
+  - **insufficient data** — fewer than `window_sessions` digest records exist
+    on either side of adoption. This is a data condition, **never** reported
+    as `neutral` — small-N honesty over a false-precision judgment.
+  - Comparison is **direction-only** on window means (v1 — no significance
+    testing; the digest carries small-N aggregate counts where formal testing
+    would be false precision).
+- Entries marked `"unmeasurable"` and **legacy** entries (written before the
+  `evidence` field existed, so the key is absent) are **surfaced as counts
+  only** — they never receive a verdict and are never proposed for rollback
+  on evidence grounds.
+- Each **harmful** verdict emits a **rollback proposal** carrying the
+  original entry's `timestamp`, `file_modified`, `section_modified`, and
+  `previous_value` — enough for `/feedback-learning`'s existing
+  [Rollback](../feedback-learning/SKILL.md#rollback) flow to act on it after
+  a human approves. Never auto-apply.
+
+Include a **Lesson Validation** section in the report (Step 8) summarizing
+verdict counts, the unmeasurable/legacy counts, and the full list of rollback
+proposals.
+
+### 6. Analyze model routing
 
 For each agent listed in `knowledge/agent-registry.md` (with model tier from its `model:` frontmatter, resolved via the PreToolUse hook per `agents/orchestrator.md` → Resolution Procedure):
 
@@ -152,7 +209,7 @@ For each agent listed in `knowledge/agent-registry.md` (with model tier from its
 2. **Under-tiered agents**: Agents on haiku that frequently miss issues caught by human review may need a higher tier.
 3. **Cost distribution**: Which agents consume the most tokens? Are the most expensive agents also the most valuable?
 
-### 6. Analyze orchestration complexity
+### 7. Analyze orchestration complexity
 
 Review the current pipeline for components that may be unnecessary overhead:
 
@@ -160,7 +217,7 @@ Review the current pipeline for components that may be unnecessary overhead:
 2. **Review checkpoint frequency**: Are inline reviews running on every step? If most steps are trivial, the complexity classification (see `skills/plan/SKILL.md` § Complexity Classification) should be catching this.
 3. **Unused skills**: Skills loaded but never applied in logged sessions.
 
-### 7. Produce report
+### 8. Produce report
 
 Write the report to the output path using this structure:
 
@@ -221,6 +278,27 @@ Write the report to the output path using this structure:
 | Checkpoint | Agents | Runs | Fix rate | Issues fixed |
 |------------|--------|------|----------|--------------|
 
+## Lesson Validation (validated-outcome weighting, #866)
+
+> Source: `metrics/config-changelog.jsonl` × `metrics/session-digest.jsonl`.
+> Report-only — verdicts are appended as new `type: "validation"` entries;
+> harmful verdicts are rollback *proposals*, never automatic.
+
+### Verdicts
+| Lesson (`timestamp`) | Metric | Direction | Verdict |
+|---|---|---|---|
+
+### Rollback Proposals (harmful verdicts — human approval required)
+| Lesson (`timestamp`) | File | Section | Recommendation |
+|---|---|---|---|
+
+> To act on a rollback proposal: run `/feedback-learning` and confirm the
+> rollback against the `timestamp` above. Never applied automatically.
+
+### Unmeasurable / Legacy (surfaced, not judged)
+- Unmeasurable lessons: <count>
+- Legacy lessons (no `evidence` field): <count>
+
 ## Model Routing Recommendations
 
 | Agent | Current tier | Suggested tier | Rationale |
@@ -238,13 +316,15 @@ Write the report to the output path using this structure:
 - Review-value drop candidates: <count>
 - Review-value high-value checkpoints: <count>
 - Re-baseline required: <yes/no>
+- Lessons validated / neutral / harmful / insufficient data: <count> / <count> / <count> / <count>
+- Rollback proposals (harmful verdicts): <count>
 
 ## Next Steps
 
 <Actionable recommendations prioritized by impact>
 ```
 
-### 8. Present results
+### 9. Present results
 
 Display a summary of the report and the file path. Do not repeat the full report in chat — the file is the artifact.
 

--- a/plugins/dev-team/skills/harness-audit/scripts/lesson_validate.py
+++ b/plugins/dev-team/skills/harness-audit/scripts/lesson_validate.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Validated-outcome weighting for feedback-learning lessons (#866).
+
+Reads `metrics/config-changelog.jsonl` (written by `/feedback-learning`) and
+`metrics/session-digest.jsonl` (written by `/session-review`) and, for every
+adopted lesson that carries a structured `evidence` field and whose
+observation window has elapsed, compares the watched metric before vs. after
+adoption and records a verdict:
+
+  validated         watched metric moved in the expected `direction`
+  neutral           window elapsed, adequate data, no meaningful movement
+  harmful           watched metric moved against the expected `direction`
+  insufficient data fewer than `window_sessions` digest records exist on
+                    either side of adoption — never reported as `neutral`
+
+Lessons whose `evidence` is the literal string `"unmeasurable"`, or that
+predate the `evidence` field entirely (legacy), are counted but never
+assigned a verdict and never proposed for rollback on evidence grounds.
+
+This module is a pure library + a thin CLI. `/harness-audit` is report-only
+(it does not modify agents or configuration) — this script mirrors that: it
+can *append* new `type: "validation"` entries to the changelog (append-only,
+mirroring how rollbacks are already logged as new entries), but it never
+rewrites or deletes an existing line, and a `harmful` verdict only ever
+produces a rollback *proposal* for a human to action via `/feedback-learning`
+— never an automatic rollback.
+
+Usage:
+  lesson_validate.py --changelog metrics/config-changelog.jsonl \
+                      --digest metrics/session-digest.jsonl \
+                      [--apply] [-o report.json]
+
+  --apply   append `type: "validation"` entries for every newly-judged
+            lesson to the changelog file (still append-only). Without
+            --apply, the report is computed but nothing is written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LESSON_TYPES = {"amend", "learn", "remember"}
+DEFAULT_WINDOW_SESSIONS = 10
+DEFAULT_METRIC = "rework"
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file, skipping blank/malformed lines. Missing file -> []."""
+    if not path.exists():
+        return []
+    records = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def append_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    """Append records to a JSONL file. Never truncates or rewrites — the file
+    is opened in append mode only, so every pre-existing byte is preserved."""
+    if not records:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _parse_ts(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Evidence field validation (Acceptance Criterion: "declare evidence or opt out")
+# ---------------------------------------------------------------------------
+
+
+def has_valid_evidence(entry: dict[str, Any]) -> bool:
+    """True if a lesson-type entry's `evidence` field is either the literal
+    string "unmeasurable" or a structured object with metrics/direction/
+    window_sessions. False if absent or malformed."""
+    if "evidence" not in entry:
+        return False
+    evidence = entry["evidence"]
+    if evidence == "unmeasurable":
+        return True
+    if isinstance(evidence, dict):
+        return (
+            isinstance(evidence.get("metrics"), list)
+            and evidence.get("metrics")
+            and evidence.get("direction") in ("increase", "decrease")
+            and isinstance(evidence.get("window_sessions"), int)
+        )
+    return False
+
+
+def default_evidence(metrics: list[str] | None = None) -> dict[str, Any]:
+    """The default structured evidence block when a lesson author names a
+    metric but not a window, or names nothing at all (maintainer-resolved
+    default: metric=rework, window=10 — see issue #866 Ambiguity Log)."""
+    return {
+        "metrics": metrics or [DEFAULT_METRIC],
+        "direction": "decrease",
+        "window_sessions": DEFAULT_WINDOW_SESSIONS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Classification: structured evidence / unmeasurable / legacy
+# ---------------------------------------------------------------------------
+
+
+def classify_changelog_entries(
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Split lesson-type changelog entries into (structured, unmeasurable,
+    legacy). Only `amend`/`learn`/`remember` entries are lessons; `rollback`
+    and `validation` entries are ignored here."""
+    structured: list[dict] = []
+    unmeasurable: list[dict] = []
+    legacy: list[dict] = []
+    for entry in entries:
+        if entry.get("type") not in LESSON_TYPES:
+            continue
+        evidence = entry.get("evidence")
+        if "evidence" not in entry:
+            legacy.append(entry)
+        elif evidence == "unmeasurable":
+            unmeasurable.append(entry)
+        elif isinstance(evidence, dict) and has_valid_evidence(entry):
+            structured.append(entry)
+        else:
+            # Malformed evidence value — treat conservatively as legacy
+            # (surfaced, never judged) rather than guessing a verdict.
+            legacy.append(entry)
+    return structured, unmeasurable, legacy
+
+
+# ---------------------------------------------------------------------------
+# Metric resolution over session-digest.jsonl records
+# ---------------------------------------------------------------------------
+
+
+def resolve_metric(record: dict[str, Any], metric_name: str) -> float | None:
+    """Resolve a metric name to a numeric value on a session-digest record.
+    Supports the named aggregate aliases plus a dotted-path fallback (e.g.
+    "rework.failed_edits")."""
+    if metric_name == "rework":
+        rework = record.get("rework")
+        if not isinstance(rework, dict):
+            return None
+        values = [v for v in rework.values() if isinstance(v, (int, float))]
+        return float(sum(values)) if values else None
+    if metric_name == "accuracy":
+        accuracy = record.get("accuracy")
+        if not isinstance(accuracy, dict):
+            return None
+        val = accuracy.get("tool_error_rate")
+        return float(val) if isinstance(val, (int, float)) else None
+    if metric_name == "cost_usd":
+        val = record.get("cost_usd")
+        return float(val) if isinstance(val, (int, float)) else None
+
+    node: Any = record
+    for part in metric_name.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return float(node) if isinstance(node, (int, float)) else None
+
+
+# ---------------------------------------------------------------------------
+# Verdict computation
+# ---------------------------------------------------------------------------
+
+INSUFFICIENT_DATA = "insufficient data"
+
+
+def validate_lesson(
+    entry: dict[str, Any], digest_records: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Compute a verdict for one structured-evidence lesson entry against the
+    session-digest stream. Direction-only comparison of window means (v1 —
+    no significance testing, per the issue's Ambiguity Log)."""
+    evidence = entry["evidence"]
+    metric_name = evidence["metrics"][0]
+    direction = evidence["direction"]
+    window = evidence["window_sessions"]
+    adoption_ts = _parse_ts(entry["timestamp"])
+
+    dated = []
+    for record in digest_records:
+        ts = record.get("recorded_at")
+        if not ts:
+            continue
+        try:
+            dated.append((_parse_ts(ts), record))
+        except ValueError:
+            continue
+    dated.sort(key=lambda pair: pair[0])
+
+    before = [record for ts, record in dated if ts < adoption_ts]
+    after = [record for ts, record in dated if ts >= adoption_ts]
+
+    # Small-N honesty: fewer records than the declared window on either side
+    # is a data condition, never a "neutral" judgment.
+    if len(before) < window or len(after) < window:
+        return {
+            "verdict": INSUFFICIENT_DATA,
+            "references_timestamp": entry["timestamp"],
+            "metric": metric_name,
+        }
+
+    before_window = before[-window:]
+    after_window = after[:window]
+
+    before_vals = [
+        v for v in (resolve_metric(r, metric_name) for r in before_window) if v is not None
+    ]
+    after_vals = [
+        v for v in (resolve_metric(r, metric_name) for r in after_window) if v is not None
+    ]
+
+    if len(before_vals) < window or len(after_vals) < window:
+        return {
+            "verdict": INSUFFICIENT_DATA,
+            "references_timestamp": entry["timestamp"],
+            "metric": metric_name,
+        }
+
+    before_mean = statistics.fmean(before_vals)
+    after_mean = statistics.fmean(after_vals)
+
+    if after_mean == before_mean:
+        verdict = "neutral"
+    elif direction == "decrease":
+        verdict = "validated" if after_mean < before_mean else "harmful"
+    else:  # direction == "increase"
+        verdict = "validated" if after_mean > before_mean else "harmful"
+
+    return {
+        "verdict": verdict,
+        "references_timestamp": entry["timestamp"],
+        "metric": metric_name,
+        "direction": direction,
+        "before_mean": before_mean,
+        "after_mean": after_mean,
+        "window_sessions": window,
+    }
+
+
+def build_validation_entry(
+    entry: dict[str, Any], result: dict[str, Any], *, now: str | None = None
+) -> dict[str, Any]:
+    """Build a new `type: "validation"` changelog entry for a verdict. This is
+    always a *new* entry — callers must append it, never edit history."""
+    return {
+        "timestamp": now or _now_iso(),
+        "type": "validation",
+        "trigger": "system",
+        "description": (
+            f"Lesson validation for entry {entry['timestamp']}: "
+            f"{result['verdict']}"
+        ),
+        "references_timestamp": entry["timestamp"],
+        "verdict": result["verdict"],
+        "metric": result.get("metric"),
+        "before_mean": result.get("before_mean"),
+        "after_mean": result.get("after_mean"),
+        "approved_by": "system",
+    }
+
+
+def build_rollback_proposal(entry: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    """Build a rollback *proposal* for a harmful verdict. Carries everything
+    `/feedback-learning`'s existing rollback flow needs, but this is never
+    applied automatically — a human must approve it."""
+    return {
+        "proposal": "rollback",
+        "verdict": "harmful",
+        "references_timestamp": entry["timestamp"],
+        "timestamp": entry.get("timestamp"),
+        "file_modified": entry.get("file_modified"),
+        "section_modified": entry.get("section_modified"),
+        "previous_value": entry.get("previous_value"),
+        "requires_human_approval": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    changelog_entries: list[dict[str, Any]], digest_records: list[dict[str, Any]]
+) -> dict[str, Any]:
+    structured, unmeasurable, legacy = classify_changelog_entries(changelog_entries)
+
+    verdicts = []
+    new_validation_entries = []
+    rollback_proposals = []
+    for entry in structured:
+        result = validate_lesson(entry, digest_records)
+        verdicts.append({"entry": entry, "result": result})
+        new_validation_entries.append(build_validation_entry(entry, result))
+        if result["verdict"] == "harmful":
+            rollback_proposals.append(build_rollback_proposal(entry, result))
+
+    return {
+        "verdicts": verdicts,
+        "new_validation_entries": new_validation_entries,
+        "rollback_proposals": rollback_proposals,
+        "unmeasurable_count": len(unmeasurable),
+        "legacy_count": len(legacy),
+        "structured_count": len(structured),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", required=True, type=Path)
+    parser.add_argument("--digest", required=True, type=Path)
+    parser.add_argument("--apply", action="store_true", help="Append validation entries")
+    parser.add_argument("-o", "--output", type=Path, help="Write JSON report here")
+    args = parser.parse_args(argv)
+
+    changelog_entries = read_jsonl(args.changelog)
+    digest_records = read_jsonl(args.digest)
+    report = build_report(changelog_entries, digest_records)
+
+    if args.apply:
+        append_jsonl(args.changelog, report["new_validation_entries"])
+
+    output_json = json.dumps(
+        {
+            "structured_count": report["structured_count"],
+            "unmeasurable_count": report["unmeasurable_count"],
+            "legacy_count": report["legacy_count"],
+            "verdicts": [
+                {
+                    "references_timestamp": v["result"].get("references_timestamp"),
+                    "verdict": v["result"]["verdict"],
+                    "metric": v["result"].get("metric"),
+                }
+                for v in report["verdicts"]
+            ],
+            "rollback_proposals": report["rollback_proposals"],
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    if args.output:
+        args.output.write_text(output_json + "\n", encoding="utf-8")
+    else:
+        print(output_json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/tests/scripts/test_lesson_validate.py
+++ b/plugins/dev-team/tests/scripts/test_lesson_validate.py
@@ -1,0 +1,366 @@
+"""Unit tests for skills/harness-audit/scripts/lesson_validate.py (#866).
+
+Covers the Acceptance Criteria from issue #866:
+  - new lessons declare evidence or opt out explicitly
+  - every matured lesson gets a verdict
+  - thin data yields "insufficient data", never "neutral"
+  - harmful verdicts produce actionable rollback proposals
+  - verdicts never mutate history (append-only)
+  - unmeasurable / legacy lessons are surfaced, never judged
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(
+    0, str(_REPO_ROOT / "plugins" / "dev-team" / "skills" / "harness-audit" / "scripts")
+)
+
+import lesson_validate as lv  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _lesson_entry(
+    timestamp: str,
+    evidence,
+    *,
+    entry_type: str = "amend",
+    file_modified: str = "CLAUDE.md",
+    section_modified: str = "Agent Overrides > Software Engineer",
+    previous_value: str = "",
+    new_value: str = "- Prefer functional patterns",
+) -> dict:
+    entry = {
+        "timestamp": timestamp,
+        "type": entry_type,
+        "trigger": "user",
+        "description": "test lesson",
+        "file_modified": file_modified,
+        "section_modified": section_modified,
+        "previous_value": previous_value,
+        "new_value": new_value,
+        "approved_by": "user",
+    }
+    if evidence is not lv.DEFAULT_METRIC or True:
+        entry["evidence"] = evidence
+    return entry
+
+
+def _digest_record(recorded_at: str, rework_total: float) -> dict:
+    return {
+        "schema": "session-digest/v1",
+        "recorded_at": recorded_at,
+        "rework": {"failed_edits": rework_total},
+        "accuracy": {"tool_calls": 5, "tool_error_rate": 0.0, "user_correction_turns": 0},
+    }
+
+
+def _digest_series(start_day: int, count: int, values: list[float]) -> list[dict]:
+    """Build `count` digest records at 2026-01-<day>, one per day, using
+    `values` cyclically for the rework total."""
+    records = []
+    for i in range(count):
+        day = start_day + i
+        records.append(
+            _digest_record(f"2026-01-{day:02d}T00:00:00Z", values[i % len(values)])
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Evidence field validation
+# ---------------------------------------------------------------------------
+
+
+def test_structured_evidence_is_valid():
+    entry = _lesson_entry(
+        "2026-06-01T00:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    assert lv.has_valid_evidence(entry)
+
+
+def test_unmeasurable_literal_is_valid():
+    entry = _lesson_entry("2026-06-01T00:00:00Z", "unmeasurable")
+    assert lv.has_valid_evidence(entry)
+
+
+def test_missing_evidence_field_is_invalid():
+    entry = _lesson_entry("2026-06-01T00:00:00Z", "unmeasurable")
+    del entry["evidence"]
+    assert not lv.has_valid_evidence(entry)
+
+
+def test_malformed_evidence_object_is_invalid():
+    entry = _lesson_entry("2026-06-01T00:00:00Z", {"metrics": ["rework"]})  # no direction/window
+    assert not lv.has_valid_evidence(entry)
+
+
+def test_default_evidence_uses_rework_metric_and_window_10():
+    evidence = lv.default_evidence()
+    assert evidence["metrics"] == ["rework"]
+    assert evidence["window_sessions"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Classification: structured / unmeasurable / legacy
+# ---------------------------------------------------------------------------
+
+
+def test_classify_splits_structured_unmeasurable_and_legacy():
+    structured_entry = _lesson_entry(
+        "2026-06-01T00:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    unmeasurable_entry = _lesson_entry("2026-06-02T00:00:00Z", "unmeasurable")
+    legacy_entry = _lesson_entry("2026-06-03T00:00:00Z", "unmeasurable")
+    del legacy_entry["evidence"]
+
+    structured, unmeasurable, legacy = lv.classify_changelog_entries(
+        [structured_entry, unmeasurable_entry, legacy_entry]
+    )
+    assert structured == [structured_entry]
+    assert unmeasurable == [unmeasurable_entry]
+    assert legacy == [legacy_entry]
+
+
+def test_classify_ignores_non_lesson_entry_types():
+    rollback_entry = {"timestamp": "2026-06-01T00:00:00Z", "type": "rollback"}
+    structured, unmeasurable, legacy = lv.classify_changelog_entries([rollback_entry])
+    assert structured == unmeasurable == legacy == []
+
+
+def test_unmeasurable_and_legacy_never_receive_a_verdict_via_report():
+    unmeasurable_entry = _lesson_entry("2026-06-02T00:00:00Z", "unmeasurable")
+    legacy_entry = _lesson_entry("2026-06-03T00:00:00Z", "unmeasurable")
+    del legacy_entry["evidence"]
+
+    report = lv.build_report([unmeasurable_entry, legacy_entry], [])
+    assert report["verdicts"] == []
+    assert report["unmeasurable_count"] == 1
+    assert report["legacy_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Thin data -> insufficient data, never neutral
+# ---------------------------------------------------------------------------
+
+
+def test_insufficient_data_when_fewer_than_window_records_before_and_after():
+    entry = _lesson_entry(
+        "2026-01-10T00:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    # Only 3 records before, 3 after — well under the window of 10.
+    digest = _digest_series(1, 3, [5]) + _digest_series(11, 3, [1])
+    result = lv.validate_lesson(entry, digest)
+    assert result["verdict"] == lv.INSUFFICIENT_DATA
+
+
+def test_insufficient_data_when_only_after_side_is_thin():
+    entry = _lesson_entry(
+        "2026-01-20T00:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    digest = _digest_series(1, 15, [5]) + _digest_series(21, 2, [1])
+    result = lv.validate_lesson(entry, digest)
+    assert result["verdict"] == lv.INSUFFICIENT_DATA
+
+
+def test_report_never_emits_neutral_for_thin_data_only_insufficient():
+    entry = _lesson_entry(
+        "2026-01-10T00:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    digest = _digest_series(1, 2, [5]) + _digest_series(11, 2, [5])
+    report = lv.build_report([entry], digest)
+    verdict = report["verdicts"][0]["result"]["verdict"]
+    assert verdict == lv.INSUFFICIENT_DATA
+    assert verdict != "neutral"
+
+
+# ---------------------------------------------------------------------------
+# Matured lessons get a real verdict: validated / harmful / neutral
+# ---------------------------------------------------------------------------
+
+
+def test_validated_when_metric_moves_in_expected_decrease_direction():
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    # 10 sessions before adoption at rework=8, 10 after at rework=2 (decreased).
+    digest = _digest_series(1, 10, [8]) + _digest_series(12, 10, [2])
+    result = lv.validate_lesson(entry, digest)
+    assert result["verdict"] == "validated"
+
+
+def test_harmful_when_metric_moves_against_expected_decrease_direction():
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    # Expected rework to decrease, but it increased instead.
+    digest = _digest_series(1, 10, [2]) + _digest_series(12, 10, [8])
+    result = lv.validate_lesson(entry, digest)
+    assert result["verdict"] == "harmful"
+
+
+def test_neutral_when_adequate_data_shows_no_movement():
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    digest = _digest_series(1, 10, [4]) + _digest_series(12, 10, [4])
+    result = lv.validate_lesson(entry, digest)
+    assert result["verdict"] == "neutral"
+
+
+def test_every_matured_structured_lesson_appears_in_report_verdicts():
+    entries = [
+        _lesson_entry(
+            "2026-01-11T12:00:00Z",
+            {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+        ),
+        _lesson_entry(
+            "2026-01-15T12:00:00Z",
+            {"metrics": ["rework"], "direction": "increase", "window_sessions": 10},
+        ),
+    ]
+    digest = _digest_series(1, 20, [4])
+    report = lv.build_report(entries, digest)
+    references = {v["result"]["references_timestamp"] for v in report["verdicts"]}
+    assert references == {"2026-01-11T12:00:00Z", "2026-01-15T12:00:00Z"}
+    for v in report["verdicts"]:
+        assert v["result"]["verdict"] in {"validated", "neutral", "harmful", lv.INSUFFICIENT_DATA}
+
+
+# ---------------------------------------------------------------------------
+# Harmful verdicts -> actionable rollback proposals
+# ---------------------------------------------------------------------------
+
+
+def test_harmful_verdict_produces_rollback_proposal_with_required_fields():
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+        file_modified="CLAUDE.md",
+        section_modified="Agent Overrides > Software Engineer",
+        previous_value="- Old preference",
+    )
+    digest = _digest_series(1, 10, [2]) + _digest_series(12, 10, [8])
+    report = lv.build_report([entry], digest)
+
+    assert len(report["rollback_proposals"]) == 1
+    proposal = report["rollback_proposals"][0]
+    assert proposal["references_timestamp"] == "2026-01-11T12:00:00Z"
+    assert proposal["timestamp"] == "2026-01-11T12:00:00Z"
+    assert proposal["file_modified"] == "CLAUDE.md"
+    assert proposal["section_modified"] == "Agent Overrides > Software Engineer"
+    assert proposal["previous_value"] == "- Old preference"
+    assert proposal["requires_human_approval"] is True
+
+
+def test_validated_and_neutral_verdicts_produce_no_rollback_proposal():
+    validated_entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    neutral_entry = _lesson_entry(
+        "2026-01-12T12:00:00Z",
+        {"metrics": ["rework"], "direction": "increase", "window_sessions": 10},
+    )
+    digest = _digest_series(1, 10, [8]) + _digest_series(12, 10, [2])
+    report = lv.build_report([validated_entry, neutral_entry], digest)
+    assert report["rollback_proposals"] == []
+
+
+# ---------------------------------------------------------------------------
+# Append-only: verdicts never mutate history
+# ---------------------------------------------------------------------------
+
+
+def test_append_jsonl_preserves_every_existing_byte(tmp_path):
+    changelog = tmp_path / "config-changelog.jsonl"
+    original_lines = [
+        json.dumps({"timestamp": "2026-01-01T00:00:00Z", "type": "amend"}),
+        json.dumps({"timestamp": "2026-01-02T00:00:00Z", "type": "learn"}),
+    ]
+    changelog.write_text("\n".join(original_lines) + "\n", encoding="utf-8")
+    before_bytes = changelog.read_bytes()
+
+    lv.append_jsonl(changelog, [{"timestamp": "2026-01-03T00:00:00Z", "type": "validation"}])
+
+    after_bytes = changelog.read_bytes()
+    assert after_bytes[: len(before_bytes)] == before_bytes
+    assert len(after_bytes) > len(before_bytes)
+
+
+def test_main_apply_flag_only_appends_never_rewrites_existing_lines(tmp_path):
+    changelog = tmp_path / "config-changelog.jsonl"
+    digest = tmp_path / "session-digest.jsonl"
+
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    changelog.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+    digest_records = _digest_series(1, 10, [8]) + _digest_series(12, 10, [2])
+    digest.write_text("\n".join(json.dumps(r) for r in digest_records) + "\n", encoding="utf-8")
+
+    before_bytes = changelog.read_bytes()
+    exit_code = lv.main(
+        ["--changelog", str(changelog), "--digest", str(digest), "--apply"]
+    )
+    assert exit_code == 0
+
+    after_bytes = changelog.read_bytes()
+    assert after_bytes[: len(before_bytes)] == before_bytes
+    assert b'"type": "validation"' in after_bytes or b'"type":"validation"' in after_bytes
+
+
+def test_apply_writes_a_new_validation_entry_referencing_original_timestamp(tmp_path):
+    changelog = tmp_path / "config-changelog.jsonl"
+    digest = tmp_path / "session-digest.jsonl"
+
+    entry = _lesson_entry(
+        "2026-01-11T12:00:00Z",
+        {"metrics": ["rework"], "direction": "decrease", "window_sessions": 10},
+    )
+    changelog.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+    digest_records = _digest_series(1, 10, [8]) + _digest_series(12, 10, [2])
+    digest.write_text("\n".join(json.dumps(r) for r in digest_records) + "\n", encoding="utf-8")
+
+    lv.main(["--changelog", str(changelog), "--digest", str(digest), "--apply"])
+
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    new_entry = json.loads(lines[1])
+    assert new_entry["type"] == "validation"
+    assert new_entry["references_timestamp"] == "2026-01-11T12:00:00Z"
+    assert new_entry["verdict"] == "validated"
+
+
+# ---------------------------------------------------------------------------
+# Malformed / missing input tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_read_jsonl_returns_empty_list_for_missing_file(tmp_path):
+    assert lv.read_jsonl(tmp_path / "does-not-exist.jsonl") == []
+
+
+def test_read_jsonl_skips_malformed_lines(tmp_path):
+    path = tmp_path / "f.jsonl"
+    path.write_text('{"a": 1}\nnot json\n{"b": 2}\n', encoding="utf-8")
+    assert lv.read_jsonl(path) == [{"a": 1}, {"b": 2}]


### PR DESCRIPTION
## Summary

- `plugins/dev-team/skills/feedback-learning/SKILL.md`: config-changelog entries for `amend`/`learn`/`remember` now document a required `evidence` field — either a structured `{metrics, direction, window_sessions}` object or the literal string `"unmeasurable"`, never silently absent. Default when an author names no metric: `evidence: rework`, `direction: "decrease"`, `window_sessions: 10` (per the issue's human-resolved Ambiguity Log).
- `plugins/dev-team/skills/harness-audit/SKILL.md`: new Step 4, "Lesson Validation — validated-outcome weighting (#866)". For adopted lessons with structured evidence whose observation window has elapsed, compares the watched `session-digest.jsonl` metric before/after adoption and records `validated` / `neutral` / `harmful` / `insufficient data` (direction-only comparison of window means, v1). `insufficient data` is reported whenever fewer than `window_sessions` digest records exist on either side of adoption — never reported as `neutral`. Report-only: harness-audit still never modifies agents or configuration.
- `plugins/dev-team/skills/harness-audit/scripts/lesson_validate.py`: new stdlib-only Python helper implementing the comparison. Verdicts are appended as new `type: "validation"` entries in `metrics/config-changelog.jsonl` (append-only — never rewrites existing lines), referencing the original entry by `timestamp`. `harmful` verdicts emit a rollback *proposal* (never automatic) carrying the original entry's `timestamp`/`file_modified`/`section_modified`/`previous_value` for a human to action via `/feedback-learning`'s existing rollback flow. Unmeasurable and legacy (pre-`evidence`-field) entries are surfaced as counts only — never assigned a verdict, never proposed for rollback.
- `plugins/dev-team/knowledge/index.json` and `agent-registry.md` regenerated/updated to reflect the doc changes.

## Test plan

- [x] `plugins/dev-team/tests/scripts/test_lesson_validate.py` — 22 new tests covering: evidence-field validation (structured/unmeasurable/missing/malformed), classification (structured/unmeasurable/legacy), insufficient-data vs neutral (including the "never neutral on thin data" guarantee), validated/harmful/neutral verdict computation, rollback-proposal shape and required fields, append-only guarantees (byte-diff check on `append_jsonl` and on `main --apply`), and malformed/missing-file tolerance.
- [x] `python3 -m pytest plugins/dev-team/tests/ -q` → 809 passed, 16 skipped, 1 pre-existing failure unrelated to this change (`test_mypy_adapter.py` — missing `jsonschema` module in this environment, not part of `requirements-dev.txt` shipped deps used here).
- [x] `python3 -m pytest tests/ -q` (excluding `tests/security-assessment`, which needs `httpx`, and `test_codebase_recon.py`/`test_orchestrator.py`, which need `jsonschema`/`pytest-asyncio` — all pre-existing environment gaps) → 1910 passed, 3 skipped.
- [x] `python3 scripts/check_md_references.py` → clean, no findings.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` (regenerated `knowledge/index.json`) then `test_knowledge_index_current.py` / `test_knowledge_index_no_leak.py` / `test_recommendations_docs_sweep.py` → all pass.

Closes #866


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_