### PR TITLE
feat: make eval replay cache fingerprint model-aware

### DIFF
--- a/scripts/eval_cache.py
+++ b/scripts/eval_cache.py
@@ -11,16 +11,32 @@ Fingerprint
 -----------
 For a pair ``<stem>::<target>`` the SHA-256 is computed over, in order:
 
-  1. the target's root definition (agent ``agents/<t>.md`` or skill
+  1. the resolved model identity the pair was (or will be) graded under
+     (``--model``; see below),
+  2. the target's root definition (agent ``agents/<t>.md`` or skill
      ``skills/<t>/SKILL.md``),
-  2. the **transitive closure** of dependency files reachable from it
+  3. the **transitive closure** of dependency files reachable from it
      (``knowledge/*.md`` it reads, ``skills/*`` it invokes — recursively),
-  3. the fixture file(s) for the stem,
-  4. the expected JSON,
-  5. the grader version (hash of the eval_graders package sources).
+  4. the fixture file(s) for the stem,
+  5. the expected JSON,
+  6. the grader version (hash of the eval_graders package sources).
 
 Any change to any contributing input changes the SHA, which busts the cache and
 forces a live dispatch. An unchanged SHA with a stored PASS replays.
+
+Model dimension (#881, band calibration slice 2)
+-------------------------------------------------
+The fingerprint includes the resolved model identity (``--model``, e.g.
+``claude-sonnet-4-6``), so a PASS memoized for one model never replays for a
+different model — each model's per-band calibration results memoize
+independently. ``--model`` defaults to ``"unspecified"`` when the caller does
+not pass one (all such callers share that one bucket). Because this dimension
+is new, every cache entry written before this change busts exactly once on
+first replay attempt after upgrade — there is no stored model to compare
+against, so the recomputed SHA (which now folds in a model) never matches the
+old stored SHA (which never did). This is a one-time, self-healing cost: the
+next ``--store`` re-populates the entry with a model-aware SHA and it replays
+normally from then on.
 
 Cache
 -----
@@ -35,6 +51,9 @@ CLI
                            write a plan JSON and a prefilled replay actuals file.
 ``--store --actuals F``    grade F and write each PASSing pair to the cache with
                            its current fingerprint and full actuals.
+``--model M``              resolved model identity to fold into the fingerprint
+                           (default "unspecified"); applies to --fingerprint,
+                           --plan and --store alike.
 """
 
 from __future__ import annotations
@@ -194,10 +213,19 @@ def contributing_files(pair: str, dirs: Dirs) -> list[Path]:
     return ordered
 
 
-def compute_fingerprint(pair: str, dirs: Dirs):
-    """Return (sha_hex, [relative file strings]) for a pair."""
+DEFAULT_MODEL = "unspecified"
+
+
+def compute_fingerprint(pair: str, dirs: Dirs, model: str = DEFAULT_MODEL):
+    """Return (sha_hex, [relative file strings]) for a pair.
+
+    ``model`` is the resolved model identity the pair is graded under (#881).
+    It is folded into the SHA as its own dimension so a PASS memoized at one
+    model is never treated as a hit for a different model.
+    """
     files = contributing_files(pair, dirs)
     h = hashlib.sha256()
+    h.update(f"model:{model}\0".encode())
     h.update(f"grader:{grader_version(dirs.graders)}\0".encode())
     rels: list[str] = []
     for f in files:
@@ -248,12 +276,13 @@ def cache_get(cache: dict, pair: str, sha: str):
     return entry.get("actual")
 
 
-def cache_put(cache: dict, pair: str, sha: str, actual: dict) -> None:
+def cache_put(cache: dict, pair: str, sha: str, actual: dict, model: str = DEFAULT_MODEL) -> None:
     from datetime import datetime, timezone
     cache.setdefault("entries", {})[pair] = {
         "sha": sha,
         "passed": True,
         "actual": actual,
+        "model": model,
         "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
@@ -294,6 +323,9 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--cache", help="cache file (default: <repo>/evals/.eval-cache.json)")
     ap.add_argument("--only", default="",
                     help="comma-separated agent/skill names to scope to")
+    ap.add_argument("--model", default=DEFAULT_MODEL,
+                    help="resolved model identity (#881) — a fingerprint dimension; "
+                         f"defaults to {DEFAULT_MODEL!r} when omitted")
     ap.add_argument("--fingerprint", metavar="PAIR",
                     help="print the SHA + contributing files for <stem>::<target>")
     ap.add_argument("--plan", action="store_true",
@@ -318,8 +350,9 @@ def main(argv: list[str]) -> int:
     only = {s.strip() for s in args.only.split(",") if s.strip()} or None
 
     if args.fingerprint:
-        sha, files = compute_fingerprint(args.fingerprint, dirs)
+        sha, files = compute_fingerprint(args.fingerprint, dirs, args.model)
         print(f"pair:        {args.fingerprint}")
+        print(f"model:       {args.model}")
         print(f"fingerprint: {sha}")
         print(f"grader:      {grader_version(dirs.graders)[:16]}…")
         print("contributing files:")
@@ -333,7 +366,7 @@ def main(argv: list[str]) -> int:
         cache = load_cache(cache_path)
         hits, misses, fingerprints = {}, [], {}
         for pair, block in corpus_pairs(dirs, only):
-            sha, _ = compute_fingerprint(pair, dirs)
+            sha, _ = compute_fingerprint(pair, dirs, args.model)
             fingerprints[pair] = sha
             actual = cache_get(cache, pair, sha)
             if actual is not None:
@@ -384,8 +417,8 @@ def main(argv: list[str]) -> int:
                 actual = entry.get("skills", {}).get(name)
             if actual is None:
                 continue
-            sha, _ = compute_fingerprint(pair, dirs)
-            cache_put(cache, pair, sha, actual)
+            sha, _ = compute_fingerprint(pair, dirs, args.model)
+            cache_put(cache, pair, sha, actual, args.model)
             stored += 1
         save_cache(cache_path, cache)
         print(f"cache: stored {stored} passing pair(s) → {cache_path}")

--- a/tests/repo/test_eval_cache.py
+++ b/tests/repo/test_eval_cache.py
@@ -1,7 +1,9 @@
 """Tests for scripts/eval_cache.py — the per-pair fingerprint replay cache that
-lets the live eval gate skip unchanged pairs (issue #311). Hermetic: every
-test builds a tiny self-contained corpus + plugin tree under a tmp repo root,
-so no model and no real corpus is touched.
+lets the live eval gate skip unchanged pairs (issue #311), and the model-aware
+fingerprint dimension (issue #881) that keeps per-band calibration results
+memoized independently per model. Hermetic: every test builds a tiny
+self-contained corpus + plugin tree under a tmp repo root, so no real model
+dispatch and no real corpus is touched.
 
 Ported from tests/repo/eval_cache_tests.bats (issue #572: bash -> Python).
 """
@@ -168,3 +170,77 @@ def test_cache_file_lives_at_evals_dot_eval_cache_json(corpus: Path) -> None:
     _write_passing_actuals(corpus)
     _run(corpus, "--store", "--actuals", str(corpus / "actuals.json"))
     assert (corpus / "evals" / ".eval-cache.json").is_file()
+
+
+# --------------------------------------------------------------------------
+# Model-aware fingerprint (#881, band calibration slice 2).
+# --------------------------------------------------------------------------
+
+MODEL_A = "claude-haiku-4-5-20251001"
+MODEL_B = "claude-sonnet-4-6"
+
+
+def test_different_model_is_a_cache_miss(corpus: Path) -> None:
+    """A PASS memoized at one model does not replay for another model."""
+    _write_passing_actuals(corpus)
+    _run(corpus, "--store", "--actuals", str(corpus / "actuals.json"), "--model", MODEL_A)
+    res = _run(corpus, "--plan", "--model", MODEL_B)
+    out = res.stdout + res.stderr
+    assert res.returncode == 0, out
+    assert "miss demo::demo-review" in out
+
+
+def test_same_model_replay_is_unaffected(corpus: Path) -> None:
+    """Same-model replay with unchanged transitive inputs still hits."""
+    _write_passing_actuals(corpus)
+    _run(corpus, "--store", "--actuals", str(corpus / "actuals.json"), "--model", MODEL_A)
+    res = _run(corpus, "--plan", "--model", MODEL_A, "--replay-out", str(corpus / "replay.json"))
+    out = res.stdout + res.stderr
+    assert res.returncode == 0, out
+    assert "1 cache hit" in out
+    assert "miss demo::demo-review" not in out
+    replay = json.loads((corpus / "replay.json").read_text())
+    assert replay["demo"]["agents"]["demo-review"]["status"] == "fail"
+
+
+def test_model_dimension_changes_fingerprint(corpus: Path) -> None:
+    """The fingerprint itself differs across models for the same inputs."""
+    a = _run(corpus, "--fingerprint", "demo::demo-review", "--model", MODEL_A)
+    b = _run(corpus, "--fingerprint", "demo::demo-review", "--model", MODEL_B)
+    sha_a = next(l for l in a.stdout.splitlines() if l.startswith("fingerprint: "))
+    sha_b = next(l for l in b.stdout.splitlines() if l.startswith("fingerprint: "))
+    assert sha_a != sha_b
+
+
+def test_legacy_entry_without_model_dimension_busts_once(corpus: Path) -> None:
+    """A cache entry stored before the model dimension existed (no "model" key,
+    sha computed without folding in any model identity) is a guaranteed miss
+    the first time it is replayed against a model-aware fingerprint — then a
+    fresh --store re-populates it as model-aware, and it replays normally
+    thereafter."""
+    cache_path = corpus / "evals" / ".eval-cache.json"
+    legacy_sha = "0" * 64  # any old-format SHA never matches a fresh model-aware one
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps({
+        "version": 1,
+        "entries": {
+            "demo::demo-review": {
+                "sha": legacy_sha,
+                "passed": True,
+                "actual": {"status": "fail", "issues": [], "summary": ""},
+                "recorded_at": "2020-01-01T00:00:00Z",
+            }
+        },
+    }))
+    # One-time bust: the legacy entry (no model dimension) cannot match any
+    # freshly computed, model-aware fingerprint.
+    res = _run(corpus, "--plan", "--model", MODEL_A)
+    out = res.stdout + res.stderr
+    assert res.returncode == 0, out
+    assert "miss demo::demo-review" in out
+    # Re-store under the model-aware scheme, then replay hits normally.
+    _write_passing_actuals(corpus)
+    _run(corpus, "--store", "--actuals", str(corpus / "actuals.json"), "--model", MODEL_A)
+    res = _run(corpus, "--plan", "--model", MODEL_A)
+    out = res.stdout + res.stderr
+    assert "miss demo::demo-review" not in out


### PR DESCRIPTION
## Summary

- Fold the resolved model identity into the `fixture::target` fingerprint (`scripts/eval_cache.py`) so per-band calibration results memoize independently per model — a PASS cached at one model is reported as a miss for another model.
- Existing cache entries have no model dimension, so they bust exactly once on first replay after this lands (documented in the module docstring under "Model dimension (#881, band calibration slice 2)"); a fresh `--store` re-populates them model-aware and they replay normally from then on.
- Added `--model` to the CLI (`--fingerprint`, `--plan`, `--store`), defaulting to `"unspecified"` for callers that don't pass one, so existing invocations (e.g. the `agent-eval.yml` workflow's `--plan`/`--store` calls, which don't pass `--model` yet) keep working unchanged.
- This slice is independent of the other #879 slices (#880, #882, #883) and lands standalone.

## Test plan

- [x] `python3 -m pytest tests/repo/test_eval_cache.py -q` — 14 passed (10 existing + 4 new: different-model miss, same-model hit, fingerprint divergence across models, one-time legacy-entry bust).
- [x] `python3 -m pytest -q` (excluding two pre-existing collection errors from missing optional deps — `httpx`, unrelated to this change) — 2708 passed, 31 pre-existing failures confirmed to also fail on `origin/main` before this change (missing `jsonschema`, orchestrator async-mock env issues — unrelated).
- [x] `python3 scripts/check_md_references.py` — clean, exit 0.

Closes #881
Part of #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_