### PR TITLE
feat: resolve JAVA_HOME/PERL5LIB for defects4j subprocess calls

### DIFF
--- a/evals/code-review-benchmark/adapters/bootstrap.py
+++ b/evals/code-review-benchmark/adapters/bootstrap.py
@@ -20,6 +20,8 @@ contract.
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -31,6 +33,60 @@ BUGSJS_REPO_URL = "https://github.com/BugsJS/bug-dataset.git"
 _DEFECTS4J_INIT_MARKER = ".d4j-init-complete"
 
 DEFAULT_RUN_FN = run_with_timeout
+
+
+def _resolve_java11_home(run_fn=DEFAULT_RUN_FN) -> Optional[str]:
+    """Best-effort Java 11 home (#951): `/usr/libexec/java_home -v 11`,
+    falling back to `brew --prefix openjdk@11`. macOS-only (Defects4J's
+    Perl wrapper resolution issue is specific to Homebrew-installed JDKs);
+    `None` on any other platform or when neither probe resolves.
+    """
+    if sys.platform != "darwin":
+        return None
+    for argv in (
+        ["/usr/libexec/java_home", "-v", "11"],
+        ["brew", "--prefix", "openjdk@11"],
+    ):
+        try:
+            proc = run_fn(10, argv, capture_output=True, text=True)
+        except (OSError, ValueError):
+            continue
+        if proc.returncode != 0:
+            continue
+        out = proc.stdout
+        if isinstance(out, bytes):
+            out = out.decode("utf-8", errors="replace")
+        out = (out or "").strip()
+        if out:
+            return out
+    return None
+
+
+def resolve_defects4j_env(
+    base_env: Optional[Dict[str, str]] = None, run_fn=DEFAULT_RUN_FN
+) -> Dict[str, str]:
+    """Merge JAVA_HOME (Java 11) and PERL5LIB resolution into a subprocess env (#951).
+
+    Defects4J's Perl wrapper shells out to `java`/`javac` using whatever's
+    on `PATH`/`JAVA_HOME`, and needs several CPAN modules installed via
+    `cpanm --local-lib=~/perl5`. Resolve both here, scoped to a returned
+    env dict passed to defects4j subprocess calls only — never touches
+    global process state (no `os.environ` mutation), and falls back to
+    the inherited environment unchanged when nothing can be resolved.
+    """
+    env = dict(base_env if base_env is not None else os.environ)
+
+    java_home = _resolve_java11_home(run_fn=run_fn)
+    if java_home:
+        env["JAVA_HOME"] = java_home
+        env["PATH"] = str(Path(java_home) / "bin") + os.pathsep + env.get("PATH", "")
+
+    perl5lib = Path.home() / "perl5" / "lib" / "perl5"
+    if perl5lib.is_dir():
+        existing = env.get("PERL5LIB", "")
+        env["PERL5LIB"] = str(perl5lib) + (os.pathsep + existing if existing else "")
+
+    return env
 
 
 def _clone_if_missing(
@@ -75,7 +131,7 @@ def ensure_defects4j_home(
     init_timeout: int = 1800,
     cache_dir: Path = CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
-    """Return `{"home": str, "bin": str}` for a usable Defects4J install.
+    """Return `{"home": str, "bin": str, "env": dict}` for a usable Defects4J install.
 
     When `explicit_home` is given, returns it unchanged with `bin` set to
     the bare `"defects4j"` command name (today's PATH-based lookup) — no
@@ -87,15 +143,26 @@ def ensure_defects4j_home(
     lookup, since Defects4J needs its project repos bootstrapped under
     *this specific* home directory regardless of any other system-wide
     install.
+
+    `env` (#951) is the JAVA_HOME/PERL5LIB-resolved environment from
+    `resolve_defects4j_env()` — callers should pass it through to every
+    defects4j subprocess call (`checkout`/`describe`/`run_tests`), since
+    Defects4J's Perl wrapper needs a real Java 11 + CPAN deps regardless
+    of whether the home was auto-cloned or explicit.
     """
     if explicit_home:
-        return {"home": explicit_home, "bin": "defects4j"}
+        return {
+            "home": explicit_home,
+            "bin": "defects4j",
+            "env": resolve_defects4j_env(run_fn=run_fn),
+        }
 
     dest = cache_dir / "defects4j"
     if not (dest / "framework" / "projects").is_dir():
         if not _clone_if_missing(DEFECTS4J_REPO_URL, dest, run_fn=run_fn):
             return None
 
+    env = resolve_defects4j_env(run_fn=run_fn)
     bin_path = dest / "framework" / "bin" / "defects4j"
     marker = dest / _DEFECTS4J_INIT_MARKER
     if not marker.is_file():
@@ -106,6 +173,7 @@ def ensure_defects4j_home(
                 cwd=str(dest),
                 capture_output=True,
                 text=True,
+                env=env,
             )
         except (OSError, ValueError):
             return None
@@ -113,4 +181,4 @@ def ensure_defects4j_home(
             return None
         marker.write_text("ok\n", encoding="utf-8")
 
-    return {"home": str(dest), "bin": str(bin_path)}
+    return {"home": str(dest), "bin": str(bin_path), "env": env}

--- a/evals/code-review-benchmark/adapters/defects4j_adapter.py
+++ b/evals/code-review-benchmark/adapters/defects4j_adapter.py
@@ -123,12 +123,16 @@ def checkout(
     defects4j_bin: str = "defects4j",
     run_fn=DEFAULT_RUN_FN,
     timeout: int = 600,
+    env: Optional[Dict[str, str]] = None,
 ) -> bool:
     """`defects4j checkout -p <project> -v <bug_id>b -w <workdir>`.
 
     Returns True on a zero exit code, False on any failure — never raises.
     `defects4j_bin` defaults to the bare command name (PATH lookup); pass
-    an explicit path for an auto-provisioned cache clone.
+    an explicit path for an auto-provisioned cache clone. `env` (#951),
+    when given, is the JAVA_HOME/PERL5LIB-resolved env from
+    `bootstrap.resolve_defects4j_env()`; `None` preserves the inherited
+    environment (subprocess default).
     """
     argv = [
         defects4j_bin,
@@ -141,7 +145,7 @@ def checkout(
         workdir,
     ]
     try:
-        proc = run_fn(timeout, argv, capture_output=True, text=True)
+        proc = run_fn(timeout, argv, capture_output=True, text=True, env=env)
     except (OSError, ValueError):
         return False
     return proc.returncode == 0
@@ -154,6 +158,7 @@ def run_tests(
     run_fn=DEFAULT_RUN_FN,
     compile_timeout: int = 300,
     test_timeout: int = 600,
+    env: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Configure (`defects4j compile`) and run (`defects4j test`) the buggy checkout.
 
@@ -164,7 +169,10 @@ def run_tests(
     is folded into the returned dict, same contract as `checkout()`/
     `describe()` above. `defects4j_bin` defaults to the bare command name
     (PATH lookup); pass an explicit path for an auto-provisioned cache
-    clone.
+    clone. `env` (#951), when given, is the JAVA_HOME/PERL5LIB-resolved
+    env from `bootstrap.resolve_defects4j_env()`, threaded to both the
+    compile and test subprocess calls; `None` preserves the inherited
+    environment (subprocess default).
     """
     try:
         compile_proc = run_fn(
@@ -173,6 +181,7 @@ def run_tests(
             cwd=checkout_dir,
             capture_output=True,
             text=True,
+            env=env,
         )
     except (OSError, ValueError) as exc:
         return {
@@ -191,6 +200,7 @@ def run_tests(
             cwd=checkout_dir,
             capture_output=True,
             text=True,
+            env=env,
         )
     except (OSError, ValueError) as exc:
         return {
@@ -222,11 +232,17 @@ def describe(
     defects4j_bin: str = "defects4j",
     run_fn=DEFAULT_RUN_FN,
     timeout: int = 60,
+    env: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
-    """Best-effort `defects4j info -p <project> -b <bug_id>`. `None` on any failure."""
+    """Best-effort `defects4j info -p <project> -b <bug_id>`. `None` on any failure.
+
+    `env` (#951), when given, is the JAVA_HOME/PERL5LIB-resolved env from
+    `bootstrap.resolve_defects4j_env()`; `None` preserves the inherited
+    environment (subprocess default).
+    """
     argv = [defects4j_bin, "info", "-p", case.project, "-b", case.bug_id]
     try:
-        proc = run_fn(timeout, argv, capture_output=True, text=True)
+        proc = run_fn(timeout, argv, capture_output=True, text=True, env=env)
     except (OSError, ValueError):
         return None
     if proc.returncode != 0:

--- a/evals/code-review-benchmark/adapters/test_bootstrap.py
+++ b/evals/code-review-benchmark/adapters/test_bootstrap.py
@@ -1,0 +1,96 @@
+"""Tests for `resolve_defects4j_env()` (#951).
+
+No real subprocess/macOS dependency — `run_fn` is faked and platform
+checks are monkeypatched, so these run identically on any CI host.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from adapters import bootstrap
+
+
+def _fake_run_fn(returncode: int, stdout: str):
+    def _run(_seconds, _argv, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=_argv, returncode=returncode, stdout=stdout, stderr=""
+        )
+
+    return _run
+
+
+@pytest.fixture
+def no_perl5_home(monkeypatch, tmp_path):
+    """Isolate `Path.home()` from the real machine's `~/perl5` (if any) so
+    Java-only assertions don't depend on whether local::lib is installed."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(bootstrap.Path, "home", classmethod(lambda cls: fake_home))
+    return fake_home
+
+
+def test_resolve_defects4j_env_noop_off_macos(monkeypatch, no_perl5_home):
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    base_env = {"PATH": "/usr/bin"}
+    env = bootstrap.resolve_defects4j_env(
+        base_env=base_env, run_fn=_fake_run_fn(0, "/opt/java11\n")
+    )
+    assert env == base_env
+    assert env is not base_env  # never mutates the caller's dict
+
+
+def test_resolve_defects4j_env_sets_java_home_on_macos(monkeypatch, no_perl5_home):
+    monkeypatch.setattr(bootstrap.sys, "platform", "darwin")
+    base_env = {"PATH": "/usr/bin"}
+    env = bootstrap.resolve_defects4j_env(
+        base_env=base_env, run_fn=_fake_run_fn(0, "/opt/java11\n")
+    )
+    assert env["JAVA_HOME"] == "/opt/java11"
+    assert env["PATH"].startswith(str(Path("/opt/java11") / "bin"))
+    assert env["PATH"].endswith("/usr/bin")
+
+
+def test_resolve_defects4j_env_no_java11_found(monkeypatch, no_perl5_home):
+    monkeypatch.setattr(bootstrap.sys, "platform", "darwin")
+    base_env = {"PATH": "/usr/bin"}
+    env = bootstrap.resolve_defects4j_env(base_env=base_env, run_fn=_fake_run_fn(1, ""))
+    assert "JAVA_HOME" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_resolve_defects4j_env_sets_perl5lib_when_present(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    (fake_home / "perl5" / "lib" / "perl5").mkdir(parents=True)
+    monkeypatch.setattr(bootstrap.Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+
+    env = bootstrap.resolve_defects4j_env(base_env={}, run_fn=_fake_run_fn(1, ""))
+
+    expected = str(fake_home / "perl5" / "lib" / "perl5")
+    assert env["PERL5LIB"] == expected
+
+
+def test_resolve_defects4j_env_preserves_existing_perl5lib(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    (fake_home / "perl5" / "lib" / "perl5").mkdir(parents=True)
+    monkeypatch.setattr(bootstrap.Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+
+    env = bootstrap.resolve_defects4j_env(
+        base_env={"PERL5LIB": "/existing/lib"}, run_fn=_fake_run_fn(1, "")
+    )
+
+    expected_prefix = str(fake_home / "perl5" / "lib" / "perl5")
+    assert env["PERL5LIB"] == f"{expected_prefix}:/existing/lib"
+
+
+def test_resolve_defects4j_env_no_perl5lib_when_absent(monkeypatch, no_perl5_home):
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+
+    env = bootstrap.resolve_defects4j_env(base_env={}, run_fn=_fake_run_fn(1, ""))
+
+    assert "PERL5LIB" not in env

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -54,11 +54,19 @@ def _list_cases(
 
 
 def _make_checkout_fn(
-    dataset: str, case: Any, home: str, defects4j_bin: str = "defects4j"
+    dataset: str,
+    case: Any,
+    home: str,
+    defects4j_bin: str = "defects4j",
+    defects4j_env: Optional[Dict[str, str]] = None,
 ):
     if dataset == "defects4j":
         return lambda workdir: defects4j_adapter.checkout(
-            case, workdir, defects4j_home=home, defects4j_bin=defects4j_bin
+            case,
+            workdir,
+            defects4j_home=home,
+            defects4j_bin=defects4j_bin,
+            env=defects4j_env,
         )
     return lambda workdir: bugsjs_adapter.checkout(case, workdir, bugsjs_home=home)
 
@@ -70,7 +78,11 @@ def _make_ground_truth_fn(dataset: str, case: Any):
 
 
 def _make_test_fn(
-    dataset: str, case: Any, enabled: bool, defects4j_bin: str = "defects4j"
+    dataset: str,
+    case: Any,
+    enabled: bool,
+    defects4j_bin: str = "defects4j",
+    defects4j_env: Optional[Dict[str, str]] = None,
 ) -> Optional[Callable[[str], Dict[str, Any]]]:
     """Build `run_case`'s `test_fn`, or `None` when verification is disabled.
 
@@ -80,7 +92,7 @@ def _make_test_fn(
         return None
     if dataset == "defects4j":
         return lambda checkout_dir: defects4j_adapter.run_tests(
-            case, checkout_dir, defects4j_bin=defects4j_bin
+            case, checkout_dir, defects4j_bin=defects4j_bin, env=defects4j_env
         )
     return lambda checkout_dir: bugsjs_adapter.run_tests(case, checkout_dir)
 
@@ -94,6 +106,7 @@ def run(args: argparse.Namespace) -> int:
         return 0
 
     defects4j_bin = "defects4j"
+    defects4j_env: Optional[Dict[str, str]] = None
     if args.dataset == "defects4j":
         explicit_home = args.defects4j_home or os.environ.get("DEFECTS4J_HOME")
         resolved = bootstrap.ensure_defects4j_home(explicit_home)
@@ -106,6 +119,7 @@ def run(args: argparse.Namespace) -> int:
             return 1
         home = resolved["home"]
         defects4j_bin = resolved["bin"]
+        defects4j_env = resolved.get("env")
     else:
         explicit_home = args.bugsjs_home or os.environ.get("BUGSJS_HOME")
         cloned_home = bootstrap.ensure_bugsjs_home(explicit_home)
@@ -166,10 +180,16 @@ def run(args: argparse.Namespace) -> int:
             executor.submit(
                 runner.run_case,
                 case_dict,
-                checkout_fn=_make_checkout_fn(args.dataset, case, home, defects4j_bin),
+                checkout_fn=_make_checkout_fn(
+                    args.dataset, case, home, defects4j_bin, defects4j_env
+                ),
                 ground_truth_fn=_make_ground_truth_fn(args.dataset, case),
                 test_fn=_make_test_fn(
-                    args.dataset, case, not args.no_verify_tests, defects4j_bin
+                    args.dataset,
+                    case,
+                    not args.no_verify_tests,
+                    defects4j_bin,
+                    defects4j_env,
                 ),
                 dispatch_fn=dispatch_fn,
                 results_dir=results_dir,

--- a/tests/scripts/test_code_review_benchmark_bootstrap.py
+++ b/tests/scripts/test_code_review_benchmark_bootstrap.py
@@ -89,8 +89,12 @@ def test_ensure_defects4j_home_returns_explicit_home_unchanged_without_cloning(
 ) -> None:
     fake = _FakeRun()
     result = bootstrap.ensure_defects4j_home("/some/existing/home", run_fn=fake)
-    assert result == {"home": "/some/existing/home", "bin": "defects4j"}
-    assert fake.calls == []
+    assert result["home"] == "/some/existing/home"
+    assert result["bin"] == "defects4j"
+    assert isinstance(
+        result["env"], dict
+    )  # #951 env resolution, contents machine-dependent
+    assert not any(c["argv"][0] in ("git", "bash") for c in fake.calls)
 
 
 def test_ensure_defects4j_home_clones_and_inits_when_missing(tmp_path: Path) -> None:
@@ -103,17 +107,20 @@ def test_ensure_defects4j_home_clones_and_inits_when_missing(tmp_path: Path) -> 
             (dest / "framework" / "projects").mkdir(parents=True)
             (dest / "framework" / "bin").mkdir(parents=True)
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
-        # `bash init.sh` -> "download" the defects4j binary.
-        assert argv == ["bash", "init.sh"]
-        assert kwargs.get("cwd") == str(dest)
-        (dest / "framework" / "bin" / "defects4j").write_text("#!/bin/sh\n")
-        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
+        if argv[0] == "bash":
+            # `bash init.sh` -> "download" the defects4j binary.
+            assert argv == ["bash", "init.sh"]
+            assert kwargs.get("cwd") == str(dest)
+            (dest / "framework" / "bin" / "defects4j").write_text("#!/bin/sh\n")
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
+        # #951 JAVA_HOME probes (/usr/libexec/java_home, brew) — simulate
+        # "not found" so env resolution no-ops without a real subprocess.
+        return subprocess.CompletedProcess(args=argv, returncode=1, stdout="")
 
     result = bootstrap.ensure_defects4j_home(None, run_fn=run_fn, cache_dir=tmp_path)
-    assert result == {
-        "home": str(dest),
-        "bin": str(dest / "framework" / "bin" / "defects4j"),
-    }
+    assert result["home"] == str(dest)
+    assert result["bin"] == str(dest / "framework" / "bin" / "defects4j")
+    assert isinstance(result["env"], dict)
     assert (dest / ".d4j-init-complete").is_file()
 
 
@@ -128,11 +135,11 @@ def test_ensure_defects4j_home_skips_init_when_marker_already_present(
 
     fake = _FakeRun()
     result = bootstrap.ensure_defects4j_home(None, run_fn=fake, cache_dir=tmp_path)
-    assert result == {
-        "home": str(dest),
-        "bin": str(dest / "framework" / "bin" / "defects4j"),
-    }
-    assert fake.calls == []  # neither clone nor init.sh re-run
+    assert result["home"] == str(dest)
+    assert result["bin"] == str(dest / "framework" / "bin" / "defects4j")
+    assert isinstance(result["env"], dict)
+    # neither clone nor init.sh re-run — only #951's env-resolution probes may fire
+    assert not any(c["argv"][0] in ("git", "bash") for c in fake.calls)
 
 
 def test_ensure_defects4j_home_none_on_clone_failure(tmp_path: Path) -> None:
@@ -165,7 +172,11 @@ def test_ensure_defects4j_home_skips_clone_when_projects_dir_already_exists(
     (dest / "framework" / "bin").mkdir(parents=True)
 
     def run_fn(timeout, argv, **kwargs):
-        assert argv == ["bash", "init.sh"]  # clone must be skipped entirely
+        assert argv[0] != "git"  # clone must be skipped entirely
+        if argv[0] != "bash":
+            # #951 JAVA_HOME probes — simulate "not found."
+            return subprocess.CompletedProcess(args=argv, returncode=1, stdout="")
+        assert argv == ["bash", "init.sh"]
         (dest / "framework" / "bin" / "defects4j").write_text("#!/bin/sh\n")
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
 


### PR DESCRIPTION
## Summary
- `bootstrap.resolve_defects4j_env()` best-effort resolves a Java 11 home (macOS: `/usr/libexec/java_home -v 11`, falling back to `brew --prefix openjdk@11`) and `~/perl5/lib/perl5` (the `cpanm --local-lib` convention), merged into an env dict scoped to defects4j subprocess calls only. No global state touched — falls back to the inherited env unchanged when nothing resolves.
- `ensure_defects4j_home()` now returns `env` alongside `home`/`bin`, for both the explicit-home and auto-clone paths, and threads it into the `init.sh` subprocess call too.
- `defects4j_adapter.checkout()`/`run_tests()`/`describe()` accept an `env` parameter, forwarded to their subprocess calls; `cli.py` wires the resolved env through `_make_checkout_fn`/`_make_test_fn`.
- Updated the pre-existing `tests/scripts/test_code_review_benchmark_bootstrap.py` fakes/assertions to accommodate the new `env` key and the extra probe calls `ensure_defects4j_home` now makes.
- Added `evals/code-review-benchmark/adapters/test_bootstrap.py` covering `resolve_defects4j_env()` directly (off-macOS no-op, Java 11 found/not-found, PERL5LIB set/preserved/absent).

## Test plan
- [x] `python3 -m pytest tests/scripts/test_code_review_benchmark_bootstrap.py evals/code-review-benchmark/adapters/test_bootstrap.py tests/scripts/test_code_review_benchmark_adapters.py -v` — all pass
- [x] Full local CI gate (`scripts/ci-local.sh` via pre-push hook) — passed, 2949 passed / 17 skipped

Closes #951