### PR TITLE
feat: add calibration floors policy table and guard test

### DIFF
--- a/plugins/dev-team/docs/model-routing.md
+++ b/plugins/dev-team/docs/model-routing.md
@@ -229,3 +229,22 @@ it in lockstep:
 
 These exist so bats tests can isolate filesystem state without touching the
 real `.claude/` directory. Setting them at runtime is not supported.
+
+## Calibration floors
+
+`knowledge/calibration-floors.json` is a separate policy table from the
+routing files above — it does not affect model selection. It declares, per
+eval-graded review agent or advisory skill, a `riskClass`
+(`high|standard|advisory`) and a `floor`: the minimum acceptable eval pass
+rate (0-1) for that target. `high` (`security-review`, `concurrency-review`,
+`arch-review`, `domain-review`) is floor `1.0`; the remaining review agents
+are `standard` at `0.9`; low-effort/lexical review agents and advisory-only
+skills (e.g. `test-design-advisor`) are `advisory` at `0.8`.
+
+This is slice 1 of epic #879 (band calibration): a pure policy artifact plus
+its guard test, `tests/repo/test_calibration_floors_sync.py`
+(`scripts/check_calibration_floors_sync.py`), which keeps the table in sync
+with the fixture-bearing `applicableAgents`/`applicableSkills` names declared
+across `evals/expected/*.json` and with the agents/skills present on disk. No
+eval run consumes these floors yet — later slices in the epic wire them into
+actual gating.

--- a/plugins/dev-team/knowledge/calibration-floors.json
+++ b/plugins/dev-team/knowledge/calibration-floors.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Calibration floor policy for eval-graded review agents/skills (issue #880, slice 1 of epic #879). riskClass drives the minimum acceptable eval pass rate (floor, 0-1) for that target. high: correctness-critical review classes named explicitly by the epic (security-review, concurrency-review, arch-review, domain-review) -- floor 1.0, zero tolerance for miscalibration. standard: the remaining review agents whose frontmatter declares effort: medium (or, for orchestrator, effort: medium with no lower-effort signal) -- floor 0.9. advisory: effort: low review agents (lexical/config/style-leaning checks) plus skills that self-describe as advisory (test-design-advisor) -- floor 0.8. Guarded by tests/repo/test_calibration_floors_sync.py via scripts/check_calibration_floors_sync.py. No eval runs are introduced by this slice -- later slices (#881-#883) wire the floors into actual gating.",
+  "security-review": { "riskClass": "high", "floor": 1.0 },
+  "concurrency-review": { "riskClass": "high", "floor": 1.0 },
+  "arch-review": { "riskClass": "high", "floor": 1.0 },
+  "domain-review": { "riskClass": "high", "floor": 1.0 },
+
+  "a11y-review": { "riskClass": "standard", "floor": 0.9 },
+  "complexity-review": { "riskClass": "standard", "floor": 0.9 },
+  "component-architecture-review": { "riskClass": "standard", "floor": 0.9 },
+  "correctness-review": { "riskClass": "standard", "floor": 0.9 },
+  "doc-review": { "riskClass": "standard", "floor": 0.9 },
+  "naming-review": { "riskClass": "standard", "floor": 0.9 },
+  "orchestrator": { "riskClass": "standard", "floor": 0.9 },
+  "performance-review": { "riskClass": "standard", "floor": 0.9 },
+  "refactor-opportunity-review": { "riskClass": "standard", "floor": 0.9 },
+  "session-analysis": { "riskClass": "standard", "floor": 0.9 },
+  "spec-compliance-review": { "riskClass": "standard", "floor": 0.9 },
+  "structure-review": { "riskClass": "standard", "floor": 0.9 },
+  "test-review": { "riskClass": "standard", "floor": 0.9 },
+  "test-smell-review": { "riskClass": "standard", "floor": 0.9 },
+
+  "claude-setup-review": { "riskClass": "advisory", "floor": 0.8 },
+  "js-fp-review": { "riskClass": "advisory", "floor": 0.8 },
+  "svelte-review": { "riskClass": "advisory", "floor": 0.8 },
+  "token-efficiency-review": { "riskClass": "advisory", "floor": 0.8 },
+  "test-design-advisor": { "riskClass": "advisory", "floor": 0.8 }
+}

