### PR TITLE
docs: link the /code-review benchmark harness from the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Every `git commit` is automatically gated by `/code-review`. A `PreToolUse` hook
 
 Developing, testing, or releasing the plugins? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — local-dev setup (including live installs via symlinks), the `/agent-eval` and `/agent-audit` test commands, the security comparative-testing harness, how to add agents and skills, and the release process.
 
+**`/code-review` benchmark harness** ([`evals/code-review-benchmark/`](evals/code-review-benchmark/README.md)): checks out real, known-defect commits from Defects4J (Java) and BugsJS (JavaScript), runs `/code-review` against the buggy revision, and scores whether its findings actually cover the real defect — with a dedicated Missed Defects report. Adapters and scoring are unit-tested against real fetched dataset samples; a live sweep against the actual corpora requires a local Defects4J/BugsJS install (see the harness README for prerequisites and usage).
+
 ## Documentation
 
 The full documentation — architecture, model routing, eval system, telemetry, ADRs, and experiment reports — lives at **[devteam.bryanfinster.com](https://devteam.bryanfinster.com/)**, with search and complete navigation.


### PR DESCRIPTION
## Summary

- Adds a short summary + link to `evals/code-review-benchmark/README.md` (the Defects4J/BugsJS `/code-review` benchmark harness built for #821) in the root README's Contributing section.

Doc-only change — no code, agent, skill, or hook touched.

Part of #821