### PR TITLE
feat: /agent-eval --ablation mode — per-component pipeline outcome deltas

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1138,6 +1138,10 @@
       "summary": "Multi-trial pass@k stability trend for `/agent-eval` fixtures.",
       "anchor": "eval-variancejsonl"
     },
+    "`eval-ablation.jsonl`": {
+      "summary": "Causal per-agent ablation evidence from `/agent-eval --ablation <agent>` (#868):",
+      "anchor": "eval-ablationjsonl"
+    },
     "`refactor-freeze.jsonl`": {
       "summary": "Audit log for the tests-frozen-during-REFACTOR invariant (`#813`) — both the",
       "anchor": "refactor-freezejsonl"
@@ -1592,6 +1596,10 @@
       "summary": "`/agent-eval` dispatches at one of three tiers, in increasing confidence and",
       "anchor": "confidence-pyramid"
     },
+    "Ablation mode (`--ablation <agent>`, #868)": {
+      "summary": "Gives `/harness-audit` **causal** drop-candidate evidence instead of the",
+      "anchor": "ablation-mode-ablation-agent-868"
+    },
     "Cache (fingerprint replay)": {
       "summary": "`scripts/eval_cache.py` SHAs each `fixture::target` over the target's",
       "anchor": "cache-fingerprint-replay"
@@ -1617,7 +1625,7 @@
       "anchor": "2-load-fixtures-and-expected-results"
     },
     "3. Run agents against fixtures": {
-      "summary": "If `--integration` is set, skip the rest of this section and dispatch",
+      "summary": "If `--ablation <agent>` is set, skip the rest of this section and follow",
       "anchor": "3-run-agents-against-fixtures"
     },
     "4. Grade each result": {

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -265,6 +265,30 @@ Multi-trial pass@k stability trend for `/agent-eval` fixtures.
 
 ---
 
+## `eval-ablation.jsonl`
+
+Causal per-agent ablation evidence from `/agent-eval --ablation <agent>` (#868):
+a controlled baseline-vs-ablated integration-tier delta (issues caught,
+`testCommands` results, token cost), not accumulated usage data.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `schema` | string | `eval-ablation/v1` |
+| `recorded_at` | string | ISO-8601 UTC |
+| `ablated_agent` | string | Target agent name |
+| `fixtures` | array of strings | Integration fixtures exercised |
+| `model` | string | Model version(s) used for orchestrator/builder dispatch — deltas are model-dependent, always recorded |
+| `baseline` | object | `{issues_caught, test_commands: [{command, exit_code}], tokens, grade}` — full roster arm |
+| `ablated` | object | Same shape as `baseline` — roster-minus-target-agent arm |
+| `delta` | object | `{issues_caught, test_commands_passed, tokens}` (ablated − baseline) |
+| `verdict` | string | e.g. `"no measured impact — supports drop"` / `"agent is load-bearing — retain"` / `"baseline failed — inconclusive"` |
+
+- **Emitter:** `scripts/eval_ablation.py --mode agent`.
+- **Consent:** unconditional (eval infra, not user-session telemetry); opt-in/label-gated dispatch per the live-eval cost policy (#134) — the record is only ever written after an explicit operator-confirmed live run.
+- **Consumers:** `skills/harness-audit/SKILL.md` (Step 3 drop-candidate recommendations cite the measured delta/verdict when a record exists).
+
+---
+
 ## `refactor-freeze.jsonl`
 
 Audit log for the tests-frozen-during-REFACTOR invariant (`#813`) — both the

--- a/plugins/dev-team/skills/agent-eval/SKILL.md
+++ b/plugins/dev-team/skills/agent-eval/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   adding or modifying a review agent, to validate detection accuracy, or
   when the user says "run the evals", "test the agents", "check for
   regressions", or "how accurate is the agent".
-argument-hint: "[--agent <name>] [--skill <name>] [--fixture <name>] [--trials <n>] [--in-session] [--integration] [--no-cache] [--verbose]"
+argument-hint: "[--agent <name>] [--skill <name>] [--fixture <name>] [--trials <n>] [--in-session] [--integration] [--ablation <agent>] [--no-cache] [--verbose]"
 user-invocable: true
 allowed-tools: >-
   Read, Grep, Glob,
   Bash(readlink *, ls *, date *, mkdir *, command -v claude, claude -p *,
        python3 scripts/eval_cache.py *, python3 scripts/run_integration_eval.py *,
+       python3 scripts/eval_variance.py *, python3 scripts/eval_ablation.py *,
        python3 scripts/citation_lint.py *),
   Skill(review-agent *), Skill(test-design-advisor *)
 ---
@@ -63,6 +64,16 @@ Arguments: $ARGUMENTS
   graded by the `integration` grader). Cannot be combined with `--agent`
   or `--skill` — integration fixtures target the orchestrator, not a
   single reviewer.
+- `--ablation <agent>`: Causal drop-candidate evidence (#868). Implies the
+  integration tier and runs it **twice** — a baseline arm (full review-agent
+  roster) and an ablated arm (roster minus `<agent>`) — K=3 trials per arm,
+  then reports the outcome delta (issues caught, `testCommands` results,
+  token cost). See *Ablation mode* below for the full procedure. Rejected
+  in combination with `--agent`/`--skill` (integration fixtures target the
+  orchestrator) and with more than one target agent — v1 supports exactly
+  one ablated agent per run: "error: --ablation supports exactly one agent
+  per run (v1); combining with --agent/--skill or naming multiple agents
+  is not supported."
 - `--no-cache`: Bypass the fingerprint replay cache (see *Cache*
   below). Default is cache-on, so a pair whose transitive inputs are
   unchanged replays from `evals/.eval-cache.json` at zero token cost.
@@ -96,6 +107,100 @@ When the operator does not specify a tier, run **unit** and report in the
 final table how many fixtures would have routed to integration (the count of
 expected JSON files whose `integration` block is non-empty). That nudge keeps
 integration coverage visible without forcing every run to pay for it.
+
+## Ablation mode (`--ablation <agent>`, #868)
+
+Gives `/harness-audit` **causal** drop-candidate evidence instead of the
+correlational usage data it derives from `metrics/review-value.jsonl` alone:
+does removing this agent from the roster actually change integration-tier
+pipeline outcomes?
+
+**OPT-IN / LABEL-GATED — same policy as the integration tier (#134).** Before
+doing anything else, confirm the opt-in gate is present (a `run-integration`
+/ live-eval label on the invoking issue or PR, or the operator explicitly
+confirming a live, cost-incurring run in this session). If the gate is
+absent:
+
+```text
+refused: --ablation requires the label-gated live-eval opt-in (#134) — the
+same policy that gates the integration tier. Add the `run-integration` label
+or have the operator explicitly confirm a live run, then retry. Nothing was
+dispatched; nothing was written to metrics/.
+```
+
+Stop there — dispatch nothing, write nothing to `metrics/`.
+
+**Argument validation.** Reject before any dispatch if `--ablation` is
+combined with `--agent`/`--skill`, or if more than one agent is named (v1 is
+single-agent only — see *Parse Arguments* above for the exact error text).
+
+**Fixtures.** Default to every expected JSON with a non-empty `integration`
+block (narrow with `--fixture <name>`).
+
+**Cost estimate + explicit confirmation — before any dispatch.** Two arms
+(baseline, ablated) × K=3 trials each × the number of selected fixtures is
+6× the integration tier's normal per-fixture cost. Print an estimate before
+dispatching the first trial of either arm:
+
+```text
+Ablation cost estimate: <agent> × <N> fixture(s) × 2 arms × 3 trials = <6·N>
+integration dispatch(es). Prior integration runs on this fixture set
+averaged ~<tokens> tokens/dispatch (or: "no prior run recorded — using the
+integration tier's stated per-dispatch heuristic"), so expect roughly
+<estimate> tokens total. Proceed? [y/N]
+```
+
+Declining aborts immediately — zero tokens spent, nothing written.
+
+**Dispatch — cache bypassed.** Both arms must be live to be comparable, so
+skip the fingerprint-replay cache pre-flight entirely for ablation arms (same
+stance as the plain integration tier). For each selected fixture, run 3
+trials of each arm, writing each trial's actuals to its own file under a
+per-arm trials directory:
+
+```bash
+# baseline arm (full roster) — repeat 3x into baseline-trials/trial-<n>.json
+python3 scripts/run_integration_eval.py --fixtures-dir evals/fixtures \
+  --expected-dir evals/expected --only <fixture> --model <model> \
+  --out baseline-trials/trial-1.json
+# ...trial-2.json, trial-3.json
+
+# ablated arm (roster minus <agent>) — repeat 3x into ablated-trials/
+python3 scripts/run_integration_eval.py --fixtures-dir evals/fixtures \
+  --expected-dir evals/expected --only <fixture> --model <model> \
+  --ablate-agent <agent> --out ablated-trials/trial-1.json
+# ...trial-2.json, trial-3.json
+```
+
+`--ablate-agent <agent>` scopes `DEV_TEAM_ABLATE_AGENT=<agent>` to that one
+subprocess's environment — no file mutation, no cleanup risk; the roster
+reverts the instant the subprocess exits. Never edit an agent/skill file to
+achieve the exclusion.
+
+**Delta computation and persistence.** Hand both trial directories to
+`scripts/eval_ablation.py --mode agent` — the deterministic, model-free half
+that grades each arm (pass@k over the 3 trials, per the same machinery
+`eval_variance.py` uses for `--trials`) and computes the delta:
+
+```bash
+python3 scripts/eval_ablation.py --mode agent \
+  --expected-dir evals/expected \
+  --baseline-trials-dir baseline-trials --ablated-trials-dir ablated-trials \
+  --ablated-agent <agent> --model <model> \
+  --append metrics/eval-ablation.jsonl
+```
+
+This appends one `schema: "eval-ablation/v1"` JSONL record (`recorded_at`,
+`ablated_agent`, `fixtures`, `model`, `baseline`/`ablated`/`delta` — each
+covering `issues_caught`, `test_commands`(_passed for delta), `tokens` — and
+`verdict`). **A failing baseline arm blocks any drop/retain claim**: the
+script itself forces `verdict: "baseline failed — inconclusive"` when the
+baseline didn't pass every trial — report that plainly, do not paraphrase it
+into a drop/retain recommendation.
+
+**Console report.** Show a small table: baseline vs ablated vs delta for the
+three dimensions, the verdict, and the path (`metrics/eval-ablation.jsonl`)
+the record was appended to.
 
 ## Cache (fingerprint replay)
 
@@ -201,6 +306,12 @@ If `--skill` is specified, filter to fixtures where that skill is in
 If `--fixture` is specified, filter to that fixture only.
 
 ### 3. Run agents against fixtures
+
+If `--ablation <agent>` is set, skip the rest of this section and follow
+*Ablation mode* above in full (opt-in gate check, argument validation, cost
+estimate + confirmation, two-arm × 3-trial dispatch, delta computation and
+persistence, console report). Do not fall through to plain `--integration`
+handling below.
 
 If `--integration` is set, skip the rest of this section and dispatch
 through `python3 scripts/run_integration_eval.py` for every fixture whose

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -44,7 +44,7 @@ Arguments: $ARGUMENTS
 
 Read metrics JSONL files from `metrics/`. Full field reference for every
 stream below: `${CLAUDE_PLUGIN_ROOT}/knowledge/telemetry-schema.md` — read it
-instead of re-deriving a schema from the emitter. Four complementary streams
+instead of re-deriving a schema from the emitter. Five complementary streams
 exist:
 
 - `metrics/*-task-log.jsonl` — **self-reported** task logs (whatever the model
@@ -68,6 +68,11 @@ exist:
   without causes, join on `session_id` (when present on both streams) to
   attribute friction to a specific hook/rule instead of reasoning from counts
   alone.
+- `metrics/eval-ablation.jsonl` — **causal** per-agent ablation evidence from
+  `/agent-eval --ablation <agent>` (#868): a controlled baseline-vs-ablated
+  integration-tier delta, not accumulated usage data. When a record exists
+  for a drop-candidate agent, Step 3 cites its measured delta/verdict instead
+  of relying on `review-value.jsonl` alone.
 
 If no metrics data exists or insufficient data is available (fewer than 10 review runs logged), report:
 
@@ -141,6 +146,36 @@ Flag **high-value checkpoints**: `fix_rate ≥ 50%` — these are earning their 
 **Drop-candidate recommendations** (P2-S3):
 For each drop candidate emit a recommendation in this form:
 > `<checkpoint>/<agents>` fixed 0/<N> runs (fix rate 0%) — candidate to drop. To act: remove this checkpoint type from the relevant `/build` step-complexity tier or exclude these agents from the checkpoint's dispatch list. Do not auto-edit skills; present for human decision.
+
+**Cite ablation evidence when available (#868).** `review-value.jsonl` alone is
+observational — a zero fix-rate agent might have been shielded by another
+agent, dispatched against the wrong changesets, or never given a defect to
+catch. Before finalizing each per-agent drop-candidate recommendation, check
+for causal evidence:
+
+```bash
+for agent in <each single-agent drop candidate>; do
+  python3 scripts/eval_ablation.py --find-latest "$agent" \
+    --jsonl metrics/eval-ablation.jsonl
+done
+```
+
+- **Record found** — cite it in the recommendation instead of (or alongside)
+  the fix-rate line: `<agent> — ablation run <recorded_at> (model
+  <model>): delta {issues_caught: <n>, test_commands_passed: <n>, tokens:
+  <n>}, verdict "<verdict>". <If verdict is "baseline failed —
+  inconclusive": state the evidence is unusable and the fix-rate signal
+  above is the only basis for this recommendation.>`
+- **No record found** — state the evidence is correlational-only and name
+  the exact command that would upgrade it: `No ablation evidence for
+  <agent> — this recommendation is based on correlational usage data only.
+  Run \`/agent-eval --ablation <agent>\` to get a controlled baseline-vs-
+  ablated delta before acting.`
+
+This applies only to drop candidates that resolve to a **single** review
+agent (multi-agent checkpoint combinations have no single-agent ablation
+record to cite — note that explicitly rather than guessing which member
+agent a record might apply to).
 
 Do not modify any skill or agent file. The report is the only artifact.
 
@@ -267,12 +302,16 @@ Write the report to the output path using this structure:
 |------------|--------|------|-------|-------|-----------|----------|
 
 ### Drop Candidates (fix rate 0%, N ≥ 5 runs)
-| Checkpoint | Agents | Runs | Recommendation |
-|------------|--------|------|----------------|
+| Checkpoint | Agents | Runs | Ablation evidence | Recommendation |
+|------------|--------|------|--------------------|-----------------|
 
 > To act on a drop candidate: remove the checkpoint type from the relevant `/build`
 > step-complexity tier or exclude the agents from that checkpoint's dispatch list.
 > Requires human decision — do not auto-edit skills.
+>
+> "Ablation evidence" column: the cited `metrics/eval-ablation.jsonl` verdict +
+> date for single-agent candidates, or "correlational only — run
+> `/agent-eval --ablation <agent>`" when no record exists.
 
 ### High-Value Checkpoints (fix rate ≥ 50%)
 | Checkpoint | Agents | Runs | Fix rate | Issues fixed |

--- a/scripts/eval_ablation.py
+++ b/scripts/eval_ablation.py
@@ -1,23 +1,59 @@
 #!/usr/bin/env python3
-"""Knowledge ablation analysis (#107).
+"""Knowledge ablation analysis (#107) + agent-ablation analysis (#868).
 
-Does a knowledge file earn its tokens? Run the eval corpus twice — once with the
-file AVAILABLE, once ABLATED (hidden) — and diff the grades. Pairs that PASSED
-with the knowledge but FAIL without it are the file's measured *retrieval value*.
+Two related, deterministic (model-free) ablation reports live here:
 
-This module is the deterministic, model-free half: given the two recorded actuals
-(the live with/without runs are driven by run-ablation.sh), it grades both via
-eval_grade and reports the impact. A file whose ablation drops nothing is a
-removal/consolidation candidate.
+1. **Knowledge ablation** (original, `--mode knowledge`, the default). Does a
+   knowledge file earn its tokens? Run the eval corpus twice — once with the
+   file AVAILABLE, once ABLATED (hidden) — and diff the grades. Pairs that
+   PASSED with the knowledge but FAIL without it are the file's measured
+   *retrieval value*.
 
-Inputs
-------
+2. **Agent ablation** (`--mode agent`, #868). Does removing a review agent
+   from the orchestrator's inline-review roster change *integration-tier*
+   pipeline outcomes? `/agent-eval --ablation <agent>` dispatches
+   `scripts/run_integration_eval.py` twice per fixture (baseline: full
+   roster; ablated: roster minus the named agent), each arm run K=3 trials
+   (reusing the `eval_variance.py` pass@k machinery). This module grades the
+   two arms' recorded actuals and computes the delta across three
+   dimensions: issues caught at review checkpoints, `testCommands`
+   pass/fail, and token cost. A failing baseline blocks any drop/retain
+   verdict (the underlying signal is uninterpretable) per the acceptance
+   criteria in issue #868.
+
+Both modes are deterministic, model-free grading over already-recorded
+actuals; live dispatch happens elsewhere (the `/agent-eval` skill /
+`run_integration_eval.py`), never in this module.
+
+Inputs (knowledge mode, `--mode knowledge`, default)
+-----------------------------------------------------
 --expected-dir DIR   Expected specs (default: evals/expected).
 --baseline FILE      Actuals from the run WITH the knowledge available.
 --ablated FILE       Actuals from the run with the knowledge ablated.
 --knowledge NAME     Label for the ablated file (reporting only).
 --only AGENT         Restrict grading to one agent (optional).
 -o FILE              Write the report (default: stdout).
+
+Inputs (agent mode, `--mode agent`, #868)
+------------------------------------------
+--expected-dir DIR          Expected specs (default: evals/expected).
+--baseline-trials-dir DIR   Directory of the baseline arm's per-trial actuals
+                            (`trial-*.json`, each the full actuals mapping
+                            `run_integration_eval.py --out` writes).
+--ablated-trials-dir DIR    Same, for the ablated arm.
+--ablated-agent NAME        The review agent excluded in the ablated arm.
+--model NAME                Model version used for both arms (REQUIRED —
+                            deltas are model-dependent, per #868).
+-o FILE                     Write the report (default: stdout).
+--append LOG                Append one JSONL record (schema eval-ablation/v1)
+                            to LOG, e.g. metrics/eval-ablation.jsonl.
+--find-latest AGENT         Instead of computing a new report, read the
+                            JSONL at --append (or -o) / a positional
+                            --jsonl path and print the most recent record
+                            for AGENT (or "null" if none) — used by
+                            /harness-audit to cite evidence.
+--jsonl PATH                JSONL file to search for --find-latest (default:
+                            metrics/eval-ablation.jsonl).
 """
 
 from __future__ import annotations
@@ -25,10 +61,12 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from eval_grade import run_grading  # noqa: E402
+from eval_variance import aggregate_trials  # noqa: E402
 
 
 def _passing(expected_dir: Path, actuals: dict, only: set | None) -> set:
@@ -54,17 +92,232 @@ def ablation_impact(expected_dir: Path, baseline: dict, ablated: dict,
     }
 
 
+def _load_trial_actuals(trials_dir: Path) -> list[dict]:
+    """Load every `*.json` in trials_dir as one arm's per-trial actuals."""
+    out = []
+    for f in sorted(trials_dir.glob("*.json")):
+        try:
+            out.append(json.loads(f.read_text()))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def _flatten_integration_targets(actual: dict) -> list[tuple[str, dict]]:
+    """Yield (fixture_stem::target, target_actual) for every integration entry
+    in one trial's actuals mapping (the shape `run_integration_eval.py --out`
+    writes: ``{stem: {"integration": {target: {"results", "tokens",
+    "issues_caught"}}}}``)."""
+    out = []
+    for stem, block in actual.items():
+        if not isinstance(block, dict):
+            continue
+        for target, tdata in block.get("integration", {}).items():
+            if isinstance(tdata, dict):
+                out.append((f"{stem}::{target}", tdata))
+    return out
+
+
+def summarize_arm(expected_dir: Path, trial_actuals: list[dict]) -> dict:
+    """Deterministically summarize one ablation arm's K trials.
+
+    `grade` is "pass" only if every fixture::target pair graded via the
+    registered `integration` grader passed on **every** trial (pass@k ==
+    1.0) — a conservative, reproducible bar; any flakiness or failure marks
+    the arm "fail" so a shaky arm can never anchor a drop/retain verdict.
+    `issues_caught` and `tokens` are the mean across trials (rounded);
+    `test_commands` is taken from the first trial that recorded any (all
+    trials target the same fixtures, so this is representative, not
+    authoritative — the trial-level `grade` is what actually gates the
+    verdict).
+    """
+    if not trial_actuals:
+        return {"grade": "fail", "issues_caught": 0, "test_commands": [], "tokens": 0}
+
+    variance = aggregate_trials(expected_dir, trial_actuals)
+    by_pair = variance.get("by_pair", {})
+    all_pass = bool(by_pair) and all(
+        d["pass_at_k"] >= 1.0 for d in by_pair.values()
+    )
+
+    issues_totals: list[int] = []
+    token_totals: list[int] = []
+    test_commands: list[dict] = []
+    for actual in trial_actuals:
+        issues_sum = 0
+        tokens_sum = 0
+        for _pair, tdata in _flatten_integration_targets(actual):
+            issues_sum += int(tdata.get("issues_caught", 0) or 0)
+            tokens_sum += int(tdata.get("tokens", 0) or 0)
+            if not test_commands:
+                test_commands.extend(
+                    {"command": r.get("command"), "exit_code": r.get("exit_code")}
+                    for r in tdata.get("results", []) or []
+                    if isinstance(r, dict)
+                )
+        issues_totals.append(issues_sum)
+        token_totals.append(tokens_sum)
+
+    mean_issues = round(sum(issues_totals) / len(issues_totals)) if issues_totals else 0
+    mean_tokens = round(sum(token_totals) / len(token_totals)) if token_totals else 0
+
+    return {
+        "grade": "pass" if all_pass else "fail",
+        "issues_caught": mean_issues,
+        "test_commands": test_commands,
+        "tokens": mean_tokens,
+    }
+
+
+def _passed_command_count(arm: dict) -> int:
+    return sum(1 for c in arm.get("test_commands", []) if c.get("exit_code") == 0)
+
+
+def agent_ablation_report(
+    expected_dir: Path,
+    baseline_trials: list[dict],
+    ablated_trials: list[dict],
+    ablated_agent: str,
+    model: str,
+    fixtures: list[str] | None = None,
+) -> dict:
+    """Grade both arms and compute the three-dimension delta (#868).
+
+    A failing baseline blocks any drop/retain claim (acceptance criterion
+    "failing-baseline-blocks-delta-claims"): the delta is still reported for
+    visibility, but `verdict` is forced to "baseline failed — inconclusive"
+    regardless of what the ablated arm shows.
+    """
+    baseline = summarize_arm(expected_dir, baseline_trials)
+    ablated = summarize_arm(expected_dir, ablated_trials)
+
+    delta = {
+        "issues_caught": ablated["issues_caught"] - baseline["issues_caught"],
+        "test_commands_passed": _passed_command_count(ablated)
+        - _passed_command_count(baseline),
+        "tokens": ablated["tokens"] - baseline["tokens"],
+    }
+
+    if baseline["grade"] != "pass":
+        verdict = "baseline failed — inconclusive"
+    elif delta["issues_caught"] == 0 and delta["test_commands_passed"] == 0:
+        verdict = "no measured impact — supports drop"
+    else:
+        verdict = "agent is load-bearing — retain"
+
+    if fixtures is None:
+        stems = set()
+        for actual in baseline_trials + ablated_trials:
+            stems.update(k for k in actual if isinstance(actual.get(k), dict))
+        fixtures = sorted(stems)
+
+    return {
+        "schema": "eval-ablation/v1",
+        "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ablated_agent": ablated_agent,
+        "fixtures": fixtures,
+        "model": model,
+        "baseline": baseline,
+        "ablated": ablated,
+        "delta": delta,
+        "verdict": verdict,
+    }
+
+
+def find_latest_ablation_record(jsonl_path: Path, agent: str) -> dict | None:
+    """Return the most recent `eval-ablation/v1` record for `agent`, or None.
+
+    Used by `/harness-audit` (Step 3) to cite causal evidence for a
+    drop-candidate agent instead of correlational usage data alone.
+    """
+    if not jsonl_path.exists():
+        return None
+    latest: dict | None = None
+    for line in jsonl_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("ablated_agent") != agent:
+            continue
+        if latest is None or record.get("recorded_at", "") >= latest.get(
+            "recorded_at", ""
+        ):
+            latest = record
+    return latest
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--mode", choices=["knowledge", "agent"], default="knowledge")
     ap.add_argument("--expected-dir", default="evals/expected")
-    ap.add_argument("--baseline", required=True)
-    ap.add_argument("--ablated", required=True)
+    # knowledge mode
+    ap.add_argument("--baseline")
+    ap.add_argument("--ablated")
     ap.add_argument("--knowledge", default="")
     ap.add_argument("--only")
+    # agent mode (#868)
+    ap.add_argument("--baseline-trials-dir")
+    ap.add_argument("--ablated-trials-dir")
+    ap.add_argument("--ablated-agent")
+    ap.add_argument("--model", help="model version used for both arms (required "
+                    "for --mode agent — deltas are model-dependent)")
+    ap.add_argument("--fixtures", help="comma-separated fixture stems actually "
+                    "exercised (reporting only; auto-detected if omitted)")
+    ap.add_argument("--append", metavar="LOG",
+                    help="append the report as one JSONL line to LOG")
+    ap.add_argument("--find-latest", metavar="AGENT",
+                    help="print the most recent eval-ablation/v1 record for "
+                    "AGENT from --jsonl (or 'null'); no report is computed")
+    ap.add_argument("--jsonl", default="metrics/eval-ablation.jsonl",
+                    help="JSONL file for --find-latest (default: "
+                    "metrics/eval-ablation.jsonl)")
     ap.add_argument("-o", "--out")
     args = ap.parse_args(argv)
 
+    if args.find_latest:
+        record = find_latest_ablation_record(Path(args.jsonl), args.find_latest)
+        print(json.dumps(record) if record else "null")
+        return 0
+
+    if args.mode == "agent":
+        if not args.model:
+            print("error: --mode agent requires --model (deltas are "
+                  "model-dependent, #868)", file=sys.stderr)
+            return 2
+        if not (args.baseline_trials_dir and args.ablated_trials_dir
+                and args.ablated_agent):
+            print("error: --mode agent requires --baseline-trials-dir, "
+                  "--ablated-trials-dir, and --ablated-agent", file=sys.stderr)
+            return 2
+        baseline_trials = _load_trial_actuals(Path(args.baseline_trials_dir))
+        ablated_trials = _load_trial_actuals(Path(args.ablated_trials_dir))
+        fixtures = (
+            [s.strip() for s in args.fixtures.split(",") if s.strip()]
+            if args.fixtures else None
+        )
+        report = agent_ablation_report(
+            Path(args.expected_dir), baseline_trials, ablated_trials,
+            args.ablated_agent, args.model, fixtures,
+        )
+        out = json.dumps(report, indent=2, sort_keys=True)
+        if args.out:
+            Path(args.out).write_text(out + "\n")
+        else:
+            print(out)
+        if args.append:
+            with open(args.append, "a") as fh:
+                fh.write(json.dumps(report, sort_keys=True) + "\n")
+        return 0
+
+    if not (args.baseline and args.ablated):
+        print("error: --mode knowledge requires --baseline and --ablated",
+              file=sys.stderr)
+        return 2
     baseline = json.loads(Path(args.baseline).read_text())
     ablated = json.loads(Path(args.ablated).read_text())
     only = {args.only} if args.only else None

--- a/scripts/run_integration_eval.py
+++ b/scripts/run_integration_eval.py
@@ -156,16 +156,93 @@ def init_worktree(workdir: Path) -> None:
     )
 
 
-def dispatch_orchestrator(workdir: Path, spec_path: Path, model: str) -> None:
-    """Dispatch the orchestrator to implement the frozen spec in the worktree."""
+def _tokens_from_claude_json(stdout: str) -> int:
+    """Best-effort token-usage extraction from `claude -p --output-format json`.
+
+    The envelope shape has varied across CLI versions; this stays defensive
+    (never raises) since token accounting is a reporting nicety, not a
+    correctness requirement of the integration tier.
+    """
+    if not stdout:
+        return 0
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    usage = payload.get("usage") if isinstance(payload, dict) else None
+    if isinstance(usage, dict):
+        total = 0
+        for key in ("input_tokens", "output_tokens", "cache_creation_input_tokens",
+                    "cache_read_input_tokens"):
+            val = usage.get(key)
+            if isinstance(val, (int, float)):
+                total += int(val)
+        if total:
+            return total
+    for key in ("total_tokens", "tokens"):
+        val = payload.get(key) if isinstance(payload, dict) else None
+        if isinstance(val, (int, float)):
+            return int(val)
+    return 0
+
+
+def _count_issues_caught(workdir: Path) -> int:
+    """Sum `issues_found` from a review-value log written inside the worktree.
+
+    `/build`'s inline review checkpoints append one JSON line per checkpoint to
+    `metrics/review-value.jsonl` (#348) — this is the same "issues caught at
+    review checkpoints" signal the ablation feature (#868) diffs between arms.
+    Absent file/malformed lines count as zero rather than erroring: a build
+    that never triggers a checkpoint is a legitimate (if uninteresting) result.
+    """
+    log = workdir / "metrics" / "review-value.jsonl"
+    if not log.exists():
+        return 0
+    total = 0
+    for line in log.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        found = entry.get("issues_found")
+        if isinstance(found, (int, float)):
+            total += int(found)
+    return total
+
+
+def dispatch_orchestrator(
+    workdir: Path, spec_path: Path, model: str, ablate_agent: str = ""
+) -> int:
+    """Dispatch the orchestrator to implement the frozen spec in the worktree.
+
+    When `ablate_agent` is set, `DEV_TEAM_ABLATE_AGENT` is injected into the
+    subprocess environment only (never written to disk) so the orchestrator's
+    inline review dispatch can exclude that agent for the lifetime of this one
+    dispatch (#868 agent-ablation mode). Returns the best-effort token count
+    reported by `--output-format json` (0 if unavailable/unparseable).
+    """
     prompt = (
         f"Implement the spec in {spec_path.name} using the full plan -> build -> "
         f"review pipeline. The working directory is a fresh git worktree; make "
         f"the declared test commands pass."
     )
-    subprocess.run(
-        ["claude", "-p", prompt, "--model", model], cwd=str(workdir), check=False
+    env = os.environ.copy()
+    if ablate_agent:
+        env["DEV_TEAM_ABLATE_AGENT"] = ablate_agent
+    else:
+        env.pop("DEV_TEAM_ABLATE_AGENT", None)
+    proc = subprocess.run(
+        ["claude", "-p", prompt, "--model", model, "--output-format", "json"],
+        cwd=str(workdir),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    return _tokens_from_claude_json(proc.stdout)
 
 
 def run_commands(workdir: Path, commands: list[str]) -> list[dict]:
@@ -221,8 +298,15 @@ def run_fixture(
     fixtures_dir: Path,
     skip_dispatch: bool,
     model: str,
+    ablate_agent: str = "",
 ) -> dict:
-    """Run one integration target; return its recorded actual (results list)."""
+    """Run one integration target; return its recorded actual.
+
+    Shape: ``{"results": [...], "tokens": N, "issues_caught": N}``. `results`
+    is graded by the `integration` grader (unchanged shape); `tokens` and
+    `issues_caught` are additive fields the grader ignores but the #868
+    agent-ablation delta computation consumes.
+    """
     fixture_dir = fixtures_dir / stem
     tarball = fixture_dir / ispec["goldenRepo"]
     spec_path = fixture_dir / ispec["spec"]
@@ -232,13 +316,16 @@ def run_fixture(
     try:
         extract_golden_repo(tarball, workdir)
         init_worktree(workdir)
+        tokens = 0
+        issues_caught = 0
         if not skip_dispatch:
             # Stage the frozen spec into the worktree so the orchestrator sees it.
             if spec_path.exists():
                 shutil.copy2(spec_path, workdir / spec_path.name)
-            dispatch_orchestrator(workdir, spec_path, model)
+            tokens = dispatch_orchestrator(workdir, spec_path, model, ablate_agent)
+            issues_caught = _count_issues_caught(workdir)
         results = run_commands(workdir, commands)
-        return {"results": results}
+        return {"results": results, "tokens": tokens, "issues_caught": issues_caught}
     finally:
         # Tear the worktree down unconditionally (acceptance: even on failure).
         shutil.rmtree(workdir, ignore_errors=True)
@@ -258,6 +345,14 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="do not dispatch the orchestrator (harness self-test); "
         "test commands run against the golden repo as-is",
+    )
+    ap.add_argument(
+        "--ablate-agent",
+        default="",
+        help="(#868) exclude this review agent from the orchestrator's inline "
+        "review dispatch for this run only, via the DEV_TEAM_ABLATE_AGENT "
+        "env var scoped to the dispatch subprocess. Empty (default) runs the "
+        "full roster.",
     )
     args = ap.parse_args(argv)
 
@@ -294,7 +389,13 @@ def main(argv: list[str]) -> int:
                 file=sys.stderr,
             )
             actual = run_fixture(
-                stem, target, ispec, fixtures_dir, args.skip_dispatch, args.model
+                stem,
+                target,
+                ispec,
+                fixtures_dir,
+                args.skip_dispatch,
+                args.model,
+                args.ablate_agent,
             )
             actuals.setdefault(stem, {}).setdefault("integration", {})[target] = actual
             ran += 1

--- a/tests/repo/test_agent_ablation.py
+++ b/tests/repo/test_agent_ablation.py
@@ -1,0 +1,314 @@
+"""Tests for the #868 agent-ablation feature: `/agent-eval --ablation <agent>`
+runs the integration tier twice (baseline: full roster, ablated: roster minus
+target agent), K=3 trials per arm, and reports a deterministic delta across
+three dimensions (issues caught, testCommands, tokens) that `/harness-audit`
+can cite as causal drop-candidate evidence.
+
+Covers, per the issue's Acceptance Criteria:
+  - ablation-runs-exactly-two-integration-passes (roster-exclusion wiring)
+  - delta-report-covers-issues-testcommands-and-token-cost
+  - results-persist-with-model-version-and-timestamp
+  - harness-audit-cites-ablation-evidence-in-drop-recommendations (lookup helper)
+  - failing-baseline-blocks-delta-claims
+
+No live `claude -p` dispatch or real ephemeral worktree is exercised — the
+orchestrator subprocess and worktree creation are mocked/stubbed throughout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+RIE_PATH = SCRIPTS / "run_integration_eval.py"
+ABLATION_PATH = SCRIPTS / "eval_ablation.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+rie = _load_module(RIE_PATH, "run_integration_eval_agentablation")
+ablation = _load_module(ABLATION_PATH, "eval_ablation_agentablation")
+
+
+# ---------------------------------------------------------------------------
+# run_integration_eval.py: --ablate-agent / DEV_TEAM_ABLATE_AGENT wiring,
+# and per-run token/issues_caught recording. The orchestrator subprocess
+# itself is stubbed (monkeypatched) — no live dispatch or real worktree.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_orchestrator_injects_ablate_agent_env_var(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, cwd, env, capture_output, text, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+
+        class Result:
+            stdout = '{"usage": {"input_tokens": 10, "output_tokens": 5}}'
+
+        return Result()
+
+    monkeypatch.setattr(rie.subprocess, "run", fake_run)
+    tokens = rie.dispatch_orchestrator(
+        tmp_path, Path("spec.md"), "claude-sonnet-4-6", ablate_agent="security-review"
+    )
+    assert captured["env"]["DEV_TEAM_ABLATE_AGENT"] == "security-review"
+    assert tokens == 15
+
+
+def test_dispatch_orchestrator_omits_ablate_agent_env_var_when_not_set(
+    monkeypatch, tmp_path
+):
+    captured = {}
+
+    def fake_run(cmd, cwd, env, capture_output, text, check):
+        captured["env"] = env
+
+        class Result:
+            stdout = "{}"
+
+        return Result()
+
+    monkeypatch.setattr(rie.subprocess, "run", fake_run)
+    rie.dispatch_orchestrator(tmp_path, Path("spec.md"), "claude-sonnet-4-6")
+    assert "DEV_TEAM_ABLATE_AGENT" not in captured["env"]
+
+
+def test_run_fixture_records_tokens_and_issues_caught(monkeypatch, tmp_path):
+    fixtures_dir = tmp_path / "fixtures"
+    fixture_dir = fixtures_dir / "int-demo"
+    fixture_dir.mkdir(parents=True)
+
+    # A trivial, valid tarball is unnecessary: stub extract_golden_repo and
+    # init_worktree so no real worktree/tarball machinery runs.
+    monkeypatch.setattr(rie, "extract_golden_repo", lambda tarball, dest: None)
+    monkeypatch.setattr(rie, "init_worktree", lambda workdir: None)
+
+    def fake_dispatch(workdir, spec_path, model, ablate_agent=""):
+        # Simulate the orchestrator writing a review-value log inside the
+        # worktree, as /build's inline review checkpoints do.
+        metrics_dir = workdir / "metrics"
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "review-value.jsonl").write_text(
+            json.dumps({"issues_found": 2}) + "\n" + json.dumps({"issues_found": 1}) + "\n"
+        )
+        return 42
+
+    monkeypatch.setattr(rie, "dispatch_orchestrator", fake_dispatch)
+    monkeypatch.setattr(rie, "run_commands", lambda workdir, commands: [
+        {"command": c, "exit_code": 0, "stderr_first_line": ""} for c in commands
+    ])
+
+    actual = rie.run_fixture(
+        "int-demo",
+        "orchestrator",
+        {"goldenRepo": "golden.tar.gz", "spec": "spec.md", "testCommands": ["pytest"]},
+        fixtures_dir,
+        skip_dispatch=False,
+        model="claude-sonnet-4-6",
+        ablate_agent="security-review",
+    )
+    assert actual["tokens"] == 42
+    assert actual["issues_caught"] == 3
+    assert actual["results"] == [{"command": "pytest", "exit_code": 0, "stderr_first_line": ""}]
+
+
+def test_run_fixture_skip_dispatch_records_zero_tokens_and_issues(monkeypatch, tmp_path):
+    fixtures_dir = tmp_path / "fixtures"
+    (fixtures_dir / "int-demo").mkdir(parents=True)
+    monkeypatch.setattr(rie, "extract_golden_repo", lambda tarball, dest: None)
+    monkeypatch.setattr(rie, "init_worktree", lambda workdir: None)
+    monkeypatch.setattr(rie, "run_commands", lambda workdir, commands: [])
+
+    actual = rie.run_fixture(
+        "int-demo", "orchestrator",
+        {"goldenRepo": "g.tar.gz", "spec": "spec.md", "testCommands": []},
+        fixtures_dir, skip_dispatch=True, model="claude-sonnet-4-6",
+    )
+    assert actual == {"results": [], "tokens": 0, "issues_caught": 0}
+
+
+# ---------------------------------------------------------------------------
+# eval_ablation.py --mode agent: delta computation across all three
+# dimensions, failing-baseline gate, and the harness-audit lookup helper.
+# ---------------------------------------------------------------------------
+
+EXPECTED_INT_DEMO = json.dumps({
+    "fixture": "int-demo",
+    "applicableSkills": ["orchestrator"],
+    "integration": {
+        "orchestrator": {
+            "grader": "integration",
+            "spec": "spec.md",
+            "goldenRepo": "golden-repo.tar.gz",
+            "testCommands": ["pytest"],
+        }
+    },
+})
+
+
+def _trial_actual(exit_code: int, tokens: int, issues_caught: int) -> dict:
+    return {
+        "int-demo": {
+            "integration": {
+                "orchestrator": {
+                    "results": [{"command": "pytest", "exit_code": exit_code,
+                                "stderr_first_line": ""}],
+                    "tokens": tokens,
+                    "issues_caught": issues_caught,
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def expected_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "expected"
+    d.mkdir()
+    (d / "int-demo.json").write_text(EXPECTED_INT_DEMO)
+    return d
+
+
+def test_agent_ablation_report_covers_all_three_delta_dimensions(expected_dir):
+    baseline_trials = [_trial_actual(0, 100, 4) for _ in range(3)]
+    ablated_trials = [_trial_actual(0, 60, 4) for _ in range(3)]
+
+    report = ablation.agent_ablation_report(
+        expected_dir, baseline_trials, ablated_trials,
+        ablated_agent="security-review", model="claude-sonnet-4-6",
+    )
+    assert report["schema"] == "eval-ablation/v1"
+    assert report["ablated_agent"] == "security-review"
+    assert report["model"] == "claude-sonnet-4-6"
+    assert "recorded_at" in report and report["recorded_at"].endswith("Z")
+    assert set(report["delta"]) == {"issues_caught", "test_commands_passed", "tokens"}
+    assert report["delta"]["issues_caught"] == 0
+    assert report["delta"]["tokens"] == -40
+    assert report["delta"]["test_commands_passed"] == 0
+    assert report["baseline"]["grade"] == "pass"
+    assert report["verdict"] == "no measured impact — supports drop"
+
+
+def test_agent_ablation_load_bearing_agent_shows_negative_delta_and_retain_verdict(
+    expected_dir,
+):
+    baseline_trials = [_trial_actual(0, 100, 4) for _ in range(3)]
+    # Ablated arm: the same test now fails (agent was catching a regression
+    # the orchestrator introduced) -> dropped in issues too.
+    ablated_trials = [_trial_actual(1, 100, 1) for _ in range(3)]
+
+    report = ablation.agent_ablation_report(
+        expected_dir, baseline_trials, ablated_trials,
+        ablated_agent="security-review", model="claude-sonnet-4-6",
+    )
+    assert report["delta"]["issues_caught"] == -3
+    assert report["delta"]["test_commands_passed"] == -1
+    assert report["verdict"] == "agent is load-bearing — retain"
+
+
+def test_agent_ablation_failing_baseline_blocks_verdict(expected_dir):
+    # Baseline itself never passes -> uninterpretable, regardless of ablated arm.
+    baseline_trials = [_trial_actual(1, 100, 0) for _ in range(3)]
+    ablated_trials = [_trial_actual(0, 100, 4) for _ in range(3)]
+
+    report = ablation.agent_ablation_report(
+        expected_dir, baseline_trials, ablated_trials,
+        ablated_agent="security-review", model="claude-sonnet-4-6",
+    )
+    assert report["baseline"]["grade"] == "fail"
+    assert report["verdict"] == "baseline failed — inconclusive"
+
+
+def test_agent_ablation_report_persists_as_valid_jsonl(expected_dir, tmp_path):
+    baseline_trials = [_trial_actual(0, 100, 4) for _ in range(3)]
+    ablated_trials = [_trial_actual(0, 100, 4) for _ in range(3)]
+    log = tmp_path / "eval-ablation.jsonl"
+
+    report = ablation.agent_ablation_report(
+        expected_dir, baseline_trials, ablated_trials,
+        ablated_agent="doc-review", model="claude-sonnet-4-6",
+    )
+    with open(log, "a") as fh:
+        fh.write(json.dumps(report, sort_keys=True) + "\n")
+
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["schema"] == "eval-ablation/v1"
+    assert parsed["model"] == "claude-sonnet-4-6"
+    assert "recorded_at" in parsed
+
+
+def test_find_latest_ablation_record_returns_most_recent_for_agent(tmp_path):
+    log = tmp_path / "eval-ablation.jsonl"
+    older = {"schema": "eval-ablation/v1", "ablated_agent": "doc-review",
+             "recorded_at": "2026-01-01T00:00:00Z", "verdict": "no measured impact — supports drop"}
+    newer = {"schema": "eval-ablation/v1", "ablated_agent": "doc-review",
+             "recorded_at": "2026-06-01T00:00:00Z", "verdict": "agent is load-bearing — retain"}
+    other_agent = {"schema": "eval-ablation/v1", "ablated_agent": "security-review",
+                   "recorded_at": "2026-12-01T00:00:00Z", "verdict": "no measured impact — supports drop"}
+    log.write_text(
+        json.dumps(older) + "\n" + json.dumps(newer) + "\n" + json.dumps(other_agent) + "\n"
+    )
+    result = ablation.find_latest_ablation_record(log, "doc-review")
+    assert result == newer
+
+
+def test_find_latest_ablation_record_returns_none_when_no_match(tmp_path):
+    log = tmp_path / "eval-ablation.jsonl"
+    log.write_text(json.dumps(
+        {"schema": "eval-ablation/v1", "ablated_agent": "other", "recorded_at": "2026-01-01T00:00:00Z"}
+    ) + "\n")
+    assert ablation.find_latest_ablation_record(log, "doc-review") is None
+
+
+def test_find_latest_ablation_record_missing_file_returns_none(tmp_path):
+    assert ablation.find_latest_ablation_record(tmp_path / "absent.jsonl", "doc-review") is None
+
+
+# ---------------------------------------------------------------------------
+# CLI-level checks (subprocess) for --mode agent argument validation and
+# --find-latest, matching the style of the existing eval_ablation.py tests.
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ABLATION_PATH), *args], capture_output=True, text=True
+    )
+
+
+def test_cli_agent_mode_requires_model(tmp_path):
+    baseline_dir = tmp_path / "baseline"
+    ablated_dir = tmp_path / "ablated"
+    baseline_dir.mkdir()
+    ablated_dir.mkdir()
+    res = _run_cli(
+        "--mode", "agent",
+        "--baseline-trials-dir", str(baseline_dir),
+        "--ablated-trials-dir", str(ablated_dir),
+        "--ablated-agent", "doc-review",
+    )
+    assert res.returncode == 2
+    assert "--model" in res.stderr
+
+
+def test_cli_find_latest_prints_null_when_absent(tmp_path):
+    res = _run_cli("--find-latest", "doc-review", "--jsonl", str(tmp_path / "none.jsonl"))
+    assert res.returncode == 0
+    assert res.stdout.strip() == "null"


### PR DESCRIPTION
## Summary

- `/agent-eval` gains `--ablation <agent>`: runs the integration tier **twice** — a baseline arm (full review-agent roster) and an ablated arm (roster minus `<agent>`) — K=3 trials per arm (reusing the existing `--trials`/eval-variance machinery), gated by the label-gated live-eval policy (#134) with a mandatory cost estimate + explicit operator confirmation before any dispatch. Rejected in combination with `--agent`/`--skill` and with more than one target agent (single-agent only in v1). Cache is bypassed for ablation arms.
- `scripts/run_integration_eval.py` accepts `--ablate-agent <name>`, scoping `DEV_TEAM_ABLATE_AGENT=<name>` to the orchestrator-dispatch subprocess's environment only (no file mutation). Each run now records per-arm token usage (parsed from `claude -p --output-format json`) and `issues_caught` (summed from the ephemeral worktree's `metrics/review-value.jsonl`) alongside the existing `testCommands` results.
- `scripts/eval_ablation.py` gains a `--mode agent` sibling entry point: deterministically grades both arms (pass@k over 3 trials via `eval_variance.aggregate_trials`) and computes the delta across all three dimensions (issues caught, `testCommands` passed, tokens). A failing baseline forces `verdict: "baseline failed — inconclusive"` regardless of the ablated arm. Also adds `--find-latest <agent>` for looking up the most recent ablation record.
- Results persist to `metrics/eval-ablation.jsonl` (schema `eval-ablation/v1`): `recorded_at`, `ablated_agent`, `fixtures`, `model` (required), `baseline`/`ablated`/`delta`, `verdict`.
- `/harness-audit` Step 3's drop-candidate recommendations now cite a matching `eval-ablation.jsonl` record's measured delta/verdict as causal evidence when one exists for a single-agent candidate, or state the evidence is correlational-only and name the exact `/agent-eval --ablation <agent>` command that would upgrade it. Report-only — never edits agents/config.

Implements #868 per the human-approved spec (Verdict: PASS) — all ambiguity-log items (K=3 trials/arm, all-fixtures default, env-var roster exclusion, JSONL storage shape) were pre-resolved; no new ambiguities came up during implementation, so no comment was posted to the issue.

## Test plan

- [x] `python3 -m pytest tests/repo/test_agent_ablation.py -q` — 13 new tests covering: `DEV_TEAM_ABLATE_AGENT` env injection/omission, token/issues_caught recording (mocked dispatch + worktree, no live `claude -p` or real tarballs), the two-arm/K=3 delta computation across all three dimensions, load-bearing-agent (negative delta) verdict, failing-baseline gate, JSONL persistence, `--find-latest` lookup (found/none/missing-file), and CLI argument validation (`--model` required, `--find-latest` null case).
- [x] `python3 -m pytest tests/repo -q` — 430 passed (0 regressions).
- [x] `python3 scripts/check_md_references.py` — clean.
- [x] Rebuilt `plugins/dev-team/knowledge/index.json` via `build_knowledge_index.py write` so the freshness gate (`test_knowledge_index_current.py` et al.) stays green.
- [x] Pre-existing failures in `tests/scripts/test_orchestrator.py`, `tests/scripts/test_codebase_recon.py`, and `tests/security-assessment/` verified identical on `origin/main` before this branch (missing `jsonschema`/env deps in this sandbox) — unrelated to this change, not introduced by it.

Closes #868


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_