### PR TITLE
chore: force dev-team's next release to 10.3.0, not 11.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
       "release-type": "simple",
       "package-name": "dev-team",
       "component": "dev-team",
+      "release-as": "10.3.0",
       "extra-files": [
         ".claude-plugin/plugin.json",
         {


### PR DESCRIPTION
## Summary
- 941e25de (`feat!: rename context-summarization skill to handoff, add fork mode`) marked an internal rename as a breaking change, which pushed release-please's computed bump for `plugins/dev-team` from minor (10.3.0) to major (11.0.0) in PR #912.
- Rewriting that commit isn't viable: it's 13 commits deep on protected `main`, which forbids force-push and requires signed commits.
- Adds a temporary per-package `release-as: "10.3.0"` override in `release-please-config.json` (release-please's own documented mechanism for this exact situation), scoped only to `plugins/dev-team` so `security-assessment` and `marketplace-dev` are unaffected.

## Test plan
- [ ] Merge this PR
- [ ] Confirm release-please regenerates PR #912 targeting `dev-team` v10.3.0 (not 11.0.0)
- [ ] After PR #912 merges and the release is cut, remove the `release-as` key from `release-please-config.json` in a follow-up PR so future releases resume normal conventional-commit computation

🤖 Generated with [Claude Code](https://claude.com/claude-code)