### PR TITLE
fix: add unconfirmed outcome to /triage's root-cause schema

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5396,13 +5396,17 @@
       "summary": "Create an ordered list of RED-GREEN cycles, each a vertical slice:",
       "anchor": "3-design-tdd-fix-plan"
     },
-    "4. Write the Triage Record": {
-      "summary": "**Resolve the slug** from the bug title/description with this 8-step algorithm:",
-      "anchor": "4-write-the-triage-record"
+    "4. Verification Checkpoint": {
+      "summary": "**Hard gate — cannot be skipped implicitly.** Before writing a `confirmed`",
+      "anchor": "4-verification-checkpoint"
     },
-    "5. Present Results": {
+    "5. Write the Triage Record": {
+      "summary": "**Resolve the slug** from the bug title/description with this 8-step algorithm:",
+      "anchor": "5-write-the-triage-record"
+    },
+    "6. Present Results": {
       "summary": "Print exactly two lines:",
-      "anchor": "5-present-results"
+      "anchor": "6-present-results"
     }
   },
   "plugins/dev-team/skills/ubiquitous-language/SKILL.md": {

--- a/plugins/dev-team/skills/triage/SKILL.md
+++ b/plugins/dev-team/skills/triage/SKILL.md
@@ -20,7 +20,9 @@ portable triage record at `.triage/<slug>.md` — no issue-tracker dependency.
 ## Worker constraints
 
 1. Investigate and record; do not fix the bug.
-2. Find root cause before recording; do not record on symptoms alone.
+2. Find root cause before recording; do not record on symptoms alone — and do
+   not record an unverified, unrelated finding as if it were the root cause;
+   use the `unconfirmed` outcome instead.
 3. **Be concise.** The record is structured; chat is the `triage-record:` line
    plus a one-line root-cause summary — not the full body.
 
@@ -31,6 +33,15 @@ portable triage record at `.triage/<slug>.md` — no issue-tracker dependency.
 Get the bug description from the arguments or conversation. If no description is
 given, ask EXACTLY one question: `What's the problem you're seeing?` and stop.
 If a description is given, ask nothing — start investigating immediately.
+
+**Scoped exception:** if the description signals a cross-service or
+intermittent symptom (it names multiple repos/services, or uses language like
+"intermittent", "sometimes", or "inconsistently"), ask ONE additional targeted
+question before investigating: `Do you have any of the following: logs, a
+sample request/response pair, trace/audit IDs, or a config/pipeline export?`
+This is a narrow exception for that signal only — the "ask nothing" rule above
+still applies to every other description, and the no-description fallback
+question above is unchanged.
 
 Arguments: $ARGUMENTS
 
@@ -47,6 +58,13 @@ related source files and dependencies, existing tests (covered vs missing),
 recent changes to affected files (`git log`), error handling in the code path,
 and similar patterns elsewhere that work correctly.
 
+**Boundary dead-end:** if static tracing (grep/`codegraph_explore`) returns
+zero hits for the relevant identifiers across all checked-out repos, name this
+explicitly as **"producer not located in scope"** — do not keep searching
+until an unrelated bug-shaped pattern turns up nearby. Carry this named
+outcome into the Verification Checkpoint (Step 4), which routes it to the
+`unconfirmed` outcome.
+
 ### 3. Design TDD Fix Plan
 
 Create an ordered list of RED-GREEN cycles, each a vertical slice:
@@ -56,7 +74,20 @@ Create an ordered list of RED-GREEN cycles, each a vertical slice:
 
 Tests verify behavior at the public interface, not implementation details.
 
-### 4. Write the Triage Record
+### 4. Verification Checkpoint
+
+**Hard gate — cannot be skipped implicitly.** Before writing a `confirmed`
+record, state in one sentence what concrete evidence (a log line, a
+reproduced failure, an observed value in the actual data path) ties the
+hypothesized cause to the *reported symptom*. A boundary dead-end from Step 2
+("producer not located in scope") counts as inadequate evidence.
+
+If that evidence exists, proceed to Step 5 with `confidence: confirmed`.
+If it does not, do not write a confirmed root-cause section — route to the
+`unconfirmed` outcome in Step 5 instead. There is no silent pass-through: a
+missing or hand-waved evidence statement means `unconfirmed`, not `confirmed`.
+
+### 5. Write the Triage Record
 
 **Resolve the slug** from the bug title/description with this 8-step algorithm:
 
@@ -84,13 +115,26 @@ If `.triage/` cannot be created or written (permission/read-only): report
 (`tmp/triage-<slug>.md` or `$TMPDIR`), and print the full record content to chat
 so nothing is lost.
 
-The record is YAML frontmatter followed by four sections:
+The record is YAML frontmatter followed by four sections. Three outcomes are
+possible, and they are mutually distinct — not variants of one another:
+
+- **`confirmed`** — the Verification Checkpoint (Step 4) found concrete
+  evidence tying the cause to the reported symptom. Full Root Cause Analysis
+  and TDD Fix Plan, no banner.
+- **`unconfirmed`** — a contributing factor was identified, but the
+  checkpoint found no evidence linking it to the reported symptom (including
+  a Step 2 boundary dead-end). Banner required; fix plan reframed as
+  addressing the contributing factor, not the confirmed cause.
+- **not determined** — no plausible cause was found at all. `## TDD Fix Plan`
+  is replaced with the fixed string below; there is no `confidence` field
+  distinction because there is nothing to mark as confirmed or unconfirmed.
 
 ```markdown
 ---
 id: <resolved-slug>
 created: <YYYY-MM-DDThh:mm:ssZ>
 status: open
+confidence: confirmed
 ---
 
 # <concise bug title>
@@ -124,6 +168,18 @@ modules and behaviors, not file paths — the record should survive refactors.]
 - [ ] No regressions introduced
 ```
 
+**`confidence` field:** omitted/absent defaults to `confirmed` — no migration
+needed for historical `.triage/*.md` files. Set `confidence: unconfirmed`
+when the Verification Checkpoint routed here without evidence. When
+`unconfirmed`, `## Root Cause Analysis` must open with:
+
+```
+> **UNCONFIRMED** — contributing factor identified; not verified against the reported symptom.
+```
+
+and `## TDD Fix Plan` must explicitly frame the plan as addressing "the
+identified contributing factor," not the confirmed root cause.
+
 At least one RED/GREEN cycle is required. **If no root cause was determined,**
 the entire `## TDD Fix Plan` body is exactly:
 
@@ -131,7 +187,7 @@ the entire `## TDD Fix Plan` body is exactly:
 Root cause not determined — manual investigation required
 ```
 
-### 5. Present Results
+### 6. Present Results
 
 Print exactly two lines:
 

--- a/tests/skills/test_triage_skill.py
+++ b/tests/skills/test_triage_skill.py
@@ -1,0 +1,166 @@
+"""Content-guard for triage/SKILL.md's unconfirmed-outcome schema (issue #918,
+sub-issues #924-#927).
+
+`/triage` used to have a binary outcome (confirmed root cause vs. "not
+determined"), which incentivized rounding an unverified, adjacent finding up
+to full "root cause" status rather than admitting partial failure. These
+guards assert the third `unconfirmed` outcome, the pre-write verification
+checkpoint that routes into it, and the two investigation-time triggers
+(cross-service/intermittent evidence request, boundary dead-end naming) all
+stay present and correctly worded.
+"""
+
+from __future__ import annotations
+
+import re
+
+from skill_doc_helpers import PLUGIN_ROOT, grep, section
+
+SKILL_MD = PLUGIN_ROOT / "skills" / "triage" / "SKILL.md"
+
+
+def _text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _collapsed(text: str) -> str:
+    """Join hard-wrapped prose lines so a phrase split across a markdown
+    line-wrap still matches a plain substring check."""
+    return re.sub(r"\s+", " ", text)
+
+
+def _constraints_section(text: str) -> str:
+    return section(text, r"^## Worker constraints", boundary_pattern=r"^## ")
+
+
+def _step(text: str, heading_pattern: str) -> str:
+    return section(text, heading_pattern, boundary_pattern=r"^### ")
+
+
+# ---------------------------------------------------------------------------
+# #924 — confidence field, unconfirmed banner, fix-plan framing, worker
+# constraint, three-outcome documentation
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_field_present_in_record_template() -> None:
+    text = _text()
+    assert grep(r"^confidence: confirmed$", text)
+    assert grep(r"omitted/absent defaults to `confirmed`", text)
+
+
+def test_unconfirmed_banner_present() -> None:
+    text = _text()
+    assert (
+        "> **UNCONFIRMED** — contributing factor identified; "
+        "not verified against the reported symptom." in text
+    )
+
+
+def test_unconfirmed_fix_plan_framing_present() -> None:
+    collapsed = _collapsed(_text())
+    assert (
+        'frame the plan as addressing "the identified contributing factor," '
+        "not the confirmed root cause" in collapsed
+    )
+
+
+def test_worker_constraint_two_tightened() -> None:
+    constraints = _collapsed(_constraints_section(_text()))
+    assert "do not record on symptoms alone" in constraints
+    assert (
+        "do not record an unverified, unrelated finding as if it were the "
+        "root cause" in constraints
+    )
+    assert "use the `unconfirmed` outcome instead" in constraints
+
+
+def test_three_outcomes_documented_as_distinct() -> None:
+    text = _text()
+    assert "mutually distinct" in text
+    assert "**`confirmed`**" in text
+    assert "**`unconfirmed`**" in text
+    assert "**not determined**" in text
+
+
+# ---------------------------------------------------------------------------
+# #925 — pre-write verification checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_verification_checkpoint_step_present_between_step_3_and_5() -> None:
+    text = _text()
+    assert grep(r"^### 3\. Design TDD Fix Plan$", text)
+    assert grep(r"^### 4\. Verification Checkpoint$", text)
+    assert grep(r"^### 5\. Write the Triage Record$", text)
+
+
+def test_checkpoint_routes_failure_to_unconfirmed() -> None:
+    checkpoint = _step(_text(), r"^### 4\. Verification Checkpoint$")
+    assert "route to the" in checkpoint
+    assert "`unconfirmed` outcome" in checkpoint
+
+
+def test_checkpoint_is_a_hard_gate_not_optional() -> None:
+    checkpoint = _step(_text(), r"^### 4\. Verification Checkpoint$")
+    assert "Hard gate" in checkpoint
+    assert "cannot be skipped implicitly" in checkpoint
+    assert "no silent pass-through" in checkpoint.lower()
+
+
+# ---------------------------------------------------------------------------
+# #926 — Step 1 evidence question for cross-service/intermittent bugs
+# ---------------------------------------------------------------------------
+
+
+def test_step_1_names_the_trigger_condition() -> None:
+    step1 = _step(_text(), r"^### 1\. Capture the Problem$")
+    assert "cross-service or" in step1
+    assert "intermittent" in step1
+    assert '"sometimes"' in step1
+    assert '"inconsistently"' in step1
+
+
+def test_step_1_asks_single_targeted_evidence_question() -> None:
+    step1 = _step(_text(), r"^### 1\. Capture the Problem$")
+    for category in (
+        "logs",
+        "sample request/response",
+        "trace/audit IDs",
+        "config/pipeline export",
+    ):
+        assert category in step1
+
+
+def test_step_1_existing_ask_nothing_rule_preserved() -> None:
+    step1 = _step(_text(), r"^### 1\. Capture the Problem$")
+    assert "ask nothing — start investigating immediately" in step1
+    assert "narrow exception" in step1
+
+
+def test_step_1_no_description_fallback_unchanged() -> None:
+    step1 = _step(_text(), r"^### 1\. Capture the Problem$")
+    assert "What's the problem you're seeing?" in step1
+
+
+# ---------------------------------------------------------------------------
+# #927 — boundary dead-end named as "producer not located in scope"
+# ---------------------------------------------------------------------------
+
+
+def test_step_2_names_boundary_dead_end_condition() -> None:
+    step2 = _step(_text(), r"^### 2\. Investigate$")
+    assert "zero hits" in step2
+    assert "checked-out repos" in step2
+
+
+def test_step_2_dead_end_outcome_named_not_silently_continued() -> None:
+    step2 = _step(_text(), r"^### 2\. Investigate$")
+    assert "producer not located in scope" in step2
+    assert "do not keep searching" in step2
+
+
+def test_step_2_dead_end_routes_to_verification_checkpoint() -> None:
+    step2 = _step(_text(), r"^### 2\. Investigate$")
+    assert "Verification Checkpoint (Step 4)" in step2
+    assert "`unconfirmed` outcome" in step2


### PR DESCRIPTION
## Summary

`/triage` had a binary outcome: full "confirmed" root-cause write-up, or the
literal "Root cause not determined" fallback. That gave the skill an
incentive to round an unverified, adjacent finding up to full root-cause
confidence rather than admit partial failure. This adds a third,
distinctly-rendered `unconfirmed` outcome plus the process changes that route
into it.

- **#924** — `confidence: confirmed|unconfirmed` frontmatter field, an
  `UNCONFIRMED` banner + reframed TDD Fix Plan when unconfirmed, worker
  constraint #2 tightened, and the three outcomes (confirmed/unconfirmed/not
  determined) documented as mutually distinct.
- **#925** — a hard verification checkpoint between "Design TDD Fix Plan" and
  "Write the Triage Record": the agent must state what concrete evidence ties
  the hypothesized cause to the reported symptom, or route to `unconfirmed`.
- **#926** — Step 1 asks one additional targeted evidence question (logs,
  sample request/response, trace/audit IDs, config/pipeline exports) when the
  bug description signals a cross-service or intermittent symptom — a scoped
  exception to the existing ask-nothing rule.
- **#927** — Step 2 names a repo-boundary dead-end (zero grep/`codegraph_explore`
  hits across all checked-out repos) explicitly as "producer not located in
  scope" and routes it to the verification checkpoint, instead of continuing
  to search until an unrelated bug-shaped pattern turns up.

Shipped as one PR since all four slices touch the same file
(`plugins/dev-team/skills/triage/SKILL.md`) and have real sequencing
dependencies (#925 needs #924's schema, #927 needs #924 + #925).

## Test plan

- [x] New content-guard suite `tests/skills/test_triage_skill.py` (15 tests)
      asserts the frontmatter field, banner, fix-plan framing, tightened
      worker constraint, three-outcome docs, checkpoint step + gate language,
      Step 1 trigger/question, and Step 2 dead-end naming/routing.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` rerun
      (index.json updated).
- [x] `bash scripts/ci-local.sh` — all checks green.

Closes #918
Closes #924
Closes #925
Closes #926
Closes #927