### PR TITLE
fix: clarify slice-checkbox flip must wait for verify and invariants

### DIFF
--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -189,7 +189,7 @@ Work each step **one behavior at a time** — never all the code then all the te
    - **UI changes (any complexity)**: After the relevant review passes (per-step for complex, at the slice checkpoint for standard), run browser verification via `/browse` in automated smoke test mode. Skip with warning if the dev server is not running. See `agents/orchestrator.md` Stage 3.
 5. **Mark step done** — Use the Edit tool to update the plan file's `## Build Progress` section on disk:
    - Change `- [ ] Step N.M: <title>` to `- [x] Step N.M: <title>` for the completed step.
-   - When every step under a slice is `[x]`, check off the parent `- [ ] Slice N: <title>`.
+   - When every step under a slice is `[x]`, that is not the same as the slice being done — check off the parent `- [ ] Slice N: <title>` only after sub-steps 4.9 (verify) and 4.10 (invariants) both pass, if applicable; a slice with no runtime surface and no declared invariants has nothing further to wait on and may be checked off once its steps and review checkpoint(s) are done.
    - After all slices are `[x]`, change `**Status**: approved` to `**Status**: in-progress`.
    - This disk write is the durable commit. If a `/clear` occurs, `/continue` reads `## Build Progress` to determine the resume point without needing conversation history.
    - **Clear freeze scope (issue #865).** When every step under the slice is `[x]` and freeze was engaged for it (dispatch bookkeeping above), run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py clear --hooks-dir <worktree>/hooks` before starting the next slice. A slice that never engaged freeze has nothing to clear.

--- a/tests/commands/test_build_slice_checkbox_order.py
+++ b/tests/commands/test_build_slice_checkbox_order.py
@@ -1,0 +1,56 @@
+"""#915 — /build SKILL.md must not contradict itself on when a slice's
+parent checkbox may flip to `[x]`.
+
+Sub-step 5 ("Mark step done") used to say "When every step under a slice
+is `[x]`, check off the parent" with no qualifier — a literal read flips the
+slice checkbox the instant the last step checkbox is checked, before
+sub-steps 4.9 (verify runtime behavior) and 4.10 (run slice invariants) have
+even run. Those two sub-steps independently say the slice may not be marked
+`[x]` until they pass. Sub-step 5's clause must explicitly defer to both, or
+the contradiction (and the risk of a plan file showing a slice "done" before
+its invariants actually passed) comes back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD = REPO_ROOT / "plugins" / "dev-team" / "skills" / "build" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def build_text() -> str:
+    return BUILD.read_text(encoding="utf-8")
+
+
+def test_slice_checkbox_flip_defers_to_verify_and_invariants(build_text: str) -> None:
+    assert "sub-steps 4.9 (verify) and 4.10 (invariants) both pass" in build_text
+
+
+def test_slice_checkbox_flip_no_longer_unqualified(build_text: str) -> None:
+    # The pre-#915 wording flipped the parent checkbox with no gate at all.
+    # If this exact unqualified sentence reappears, the contradiction is back.
+    assert "is `[x]`, check off the parent `- [ ] Slice N: <title>`." not in build_text
+
+
+def test_slice_checkbox_flip_bullet_gates_on_verify_and_invariants(
+    build_text: str,
+) -> None:
+    # Co-location check: the 4.9/4.10 gate must live in the SAME bullet as the
+    # checkbox-flip instruction, not just appear somewhere else in the file.
+    # A passing "defers to 4.9/4.10" substring check alone wouldn't catch a
+    # rewording that relocates the flip instruction away from its gate.
+    matching_lines = [
+        line
+        for line in build_text.splitlines()
+        if "check off the parent `- [ ] slice n: <title>`" in line.lower()
+    ]
+    assert len(matching_lines) == 1, (
+        "expected exactly one bullet mentioning the Slice N checkbox flip"
+    )
+    bullet = matching_lines[0]
+    assert "4.9" in bullet
+    assert "4.10" in bullet


### PR DESCRIPTION
## Summary

- `/build`'s SKILL.md gave two conflicting rules for when a build slice's parent checkbox (`- [ ] Slice N: <title>`) may flip to `[x]`: sub-step 5 said to flip it as soon as every step under the slice was `[x]`, while sub-steps 4.9 (verify, issue #727) and 4.10 (invariants, issue #865) independently said the slice may not be marked done until those gates pass.
- Rewrites sub-step 5's bullet to explicitly defer the parent-checkbox flip to sub-steps 4.9 and 4.10, so a literal reading of the file no longer flips the checkbox before verify/invariants have run.
- Adds a regression test (`tests/commands/test_build_slice_checkbox_order.py`) that fails if the flip instruction is ever reworded away from that gate, including a co-location check so the fix can't be defeated by relocating the qualifying clause elsewhere in the file.

## Test plan

- [x] `python3 -m pytest tests/commands/test_build_slice_checkbox_order.py tests/commands/test_build_parallel_doc.py tests/repo/test_plan_template.py` — all green
- [x] Knowledge index rebuilt (`python3 plugins/dev-team/hooks/lib/build_knowledge_index.py`) — no changes needed
- [x] `/code-review` run (doc-review, arch-review, claude-setup-review, token-efficiency-review, test-review dispatched in parallel) — one actionable finding (verbose bullet wording) applied
- [x] `bash scripts/ci-local.sh` — green except a pre-existing, unrelated `eslint` failure in `evals/fixtures/cr-*.js` (verified identical to `main` at the merge-base, not part of actual CI's `--only=` scoping — tracked separately in #930)

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)