### PR TITLE
feat: resolve Java 11 + Perl CPAN env for defects4j subprocess calls

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -41,8 +41,27 @@ repo-local `.cache/` on first use — no manual cloning required:
   silently overridden).
 
 Auto-provisioning does **not** remove every system-level prerequisite:
-Defects4J's `init.sh` still needs Perl (+ its cpan modules), Java, `git`,
-and `svn` on the machine; `git` itself is needed for both clones.
+Defects4J's `init.sh` still needs `wget`, Perl (+ its cpan modules), a
+Java 11 JDK, `git`, and `svn` on the machine; `git` itself is needed for
+both clones. Confirmed live on a real machine: `brew install wget
+openjdk@11 cpanminus` + `cpanm --local-lib=~/perl5 --installdeps .` (run
+inside `.cache/defects4j`) covers all of it on macOS.
+
+Two of those (Java 11, the Perl CPAN modules) are resolved **inside the
+harness itself** (#951), not via your shell profile — every `defects4j`
+subprocess call gets a scoped `env` override, built by
+`adapters/bootstrap.build_defects4j_env()`:
+
+- **Java 11**: tries `/usr/libexec/java_home -v 11` (macOS), then `brew
+  --prefix openjdk@11` (the common case for a keg-only Homebrew install).
+- **Perl CPAN deps**: `~/perl5/lib/perl5` if present (the `cpanm
+  --local-lib=~/perl5` convention above).
+
+This never touches your actual `JAVA_HOME`/`PATH`/`PERL5LIB` or `~/.zshrc`
+— only the subprocess environment `defects4j` itself runs under. If
+neither resolves, `defects4j` calls fall back to your inherited
+environment unchanged (today's behavior, and where you'd see the Perl/Java
+errors this was built to avoid).
 
 - The `claude` CLI available on `PATH` (used headlessly via
   `plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py`'s
@@ -166,7 +185,7 @@ about hitting rate limits on the underlying `claude -p` dispatches.
 ```
 adapters/
   common.py              # BenchmarkCase, unified_diff_hunks(), run_with_timeout
-  bootstrap.py            # auto-clone/init both dataset homes into .cache/ (#949)
+  bootstrap.py            # auto-clone/init both dataset homes into .cache/ (#949); resolves Java 11 + Perl CPAN env for defects4j subprocess calls (#951)
   defects4j_adapter.py    # active-bugs.csv + .src.patch -> BenchmarkCase; run_tests() = compile+test
   bugsjs_adapter.py       # Projects.csv + <Project>_bugs.csv + git tags -> BenchmarkCase; run_tests() = npm install+test
 runner.py                 # checkout -> scope -> dispatch -> parse -> score -> JSONL

--- a/evals/code-review-benchmark/adapters/bootstrap.py
+++ b/evals/code-review-benchmark/adapters/bootstrap.py
@@ -20,6 +20,8 @@ contract.
 
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -31,6 +33,12 @@ BUGSJS_REPO_URL = "https://github.com/BugsJS/bug-dataset.git"
 _DEFECTS4J_INIT_MARKER = ".d4j-init-complete"
 
 DEFAULT_RUN_FN = run_with_timeout
+
+# Module-level so tests can monkeypatch it to a nonexistent path and force
+# the "not on this machine" branch deterministically, rather than depending
+# on whether the real macOS tool happens to exist on whatever host runs the
+# suite (#951 — hermetic tests, not host-environment-dependent ones).
+JAVA_HOME_TOOL = "/usr/libexec/java_home"
 
 
 def _clone_if_missing(
@@ -55,6 +63,86 @@ def _clone_if_missing(
     return proc.returncode == 0
 
 
+def _resolve_java11_home(run_fn=DEFAULT_RUN_FN, timeout: int = 10) -> Optional[str]:
+    """Best-effort discovery of a Java 11 JDK's home (#951).
+
+    Defects4J 3.x requires exactly Java 11 — on a machine whose default
+    `java` is newer (or missing entirely), every `defects4j` subprocess
+    call fails with an opaque Perl error. This never touches the caller's
+    own `JAVA_HOME`/`PATH`; it only *discovers* a path for
+    `build_defects4j_env()` to scope onto the subprocess env it builds.
+
+    Tries `/usr/libexec/java_home -v 11` first (macOS — only finds JDKs
+    registered under `/Library/Java/JavaVirtualMachines/`), then `brew
+    --prefix openjdk@11` (the common case for a keg-only Homebrew install,
+    which deliberately isn't registered there). Returns `None` if neither
+    resolves — the caller then falls back to the inherited environment.
+    """
+    if Path(JAVA_HOME_TOOL).is_file():
+        try:
+            proc = run_fn(
+                timeout,
+                [JAVA_HOME_TOOL, "-v", "11"],
+                capture_output=True,
+                text=True,
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                return proc.stdout.strip()
+        except (OSError, ValueError):
+            pass
+
+    if shutil.which("brew") is None:
+        return None
+    try:
+        proc = run_fn(
+            timeout, ["brew", "--prefix", "openjdk@11"], capture_output=True, text=True
+        )
+    except (OSError, ValueError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    prefix = Path(proc.stdout.strip())
+    mac_home = prefix / "libexec" / "openjdk.jdk" / "Contents" / "Home"
+    return str(mac_home) if mac_home.is_dir() else str(prefix)
+
+
+def _resolve_perl5lib(home: Optional[Path] = None) -> Optional[str]:
+    """`~/perl5/lib/perl5` — the `cpanm --local-lib=~/perl5` convention for
+    installing Defects4J's own CPAN dependencies (see its `cpanfile`)
+    without a system-wide Perl module install."""
+    candidate = (home or Path.home()) / "perl5" / "lib" / "perl5"
+    return str(candidate) if candidate.is_dir() else None
+
+
+def build_defects4j_env(
+    run_fn=DEFAULT_RUN_FN, perl5_home: Optional[Path] = None
+) -> Optional[Dict[str, str]]:
+    """Merge `JAVA_HOME`/`PATH`/`PERL5LIB` overrides into a copy of the
+    current environment, scoped to `defects4j` subprocess calls only.
+
+    Never mutates this process's own environment or the user's shell
+    profile — every override is discovery-only (#951). Returns `None`
+    (meaning "inherit unchanged") when nothing needed overriding, so
+    callers can pass the result straight through as `env=` without a
+    conditional. `perl5_home` overrides `_resolve_perl5lib()`'s search root
+    (defaults to the real `Path.home()`) — mainly so tests don't depend on
+    whatever happens to exist under the real user's home directory.
+    """
+    java_home = _resolve_java11_home(run_fn=run_fn)
+    perl5lib = _resolve_perl5lib(home=perl5_home)
+    if java_home is None and perl5lib is None:
+        return None
+
+    env = dict(os.environ)
+    if java_home is not None:
+        env["JAVA_HOME"] = java_home
+        env["PATH"] = f"{java_home}/bin:{env.get('PATH', '')}"
+    if perl5lib is not None:
+        existing = env.get("PERL5LIB")
+        env["PERL5LIB"] = f"{perl5lib}:{existing}" if existing else perl5lib
+    return env
+
+
 def ensure_bugsjs_home(
     explicit_home: Optional[str],
     run_fn=DEFAULT_RUN_FN,
@@ -74,28 +162,34 @@ def ensure_defects4j_home(
     run_fn=DEFAULT_RUN_FN,
     init_timeout: int = 1800,
     cache_dir: Path = CACHE_DIR,
+    perl5_home: Optional[Path] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Return `{"home": str, "bin": str}` for a usable Defects4J install.
+    """Return `{"home": str, "bin": str, "env": Optional[dict]}` for a usable
+    Defects4J install.
 
     When `explicit_home` is given, returns it unchanged with `bin` set to
-    the bare `"defects4j"` command name (today's PATH-based lookup) — no
-    auto-clone over an explicit path. Otherwise clones `rjust/defects4j`
-    into the cache and runs its `init.sh` once (skipped on later calls via
-    a marker file — `init.sh` is slow and network-heavy). The resolved
-    `bin` is always the cache clone's own `framework/bin/defects4j` (a
-    committed, already-executable script — no build step), never a PATH
-    lookup, since Defects4J needs its project repos bootstrapped under
-    *this specific* home directory regardless of any other system-wide
-    install.
+    the bare `"defects4j"` command name (today's PATH-based lookup) and
+    `env: None` (inherit unchanged) — no auto-clone or env resolution over
+    an explicit path; assumes the operator already configured their own
+    environment. Otherwise clones `rjust/defects4j` into the cache and
+    runs its `init.sh` once (skipped on later calls via a marker file —
+    `init.sh` is slow and network-heavy), then resolves `env` via
+    `build_defects4j_env()` (#951 — Java 11 + Perl CPAN deps discovery).
+    The resolved `bin` is always the cache clone's own
+    `framework/bin/defects4j` (a committed, already-executable script — no
+    build step), never a PATH lookup, since Defects4J needs its project
+    repos bootstrapped under *this specific* home directory regardless of
+    any other system-wide install.
     """
     if explicit_home:
-        return {"home": explicit_home, "bin": "defects4j"}
+        return {"home": explicit_home, "bin": "defects4j", "env": None}
 
     dest = cache_dir / "defects4j"
     if not (dest / "framework" / "projects").is_dir():
         if not _clone_if_missing(DEFECTS4J_REPO_URL, dest, run_fn=run_fn):
             return None
 
+    env = build_defects4j_env(run_fn=run_fn, perl5_home=perl5_home)
     bin_path = dest / "framework" / "bin" / "defects4j"
     marker = dest / _DEFECTS4J_INIT_MARKER
     if not marker.is_file():
@@ -106,6 +200,7 @@ def ensure_defects4j_home(
                 cwd=str(dest),
                 capture_output=True,
                 text=True,
+                env=env,
             )
         except (OSError, ValueError):
             return None
@@ -113,4 +208,4 @@ def ensure_defects4j_home(
             return None
         marker.write_text("ok\n", encoding="utf-8")
 
-    return {"home": str(dest), "bin": str(bin_path)}
+    return {"home": str(dest), "bin": str(bin_path), "env": env}

--- a/evals/code-review-benchmark/adapters/defects4j_adapter.py
+++ b/evals/code-review-benchmark/adapters/defects4j_adapter.py
@@ -121,6 +121,7 @@ def checkout(
     workdir: str,
     defects4j_home: Optional[str] = None,
     defects4j_bin: str = "defects4j",
+    env: Optional[Dict[str, str]] = None,
     run_fn=DEFAULT_RUN_FN,
     timeout: int = 600,
 ) -> bool:
@@ -128,7 +129,10 @@ def checkout(
 
     Returns True on a zero exit code, False on any failure — never raises.
     `defects4j_bin` defaults to the bare command name (PATH lookup); pass
-    an explicit path for an auto-provisioned cache clone.
+    an explicit path for an auto-provisioned cache clone. `env`, when
+    given, overrides the subprocess environment (#951 — an auto-resolved
+    Java 11 + Perl CPAN env from `bootstrap.build_defects4j_env()`);
+    `None` inherits this process's environment unchanged.
     """
     argv = [
         defects4j_bin,
@@ -141,7 +145,7 @@ def checkout(
         workdir,
     ]
     try:
-        proc = run_fn(timeout, argv, capture_output=True, text=True)
+        proc = run_fn(timeout, argv, capture_output=True, text=True, env=env)
     except (OSError, ValueError):
         return False
     return proc.returncode == 0
@@ -151,6 +155,7 @@ def run_tests(
     case: BenchmarkCase,
     checkout_dir: str,
     defects4j_bin: str = "defects4j",
+    env: Optional[Dict[str, str]] = None,
     run_fn=DEFAULT_RUN_FN,
     compile_timeout: int = 300,
     test_timeout: int = 600,
@@ -164,7 +169,8 @@ def run_tests(
     is folded into the returned dict, same contract as `checkout()`/
     `describe()` above. `defects4j_bin` defaults to the bare command name
     (PATH lookup); pass an explicit path for an auto-provisioned cache
-    clone.
+    clone. `env` overrides the subprocess environment (#951); `None`
+    inherits this process's environment unchanged.
     """
     try:
         compile_proc = run_fn(
@@ -173,6 +179,7 @@ def run_tests(
             cwd=checkout_dir,
             capture_output=True,
             text=True,
+            env=env,
         )
     except (OSError, ValueError) as exc:
         return {
@@ -191,6 +198,7 @@ def run_tests(
             cwd=checkout_dir,
             capture_output=True,
             text=True,
+            env=env,
         )
     except (OSError, ValueError) as exc:
         return {
@@ -220,13 +228,14 @@ def run_tests(
 def describe(
     case: BenchmarkCase,
     defects4j_bin: str = "defects4j",
+    env: Optional[Dict[str, str]] = None,
     run_fn=DEFAULT_RUN_FN,
     timeout: int = 60,
 ) -> Optional[str]:
     """Best-effort `defects4j info -p <project> -b <bug_id>`. `None` on any failure."""
     argv = [defects4j_bin, "info", "-p", case.project, "-b", case.bug_id]
     try:
-        proc = run_fn(timeout, argv, capture_output=True, text=True)
+        proc = run_fn(timeout, argv, capture_output=True, text=True, env=env)
     except (OSError, ValueError):
         return None
     if proc.returncode != 0:

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -54,11 +54,19 @@ def _list_cases(
 
 
 def _make_checkout_fn(
-    dataset: str, case: Any, home: str, defects4j_bin: str = "defects4j"
+    dataset: str,
+    case: Any,
+    home: str,
+    defects4j_bin: str = "defects4j",
+    defects4j_env: Optional[Dict[str, str]] = None,
 ):
     if dataset == "defects4j":
         return lambda workdir: defects4j_adapter.checkout(
-            case, workdir, defects4j_home=home, defects4j_bin=defects4j_bin
+            case,
+            workdir,
+            defects4j_home=home,
+            defects4j_bin=defects4j_bin,
+            env=defects4j_env,
         )
     return lambda workdir: bugsjs_adapter.checkout(case, workdir, bugsjs_home=home)
 
@@ -70,7 +78,11 @@ def _make_ground_truth_fn(dataset: str, case: Any):
 
 
 def _make_test_fn(
-    dataset: str, case: Any, enabled: bool, defects4j_bin: str = "defects4j"
+    dataset: str,
+    case: Any,
+    enabled: bool,
+    defects4j_bin: str = "defects4j",
+    defects4j_env: Optional[Dict[str, str]] = None,
 ) -> Optional[Callable[[str], Dict[str, Any]]]:
     """Build `run_case`'s `test_fn`, or `None` when verification is disabled.
 
@@ -80,7 +92,7 @@ def _make_test_fn(
         return None
     if dataset == "defects4j":
         return lambda checkout_dir: defects4j_adapter.run_tests(
-            case, checkout_dir, defects4j_bin=defects4j_bin
+            case, checkout_dir, defects4j_bin=defects4j_bin, env=defects4j_env
         )
     return lambda checkout_dir: bugsjs_adapter.run_tests(case, checkout_dir)
 
@@ -94,6 +106,7 @@ def run(args: argparse.Namespace) -> int:
         return 0
 
     defects4j_bin = "defects4j"
+    defects4j_env: Optional[Dict[str, str]] = None
     if args.dataset == "defects4j":
         explicit_home = args.defects4j_home or os.environ.get("DEFECTS4J_HOME")
         resolved = bootstrap.ensure_defects4j_home(explicit_home)
@@ -106,6 +119,7 @@ def run(args: argparse.Namespace) -> int:
             return 1
         home = resolved["home"]
         defects4j_bin = resolved["bin"]
+        defects4j_env = resolved["env"]
     else:
         explicit_home = args.bugsjs_home or os.environ.get("BUGSJS_HOME")
         cloned_home = bootstrap.ensure_bugsjs_home(explicit_home)
@@ -166,10 +180,16 @@ def run(args: argparse.Namespace) -> int:
             executor.submit(
                 runner.run_case,
                 case_dict,
-                checkout_fn=_make_checkout_fn(args.dataset, case, home, defects4j_bin),
+                checkout_fn=_make_checkout_fn(
+                    args.dataset, case, home, defects4j_bin, defects4j_env
+                ),
                 ground_truth_fn=_make_ground_truth_fn(args.dataset, case),
                 test_fn=_make_test_fn(
-                    args.dataset, case, not args.no_verify_tests, defects4j_bin
+                    args.dataset,
+                    case,
+                    not args.no_verify_tests,
+                    defects4j_bin,
+                    defects4j_env,
                 ),
                 dispatch_fn=dispatch_fn,
                 results_dir=results_dir,

--- a/tests/scripts/test_code_review_benchmark_adapters.py
+++ b/tests/scripts/test_code_review_benchmark_adapters.py
@@ -153,6 +153,14 @@ def test_defects4j_checkout_uses_explicit_bin(d4j_home: Path) -> None:
     assert fake.calls[0]["argv"][0] == "/cache/defects4j/framework/bin/defects4j"
 
 
+def test_defects4j_checkout_passes_env_through(d4j_home: Path) -> None:
+    cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
+    fake = _FakeRun(returncode=0)
+    custom_env = {"JAVA_HOME": "/opt/openjdk11", "PERL5LIB": "/home/x/perl5"}
+    defects4j_adapter.checkout(cases[0], "/tmp/workdir", env=custom_env, run_fn=fake)
+    assert fake.calls[0]["kwargs"]["env"] == custom_env
+
+
 def test_defects4j_checkout_false_on_nonzero_exit(d4j_home: Path) -> None:
     cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
     fake = _FakeRun(returncode=1)
@@ -219,6 +227,15 @@ def test_defects4j_run_tests_uses_explicit_bin(d4j_home: Path, tmp_path: Path) -
         "compile",
     ]
     assert fake.calls[1]["argv"] == ["/cache/defects4j/framework/bin/defects4j", "test"]
+
+
+def test_defects4j_run_tests_passes_env_through(d4j_home: Path, tmp_path: Path) -> None:
+    cases = defects4j_adapter.list_bugs("Lang", str(d4j_home))
+    fake = _SequencedFakeRun([(0, ""), (0, "")])
+    custom_env = {"JAVA_HOME": "/opt/openjdk11"}
+    defects4j_adapter.run_tests(cases[0], str(tmp_path), env=custom_env, run_fn=fake)
+    assert fake.calls[0]["kwargs"]["env"] == custom_env
+    assert fake.calls[1]["kwargs"]["env"] == custom_env
 
 
 def test_defects4j_run_tests_not_reproduced_without_failing_tests_file(

--- a/tests/scripts/test_code_review_benchmark_bootstrap.py
+++ b/tests/scripts/test_code_review_benchmark_bootstrap.py
@@ -7,6 +7,7 @@ contract in this harness.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +33,21 @@ class _FakeRun:
         return subprocess.CompletedProcess(
             args=list(argv), returncode=self.returncode, stdout=self.stdout, stderr=""
         )
+
+
+@pytest.fixture()
+def no_java11(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Force `_resolve_java11_home()`/`_resolve_perl5lib()` to resolve to
+    `None`, regardless of what's actually installed on the machine running
+    this test — hermetic, not host-environment-dependent (#951). Returns a
+    `perl5_home` to pass through so `_resolve_perl5lib()` doesn't stumble
+    on a real `~/perl5` some dev machine happens to have.
+    """
+    monkeypatch.setattr(
+        bootstrap, "JAVA_HOME_TOOL", str(tmp_path / "no-java-home-tool")
+    )
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    return tmp_path / "no-perl5-here"
 
 
 # ---------------------------------------------------------------------------
@@ -89,11 +105,13 @@ def test_ensure_defects4j_home_returns_explicit_home_unchanged_without_cloning(
 ) -> None:
     fake = _FakeRun()
     result = bootstrap.ensure_defects4j_home("/some/existing/home", run_fn=fake)
-    assert result == {"home": "/some/existing/home", "bin": "defects4j"}
+    assert result == {"home": "/some/existing/home", "bin": "defects4j", "env": None}
     assert fake.calls == []
 
 
-def test_ensure_defects4j_home_clones_and_inits_when_missing(tmp_path: Path) -> None:
+def test_ensure_defects4j_home_clones_and_inits_when_missing(
+    tmp_path: Path, no_java11: Path
+) -> None:
     dest = tmp_path / "defects4j"
 
     def run_fn(timeout, argv, **kwargs):
@@ -109,16 +127,19 @@ def test_ensure_defects4j_home_clones_and_inits_when_missing(tmp_path: Path) -> 
         (dest / "framework" / "bin" / "defects4j").write_text("#!/bin/sh\n")
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
 
-    result = bootstrap.ensure_defects4j_home(None, run_fn=run_fn, cache_dir=tmp_path)
+    result = bootstrap.ensure_defects4j_home(
+        None, run_fn=run_fn, cache_dir=tmp_path, perl5_home=no_java11
+    )
     assert result == {
         "home": str(dest),
         "bin": str(dest / "framework" / "bin" / "defects4j"),
+        "env": None,
     }
     assert (dest / ".d4j-init-complete").is_file()
 
 
 def test_ensure_defects4j_home_skips_init_when_marker_already_present(
-    tmp_path: Path,
+    tmp_path: Path, no_java11: Path
 ) -> None:
     dest = tmp_path / "defects4j"
     (dest / "framework" / "projects").mkdir(parents=True)
@@ -127,10 +148,13 @@ def test_ensure_defects4j_home_skips_init_when_marker_already_present(
     (dest / ".d4j-init-complete").write_text("ok\n", encoding="utf-8")
 
     fake = _FakeRun()
-    result = bootstrap.ensure_defects4j_home(None, run_fn=fake, cache_dir=tmp_path)
+    result = bootstrap.ensure_defects4j_home(
+        None, run_fn=fake, cache_dir=tmp_path, perl5_home=no_java11
+    )
     assert result == {
         "home": str(dest),
         "bin": str(dest / "framework" / "bin" / "defects4j"),
+        "env": None,
     }
     assert fake.calls == []  # neither clone nor init.sh re-run
 
@@ -142,7 +166,7 @@ def test_ensure_defects4j_home_none_on_clone_failure(tmp_path: Path) -> None:
 
 
 def test_ensure_defects4j_home_none_on_init_failure_and_no_marker_written(
-    tmp_path: Path,
+    tmp_path: Path, no_java11: Path
 ) -> None:
     dest = tmp_path / "defects4j"
 
@@ -152,13 +176,15 @@ def test_ensure_defects4j_home_none_on_init_failure_and_no_marker_written(
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
         return subprocess.CompletedProcess(args=argv, returncode=1, stdout="")
 
-    result = bootstrap.ensure_defects4j_home(None, run_fn=run_fn, cache_dir=tmp_path)
+    result = bootstrap.ensure_defects4j_home(
+        None, run_fn=run_fn, cache_dir=tmp_path, perl5_home=no_java11
+    )
     assert result is None
     assert not (dest / ".d4j-init-complete").is_file()
 
 
 def test_ensure_defects4j_home_skips_clone_when_projects_dir_already_exists(
-    tmp_path: Path,
+    tmp_path: Path, no_java11: Path
 ) -> None:
     dest = tmp_path / "defects4j"
     (dest / "framework" / "projects").mkdir(parents=True)
@@ -169,5 +195,86 @@ def test_ensure_defects4j_home_skips_clone_when_projects_dir_already_exists(
         (dest / "framework" / "bin" / "defects4j").write_text("#!/bin/sh\n")
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
 
-    result = bootstrap.ensure_defects4j_home(None, run_fn=run_fn, cache_dir=tmp_path)
+    result = bootstrap.ensure_defects4j_home(
+        None, run_fn=run_fn, cache_dir=tmp_path, perl5_home=no_java11
+    )
     assert result["home"] == str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Java 11 / Perl CPAN env resolution (#951)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_java11_home_via_java_home_tool(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_tool = tmp_path / "java_home"
+    fake_tool.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(bootstrap, "JAVA_HOME_TOOL", str(fake_tool))
+    fake = _FakeRun(returncode=0, stdout="/path/to/jdk-11\n")
+    assert bootstrap._resolve_java11_home(run_fn=fake) == "/path/to/jdk-11"
+    assert fake.calls[0]["argv"] == [str(fake_tool), "-v", "11"]
+
+
+def test_resolve_java11_home_falls_back_to_brew_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bootstrap, "JAVA_HOME_TOOL", str(tmp_path / "no-such-tool"))
+    monkeypatch.setattr(shutil, "which", lambda name: "/opt/homebrew/bin/brew")
+    mac_home = tmp_path / "openjdk@11" / "libexec" / "openjdk.jdk" / "Contents" / "Home"
+    mac_home.mkdir(parents=True)
+
+    fake = _FakeRun(returncode=0, stdout=f"{tmp_path / 'openjdk@11'}\n")
+    result = bootstrap._resolve_java11_home(run_fn=fake)
+    assert result == str(mac_home)
+    assert fake.calls[0]["argv"] == ["brew", "--prefix", "openjdk@11"]
+
+
+def test_resolve_java11_home_none_when_nothing_resolves(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bootstrap, "JAVA_HOME_TOOL", str(tmp_path / "no-such-tool"))
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    assert bootstrap._resolve_java11_home(run_fn=_FakeRun()) is None
+
+
+def test_resolve_perl5lib_finds_local_lib_convention(tmp_path: Path) -> None:
+    perl5 = tmp_path / "perl5" / "lib" / "perl5"
+    perl5.mkdir(parents=True)
+    assert bootstrap._resolve_perl5lib(home=tmp_path) == str(perl5)
+
+
+def test_resolve_perl5lib_none_when_absent(tmp_path: Path) -> None:
+    assert bootstrap._resolve_perl5lib(home=tmp_path) is None
+
+
+def test_build_defects4j_env_none_when_nothing_resolves(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bootstrap, "JAVA_HOME_TOOL", str(tmp_path / "no-such-tool"))
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    result = bootstrap.build_defects4j_env(run_fn=_FakeRun(), perl5_home=tmp_path)
+    assert result is None
+
+
+def test_build_defects4j_env_merges_java_home_and_perl5lib(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bootstrap, "JAVA_HOME_TOOL", str(tmp_path / "no-such-tool"))
+    monkeypatch.setattr(shutil, "which", lambda name: "/opt/homebrew/bin/brew")
+    mac_home = tmp_path / "openjdk@11" / "libexec" / "openjdk.jdk" / "Contents" / "Home"
+    mac_home.mkdir(parents=True)
+    perl5 = tmp_path / "perl5" / "lib" / "perl5"
+    perl5.mkdir(parents=True)
+
+    fake = _FakeRun(returncode=0, stdout=f"{tmp_path / 'openjdk@11'}\n")
+    env = bootstrap.build_defects4j_env(run_fn=fake, perl5_home=tmp_path)
+    assert env["JAVA_HOME"] == str(mac_home)
+    assert env["PATH"].startswith(f"{mac_home}/bin:")
+    assert env["PERL5LIB"] == str(perl5)
+    # A full env copy, not a partial replacement — the subprocess still
+    # inherits everything else (e.g. its own PATH tail).
+    import os
+
+    assert env["PATH"].endswith(os.environ.get("PATH", ""))


### PR DESCRIPTION
## Summary
- Defects4J 3.x requires exactly Java 11 and several CPAN modules (`String::Interpolate`, `JSON::Parse`, `DBD::CSV`, etc. — see its own `cpanfile`); without them every `defects4j` subprocess call fails with an opaque Perl error rather than anything actionable.
- `adapters/bootstrap.py` now resolves both — via `/usr/libexec/java_home -v 11` / `brew --prefix openjdk@11` for Java, and `~/perl5/lib/perl5` (the `cpanm --local-lib` convention) for Perl — into a scoped env dict passed to every `defects4j` subprocess call (`checkout()`/`describe()`/`run_tests()`/`init.sh`).
- Never touches the user's actual `JAVA_HOME`/`PATH`/`PERL5LIB` or shell profile — deliberately ruled out per-conversation, since `~/.zshrc` is shared/version-controlled across machines and already juggles multiple JDKs.
- Falls back to the inherited environment unchanged when nothing resolves (today's behavior, unaffected).

Closes #951
Part of #821

## Test plan
- [x] `python3 -m pytest tests/scripts/test_code_review_benchmark_*.py -q` — 74 passed
- [x] `python3 -m pytest tests/ -q` — 2124 passed, 3 skipped
- [x] Confirmed live end-to-end on a real machine this session: `brew install wget openjdk@11 cpanminus` + `cpanm --local-lib=~/perl5 --installdeps .`, then `cli.py --dataset defects4j --project Lang --sample 1` ran the real checkout → dispatch flow with **zero manual env exports** (previously required exporting `JAVA_HOME`/`PATH`/`PERL5LIB` by hand)
- [x] `scripts/ci-local.sh` (via pre-push hook) — all checks passed