### PR TITLE
feat: add test-suite verification and parallel execution to code-review-benchmark

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -95,6 +95,8 @@ python3 cli.py --report-only
 | `--tolerance N` | Line-range tolerance for hit scoring (default 3) |
 | `--model` | Model tier passed to the `/code-review` dispatch (default `sonnet`) |
 | `--timeout` | Per-case dispatch timeout in seconds (default 900) |
+| `--workers` | Number of bug cases run concurrently, thread pool (default 4) |
+| `--no-verify-tests` | Skip building/installing deps and running the project's own test suite per case (on by default; diagnostic only — see below) |
 | `--defects4j-home`, `--bugsjs-home` | Dataset home dirs (or the matching env vars) |
 | `--results-dir` | Where `results.jsonl`/`skipped.jsonl`/`report.md`/`raw/` are written (default `./results`) |
 | `--report-only` | Only (re)generate `report.md` from existing results |
@@ -102,7 +104,8 @@ python3 cli.py --report-only
 ## Output artifacts (`results/`, gitignored)
 
 - `results.jsonl` — one record per attempted bug: `{dataset, project, bug_id,
-  hit, ground_truth_hunks, findings, unmatched_findings, raw_output_path}`.
+  hit, ground_truth_hunks, findings, unmatched_findings, raw_output_path,
+  test_verification}`.
 - `skipped.jsonl` — one record per bug that couldn't be checked out or
   scored: `{dataset, project, bug_id, reason}`.
 - `raw/<dataset>-<project>-<bug_id>.txt` — the dispatch's raw stdout,
@@ -112,13 +115,41 @@ python3 cli.py --report-only
   findings per hit run — "unmatched," not "false positive": the review may
   have found a real, different issue).
 
+## Test verification (diagnostic, not a gate)
+
+By default, before dispatching `/code-review`, each case configures and runs
+the checked-out project's own test suite against the full checkout (not the
+`fix-only` scoped copy, which won't have build files):
+
+- **Defects4J**: `defects4j compile` then `defects4j test`, reading
+  `<checkout>/failing_tests` for the reproduced trigger test(s).
+- **BugsJS**: `npm ci` (if `package-lock.json` exists) or `npm install`,
+  then `npm test`; a non-zero exit is the expected "bug reproduces" signal.
+
+The result lands on the record as `test_verification: {configured, ran,
+reproduced, ...}` (`None` when disabled). It is **never** used to skip or
+exclude a case from scoring — Defects4J/BugsJS checkouts can fail to build
+for reasons unrelated to the actual bug (JDK mismatch, npm registry
+hiccup), and the harness's actual purpose (`/code-review` recall) must not
+be silently distorted by environment noise. Disable it with
+`--no-verify-tests` for a faster, cheaper smoke run. `report.md` summarizes
+reproduced-vs-not when any case ran verification.
+
+## Parallel execution
+
+Cases run concurrently across a thread pool (`--workers`, default 4) — each
+case does its own checkout into a private temp dir and its own subprocess
+calls (git/defects4j/npm/`claude`), so cases don't share mutable state.
+Raise `--workers` for a faster full sweep; keep it low if you're worried
+about hitting rate limits on the underlying `claude -p` dispatches.
+
 ## Layout
 
 ```
 adapters/
   common.py              # BenchmarkCase, unified_diff_hunks(), run_with_timeout
-  defects4j_adapter.py    # active-bugs.csv + .src.patch -> BenchmarkCase
-  bugsjs_adapter.py       # Projects.csv + <Project>_bugs.csv + git tags -> BenchmarkCase
+  defects4j_adapter.py    # active-bugs.csv + .src.patch -> BenchmarkCase; run_tests() = compile+test
+  bugsjs_adapter.py       # Projects.csv + <Project>_bugs.csv + git tags -> BenchmarkCase; run_tests() = npm install+test
 runner.py                 # checkout -> scope -> dispatch -> parse -> score -> JSONL
 scorer.py                 # hit/miss/tolerance/unmatched-findings
 report.py                 # results.jsonl + skipped.jsonl -> report.md

