### PR TITLE
fix: remove test-health pain-point calibration question

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5211,48 +5211,44 @@
       "anchor": "parse-arguments"
     },
     "Steps": {
-      "summary": "In the first response, ask **one** optional question — \"What hurts most about testing here right now (slow suite / flaky CI / fear of changing code / low confidence / something else)?\" — then **continue the audit immediately** without waiting for an answer.",
+      "summary": "If the suite is tiny (few test files), shows no shape pathology, and follows clear conventions, **stop here** and return a one-paragraph summary (\"suite is small and healthy; nothing structural to fix; revisit when it grows\") instead of the full diagnostic.",
       "anchor": "steps"
     },
-    "1. Pain-point calibration (non-blocking)": {
-      "summary": "In the first response, ask **one** optional question — \"What hurts most about testing here right now (slow suite / flaky CI / fear of changing code / low confidence / something else)?\" — then **continue the audit immediately** without waiting for an answer.",
-      "anchor": "1-pain-point-calibration-non-blocking"
-    },
-    "2. Trivial-suite short-circuit": {
+    "1. Trivial-suite short-circuit": {
       "summary": "If the suite is tiny (few test files), shows no shape pathology, and follows clear conventions, **stop here** and return a one-paragraph summary (\"suite is small and healthy; nothing structural to fix; revisit when it grows\") instead of the full diagnostic.",
-      "anchor": "2-trivial-suite-short-circuit"
+      "anchor": "1-trivial-suite-short-circuit"
     },
-    "3. Derive the test shape + architecture fit": {
+    "2. Derive the test shape + architecture fit": {
       "summary": "Inventory tests by layer (unit / integration / component / contract / E2E).",
-      "anchor": "3-derive-the-test-shape-architecture-fit"
+      "anchor": "2-derive-the-test-shape-architecture-fit"
     },
-    "4. Quadrant coverage": {
+    "3. Quadrant coverage": {
       "summary": "Classify coverage across the four quadrants (`testing-quadrants.md`) as strong / thin / empty, and for each gap name the **business impact** of leaving it empty (e.g.",
-      "anchor": "4-quadrant-coverage"
+      "anchor": "3-quadrant-coverage"
     },
-    "5. Delegate architecture + pipeline": {
+    "4. Delegate architecture + pipeline": {
       "summary": "Invoke `cd-test-architecture` on the target.",
-      "anchor": "5-delegate-architecture-pipeline"
+      "anchor": "4-delegate-architecture-pipeline"
     },
-    "6. Test-design + mutation health (ROI)": {
+    "5. Test-design + mutation health (ROI)": {
       "summary": "Invoke `/test-design` on the target, passing the same scope this run was",
-      "anchor": "6-test-design-mutation-health-roi"
+      "anchor": "5-test-design-mutation-health-roi"
     },
-    "7. Flaky-test + automation maturity": {
+    "6. Flaky-test + automation maturity": {
       "summary": "Flag flakiness signals (`test-smells.md` project/behavior smells: order-dependence, unstubbed clock/RNG, real I/O at unit level) and a management recommendation (quarantine + fix, don't `retry`).",
-      "anchor": "7-flaky-test-automation-maturity"
+      "anchor": "6-flaky-test-automation-maturity"
     },
-    "8. Classify gaps + recommend removals": {
-      "summary": "Classify every gap the audit surfaces into one of three classes, so the improvement plan (Step 9) only ever plans work that delivers signal:",
-      "anchor": "8-classify-gaps-recommend-removals"
+    "7. Classify gaps + recommend removals": {
+      "summary": "Classify every gap the audit surfaces into one of three classes, so the improvement plan (Step 8) only ever plans work that delivers signal:",
+      "anchor": "7-classify-gaps-recommend-removals"
     },
-    "9. Ordered improvement plan": {
-      "summary": "Produce a risk-ordered, incremental plan — each item a concrete next move (which layer to add, which shape to correct, which quadrant to fill, which abstraction to extract, which weak-assertion or smell cluster to fix), driven by the test-design themes and mutation hotspots from Step 6 and weighted by the pain point from Step 1.",
-      "anchor": "9-ordered-improvement-plan"
+    "8. Ordered improvement plan": {
+      "summary": "Produce a risk-ordered, incremental plan — each item a concrete next move (which layer to add, which shape to correct, which quadrant to fill, which abstraction to extract, which weak-assertion or smell cluster to fix), driven by the test-design themes and mutation hotspots from Step 5.",
+      "anchor": "8-ordered-improvement-plan"
     },
-    "10. Report": {
+    "9. Report": {
       "summary": "Write `reports/test-health-<date>.md`.",
-      "anchor": "10-report"
+      "anchor": "9-report"
     },
     "Output": {
       "summary": "**Front door** for periodic test-strategy review; the unified entry point that runs `cd-test-architecture` + `/test-design` + `mutation-testing` and rolls their results into one strategic view.",

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -32,27 +32,23 @@ Target repo/subtree path (default: cwd). Detect the test runner, coverage tool, 
 
 ## Steps
 
-### 1. Pain-point calibration (non-blocking)
-
-In the first response, ask **one** optional question — "What hurts most about testing here right now (slow suite / flaky CI / fear of changing code / low confidence / something else)?" — then **continue the audit immediately** without waiting for an answer. If the user answers later, weight the improvement plan toward it.
-
-### 2. Trivial-suite short-circuit
+### 1. Trivial-suite short-circuit
 
 If the suite is tiny (few test files), shows no shape pathology, and follows clear conventions, **stop here** and return a one-paragraph summary ("suite is small and healthy; nothing structural to fix; revisit when it grows") instead of the full diagnostic.
 
-### 3. Derive the test shape + architecture fit
+### 2. Derive the test shape + architecture fit
 
 Inventory tests by layer (unit / integration / component / contract / E2E). Derive the actual **shape** and compare it to the shape the architecture *should* produce, using the *Other shapes* + *Shape ↔ architecture fit* tables in `test-pyramid.md`. Report the mismatch (e.g. tall pyramid over thin-glue code, or ice-cream cone), not the silhouette alone.
 
-### 4. Quadrant coverage
+### 3. Quadrant coverage
 
 Classify coverage across the four quadrants (`testing-quadrants.md`) as strong / thin / empty, and for each gap name the **business impact** of leaving it empty (e.g. empty Q3 → no human catches confusing flows; empty Q4 → non-functional failures reach prod).
 
-### 5. Delegate architecture + pipeline
+### 4. Delegate architecture + pipeline
 
 Invoke `cd-test-architecture` on the target. Summarize its findings (which tests can't run in a clean pre-merge gate, target architecture, migration path) in one section — **do not re-derive**.
 
-### 6. Test-design + mutation health (ROI)
+### 5. Test-design + mutation health (ROI)
 
 Invoke `/test-design` on the target, passing the same scope this run was
 invoked with — the dispatch must be explicit so a subtree audit never
@@ -71,20 +67,20 @@ advisor's testability verdicts. Then invoke `mutation-testing` on the
 framing). Roll both up: where is coverage high but mutation-weak
 (assertions that don't catch bugs)? Where do test-design smells
 concentrate? Where is critical logic under-covered? Prioritize by risk,
-not by raw %. Both feed the ordered plan (Step 8) — summarize the themes
+not by raw %. Both feed the ordered plan (Step 7) — summarize the themes
 and link to the `/test-design` report for per-file detail; do not
 reproduce it.
 
-### 7. Flaky-test + automation maturity
+### 6. Flaky-test + automation maturity
 
 Flag flakiness signals (`test-smells.md` project/behavior smells: order-dependence, unstubbed clock/RNG, real I/O at unit level) and a management recommendation (quarantine + fix, don't `retry`). Assess automation maturity with `test-automation-maturity.md`: report the rung and the single-point-of-change metric, scaled by suite size (graduated thresholds).
 
-### 8. Classify gaps + recommend removals
+### 7. Classify gaps + recommend removals
 
-Classify every gap the audit surfaces into one of three classes, so the improvement plan (Step 9) only ever plans work that delivers signal:
+Classify every gap the audit surfaces into one of three classes, so the improvement plan (Step 8) only ever plans work that delivers signal:
 
 | Class | Meaning | Action |
-|---|---|---|
+| --- | --- | --- |
 | `NO_REFACTOR` | A test can be added against the code as it stands | Plan it |
 | `REFACTOR_REQUIRED` | Production code needs a testability change before a meaningful test is possible | Plan the production-code change first |
 | `LOW_VALUE` | Technically feasible but delivers no signal — **skip, never plan** | List for removal, not for work |
@@ -97,11 +93,11 @@ A finding is `LOW_VALUE` only when **all three** hold:
 
 For existing tests that meet all three criteria, emit a **Recommended removals** table: the redundant test, the higher-layer test that already covers it, and a one-line rationale. These are the suite's `LOW_VALUE` tests — keeping them costs maintenance for no defect-localization gain.
 
-### 9. Ordered improvement plan
+### 8. Ordered improvement plan
 
-Produce a risk-ordered, incremental plan — each item a concrete next move (which layer to add, which shape to correct, which quadrant to fill, which abstraction to extract, which weak-assertion or smell cluster to fix), driven by the test-design themes and mutation hotspots from Step 6 and weighted by the pain point from Step 1. `LOW_VALUE` findings never appear here — they live only in the Recommended removals table.
+Produce a risk-ordered, incremental plan — each item a concrete next move (which layer to add, which shape to correct, which quadrant to fill, which abstraction to extract, which weak-assertion or smell cluster to fix), driven by the test-design themes and mutation hotspots from Step 5. `LOW_VALUE` findings never appear here — they live only in the Recommended removals table.
 
-### 10. Report
+### 9. Report
 
 Write `reports/test-health-<date>.md`.
 
@@ -141,4 +137,4 @@ mutation ROI hotspots · under-covered critical logic>
 ## Integration
 
 - **Front door** for periodic test-strategy review; the unified entry point that runs `cd-test-architecture` + `/test-design` + `mutation-testing` and rolls their results into one strategic view.
-- `/test-design` runs inside this flow (Step 6) and also stands alone for a focused per-file review. For *forward* design of a specific module, use `test-design-advisor`. This skill is the strategic rollup that consumes their output.
+- `/test-design` runs inside this flow (Step 5) and also stands alone for a focused per-file review. For *forward* design of a specific module, use `test-design-advisor`. This skill is the strategic rollup that consumes their output.


### PR DESCRIPTION
## Summary
- Removes the optional "What hurts most about testing here right now" question from `/test-health` Step 1 — it fired unprompted on every run.
- Renumbers the remaining steps (2-10 -> 1-9) and drops the dangling "weighted by the pain point from Step 1" reference in the improvement-plan step.
- Rebuilds `plugins/dev-team/knowledge/index.json` so the generated index no longer quotes the removed text.

Closes #939

## Test plan
- [x] `bash scripts/ci-local.sh` (ran automatically via pre-push hook) — all 18 checks green, 2869 pytest tests passed
- [x] Verified no remaining references to the removed step or its text anywhere in `test-health/SKILL.md` or `knowledge/index.json`