### PR TITLE
fix: extract JSON from a preamble+fence /code-review dispatch response

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -107,8 +107,16 @@ stdout and nothing else:
 `plugins/dev-team/skills/code-review/SKILL.md` / `output-format.md`). When
 run headlessly via `claude -p ... --output-format json`, this payload is
 the model's final text, nested in the wrapper JSON's `result` field —
-`runner.make_isolated_dispatch_fn()` extracts it (stripping a markdown code
-fence if the model added one).
+`runner._extract_review_json()` extracts it. In practice the model often
+narrates before the fence despite the contract (e.g. "Emitting the
+required aggregated JSON per contract:\n\n```json\n{...}"), confirmed live
+in a real sweep where this cost 40% recall (#963) — the extractor
+searches for a fenced```json block anywhere in the text (last one first,
+falling back to earlier ones) rather than requiring the whole response to
+be just the fence. If the model's final text has no JSON at all (not just
+a formatting quirk — the payload was never actually emitted in that
+turn), that's unrecoverable and still shows up as "unparseable --json
+output".
 
 ## Usage
 

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -29,22 +29,33 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 import scorer
 
-_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(.*)\n```\s*$", re.DOTALL)
+_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
 
 
 def _extract_review_json(result_text: Optional[str]) -> Optional[Dict[str, Any]]:
     """Parse `/code-review --json`'s payload out of a dispatch's final text.
 
-    Handles the payload being wrapped in a markdown code fence (models
-    sometimes do this even when told to emit JSON only) before parsing.
-    Returns None on any failure — the caller logs a skip, never raises.
+    `/code-review --json` is contractually supposed to print the payload
+    and nothing else, but models sometimes narrate first, e.g. "Emitting
+    the required aggregated JSON per contract:\n\n```json\n{...}" (#963,
+    confirmed live — 40% of an early real sweep was lost to exactly this).
+    `_FENCE_RE` therefore searches for a fenced block ANYWHERE in the text
+    rather than anchoring to the whole string, and tries the LAST fenced
+    block first — if a model emits more than one (an inline example ahead
+    of the real payload, say), the final one is the more likely candidate
+    — falling back to earlier fences, then to parsing the raw text
+    directly if no fence exists at all. Returns `None` on total failure —
+    the caller logs a skip, never raises.
     """
     if not result_text:
         return None
     text = result_text.strip()
-    fence_match = _FENCE_RE.match(text)
-    if fence_match:
-        text = fence_match.group(1).strip()
+    fence_matches = list(_FENCE_RE.finditer(text))
+    for match in reversed(fence_matches):
+        try:
+            return json.loads(match.group(1).strip())
+        except (json.JSONDecodeError, ValueError):
+            continue
     try:
         return json.loads(text)
     except (json.JSONDecodeError, ValueError):

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -272,6 +272,45 @@ def test_extract_review_json_none_on_garbage() -> None:
     assert runner._extract_review_json(None) is None
 
 
+def test_extract_review_json_handles_preamble_before_fence() -> None:
+    """#963: models sometimes narrate before the JSON fence, violating
+    the --json contract but not actually losing the payload."""
+    narrated = (
+        "Emitting the required aggregated JSON per contract "
+        "(no file writes, stdout only):\n\n"
+        "```json\n" + json.dumps(_REVIEW_JSON) + "\n```"
+    )
+    assert runner._extract_review_json(narrated) == _REVIEW_JSON
+
+
+def test_extract_review_json_prefers_last_fence_when_multiple() -> None:
+    """If a model emits more than one fenced block, the LAST one is the
+    more likely candidate for the real payload."""
+    other_json = {"overall": "pass", "agents": []}
+    text = (
+        "Here's an example of the shape:\n\n"
+        "```json\n" + json.dumps(other_json) + "\n```\n\n"
+        "Emitting the real result:\n\n"
+        "```json\n" + json.dumps(_REVIEW_JSON) + "\n```"
+    )
+    assert runner._extract_review_json(text) == _REVIEW_JSON
+
+
+def test_extract_review_json_falls_back_to_earlier_fence_if_last_invalid() -> None:
+    """A trailing fence that isn't valid JSON must not shadow an earlier
+    valid one."""
+    text = (
+        "```json\n" + json.dumps(_REVIEW_JSON) + "\n```\n\n"
+        "(note: the above is the final answer)\n\n"
+        "```\nnot actually json\n```"
+    )
+    assert runner._extract_review_json(text) == _REVIEW_JSON
+
+
+def test_extract_review_json_no_fence_parses_raw_json() -> None:
+    assert runner._extract_review_json(json.dumps(_REVIEW_JSON)) == _REVIEW_JSON
+
+
 def test_make_isolated_dispatch_fn_carries_over_auth_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

A live 20-case sweep (10 Defects4J/Lang + 10 BugsJS/Express, run with the operator's help after #950/#955/#960 landed) surfaced a real parsing gap: **8/20 (40%) cases were skipped as "unparseable --json output"** even though the dispatch actually returned valid JSON.

Root cause: the model consistently narrates before emitting the JSON, e.g.:
> *"Emitting the required aggregated JSON per contract (no file writes, stdout only):\n\n```json\n{...}"*

This violates `/code-review --json`'s own contract ("prints one aggregated JSON object to stdout and nothing else"), but harmlessly — the JSON itself is still there, just preceded by a sentence. `runner._extract_review_json()`'s `_FENCE_RE` was anchored to the whole string (`^```...```$`), so any leading sentence broke the match entirely.

## Fix

`_FENCE_RE` now searches for a fenced ` ```json ` block anywhere in the text (not anchored), trying the **last** fenced block first (the more likely candidate if a model emits more than one — e.g. an inline example ahead of the real payload), falling back to earlier fences, then to a direct `json.loads()` of the raw text if no fence exists at all.

**Verified against the actual raw dispatch outputs from the live sweep**: 5 of 6 previously-"unparseable" cases with real content now parse correctly. The 6th (`defects4j-Lang-7`) has **no JSON anywhere** in its final text at all — the model claimed compliance ("Aggregated JSON emitted to stdout per `--json` contract...") without actually emitting the payload in that turn. That's a genuinely different, unrecoverable case (a `/code-review` skill/model behavior gap, not a formatting quirk) — out of scope for this fix, noted for future investigation.

Closes #963
Part of #821

## Test plan
- [x] `python3 -m pytest tests/scripts/test_code_review_benchmark_runner.py -q` — 17 passed, including 4 new tests: preamble+fence, multiple fences (last wins), fallback to earlier fence if last is invalid, no-fence raw JSON
- [x] `python3 -m pytest tests/ -q` — 2137 passed, 3 skipped
- [x] Re-parsed all 6 raw dispatch files from the actual live sweep that were skipped as "unparseable" — 5/6 now recover the real JSON payload
- [x] `scripts/ci-local.sh` (via pre-push hook) — all checks passed