### PR TITLE
feat: shared directory-enumeration guidance for existence-checking agents

### DIFF
--- a/plugins/dev-team/agents/claude-setup-review.md
+++ b/plugins/dev-team/agents/claude-setup-review.md
@@ -3,7 +3,7 @@ name: claude-setup-review
 description: CLAUDE.md completeness, rules, skills, path accuracy, and agent frontmatter schema compliance
 tools: Read, Grep, Glob
 effort: low
-cites: [adversarial-review-protocol]
+cites: [adversarial-review-protocol, directory-enumeration]
 enforcement: script
 ---
 
@@ -30,7 +30,7 @@ Return `{"status": "skip", "issues": [], "summary": "Not a Claude Code project"}
 - No CLAUDE.md, `.claude/` directory, agent files, or `.clinerules` file exists
 - Target is clearly not a Claude Code-enabled project
 
-Check existence with `Glob` only — e.g. `Glob("CLAUDE.md")`, `Glob(".claude/**")`, `Glob("**/agents/*.md")`, `Glob(".clinerules")`. Never `Read` a directory path (the repo root, `.claude/`, `agents/`) to see what it contains — `Read` on a directory fails with `EISDIR`. `Read` only specific files `Glob` has confirmed exist.
+Check existence with `Glob` only — e.g. `Glob("CLAUDE.md")`, `Glob(".claude/**")`, `Glob("**/agents/*.md")`, `Glob(".clinerules")`. Never `Read` a directory path (the repo root, `.claude/`, `agents/`) to see what it contains — `Read` on a directory fails with `EISDIR`. `Read` only specific files `Glob` has confirmed exist. See `knowledge/directory-enumeration.md` for the shared rule (Whole-file load: a short single-rule reference).
 
 ## Detect — CLAUDE.md
 
@@ -61,7 +61,7 @@ Accuracy:
 
 ## Detect — Agent frontmatter schema
 
-Apply to every `.md` file found in `agents/` directories within the target — enumerate them with `Glob("**/agents/*.md")`, never by `Read`ing the directory. Check against the official Claude Code sub-agent specification.
+Apply to every `.md` file found in `agents/` directories within the target — enumerate them with `Glob("**/agents/*.md")`, never by `Read`ing the directory (`knowledge/directory-enumeration.md` — Whole-file load: a short single-rule reference). Check against the official Claude Code sub-agent specification.
 
 ### Required fields
 

--- a/plugins/dev-team/agents/progress-guardian.md
+++ b/plugins/dev-team/agents/progress-guardian.md
@@ -3,7 +3,7 @@ name: progress-guardian
 description: Tracks plan step completion, enforces commit discipline, and gates plan changes through human approval
 tools: Read, Grep, Glob
 effort: medium
-cites: [adversarial-review-protocol]
+cites: [adversarial-review-protocol, directory-enumeration]
 enforcement: script
 ---
 
@@ -27,7 +27,7 @@ Context needs: full-file (reads plan + git state)
 
 Produces `{"status": "skip", "issues": [], "summary": "No active plan found"}` when:
 
-- No plan files exist in `plans/` or `memory/`
+- No plan files exist in `plans/` or `memory/` — check with `Glob("plans/**")` / `Glob("memory/**")`, never a bare `Read` of the directory (`knowledge/directory-enumeration.md`, Whole-file load: a short single-rule reference)
 - The current task has no associated plan
 
 ## What the script detects

--- a/plugins/dev-team/agents/spec-compliance-review.md
+++ b/plugins/dev-team/agents/spec-compliance-review.md
@@ -3,7 +3,7 @@ name: spec-compliance-review
 description: Verify implementation matches specification before quality review agents run
 tools: Read, Grep, Glob
 effort: medium
-cites: [adversarial-review-protocol]
+cites: [adversarial-review-protocol, directory-enumeration]
 ---
 
 # Spec Compliance Review
@@ -69,7 +69,7 @@ This agent answers one question: **does the code do what the spec says?** It run
 
 Return `{"status": "skip", "issues": [], "summary": "No spec artifacts found"}` when:
 
-- No plan file (with its slice scenarios), spec, design doc, or acceptance criteria can be located for the target
+- No plan file (with its slice scenarios), spec, design doc, or acceptance criteria can be located for the target — locate with `Glob("docs/specs/**/*.md")` / `Glob("plans/**")`, never a bare `Read` of the directory (`knowledge/directory-enumeration.md`, Whole-file load: a short single-rule reference)
 - Target is a standalone script or utility with no associated specification
 
 ## Severity Rules

--- a/plugins/dev-team/knowledge/directory-enumeration.md
+++ b/plugins/dev-team/knowledge/directory-enumeration.md
@@ -1,0 +1,38 @@
+# Directory Enumeration
+
+## The rule
+
+**Never `Read` a directory path to check whether something exists or to see
+what it contains.** `Read` expects a file; pointed at a directory it throws
+`EISDIR`. This hazard fires whenever an instruction says *what* to detect
+("no plan files exist in `plans/`", "no spec artifacts found", "no `agents/`
+directory") without saying *how* — the model reaches for the nearest tool
+(`Read`) instead of the correct one.
+
+**Use `Glob` for existence checks and enumeration:**
+
+- Existence of a known directory: `Glob(".claude/**")`, `Glob("plans/**")`.
+- Enumerating a directory's contents: `Glob("agents/*.md")`,
+  `Glob("docs/specs/**/*.md")`.
+- Checking for one specific candidate file: a targeted `Read` of that exact
+  path is fine (e.g. `Read("docs/specs/foo/spec.md")`) — the hazard is only
+  `Read`-ing the *directory itself*, not a known filename inside it.
+
+An empty `Glob` result means "not present" — no directory read is needed to
+reach that conclusion.
+
+## Why this is shared, not local
+
+This same hazard has been independently discovered and locally patched three
+times (agent-roster enumeration, `--path` target resolution, `## Skip`
+existence probing) before this file existed. Citing this file from any
+Skip/detection section that implies "check whether X exists" prevents a
+fourth local fix.
+
+## How this connects to the rest of the toolkit
+
+Cited by `skills/code-review/SKILL.md` and by review-agent/skill Skip or
+detection sections that probe for a directory's presence or contents
+(`claude-setup-review`, `progress-guardian`, `spec-compliance-review`, the
+`continue` skill) — add a citation here rather than re-explaining the
+mechanism inline.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -523,6 +523,20 @@
       "anchor": "what-not-to-flag-1"
     }
   },
