### PR TITLE
chore: remove temporary dev-team release-as override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,6 @@
       "release-type": "simple",
       "package-name": "dev-team",
       "component": "dev-team",
-      "release-as": "10.3.0",
       "extra-files": [
         ".claude-plugin/plugin.json",
         {


### PR DESCRIPTION
## Summary
- Follow-up to #921, which added a temporary `release-as: "10.3.0"` override to `release-please-config.json` for `plugins/dev-team` to correct a version bump inflated by a mistaken `feat!:` commit (941e25de).
- Removes that override now that its job is done.

**⚠️ Merge-order dependency: do not merge this until after #912 has regenerated targeting `10.3.0` and that release has actually been cut (tag/release published).** Merging this beforehand puts release-please back into normal conventional-commits mode before the correction takes effect, which reintroduces the 11.0.0 bump.

## Test plan
- [ ] Confirm PR #912 merged and a `dev-team-v10.3.0` tag/release exists
- [ ] Merge this PR
- [ ] Confirm the next `plugins/dev-team` release PR computes its bump from conventional commits again, with no `release-as` in play

🤖 Generated with [Claude Code](https://claude.com/claude-code)