### PR TITLE
feat: correctness-review recall gaps on trailing-decimal validation and missing guard clauses

### DIFF
--- a/evals/expected/cr-extra-validation-clause.json
+++ b/evals/expected/cr-extra-validation-clause.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-extra-validation-clause",
+  "description": "Regression fixture for #966/Defects4J Lang-36: a validation condition has an extra boolean clause (`&& lastChar != '.'`) that directly contradicts the function's own docstring, silently accepting an invalid trailing decimal point. Also carries a decoy defect (allZeros() called with decPart dropped) to prove detection of the target isn't incidental to finding something else in the file.",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 4 },
+      "severities": { "error": { "min": 2, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["lastChar"]
+    }
+  }
+}

--- a/evals/expected/cr-missing-degenerate-guard.json
+++ b/evals/expected/cr-missing-degenerate-guard.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "cr-missing-degenerate-guard",
+  "description": "Regression fixture for #966/Defects4J Lang-44: a parsing function's docstring requires rejecting a degenerate single-character non-digit input before parsing, but no guard clause enforces it at the top of the function. Also carries a decoy defect (exponentPosition() double-counts indexOf('e')+indexOf('E')) to prove detection of the target isn't incidental to finding something else in the file.",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 4 },
+      "severities": { "error": { "min": 2, "max": 4 } },
+      "minConfidenceAnyOf": ["high", "medium"],
+      "mustMention": ["parse"]
+    }
+  }
+}

--- a/evals/expected/cr-present-degenerate-guard.json
+++ b/evals/expected/cr-present-degenerate-guard.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "cr-present-degenerate-guard",
+  "description": "True-negative counterpart to cr-missing-degenerate-guard (#966): the same 'parsing function with a docstring requiring a degenerate single-character guard' surface shape, but the guard is actually present at function entry. Guards against the #966 checklist sharpening over-firing when the guard already exists.",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 2 }
+    }
+  }
+}

--- a/evals/expected/cr-sanctioned-extra-clause.json
+++ b/evals/expected/cr-sanctioned-extra-clause.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "cr-sanctioned-extra-clause",
+  "description": "True-negative counterpart to cr-extra-validation-clause (#966): the same 'extra boolean clause on a trailing-char check' surface shape, but the extra clause is explicitly sanctioned by its own docstring (gated behind an `allowTrailingDot` parameter). Guards against the #966 checklist sharpening over-firing on legitimate, correctly-guarded extra clauses.",
+  "applicableAgents": ["correctness-review"],
+  "agents": {
+    "correctness-review": {
+      "expectedStatus": "pass",
+      "issueCount": { "min": 0, "max": 2 }
+    }
+  }
+}

