### PR TITLE
fix: copy_auth_state() must copy ~/.claude/, not just ~/.claude.json

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -66,12 +66,18 @@ errors this was built to avoid).
 - The `claude` CLI available on `PATH` (used headlessly via
   `plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py`'s
   session-isolation approach — see #842), authenticated via `claude login`
-  (a subscription). Each dispatch runs in a fresh, isolated `HOME` (no
-  shared memory/conversation history), but carries your real
-  `~/.claude.json` login state into that sandbox (`copy_auth_state()`,
-  #957) so it doesn't need `ANTHROPIC_API_KEY` — this also means your
-  configured `mcpServers` list rides along into the dispatch, a deliberate
-  tradeoff over stricter isolation.
+  (a subscription). Each dispatch runs in a fresh, isolated `HOME` — but
+  `~/.claude.json` alone isn't enough to keep that dispatch logged in
+  (confirmed empirically), so `copy_auth_state()` (#957) also carries over
+  most of `~/.claude/` itself (settings, `projects/`, `sessions/`,
+  `mcpServers`, `plugins/`) so it doesn't need `ANTHROPIC_API_KEY`. The
+  clearly bulky, clearly-not-auth-related pieces (`history.jsonl`,
+  `file-history/`, `session-env/`, `paste-cache/`, `shell-snapshots/`,
+  `debug/`, `telemetry/`, `downloads/`) are excluded — see
+  `_CLAUDE_DIR_EXCLUDE` in `isolated_dispatch.py` — but this is still a
+  real departure from the "clean isolated HOME" the underlying script was
+  built for; there's no confirmed narrower answer for exactly which single
+  piece under `~/.claude/` gates the login check.
 
 ## Invocation contract (confirmed against the real skill, not assumed)
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3565,7 +3565,7 @@
       "anchor": "isolation-guarantees"
     },
     "Auth vs. isolation (#957)": {
-      "summary": "The fresh `HOME` also wipes `~/.claude.json`, which holds account/",
+      "summary": "The fresh `HOME` also wipes Claude Code's login state, so a dispatch",
       "anchor": "auth-vs-isolation-957"
     },
     "Honest upstream caveat": {

--- a/plugins/dev-team/skills/headless-run/SKILL.md
+++ b/plugins/dev-team/skills/headless-run/SKILL.md
@@ -52,17 +52,24 @@ The helper builds each dispatch to leak as little parent state as possible:
 
 ## Auth vs. isolation (#957)
 
-The fresh `HOME` also wipes `~/.claude.json`, which holds account/
-subscription markers Claude Code checks before its actual (Keychain-backed)
-OAuth token lookup — without it, a dispatch reports "Not logged in" unless
-`ANTHROPIC_API_KEY` is set. Pass `--preserve-auth` to copy that file into
-the cell home first, restoring login for operators who authenticate via
-`claude login` rather than an API key. This is a real tradeoff, not free:
-`~/.claude.json` also carries `mcpServers` and other app state, so
-`--preserve-auth` reintroduces that into the "isolated" dispatch. Off by
-default; the code-review-benchmark harness (`runner.make_isolated_dispatch_fn()`)
-turns it on unconditionally, since running that harness at all presupposes
-the operator's own subscription.
+The fresh `HOME` also wipes Claude Code's login state, so a dispatch
+reports "Not logged in" unless `ANTHROPIC_API_KEY` is set. `~/.claude.json`
+alone does **not** fix this — confirmed empirically, twice — something
+under `~/.claude/` itself gates the login check ahead of Claude Code's
+actual (Keychain-backed) OAuth token lookup. Pass `--preserve-auth` to
+copy `~/.claude.json` and most of `~/.claude/` into the cell home first,
+restoring login for operators who authenticate via `claude login` rather
+than an API key. This is a real tradeoff, not free: it carries over
+`settings.json`, `projects/`, `sessions/`, `mcpServers`, `plugins/`, and
+other app state — `copy_auth_state()`'s `_CLAUDE_DIR_EXCLUDE` skips the
+clearly bulky, clearly-not-auth-related pieces (`history.jsonl`,
+`file-history/`, `session-env/`, `paste-cache/`, `shell-snapshots/`,
+`debug/`, `telemetry/`, `downloads/`), but everything else rides along
+since we don't have a confirmed narrower answer for exactly which piece
+satisfies the login check. Off by default; the code-review-benchmark
+harness (`runner.make_isolated_dispatch_fn()`) turns it on unconditionally,
+since running that harness at all presupposes the operator's own
+subscription.
 
 It improves on the existing precedent in `scripts/run_tdd_experiment.py`
 (`make_cell_home` / `cell_env` / `dispatch`), which does `env = dict(os.environ)`

--- a/plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py
+++ b/plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py
@@ -30,11 +30,14 @@ Stdlib only, Python 3.8+ (ADR 0014 / 0015). uuid/tempfile/subprocess are fine
 in a shipped script — the no-random/no-Date restriction applies only to
 Workflow scripts, not shipped Python.
 
-Auth (#957): the fresh HOME also wipes `~/.claude.json`'s account/
-subscription markers, so a dispatch reports "Not logged in" unless
-`ANTHROPIC_API_KEY` is set. Pass `--preserve-auth` to copy that file into
-the cell home first — see `copy_auth_state()`'s docstring for the tradeoff
-(it also carries over `mcpServers`). Off by default here; the
+Auth (#957): the fresh HOME also wipes Claude Code's login state, so a
+dispatch reports "Not logged in" unless `ANTHROPIC_API_KEY` is set.
+`~/.claude.json` alone is NOT sufficient to fix this (confirmed
+empirically) — something under `~/.claude/` itself gates the login check.
+Pass `--preserve-auth` to copy both into the cell home first (most of
+`~/.claude/`, minus a `_CLAUDE_DIR_EXCLUDE` allowlist-complement of bulky
+conversation/session/telemetry state) — see `copy_auth_state()`'s
+docstring for the full tradeoff. Off by default here; the
 code-review-benchmark harness turns it on unconditionally.
 
 Usage:
@@ -113,29 +116,91 @@ def make_cell_home(root: Optional[Path] = None) -> Path:
     return base
 
 
+# Top-level entries under `~/.claude/` deliberately NOT copied by
+# `copy_auth_state()` — bulky conversation/session/telemetry state that
+# empirically is not needed to satisfy Claude Code's login check (verified
+# live: a dispatch with these excluded still authenticated successfully).
+# Named explicitly, not inferred, so this list stays auditable as the real
+# `~/.claude/` layout evolves.
+_CLAUDE_DIR_EXCLUDE = frozenset(
+    {
+        "history.jsonl",  # full conversation history
+        "file-history",  # per-edit undo history
+        "session-env",  # per-session environment captures (can be thousands of entries)
+        "paste-cache",  # clipboard paste cache
+        "shell-snapshots",  # shell state snapshots
+        "debug",  # debug logs
+        "telemetry",  # usage telemetry
+        "downloads",  # downloaded artifacts
+    }
+)
+
+
+def _make_bulky_state_ignorer(source_root: str):
+    """Build a `shutil.copytree`-compatible `ignore` callback for
+    `copy_auth_state()`, bound to `source_root` via closure (not a shared
+    mutable attribute — `copy_auth_state()` runs concurrently across the
+    benchmark harness's `--workers` thread pool, so shared mutable state
+    here would race).
+
+    Only excludes `_CLAUDE_DIR_EXCLUDE` entries when `root == source_root`
+    (the top level of the copy) — not by name against every nested
+    directory the walk visits, since a plugin could legitimately have its
+    own `cache/`-or-similar-named subdir that must NOT be excluded just
+    because the name matches.
+    """
+
+    def _ignore(root: str, names: List[str]) -> List[str]:
+        if root != source_root:
+            return []
+        return [n for n in names if n in _CLAUDE_DIR_EXCLUDE]
+
+    return _ignore
+
+
 def copy_auth_state(home: Path, source_home: Optional[Path] = None) -> bool:
-    """Copy `<source_home or Path.home()>/.claude.json` into the fresh cell
+    """Copy `~/.claude.json` + (most of) `~/.claude/` into the fresh cell
     home so the dispatch keeps its Claude Code OAuth login (#957).
 
-    A fresh `HOME` wipes out this file, which holds account/subscription
-    markers (`userID`, `hasAvailableSubscription`, etc.) Claude Code checks
-    before its actual (Keychain-backed, `HOME`-independent) token lookup —
-    without it, every dispatch reports "Not logged in" unless
-    `ANTHROPIC_API_KEY` is set. Best-effort: returns `False` (never raises)
-    if the source file doesn't exist.
+    A fresh `HOME` wipes out both, and — confirmed empirically, twice —
+    `~/.claude.json` alone (even including its `oauthAccount` key) is NOT
+    sufficient to restore login; something else under `~/.claude/` itself
+    gates Claude Code's login check ahead of its actual (Keychain-backed,
+    `HOME`-independent) token lookup. Copying the whole `.claude/` tree
+    does restore it. `_CLAUDE_DIR_EXCLUDE` skips the clearly bulky,
+    clearly-not-auth-related pieces (conversation history, per-session
+    captures, telemetry, debug logs) to keep the isolation tradeoff as
+    small as it can be while still working — everything else (`settings
+    .json`, `projects/`, `sessions/`, `plugins/`, `skills/`, etc.) is
+    copied, since we don't have a confirmed narrower answer for which of
+    those specifically satisfies the login check.
 
-    Deliberately copies the whole file, not a filtered subset — it also
-    carries over `mcpServers` and other app state into the dispatch. That
-    trades a bit of the tool-surface isolation this script exists for
-    (#842) for actually working when the operator authenticates via
-    `claude login` rather than an API key. Opt-in here via `--preserve-auth`
-    (other callers keep today's stricter default); the code-review
-    benchmark harness turns it on unconditionally (see `runner.py`).
+    Best-effort: returns `False` (never raises) if neither source exists.
+    Broken/dangling symlinks under `.claude/` (e.g. stale plugin
+    marketplace paths) are copied as links, not followed/failed on.
+
+    Opt-in here via `--preserve-auth` (other callers keep today's
+    stricter default); the code-review benchmark harness turns it on
+    unconditionally (see `runner.py`).
     """
-    source = (source_home or Path.home()) / ".claude.json"
-    if not source.is_file():
+    source_home = source_home or Path.home()
+    source_claude_json = source_home / ".claude.json"
+    source_claude_dir = source_home / ".claude"
+    if not source_claude_json.is_file() and not source_claude_dir.is_dir():
         return False
-    shutil.copy(source, Path(home) / ".claude.json")
+
+    if source_claude_json.is_file():
+        shutil.copy(source_claude_json, Path(home) / ".claude.json")
+
+    if source_claude_dir.is_dir():
+        shutil.copytree(
+            source_claude_dir,
+            Path(home) / ".claude",
+            symlinks=True,
+            ignore_dangling_symlinks=True,
+            ignore=_make_bulky_state_ignorer(str(source_claude_dir)),
+            dirs_exist_ok=True,
+        )
     return True
 
 

--- a/tests/skills/test_isolated_dispatch.py
+++ b/tests/skills/test_isolated_dispatch.py
@@ -134,6 +134,91 @@ def test_copy_auth_state_false_when_source_missing(tmp_path):
     assert not (cell_home / ".claude.json").exists()
 
 
+def test_copy_auth_state_copies_claude_dir_excluding_bulky_state(tmp_path):
+    """#957 correction: ~/.claude.json alone doesn't restore login —
+    confirmed empirically. Most of ~/.claude/ must come along too, minus
+    the clearly bulky, clearly-not-auth-related entries."""
+    mod = _load()
+    source_home = tmp_path / "real-home"
+    claude_dir = source_home / ".claude"
+    claude_dir.mkdir(parents=True)
+    (source_home / ".claude.json").write_text("{}", encoding="utf-8")
+
+    # A kept entry (settings, plugins) alongside every excluded one.
+    (claude_dir / "settings.json").write_text("{}", encoding="utf-8")
+    (claude_dir / "history.jsonl").write_text("conversation history\n")
+    for excluded_dir in (
+        "file-history",
+        "session-env",
+        "paste-cache",
+        "shell-snapshots",
+        "debug",
+        "telemetry",
+        "downloads",
+    ):
+        (claude_dir / excluded_dir).mkdir()
+        (claude_dir / excluded_dir / "some-file").write_text("stub")
+
+    cell_home = tmp_path / "cell-home"
+    cell_home.mkdir()
+    (cell_home / ".claude").mkdir()
+
+    assert mod.copy_auth_state(cell_home, source_home=source_home) is True
+
+    copied_claude = cell_home / ".claude"
+    assert (copied_claude / "settings.json").is_file()
+    assert not (copied_claude / "history.jsonl").exists()
+    for excluded_dir in (
+        "file-history",
+        "session-env",
+        "paste-cache",
+        "shell-snapshots",
+        "debug",
+        "telemetry",
+        "downloads",
+    ):
+        assert not (copied_claude / excluded_dir).exists(), excluded_dir
+
+
+def test_copy_auth_state_does_not_exclude_same_named_nested_dirs(tmp_path):
+    """The exclude list is scoped to the TOP level of ~/.claude/ only —
+    a plugin's own nested `debug/`-or-similar-named subdir must survive."""
+    mod = _load()
+    source_home = tmp_path / "real-home"
+    claude_dir = source_home / ".claude"
+    (claude_dir / "plugins" / "some-plugin" / "debug").mkdir(parents=True)
+    (claude_dir / "plugins" / "some-plugin" / "debug" / "keep-me").write_text("stub")
+    (source_home / ".claude.json").write_text("{}", encoding="utf-8")
+
+    cell_home = tmp_path / "cell-home"
+    cell_home.mkdir()
+    (cell_home / ".claude").mkdir()
+
+    assert mod.copy_auth_state(cell_home, source_home=source_home) is True
+    nested = cell_home / ".claude" / "plugins" / "some-plugin" / "debug" / "keep-me"
+    assert nested.is_file()
+
+
+def test_copy_auth_state_handles_dangling_symlinks(tmp_path):
+    """A stale plugin-marketplace symlink under ~/.claude/ must not crash
+    the copy — copied as a (broken) link, not followed/failed on."""
+    mod = _load()
+    source_home = tmp_path / "real-home"
+    claude_dir = source_home / ".claude"
+    claude_dir.mkdir(parents=True)
+    (source_home / ".claude.json").write_text("{}", encoding="utf-8")
+    dangling = claude_dir / "broken-link"
+    dangling.symlink_to(source_home / "does-not-exist")
+
+    cell_home = tmp_path / "cell-home"
+    cell_home.mkdir()
+    (cell_home / ".claude").mkdir()
+
+    assert mod.copy_auth_state(cell_home, source_home=source_home) is True
+    copied_link = cell_home / ".claude" / "broken-link"
+    assert copied_link.is_symlink()
+
+
 def test_main_preserve_auth_flag_defaults_off(monkeypatch, tmp_path):
     mod = _load()
     captured = {}


### PR DESCRIPTION
## Summary

PR #958's `copy_auth_state()` only copied `~/.claude.json` into the fresh cell home, which does **not** actually restore Claude Code's OAuth login into an isolated dispatch — confirmed empirically, twice, that the dispatch still reports `"Not logged in"` with just that file present.

Confirmed live this session (with operator help running diagnostics in their own terminal, since the auto-mode safety classifier correctly blocks me from repeatedly re-testing real `claude -p` auth flows myself): copying the **whole `~/.claude/` directory tree** (plus `~/.claude.json`) does restore login. Something under `~/.claude/` itself gates Claude Code's login check ahead of its actual Keychain-backed token lookup — exactly which single file wasn't isolated further (would need more live-test rounds), so `copy_auth_state()` now copies most of `~/.claude/`, minus a named `_CLAUDE_DIR_EXCLUDE` allowlist-complement of clearly bulky, clearly-not-auth-related state:

- `history.jsonl` (full conversation history)
- `file-history/`, `session-env/`, `paste-cache/`, `shell-snapshots/`, `debug/`, `telemetry/`, `downloads/`

This keeps the isolation tradeoff as small as it can be while still working, but it's a bigger departure from "clean isolated HOME" than originally scoped (`settings.json`, `projects/`, `sessions/`, `mcpServers`, `plugins/` all ride along) — operator explicitly confirmed accepting this scope over spending more rounds narrowing it further.

The `copytree` `ignore` callback is scoped to the top level of the source `.claude/` dir via **closure**, not a shared mutable attribute — this runs concurrently across the benchmark harness's `--workers` thread pool, so shared mutable state would race. A plugin's own same-named nested subdir (e.g. `plugins/x/debug/`) is correctly NOT excluded. Dangling symlinks (stale plugin marketplace paths — hit this in testing) are copied as links, not followed/failed on.

Closes #957
Part of #821

## Test plan
- [x] `python3 -m pytest tests/skills/test_isolated_dispatch.py tests/skills/test_headless_run_skill.py -q` — 22 passed, including new coverage for: full-dir copy + exclusion, same-named-nested-dir non-exclusion, dangling symlink handling
- [x] `python3 -m pytest tests/ -q` — 2133 passed, 3 skipped
- [x] `scripts/ci-local.sh` (via pre-push hook) — all checks passed
- [x] **Operator-verified live**: ran the corrected `copy_auth_state()` logic pattern (full `.claude/` copy incl. dangling-symlink fix) against a real fresh `$HOME` + real `claude -p "say hi"` dispatch — returned `is_error: false`, `"result": "Hi!"`