### PR TITLE
fix: guard /pr against accidental issue auto-close via negated closing keywords

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4263,7 +4263,7 @@
       "anchor": "3-generate-pr-summary"
     },
     "4. Create the PR": {
-      "summary": "Use the structured template:",
+      "summary": "**Never phrase a non-closing issue reference with a closing keyword, even",
       "anchor": "4-create-the-pr"
     },
     "5. Enable auto-merge (default)": {

--- a/plugins/dev-team/scripts/pr_close_keyword_lint.py
+++ b/plugins/dev-team/scripts/pr_close_keyword_lint.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""pr_close_keyword_lint.py — flag accidental issue auto-close phrasing (#977).
+
+GitHub's closing-keyword parser pattern-matches
+`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\\s+#\\d+`
+literally, anywhere in a merged PR/commit body — it does not understand
+negation. "This does not close #123" still auto-closes #123 on merge.
+
+This script scans a drafted PR body and flags two accidental-match shapes,
+never blocking:
+
+1. A closing keyword immediately preceding an issue number, with a negation
+   word (not, never, won't, doesn't, ...) earlier in the same sentence —
+   the exact shape that caused #977.
+2. A closing keyword match for an issue number that the body also lists
+   under a non-closing `Part of #N` reference — a self-contradictory body.
+
+Usage:
+  python3 pr_close_keyword_lint.py --body-file <path> [--json]
+  echo "$BODY" | python3 pr_close_keyword_lint.py [--json]
+
+Always exits 0 (advisory only). Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from typing import List
+
+CLOSE_RE = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE
+)
+PART_OF_RE = re.compile(r"\bpart of\s+#(\d+)", re.IGNORECASE)
+NEGATION_RE = re.compile(
+    r"\b(not|never|no longer|won't|wont|don't|dont|doesn't|doesnt|"
+    r"isn't|isnt|cannot|can't|cant)\b",
+    re.IGNORECASE,
+)
+SENTENCE_BOUNDARY_RE = re.compile(r"[.\n]")
+
+
+@dataclass
+class Finding:
+    issue: int
+    type: str
+    context: str
+
+
+def _sentence_start(body: str, match_start: int) -> int:
+    """Return the index just after the nearest sentence boundary before
+    match_start, or 0 if none (start of body)."""
+    boundary = -1
+    for m in SENTENCE_BOUNDARY_RE.finditer(body, 0, match_start):
+        boundary = m.end()
+    return max(boundary, 0)
+
+
+def find_findings(body: str) -> List[Finding]:
+    part_of_issues = {int(n) for n in PART_OF_RE.findall(body)}
+    findings: List[Finding] = []
+
+    for match in CLOSE_RE.finditer(body):
+        issue = int(match.group(2))
+        clause_start = _sentence_start(body, match.start())
+        clause = body[clause_start : match.start()]
+        context = body[clause_start : match.end()].strip()
+
+        if NEGATION_RE.search(clause):
+            findings.append(
+                Finding(issue=issue, type="negated-closing-keyword", context=context)
+            )
+        elif issue in part_of_issues:
+            findings.append(
+                Finding(issue=issue, type="conflicts-with-part-of", context=context)
+            )
+
+    return findings
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", help="Path to the drafted PR body")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    args = parser.parse_args(argv[1:])
+
+    if args.body_file:
+        with open(args.body_file, "r", encoding="utf-8") as handle:
+            body = handle.read()
+    else:
+        body = sys.stdin.read()
+
+    findings = find_findings(body)
+
+    if args.json:
+        print(json.dumps({"findings": [asdict(f) for f in findings]}))
+    elif findings:
+        for finding in findings:
+            print(
+                f'warning: issue #{finding.issue} ({finding.type}): "{finding.context}"'
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -118,6 +118,26 @@ Analyze the diff against the base branch (`git diff <base>...HEAD`) and commit h
 
 ### 4. Create the PR
 
+**Never phrase a non-closing issue reference with a closing keyword, even
+negated.** GitHub's closing-keyword parser is a dumb regex over the PR body:
+`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+`. It
+fires on that pattern regardless of grammar — "does not close #123", "won't
+fix #123", and "this doesn't resolve #123" all still auto-close #123 on
+merge (issue #977). If an issue is only partially addressed or deferred,
+write around the keyword instead: "leaves #123 open", "the remaining scope
+is deferred to #124", "see #123 for the rest of this work" — never
+`<closing-keyword> #123` in any form, negated or not.
+
+Before calling `gh pr create`, lint the drafted body for accidental matches:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py --body-file <body-file>
+```
+
+This is advisory only (always exits 0). If it prints warnings, rephrase the
+flagged sentence per the guidance above before creating the PR — do not
+proceed with a body the linter flagged without fixing the phrasing.
+
 ```bash
 gh pr create --title "<title>" --body "<body>" [--draft] --base <base>
 ```

--- a/plugins/dev-team/tests/scripts/test_pr_close_keyword_lint.py
+++ b/plugins/dev-team/tests/scripts/test_pr_close_keyword_lint.py
@@ -1,0 +1,60 @@
+"""Unit tests for scripts/pr_close_keyword_lint.py (issue #977).
+
+Covers the two accidental-auto-close shapes: a closing keyword negated in
+the same sentence, and a closing keyword match that contradicts a
+`Part of #N` reference elsewhere in the body.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import pr_close_keyword_lint as lint  # noqa: E402
+
+
+def test_negated_closing_keyword_is_flagged():
+    """The exact #975 shape: "does not close #967" still matches GitHub's
+    dumb regex and must be flagged even though the sentence negates it."""
+    body = "This PR does not close #967, only part of it is fixed."
+    findings = lint.find_findings(body)
+    assert len(findings) == 1
+    assert findings[0].issue == 967
+    assert findings[0].type == "negated-closing-keyword"
+
+
+def test_clean_closes_and_part_of_is_not_flagged():
+    body = "Closes #123.\nPart of #200."
+    assert lint.find_findings(body) == []
+
+
+def test_closing_keyword_conflicting_with_part_of_is_flagged():
+    body = "Closes #123 and Part of #123 both listed."
+    findings = lint.find_findings(body)
+    assert len(findings) == 1
+    assert findings[0].issue == 123
+    assert findings[0].type == "conflicts-with-part-of"
+
+
+def test_wont_fix_phrasing_is_flagged():
+    body = "This change won't fix #55 — that's tracked separately."
+    findings = lint.find_findings(body)
+    assert len(findings) == 1
+    assert findings[0].issue == 55
+
+
+def test_negation_in_prior_sentence_does_not_leak_across_boundary():
+    """A negation word in an earlier, unrelated sentence must not suppress
+    a genuine, intentional closing reference in a later sentence."""
+    body = "This does not touch auth. Closes #10."
+    assert lint.find_findings(body) == []
+
+
+def test_multiple_issues_only_flags_the_problematic_one():
+    body = "Closes #10. This does not close #20, deferred to a follow-up."
+    findings = lint.find_findings(body)
+    assert len(findings) == 1
+    assert findings[0].issue == 20


### PR DESCRIPTION
## Summary
- GitHub's closing-keyword parser pattern-matches `close/fix/resolve #N` literally regardless of grammar, so a negated sentence like "does not close #967" still auto-closes the issue on merge (this happened with PR #975 against #967).
- `/pr`'s SKILL.md now carries explicit phrasing guidance: never write a closing keyword immediately before an issue number, even negated — use "leaves #123 open" style phrasing instead.
- Adds a new advisory, stdlib-only lint script (`pr_close_keyword_lint.py`) that scans the drafted PR body for negated-closing-keyword matches and closing-keyword/`Part of #N` contradictions, wired into `/pr` Step 4 before `gh pr create`.
- `/ship`'s SKILL.md needed no change — it delegates PR body authoring entirely to `/pr`.

## Test plan
- [x] New unit tests (`test_pr_close_keyword_lint.py`), including the exact #975/#967 reproduction — 6 passed
- [x] Full plugin test suite — 2983 passed, 17 skipped (pre-existing skips, unrelated)
- [x] `scripts/citation_lint.py`, `scripts/check_registry_sync.py`, `scripts/check-python-only.py` — clean
- [x] `scripts/ci-local.sh` (full local CI mirror) — all checks passed

Closes #977