--- a/evals/fixtures/cr-extra-validation-clause.java
+++ b/evals/fixtures/cr-extra-validation-clause.java
@@ -1,0 +1,49 @@
+/**
+ * Numeric-literal helpers for a lightweight number parser.
+ */
+public final class NumberValidator {
+
+    /**
+     * True when every character in `digits` is the zero digit '0' — used to
+     * detect a value that is numerically zero regardless of its decimal or
+     * exponent parts (e.g. "0", "0.0", "0.00e0" are all "all zeros").
+     * Callers must pass BOTH the integer part and the decimal part
+     * concatenated, since a value like "0.5" is not all zeros even though
+     * its integer part is.
+     */
+    private static boolean isAllZeros(String intPart, String decPart) {
+        String digits = intPart + decPart;
+        for (int i = 0; i < digits.length(); i++) {
+            if (digits.charAt(i) != '0') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isEffectivelyZero(String intPart, String decPart) {
+        // BUG (decoy -- a different, real defect): isAllZeros() is documented
+        // as requiring BOTH intPart and decPart, but decPart is silently
+        // dropped here (an empty string is passed instead), so "0.5" is
+        // wrongly reported as zero.
+        return isAllZeros(intPart, "");
+    }
+
+    /**
+     * Checks whether the trailing character of a numeric literal is
+     * acceptable. A trailing decimal point (e.g. "123.") is never a valid
+     * ending for a numeric literal -- only a trailing digit is acceptable.
+     */
+    public static boolean hasValidTrailingChar(char[] chars) {
+        char lastChar = chars[chars.length - 1];
+        // BUG (target -- Defects4J Lang-36 shape): the docstring above states a
+        // trailing decimal point is NEVER acceptable, but this condition
+        // adds `&& lastChar != '.'`, which *exempts* a trailing '.' from
+        // rejection -- directly contradicting the stated rule and letting
+        // a value like "123." pass validation.
+        if (!Character.isDigit(lastChar) && lastChar != '.') {
+            return false;
+        }
+        return true;
+    }
+}

--- a/evals/fixtures/cr-missing-degenerate-guard.java
+++ b/evals/fixtures/cr-missing-degenerate-guard.java
@@ -1,0 +1,35 @@
+/**
+ * Parses a numeric literal into its internal representation.
+ */
+public final class DegenerateInputParser {
+
+    /**
+     * Locates the position immediately after the exponent marker ('e' or
+     * 'E') in `val`, or -1 if there is no exponent marker. Exactly one of
+     * 'e'/'E' can be present in a valid literal, never both.
+     */
+    private static int exponentPosition(String val) {
+        // BUG (decoy -- a different, real defect): when only one of 'e'/'E'
+        // is present, indexOf() returns -1 for the other, so this sum
+        // double-counts and returns the wrong position (e.g. "1e5" with no
+        // 'E' present computes indexOf('e')(=1) + indexOf('E')(=-1) + 1 = 1,
+        // silently pointing one character before the actual exponent digit).
+        return val.indexOf('e') + val.indexOf('E') + 1;
+    }
+
+    /**
+     * Parses a numeric literal into a double. A single-character input that
+     * is not a digit (e.g. "e", "-", ".") is degenerate and must be
+     * rejected before any further parsing is attempted -- there is no valid
+     * one-character non-digit number.
+     */
+    public static double parse(String val) {
+        // BUG (target -- Defects4J Lang-44 shape): the docstring above requires
+        // rejecting a single-character, non-digit input before parsing
+        // proceeds, but no such guard exists here -- a value like "e" or
+        // "." falls straight through to Double.parseDouble, which throws a
+        // raw, uncontrolled NumberFormatException instead of the documented
+        // rejection.
+        return Double.parseDouble(val);
+    }
+}

--- a/evals/fixtures/cr-present-degenerate-guard.java
+++ b/evals/fixtures/cr-present-degenerate-guard.java
@@ -1,0 +1,21 @@
+/**
+ * Parses a numeric literal into its internal representation.
+ */
+public final class DegenerateInputParser {
+
+    /**
+     * Parses a numeric literal into a double. A single-character input that
+     * is not a digit (e.g. "e", "-", ".") is degenerate and must be
+     * rejected before any further parsing is attempted -- there is no valid
+     * one-character non-digit number.
+     */
+    public static double parse(String val) {
+        // Not a bug: the guard the docstring above requires is present,
+        // right at function entry, before the underlying parser ever sees
+        // a degenerate single-character input.
+        if (val.length() == 1 && !Character.isDigit(val.charAt(0))) {
+            throw new NumberFormatException(val + " is not a valid number.");
+        }
+        return Double.parseDouble(val);
+    }
+}

--- a/evals/fixtures/cr-sanctioned-extra-clause.java
+++ b/evals/fixtures/cr-sanctioned-extra-clause.java
@@ -1,0 +1,26 @@
+/**
+ * Numeric-literal helpers for a lightweight number parser.
+ */
+public final class TrailingCharValidator {
+
+    /**
+     * Checks whether the trailing character of a numeric literal is
+     * acceptable. A trailing decimal point (e.g. "123.") IS a valid ending
+     * when the caller has flagged this literal as float-typed
+     * (`allowTrailingDot`), since a trailing '.' with no fractional digits
+     * is valid Java float/double syntax in that mode (e.g. "123." parses as
+     * 123.0). When `allowTrailingDot` is false, only a trailing digit is
+     * acceptable.
+     */
+    public static boolean hasValidTrailingChar(char[] chars, boolean allowTrailingDot) {
+        char lastChar = chars[chars.length - 1];
+        // Not a bug: the extra clause is exactly the case the docstring
+        // above sanctions -- a trailing '.' is only exempted from
+        // rejection when the caller explicitly opted in via
+        // `allowTrailingDot`, matching the stated rule precisely.
+        if (!Character.isDigit(lastChar) && !(allowTrailingDot && lastChar == '.')) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/plugins/dev-team/agents/correctness-review.md
+++ b/plugins/dev-team/agents/correctness-review.md
@@ -59,6 +59,17 @@ the code is supposed to do — before treating it as a finding.
    function or comment establishes a condition under which that operation
    should NOT happen, but no corresponding `if`/early-return enforces it.
 
+   **Named sub-case — missing degenerate-input guard at function entry** —
+   for a parsing or validation function whose docstring/name implies
+   a class of degenerate inputs (empty string, a single character, a bare
+   sign, whitespace-only) is invalid, check specifically whether a guard
+   rejecting that class exists at the *top* of the function, before the
+   main parsing logic runs. A function that correctly handles the general
+   case can still let a degenerate input fall through to an unguarded
+   library call (e.g. a bare non-digit character reaching a numeric parser
+   uncaught) — check function entry explicitly, don't infer safety from the
+   general-case logic being otherwise correct.
+
 4. **Boundary-condition / off-by-one omission** — a numeric, length, or
    index comparison that correctly handles the documented general case
    but silently drops an edge case that a comment, adjacent constant, or
@@ -78,6 +89,19 @@ the code is supposed to do — before treating it as a finding.
    conditionals); do not re-flag findings that are purely
    security-relevant here if `security-review` would already cover them,
    but do flag general-purpose inverted logic with no security angle.
+
+   **Named sub-case — extra or missing boolean clause in a validation
+   condition** — when a docstring/comment states a validation rule in
+   terms of specific conditions ("X is valid only when...", "Y is never
+   acceptable"), compare the condition's actual clauses one-by-one against
+   that stated rule — not just its overall pass/fail behavior on an obvious
+   input. An *extra* clause can silently loosen a rejection (e.g. a stated
+   "never acceptable" case gets exempted by an added `&& value != <case>`),
+   and a *missing* clause can silently loosen an acceptance rule the same
+   way. The defect is easy to miss because the condition still reads as
+   plausible validation logic — it's wrong only relative to the specific
+   rule stated elsewhere, so the comparison must be clause-by-clause against
+   that stated rule, not a general plausibility check of the condition.
 
 ## Self-Challenge
 


### PR DESCRIPTION
## Summary
- Sharpens correctness-review's existing "missing guard/validation branch" and "inverted or incomplete conditionals" Detect categories with two named sub-cases, targeting the exact defect shapes a live Defects4J/Lang sweep missed: Lang-36 (an extra boolean clause in a validation condition contradicting its own docstring) and Lang-44 (a missing guard rejecting a degenerate single-character input at the top of a parsing function).
- Adds 4 new `/agent-eval` fixtures: 2 positive (target defect + a decoy, mirroring the sweep's "found other issues, missed this one" shape) and 2 true-negative (same surface shape used legitimately, guarding against the sharpened wording over-firing).
- Classified `feat:` (not `fix:`) because the eval-corpus semver contract requires a minor bump for additive corpus growth (4 new fixtures) — confirmed by `scripts/eval_semver_classify.sh`.

## Quality Gate
- [x] Tests: 2977 passed, 17 skipped (`pytest plugins/dev-team/tests`)
- [x] Eval corpus: 108 expected fixtures valid (`scripts/eval_grade.py --check-corpus`)
- [x] Eval-corpus semver contract: OK (additive → minor bump, `feat:` commit matches)
- [x] Code review: 5-agent panel (claude-setup-review, doc-review, naming-review, structure-review, arch-review) — 3 pass, 2 warn → both actionable findings fixed (removed tracker-ID-in-comment per doc-review, renamed `expPos`→`exponentPosition` and `allZeros`→`isAllZeros` per naming-review)
- [x] `/agent-audit`-equivalent structural checks: frontmatter/registry/citation lint all clean (no drift introduced)

## Decisions & Assumptions
- Kept both new checklist items as *named sub-cases* under the existing categories 3/5 rather than new top-level categories — they're specific instances of "missing guard" and "inverted/incomplete conditional" respectively; new top-level categories would fragment the checklist without changing its coverage shape.
- **Honesty note surfaced at plan review and preserved in the plan file**: the two positive fixtures pass even against the *unedited* agent (isolated, low-noise files don't reproduce the real-world miss, which required a large multi-hundred-line source file's surrounding noise to suppress the signal). They still ship as regression guards for these two defect *classes*; reproducing the exact noise-induced miss was explicitly declined as disproportionate effort (would require embedding a large third-party source file) — see the plan's `## Skipped` section.
- Declined a synthetic "noisy variant" fixture (raised by the acceptance-test critic as an alternative) — would manufacture noise tuned to today's model's specific blind spot rather than testing a real defect shape, a weaker regression signal than it appears.
- A live 20-case sweep re-run to confirm the actual recall improvement on real noisy files is out of scope for this issue — the epic's own acceptance criteria treats that as a separate, epic-level criterion.

## Test Plan
- [x] Direct agent dispatch against all 4 fixtures (pre- and post-checklist-edit for the 2 positive fixtures) confirms: both positive fixtures report the target defect + decoy; both true-negative fixtures report no error-severity finding on the sanctioned pattern.
- [ ] A fresh benchmark sweep re-run against the live Defects4J/Lang dataset confirms Lang-36/Lang-44 are now caught in real (noisy) conditions — deferred, epic-level criterion, not this issue's.

## Evidence Bundle
**Checks run**
- `pytest plugins/dev-team/tests` — 2977 passed, 17 skipped
- `scripts/eval_grade.py --check-corpus` — 108 expected fixtures valid (104 → 108)
- `scripts/eval_semver_classify.sh` — additive corpus change, minor bump required and matched
- `/code-review` (5 agents: claude-setup-review, doc-review, naming-review, structure-review, arch-review) — 3 pass, 2 warn → both fixed
- Direct `correctness-review` agent dispatch against all 4 fixtures, pre- and post-edit

**Scope notes**
- Application-code review agents (correctness/complexity/performance/security/concurrency) were not dispatched via `/code-review` on this diff beyond the direct fixture-verification dispatches above — this diff is prompt-content + eval fixtures, not application code

**Untested regions**
- Not measured — no coverage tool applies to prompt-template agent files

**Residual risks**
- None identified — no escalations, no non-interactive gate bypasses. The checklist-wording effectiveness on real noisy files (vs. isolated fixtures) is inherently unverifiable without a live sweep; documented as a known limitation in the plan rather than hidden.

Closes #966
Part of #970