### PR TITLE
feat: preventive Bash-aware test-freeze guard + boundary-events wiring for revert guard

### DIFF
--- a/plugins/dev-team/hooks/refactor-bash-write-patterns.json
+++ b/plugins/dev-team/hooks/refactor-bash-write-patterns.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Regex library for refactor_test_bash_guard.py (#906). Each entry recognizes one Bash file-modifying shape and extracts the apparent write target via a named 'target' capture group. First match wins, in list order. Ambiguous/unparseable commands (no entry matches) are never blocked - false-negative-favoring by design, see the issue's Non-goals.",
+  "patterns": [
+    {
+      "id": "sed-i",
+      "regex": "\\bsed\\s+-i(?:\\.\\S+)?\\s+(?:-e\\s+)?(?:'[^']*'|\"[^\"]*\")\\s+(?P<target>[^\\s;&|]+)"
+    },
+    {
+      "id": "perl-i",
+      "regex": "\\bperl\\s+-i(?:\\.\\S+)?\\s+(?:-[a-zA-Z]+\\s+)*(?:'[^']*'|\"[^\"]*\")\\s+(?P<target>[^\\s;&|]+)"
+    },
+    {
+      "id": "tee",
+      "regex": "\\btee\\s+(?:-a\\s+)?(?P<target>[^\\s;&|]+)"
+    },
+    {
+      "id": "redirect",
+      "regex": "(?<![\\w&])>{1,2}(?!\\S*&)\\s*(?P<target>[^\\s;&|>]+)"
+    },
+    {
+      "id": "mv-cp",
+      "regex": "\\b(?:mv|cp)\\s+(?:-\\S+\\s+)*(?P<src>[^\\s;&|]+)\\s+(?P<target>[^\\s;&|]+)\\s*(?:[;&|]|$)"
+    },
+    {
+      "id": "python-open-write",
+      "regex": "open\\(\\s*['\"](?P<target>[^'\"]+)['\"]\\s*,\\s*['\"](?:w|a|wb|ab|w\\+|a\\+)['\"]"
+    }
+  ]
+}

