### PR TITLE
fix: skip benchmark cases whose ground truth touches no recognized source files

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -164,7 +164,13 @@ python3 cli.py --report-only
   hit, ground_truth_hunks, findings, unmatched_findings, raw_output_path,
   test_verification}`.
 - `skipped.jsonl` — one record per bug that couldn't be checked out or
-  scored: `{dataset, project, bug_id, reason}`.
+  scored: `{dataset, project, bug_id, reason}`. `reason` is one of:
+  `checkout failed`, `no ground-truth hunks`, `unparseable --json output`, or
+  `ground truth touches no recognized source files` (the fix's own commit
+  bundled with its tests touched nothing but a changelog/manifest/CI-config
+  file — e.g. `History.md`, `package.json`, `.travis.yml` — so there was no
+  source change for `/code-review` to have found; scored as a skip, not a
+  recall miss).
 - `raw/<dataset>-<project>-<bug_id>.txt` — the dispatch's raw stdout,
   verbatim, saved before any parsing (so a parser bug never loses data).
 - `report.md` — overall/per-dataset/per-project recall, a **Missed Defects**

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -31,6 +31,46 @@ import scorer
 
 _FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
 
+# Recognized source-file extensions per dataset language (#965). A language
+# absent from this mapping is treated as "unknown" — see
+# `_touches_recognized_source()` for why that means "don't skip."
+_SOURCE_EXTENSIONS: Dict[str, tuple] = {
+    "java": (".java",),
+    "javascript": (".js", ".jsx", ".mjs", ".cjs"),
+}
+
+
+def _touches_recognized_source(files: List[str], language: str) -> bool:
+    """True unless `language` has a recognized-extension mapping and none of
+    `files` match it.
+
+    An unmapped `language` returns True (safe default) so a future adapter
+    for a language not yet in `_SOURCE_EXTENSIONS` never has all its cases
+    silently skipped by this check.
+    """
+    extensions = _SOURCE_EXTENSIONS.get(language)
+    if not extensions:
+        return True
+    return any(f.endswith(extensions) for f in files)
+
+
+def _resolve_ground_truth_hunks(
+    case: Dict[str, Any],
+    checkout_dir: str,
+    ground_truth_fn: Optional[Callable[[str], List[Any]]],
+) -> List[Dict[str, Any]]:
+    """The case's own `ground_truth_hunks`, or `ground_truth_fn(checkout_dir)`'s
+    when the case doesn't carry them inline (e.g. BugsJS, whose ground truth
+    requires the post-checkout git history). Returns `[]` (never `None`) when
+    neither source has hunks — same "empty means skip" contract as before."""
+    ground_truth_hunks = list(case.get("ground_truth_hunks") or [])
+    if not ground_truth_hunks and ground_truth_fn is not None:
+        hunks = ground_truth_fn(checkout_dir)
+        ground_truth_hunks = [
+            h.to_dict() if hasattr(h, "to_dict") else h for h in hunks
+        ]
+    return ground_truth_hunks
+
 
 def _extract_review_json(result_text: Optional[str]) -> Optional[Dict[str, Any]]:
     """Parse `/code-review --json`'s payload out of a dispatch's final text.
@@ -141,16 +181,16 @@ def run_case(
         if not checkout_fn(checkout_dir):
             return skip_record(case, "checkout failed")
 
-        ground_truth_hunks = list(case.get("ground_truth_hunks") or [])
-        if not ground_truth_hunks and ground_truth_fn is not None:
-            hunks = ground_truth_fn(checkout_dir)
-            ground_truth_hunks = [
-                h.to_dict() if hasattr(h, "to_dict") else h for h in hunks
-            ]
+        ground_truth_hunks = _resolve_ground_truth_hunks(
+            case, checkout_dir, ground_truth_fn
+        )
         if not ground_truth_hunks:
             return skip_record(case, "no ground-truth hunks")
 
         ground_truth_files = sorted({h["file"] for h in ground_truth_hunks})
+
+        if not _touches_recognized_source(ground_truth_files, case.get("language", "")):
+            return skip_record(case, "ground truth touches no recognized source files")
 
         test_verification: Optional[Dict[str, Any]] = None
         if test_fn is not None:

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -144,6 +144,114 @@ def test_run_case_uses_ground_truth_fn_when_case_has_none(tmp_path: Path) -> Non
     assert record["hit"] is True
 
 
+@pytest.mark.parametrize(
+    "language,files",
+    [
+        pytest.param(
+            "javascript",
+            ["History.md", "package.json"],
+            id="javascript-changelog-and-manifest",
+        ),
+        pytest.param(
+            "java", ["pom.xml", "CHANGES.md"], id="java-build-file-and-changelog"
+        ),
+    ],
+)
+def test_run_case_non_source_ground_truth_is_skipped(
+    tmp_path: Path, language: str, files: List[str]
+) -> None:
+    """#965: ground truth touching only non-source files (a changelog entry
+    and a package.json/pom.xml, say) must not be scored as a recall miss —
+    for every recognized language, not just one."""
+    case = dict(
+        _CASE,
+        language=language,
+        ground_truth_hunks=[{"file": f, "start_line": 1, "end_line": 1} for f in files],
+        ground_truth_files=files,
+    )
+    dispatched = []
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        dispatched.append(prompt)
+        return _dispatch_result()
+
+    record = runner.run_case(
+        case,
+        checkout_fn=lambda workdir: True,
+        dispatch_fn=dispatch_fn,
+        results_dir=tmp_path,
+    )
+    assert record["skipped"] is True
+    assert record["reason"] == "ground truth touches no recognized source files"
+    assert dispatched == []
+
+
+@pytest.mark.parametrize(
+    "language,files",
+    [
+        pytest.param(
+            "javascript",
+            ["History.md", "lib/foo.js"],
+            id="mixed-source-and-nonsource",
+        ),
+        pytest.param(
+            "javascript",
+            ["History.md", "lib/foo.jsx"],
+            id="non-js-recognized-extension",
+        ),
+        pytest.param("ruby", ["main.rb"], id="unmapped-language-safe-default"),
+    ],
+)
+def test_run_case_is_scored_when_source_is_touched_or_language_unmapped(
+    tmp_path: Path, language: str, files: List[str]
+) -> None:
+    """Must NOT skip: a non-source file alongside a real source file (only
+    ZERO recognized extensions triggers the skip), a non-`.js` recognized
+    javascript extension (#965 AC: `.jsx`/`.mjs`/`.cjs` are wired in, not
+    just declared), and an unmapped language (safe default so a future
+    adapter's cases aren't silently lost to this check)."""
+    case = dict(
+        _CASE,
+        language=language,
+        ground_truth_hunks=[{"file": f, "start_line": 1, "end_line": 1} for f in files],
+        ground_truth_files=files,
+    )
+    dispatched = []
+
+    def checkout_fn(workdir: str) -> bool:
+        _seed_checkout(workdir, files)
+        return True
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        dispatched.append(prompt)
+        return _dispatch_result()
+
+    record = runner.run_case(
+        case,
+        checkout_fn=checkout_fn,
+        dispatch_fn=dispatch_fn,
+        results_dir=tmp_path,
+    )
+    assert record["skipped"] is False
+    assert len(dispatched) == 1
+
+
+def test_touches_recognized_source_boundary_cases() -> None:
+    """Direct unit coverage of `_touches_recognized_source()`'s own boundary
+    matrix — the `run_case`-level tests above prove the check is actually
+    wired into the skip/dispatch decision, not that every extension/language
+    combination is correct; that's this test's job."""
+    assert runner._touches_recognized_source(["main.rb"], "ruby") is True
+    assert runner._touches_recognized_source([], "") is True
+    assert runner._touches_recognized_source(["History.md"], "javascript") is False
+    assert (
+        runner._touches_recognized_source(["History.md", "lib/foo.js"], "javascript")
+        is True
+    )
+    assert runner._touches_recognized_source(["src/Foo.java"], "java") is True
+    assert runner._touches_recognized_source(["pom.xml"], "java") is False
+
+
 def test_run_case_unparseable_json_is_skipped(tmp_path: Path) -> None:
     def checkout_fn(workdir: str) -> bool:
         _seed_checkout(workdir, ["src/Foo.java"])


### PR DESCRIPTION
## Summary
- `run_case()` now skips-and-logs a benchmark case (instead of scoring it as a recall miss) when its ground-truth files touch zero recognized source extensions for the case's language.
- Fixes 3 BugsJS false "missed defects" from the live 20-case sweep (Express bugs 11, 9, 17) whose ground truth is entirely a changelog entry, a `package.json` bump, or a `.travis.yml` tweak — `/code-review` correctly found nothing to review there.
- Extracted `_resolve_ground_truth_hunks()` and parametrized 5 near-duplicate regression tests into 2, per code-review's token-efficiency/test-smell findings.

## Quality Gate
- [x] Tests: 508 passed, 3 skipped (`pytest tests/scripts/`)
- [x] Type check: not applicable (no type-checked Python config in this repo)
- [x] Lint: clean (`scripts/ci-local.sh` — 18/18 checks passed)
- [x] Code review: 11-agent panel, 9 pass / 2 warn — both actionable warnings fixed (helper extraction + test parametrization)

## Decisions & Assumptions
- Recognized-extension mapping is `{java: .java, javascript: .js/.jsx/.mjs/.cjs}` — the only two languages this harness currently supports; an unmapped language safely defaults to "don't skip" so a future adapter isn't silently lost to this check (see plan `## Risks & Open Questions`).
- Broader BugsJS-corpus sampling ("is this common more broadly?") was explicitly out of scope — issue #965 lists it as an optional investigation, not an acceptance criterion; the fix is dataset-agnostic (keys off `language`, not per-project heuristics).
- Live end-to-end verification against a real BugsJS/Defects4J checkout wasn't run — no dataset provisioned in this session; behavior is fully exercised through `run_case()` via dependency-injected fakes instead (see `metrics/verify-log.jsonl`).

