### PR TITLE
docs: fix C#/Reqnroll wiring instructions in bdd-frameworks.md

### DIFF
--- a/plugins/dev-team/knowledge/test-stack-profiles/bdd-frameworks.md
+++ b/plugins/dev-team/knowledge/test-stack-profiles/bdd-frameworks.md
@@ -17,6 +17,7 @@ so the BDD suite plugs into the existing pipeline without new reporting.
   - `features/` — `.feature` files.
   - `features/support/` — step definitions and world/hooks.
 - **Runner config** — `cucumber.yaml` (or `cucumber.js`) at repo root:
+
   ```yaml
   default:
     require:
@@ -24,13 +25,16 @@ so the BDD suite plugs into the existing pipeline without new reporting.
     format:
       - "junit:reports/cucumber-junit.xml"
   ```
+
 - **Step stub (pending):**
+
   ```js
   import { Given } from "@cucumber/cucumber";
   Given("a precondition", function () {
     return this.pending(); // marks the step (and scenario) pending
   });
   ```
+
 - **Run:** `npx cucumber-js`
 - **CI note:** the `junit` formatter writes `reports/cucumber-junit.xml`; point the existing JUnit reporter at it. Cucumber.js runs alongside Vitest/Jest — they are complementary, not alternatives.
 
@@ -40,6 +44,7 @@ so the BDD suite plugs into the existing pipeline without new reporting.
 
 - **Framework:** [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm) on the JUnit 5 platform.
 - **Install** — add to `pom.xml`:
+
   ```xml
   <dependency>
     <groupId>io.cucumber</groupId>
@@ -54,10 +59,12 @@ so the BDD suite plugs into the existing pipeline without new reporting.
     <scope>test</scope>
   </dependency>
   ```
+
 - **Directory layout:**
   - `src/test/resources/features/` — `.feature` files.
   - `src/test/java/.../steps/` — step-definition classes.
 - **Runner config** — a suite entry point:
+
   ```java
   import org.junit.platform.suite.api.*;
 
@@ -66,8 +73,10 @@ so the BDD suite plugs into the existing pipeline without new reporting.
   @SelectClasspathResource("features")
   public class RunCucumberTest {}
   ```
+
   (add `import static io.cucumber.junit.platform.engine.Constants.*;` only if you also set `@ConfigurationParameter` options such as the `pretty` plugin.)
 - **Step stub (pending):**
+
   ```java
   import io.cucumber.java.en.Given;
   import io.cucumber.java.PendingException;
@@ -77,6 +86,7 @@ so the BDD suite plugs into the existing pipeline without new reporting.
     public void a_precondition() { throw new io.cucumber.java.PendingException(); }
   }
   ```
+
 - **Run:** `mvn test` (Surefire discovers the JUnit 5 suite automatically).
 - **CI note:** Surefire emits JUnit XML under `target/surefire-reports/` — no extra config.
 
@@ -87,18 +97,22 @@ so the BDD suite plugs into the existing pipeline without new reporting.
 Same engine as Maven; only the wiring differs.
 
 - **Install** — add to `build.gradle`:
+
   ```groovy
   testImplementation 'io.cucumber:cucumber-java:7.18.1'
   testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.18.1'
   testImplementation 'org.junit.platform:junit-platform-suite:1.10.2'
   ```
+
 - **Runner config** — ensure the `test` task uses the JUnit Platform and sees the feature resources:
+
   ```groovy
   test {
     useJUnitPlatform()
     systemProperty 'cucumber.junit-platform.naming-strategy', 'long'
   }
   ```
+
   Keep `.feature` files under `src/test/resources/features/` (same suite class as Maven).
 - **Step stub:** identical to Maven (`io.cucumber.java.PendingException`).
 - **Run:** `./gradlew test`
