### PR TITLE
fix: harden /code-review --json instruction against narration-instead-of-emission

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -279,6 +279,8 @@ Read `knowledge/review-template.md` for the structure.
 
 **If `--json`: the JSON object is the ONLY output for this run — non-negotiable, not model discretion.** Emit the aggregated JSON object per the schema in [`output-format.md`](output-format.md#aggregated-json-result---json-flag) to **stdout**, write no file, and **stop: do not proceed to step 8 or step 9 in this run, regardless of how many issues were found or whether any are actionable.** There is no fallback to prose, and no `corrections/`/`.review-passed` persistence, in `--json` mode — ever. (`/pr`'s `--json` call already only reads this JSON object's `overall`/`status` field, so this loses nothing a caller depends on.)
 
+**A sentence describing the JSON is not the JSON.** A completed run whose final text reads like "Aggregated JSON emitted to stdout per `--json` contract; run stops here" — with no `{...}` object actually present anywhere in that text — is a contract violation, not compliance, even though it correctly stopped rather than proceeding further. The literal final output of the turn must be the JSON object itself, not a narration of having produced it. If the next action being considered is a summary sentence announcing that the JSON was (or is about to be) emitted, that is the signal to emit the actual object instead — there is no valid end state for a `--json` run that consists of prose alone.
+
 Otherwise (no `--json`): emit the prose summary using the Code Review Summary template in [`output-format.md`](output-format.md#code-review-summary-report-step-7-prose-mode). Append the iteration table, then continue to step 8.
 
 ### 8. Save correction prompts for remaining issues


### PR DESCRIPTION
## Summary
- Adds an explicit rule to `/code-review`'s `--json` step-7 instruction naming a specific failure mode observed in a live sweep: a completion sentence claiming JSON was emitted ("Aggregated JSON emitted to stdout per `--json` contract...") with no actual JSON object anywhere in the final text.
- Scoped to this finding only (issue #967's finding #1). Finding #2 (a 900s single-file timeout on Lang-23/Lang-56) requires re-running those cases against a live Defects4J checkout to rule out machine contention — not available in this session — and is deferred to #974, a new sub-issue of #967.
- **This PR does not close #967** — only finding #1 is resolved; #967 stays open until #974 is addressed.

## Quality Gate
- [x] Tests: 2977 passed, 17 skipped (`pytest plugins/dev-team/tests`)
- [x] Code review: 2-agent panel (doc-review, claude-setup-review) — both pass, no actionable findings
- [x] Local CI mirror (`scripts/ci-local.sh`) — all checks passed

## Decisions & Assumptions
- Scope split between "fixable now" (JSON-emission narration) and "needs live infrastructure to investigate" (timeout) was an explicit operator decision during this session, not an autonomous judgment call — see the deferred sub-issue #974 for the full rationale.
- This is a prompt-wording change graded by LLM judgment, not a deterministic code fix — its effectiveness against the actual narration failure mode can't be re-verified without re-running the live sweep, which is out of scope here (the epic's own acceptance criteria treats a fresh sweep as a separate, epic-level criterion).
- No eval-corpus fixtures added by this change (pure instruction edit, no new detection capability to regression-test), so `fix:` is the correct semver classification — unlike #966, the additive-corpus minor-bump gate doesn't apply here.

## Test Plan
- [x] Structural review confirms the new paragraph is internally consistent with the rest of the `--json` contract (step 1's short-circuit example, step 6a's non-interactive branch, steps 8/9's skip logic).
- [ ] A fresh benchmark sweep re-run would confirm whether `defects4j-Lang-7`'s specific failure mode no longer recurs — deferred, no live dataset in this session.

## Evidence Bundle
**Checks run**
- `pytest plugins/dev-team/tests` — 2977 passed, 17 skipped
- `/code-review`-equivalent (doc-review, claude-setup-review dispatched directly) — both pass
- `scripts/ci-local.sh` — all local CI checks passed

**Scope notes**
- Application-code review agents (correctness/complexity/performance/security) not dispatched — this diff is a single-sentence prompt-content addition to a skill file, no application code changed

**Untested regions**
- Not measured — no coverage tool applies to prompt-template skill files; effectiveness against the live narration failure mode is unverifiable without re-running the actual sweep

**Residual risks**
- None identified for this diff. The deferred timeout investigation (#974) is a known, tracked residual risk at the epic level, not silently dropped.

Part of #967
Part of #970