### PR TITLE
fix: reclassify correctness-review to high-risk calibration floor

### DIFF
--- a/plugins/dev-team/knowledge/calibration-floors.json
+++ b/plugins/dev-team/knowledge/calibration-floors.json
@@ -1,14 +1,14 @@
 {
-  "_comment": "Calibration floor policy for eval-graded review agents/skills (issue #880, slice 1 of epic #879). riskClass drives the minimum acceptable eval pass rate (floor, 0-1) for that target. high: correctness-critical review classes named explicitly by the epic (security-review, concurrency-review, arch-review, domain-review) -- floor 1.0, zero tolerance for miscalibration. standard: the remaining review agents whose frontmatter declares effort: medium (or, for orchestrator, effort: medium with no lower-effort signal) -- floor 0.9. advisory: effort: low review agents (lexical/config/style-leaning checks) plus skills that self-describe as advisory (test-design-advisor) -- floor 0.8. Guarded by tests/repo/test_calibration_floors_sync.py via scripts/check_calibration_floors_sync.py. No eval runs are introduced by this slice -- later slices (#881-#883) wire the floors into actual gating.",
+  "_comment": "Calibration floor policy for eval-graded review agents/skills (issue #880, slice 1 of epic #879). riskClass drives the minimum acceptable eval pass rate (floor, 0-1) for that target. high: correctness-critical review classes -- the epic's four originally-named agents (security-review, concurrency-review, arch-review, domain-review) plus later effort:high additions judged equally consequential on missed findings (correctness-review, added post-epic by #885/#900: catches functional/behavioral defects other agents miss) -- floor 1.0, zero tolerance for miscalibration. standard: the remaining review agents whose frontmatter declares effort: medium (or, for orchestrator, effort: medium with no lower-effort signal) -- floor 0.9. advisory: effort: low review agents (lexical/config/style-leaning checks) plus skills that self-describe as advisory (test-design-advisor) -- floor 0.8. Guarded by tests/repo/test_calibration_floors_sync.py via scripts/check_calibration_floors_sync.py. No eval runs are introduced by this slice -- later slices (#881-#883) wire the floors into actual gating.",
   "security-review": { "riskClass": "high", "floor": 1.0 },
   "concurrency-review": { "riskClass": "high", "floor": 1.0 },
   "arch-review": { "riskClass": "high", "floor": 1.0 },
   "domain-review": { "riskClass": "high", "floor": 1.0 },
+  "correctness-review": { "riskClass": "high", "floor": 1.0 },
 
   "a11y-review": { "riskClass": "standard", "floor": 0.9 },
   "complexity-review": { "riskClass": "standard", "floor": 0.9 },
   "component-architecture-review": { "riskClass": "standard", "floor": 0.9 },
-  "correctness-review": { "riskClass": "standard", "floor": 0.9 },
   "doc-review": { "riskClass": "standard", "floor": 0.9 },
   "naming-review": { "riskClass": "standard", "floor": 0.9 },
   "orchestrator": { "riskClass": "standard", "floor": 0.9 },


### PR DESCRIPTION
## Summary

Follow-up to #902 (closes #880). `correctness-review` (added by #900/#885, merged after #902 was originally authored) was classified `standard` (0.9) in the merged version of #902 — but that classification raced against a maintainer decision made in chat after #902 had already auto-merged, so the intended decision never landed on `main`.

**Maintainer decision**: `correctness-review` should be `high` (floor 1.0), not `standard` (0.9) — it's `effort: high` and exists specifically to catch functional/behavioral defects other review agents miss, judged equally consequential on missed findings as the epic's four originally-named high-risk agents (`security-review`, `concurrency-review`, `arch-review`, `domain-review`).

This PR corrects that: reclassifies `correctness-review` from `standard` to `high` in `plugins/dev-team/knowledge/calibration-floors.json`, and updates the file's own policy comment to reflect that the `high` tier isn't a strictly closed enumeration — later `effort:high` additions can qualify when judged equally consequential.

## Test plan

- [x] `python3 scripts/check_calibration_floors_sync.py` — in sync
- [x] `python3 -m pytest tests/repo/test_calibration_floors_sync.py -q` — 8 passed
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo -q` — 1365 passed, 16 skipped, no regressions

Part of #879


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJJnVkE4Vvc5GYYX9EoE8)_