### PR TITLE
fix: add missing Role declarations to /specs, /design-doc, and workflow skills

### DIFF
--- a/plugins/dev-team/hooks/eval_compliance_check.py
+++ b/plugins/dev-team/hooks/eval_compliance_check.py
@@ -69,6 +69,28 @@ def _grep_matches(content: str, pattern: str) -> bool:
     return re.search(pattern, content) is not None
 
 
+def _split_frontmatter(content: str) -> "tuple[str, str]":
+    """Split a SKILL.md file into (frontmatter, body). If the file has no
+    `---`-delimited frontmatter block, frontmatter is '' and body is the
+    whole content."""
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            return content[3:end], content[end + 4 :]
+    return "", content
+
+
+def _is_user_invocable(frontmatter: str) -> bool:
+    """True when the skill's frontmatter declares `user-invocable: true`
+    (i.e. it's a slash command, not a purely agent-loaded knowledge skill)."""
+    return (
+        re.search(
+            r"^user-invocable:\s*true\s*$", frontmatter, re.MULTILINE | re.IGNORECASE
+        )
+        is not None
+    )
+
+
 def _project_root(payload: dict) -> Path:
     """Resolve the project root the same way for every hook that needs one
     (docs/python-hook-contract.md § Environment variables): prefer
@@ -247,7 +269,30 @@ def _skill_checks(content: str, skill_name: str) -> str:
         warnings.append(f"  WARN: {msg}\n")
 
     # 1. Role declaration (WARN)
-    if not _grep_i_matches(
+    #
+    # User-invocable skills (slash commands) are workflow initiators — they
+    # need an explicit `Role:` line in the SKILL.md *body* (immediately after
+    # the H1, matching /plan, /build, /code-review, /pr, /ship). A
+    # frontmatter-only `role:` field is not sufficient for these: it's easy
+    # to add without ever stating the orchestration-discipline contract the
+    # body line carries (see agents/orchestrator.md). Agent-loaded,
+    # non-user-invocable knowledge skills are exempt from the stricter body
+    # check — a frontmatter `role:` (or nothing, for pure reference material)
+    # is fine for those.
+    frontmatter, body = _split_frontmatter(content)
+    if _is_user_invocable(frontmatter):
+        if not re.search(
+            r"^Role:\s*(orchestrator|worker|implementation)\b",
+            body,
+            re.MULTILINE,
+        ):
+            warn(
+                f"{skill_name}: Missing explicit 'Role:' line in the skill body "
+                f"(user-invocable workflow skills must declare Role: orchestrator, "
+                f"worker, or implementation right after the H1 — a frontmatter-only "
+                f"`role:` field does not satisfy this)."
+            )
+    elif not _grep_i_matches(
         content,
         r"role:\s*(orchestrator|worker|implementation)",
     ):

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -242,13 +242,23 @@ those agents run under `/code-review` for semantic depth.
 Read each file in `.claude/skills/*.md` and `.claude/skills/*/SKILL.md` and check:
 
 1. **Role declaration**: Does the skill declare its role?
-   - All skills MUST have a `Role:` line (orchestrator, worker, or
-     implementation)
+   - **User-invocable skills** (`user-invocable: true` — slash commands and
+     workflow initiators) MUST have an explicit `Role:` line in the SKILL.md
+     **body**, immediately after the H1 (matching `/plan`, `/build`,
+     `/code-review`, `/pr`, `/ship`): `Role: orchestrator`, `Role: worker`, or
+     `Role: implementation`. A frontmatter-only `role:` field (lowercase key)
+     does NOT satisfy this — it's easy to add without stating the
+     orchestration-discipline contract the body line carries. WARN if a
+     user-invocable skill has no body `Role:` line.
+   - **Agent-loaded, non-user-invocable knowledge skills** (no
+     `user-invocable: true`) are exempt from the body-line requirement — a
+     frontmatter `role:` field, or no role at all for pure reference
+     material, is acceptable. WARN only if such a skill has no role
+     declared anywhere (frontmatter or body).
    - Orchestrators route work and aggregate results — they must not
      review or modify code
    - Workers perform semantic analysis using agent definitions
    - Implementation skills modify code following correction prompts
-   - WARN if role is missing
 
 2. **Constraints section**: Does the skill declare its boundaries?
    - All skills SHOULD have a constraints section matching their role

--- a/plugins/dev-team/skills/branch-workflow/SKILL.md
+++ b/plugins/dev-team/skills/branch-workflow/SKILL.md
@@ -7,6 +7,9 @@ user-invocable: true
 
 # Branch Workflow
 
+Role: worker. This command performs PR creation, merge, and branch cleanup
+directly via git/gh commands.
+
 ## Overview
 
 The three-phase workflow ends at the Phase 3 human gate. This skill formalizes what happens after approval: PR creation, merge decision, and branch cleanup. Without this, branches linger and merge conflicts accumulate.

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -7,6 +7,9 @@ user-invocable: true
 
 # CD Test Architecture
 
+Role: worker. This command assesses and reports — it does not write tests or
+refactor code; it hands the migration steps to `/plan` or `/build`.
+
 ## Overview
 
 An **advisory, application-level** skill: it assesses how an existing application is tested, classifies that against a CD-aligned test taxonomy, finds the tests that can't run in a clean CI gate, and recommends a target architecture plus a migration path. It does not write tests or refactor code.

--- a/plugins/dev-team/skills/design-doc/SKILL.md
+++ b/plugins/dev-team/skills/design-doc/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: design-doc
 description: Produce a written design document in docs/specs/ with user approval before planning begins. Use this skill during the Research phase when a feature request, architectural change, or non-trivial task enters the pipeline. Ensures misunderstandings are caught before any planning or implementation work starts. Also use when the user says "brainstorm", "design", "spec", or "let's think through this".
-role: worker
+role: orchestrator
 user-invocable: true
 ---
 
 # Design Document
+
+Role: orchestrator. This command produces a design document and gates
+progression to Phase 2 (Plan) — it does not write implementation code,
+scaffold a project, or take any implementation action.
 
 ## Overview
 

--- a/plugins/dev-team/skills/domain-analysis/SKILL.md
+++ b/plugins/dev-team/skills/domain-analysis/SKILL.md
@@ -7,6 +7,9 @@ user-invocable: true
 
 # Domain Analysis
 
+Role: worker. This command produces a domain-health report — it is analytical,
+not prescriptive; it does not redesign code or write implementation.
+
 ## Overview
 
 Assess the domain health of an existing multi-component system. Produce a structured report covering bounded context boundaries, context map relationships, domain event flows, value stream throughput, and a friction report identifying where the architecture inhibits continuous delivery.

--- a/plugins/dev-team/skills/legacy-code/SKILL.md
+++ b/plugins/dev-team/skills/legacy-code/SKILL.md
@@ -7,6 +7,9 @@ user-invocable: true
 
 # Legacy Code
 
+Role: worker. This command applies characterization-testing and
+dependency-breaking techniques directly to the code under change.
+
 ## Overview
 
 Techniques for safely modifying code that lacks tests or has poor structure. Based on the principle that legacy code is code without tests (Michael Feathers' definition) — regardless of age. The goal is to get code under test before changing it, then improve structure incrementally.

--- a/plugins/dev-team/skills/mutation-testing/SKILL.md
+++ b/plugins/dev-team/skills/mutation-testing/SKILL.md
@@ -7,6 +7,10 @@ user-invocable: true
 
 # Mutation Testing
 
+Role: worker. This command runs the mutation tool and triages survivors
+directly — it does not generate or estimate mutations, and it does not
+replace the tests it validates.
+
 Wraps a real mutation tool (Stryker, pitest, mutmut, Stryker.NET, go-mutesting) and adds AI triage of survivors. The tool generates mutations and reports survivors; the AI classifies survivors and writes fix tests. **Never estimate or guess mutation outcomes** — if no tool is available, help set one up; do not substitute reasoning for execution.
 
 This file describes the language-agnostic workflow and the data contract. **Per-language detail — install, run commands, timeout flag names, native-report mapping — lives in [`references/languages/`](references/languages/).** Detect the language first via [`references/tool-detection.md`](references/tool-detection.md), then load the matching language file.

--- a/plugins/dev-team/skills/specs/SKILL.md
+++ b/plugins/dev-team/skills/specs/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: specs
 description: Collaborative workflow for producing the three specification artifacts (intent, architecture notes, acceptance criteria) that describe a change and its goals before any implementation begins. Its value is resolving ambiguity with a human before build starts — not synthesizing edge cases. Use when starting any new feature or behavior change — do not write code until artifacts pass the consistency gate. BDD/Gherkin scenarios are authored later, per slice, in /plan.
-role: worker
+role: orchestrator
 user-invocable: true
 ---
 
 # Agent-Assisted Specification
+
+Role: orchestrator. This command produces specification artifacts and gates
+progression to `/plan` — it does not write implementation code, author
+per-slice Gherkin scenarios, or begin building.
 
 ## Positioning — what this skill is for
 

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -8,6 +8,10 @@ argument-hint: "[--path <dir>]"
 
 # Test Health
 
+Role: worker. This command produces a strategic test-health report — it does
+not edit code or tests; fixes go to `/apply-fixes`, refactors to `/plan` /
+`/build`.
+
 ## Overview
 
 An **advisory, project-wide** skill: it produces the *strategic-health* view of a test suite that a team needs periodically — the suite's **shape** vs. its architecture, **Agile Testing Quadrant** coverage, **coverage + mutation** health rolled up to ROI, flaky-test management, and **automation maturity** — then an ordered improvement plan. It complements, and does not duplicate, `cd-test-architecture`: that skill owns the CD-determinism + pipeline-placement assessment, which this skill **delegates to** rather than re-deriving.

--- a/plugins/dev-team/skills/threat-modeling/SKILL.md
+++ b/plugins/dev-team/skills/threat-modeling/SKILL.md
@@ -7,6 +7,9 @@ user-invocable: true
 
 # Threat Modeling
 
+Role: worker. This command performs STRIDE analysis directly and documents
+threats/mitigations — it does not implement the mitigations it identifies.
+
 ## Overview
 
 Structured security analysis for identifying threats, attack surfaces, and mitigations during design or review phases. Ensures security considerations are addressed before implementation, not after.

--- a/tests/hooks/test_eval_compliance_check_role.py
+++ b/tests/hooks/test_eval_compliance_check_role.py
@@ -1,0 +1,151 @@
+"""Pytest tests for the `Role:` declaration check in hooks/eval_compliance_check.py
+(issue #884).
+
+Regression fixture: before this fix, a user-invocable skill with only a
+frontmatter `role: worker` field (no explicit `Role:` line in the SKILL.md
+body) satisfied the old regex — `role:\\s*(orchestrator|worker|implementation)`
+matched anywhere in the file, including frontmatter — so /specs and
+/design-doc silently passed with no visible role declaration in their bodies.
+The tightened check requires the explicit body line for user-invocable
+skills; frontmatter-only `role:` is exempt only for non-user-invocable,
+agent-loaded knowledge skills.
+
+Drives main() via subprocess with representative PostToolUse JSON payloads,
+matching the pattern used by tests/hooks/test_js_fp_review.py. The hook is
+advisory-only (always exits 0).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "eval_compliance_check.py"
+
+
+def _run(file_path: Path) -> subprocess.CompletedProcess:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LANG": "C.UTF-8"}
+    payload = {"tool_input": {"file_path": str(file_path)}}
+    return subprocess.run(
+        [sys.executable, str(_HOOK_PY)],
+        input=json.dumps(payload).encode(),
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def _write_skill(tmp_path: Path, name: str, body: str) -> Path:
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(body, encoding="utf-8")
+    return skill_file
+
+
+# Minimal skill bodies share the mechanical scaffolding (numbered steps,
+# constraints, concise directive) so only the Role: declaration varies —
+# the other WARN/FAIL checks are covered by other test files.
+_SCAFFOLD = """
+## Constraints
+
+- Be concise.
+
+## Steps
+
+### 1. Do the thing
+"""
+
+
+def test_user_invocable_skill_with_only_frontmatter_role_is_flagged(
+    tmp_path: Path,
+) -> None:
+    """The exact bug shape: pre-fix /specs and /design-doc — a user-invocable
+    skill declares `role: worker` in frontmatter but has no body `Role:` line.
+    This must now be WARNed."""
+    content = f"""---
+name: fixture-pipeline-initiator
+description: A fixture workflow skill with no explicit Role line.
+role: worker
+user-invocable: true
+---
+
+# Fixture Pipeline Initiator
+{_SCAFFOLD}
+"""
+    skill_file = _write_skill(tmp_path, "fixture-pipeline-initiator", content)
+    result = _run(skill_file)
+    assert result.returncode == 0
+    out = result.stdout.decode()
+    assert "Missing explicit 'Role:' line in the skill body" in out
+
+
+def test_user_invocable_skill_with_explicit_body_role_line_passes(
+    tmp_path: Path,
+) -> None:
+    """Same fixture, fixed: an explicit body `Role:` line silences the WARN."""
+    content = f"""---
+name: fixture-pipeline-initiator
+description: A fixture workflow skill with an explicit Role line.
+role: worker
+user-invocable: true
+---
+
+# Fixture Pipeline Initiator
+
+Role: worker. This command does the fixture's work directly.
+{_SCAFFOLD}
+"""
+    skill_file = _write_skill(tmp_path, "fixture-pipeline-initiator", content)
+    result = _run(skill_file)
+    assert result.returncode == 0
+    out = result.stdout.decode()
+    assert "Missing explicit 'Role:' line in the skill body" not in out
+    assert "Missing 'Role:' declaration" not in out
+
+
+def test_non_user_invocable_knowledge_skill_exempt_from_body_line(
+    tmp_path: Path,
+) -> None:
+    """Agent-loaded, non-user-invocable knowledge skills are exempt from the
+    stricter body-line requirement — a frontmatter `role:` field is enough."""
+    content = f"""---
+name: fixture-knowledge-skill
+description: A fixture agent-loaded knowledge skill.
+role: worker
+---
+
+# Fixture Knowledge Skill
+{_SCAFFOLD}
+"""
+    skill_file = _write_skill(tmp_path, "fixture-knowledge-skill", content)
+    result = _run(skill_file)
+    assert result.returncode == 0
+    out = result.stdout.decode()
+    assert "Missing explicit 'Role:' line in the skill body" not in out
+    assert "Missing 'Role:' declaration" not in out
+
+
+def test_non_user_invocable_skill_with_no_role_anywhere_still_flagged(
+    tmp_path: Path,
+) -> None:
+    """The original, lenient check is preserved for non-user-invocable
+    skills: a role declared nowhere at all is still WARNed."""
+    content = f"""---
+name: fixture-knowledge-skill-no-role
+description: A fixture agent-loaded knowledge skill missing role entirely.
+---
+
+# Fixture Knowledge Skill No Role
+{_SCAFFOLD}
+"""
+    skill_file = _write_skill(tmp_path, "fixture-knowledge-skill-no-role", content)
+    result = _run(skill_file)
+    assert result.returncode == 0
+    out = result.stdout.decode()
+    assert "Missing 'Role:' declaration" in out


### PR DESCRIPTION
## Summary

- `/specs` and `/design-doc` declared no explicit `Role:` line in the SKILL.md body — the only two pipeline-phase skills silent on it, while `/plan`, `/build`, `/code-review`, `/pr`, `/ship` all declare `Role: orchestrator` right after the H1. Both actually fit `orchestrator` (they gate progression to the next phase and never touch code, per `agents/orchestrator.md`'s taxonomy) — their stale frontmatter `role: worker` field is corrected to `orchestrator` alongside the new body line, removing the drift between the two declarations.
- Follow-on sweep: `cd-test-architecture`, `test-health`, `legacy-code`, `domain-analysis`, `threat-modeling`, `branch-workflow`, `mutation-testing` each get a body `Role: worker` line matching their existing (unchanged) frontmatter — they do their work inline rather than gating a phase transition.
- Tightened `hooks/eval_compliance_check.py`'s `Role:` check: a frontmatter-only `role:` field no longer silently satisfies the requirement for **user-invocable** skills (this is exactly how `/specs`/`/design-doc` slipped through before — the old regex matched `role: worker` in frontmatter, so the gap was never flagged). Non-user-invocable, agent-loaded knowledge skills remain exempt from the stricter body-line requirement.
- Updated `skills/agent-audit/SKILL.md` §3 ("Audit skills") to document the same distinction, so `/agent-audit` reports the gap consistently with the hook.
- Added `tests/hooks/test_eval_compliance_check_role.py`, a regression fixture reproducing the exact bug shape (user-invocable skill, frontmatter-only `role:`, no body line) and proving detection now works, plus the exemption cases (knowledge-only skills, fixed skills).

See the judgment-call notes posted on #884 for why `orchestrator` (not `worker`) was chosen for `/specs`/`/design-doc`, and why the detection fix lives in `agent-audit`/`eval_compliance_check.py` rather than `claude-setup-review`.

## Test plan

- [x] `python3 -m pytest tests/hooks/test_eval_compliance_check_role.py -v` — 4/4 pass
- [x] `python3 -m pytest tests/hooks/ tests/agents/ tests/scripts/test_agent_audit_integration.py tests/commands/test_agent_audit_effort.py -q` — 178 passed
- [x] `python3 -m pytest tests/ -q --ignore=tests/security-assessment` — 1922 passed (17 pre-existing failures unrelated to this change: missing `jsonschema`/`pytest-asyncio` deps in `test_codebase_recon.py`/`test_orchestrator.py`, not touched by this PR)
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py --check` — clean (no `##` headings changed, so `knowledge/index.json` needed no regeneration)
- [x] Manually ran `eval_compliance_check.py` against all 9 edited SKILL.md files — no `Role:` warning on any

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_