### PR TITLE
feat: add correctness-review agent for functional-defect detection

### DIFF
--- a/evals/expected/cr-boundary-omission.json
+++ b/evals/expected/cr-boundary-omission.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-boundary-omission",
+  "description": "Regression fixture for #885/#852 Defects4J commons-lang LANG-747: hex-digit overflow check only tests digit count, dropping the documented sign-bit boundary case (8 hex digits with firstSigDigit > '7')",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "error": { "min": 1, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["firstSigDigit"]
+    }
+  }
+}

--- a/evals/expected/cr-clean-baseline.json
+++ b/evals/expected/cr-clean-baseline.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "cr-clean-baseline",
+  "description": "False-positive budget: a real, already-shipped repo utility (plugins/dev-team/hooks/lib/knowledge_index_paths.py) with no known correctness defects. Noise budget for #885: at most 2 unmatched findings allowed on a clean, well-reviewed file",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 2 }
+    }
+  }
+}

--- a/evals/expected/cr-literal-vs-interpolation.json
+++ b/evals/expected/cr-literal-vs-interpolation.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-literal-vs-interpolation",
+  "description": "Regression fixture for #885/#852 shields Bug-1: cache key template literal writes `match[0]` as a literal string instead of interpolating it, so every request collides on one cache key",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "error": { "min": 1, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["cacheKey"]
+    }
+  }
+}

--- a/evals/expected/cr-missing-assignment.json
+++ b/evals/expected/cr-missing-assignment.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-missing-assignment",
+  "description": "Regression fixture for #885/#852 hessian.js Bug-1: `keys` is read in a write loop but never assigned from `this._classRefFields[className]` before the loop, leaving it stale/undefined",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "error": { "min": 1, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["keys"]
+    }
+  }
+}

--- a/evals/expected/cr-missing-guard.json
+++ b/evals/expected/cr-missing-guard.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-missing-guard",
+  "description": "Regression fixture for #885/#852 bower Bug-1: a documented `isCacheable` guard exists but is never called before caching a resolution, so non-cacheable (file:// / branch) sources get cached as moving targets",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 1, "max": 4 },
+      "severities": { "error": { "min": 1, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["isCacheable"]
+    }
+  }
+}