+  "plugins/dev-team/knowledge/directory-enumeration.md": {
+    "The rule": {
+      "summary": "**Never `Read` a directory path to check whether something exists or to see",
+      "anchor": "the-rule"
+    },
+    "Why this is shared, not local": {
+      "summary": "This same hazard has been independently discovered and locally patched three",
+      "anchor": "why-this-is-shared-not-local"
+    },
+    "How this connects to the rest of the toolkit": {
+      "summary": "Cited by `skills/code-review/SKILL.md` and by review-agent/skill Skip or",
+      "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
+    }
+  },
   "plugins/dev-team/knowledge/domain-modeling.md": {
     "Exploration Patterns": {
       "summary": "Map the project structure before detecting issues.",
@@ -2365,11 +2379,11 @@
       "anchor": "orchestrator-constraints"
     },
     "Steps": {
-      "summary": "Read all files in `memory/` looking for phase progress files.",
+      "summary": "Find phase progress files with `Glob(\"memory/*.md\")` — never `Read` the bare `memory/` directory to see what it contains (`${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`).",
       "anchor": "steps"
     },
     "1. Scan for in-progress work": {
-      "summary": "Read all files in `memory/` looking for phase progress files.",
+      "summary": "Find phase progress files with `Glob(\"memory/*.md\")` — never `Read` the bare `memory/` directory to see what it contains (`${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`).",
       "anchor": "1-scan-for-in-progress-work"
     },
     "2. Check git state": {

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -92,7 +92,7 @@ Priority order:
 3. `--all` — all source files
 4. **Auto-scope** (no flags): run `git diff --name-only` + `git diff --cached --name-only`, combine and dedupe. If non-empty, review those files. If empty, review the full repository.
 
-**Never `Read` a directory path directly to enumerate its contents** — `Read` on a directory throws `EISDIR` (the same hazard step 3 avoids for agent-roster enumeration). This applies to `--path <dir>`, `--all`, and the full-repository fallback alike: always list files with `Glob` (e.g. `Glob("<dir>/**/*")`), never a bare `Read` on the directory itself.
+**Never `Read` a directory path directly to enumerate its contents** — `Read` on a directory throws `EISDIR` (the same hazard step 3 avoids for agent-roster enumeration). This applies to `--path <dir>`, `--all`, and the full-repository fallback alike: always list files with `Glob` (e.g. `Glob("<dir>/**/*")`), never a bare `Read` on the directory itself. See `${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md` for the shared rule.
 
 **Scope validation** (full-repo paths only):
 
@@ -166,7 +166,7 @@ If Semgrep already ran in the pre-flight gate, reuse those findings. Do not run 
 
 If `--background`: run only `doc-review`, `arch-review`, `naming-review`, `structure-review`. Skip all others.
 
-Otherwise read the roster from the **Review Agents** section of `knowledge/agent-registry.md` — each row names an agent and its `agents/<name>.md` file. **Never `Read` the bare `agents/` directory** (it throws `EISDIR`); if you must confirm files on disk, list them with `Glob("agents/*.md")`, never a directory `Read`. All are enabled by default.
+Otherwise read the roster from the **Review Agents** section of `knowledge/agent-registry.md` — each row names an agent and its `agents/<name>.md` file. **Never `Read` the bare `agents/` directory** (it throws `EISDIR`); if you must confirm files on disk, list them with `Glob("agents/*.md")`, never a directory `Read` (see `${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`). All are enabled by default.
 
 **Language-agnostic agents always run** regardless of tech stack: `doc-review`, `arch-review`, `claude-setup-review`, `token-efficiency-review`.
 

--- a/plugins/dev-team/skills/continue/SKILL.md
+++ b/plugins/dev-team/skills/continue/SKILL.md
@@ -28,14 +28,14 @@ You have been invoked with the `/continue` command.
 
 ### 1. Scan for in-progress work
 
-Read all files in `memory/` looking for phase progress files. These follow the pattern:
+Find phase progress files with `Glob("memory/*.md")` — never `Read` the bare `memory/` directory to see what it contains (`${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`). These follow the pattern:
 
 - `memory/research-progress-*.md` — Research phase output
 - `memory/plan-progress-*.md` — Plan phase output
 - `memory/implementation-progress-*.md` — Implementation phase output
 - `memory/decisions.md` — Accumulated decision log
 
-Also check:
+Also check (same rule — `Glob`, not a directory `Read`):
 
 - `plans/` directory for active plan files
 - `docs/specs/` for design documents without corresponding implementation


### PR DESCRIPTION
## Summary

- Add `plugins/dev-team/knowledge/directory-enumeration.md`: a short (236-word) shared reference stating the single rule — never `Read` a directory path for existence checks or enumeration; use `Glob` (or a targeted `Read` of one known candidate filename) instead. This is the canonical source the three prior local fixes (#841, #857, #876/#877) lacked.
- Cite it from `skills/code-review/SKILL.md`'s two existing inline `EISDIR` warnings (`--path`/`--all` target resolution, and agent-roster enumeration).
- Audited every review agent's `## Skip`/detection section for the same implicit "check whether X exists" gap and added citations to the three genuine matches found — cases that name a directory to probe (`plans/`, `memory/`, `docs/specs/`) without saying *how*:
  - `agents/claude-setup-review.md` — already had inline `Glob` guidance from #877; consolidated onto the shared file.
  - `agents/progress-guardian.md` — `## Skip` said "No plan files exist in `plans/` or `memory/`" with no enumeration method.
  - `agents/spec-compliance-review.md` — `## Skip` said a plan/spec/design doc "can be located" across directories with no enumeration method.
  - `skills/continue/SKILL.md` — literally said "Read all files in `memory/`" and "check `plans/`/`docs/specs/`" with no method; the closest literal match to the anti-pattern in the issue.
- Registered the new file in `knowledge/index.json` via `plugins/dev-team/hooks/lib/build_knowledge_index.py`.

Agents/skills audited but **not** touched because their existence checks already operate over a pre-scoped file list (from `code-review`'s own target-resolution step) rather than probing a directory themselves, or already route through `Glob`-based knowledge files: `arch-review` (via `knowledge/architecture-assessment.md`'s discovery sequence, already all-`Glob`), `doc-review`, `domain-review`, `security-review`, `a11y-review`, `component-architecture-review`, `test-review`/`test-smell-review` (via `knowledge/test-file-indicators.md`), `codebase-recon` (enumeration is delegated to a canonical script, not ad hoc `Read`).

## Test plan

- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py --check` — index is current
- [x] `python3 scripts/check_md_references.py` — no broken references
- [x] `python3 scripts/citation_lint.py` — no new warnings (pre-existing unrelated advisories only)
- [x] `pytest tests/agents/ tests/scripts/test_agent_audit_integration.py tests/commands/test_agent_audit_effort.py tests/repo/test_knowledge_index_current.py` — 110 passed, including `test_agent_knowledge_anchor.py` (every `knowledge/`/`skills/` reference in `agents/*.md` now anchors correctly or declares whole-file load)

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_