--- a/scripts/check_calibration_floors_sync.py
+++ b/scripts/check_calibration_floors_sync.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Calibration-floors sensor — keep knowledge/calibration-floors.json in sync
+with the eval corpus and the agents/skills on disk (issue #880, slice 1 of
+epic #879).
+
+`calibration-floors.json` is the central policy table declaring the minimum
+acceptable eval pass rate (`floor`, 0-1) per `riskClass` (`high|standard|
+advisory`) for every fixture-bearing review agent or advisory skill. A
+"fixture-bearing" target is any name that appears in an `applicableAgents` or
+`applicableSkills` array under `evals/expected/*.json` AND still has a real
+agent (`agents/<name>.md`) or skill (`skills/<name>/SKILL.md`) definition on
+disk — a name left over in a fixture after its agent was intentionally
+removed (e.g. `test-modernization-review`, retired by issue #536) is stale
+fixture data, not a live calibration target, and is not required to have a
+floor entry.
+
+Three failure classes, mirroring check_registry_sync.py's MISSING/ORPHAN
+shape:
+
+  * MISSING — a fixture-bearing agent/skill has no entry in
+    calibration-floors.json.
+  * ORPHAN  — a calibration-floors.json entry names a target with no agent or
+    skill definition on disk.
+  * INVALID — an entry's `floor` is not a number in [0, 1], or its
+    `riskClass` is not one of high/standard/advisory.
+
+Keys starting with `_` (e.g. `_comment`) are metadata, not targets, and are
+ignored by every check.
+
+Exit 0 when the table is fully in sync; exit 1 with a per-discrepancy report
+otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PLUGIN = "plugins/dev-team"
+VALID_RISK_CLASSES = {"high", "standard", "advisory"}
+
+
+def disk_agent_names(root: Path) -> set:
+    folder = root / PLUGIN / "agents"
+    if not folder.is_dir():
+        return set()
+    return {p.stem for p in folder.glob("*.md")}
+
+
+def disk_skill_names(root: Path) -> set:
+    folder = root / PLUGIN / "skills"
+    if not folder.is_dir():
+        return set()
+    return {p.parent.name for p in folder.glob("*/SKILL.md")}
+
+
+def fixture_bearing_names(root: Path, known: set) -> set:
+    """Names referenced by evals/expected/*.json applicableAgents/
+    applicableSkills, restricted to names that still resolve to a real
+    agent or skill on disk (see module docstring for the rationale)."""
+    names = set()
+    expected_dir = root / "evals" / "expected"
+    if not expected_dir.is_dir():
+        return names
+    for path in sorted(expected_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for key in ("applicableAgents", "applicableSkills"):
+            for name in data.get(key) or []:
+                if name in known:
+                    names.add(name)
+    return names
+
+
+def load_floors(root: Path) -> dict:
+    path = root / PLUGIN / "knowledge" / "calibration-floors.json"
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"calibration-floors.json is not valid JSON: {exc}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Check calibration-floors.json matches the eval corpus and "
+        "the agents/skills on disk."
+    )
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd).")
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    agents = disk_agent_names(root)
+    skills = disk_skill_names(root)
+    known = agents | skills
+
+    floors = load_floors(root)
+    entries = {k: v for k, v in floors.items() if not k.startswith("_")}
+
+    required = fixture_bearing_names(root, known)
+
+    problems = []
+
+    missing = sorted(required - entries.keys())
+    for name in missing:
+        problems.append(
+            f"  MISSING  floor: {name} is fixture-bearing but absent from "
+            "calibration-floors.json"
+        )
+
+    orphans = sorted(name for name in entries if name not in known)
+    for name in orphans:
+        problems.append(
+            f"  ORPHAN   floor: '{name}' has no agent or skill definition on disk"
+        )
+
+    for name in sorted(entries):
+        entry = entries[name]
+        if not isinstance(entry, dict):
+            problems.append(f"  INVALID  floor: '{name}' entry is not an object")
+            continue
+        risk_class = entry.get("riskClass")
+        floor_value = entry.get("floor")
+        if risk_class not in VALID_RISK_CLASSES:
+            problems.append(
+                f"  INVALID  floor: '{name}' has unknown riskClass "
+                f"'{risk_class}' (expected one of {sorted(VALID_RISK_CLASSES)})"
+            )
+        is_number = isinstance(floor_value, (int, float)) and not isinstance(
+            floor_value, bool
+        )
+        if not is_number or not (0 <= floor_value <= 1):
+            problems.append(
+                f"  INVALID  floor: '{name}' has out-of-range or non-numeric "
+                f"floor '{floor_value}' (expected a number in [0, 1])"
+            )
+
+    if problems:
+        print("Calibration floors out of sync with eval corpus / disk:")
+        print("\n".join(problems))
+        print(
+            f"\n{len(problems)} discrepancy(ies). Update "
+            f"{PLUGIN}/knowledge/calibration-floors.json."
+        )
+        return 1
+
+    print(
+        "Calibration floors in sync: every fixture-bearing agent/skill has a "
+        "valid floor entry, and every entry resolves to a real agent or skill."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repo/test_calibration_floors_sync.py
+++ b/tests/repo/test_calibration_floors_sync.py
@@ -1,0 +1,150 @@
+"""Calibration-floors completeness sensor. knowledge/calibration-floors.json
+must stay in sync with (a) the fixture-bearing agents/skills declared across
+evals/expected/*.json and (b) the agents/ and skills/ directories on disk.
+Guards the policy artifact introduced by issue #880 (slice 1 of epic #879):
+without this test a new eval fixture could reference an agent with no
+calibration floor, or a hand-edited floor entry could drift into an invalid
+riskClass/value or point at a target that no longer exists.
+
+Structural template: tests/repo/test_registry_sync.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK = REPO_ROOT / "scripts" / "check_calibration_floors_sync.py"
+
+_BASELINE_FLOORS = {
+    "foo": {"riskClass": "standard", "floor": 0.9},
+    "bar": {"riskClass": "advisory", "floor": 0.8},
+}
+
+
+@pytest.fixture
+def fixture_root(tmp_path: Path) -> Path:
+    """A minimal synthetic tree: one agent (foo), one skill (bar), one eval
+    fixture referencing both, and a floors table covering both."""
+    (tmp_path / "plugins" / "dev-team" / "agents").mkdir(parents=True)
+    (tmp_path / "plugins" / "dev-team" / "skills" / "bar").mkdir(parents=True)
+    (tmp_path / "plugins" / "dev-team" / "knowledge").mkdir(parents=True)
+    (tmp_path / "evals" / "expected").mkdir(parents=True)
+
+    (tmp_path / "plugins" / "dev-team" / "agents" / "foo.md").write_text(
+        "---\nname: foo\neffort: medium\n---\n"
+    )
+    (tmp_path / "plugins" / "dev-team" / "skills" / "bar" / "SKILL.md").write_text(
+        "---\nname: bar\n---\n"
+    )
+    (tmp_path / "evals" / "expected" / "sample.json").write_text(
+        json.dumps(
+            {
+                "fixture": "sample",
+                "applicableAgents": ["foo"],
+                "applicableSkills": ["bar"],
+            }
+        )
+    )
+    _write_floors(tmp_path, _BASELINE_FLOORS)
+    return tmp_path
+
+
+def _write_floors(root: Path, floors: dict) -> None:
+    (root / "plugins" / "dev-team" / "knowledge" / "calibration-floors.json").write_text(
+        json.dumps(floors)
+    )
+
+
+def _run(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CHECK), "--root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_check_passes_on_the_real_repository_tree() -> None:
+    res = _run(REPO_ROOT)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_a_fully_registered_fixture_is_in_sync(fixture_root: Path) -> None:
+    res = _run(fixture_root)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_a_fixture_bearing_agent_with_no_floor_entry_fails_missing(
+    fixture_root: Path,
+) -> None:
+    (fixture_root / "plugins" / "dev-team" / "agents" / "baz.md").write_text(
+        "---\nname: baz\neffort: low\n---\n"
+    )
+    (fixture_root / "evals" / "expected" / "sample2.json").write_text(
+        json.dumps({"fixture": "sample2", "applicableAgents": ["baz"]})
+    )
+    res = _run(fixture_root)
+    assert res.returncode == 1
+    out = res.stdout + res.stderr
+    assert "MISSING" in out
+    assert "baz" in out
+
+
+def test_an_orphan_floor_entry_fails_orphan(fixture_root: Path) -> None:
+    floors = dict(_BASELINE_FLOORS)
+    floors["ghost"] = {"riskClass": "standard", "floor": 0.9}
+    _write_floors(fixture_root, floors)
+    res = _run(fixture_root)
+    assert res.returncode == 1
+    out = res.stdout + res.stderr
+    assert "ORPHAN" in out
+    assert "ghost" in out
+
+
+def test_an_out_of_range_floor_fails_invalid(fixture_root: Path) -> None:
+    floors = dict(_BASELINE_FLOORS)
+    floors["foo"] = {"riskClass": "standard", "floor": 1.5}
+    _write_floors(fixture_root, floors)
+    res = _run(fixture_root)
+    assert res.returncode == 1
+    out = res.stdout + res.stderr
+    assert "INVALID" in out
+    assert "foo" in out
+
+
+def test_an_unknown_risk_class_fails_invalid(fixture_root: Path) -> None:
+    floors = dict(_BASELINE_FLOORS)
+    floors["bar"] = {"riskClass": "critical", "floor": 0.8}
+    _write_floors(fixture_root, floors)
+    res = _run(fixture_root)
+    assert res.returncode == 1
+    out = res.stdout + res.stderr
+    assert "INVALID" in out
+    assert "bar" in out
+
+
+def test_a_stale_fixture_reference_to_a_removed_agent_is_not_required(
+    fixture_root: Path,
+) -> None:
+    # A fixture may still reference an agent that was intentionally removed
+    # from disk (e.g. test-modernization-review, retired by issue #536). That
+    # name is not "fixture-bearing" in the live sense -- it must not be
+    # reported MISSING, since the agent it would calibrate no longer exists.
+    (fixture_root / "evals" / "expected" / "sample3.json").write_text(
+        json.dumps({"fixture": "sample3", "applicableAgents": ["long-gone-agent"]})
+    )
+    res = _run(fixture_root)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_a_metadata_comment_key_is_ignored(fixture_root: Path) -> None:
+    floors = dict(_BASELINE_FLOORS)
+    floors["_comment"] = "not a target, just documentation"
+    _write_floors(fixture_root, floors)
+    res = _run(fixture_root)
+    assert res.returncode == 0, res.stdout + res.stderr


### PR DESCRIPTION
## Summary

Slice 1 of epic #879 (band calibration): a pure policy artifact plus its guard test — no eval dispatch changes.

- Adds `plugins/dev-team/knowledge/calibration-floors.json`: one `{"<name>": {"riskClass": "high|standard|advisory", "floor": <0..1>}}` entry per fixture-bearing review agent / advisory skill.
- Adds `tests/repo/test_calibration_floors_sync.py` (pytest, registry-sync style) backed by `scripts/check_calibration_floors_sync.py`, which enforces:
  1. every fixture-bearing agent/skill (declared via `applicableAgents`/`applicableSkills` in `evals/expected/*.json`) has a floor entry — fails naming any missing one;
  2. orphan floor entries (a target with no agent/skill definition on disk) are rejected — fails naming the orphan;
  3. floors are valid pass rates (0–1) and `riskClass` is a known value — fails naming the invalid entry.
- Adds a "Calibration floors" doc note to `plugins/dev-team/docs/model-routing.md` introducing the table (same-change doc alignment; this table does not affect model routing itself).

## Floor-classification rationale

The complete target set was built by scanning every `applicableAgents`/`applicableSkills` array across `evals/expected/*.json` (99 fixtures), then filtering to names that still resolve to a real `agents/<name>.md` or `skills/<name>/SKILL.md` on disk:

- **`high` (floor 1.0)** — the four agents the epic names explicitly: `security-review`, `concurrency-review`, `arch-review`, `domain-review`.
- **`standard` (floor 0.9)** — every remaining review agent whose frontmatter declares `effort: medium` (`a11y-review`, `complexity-review`, `component-architecture-review`, `doc-review`, `naming-review`, `performance-review`, `refactor-opportunity-review`, `session-analysis`, `spec-compliance-review`, `structure-review`, `test-review`, `test-smell-review`), plus `orchestrator` (`effort: medium`, dispatched in the integration-kata fixture).
- **`advisory` (floor 0.8)** — review agents whose frontmatter declares `effort: low` (`claude-setup-review`, `js-fp-review`, `svelte-review`, `token-efficiency-review`), plus `test-design-advisor`, a skill that self-describes as "An **advisory** skill" in its own `SKILL.md`.

**Judgment call / ambiguity, resolved without escalation:** two fixtures (`tmr-phase1-missing-seams.json`, `tmr-phase1-pass.json`) reference `test-modernization-review` in `applicableAgents`, but that agent was intentionally removed from disk by issue #536 (`tests/repo/test_removed_orchestrators_absence.py` asserts its absence). Treating it as a live "fixture-bearing" target would force either (a) adding a floor entry for an agent that doesn't exist — which the guard test's own orphan-rejection scenario would then reject — or (b) leaving it out and having the MISSING-detection scenario false-fire on every future run. I resolved this by scoping "fixture-bearing" to names that resolve to a real agent/skill definition on disk (see the module docstring in `scripts/check_calibration_floors_sync.py` and the dedicated regression test `test_a_stale_fixture_reference_to_a_removed_agent_is_not_required`). Cleaning up those two stale fixture files is out of this slice's scope; flagging here rather than filing a separate issue since it's a one-line note, not new scope.

## Test plan

- [x] `python3 -m pytest tests/repo/test_calibration_floors_sync.py -v` — 8/8 pass, including against the real repo tree.
- [x] `python3 -m pytest tests/repo/ -q` — 425/425 pass (no regressions).
- [x] `python3 scripts/check_md_references.py` — exit 0.
- [x] `python3 -c "import json; json.load(open('plugins/dev-team/knowledge/calibration-floors.json'))"` — valid JSON.
- [x] `python3 -m pytest -q` (full suite, minus two pre-existing unrelated collection errors from a missing `httpx`/`pytest-asyncio` dependency in this sandbox) — 31 pre-existing failures unrelated to this change (cost-meter, codebase-recon, orchestrator async tests — all failing on `main` before this branch for missing deps), none touching calibration floors.

No `npm ci`/husky available in this sandbox (`node >=24` required, sandbox has `node 22`) — commit landed without local hook enforcement; CI will re-run the full gate.

Closes #880
Part of #879


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_