--- a/evals/fixtures/cr-boundary-omission.js
+++ b/evals/fixtures/cr-boundary-omission.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * Determine whether a hex-digit string, if parsed as a Java-style `int`
+ * (32-bit signed, two's complement), would overflow.
+ *
+ * A 32-bit signed int overflows in hex when it has more than 8 hex digits,
+ * OR when it has exactly 8 hex digits and the first significant digit's
+ * high bit would set the sign bit past the representable magnitude — i.e.
+ * the first significant hex digit is greater than '7'. That sign-bit case
+ * is part of the overflow contract this function documents and must check.
+ */
+function isHexOverflow(hexDigits, firstSigDigit) {
+  // BUG: only the digit-count boundary is checked. The documented sign-bit
+  // case (exactly 8 hex digits AND firstSigDigit > '7') is never tested,
+  // so an 8-digit hex literal whose leading digit is '8'-'f' is reported
+  // as in-range when it actually overflows a signed 32-bit int.
+  return hexDigits > 8;
+}
+
+function createNumber(hexDigits, firstSigDigit) {
+  if (isHexOverflow(hexDigits, firstSigDigit)) {
+    return { type: "long" };
+  }
+  return { type: "int" };
+}
+
+module.exports = { isHexOverflow, createNumber };

--- a/evals/fixtures/cr-clean-baseline.py
+++ b/evals/fixtures/cr-clean-baseline.py
@@ -1,0 +1,64 @@
+"""knowledge_index_paths — single source of truth for the indexed corpus.
+
+Python port of hooks/lib/knowledge-index-paths.sh (#575 / #572 Cluster A).
+
+Imported (not executed) by the Python siblings of the three .sh callers:
+  - hooks/knowledge-index.py                   (PostToolUse regenerator)
+  - hooks/pre-commit-knowledge-index.py        (pre-commit freshness gate)
+  - tests/agents/… anchor-citation gate        (still bats today; the .py
+                                                port will import this module)
+
+The corpus is:
+  - plugins/dev-team/knowledge/*.md         (top-level .md only)
+  - plugins/dev-team/skills/<name>/SKILL.md
+
+Excluded:
+  - plugins/dev-team/knowledge/schemas/**   (json schemas, not docs)
+  - everything else (agents/, commands/, docs/, README.md, …)
+
+Anchor: top-level knowledge .md OR <skills-dir>/<one segment>/SKILL.md.
+A leading `(^|/)` allows repo-relative or absolute paths.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+# Regex matching corpus paths (POSIX ERE from the .sh sibling, ported to
+# Python re syntax). Anchor: end-of-string; a leading segment is optional so
+# absolute and repo-relative inputs both match. Alternation covers the two
+# corpus shapes: top-level knowledge markdown, and per-skill SKILL.md.
+CORPUS_REGEX: str = (
+    r"(^|/)plugins/dev-team/(knowledge/[^/]+\.md|skills/[^/]+/SKILL\.md)$"
+)
+
+_CORPUS_RE = re.compile(CORPUS_REGEX)
+
+
+def is_corpus_path(path: str) -> bool:
+    """Return True iff `path` is part of the indexed corpus.
+
+    Byte-parity with the .sh's `_is_corpus_path`. Windows backslash paths
+    do NOT match — the corpus is a forward-slash convention and Git Bash
+    surfaces forward slashes even on Windows.
+    """
+    if not path:
+        return False
+    return _CORPUS_RE.search(path) is not None
+
+
+def filter_corpus_paths(paths: Iterable[str]) -> List[str]:
+    """Return the input list filtered to corpus paths, preserving order.
+
+    Convenience for hook callers that receive a batch of changed files and
+    want only the ones the index cares about. Order-preserving because
+    downstream builds are order-sensitive (see build_knowledge_index.py).
+    """
+    return [p for p in paths if is_corpus_path(p)]
+
+
+__all__ = ("CORPUS_REGEX", "is_corpus_path", "filter_corpus_paths")

--- a/evals/fixtures/cr-literal-vs-interpolation.js
+++ b/evals/fixtures/cr-literal-vs-interpolation.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/**
+ * Builds the cache key for a badge request. The key MUST be unique per
+ * matched route segment (`match[0]`) plus its stringified query params,
+ * so that requests for different routes never collide on the same cache
+ * entry.
+ */
+function buildCacheKey(match, query) {
+  const stringified = JSON.stringify(query || {});
+
+  // BUG: `match[0]` is written as a literal `match[0]` character sequence
+  // instead of being interpolated. Every request produces the exact same
+  // cache key string "match[0]?<stringified>" regardless of which route
+  // actually matched, so unrelated requests collide on one cache entry.
+  const cacheKey = `match[0]?${stringified}`;
+
+  return cacheKey;
+}
+
+function handleRequest(req, cache, match) {
+  const key = buildCacheKey(match, req.query);
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+  const result = computeBadge(match, req.query);
+  cache.set(key, result);
+  return result;
+}
+
+function computeBadge(match, query) {
+  return { label: match[0], query };
+}
+
+module.exports = { buildCacheKey, handleRequest };

--- a/evals/fixtures/cr-missing-assignment.js
+++ b/evals/fixtures/cr-missing-assignment.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/**
+ * Encoder for a class-instance write, keyed by the class's declared field
+ * order. Every value written for this instance MUST come from the current
+ * class's field list — `_classRefFields` maps className -> ordered field
+ * names, refreshed on every new class definition.
+ */
+class InstanceEncoder {
+  constructor() {
+    this._classRefFields = Object.create(null);
+  }
+
+  registerClassFields(className, fieldNames) {
+    this._classRefFields[className] = fieldNames;
+  }
+
+  /**
+   * Write the fields of `instance` (whose class is `className`) to `out`,
+   * in the field order declared for that class.
+   */
+  writeInstance(out, className, instance) {
+    let keys;
+    // BUG: `keys` is declared above but the current class's field list is
+    // never loaded into it before the write loop below. On the first call
+    // for a class, `keys` stays `undefined`; on later calls it silently
+    // holds whichever class's fields happened to be encoded previously,
+    // so every field after the first class gets written under the wrong
+    // key order.
+    for (let i = 0; i < keys.length; i++) {
+      const fieldName = keys[i];
+      out.push(fieldName, instance[fieldName]);
+    }
+  }
+}
+
+module.exports = { InstanceEncoder };

--- a/evals/fixtures/cr-missing-guard.js
+++ b/evals/fixtures/cr-missing-guard.js
@@ -1,0 +1,40 @@
+"use strict";
+
+/**
+ * Determines whether a resolved package source is safe to cache and reuse
+ * across installs. Sources are cacheable only when they resolve to an
+ * immutable target: a pinned version or tag. Local filesystem sources
+ * (`file://`) and floating branch resolutions are moving targets and must
+ * never be treated as cacheable — caching them would serve stale or
+ * wrong content on the next install.
+ */
+function isCacheable(source) {
+  if (!source) return false;
+  // Deliberately excludes file:// and branch resolutions (see docstring).
+  return true;
+}
+
+/**
+ * Store a resolved package in the shared cache, keyed by its source.
+ */
+class PackageRepository {
+  constructor() {
+    this._cache = new Map();
+  }
+
+  store(source, resolution) {
+    // BUG: `isCacheable` exists specifically to reject file:// sources and
+    // branch resolutions (per its own docstring), but this call site never
+    // invokes it before caching — every resolution is cached unconditionally,
+    // including local filesystem sources and floating branches, which then
+    // get served as stale cached content on later installs.
+    this._cache.set(source, resolution);
+    return resolution;
+  }
+
+  get(source) {
+    return this._cache.get(source);
+  }
+}
+
+module.exports = { isCacheable, PackageRepository };

--- a/plugins/dev-team/agents/correctness-review.md
+++ b/plugins/dev-team/agents/correctness-review.md
@@ -1,0 +1,123 @@
+---
+name: correctness-review
+description: Functional/behavioral defects where implementation diverges from evident intent (missing assignments, wrong operators, inverted conditions, missing guard clauses, off-by-one/boundary errors)
+tools: Read, Grep, Glob
+effort: high
+cites: [adversarial-review-protocol]
+---
+
+# Correctness Review
+
+Output JSON:
+
+```json
+{"status": "pass|warn|fail|skip", "issues": [{"severity": "error|warning|suggestion", "confidence": "high|medium|none", "file": "", "line": 0, "message": "", "suggestedFix": ""}], "summary": ""}
+```
+
+Status: pass=implementation matches evident intent everywhere reviewed, warn=one or more suspected divergences that need human confirmation, fail=a clear behavioral defect where the code visibly contradicts its own name/comment/sibling logic
+Severity: error=the implementation will silently produce the wrong result on a realistic input path (missing assignment, non-interpolated string, missing guard, dropped boundary case, inverted condition); warning=the divergence is plausible but the evident intent is inferred rather than explicitly stated; suggestion=a minor mismatch between docstring/name and behavior with no observed defect
+Confidence: high=the evident intent is explicit (a docstring, comment, sibling branch, or unambiguous name) and the code visibly fails to satisfy it; medium=the evident intent is inferred from context (naming pattern, surrounding structure) rather than stated outright; none=not used — a finding with no articulable evident intent is dropped, not reported (see Self-Challenge)
+
+Context needs: full-file
+
+## What This Agent Checks
+
+This agent answers one question: **does this code do what it evidently intends to do?** It infers intent from the code itself — the function's name, its docstring/comments, its sibling branches, and its call sites — not from an external spec (that is `spec-compliance-review`'s job, comparing code against a written spec). It does not evaluate structure, security-specific bypass patterns, naming style, or test quality. Every other review agent's lens is code *quality*; this agent's lens is: is the code's own evident promise kept?
+
+## Detect
+
+Work through the file(s) under review looking for these five categories.
+For every candidate, first identify the "evident intent" — the specific
+name, docstring, comment, sibling branch, or call site that establishes what
+the code is supposed to do — before treating it as a finding.
+
+1. **Missing/incomplete assignment** — a variable is declared, or reused
+   from an outer scope, but never (re)assigned the value that the
+   surrounding logic clearly requires before it's read. Look for: a loop
+   or block that reads a variable which should have been reassigned from a
+   lookup/computation immediately above it, but the assignment line is
+   absent (the value is stale, `undefined`, or from an unrelated prior
+   iteration). Grep for the variable's declaration and every write site;
+   if a read has no preceding write on the path that reaches it, flag it.
+
+2. **Literal-vs-interpolation errors** — a string clearly intended as a
+   template/format string (it contains `${...}`-shaped placeholders,
+   `%s`-style tokens, or string concatenation everywhere else in the same
+   function) but a specific placeholder is written as a literal character
+   sequence instead of the interpolation syntax the language requires
+   (e.g., `` `foo?${bar}` `` where `foo` should also have been
+   interpolated, `"literal_var"` where `f"{var}"`/`${var}` was clearly
+   intended). The signal is inconsistency: some parts of the string
+   interpolate, one part doesn't, and the un-interpolated part reads as a
+   variable name or expression.
+
+3. **Missing guard/validation branch** — a function's own name, docstring,
+   or sibling functions imply a precondition or exclusion case (e.g., "is
+   cacheable", "validate", "sanitize", "guard") that the function's body
+   does not actually check before proceeding. Look for functions that
+   perform an effectful operation (write, cache, mutate) where a sibling
+   function or comment establishes a condition under which that operation
+   should NOT happen, but no corresponding `if`/early-return enforces it.
+
+4. **Boundary-condition / off-by-one omission** — a numeric, length, or
+   index comparison that correctly handles the documented general case
+   but silently drops an edge case that a comment, adjacent constant, or
+   sibling comparison implies should also be handled (classic: a
+   `>=`/`>` or `<=`/`<` that should include an equal-length or
+   sign/overflow boundary; a loop bound off by one relative to the
+   collection it iterates; a digit-count check that omits the sign-bit or
+   most-significant-digit case).
+
+5. **Inverted or incomplete conditionals** — an `if`/`while`/ternary
+   condition whose polarity or coverage contradicts the behavior implied
+   by the surrounding code, comment, or the branch bodies themselves (a
+   comment says "skip when X" but the code proceeds when X; an early
+   return guards the wrong branch; an `else` handles what the `if`'s own
+   name implies it should have handled). This is the general case —
+   `security-review` owns the security-specific subset (auth-bypass
+   conditionals); do not re-flag findings that are purely
+   security-relevant here if `security-review` would already cover them,
+   but do flag general-purpose inverted logic with no security angle.
+
+## Self-Challenge
+
+After producing findings, run the shared challenger loop in
+`knowledge/adversarial-review-protocol.md` (Whole-file load: the slim shared
+methodology — The Loop + Output format — read in full), then work this
+correctness-review-specific challenge before finalizing each finding:
+
+- For every candidate finding, can you cite the *specific* docstring line,
+  comment, sibling function/branch, or unambiguous name that establishes the
+  evident intended behavior being violated? Quote it in the `message`.
+- If you cannot articulate that evident intent concretely, the finding is
+  **out of scope for this agent — drop it entirely**. Do not downgrade it to
+  `confidence: none` and report it as noise; a correctness finding with no
+  articulable intent is not a correctness finding.
+- Did you check that the finding isn't better explained as intentional
+  (e.g., a guard the caller already performs, a boundary the type system
+  already rules out)? If genuinely ambiguous, use `confidence: medium` and
+  say what would confirm it, rather than `high`.
+- Did you trace the actual data flow (declaration → assignment sites → read
+  sites) for "missing assignment" findings, rather than assuming a variable
+  is stale from its name alone?
+- For "missing guard" findings, did you confirm the guard is truly absent
+  on every path that reaches the effectful operation, not just the one you
+  read first?
+
+Append confidence level (High/Medium/Low) to the `summary` field.
+
+## Skip
+
+Return `{"status": "skip", "issues": [], "summary": "No behavioral logic to analyze"}` when:
+
+- Target contains only static assets, configuration, markup, or documentation with no executable logic
+- Target is generated code, vendored dependencies, or lockfiles
+
+## Ignore
+
+Code style and naming (`naming-review`), structure/DRY/coupling
+(`structure-review`), security-specific logic bypass such as auth-bypass
+conditionals (`security-review`), test quality (`test-review`),
+business-boundary/DDD placement (`domain-review`), spec-to-code matching
+against an explicit written spec (`spec-compliance-review`), refactoring
+opportunities (`refactor-opportunity-review`).

--- a/plugins/dev-team/docs/agent_info.md
+++ b/plugins/dev-team/docs/agent_info.md
@@ -32,6 +32,7 @@ Review agents run as sub-agents during Phase 3 inline checkpoints and full `/cod
 | `complexity-review` | [`complexity-review.md`](../agents/complexity-review.md) | haiku | Function size, cyclomatic complexity, nesting |
 | `component-architecture-review` | [`component-architecture-review.md`](../agents/component-architecture-review.md) | sonnet | Reusable component extraction, UI duplication, prop drilling, component APIs |
 | `concurrency-review` | [`concurrency-review.md`](../agents/concurrency-review.md) | sonnet | Race conditions, async pitfalls |
+| `correctness-review` | [`correctness-review.md`](../agents/correctness-review.md) | opus | Functional/behavioral defects — implementation diverges from evident intent |
 | `data-flow-tracer` | [`data-flow-tracer.md`](../agents/data-flow-tracer.md) | sonnet | Data flow tracing through architecture layers (analysis-only) |
 | `doc-review` | [`doc-review.md`](../agents/doc-review.md) | sonnet | README accuracy, API doc alignment, comment drift |
 | `domain-review` | [`domain-review.md`](../agents/domain-review.md) | opus | Abstraction leaks, boundary violations |

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -31,6 +31,7 @@ Spawned by the orchestrator during Phase 3 inline checkpoints and full `/code-re
 | complexity-review | `agents/complexity-review.md` | Function size, cyclomatic complexity, nesting, parameters |
 | component-architecture-review | `agents/component-architecture-review.md` | Reusable component extraction, frontend UI duplication, prop drilling, component granularity, inconsistent component APIs |
 | concurrency-review | `agents/concurrency-review.md` | Race conditions, async pitfalls, shared state |
+| correctness-review | `agents/correctness-review.md` | Functional/behavioral defects — implementation diverges from evident intent |
 | data-flow-tracer | `agents/data-flow-tracer.md` | Data flow tracing through architecture layers (analysis-only) |
 | doc-review | `agents/doc-review.md` | README accuracy, API doc alignment, inline comment drift, ADR update triggers |
 | domain-review | `agents/domain-review.md` | Domain boundaries, abstraction leaks, entity/DTO confusion |
@@ -126,7 +127,7 @@ Knowledge files in `knowledge/` provide progressive disclosure — agents read t
 
 | Name | File | ~Tokens | Used By |
 | ------ | ------ | --------- | --------- |
-| Adversarial Review Protocol | `knowledge/adversarial-review-protocol.md` | ~600 | all 22 review agents (a11y-review, arch-review, claude-setup-review, complexity-review, component-architecture-review, concurrency-review, data-flow-tracer, doc-review, domain-review, js-fp-review, naming-review, performance-review, progress-guardian, refactor-opportunity-review, security-review, session-analysis, spec-compliance-review, structure-review, svelte-review, test-review, test-smell-review, token-efficiency-review) |
+| Adversarial Review Protocol | `knowledge/adversarial-review-protocol.md` | ~600 | all 23 review agents (a11y-review, arch-review, claude-setup-review, complexity-review, component-architecture-review, concurrency-review, correctness-review, data-flow-tracer, doc-review, domain-review, js-fp-review, naming-review, performance-review, progress-guardian, refactor-opportunity-review, security-review, session-analysis, spec-compliance-review, structure-review, svelte-review, test-review, test-smell-review, token-efficiency-review) |
 | Agent Registry | `knowledge/agent-registry.md` | 1,200 | Orchestrator (routing decisions) |
 | Architecture Assessment | `knowledge/architecture-assessment.md` | 450 | arch-review |
 | CD Maturity Model | `knowledge/cd-maturity-model.md` | ~870 | Platform Engineer, QA Engineer |

--- a/scripts/eval_graders/verdict.py
+++ b/scripts/eval_graders/verdict.py
@@ -37,6 +37,18 @@ def grade_verdict(spec: dict, actual: dict) -> list[str]:
                 f"{rng.get('max', '∞')}, got {count}"
             )
 
+    # `minConfidenceAnyOf` (issue #885): assert at least one issue carries a
+    # confidence in the given set — used by fixtures that require the agent
+    # to flag a known defect at high-or-medium confidence without pinning an
+    # exact count (an agent may reasonably report the same defect more than
+    # once, or bundle it with a related finding).
+    min_conf = spec.get("minConfidenceAnyOf")
+    if min_conf and not any(i.get("confidence") in min_conf for i in issues):
+        fails.append(
+            f"minConfidenceAnyOf: expected at least one issue with "
+            f"confidence in {min_conf!r}, found none"
+        )
+
     text = " ".join(str(i.get("message", "")) for i in issues)
     text += " " + str(actual.get("summary", ""))
     for kw in spec.get("mustMention", []):

--- a/tests/repo/test_eval_grader.py
+++ b/tests/repo/test_eval_grader.py
@@ -177,6 +177,80 @@ def test_severity_count_out_of_range_fails(case: Path) -> None:
     assert "severities.error" in out
 
 
+def test_min_confidence_any_of_passes_when_one_issue_matches(case: Path) -> None:
+    # issue #885: correctness-review fixtures assert at least one issue at
+    # high-or-medium confidence, without pinning an exact per-confidence count.
+    _write(
+        case,
+        "expected/ar-demo.json",
+        """{
+  "fixture": "ar-demo.ts",
+  "applicableAgents": ["arch-review"],
+  "agents": {
+    "arch-review": {
+      "expectedStatus": "fail",
+      "minConfidenceAnyOf": ["high", "medium"]
+    }
+  }
+}
+""",
+    )
+    _write(
+        case,
+        "actuals.json",
+        """{ "ar-demo": { "agents": { "arch-review": {
+  "status": "fail",
+  "issues": [{ "severity": "error", "confidence": "high", "message": "layer violation" }],
+  "summary": "" } } } }
+""",
+    )
+    res = _grade(
+        case,
+        "--expected-dir",
+        str(case / "expected"),
+        "--actuals",
+        str(case / "actuals.json"),
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_min_confidence_any_of_fails_when_no_issue_matches(case: Path) -> None:
+    _write(
+        case,
+        "expected/ar-demo.json",
+        """{
+  "fixture": "ar-demo.ts",
+  "applicableAgents": ["arch-review"],
+  "agents": {
+    "arch-review": {
+      "expectedStatus": "fail",
+      "minConfidenceAnyOf": ["high", "medium"]
+    }
+  }
+}
+""",
+    )
+    _write(
+        case,
+        "actuals.json",
+        """{ "ar-demo": { "agents": { "arch-review": {
+  "status": "fail",
+  "issues": [{ "severity": "error", "confidence": "none", "message": "layer violation" }],
+  "summary": "" } } } }
+""",
+    )
+    res = _grade(
+        case,
+        "--expected-dir",
+        str(case / "expected"),
+        "--actuals",
+        str(case / "actuals.json"),
+    )
+    out = res.stdout + res.stderr
+    assert res.returncode == 1, out
+    assert "minConfidenceAnyOf" in out
+
+
 def test_baseline_isolates_regressions(case: Path) -> None:
     """Baseline says arch-review WAS passing; a new failure is a [REGRESSION]."""
     (case / "baseline.json").write_text('{ "passing": ["ar-demo::arch-review"] }')


### PR DESCRIPTION
## Summary

Adds `correctness-review`, a new review agent whose lens is **functional/behavioral correctness** — does an implementation match the behavior implied by its own name, docstring/comments, sibling code, and call sites. This closes the recall gap the #852 stress test found: `/code-review`'s 22-agent roster missed all four real, characterized bugs (missing assignment, non-interpolated template literal, missing cacheability guard, hex-overflow sign-bit boundary) because every existing agent targets code *quality*, not "does this code do what it evidently intends to do."

- `plugins/dev-team/agents/correctness-review.md` — `effort: high`, `tools: Read, Grep, Glob`, `cites: [adversarial-review-protocol]`. Five detection categories grounded in the four #852 misses (missing/incomplete assignment, literal-vs-interpolation errors, missing guard/validation branch, boundary-condition/off-by-one omission, inverted/incomplete conditionals). Self-challenge requires citing the specific evident intent (docstring/comment/sibling-code/name) a finding violates — no articulable intent means the finding is dropped, not reported as noise.
- Registered in `plugins/dev-team/knowledge/agent-registry.md` (Review Agents table + the adversarial-review-protocol citation list, now 23 agents) and `plugins/dev-team/docs/agent_info.md`. Verified `code-review/SKILL.md` reads the roster dynamically from the registry table — no SKILL.md change needed, and `/code-review`'s roster picks the new agent up automatically.
- **Eval fixtures** (`evals/fixtures/cr-*`, `evals/expected/cr-*.json`): one synthetic, pattern-equivalent reproduction per #852 bug (the real bugs live in external repos — hessian.js, shields, bower, commons-lang — out of scope to vendor), plus a clean-baseline fixture copied verbatim from a real, already-shipped repo utility (`hooks/lib/knowledge_index_paths.py`) to measure the false-positive rate.
- Extended the shared eval `verdict` grader (`scripts/eval_graders/verdict.py`) with an additive `minConfidenceAnyOf` field so a fixture can assert "flagged at confidence high|medium" without pinning an exact issue count — backward compatible, covered by two new unit tests in `tests/repo/test_eval_grader.py`.

## Eval results (live dispatch against the on-disk agent definition)

| Bug | Fixture | Result |
|---|---|---|
| hessian.js — missing `keys` assignment | `cr-missing-assignment.js` | ✅ flagged, confidence high |
| shields — non-interpolated cache key | `cr-literal-vs-interpolation.js` | ✅ flagged, confidence high |
| bower — missing cacheability guard | `cr-missing-guard.js` | ✅ flagged, confidence high (2 linked findings) |
| commons-lang LANG-747 — hex sign-bit boundary | `cr-boundary-omission.js` | ✅ flagged, confidence high |
| clean baseline | `cr-clean-baseline.py` | ✅ pass, 0 findings (budget ≤2) |

`python3 scripts/eval_grade.py --only correctness-review` → **5/5 pairs passed**. Full `--check-corpus` (104 fixtures) and the targeted pytest suites (`test_eval_grader.py`, `test_agent_info_registry_sync.py`, `check_registry_sync.py`, `citation_lint.py`, `token_efficiency_review.py`) all pass; the full `pytest tests/` run shows the same 17 pre-existing failures present on `origin/main` (missing `httpx`/`jsonschema` test deps, unrelated to this change) — verified via `git stash` comparison.

## Scope notes

- Explicitly excludes #821's broader benchmark-harness scope — no changes there.
- Acceptance criterion 4 from #885 (re-running the full #852 stress test against the external repos and reporting a recall number on #821) is **not** done here — that requires cloning external corpora and live dispatch at scale, called out as out of scope for this PR. See judgment-call comment on #885 for details.

Closes #885
Part of #821

## Test plan

- [x] `python3 scripts/eval_grade.py --check-corpus`
- [x] `python3 scripts/eval_grade.py --only correctness-review` (5/5 pass)
- [x] `python3 scripts/check_registry_sync.py`
- [x] `python3 scripts/citation_lint.py` (no new warnings)
- [x] `python3 scripts/token_efficiency_review.py --files plugins/dev-team/agents/correctness-review.md`
- [x] `python3 -m pytest tests/repo/test_eval_grader.py tests/docs/test_agent_info_registry_sync.py -q`
- [x] `python3 -m pytest tests/ -q --ignore=tests/security-assessment` (same pre-existing failures as `origin/main`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_