--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -78,6 +78,11 @@ python3 cli.py --dataset bugsjs --project Bower --resume
 # Everything Defects4J has, capped to the first 2 projects, full-repo scope
 python3 cli.py --dataset defects4j --limit-projects 2 --full-repo
 
+# Full sweep: every project in both datasets (same --results-dir, so
+# results.jsonl accumulates across both runs and report.md covers both)
+python3 cli.py --dataset defects4j --workers 4
+python3 cli.py --dataset bugsjs --workers 4
+
 # Regenerate report.md from existing results.jsonl without re-dispatching
 python3 cli.py --report-only
 ```

--- a/evals/code-review-benchmark/adapters/bugsjs_adapter.py
+++ b/evals/code-review-benchmark/adapters/bugsjs_adapter.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .common import BenchmarkCase, Hunk, run_with_timeout, unified_diff_hunks
 
@@ -130,6 +130,75 @@ def checkout(
     except (OSError, ValueError):
         return False
     return checkout_proc.returncode == 0
+
+
+def run_tests(
+    case: BenchmarkCase,
+    checkout_dir: str,
+    run_fn=DEFAULT_RUN_FN,
+    install_timeout: int = 300,
+    test_timeout: int = 600,
+) -> Dict[str, Any]:
+    """Configure (`npm ci`/`npm install`) and run (`npm test`) the buggy checkout.
+
+    Diagnostic sanity check, not a gate: a non-zero `npm test` exit on the
+    buggy revision is the expected signal that the bug reproduces. Never
+    raises — any subprocess/OS failure is folded into the returned dict,
+    same contract as `checkout()`/`ground_truth()` above.
+    """
+    if not (Path(checkout_dir) / "package.json").is_file():
+        return {
+            "configured": False,
+            "ran": False,
+            "reproduced": False,
+            "error": "no package.json",
+        }
+
+    install_cmd = (
+        ["npm", "ci"]
+        if (Path(checkout_dir) / "package-lock.json").is_file()
+        else ["npm", "install"]
+    )
+    try:
+        install_proc = run_fn(
+            install_timeout,
+            install_cmd,
+            cwd=checkout_dir,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        return {
+            "configured": False,
+            "ran": False,
+            "reproduced": False,
+            "error": str(exc),
+        }
+    if install_proc.returncode != 0:
+        return {"configured": False, "ran": False, "reproduced": False}
+
+    try:
+        test_proc = run_fn(
+            test_timeout,
+            ["npm", "test"],
+            cwd=checkout_dir,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        return {
+            "configured": True,
+            "ran": False,
+            "reproduced": False,
+            "error": str(exc),
+        }
+
+    return {
+        "configured": True,
+        "ran": True,
+        "reproduced": test_proc.returncode != 0,
+        "exit_code": test_proc.returncode,
+    }
 
 
 def _is_test_path(path: str) -> bool:

--- a/evals/code-review-benchmark/adapters/defects4j_adapter.py
+++ b/evals/code-review-benchmark/adapters/defects4j_adapter.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import csv
 import shutil
 from pathlib import Path
-from typing import Any, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from .common import BenchmarkCase, run_with_timeout, unified_diff_hunks
 
@@ -133,6 +133,73 @@ def checkout(
     except (OSError, ValueError):
         return False
     return proc.returncode == 0
+
+
+def run_tests(
+    case: BenchmarkCase,
+    checkout_dir: str,
+    run_fn=DEFAULT_RUN_FN,
+    compile_timeout: int = 300,
+    test_timeout: int = 600,
+) -> Dict[str, Any]:
+    """Configure (`defects4j compile`) and run (`defects4j test`) the buggy checkout.
+
+    Diagnostic sanity check, not a gate: confirms the buggy revision
+    actually reproduces a failing test via Defects4J's own bookkeeping
+    (`<checkout_dir>/failing_tests`), which lists trigger tests as lines
+    `--- <test.class>::<method>`. Never raises — any subprocess/OS failure
+    is folded into the returned dict, same contract as `checkout()`/
+    `describe()` above.
+    """
+    try:
+        compile_proc = run_fn(
+            compile_timeout,
+            ["defects4j", "compile"],
+            cwd=checkout_dir,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        return {
+            "configured": False,
+            "ran": False,
+            "reproduced": False,
+            "error": str(exc),
+        }
+    if compile_proc.returncode != 0:
+        return {"configured": False, "ran": False, "reproduced": False}
+
+    try:
+        test_proc = run_fn(
+            test_timeout,
+            ["defects4j", "test"],
+            cwd=checkout_dir,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        return {
+            "configured": True,
+            "ran": False,
+            "reproduced": False,
+            "error": str(exc),
+        }
+
+    failing_tests: List[str] = []
+    failing_tests_path = Path(checkout_dir) / "failing_tests"
+    if failing_tests_path.is_file():
+        failing_tests = [
+            line[len("---") :].strip()
+            for line in failing_tests_path.read_text(encoding="utf-8").splitlines()
+            if line.startswith("---")
+        ]
+
+    return {
+        "configured": True,
+        "ran": test_proc.returncode == 0,
+        "reproduced": bool(failing_tests),
+        "failing_tests": failing_tests,
+    }
 
 
 def describe(

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -20,8 +20,9 @@ import argparse
 import os
 import random
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -67,6 +68,19 @@ def _make_ground_truth_fn(dataset: str, case: Any):
     return None
 
 
+def _make_test_fn(
+    dataset: str, case: Any, enabled: bool
+) -> Optional[Callable[[str], Dict[str, Any]]]:
+    """Build `run_case`'s `test_fn`, or `None` when verification is disabled.
+
+    Diagnostic only (see runner.run_case) — never gates/skips a case.
+    """
+    if not enabled:
+        return None
+    adapter = defects4j_adapter if dataset == "defects4j" else bugsjs_adapter
+    return lambda checkout_dir: adapter.run_tests(case, checkout_dir)
+
+
 def run(args: argparse.Namespace) -> int:
     results_dir = Path(args.results_dir)
 
@@ -109,30 +123,50 @@ def run(args: argparse.Namespace) -> int:
         model=args.model, timeout=args.timeout
     )
 
-    processed = 0
+    pending = []
     for case in cases:
         case_dict = case.to_dict()
-        key = runner.case_key(case_dict)
-        if key in already:
+        if runner.case_key(case_dict) in already:
             continue
+        pending.append((case, case_dict))
 
-        record = runner.run_case(
-            case_dict,
-            checkout_fn=_make_checkout_fn(args.dataset, case, home),
-            ground_truth_fn=_make_ground_truth_fn(args.dataset, case),
-            dispatch_fn=dispatch_fn,
-            results_dir=results_dir,
-            scope="full-repo" if args.full_repo else "fix-only",
-            tolerance=args.tolerance,
-        )
-        runner.append_result(record, results_dir)
-        processed += 1
-        status = (
-            "HIT"
-            if record.get("hit")
-            else ("SKIP" if record.get("skipped") else "MISS")
-        )
-        print(f"[{processed}/{len(cases)}] {key}: {status}")
+    processed = 0
+    total = len(pending)
+    workers = max(1, args.workers)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                runner.run_case,
+                case_dict,
+                checkout_fn=_make_checkout_fn(args.dataset, case, home),
+                ground_truth_fn=_make_ground_truth_fn(args.dataset, case),
+                test_fn=_make_test_fn(args.dataset, case, not args.no_verify_tests),
+                dispatch_fn=dispatch_fn,
+                results_dir=results_dir,
+                scope="full-repo" if args.full_repo else "fix-only",
+                tolerance=args.tolerance,
+            ): case_dict
+            for case, case_dict in pending
+        }
+        # Drain in the main thread as futures complete: keeps append_result()/
+        # print() single-threaded (no lock needed) and isolates one case's
+        # crash from aborting the rest of the batch.
+        for future in as_completed(futures):
+            case_dict = futures[future]
+            key = runner.case_key(case_dict)
+            try:
+                record = future.result()
+            except Exception as exc:  # noqa: BLE001 - one case's crash must not abort the batch
+                record = runner.skip_record(case_dict, f"internal error: {exc}")
+
+            runner.append_result(record, results_dir)
+            processed += 1
+            status = (
+                "HIT"
+                if record.get("hit")
+                else ("SKIP" if record.get("skipped") else "MISS")
+            )
+            print(f"[{processed}/{total}] {key}: {status}")
 
     path = report.write_report(results_dir)
     print(f"Wrote {path}")
@@ -174,6 +208,21 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     parser.add_argument(
         "--timeout", type=int, default=900, help="Per-case dispatch timeout, seconds."
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Number of bug cases to run concurrently (thread pool).",
+    )
+    parser.add_argument(
+        "--no-verify-tests",
+        action="store_true",
+        help=(
+            "Skip building/installing deps and running the project's own "
+            "test suite per case (on by default; diagnostic only, never "
+            "gates scoring)."
+        ),
     )
     parser.add_argument(
         "--defects4j-home", help="Defects4J framework checkout (or set DEFECTS4J_HOME)."

--- a/evals/code-review-benchmark/report.py
+++ b/evals/code-review-benchmark/report.py
@@ -123,6 +123,18 @@ def build_report(results_dir: Any) -> str:
             lines.append("")
     lines.append("")
 
+    verified = [r for r in results if r.get("test_verification") is not None]
+    if verified:
+        reproduced = sum(
+            1 for r in verified if r["test_verification"].get("reproduced")
+        )
+        lines.append("## Test verification")
+        lines.append("")
+        lines.append(
+            f"Buggy revision reproduced a failing test: {reproduced}/{len(verified)}"
+        )
+        lines.append("")
+
     lines.append("## Noise summary")
     lines.append("")
     hit_records = [r for r in results if r.get("hit")]

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -83,7 +83,7 @@ def _build_scoped_dir(checkout_dir: str, files: List[str]) -> str:
     return scoped
 
 
-def _skip_record(
+def skip_record(
     case: Dict[str, Any], reason: str, raw_output_path: Optional[str] = None
 ) -> Dict[str, Any]:
     return {
@@ -103,6 +103,7 @@ def run_case(
     dispatch_fn: Callable[[str, str], Dict[str, Any]],
     results_dir: Any,
     ground_truth_fn: Optional[Callable[[str], List[Any]]] = None,
+    test_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
     scope: str = "fix-only",
     tolerance: int = scorer.DEFAULT_TOLERANCE,
     workdir_root: Optional[str] = None,
@@ -113,7 +114,11 @@ def run_case(
     (used only when `case["ground_truth_hunks"]` is empty, e.g. BugsJS, whose
     ground truth requires the post-checkout git history) are pre-bound
     closures the caller builds per case — this function has no knowledge of
-    which dataset/adapter it's running.
+    which dataset/adapter it's running. `test_fn(checkout_dir) -> dict`,
+    when supplied, is called against the full checkout (before any
+    `fix-only` scoping copies files out) as a diagnostic sanity check that
+    the buggy revision reproduces a failing test; it never gates or skips
+    the case, and its result lands in the record as `test_verification`.
     """
     results_dir = Path(results_dir)
     raw_dir = results_dir / "raw"
@@ -123,7 +128,7 @@ def run_case(
     review_dir: Optional[str] = None
     try:
         if not checkout_fn(checkout_dir):
-            return _skip_record(case, "checkout failed")
+            return skip_record(case, "checkout failed")
 
         ground_truth_hunks = list(case.get("ground_truth_hunks") or [])
         if not ground_truth_hunks and ground_truth_fn is not None:
@@ -132,9 +137,21 @@ def run_case(
                 h.to_dict() if hasattr(h, "to_dict") else h for h in hunks
             ]
         if not ground_truth_hunks:
-            return _skip_record(case, "no ground-truth hunks")
+            return skip_record(case, "no ground-truth hunks")
 
         ground_truth_files = sorted({h["file"] for h in ground_truth_hunks})
+
+        test_verification: Optional[Dict[str, Any]] = None
+        if test_fn is not None:
+            try:
+                test_verification = test_fn(checkout_dir)
+            except Exception as exc:  # noqa: BLE001 - a broken test_fn must not crash the case
+                test_verification = {
+                    "configured": False,
+                    "ran": False,
+                    "reproduced": False,
+                    "error": str(exc),
+                }
 
         if scope == "full-repo":
             review_dir = checkout_dir
@@ -149,7 +166,7 @@ def run_case(
 
         review_json = _extract_review_json(dispatch_result.get("result_text"))
         if review_json is None:
-            return _skip_record(case, "unparseable --json output", str(raw_path))
+            return skip_record(case, "unparseable --json output", str(raw_path))
 
         findings = _flatten_findings(review_json)
         scored = scorer.score(ground_truth_hunks, findings, tolerance=tolerance)
@@ -164,6 +181,7 @@ def run_case(
             "findings": findings,
             "unmatched_findings": scored["unmatched"],
             "raw_output_path": str(raw_path),
+            "test_verification": test_verification,
         }
     finally:
         shutil.rmtree(checkout_dir, ignore_errors=True)

--- a/tests/scripts/test_code_review_benchmark_adapters.py
+++ b/tests/scripts/test_code_review_benchmark_adapters.py
@@ -41,6 +41,22 @@ class _FakeRun:
         )
 
 
+class _SequencedFakeRun:
+    """Injected `run_fn` returning a different canned (returncode, stdout) per call,
+    in call order — for `run_tests()`, whose configure/run steps need distinct results."""
+
+    def __init__(self, results: List[tuple]) -> None:
+        self._results = list(results)
+        self.calls: List[dict] = []
+
+    def __call__(self, timeout, argv, **kwargs):
+        self.calls.append({"timeout": timeout, "argv": list(argv), "kwargs": kwargs})
+        returncode, stdout = self._results.pop(0)
+        return subprocess.CompletedProcess(
+            args=list(argv), returncode=returncode, stdout=stdout, stderr=""
+        )
+
+
 # ---------------------------------------------------------------------------
 # Defects4J
 # ---------------------------------------------------------------------------
@@ -130,6 +146,54 @@ def test_defects4j_describe_returns_stdout_on_success(d4j_home: Path) -> None:
     assert defects4j_adapter.describe(cases[0], run_fn=fake) == "Bug info text"
 
 
+def test_defects4j_run_tests_configure_failure_short_circuits(
+    d4j_home: Path, tmp_path: Path
+) -> None:
+    cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
+    fake = _SequencedFakeRun([(1, "")])
+    result = defects4j_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert result == {"configured": False, "ran": False, "reproduced": False}
+    assert len(fake.calls) == 1  # `defects4j test` never runs after a failed compile
+    assert fake.calls[0]["argv"] == ["defects4j", "compile"]
+
+
+def test_defects4j_run_tests_reproduced_parses_failing_tests(
+    d4j_home: Path, tmp_path: Path
+) -> None:
+    (tmp_path / "failing_tests").write_text(
+        "--- org.apache.commons.lang3.math.NumberUtilsTest::testCreateNumber\n"
+        "java.lang.AssertionError\n"
+        "\tat org.apache.commons.lang3.math.NumberUtilsTest.testCreateNumber\n",
+        encoding="utf-8",
+    )
+    cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
+    fake = _SequencedFakeRun([(0, ""), (0, "")])
+    result = defects4j_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert result == {
+        "configured": True,
+        "ran": True,
+        "reproduced": True,
+        "failing_tests": [
+            "org.apache.commons.lang3.math.NumberUtilsTest::testCreateNumber"
+        ],
+    }
+    assert fake.calls[1]["argv"] == ["defects4j", "test"]
+
+
+def test_defects4j_run_tests_not_reproduced_without_failing_tests_file(
+    d4j_home: Path, tmp_path: Path
+) -> None:
+    cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
+    fake = _SequencedFakeRun([(0, ""), (0, "")])
+    result = defects4j_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert result == {
+        "configured": True,
+        "ran": True,
+        "reproduced": False,
+        "failing_tests": [],
+    }
+
+
 # ---------------------------------------------------------------------------
 # BugsJS
 # ---------------------------------------------------------------------------
@@ -216,3 +280,63 @@ def test_bugsjs_ground_truth_empty_on_git_failure(bugsjs_home: Path) -> None:
     cases = bugsjs_adapter.list_bugs("Bower", str(bugsjs_home))
     fake = _FakeRun(returncode=1)
     assert bugsjs_adapter.ground_truth(cases[0], "/tmp/bower-work", run_fn=fake) == []
+
+
+def test_bugsjs_run_tests_no_package_json_short_circuits(
+    bugsjs_home: Path, tmp_path: Path
+) -> None:
+    cases = bugsjs_adapter.list_bugs("Bower", str(bugsjs_home))
+    fake = _SequencedFakeRun([])
+    result = bugsjs_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert result == {
+        "configured": False,
+        "ran": False,
+        "reproduced": False,
+        "error": "no package.json",
+    }
+    assert fake.calls == []
+
+
+def test_bugsjs_run_tests_uses_npm_ci_when_lockfile_present(
+    bugsjs_home: Path, tmp_path: Path
+) -> None:
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    cases = bugsjs_adapter.list_bugs("Bower", str(bugsjs_home))
+    fake = _SequencedFakeRun([(0, ""), (1, "")])
+    result = bugsjs_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert fake.calls[0]["argv"] == ["npm", "ci"]
+    assert fake.calls[1]["argv"] == ["npm", "test"]
+    assert result == {
+        "configured": True,
+        "ran": True,
+        "reproduced": True,
+        "exit_code": 1,
+    }
+
+
+def test_bugsjs_run_tests_uses_npm_install_without_lockfile(
+    bugsjs_home: Path, tmp_path: Path
+) -> None:
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    cases = bugsjs_adapter.list_bugs("Bower", str(bugsjs_home))
+    fake = _SequencedFakeRun([(0, ""), (0, "")])
+    result = bugsjs_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert fake.calls[0]["argv"] == ["npm", "install"]
+    assert result == {
+        "configured": True,
+        "ran": True,
+        "reproduced": False,
+        "exit_code": 0,
+    }
+
+
+def test_bugsjs_run_tests_install_failure_short_circuits(
+    bugsjs_home: Path, tmp_path: Path
+) -> None:
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    cases = bugsjs_adapter.list_bugs("Bower", str(bugsjs_home))
+    fake = _SequencedFakeRun([(1, "")])
+    result = bugsjs_adapter.run_tests(cases[0], str(tmp_path), run_fn=fake)
+    assert result == {"configured": False, "ran": False, "reproduced": False}
+    assert len(fake.calls) == 1  # `npm test` never runs after a failed install

--- a/tests/scripts/test_code_review_benchmark_report.py
+++ b/tests/scripts/test_code_review_benchmark_report.py
@@ -75,6 +75,67 @@ def test_report_recall_math_and_missed_defects(tmp_path: Path) -> None:
     assert "defects4j / Lang / bug 9: checkout failed" in text
 
 
+def test_report_test_verification_section_when_present(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "results.jsonl",
+        [
+            {
+                "dataset": "bugsjs",
+                "project": "Bower",
+                "bug_id": "1",
+                "hit": True,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r1.txt",
+                "test_verification": {
+                    "configured": True,
+                    "ran": True,
+                    "reproduced": True,
+                },
+            },
+            {
+                "dataset": "bugsjs",
+                "project": "Bower",
+                "bug_id": "2",
+                "hit": False,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r2.txt",
+                "test_verification": {
+                    "configured": True,
+                    "ran": True,
+                    "reproduced": False,
+                },
+            },
+        ],
+    )
+    text = report.build_report(tmp_path)
+    assert "## Test verification" in text
+    assert "Buggy revision reproduced a failing test: 1/2" in text
+
+
+def test_report_omits_test_verification_section_when_absent(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "results.jsonl",
+        [
+            {
+                "dataset": "bugsjs",
+                "project": "Bower",
+                "bug_id": "1",
+                "hit": True,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r1.txt",
+            }
+        ],
+    )
+    text = report.build_report(tmp_path)
+    assert "## Test verification" not in text
+
+
 def test_report_no_results_is_well_formed(tmp_path: Path) -> None:
     text = report.build_report(tmp_path)
     assert "Overall recall: n/a (0 attempted)" in text

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -189,6 +189,79 @@ def test_run_case_full_repo_scope_passes_full_checkout(tmp_path: Path) -> None:
     assert seen_cwd["cwd"]
 
 
+def test_run_case_records_test_verification_against_full_checkout(
+    tmp_path: Path,
+) -> None:
+    seen_checkout_dir = {}
+
+    def checkout_fn(workdir: str) -> bool:
+        _seed_checkout(workdir, ["src/Foo.java"])
+        return True
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        return _dispatch_result()
+
+    def test_fn(checkout_dir: str) -> Dict[str, Any]:
+        # Called against the full checkout, not the fix-only scoped copy —
+        # assert while the checkout dir still exists (run_case tears it
+        # down in its `finally` before returning).
+        seen_checkout_dir["found_unrelated_file"] = (
+            Path(checkout_dir) / "src" / "Foo.java"
+        ).is_file()
+        return {"configured": True, "ran": True, "reproduced": True}
+
+    record = runner.run_case(
+        _CASE,
+        checkout_fn=checkout_fn,
+        dispatch_fn=dispatch_fn,
+        test_fn=test_fn,
+        results_dir=tmp_path,
+    )
+    assert record["test_verification"] == {
+        "configured": True,
+        "ran": True,
+        "reproduced": True,
+    }
+    assert seen_checkout_dir["found_unrelated_file"] is True
+
+
+def test_run_case_test_fn_exception_does_not_crash_the_case(tmp_path: Path) -> None:
+    def checkout_fn(workdir: str) -> bool:
+        _seed_checkout(workdir, ["src/Foo.java"])
+        return True
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        return _dispatch_result()
+
+    def test_fn(checkout_dir: str) -> Dict[str, Any]:
+        raise RuntimeError("boom")
+
+    record = runner.run_case(
+        _CASE,
+        checkout_fn=checkout_fn,
+        dispatch_fn=dispatch_fn,
+        test_fn=test_fn,
+        results_dir=tmp_path,
+    )
+    assert record["skipped"] is False
+    assert record["test_verification"]["configured"] is False
+    assert record["test_verification"]["error"] == "boom"
+
+
+def test_run_case_test_verification_none_without_test_fn(tmp_path: Path) -> None:
+    def checkout_fn(workdir: str) -> bool:
+        _seed_checkout(workdir, ["src/Foo.java"])
+        return True
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        return _dispatch_result()
+
+    record = runner.run_case(
+        _CASE, checkout_fn=checkout_fn, dispatch_fn=dispatch_fn, results_dir=tmp_path
+    )
+    assert record["test_verification"] is None
+
+
 def test_extract_review_json_handles_markdown_fence() -> None:
     fenced = "```json\n" + json.dumps(_REVIEW_JSON) + "\n```"
     assert runner._extract_review_json(fenced) == _REVIEW_JSON


### PR DESCRIPTION
## Summary
- `run_tests()` in both dataset adapters (Defects4J: `compile`+`test`, parsing `failing_tests`; BugsJS: `npm ci`/`install`+`test`) — a diagnostic sanity check that the buggy revision reproduces a failing test, threaded through `runner.run_case` as `test_verification` on the result record. Never gates/skips scoring, since a build/install failure can be environmental noise unrelated to the actual bug.
- Parallelizes `cli.py`'s case loop with a capped `ThreadPoolExecutor` (`--workers`, default 4) instead of the previous serial `for` loop — each case already does its own checkout into a private temp dir and its own subprocess calls, so no shared mutable state.
- `--no-verify-tests` opts out of the (default-on) test verification for fast/cheap smoke runs.
- `report.py` gets a "Test verification" section, shown only when any result carries the new field.
- README documents both new flags/behaviors.

Closes #945
Part of #821

## Test plan
- [x] `python3 -m pytest tests/scripts/test_code_review_benchmark_*.py -q` — 52 passed
- [x] `python3 -m pytest tests/ -q` — 2102 passed, 3 skipped
- [x] `python3 evals/code-review-benchmark/cli.py --help` — new `--workers`/`--no-verify-tests` flags parse correctly
- [x] `scripts/ci-local.sh` (via pre-push hook) — all checks passed