### PR TITLE
fix: auto-detect src-layout Python projects for mypy invocation

### DIFF
--- a/plugins/dev-team/skills/static-analysis-integration/adapters/mypy-src-layout.py
+++ b/plugins/dev-team/skills/static-analysis-integration/adapters/mypy-src-layout.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Detect a plain src/-layout Python project and emit the mypy flags it needs.
+
+mypy fails outright on a common, unremarkable layout — a ``src/`` directory
+holding modules with no ``__init__.py``, and no project-level mypy
+package-base configuration (``mypy_path`` / ``explicit_package_bases`` / a
+``pyproject.toml`` ``[tool.mypy]`` section). The moment any other checked
+file imports one of those modules via its dotted ``src.`` path (a root-level
+entry point, a test, ...), mypy resolves the same file two different ways
+and refuses to proceed:
+
+    Source file found twice under different module names: "calc" and "src.calc"
+
+mypy >= 0.990 accepts ``--explicit-package-bases`` to resolve this without
+requiring ``__init__.py`` files or hand-written config. This script detects
+the layout and prints the extra flag(s) to pass (empty when not applicable)
+so the caller can splice them into the mypy invocation documented in
+``../references/tool-configs.md``:
+
+    mypy $(python3 adapters/mypy-src-layout.py .) --output json .
+
+Detection deliberately never overrides a project that already owns its mypy
+config — "bind, don't replace" (see static-self-heal.md's provider-binding
+rule): if any recognized mypy config file/section is present, this reports
+no src-layout regardless of what src/ contains.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# name -> marker string that must appear in the file for it to count as a
+# mypy package-base config; None means the file's mere presence counts.
+_CONFIG_MARKERS = {
+    "mypy.ini": None,
+    ".mypy.ini": None,
+    "setup.cfg": "[mypy]",
+    "tox.ini": "[mypy]",
+    "pyproject.toml": "[tool.mypy]",
+}
+
+
+def _has_mypy_config(root: Path) -> bool:
+    for name, marker in _CONFIG_MARKERS.items():
+        path = root / name
+        if not path.is_file():
+            continue
+        if marker is None:
+            return True
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if marker in text:
+            return True
+    return False
+
+
+def _src_has_modules_without_init(src: Path) -> bool:
+    has_module = False
+    for path in src.rglob("*.py"):
+        if path.name == "__init__.py":
+            return False
+        has_module = True
+    return has_module
+
+
+def is_src_layout(root: Path) -> bool:
+    """True when `root` needs `--explicit-package-bases` to resolve mypy's
+    src/-layout module-naming ambiguity, and nothing in the project already
+    tells mypy how to resolve it."""
+    src = root / "src"
+    if not src.is_dir():
+        return False
+    if not _src_has_modules_without_init(src):
+        return False
+    return not _has_mypy_config(root)
+
+
+def extra_args(root: Path) -> list:
+    return ["--explicit-package-bases"] if is_src_layout(root) else []
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    root = Path(argv[0]) if argv else Path(".")
+    print(" ".join(extra_args(root)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
@@ -52,7 +52,11 @@ source of truth for the manual commands.
    when present (Ruff's default config discovery — no override flags) and
    falls back to Ruff's defaults; the plugin pins no curated rule set — the
    project owns its quality bar. mypy honors `mypy.ini`/`pyproject.toml`
-   (`[tool.mypy]`).
+   (`[tool.mypy]`). A plain `src/`-layout project (modules with no
+   `__init__.py`, no mypy package-base config) needs no manual setup
+   either — both mypy invocations auto-detect the layout and add
+   `--explicit-package-bases` for you; see the mypy Tier 3 entry in
+   `tool-configs.md`.
 4. **Verification** — the lane's detection probes are `command -v ruff` and
    `command -v mypy`; run them (with the project venv active) to confirm
    the setup will be detected.

--- a/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
@@ -257,7 +257,7 @@ Placeholder — populated by Step 3b. Expected tools: detect-secrets, depcheck, 
 ### mypy
 
 ```bash
-mypy --output json . 2>&1 | python3 adapters/mypy-adapter.py
+mypy $(python3 adapters/mypy-src-layout.py .) --output json . 2>&1 | python3 adapters/mypy-adapter.py
 ```
 
 - **Minimum version**: 1.11 — the first release with `--output json`. Older mypy rejects the flag; the adapter detects the rejection and degrades to a skip-with-warning (exit 0, zero findings) — never a pipeline failure.
@@ -266,6 +266,7 @@ mypy --output json . 2>&1 | python3 adapters/mypy-adapter.py
 - **Detection**: `command -v mypy`
 - **Capability tier**: Python type checking
 - **Presence**: language-conditional, like ruff — dispatched only when `.py` files are in the target set.
+- **src/-layout auto-detection**: `../adapters/mypy-src-layout.py` (invoked as `python3 adapters/mypy-src-layout.py <project-root>`) detects a plain `src/` layout — a `src/` directory holding `.py` modules with no `__init__.py` anywhere under it, and no project-level mypy package-base config (`mypy.ini`/`.mypy.ini` present, or a `[mypy]` section in `setup.cfg`/`tox.ini`, or a `[tool.mypy]` section in `pyproject.toml`) — and prints `--explicit-package-bases` (mypy >= 0.990) so mypy can resolve the layout without requiring `__init__.py` files or hand-written config. Prints nothing when the layout doesn't apply or the project already owns its mypy config ("bind, don't replace"). Without this, a project on this layout hits a stable, deterministic `mypy` failure — `Source file found twice under different module names: "calc" and "src.calc"` — the moment any checked file imports a `src/` module by its dotted `src.` path; degradation rung 4 then silently drops all mypy coverage for the run.
 - **Adapter**: `../adapters/mypy-adapter.py` (≤ 40 LOC) maps mypy's JSONL diagnostics to the unified finding envelope:
 
 | mypy JSON field | Unified finding field | Notes |
@@ -336,8 +337,9 @@ the self-heal pass with one info line — never a failure.
   2. **black + flake8** — qualifies only as a **combined pair**: black fills the format-autofix half (`black <scoped-files>`), flake8 the lint-diagnostic half (`flake8 <scoped-files>`). Probes `command -v black` **and** `command -v flake8`; both must be present for the pair to bind. Qualification: qualified as a pair, with a recorded caveat — a **partial mapping**, not 1:1 with ruff's rule surface; the binding info line must say so.
 - **Diagnostic slot** — ordered provider list:
   1. **mypy** (default, last-resort provider) — probe `command -v mypy`. Qualification: qualified; diagnostic-only — no autofix, no mechanical pre-fix; findings go to the coding agent inside the shared fix loop.
-     - Verify: `mypy --follow-imports=silent <scoped-files>`
+     - Verify: `mypy $(python3 adapters/mypy-src-layout.py <project-root>) --follow-imports=silent <scoped-files>`
      - `--follow-imports=silent` keeps a scoped run honest: imported modules are still analyzed for type context, but errors are reported only in the scoped files — without it a scoped pass reports errors in unchanged followed modules, polluting the loop.
+     - The `$(...)` prefix is the src/-layout auto-detection documented in the mypy Tier 3 entry above (`../adapters/mypy-src-layout.py`) — prints `--explicit-package-bases` when the project needs it, nothing otherwise. Same detection, same script, for both the build-time lane and the `/code-review` backstop.
   2. **pyright** — Qualification: **gated** — machine-readable output qualifies it in principle, but recognition requires a ≤ 40 LOC Tier 3 adapter in this skill's `adapters/`, which does not exist yet; until that adapter lands, pyright binds nothing and is reported honestly with the mypy default offered alongside.
 - **`/code-review` counterparts**: ruff is the Tier 1 native-SARIF source and mypy the Tier 3 JSON adapter documented above — same tools, full-repo invocations.
 

--- a/plugins/dev-team/tests/adapters/test_mypy_src_layout.py
+++ b/plugins/dev-team/tests/adapters/test_mypy_src_layout.py
@@ -1,0 +1,176 @@
+"""src/-layout detection -> mypy `--explicit-package-bases` flag.
+
+A plain `src/` layout (modules with no `__init__.py`, no project-level mypy
+package-base config) makes mypy fail outright the moment any checked file
+imports a `src/` module by its dotted `src.` path — `Source file found
+twice under different module names: "calc" and "src.calc"`.
+`mypy-src-layout.py` detects the layout and prints
+`--explicit-package-bases` so the caller can splice it into the mypy
+invocation; see `../references/tool-configs.md`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Hermetic env for the real-mypy subprocess calls below: a host-level
+# MYPYPATH (or similar mypy env var) would change module resolution and
+# make the "broken" repro non-deterministic — strip everything except what
+# mypy needs to run (PATH to find its own interpreter, HOME for its cache).
+_HERMETIC_MYPY_ENV = {
+    key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ
+}
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    PLUGIN_ROOT
+    / "skills"
+    / "static-analysis-integration"
+    / "adapters"
+    / "mypy-src-layout.py"
+)
+
+
+def run_script(*args: str, cwd: Path = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+        timeout=30,
+    )
+
+
+def test_plain_src_layout_without_init_is_detected(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "calc.py").write_text("def add(a, b):\n    return a + b\n")
+
+    result = run_script(str(tmp_path))
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "--explicit-package-bases"
+
+
+def test_src_layout_with_init_py_is_not_detected(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "__init__.py").write_text("")
+    (tmp_path / "src" / "calc.py").write_text("def add(a, b):\n    return a + b\n")
+
+    result = run_script(str(tmp_path))
+
+    assert result.stdout.strip() == ""
+
+
+def test_no_src_directory_is_not_detected(tmp_path):
+    result = run_script(str(tmp_path))
+
+    assert result.stdout.strip() == ""
+
+
+def test_src_with_no_python_files_is_not_detected(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "data.json").write_text("{}")
+
+    result = run_script(str(tmp_path))
+
+    assert result.stdout.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "config_name,config_text",
+    [
+        ("mypy.ini", "[mypy]\n"),
+        (".mypy.ini", "[mypy]\n"),
+        ("setup.cfg", "[mypy]\nmypy_path = src\n"),
+        ("tox.ini", "[mypy]\nmypy_path = src\n"),
+        ("pyproject.toml", '[tool.mypy]\nmypy_path = "src"\n'),
+    ],
+)
+def test_existing_package_base_config_short_circuits_detection(
+    tmp_path, config_name, config_text
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "calc.py").write_text("def add(a, b):\n    return a + b\n")
+    (tmp_path / config_name).write_text(config_text)
+
+    result = run_script(str(tmp_path))
+
+    assert result.stdout.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "config_name,config_text",
+    [
+        ("setup.cfg", "[bdist_wheel]\nuniversal = 1\n"),
+        ("tox.ini", "[tox]\nenvlist = py311\n"),
+        ("pyproject.toml", "[tool.black]\nline-length = 100\n"),
+    ],
+)
+def test_unrelated_config_section_does_not_short_circuit_detection(
+    tmp_path, config_name, config_text
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "calc.py").write_text("def add(a, b):\n    return a + b\n")
+    (tmp_path / config_name).write_text(config_text)
+
+    result = run_script(str(tmp_path))
+
+    assert result.stdout.strip() == "--explicit-package-bases"
+
+
+def test_defaults_to_current_directory_when_no_argument_given(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "calc.py").write_text("def add(a, b):\n    return a + b\n")
+
+    result = run_script(cwd=tmp_path)
+
+    assert result.stdout.strip() == "--explicit-package-bases"
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy not installed")
+def test_src_layout_reproduces_and_the_detected_flag_fixes_source_file_found_twice(
+    tmp_path,
+):
+    """End-to-end reproduction of the src/-layout mypy failure: a module
+    with no __init__.py, referenced from another checked file by its
+    dotted `src.` path, reproduces the false module-name collision this
+    detector exists to resolve — and the detected flag resolves it."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "calc.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\n")
+    (tmp_path / "main.py").write_text("from src.calc import add\n\nprint(add(1, 2))\n")
+
+    broken = subprocess.run(
+        ["mypy", "--output", "json", "."],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=_HERMETIC_MYPY_ENV,
+        timeout=60,
+    )
+    assert "Source file found twice under different module names" in (
+        broken.stdout + broken.stderr
+    )
+
+    detect = run_script(str(tmp_path))
+    extra_args = detect.stdout.split()
+    assert extra_args == ["--explicit-package-bases"]
+
+    fixed = subprocess.run(
+        ["mypy", *extra_args, "--output", "json", "."],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=_HERMETIC_MYPY_ENV,
+        timeout=60,
+    )
+    assert "Source file found twice under different module names" not in (
+        fixed.stdout + fixed.stderr
+    )
+    assert fixed.returncode == 0

--- a/tests/skills/test_static_analysis_python_lane.py
+++ b/tests/skills/test_static_analysis_python_lane.py
@@ -20,6 +20,7 @@ SAI_SKILL = SAI / "SKILL.md"
 TOOL_CONFIGS = SAI / "references" / "tool-configs.md"
 LANGUAGE_SETUP = SAI / "references" / "language-setup.md"
 MYPY_ADAPTER = SAI / "adapters" / "mypy-adapter.py"
+MYPY_SRC_LAYOUT = SAI / "adapters" / "mypy-src-layout.py"
 REQUIREMENTS_DEV = REPO_ROOT / "requirements-dev.txt"
 DEV_SETUP = REPO_ROOT / "scripts" / "dev-setup.sh"
 
@@ -51,28 +52,36 @@ def _flat(text: str) -> str:
 
 def _ruff_entry() -> str:
     return section_outside_code(
-        _configs_text(), r"^### ruff$", boundary_pattern=r"^#{2,3} ",
+        _configs_text(),
+        r"^### ruff$",
+        boundary_pattern=r"^#{2,3} ",
         include_start_line=True,
     )
 
 
 def _mypy_entry() -> str:
     return section_outside_code(
-        _configs_text(), r"^### mypy$", boundary_pattern=r"^#{2,3} ",
+        _configs_text(),
+        r"^### mypy$",
+        boundary_pattern=r"^#{2,3} ",
         include_start_line=True,
     )
 
 
 def _python_lane() -> str:
     return section_outside_code(
-        _configs_text(), r"^### Python lane$", boundary_pattern=r"^#{2,3} ",
+        _configs_text(),
+        r"^### Python lane$",
+        boundary_pattern=r"^#{2,3} ",
         include_start_line=False,
     )
 
 
 def _python_guide() -> str:
     return section_outside_code(
-        LANGUAGE_SETUP.read_text(), r"^## Python$", boundary_pattern=r"^## ",
+        LANGUAGE_SETUP.read_text(),
+        r"^## Python$",
+        boundary_pattern=r"^## ",
         include_start_line=False,
     )
 
@@ -82,7 +91,9 @@ def _python_guide() -> str:
 
 def test_skill_tier1_table_lists_ruff():
     tier1 = section_outside_code(
-        _skill_text(), r"^### Tier 1", boundary_pattern=r"^### ",
+        _skill_text(),
+        r"^### Tier 1",
+        boundary_pattern=r"^### ",
         include_start_line=True,
     )
     assert grep(r"^\|\s*ruff\s*\|", tier1)
@@ -125,7 +136,9 @@ def test_ruff_honors_project_config_with_no_plugin_curated_rule_set():
 
 def test_skill_tier3_registers_the_mypy_adapter():
     tier3 = section_outside_code(
-        _skill_text(), r"^### Tier 3", boundary_pattern=r"^### ",
+        _skill_text(),
+        r"^### Tier 3",
+        boundary_pattern=r"^### ",
         include_start_line=True,
     )
     flat = _flat(tier3)
@@ -152,6 +165,19 @@ def test_mypy_entry_maps_rule_ids_into_the_mypy_python_namespace():
 
 def test_mypy_adapter_exists_next_to_the_tier3_precedent():
     assert MYPY_ADAPTER.is_file()
+
+
+def test_mypy_src_layout_detector_exists_and_is_documented():
+    """#917: a plain src/-layout project (no __init__.py, no mypy
+    package-base config) makes mypy fail outright the moment any checked
+    file imports a src/ module by its dotted path. The detector script
+    prints --explicit-package-bases for that layout; both mypy invocation
+    sites (this Tier 3 entry and the build-time lane below) splice it in."""
+    assert MYPY_SRC_LAYOUT.is_file()
+    entry = _flat(_mypy_entry())
+    assert "adapters/mypy-src-layout.py" in entry
+    assert "--explicit-package-bases" in entry
+    assert "Source file found twice under different module names" in entry
 
 
 # --- pylint: retired outright, replaced by Ruff
@@ -187,8 +213,14 @@ def test_python_lane_autofix_slot_runs_ruff_fix_then_verify():
 
 def test_python_lane_diagnostic_slot_is_mypy_with_scoped_follow_imports():
     lane = _flat(_python_lane())
-    assert "mypy --follow-imports=silent <scoped-files>" in lane
+    assert "--follow-imports=silent <scoped-files>" in lane
     assert "diagnostic-only" in lane
+
+
+def test_python_lane_diagnostic_slot_verify_carries_the_src_layout_detector():
+    lane = _flat(_python_lane())
+    assert "adapters/mypy-src-layout.py" in lane
+    assert "mypy $(python3 adapters/mypy-src-layout.py" in lane
 
 
 def test_python_lane_carries_both_detection_probes():


### PR DESCRIPTION
## Summary

- mypy fails outright on a plain `src/`-layout Python project (modules with no `__init__.py`, no mypy package-base config) the moment any checked file imports a `src/` module by its dotted `src.` path — `Source file found twice under different module names: "calc" and "src.calc"` — a stable, deterministic failure that the static self-heal lane's rung-4 degradation silently absorbs, dropping all mypy coverage for the run (per #917's #907 smoke-test reproduction).
- Implements the issue's preferred Option 1: `plugins/dev-team/skills/static-analysis-integration/adapters/mypy-src-layout.py` detects the layout (a `src/` dir with `.py` modules, no `__init__.py` anywhere under it, and no existing mypy package-base config in `mypy.ini`/`.mypy.ini`/`setup.cfg` `[mypy]`/`tox.ini` `[mypy]`/`pyproject.toml` `[tool.mypy]`) and prints `--explicit-package-bases`, which both mypy invocation sites — the `/code-review` Tier 3 backstop and the build-time Python lane's scoped diagnostic verify — now splice into their command. Never overrides a project that already owns its mypy config ("bind, don't replace").
- Updated `tool-configs.md` (both invocation sites + new prose) and `language-setup.md` (Python Configuration bullet) to document the auto-detection.

## Test plan

- [x] New `plugins/dev-team/tests/adapters/test_mypy_src_layout.py`: unit tests for the detector (plain src-layout, `__init__.py` present, no `src/`, no `.py` files, all 5 config-marker short-circuits, unrelated config sections that must NOT short-circuit, default-cwd behavior) plus an end-to-end test (skipped if mypy isn't installed) that reproduces the exact `#917` fixture — `src/calc.py` with no `__init__.py`, referenced via `from src.calc import ...` — confirms mypy fails with the documented error without the flag, and passes with it.
- [x] Verified manually with a local mypy 2.1.0 install: reproduced `Source file found twice under different module names` on the described layout, confirmed `--explicit-package-bases` alone (no `MYPYPATH`) resolves it.
- [x] Updated `tests/skills/test_static_analysis_python_lane.py` for the new invocation string and added coverage asserting the detector script + its doc prose exist.
- [x] `bash scripts/ci-local.sh` — all pytest suites green (2824 passed, 18 skipped, 1 xfailed). The one failing check (`eslint`) is a pre-existing, unrelated failure in `evals/fixtures/cr-*.js` fixtures (tracked as #930); confirmed present identically on `origin/main` before this branch's changes.
- [x] `/code-review` run: doc-review, correctness-review (via code-reviewer), and structure-review dispatched. Two suggestion-level findings addressed — hermetic env stripping (`MYPYPATH`) in the new integration test's real-`mypy` subprocess calls, and a `language-setup.md` note so a src-layout user isn't left unaware the fix is automatic. A test-docstring wording tweak (drop the bare tracker-ID framing) was also applied.

Closes #917