### PR TITLE
feat: add recalibration staleness advisory to /model-routing-check

### DIFF
--- a/plugins/dev-team/docs/model-routing.md
+++ b/plugins/dev-team/docs/model-routing.md
@@ -261,7 +261,37 @@ refuses `--in-session` (calibration must grade what's on disk). Output lands
 at `.claude/evals/reports/<timestamp>-calibration.md` (per-band pass rates
 and, on drift, a ready-to-apply `effort:` diff) and
 `.claude/evals/calibration-records.json` (one record per target — the input
-a future staleness check, #883, will consume). This run never edits any file
+the staleness check below consumes). This run never edits any file
 under `plugins/dev-team/agents/` or `plugins/dev-team/skills/` — report-only,
 always. See [agent-eval's SKILL.md](../skills/agent-eval/SKILL.md#calibration-mode)
 for the full procedure.
+
+## Recalibration staleness advisory (`/model-routing-check`)
+
+Slice 4 of epic #879 (issue #883) is the recalibration trigger: routing-map
+edits and model releases invalidate a target's last calibration, and this
+surfaces that drift instead of leaving it silent. `/model-routing-check`'s
+fifth section reads `knowledge/calibration-floors.json` for the target
+universe and `.claude/evals/calibration-records.json` for each target's last
+calibration record (both written by slice 1 `#880` and slice 3 `#882`
+respectively), and recomputes the current content hash of
+`knowledge/model-routing.json` + `.claude/model-ladder.json` using the exact
+same `routing_hash()` construction `scripts/agent_calibrate.py` used to stamp
+the record. Three states per target:
+
+- **`calibration-current`** — the record's `routing_hash` matches the
+  current hash. Nothing to do.
+- **`calibration-stale`** — the routing map or ladder changed since the
+  target was last calibrated (hash drift). Flagged with a pointer to
+  `/agent-eval --calibrate --agent <target>`.
+- **`never-calibrated`** — the target has a floors entry but no calibration
+  record yet. Listed with the same pointer.
+
+**This is advisory only — it never blocks dispatch.** Even when every
+calibration record is stale (or none exist at all), `hooks/
+agent_model_resolve.py`'s dispatch behavior is completely unchanged; the
+advisory is a read-only diagnostic, matching the model-resolution hook's
+fail-open contract. See [model-routing-check's SKILL.md](
+../skills/model-routing-check/SKILL.md) for the exec block and the
+`CALIBRATION_FLOORS_JSON`/`CALIBRATION_RECORDS_JSON` test-only injection
+seams.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3933,7 +3933,7 @@
       "anchor": "worker-constraints"
     },
     "What it shows": {
-      "summary": "Four sections, in order:",
+      "summary": "Five sections, in order:",
       "anchor": "what-it-shows"
     },
     "How to fix common findings": {

--- a/plugins/dev-team/skills/model-routing-check/SKILL.md
+++ b/plugins/dev-team/skills/model-routing-check/SKILL.md
@@ -28,7 +28,7 @@ Arguments: none.
 
 ## What it shows
 
-Four sections, in order:
+Five sections, in order:
 
 1. **Effective band → model map** — the result of resolving each effort
    band (`low`, `medium`, `high`) through the shipped default map in
@@ -44,6 +44,17 @@ Four sections, in order:
    `.claude/metrics/model-routing.log`, formatted as
    `<ts>  <band> → <served>  [<reason>]  session=<session>  caller=<caller>`.
    Raise `MODEL_BUMP_TAIL` to see more.
+5. **Recalibration staleness advisory** — **advisory only, never blocks
+   dispatch** (fail-open, matching the model-resolution hook's contract).
+   For every target with an entry in `knowledge/calibration-floors.json`
+   (#880), compares its last calibration record's routing/ladder content
+   hash (written by `/agent-eval --calibrate`, #882) against the current
+   hash of `knowledge/model-routing.json` + `.claude/model-ladder.json`.
+   Three states per target: `calibration-current` (hash matches),
+   `calibration-stale` (hash drift since the last calibration — routing map
+   or ladder changed), and `never-calibrated` (no record exists yet). Stale
+   and never-calibrated rows point at `/agent-eval --calibrate --agent
+   <target>`.
 
 ## How to fix common findings
 
@@ -74,6 +85,8 @@ LADDER_PATH="${MODEL_LADDER_JSON:-.claude/model-ladder.json}"
 SESSION_PATH="${SESSION_MODEL_FILE:-.claude/session-model}"
 BUMP_LOG_PATH="${MODEL_BUMP_LOG:-.claude/metrics/model-routing.log}"
 TAIL_N="${MODEL_BUMP_TAIL:-10}"
+FLOORS_PATH="${CALIBRATION_FLOORS_JSON:-$PLUGIN_DIR/knowledge/calibration-floors.json}"
+RECORDS_PATH="${CALIBRATION_RECORDS_JSON:-.claude/evals/calibration-records.json}"
 
 echo "Model Routing Check"
 echo "==================="
@@ -118,6 +131,68 @@ if [[ -f "$BUMP_LOG_PATH" ]]; then
 else
   echo "Recent routing bumps: none recorded"
 fi
+echo
+
+# Recalibration staleness advisory (advisory only — never blocks dispatch;
+# fail-open, matching the model-resolution hook's contract).
+echo "Recalibration staleness advisory (advisory only — never blocks dispatch):"
+python3 - "$ROUTING_PATH" "$LADDER_PATH" "$FLOORS_PATH" "$RECORDS_PATH" <<'PYEOF'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+routing_path = Path(sys.argv[1])
+ladder_path = Path(sys.argv[2])
+floors_path = Path(sys.argv[3])
+records_path = Path(sys.argv[4])
+
+
+def routing_hash(routing_path, ladder_path):
+    # Mirrors scripts/agent_calibrate.py's routing_hash() exactly: a
+    # sha256 over routing bytes, a null separator, ladder bytes when the
+    # ladder exists, and a trailing null separator.
+    h = hashlib.sha256()
+    for p in (routing_path, ladder_path):
+        if p is not None and p.exists():
+            try:
+                h.update(p.read_bytes())
+            except OSError:
+                pass
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+floors = load_json(floors_path)
+if not isinstance(floors, dict):
+    floors = {}
+targets = sorted(k for k in floors if not k.startswith("_"))
+
+records = load_json(records_path)
+if not isinstance(records, dict):
+    records = {}
+
+current_hash = routing_hash(routing_path, ladder_path if ladder_path.exists() else None)
+
+if not targets:
+    print("  no calibration-floors.json entries found")
+else:
+    for target in targets:
+        record = records.get(target)
+        if not isinstance(record, dict) or "routing_hash" not in record:
+            print(f"  {target:<32} never-calibrated   -> run /agent-eval --calibrate --agent {target}")
+        elif record["routing_hash"] != current_hash:
+            print(f"  {target:<32} calibration-stale  -> run /agent-eval --calibrate --agent {target}")
+        else:
+            print(f"  {target:<32} calibration-current")
+PYEOF
 ```
 <!-- END EXEC -->
 
@@ -126,7 +201,14 @@ fi
 - Defaults to `N=10` bump events in the tail. Override with
   `MODEL_BUMP_TAIL=<n>`.
 - `MODEL_ROUTING_PLUGIN_DIR`, `MODEL_ROUTING_RESOLVER`, `MODEL_ROUTING_JSON`,
-  `MODEL_LADDER_JSON`, `SESSION_MODEL_FILE`, and `MODEL_BUMP_LOG` are
-  **test-only** injection seams. Do not set them by hand in normal use.
+  `MODEL_LADDER_JSON`, `SESSION_MODEL_FILE`, `MODEL_BUMP_LOG`,
+  `CALIBRATION_FLOORS_JSON`, and `CALIBRATION_RECORDS_JSON` are **test-only**
+  injection seams. Do not set them by hand in normal use.
 - For the ladder schema, resolution precedence, and restricted-endpoint
   setup, see `docs/model-routing.md` and `docs/model-routing-overrides.md`.
+- The recalibration staleness advisory is read-only and fail-open: a missing
+  `calibration-floors.json` or `calibration-records.json` is reported (empty
+  or all-`never-calibrated`) rather than erroring, and it never affects
+  `hooks/agent_model_resolve.py`'s dispatch behavior. See `docs/model-
+  routing.md`'s "Recalibration staleness advisory" section and
+  `skills/agent-eval/SKILL.md#calibration-mode` for `/agent-eval --calibrate`.

--- a/tests/commands/test_model_routing_check.py
+++ b/tests/commands/test_model_routing_check.py
@@ -9,6 +9,7 @@ bats -> pytest).
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import subprocess
@@ -63,6 +64,10 @@ def case(tmp_path: Path) -> dict:
     env["SESSION_MODEL_FILE"] = str(tmp_path / ".claude" / "session-model")
     env["MODEL_BUMP_LOG"] = str(tmp_path / ".claude" / "metrics" / "model-routing.log")
     env["MODEL_ROUTING_RESOLVER"] = str(RESOLVER)
+    env["CALIBRATION_FLOORS_JSON"] = str(tmp_path / "knowledge" / "calibration-floors.json")
+    env["CALIBRATION_RECORDS_JSON"] = str(
+        tmp_path / ".claude" / "evals" / "calibration-records.json"
+    )
 
     return {
         "tmp_path": tmp_path,
@@ -70,6 +75,28 @@ def case(tmp_path: Path) -> dict:
         "env": env,
         "command_text": command_text,
     }
+
+
+def _routing_hash(routing_path: Path, ladder_path: Path | None) -> str:
+    """Mirrors scripts/agent_calibrate.py's routing_hash() exactly."""
+    h = hashlib.sha256()
+    for p in (routing_path, ladder_path):
+        if p is not None and p.exists():
+            h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _write_floors(case: dict, entries: dict) -> None:
+    Path(case["env"]["CALIBRATION_FLOORS_JSON"]).write_text(
+        json.dumps(entries), encoding="utf-8"
+    )
+
+
+def _write_records(case: dict, records: dict) -> None:
+    records_path = Path(case["env"]["CALIBRATION_RECORDS_JSON"])
+    records_path.parent.mkdir(parents=True, exist_ok=True)
+    records_path.write_text(json.dumps(records), encoding="utf-8")
 
 
 def _run(case: dict, extra_env: dict | None = None) -> subprocess.CompletedProcess:
@@ -314,3 +341,135 @@ def test_model_bump_tail_30_shows_all_25_no_showing_last_line(
     assert "caller=caller-0" in result.stdout
     assert "caller=caller-24" in result.stdout
     assert "Showing last 10 of 25" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Recalibration staleness advisory (issue #883, slice 4 of epic #879)
+# ---------------------------------------------------------------------------
+
+
+def test_doc_body_documents_recalibration_staleness_advisory(case: dict) -> None:
+    text = case["command_text"].lower()
+    assert "recalibration staleness advisory" in text
+    assert "never blocks dispatch" in text
+    assert "calibration-stale" in text
+    assert "never-calibrated" in text
+
+
+def test_doc_body_documents_five_sections(case: dict) -> None:
+    assert "Five sections" in case["command_text"]
+
+
+def test_routing_map_changed_since_last_calibration_flags_stale(case: dict) -> None:
+    """Gherkin: Routing map changed since last calibration."""
+    _write_floors(case, {"security-review": {"riskClass": "high", "floor": 1.0}})
+    routing_path = Path(case["env"]["MODEL_ROUTING_JSON"])
+    ladder_path = Path(case["env"]["MODEL_LADDER_JSON"])
+    stale_hash = _routing_hash(routing_path, None)  # hash of a prior, different state
+    _write_records(
+        case,
+        {
+            "security-review": {
+                "target": "security-review",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "declared_band": "high",
+                "calibrated_band": "high",
+                "verdict": "aligned",
+                "routing_hash": "not-the-current-hash-" + stale_hash[:8],
+            }
+        },
+    )
+
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    assert "security-review" in result.stdout
+    assert "calibration-stale" in result.stdout
+    assert "/agent-eval --calibrate --agent security-review" in result.stdout
+
+
+def test_target_never_calibrated_is_listed(case: dict) -> None:
+    """Gherkin: Target never calibrated."""
+    _write_floors(case, {"naming-review": {"riskClass": "standard", "floor": 0.9}})
+    # No calibration-records.json written at all.
+
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    assert "naming-review" in result.stdout
+    assert "never-calibrated" in result.stdout
+    assert "/agent-eval --calibrate --agent naming-review" in result.stdout
+
+
+def test_calibration_current_when_hash_matches(case: dict) -> None:
+    routing_path = Path(case["env"]["MODEL_ROUTING_JSON"])
+    ladder_path = Path(case["env"]["MODEL_LADDER_JSON"])
+    _write_floors(case, {"doc-review": {"riskClass": "standard", "floor": 0.9}})
+    current_hash = _routing_hash(routing_path, None)  # ladder doesn't exist yet
+    _write_records(
+        case,
+        {
+            "doc-review": {
+                "target": "doc-review",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "declared_band": "medium",
+                "calibrated_band": "medium",
+                "verdict": "aligned",
+                "routing_hash": current_hash,
+            }
+        },
+    )
+
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    assert "doc-review" in result.stdout
+    assert "calibration-current" in result.stdout
+
+
+def test_advisory_never_blocks_even_when_every_record_is_stale(case: dict) -> None:
+    """Gherkin: Advisory never blocks — the model-resolution hook's dispatch
+    behavior (here, the band -> model map this same command prints) is
+    unchanged regardless of how many targets are stale/never-calibrated."""
+    _write_floors(
+        case,
+        {
+            "security-review": {"riskClass": "high", "floor": 1.0},
+            "concurrency-review": {"riskClass": "high", "floor": 1.0},
+        },
+    )
+    _write_records(
+        case,
+        {
+            "security-review": {
+                "target": "security-review",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "declared_band": "high",
+                "calibrated_band": "high",
+                "verdict": "aligned",
+                "routing_hash": "definitely-stale",
+            },
+            "concurrency-review": {
+                "target": "concurrency-review",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "declared_band": "high",
+                "calibrated_band": "high",
+                "verdict": "aligned",
+                "routing_hash": "also-stale",
+            },
+        },
+    )
+
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    assert result.stdout.count("calibration-stale") == 2
+    # The band -> model map (a stand-in for hook dispatch resolution) is
+    # still printed correctly, unaffected by the advisory findings.
+    assert "low" in result.stdout and "claude-haiku-4-5-20251001" in result.stdout
+    assert "medium" in result.stdout and "claude-sonnet-4-6" in result.stdout
+    assert "high" in result.stdout and "claude-opus-4-8" in result.stdout
+
+
+def test_no_floors_entries_prints_graceful_message(case: dict) -> None:
+    """No calibration-floors.json at all — advisory degrades gracefully,
+    never errors."""
+    result = _run(case)
+    assert result.returncode == 0, result.stdout
+    assert "no calibration-floors.json entries found" in result.stdout


### PR DESCRIPTION
## Summary

Slice 4 of epic #879 (band calibration): `/model-routing-check` gains a fifth, advisory-only section that surfaces recalibration staleness — the trigger for model releases and routing-map edits.

- For every target with an entry in `knowledge/calibration-floors.json` (#880), compares its last calibration record's routing/ladder content hash (written by `/agent-eval --calibrate`, #882) against the current hash of `knowledge/model-routing.json` + `.claude/model-ladder.json`.
- Three states: `calibration-current` (hash matches), `calibration-stale` (hash drift — routing map or ladder changed since last calibration), `never-calibrated` (floors entry exists, no record yet). Stale/never-calibrated rows point at `/agent-eval --calibrate --agent <target>`.
- **Advisory only — never blocks dispatch.** Fail-open by construction: it never touches `hooks/agent_model_resolve.py`'s dispatch behavior, even when every record is stale.
- Doc alignment: new "Recalibration staleness advisory" section in `docs/model-routing.md`.

## Dependency chain

**This PR depends on #904** (branch `issue-882-agent-eval-calibrate`, itself built on #902/#903 for slices #880/#881). None of the three dependency PRs are merged yet, so this diff currently includes their commits too (`calibration-floors.json`, the model-aware `scripts/eval_cache.py`, and `scripts/agent_calibrate.py`'s calibration-record writer, plus their tests) in addition to this slice's own changes.

**Please merge in this order: #902 → #903 → #904 → this PR.** Once #902, #903, and #904 land on `main`, this PR's diff will shrink to just this slice's own changes (the `/model-routing-check` advisory section, its doc update, and its tests).

## Test plan

- [x] `pytest tests/commands/test_model_routing_check.py` — 27 passed, including 6 new tests covering all three Gherkin scenarios (routing-map-changed → calibration-stale, never-calibrated, and advisory-never-blocks) plus doc/graceful-degradation checks.
- [x] `pytest tests/repo/test_agent_calibrate.py tests/repo/test_calibration_floors_sync.py tests/repo/test_eval_cache.py tests/agents/test_orchestrator_routing_doc.py tests/repo/test_routing_stale_refs.py` — 56 passed (dependency-slice suites unaffected).
- [x] `python3 scripts/check_md_references.py` — clean, no stale references.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` (regenerated `knowledge/index.json` after the SKILL.md summary-line change) and confirmed `tests/repo/test_knowledge_index_no_leak.py` / `tests/repo/test_recommendations_docs_sweep.py` are green.
- [x] Full repo `pytest` suite: same 31 pre-existing failures present on `main`/dependency branch before this change (missing `jsonschema`/`httpx` in this sandbox, `pytest.mark.asyncio` unregistered, and full-suite test-order pollution in `test_cost_meter_lib.py`) — verified identical via `git stash` diff before/after this change. Zero new failures introduced.

Closes #883
Part of #879


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_