@@ -109,27 +123,35 @@ Same engine as Maven; only the wiring differs.
 ## C# — Reqnroll
 
 - **Framework:** [Reqnroll](https://reqnroll.net/) — the actively-maintained, MIT-licensed successor to SpecFlow. **Prefer Reqnroll over SpecFlow:** identical API, but SpecFlow requires a commercial license for teams larger than one, while Reqnroll is free.
-- **Install:** `dotnet add package Reqnroll.xUnit` (or `Reqnroll.NUnit` / `Reqnroll.MsTest` to match the project's test runner).
+- **Install:** `dotnet add package Reqnroll.xUnit` (or `Reqnroll.NUnit` / `Reqnroll.MsTest` to match the project's test runner) **and** `dotnet add package Reqnroll.Tools.MsBuild.Generation`. The second package is required, not optional — it's the `.feature` → C# code generator; the runtime-bindings package alone leaves `.feature` files silently uncompiled (`dotnet test` reports "No test is available," with no error at all).
 - **Directory layout:**
-  - `Features/` — `.feature` files (set as `AdditionalFiles` / Reqnroll items).
+  - `Features/` — `.feature` files. The default MSBuild wildcard include only reaches `.feature` files under the test project's own directory tree. To reference files living outside it (e.g. a shared `features/` convention dir consumed by multiple projects), add them explicitly as `ReqnrollFeatureFile` items — **not** `AdditionalFiles` (that's a Roslyn-source-generator convention; MSBuild-based Reqnroll codegen doesn't key on it):
+
+    ```xml
+    <ItemGroup>
+      <ReqnrollFeatureFile Include="..\..\features\*.feature" Link="Features\%(Filename)%(Extension)" />
+    </ItemGroup>
+    ```
+
   - `StepDefinitions/` — `[Binding]` step classes.
 - **Runner config** — `reqnroll.json` at the project root:
+
   ```json
   { "language": { "feature": "en" } }
   ```
-- **Step stub (pending):** inject `ScenarioContext` via the constructor and call `StepIsPending()` on the instance (it is not a static method):
+
+- **Step stub (pending):** throw `PendingStepException` directly — this is Reqnroll's own auto-suggested stub for an undefined step. (`ScenarioContext.StepIsPending()` is deprecated as of Reqnroll 3.3.4 and will be removed in v4; it is also a **static** method, not an instance method, despite older examples showing it called via constructor-injected `ScenarioContext`.)
+
   ```csharp
   using Reqnroll;
 
   [Binding]
   public class Steps {
-    private readonly ScenarioContext _scenarioContext;
-    public Steps(ScenarioContext scenarioContext) => _scenarioContext = scenarioContext;
-
     [Given("a precondition")]
-    public void GivenAPrecondition() => _scenarioContext.StepIsPending();
+    public void GivenAPrecondition() => throw new PendingStepException();
   }
   ```
+
 - **Run:** `dotnet test`
 - **CI note:** `dotnet test --logger "junit;LogFilePath=reports/reqnroll-junit.xml"` (via the JUnit test logger) produces JUnit XML for the pipeline.
 
@@ -144,6 +166,7 @@ Same engine as Maven; only the wiring differs.
   - pytest-bdd: step definitions in `tests/step_defs/test_*.py`, bound with `scenarios("../../features")`.
   - behave: step definitions in `features/steps/*.py`.
 - **Step stub (pending):**
+
   ```python
   # pytest-bdd
   import pytest
@@ -160,6 +183,7 @@ Same engine as Maven; only the wiring differs.
   def step_a_precondition(context):
       raise NotImplementedError("pending")
   ```
+
 - **Run:** `pytest` (pytest-bdd) or `behave --junit --junit-directory reports/` (behave).
 - **CI note:** pytest-bdd scenarios surface through the existing pytest JUnit reporter (`--junitxml`); behave's `--junit` flag writes per-feature JUnit XML the pipeline can pick up directly.
 
@@ -173,6 +197,7 @@ Same engine as Maven; only the wiring differs.
   - `features/` — `.feature` files.
   - step definitions live in a `*_test.go` file beside the suite entry point.
 - **Runner config** — a suite entry point in `*_test.go` so Godog runs inside `go test` (no separate binary):
+
   ```go
   func TestFeatures(t *testing.T) {
     suite := godog.TestSuite{
@@ -182,7 +207,9 @@ Same engine as Maven; only the wiring differs.
     if suite.Run() != 0 { t.Fatal("non-zero status returned, failed to run feature tests") }
   }
   ```
+
 - **Step stub (pending):**
+
   ```go
   func aPrecondition() error { return godog.ErrPending }
 
@@ -190,5 +217,6 @@ Same engine as Maven; only the wiring differs.
     sc.Step(`^a precondition$`, aPrecondition)
   }
   ```
+
 - **Run:** `go test ./...` (the suite runs as an ordinary Go test).
 - **CI note:** with the `TestingT` option set (above), scenario failures surface as normal `go test` results, so the existing pipeline already sees them. For a separate JUnit-XML artifact, point `Options.Output` at a file writer (e.g. `f, _ := os.Create("reports/godog-junit.xml"); opts.Output = f`) with `Format: "junit"`.


### PR DESCRIPTION
## Summary
- `Reqnroll.Tools.MsBuild.Generation` documented as a required second install package (the actual `.feature` → C# code generator) — its absence causes a silent "No test is available" with zero error output.
- Corrects the out-of-project `.feature` file item name to `ReqnrollFeatureFile` (was incorrectly documented as `AdditionalFiles`, a Roslyn-source-generator convention Reqnroll's MSBuild codegen doesn't use).
- Replaces the deprecated instance-based `ScenarioContext.StepIsPending()` step-stub example with `throw new PendingStepException()`, matching Reqnroll's own auto-suggested stub in 3.3.4+.

Doc-only change, no code/agent/hook touched.

Closes #948