## Test Plan
- [x] `pytest tests/scripts/test_code_review_benchmark_runner.py` — new parametrized tests cover: all-non-source ground truth (java + javascript), mixed source+non-source, a non-`.js` recognized extension (`.jsx`), and an unmapped language, plus a direct boundary-matrix unit test on `_touches_recognized_source()`.
- [ ] A fresh benchmark sweep re-run against the live BugsJS dataset confirms Express bugs 11/9/17 now land in `skipped.jsonl` with reason `"ground truth touches no recognized source files"` instead of `results.jsonl` as a miss (deferred — no dataset provisioned in this session).

## Evidence Bundle
**Checks run**
- `pytest tests/scripts/` — 508 passed, 3 skipped
- `/code-review` (11 agents: correctness, test, test-smell, structure, naming, complexity, performance, security, doc, arch, token-efficiency) — 9 pass, 2 warn → both fixed
- `scripts/ci-local.sh` (pre-push, 18 checks) — all passed, including the 2977-test plugin hook/script suite

**Scope notes**
- a11y-review, svelte-review, component-architecture-review skipped — no matching files in this diff (Python-only change)

**Untested regions**
- not measured — no coverage tool configured for `evals/code-review-benchmark/`

**Residual risks**
- None identified — no escalations, no non-interactive gate bypasses, no unresolved `/verify` failures.

Closes #965
Part of #970