--- a/plugins/dev-team/hooks/refactor_test_bash_guard.py
+++ b/plugins/dev-team/hooks/refactor_test_bash_guard.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""refactor_test_bash_guard.py — PreToolUse hook (Bash), issue #906.
+
+The preventive, Bash-aware half of the tests-frozen-during-refactor
+invariant (#813). `refactor_test_freeze_guard.py` blocks Write/Edit at a
+test file during a recorded REFACTOR phase, but Bash-driven edits (`sed -i`,
+`tee`, shell redirection, `mv`/`cp` onto a target, `python -c` with an
+`open(..., "w")`) bypass that guard entirely and were previously only
+caught reactively, after the fact, by `refactor_test_revert_guard.py`
+(PostToolUse) — which reverts/removes the damage once it has already
+landed on disk.
+
+This hook recognizes a conservative library of common file-modifying Bash
+shapes (`hooks/refactor-bash-write-patterns.json`), extracts the apparent
+write target, and — only when a recorded REFACTOR phase is active AND the
+target resolves to a file in the step's `test_files_staged` (or would newly
+create a file `test_file_classify.is_test_file()` classifies as a test) —
+blocks with exit 2 before the command ever runs.
+
+Ambiguous/unparseable commands (no pattern matches, or the matched target
+cannot be confidently resolved) are NEVER blocked: the false-positive budget
+favors letting the command through and relying on
+`refactor_test_revert_guard.py` as the safety net (defense-in-depth, not a
+replacement — see the issue's Non-goals). This is not a general-purpose
+shell parser.
+
+Fails OPEN on any internal error, with one audit line in
+`metrics/refactor-freeze.jsonl` (hook="bash-freeze") — a broken guard must
+never block work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from stdin_json import read_stdin_json  # noqa: E402
+from test_file_classify import is_test_file, read_build_phase  # noqa: E402
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+from refactor_test_freeze_guard import audit  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
+
+_PATTERNS_FILE = _SCRIPT_DIR / "refactor-bash-write-patterns.json"
+
+RECOVERY = (
+    "tests are frozen during REFACTOR; return to the TEST phase, make the "
+    "change there, re-verify green, then re-enter REFACTOR"
+)
+
+# Inline fallback — kept in the same order as the shipped JSON so behavior
+# is byte-identical when the config file is missing or malformed.
+_DEFAULT_PATTERNS: List[Tuple[str, str]] = [
+    (
+        "sed-i",
+        r"\bsed\s+-i(?:\.\S+)?\s+(?:-e\s+)?(?:'[^']*'|\"[^\"]*\")\s+(?P<target>[^\s;&|]+)",
+    ),
+    (
+        "perl-i",
+        r"\bperl\s+-i(?:\.\S+)?\s+(?:-[a-zA-Z]+\s+)*(?:'[^']*'|\"[^\"]*\")\s+(?P<target>[^\s;&|]+)",
+    ),
+    ("tee", r"\btee\s+(?:-a\s+)?(?P<target>[^\s;&|]+)"),
+    ("redirect", r"(?<![\w&])>{1,2}(?!\S*&)\s*(?P<target>[^\s;&|>]+)"),
+    (
+        "mv-cp",
+        r"\b(?:mv|cp)\s+(?:-\S+\s+)*(?P<src>[^\s;&|]+)\s+(?P<target>[^\s;&|]+)\s*(?:[;&|]|$)",
+    ),
+    (
+        "python-open-write",
+        r"open\(\s*['\"](?P<target>[^'\"]+)['\"]\s*,\s*['\"](?:w|a|wb|ab|w\+|a\+)['\"]",
+    ),
+]
+
+
+def _load_patterns() -> List[Tuple[str, str]]:
+    """Load (id, regex) pairs from the config file, falling back to inline
+    defaults on any error — attempt-and-degrade, matches destructive_guard.py."""
+    try:
+        data = json.loads(_PATTERNS_FILE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return list(_DEFAULT_PATTERNS)
+    if not isinstance(data, dict):
+        return list(_DEFAULT_PATTERNS)
+    raw = data.get("patterns")
+    if not isinstance(raw, list):
+        return list(_DEFAULT_PATTERNS)
+    pairs: List[Tuple[str, str]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        rule_id = entry.get("id")
+        regex = entry.get("regex")
+        if isinstance(rule_id, str) and rule_id and isinstance(regex, str) and regex:
+            pairs.append((rule_id, regex))
+    return pairs if pairs else list(_DEFAULT_PATTERNS)
+
+
+def _extract_target(
+    command: str, patterns: List[Tuple[str, str]]
+) -> Optional[Tuple[str, str]]:
+    """Return (rule_id, raw_target) for the first pattern that matches, or
+    None when the command is unparseable/ambiguous — never raises."""
+    for rule_id, regex in patterns:
+        try:
+            match = re.search(regex, command)
+        except re.error:
+            continue
+        if match is None:
+            continue
+        target = match.groupdict().get("target")
+        if target:
+            return rule_id, target
+    return None
+
+
+def _normalize_target(target: str) -> str:
+    """Strip a matching pair of quotes and a leading './' — best-effort only."""
+    stripped = target.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ("'", '"'):
+        stripped = stripped[1:-1]
+    if stripped.startswith("./"):
+        stripped = stripped[2:]
+    return stripped
+
+
+def _resolve_relative(target: str, project_dir: Path) -> str:
+    """Best-effort project-relative posix path for `target`. Falls back to
+    the normalized target string when it can't be resolved under
+    `project_dir` (e.g. an absolute path outside the project)."""
+    normalized = _normalize_target(target)
+    candidate = Path(normalized)
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(project_dir.resolve()).as_posix()
+        except (OSError, ValueError):
+            return normalized
+    return normalized
+
+
+def _matches_staged_or_new_test(rel_target: str, staged: List[str]) -> bool:
+    if rel_target in staged:
+        return True
+    return is_test_file(rel_target)
+
+
+def evaluate(
+    command: str, project_dir: Path, now: Optional[float] = None
+) -> Tuple[int, List[str], Optional[str]]:
+    """Return (exit_code, stdout_lines, matched_rule_id).
+
+    `matched_rule_id` is the pattern id that triggered a block, or None
+    (including for every non-blocking outcome).
+    """
+    if not command:
+        return 0, [], None
+    state, error = read_build_phase(project_dir, now=now)
+    if error is not None:
+        audit(project_dir, "bash-freeze", "fail-open", reason=error)
+        return 0, [], None
+    if state is None or state.get("phase") != "refactor":
+        return 0, [], None
+
+    match = _extract_target(command, _load_patterns())
+    if match is None:
+        return 0, [], None
+    rule_id, raw_target = match
+
+    staged = state.get("test_files_staged", [])
+    rel_target = _resolve_relative(raw_target, project_dir)
+    if not _matches_staged_or_new_test(rel_target, staged):
+        return 0, [], None
+
+    step = state.get("step") if isinstance(state.get("step"), str) else None
+    audit(project_dir, "bash-freeze", "block", file=rel_target, step=step)
+    step_label = " (step {})".format(step) if step else ""
+    return (
+        2,
+        [
+            "[BLOCK] Tests are frozen during REFACTOR{}.".format(step_label),
+            "A refactor step must never change a test — refactoring is",
+            "behavior-preserving by definition (tests-frozen invariant, Rec 4,",
+            "docs/experiments/RECOMMENDATIONS.md).",
+            "File: {}".format(rel_target),
+            "Recovery: leave REFACTOR and return to the TEST phase, make the",
+            "test change there, re-verify the full suite green (pasted",
+            "evidence), then re-enter REFACTOR.",
+        ],
+        rule_id,
+    )
+
+
+def main() -> int:
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    exit_code, lines = 0, []
+    try:
+        payload = read_stdin_json()
+        tool_input = payload.get("tool_input") if isinstance(payload, dict) else None
+        command = ""
+        if isinstance(tool_input, dict):
+            raw = tool_input.get("command")
+            if isinstance(raw, str):
+                command = raw
+        exit_code, lines, rule_id = evaluate(command, project_dir)
+        if exit_code == 2:
+            session_id = payload.get("session_id") if isinstance(payload, dict) else None
+            emit_boundary_event(
+                project_dir,
+                "refactor_test_bash_guard",
+                "Bash",
+                "block",
+                rule_id or "bash-write",
+                session_id,
+            )
+    except Exception as exc:  # fail open — a broken guard never blocks work
+        audit(
+            project_dir,
+            "bash-freeze",
+            "fail-open",
+            reason="internal error: {}".format(exc),
+        )
+        return 0
+    for line in lines:
+        print(line)
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/hooks/refactor_test_revert_guard.py
+++ b/plugins/dev-team/hooks/refactor_test_revert_guard.py
@@ -28,6 +28,21 @@ sys.path.insert(0, str(_LIB_DIR))
 
 from refactor_test_freeze_guard import audit  # noqa: E402
 from test_file_classify import is_test_file, read_build_phase  # noqa: E402
+from boundary_events import emit_boundary_event as _emit_boundary_event  # noqa: E402
+from stdin_json import read_stdin_json  # noqa: E402
+
+
+def emit_boundary_event(*args, **kwargs) -> None:
+    """Local safety net (#859): even a misbehaving helper must never affect
+    this hook's exit code, stdout, or stderr. Also degrades silently (no
+    error, no extra output) on a tree that predates #859/PR #887 and lacks
+    the boundary-events channel — attempt-and-degrade, same pattern #862
+    uses."""
+    try:
+        _emit_boundary_event(*args, **kwargs)
+    except Exception:  # noqa: BLE001 - fail-open by design
+        pass
+
 
 RECOVERY = (
     "tests are frozen during REFACTOR; return to the TEST phase, make the "
@@ -53,7 +68,9 @@ def _git(project_dir: Path, args: List[str]) -> Optional[str]:
 
 
 def evaluate(
-    project_dir: Path, now: Optional[float] = None
+    project_dir: Path,
+    now: Optional[float] = None,
+    session_id: Optional[str] = None,
 ) -> Tuple[int, List[str]]:
     """Return (exit_code, stdout_lines). Always exits 0 — advisory only."""
     state, error = read_build_phase(project_dir, now=now)
@@ -91,6 +108,14 @@ def evaluate(
                 )
                 continue
             audit(project_dir, "revert", "revert", file=dirty, step=step)
+            emit_boundary_event(
+                project_dir,
+                "refactor_test_revert_guard",
+                "Bash",
+                "revert",
+                "restore-baseline",
+                session_id,
+            )
             lines.append(
                 "ADVISORY: restored test file '{}' to its TEST-phase baseline "
                 "({}).".format(dirty, RECOVERY)
@@ -124,6 +149,14 @@ def evaluate(
             )
             continue
         audit(project_dir, "revert", "remove", file=rel, step=step)
+        emit_boundary_event(
+            project_dir,
+            "refactor_test_revert_guard",
+            "Bash",
+            "revert",
+            "remove-untracked-test",
+            session_id,
+        )
         lines.append(
             "ADVISORY: removed test file '{}' created during REFACTOR "
             "({}).".format(rel, RECOVERY)
@@ -133,14 +166,14 @@ def evaluate(
 
 def main() -> int:
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    # The guard inspects disk state, not the payload — but stdin must still
+    # be drained (so the hook runner never blocks on a full pipe) and the
+    # session_id, when present, is worth threading into the boundary-events
+    # emission for cross-stream joins with session-digest.jsonl.
+    payload = read_stdin_json()
+    session_id = payload.get("session_id") if isinstance(payload, dict) else None
     try:
-        # Payload is unused — the guard inspects disk state — but stdin must
-        # be drained so the hook runner never blocks on a full pipe.
-        sys.stdin.read()
-    except OSError:
-        pass
-    try:
-        exit_code, lines = evaluate(project_dir)
+        exit_code, lines = evaluate(project_dir, session_id=session_id)
     except Exception as exc:  # fail open — never revert, never block
         audit(project_dir, "revert", "fail-open", reason="internal error: {}".format(exc))
         return 0

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -25,19 +25,21 @@ in shipped code against this doc's coverage and fails on omission.
 ## `boundary-events.jsonl`
 
 **Added by #859.** The boundary-level (policy-gateway) channel: every guard
-hook's block/warn/bypass decision, plus human-intervention keywords.
+hook's block/warn/bypass decision, plus human-intervention keywords. Extended
+by #906 with a fifth decision, `revert`, for hooks that don't warn or block
+but actively correct state after the fact.
 
 | Field | Type | Values / source |
 |---|---|---|
 | `ts` | string | ISO-8601 UTC `%Y-%m-%dT%H:%M:%SZ` |
 | `hook` | string | Emitting hook's module name, e.g. `destructive_guard`, `verify_guard`, `pre_commit_review`, `telemetry` |
 | `tool` | string | Hooked tool/event: `Bash`, `Write`, `Edit`, `Skill`, `Agent`, `UserPromptSubmit` |
-| `decision` | string enum | `block` \| `warn` \| `bypass` \| `intervention` |
+| `decision` | string enum | `block` \| `warn` \| `bypass` \| `intervention` \| `revert` |
 | `matched_rule` | string | Rule ID from a closed vocabulary (pattern ID, hook-defined constant, bypass flag name, or intervention keyword) — never free text |
 | `plugin_version` | string | From `.claude-plugin/plugin.json` |
 | `session_id` | string, optional | Opaque per-session ID, when present in the hook payload — enables joins with `session-digest.jsonl` |
 
-- **Emitter:** `hooks/lib/boundary_events.py::emit_boundary_event()`, called from `destructive_guard.py`, `verify_guard.py`, `pre_commit_review.py`, `telemetry.py` (intervention keywords), and the mechanically-adopted guards (`pre_tool_guard.py`, `context_ceiling_guard.py`, `bash_retry_guard.py`, `refactor_test_freeze_guard.py`, `contract_version_guard.py`, `mutation_testing_smoke_gate.py`, `mutation_gate.py`, `tdd_guard.py`).
+- **Emitter:** `hooks/lib/boundary_events.py::emit_boundary_event()`, called from `destructive_guard.py`, `verify_guard.py`, `pre_commit_review.py`, `telemetry.py` (intervention keywords), and the mechanically-adopted guards (`pre_tool_guard.py`, `context_ceiling_guard.py`, `bash_retry_guard.py`, `refactor_test_freeze_guard.py`, `refactor_test_bash_guard.py`, `refactor_test_revert_guard.py` (decision `revert`, #906), `contract_version_guard.py`, `mutation_testing_smoke_gate.py`, `mutation_gate.py`, `tdd_guard.py`).
 - **Consent:** ALWAYS-ON — not gated by `DEV_TEAM_TELEMETRY`. Local-only, rule-IDs-only safety/accountability channel; no observability holes by design.
 - **Fail-open:** every exception in the emit helper is swallowed — never changes the calling hook's exit code, stdout, or stderr.
 - **Consumers:** `skills/session-review/SKILL.md`, `skills/harness-audit/SKILL.md`, `agents/session-analysis.md`, `skills/cost-report/`, future `agent-telemetry` cross-machine aggregation (#178).
@@ -292,18 +294,19 @@ a controlled baseline-vs-ablated integration-tier delta (issues caught,
 ## `refactor-freeze.jsonl`
 
 Audit log for the tests-frozen-during-REFACTOR invariant (`#813`) — both the
-enforcement decision and any fail-open diagnostic.
+enforcement decision and any fail-open diagnostic. Extended by `#906` with
+`bash-freeze`, the preventive PreToolUse(Bash) sibling of `freeze`.
 
 | Field | Type | Values / source |
 |---|---|---|
 | `timestamp` | string | ISO-8601 |
-| `hook` | string | `freeze` or `revert` |
+| `hook` | string | `freeze` \| `bash-freeze` \| `revert` |
 | `event` | string enum | `block` \| `fail-open` \| `revert` \| `remove` |
 | `file` | string, optional | File path involved |
 | `step` | string, optional | Plan step label |
 | `reason` | string, optional | Fail-open diagnostic (existing precedent — internal-error text, not a rule ID; unchanged by #859) |
 
-- **Emitter:** `hooks/refactor_test_freeze_guard.py::audit()`, `hooks/refactor_test_revert_guard.py` (via the same `audit()` import).
+- **Emitter:** `hooks/refactor_test_freeze_guard.py::audit()`, `hooks/refactor_test_revert_guard.py` and `hooks/refactor_test_bash_guard.py` (both via the same `audit()` import).
 - **Consent:** unconditional (fails open, audits itself).
 - **Consumers:** none automated yet; inspected manually when the freeze invariant is investigated.
 

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -76,6 +76,10 @@
           },
           {
             "type": "command",
+            "command": "python3 hooks/refactor_test_bash_guard.py"
+          },
+          {
+            "type": "command",
             "command": "python3 hooks/pre_commit_review.py"
           },
           {

--- a/plugins/dev-team/tests/hooks/test_boundary_events.py
+++ b/plugins/dev-team/tests/hooks/test_boundary_events.py
@@ -41,7 +41,7 @@ for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
 import boundary_events  # type: ignore[import-not-found]  # noqa: E402
 from hermetic import hermetic_git_env  # type: ignore[import-not-found]  # noqa: E402
 
-_DECISION_ENUM = {"block", "warn", "bypass", "intervention"}
+_DECISION_ENUM = {"block", "warn", "bypass", "intervention", "revert"}
 _SCHEMA_FIELDS = {"ts", "hook", "tool", "decision", "matched_rule", "plugin_version"}
 _OPTIONAL_FIELDS = {"session_id"}
 

--- a/plugins/dev-team/tests/hooks/test_refactor_test_bash_guard.py
+++ b/plugins/dev-team/tests/hooks/test_refactor_test_bash_guard.py
@@ -1,0 +1,266 @@
+"""Unit tests for hooks/refactor_test_bash_guard.py (#906).
+
+The preventive, Bash-aware sibling of refactor_test_freeze_guard.py: block,
+pass-through, staleness, and fail-open paths, plus per-shape coverage of the
+regex library and the boundary-events wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"))
+
+import refactor_test_bash_guard as guard  # noqa: E402
+from test_file_classify import STALE_AFTER_SECONDS  # noqa: E402
+
+_WRITTEN_AT = "2026-07-04T10:00:00+00:00"
+_WRITTEN_AT_EPOCH = 1783159200.0
+_NOW = _WRITTEN_AT_EPOCH + 60
+
+
+def _write_state(tmp_path: Path, phase: str = "refactor", **overrides) -> None:
+    state = {
+        "phase": phase,
+        "step": "2.1",
+        "written_at": _WRITTEN_AT,
+        "test_files_staged": ["src/thing.test.js"],
+    }
+    state.update(overrides)
+    path = tmp_path / "memory" / "build-phase.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state))
+
+
+def _audit_events(tmp_path: Path):
+    path = tmp_path / "metrics" / "refactor-freeze.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+# ---------------------------------------------------------------------------
+# One true-positive block per recognized Bash shape.
+# ---------------------------------------------------------------------------
+
+_TRUE_POSITIVE_COMMANDS = [
+    ("sed-i", "sed -i 's/x/y/' src/thing.test.js"),
+    ("sed-i", "sed -i.bak 's/x/y/' src/thing.test.js"),
+    ("perl-i", "perl -i -pe 's/x/y/' src/thing.test.js"),
+    ("tee", "tee src/thing.test.js <<< 'x'"),
+    ("tee", "tee -a src/thing.test.js <<< 'x'"),
+    ("redirect", "echo 'x' > src/thing.test.js"),
+    ("redirect", "echo 'x' >> src/thing.test.js"),
+    ("mv-cp", "mv src/a.js src/thing.test.js"),
+    ("mv-cp", "cp src/a.js src/thing.test.js"),
+    (
+        "python-open-write",
+        "python3 -c \"open('src/thing.test.js', 'w').write('x')\"",
+    ),
+]
+
+
+def test_each_recognized_shape_blocks_a_staged_test_file(tmp_path):
+    for rule_id, command in _TRUE_POSITIVE_COMMANDS:
+        _write_state(tmp_path)
+        (tmp_path / "metrics" / "refactor-freeze.jsonl").unlink(missing_ok=True)
+        code, lines, matched_rule = guard.evaluate(command, tmp_path, now=_NOW)
+        assert code == 2, command
+        assert lines[0].startswith("[BLOCK]"), command
+        assert matched_rule == rule_id, command
+
+
+def test_block_names_the_file_and_recovery(tmp_path):
+    _write_state(tmp_path)
+    _, lines, _ = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+    )
+    body = " ".join(lines)
+    assert "src/thing.test.js" in body
+    assert "TEST" in body and "REFACTOR" in body
+
+
+def test_block_is_recorded_in_the_audit_log(tmp_path):
+    _write_state(tmp_path)
+    guard.evaluate("sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW)
+    events = _audit_events(tmp_path)
+    assert [e["event"] for e in events] == ["block"]
+    assert events[0]["file"] == "src/thing.test.js"
+    assert events[0]["step"] == "2.1"
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous / non-matching / out-of-scope commands never block.
+# ---------------------------------------------------------------------------
+
+_NO_BLOCK_COMMANDS = [
+    "ls -la",
+    "git commit -m 'wip'",
+    "npm test",
+    "cmd 2>&1",
+    "echo hello world",
+]
+
+
+def test_unparseable_commands_never_block(tmp_path):
+    _write_state(tmp_path)
+    for command in _NO_BLOCK_COMMANDS:
+        assert guard.evaluate(command, tmp_path, now=_NOW) == (0, [], None), command
+
+
+def test_matching_shape_on_a_non_test_target_is_a_no_op(tmp_path):
+    _write_state(tmp_path)
+    code, lines, matched_rule = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.ts", tmp_path, now=_NOW
+    )
+    assert (code, lines, matched_rule) == (0, [], None)
+
+
+def test_matching_shape_outside_refactor_phase_is_a_no_op(tmp_path):
+    for phase in ("implement", "test", "red", "green"):
+        _write_state(tmp_path, phase=phase)
+        result = guard.evaluate(
+            "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+        )
+        assert result == (0, [], None), phase
+
+
+def test_no_op_when_no_phase_is_recorded(tmp_path):
+    assert guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+    ) == (0, [], None)
+
+
+def test_stale_refactor_state_does_not_linger(tmp_path):
+    _write_state(tmp_path)
+    result = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js",
+        tmp_path,
+        now=_WRITTEN_AT_EPOCH + STALE_AFTER_SECONDS + 1,
+    )
+    assert result == (0, [], None)
+
+
+def test_empty_command_passes_silently(tmp_path):
+    _write_state(tmp_path)
+    assert guard.evaluate("", tmp_path, now=_NOW) == (0, [], None)
+
+
+# ---------------------------------------------------------------------------
+# New-test-file creation is blocked preemptively (never reaches disk).
+# ---------------------------------------------------------------------------
+
+
+def test_new_test_file_creation_is_blocked_preemptively(tmp_path):
+    _write_state(tmp_path)  # baseline staged file is src/thing.test.js only
+    code, lines, matched_rule = guard.evaluate(
+        "tee src/rogue.spec.js <<< 'x'", tmp_path, now=_NOW
+    )
+    assert code == 2
+    assert matched_rule == "tee"
+    assert not (tmp_path / "src" / "rogue.spec.js").exists()
+
+
+def test_new_non_test_file_creation_is_allowed(tmp_path):
+    _write_state(tmp_path)
+    result = guard.evaluate("tee src/scratch.js <<< 'x'", tmp_path, now=_NOW)
+    assert result == (0, [], None)
+
+
+# ---------------------------------------------------------------------------
+# Fail-open paths.
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_state_fails_open_with_an_audit_line(tmp_path):
+    path = tmp_path / "memory" / "build-phase.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json")
+    result = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+    )
+    assert result == (0, [], None)
+    events = _audit_events(tmp_path)
+    assert [e["event"] for e in events] == ["fail-open"]
+
+
+def test_main_fails_open_on_internal_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        guard, "read_stdin_json", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert guard.main() == 0
+    assert capsys.readouterr().out == ""
+    events = _audit_events(tmp_path)
+    assert [e["event"] for e in events] == ["fail-open"]
+
+
+def test_missing_pattern_file_falls_back_to_defaults(tmp_path, monkeypatch):
+    _write_state(tmp_path)
+    monkeypatch.setattr(guard, "_PATTERNS_FILE", tmp_path / "does-not-exist.json")
+    code, lines, matched_rule = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+    )
+    assert code == 2
+    assert matched_rule == "sed-i"
+
+
+def test_malformed_pattern_file_falls_back_to_defaults(tmp_path, monkeypatch):
+    _write_state(tmp_path)
+    bogus = tmp_path / "bogus-patterns.json"
+    bogus.write_text("{not json")
+    monkeypatch.setattr(guard, "_PATTERNS_FILE", bogus)
+    code, lines, matched_rule = guard.evaluate(
+        "sed -i 's/x/y/' src/thing.test.js", tmp_path, now=_NOW
+    )
+    assert code == 2
+    assert matched_rule == "sed-i"
+
+
+# ---------------------------------------------------------------------------
+# main() end-to-end + boundary-events emission.
+# ---------------------------------------------------------------------------
+
+
+def test_main_blocks_via_stdin_payload_and_emits_boundary_event(
+    tmp_path, monkeypatch, capsys
+):
+    import datetime
+
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    _write_state(tmp_path, written_at=now_iso)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        guard,
+        "read_stdin_json",
+        lambda: {
+            "tool_input": {"command": "sed -i 's/x/y/' src/thing.test.js"},
+            "session_id": "sess-1",
+        },
+    )
+    assert guard.main() == 2
+    assert "[BLOCK]" in capsys.readouterr().out
+
+    events_path = tmp_path / "metrics" / "boundary-events.jsonl"
+    assert events_path.is_file()
+    events = [json.loads(line) for line in events_path.read_text().splitlines() if line]
+    assert events[-1]["decision"] == "block"
+    assert events[-1]["hook"] == "refactor_test_bash_guard"
+    assert events[-1]["matched_rule"] == "sed-i"
+    assert events[-1]["session_id"] == "sess-1"
+
+
+def test_main_allows_non_matching_command(tmp_path, monkeypatch, capsys):
+    _write_state(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        guard,
+        "read_stdin_json",
+        lambda: {"tool_input": {"command": "npm test"}},
+    )
+    assert guard.main() == 0
+    assert capsys.readouterr().out == ""

--- a/plugins/dev-team/tests/hooks/test_refactor_test_revert_guard.py
+++ b/plugins/dev-team/tests/hooks/test_refactor_test_revert_guard.py
@@ -74,6 +74,13 @@ def _audit_events(repo: Path):
     return [json.loads(line) for line in path.read_text().splitlines() if line]
 
 
+def _boundary_events(repo: Path):
+    path = repo / "metrics" / "boundary-events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
 def test_baseline_carryover_is_never_reverted(repo):
     _write_state(repo)
     code, lines = guard.evaluate(repo, now=_NOW)
@@ -96,6 +103,21 @@ def test_post_baseline_change_is_restored_with_advisory_and_audit(repo):
     assert events[0]["file"] == "src/thing.test.js"
 
 
+def test_post_baseline_restore_emits_a_revert_boundary_event(repo):
+    """#906: restoring a dirtied baseline test file emits one boundary
+    event with decision "revert" and matched_rule "restore-baseline"."""
+    _write_state(repo)
+    (repo / "src" / "thing.test.js").write_text("test('weakened', () => {});\n")
+    guard.evaluate(repo, now=_NOW, session_id="sess-1")
+    events = _boundary_events(repo)
+    assert len(events) == 1
+    assert events[0]["decision"] == "revert"
+    assert events[0]["hook"] == "refactor_test_revert_guard"
+    assert events[0]["tool"] == "Bash"
+    assert events[0]["matched_rule"] == "restore-baseline"
+    assert events[0]["session_id"] == "sess-1"
+
+
 def test_deleted_baseline_test_file_is_restored(repo):
     _write_state(repo)
     (repo / "src" / "thing.test.js").unlink()
@@ -114,6 +136,37 @@ def test_test_file_created_during_refactor_is_removed(repo):
     events = _audit_events(repo)
     assert [e["event"] for e in events] == ["remove"]
     assert events[0]["file"] == "src/rogue.spec.js"
+
+
+def test_new_test_file_removal_emits_a_revert_boundary_event(repo):
+    """#906: removing an untracked test file created during REFACTOR emits
+    one boundary event with decision "revert" and matched_rule
+    "remove-untracked-test"."""
+    _write_state(repo)
+    rogue = repo / "src" / "rogue.spec.js"
+    rogue.write_text("test('unreviewed', () => {});\n")
+    guard.evaluate(repo, now=_NOW, session_id="sess-2")
+    events = _boundary_events(repo)
+    assert len(events) == 1
+    assert events[0]["decision"] == "revert"
+    assert events[0]["hook"] == "refactor_test_revert_guard"
+    assert events[0]["matched_rule"] == "remove-untracked-test"
+    assert events[0]["session_id"] == "sess-2"
+
+
+def test_boundary_event_channel_absence_degrades_silently(repo, monkeypatch):
+    """Soft dependency on #859/PR #887 (attempt-and-degrade, same pattern
+    #862 uses): even if the boundary-events channel raises internally, the
+    revert guard's own behavior, stdout, and exit code are unaffected."""
+    _write_state(repo)
+    (repo / "src" / "thing.test.js").write_text("test('weakened', () => {});\n")
+    monkeypatch.setattr(
+        guard, "_emit_boundary_event", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    code, lines = guard.evaluate(repo, now=_NOW)
+    assert code == 0
+    assert (repo / "src" / "thing.test.js").read_text() == _BASELINE_CONTENT
+    assert any(line.startswith("ADVISORY:") for line in lines)
 
 
 def test_untracked_non_test_file_is_left_alone(repo):


### PR DESCRIPTION
Closes #906
Part of #859 (via #887)

**Depends on #887 (closes #859) — please merge #887 first.** This branch was built on top of the unmerged `issue-859-boundary-events` branch (`git merge origin/issue-859-boundary-events --no-edit`, fast-forward), so this PR's diff currently includes #887's boundary-events changes. Once #887 lands on `main`, this branch should be rebased and the diff will shrink to just this issue's changes.

## Summary

Two independent-but-complementary changes, both scoped to the tests-frozen-during-refactor invariant (#813):

**1. Boundary-events wiring for `refactor_test_revert_guard.py`.** Extends the boundary-events decision enum (#859/#887) with a fifth value, `"revert"`, for hooks that don't warn/block but actively correct state after the fact. Wires `emit_boundary_event()` into the guard's two action sites:
- restoring a dirtied baseline test file → `decision: "revert"`, `matched_rule: "restore-baseline"`
- removing an untracked test file created during REFACTOR → `decision: "revert"`, `matched_rule: "remove-untracked-test"`

Both call sites use a local `emit_boundary_event()` safety wrapper (same attempt-and-degrade pattern as the sibling guards) so the revert guard keeps working byte-identically on a tree that predates the boundary-events channel.

**2. New preventive hook: `hooks/refactor_test_bash_guard.py` (PreToolUse, Bash).** The Bash-aware sibling of `refactor_test_freeze_guard.py`. Recognizes a conservative regex library of file-modifying Bash shapes — `sed -i`, `perl -i`, `tee`, shell redirection (`>`/`>>`), `mv`/`cp` onto a target, and `python -c` containing `open(..., "w"/"a")` — and extracts the apparent write target. When a REFACTOR phase is active (`memory/build-phase.json`) and the target is in the step's `test_files_staged`, or would newly create a file `test_file_classify.is_test_file()` classifies as a test, it blocks with exit 2 and the standard `RECOVERY` message before the command ever runs. Ambiguous/unparseable commands never block — false-negative-favoring, per the issue's stated false-positive budget; `refactor_test_revert_guard.py` remains the safety net for anything this guard misses. Fails open on any internal error. Registered in `settings.json` as a `PreToolUse`/`Bash` hook, alongside `destructive_guard.py`.

## Implementation choices (no formal Ambiguity Log — judgment calls made in-line with existing conventions)

- **Hook filename:** `refactor_test_bash_guard.py`, following the existing `refactor_test_freeze_guard.py` / `refactor_test_revert_guard.py` naming.
- **Regex library format:** a new JSON config file, `hooks/refactor-bash-write-patterns.json` (`{"patterns": [{"id": ..., "regex": ...}]}`), loaded with the same attempt-and-degrade fallback-to-inline-defaults pattern `destructive_guard.py` uses for `destructive-commands.json`. Chose a JSON file over inline-only because these patterns benefit from the same "team can tune the library without touching code" property destructive-commands.json already has.
- **`matched_rule` values:** the regex library's `id` strings (`sed-i`, `perl-i`, `tee`, `redirect`, `mv-cp`, `python-open-write`) for the new hook; `restore-baseline` / `remove-untracked-test` for the revert guard's two action sites, per the issue text verbatim.
- **Audit trail:** the new hook reuses `refactor_test_freeze_guard.audit()` and appends to the existing `metrics/refactor-freeze.jsonl` stream with `hook: "bash-freeze"` (new value alongside `freeze`/`revert`), rather than introducing a new metrics file — it's the same invariant, just enforced from a different tool. `knowledge/telemetry-schema.md` documents the new `hook` value.
- **`mv`/`cp` target resolution:** takes the last whitespace-separated argument as the destination (common two-arg case). Multi-source `mv a b c dir/` invocations are a known false negative, acceptable per the issue's Non-goals.

## Test plan

- `python3 -m pytest plugins/dev-team/tests/hooks -q` → 780 passed (includes new `test_refactor_test_bash_guard.py` and the boundary-events additions to `test_refactor_test_revert_guard.py` and `test_boundary_events.py`).
- `python3 -m pytest plugins/dev-team/tests -q` → 829 passed, 16 skipped, 1 pre-existing failure (`test_mypy_adapter.py::test_emitted_findings_validate_against_unified_finding_v1`, `ModuleNotFoundError: No module named 'jsonschema'` — confirmed pre-existing on `origin/main` before this branch's changes, unrelated to this issue).
- `python3 scripts/check_md_references.py` → exit 0, no broken references.
- `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py --check` → exit 0, `knowledge/index.json` still fresh.
- Coverage per Acceptance Criteria: one true-positive test per recognized Bash shape, unparseable-command no-block, new-test-file-creation blocked preemptively, non-REFACTOR/non-test-target no-ops, malformed-state and internal-error fail-open paths, pattern-file-missing/malformed fallback-to-defaults, and end-to-end `main()` boundary-event emission (including the channel-absence degrade-silently case for the revert guard).

Note: `npm ci` could not be run in this worktree (`engine "node": ">=24"` required, sandbox has Node 22) so Husky git hooks are not installed here; `scripts/ci-local.sh`/CI are documented as the backstop for that case. Local commits in this branch are unsigned for the same sandbox reason — flagging per the repo's signed-commit merge requirement.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_