### PR TITLE
feat: add podman dev environment

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,17 @@
+# Keep the podman build context small and hermetic. The image installs deps from
+# requirements-dev.txt + package-lock.json (COPYed explicitly in the Containerfile);
+# the working tree is mounted at run time (-v "$PWD":/workspace), so nothing else
+# needs to enter the build context.
+.git
+node_modules
+.venv
+graphify-out
+.codegraph
+.husky/_
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+reports
+metrics

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,95 @@
+# Containerfile — reproducible dev/CI environment for agentic-dev-team.
+#
+# Mirrors the toolchain the local gates need (scripts/ci-local.sh, run by the
+# pre-push hook) and the cloud setup (.claude/cloud-setup.sh). Modelled on
+# setup-prereqs-linux.sh's apt path, pinned to an Ubuntu base so it matches the
+# Ubuntu VMs used by Claude Code on the web and GitHub Actions.
+#
+# What it provides:
+#   * hard deps:        jq, shellcheck, python3 + pip, git
+#   * Python dev deps:  requirements-dev.txt (PyYAML, semgrep, httpx, pytest,
+#                       ruff, mypy, …) — the same set CI installs
+#   * Node 24+:         drives husky hooks, eslint, commitlint (engines floor)
+#   * gh CLI:           PR operations in CI/cloud
+#
+# Build:
+#   podman build -t agentic-dev-team:dev .
+#
+# Run an interactive shell with the repo mounted (SELinux-safe :Z relabel):
+#   podman run --rm -it -v "$PWD":/workspace:Z agentic-dev-team:dev
+#
+# Run the local gates non-interactively:
+#   podman run --rm -v "$PWD":/workspace:Z agentic-dev-team:dev \
+#     bash scripts/ci-local.sh
+#
+# See docs/podman-dev-environment.md for the full walkthrough.
+
+FROM ubuntu:24.04
+
+# Single source of truth for the Node major version mirrors .nvmrc (fallback 24).
+ARG NODE_MAJOR=24
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# --- Hard dependencies + build basics --------------------------------------
+# jq, shellcheck, python3/pip, git are what ci-local.sh checks for up front.
+# curl/ca-certificates/gnupg bootstrap the NodeSource and GitHub CLI apt repos.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        git \
+        jq \
+        shellcheck \
+        python3 \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Node (engines floor >=24, from .nvmrc) --------------------------------
+# husky's `prepare` script + lint-staged/commitlint/eslint need Node; the repo's
+# package.json engines floor is >=24, enforced by engine-strict in .npmrc.
+RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- GitHub CLI (PR operations in CI/cloud) --------------------------------
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# The repo is bind-mounted at run time and owned by the host user, so git flags
+# it as "dubious ownership" and refuses to operate. Trust it inside the image so
+# ci-local.sh and the git-driven test suites run without extra setup.
+RUN git config --system --add safe.directory /workspace
+
+# --- Python dev dependencies (requirements-dev.txt) ------------------------
+# Copied and installed first so the layer caches independently of source churn.
+# Ubuntu 24.04's pip is PEP 668 externally-managed; --break-system-packages is
+# the intended escape hatch inside a disposable container (mirrors dev-setup.sh's
+# fallback), keeping the deps on the system interpreter the gates invoke.
+COPY requirements-dev.txt ./
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+        -r requirements-dev.txt
+
+# --- Node dev dependencies -------------------------------------------------
+# Prime the npm layer from the lockfile so `npm ci` is cached across source-only
+# rebuilds. HUSKY=0 stops husky's `prepare` from trying to install git hooks at
+# build time (there is no .git in the build context); hooks are (re)installed by
+# `npm ci` when you mount the real repo and run it.
+COPY package.json package-lock.json ./
+RUN HUSKY=0 npm ci
+
+# Default to an interactive shell; override with the command you want to run.
+CMD ["bash"]

--- a/docs/podman-dev-environment.md
+++ b/docs/podman-dev-environment.md
@@ -1,0 +1,78 @@
+# Podman dev environment
+
+A reproducible container that ships the full toolchain this repo's gates need,
+so you can run the local checks (and everything the pre-push hook runs) without
+installing anything on your host beyond [Podman](https://podman.io/).
+
+It is the container equivalent of [`setup-prereqs-linux.sh`](../setup-prereqs-linux.sh)
+and [`scripts/dev-setup.sh`](../scripts/dev-setup.sh): same tools, pinned to an
+Ubuntu base so it matches the Ubuntu VMs used by Claude Code on the web and by
+GitHub Actions.
+
+## What's in the image
+
+Defined in [`Containerfile`](../Containerfile):
+
+| Layer            | Contents                                                              |
+| ---------------- | -------------------------------------------------------------------- |
+| Hard deps        | `jq`, `shellcheck`, `python3` + `pip`, `git` — what `ci-local.sh` checks |
+| Python dev deps  | everything in [`requirements-dev.txt`](../requirements-dev.txt) (PyYAML, semgrep, httpx, jsonschema, pytest(+asyncio/xdist), ruff, mypy, …) |
+| Node             | Node 24+ (the `engines` floor; version tracks [`.nvmrc`](../.nvmrc)) plus `npm ci` deps (husky, eslint, commitlint, lint-staged) |
+| GitHub CLI       | `gh` for PR operations                                                |
+
+## Build
+
+```bash
+podman build -t agentic-dev-team:dev .
+```
+
+The Node major version can be overridden to match `.nvmrc` if it ever changes:
+
+```bash
+podman build --build-arg NODE_MAJOR=24 -t agentic-dev-team:dev .
+```
+
+## Run
+
+Mount the repo at `/workspace` and open a shell. The `:Z` suffix relabels the
+volume for SELinux (Fedora/RHEL); it is a harmless no-op on other hosts.
+
+```bash
+podman run --rm -it -v "$PWD":/workspace:Z agentic-dev-team:dev
+```
+
+Run the same deterministic checks GitHub CI runs, without dropping into a shell:
+
+```bash
+podman run --rm -v "$PWD":/workspace:Z agentic-dev-team:dev \
+  bash scripts/ci-local.sh
+```
+
+Run the Python test suites directly:
+
+```bash
+podman run --rm -v "$PWD":/workspace:Z agentic-dev-team:dev \
+  python3 -m pytest
+```
+
+### Git hooks (husky)
+
+The image bakes in the npm dev-dependencies, but git hooks are per-clone (they
+embed absolute paths and need a `.git`). When you mount the real repo, install
+them once inside the container:
+
+```bash
+podman run --rm -v "$PWD":/workspace:Z agentic-dev-team:dev npm ci
+```
+
+## Notes
+
+- **Rebuild after dependency changes.** The image caches
+  `requirements-dev.txt` and `package-lock.json` in their own layers; rebuild
+  (`podman build …`) after either changes so the container picks up new deps.
+- **PEP 668.** Ubuntu 24.04's system pip is externally-managed. Inside this
+  disposable container we install with `--break-system-packages` onto the system
+  interpreter the gates invoke — the same escape hatch `dev-setup.sh` falls back
+  to. Don't copy that flag to your host; use a virtualenv there instead.
+- **Graphify / CodeGraph** are intentionally omitted — they are optional,
+  user-level code-intelligence tools, not gate prerequisites.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
 
   - Guides:
       - Cloud Setup: docs/cloud-setup.md
+      - Podman Dev Environment: docs/podman-dev-environment.md
       - Using Skills in Web Environment: docs/using-plugin-skills-in-the-web-environment.md
       - Marketplace Builder Playbook: docs/marketplace-builder-plugin-playbook.md
       - CD Coverage Review: docs/continuous-delivery-coverage-review.md


### PR DESCRIPTION
Adds a reproducible Podman container that ships the full toolchain this repo's gates need, so contributors can run the local checks (and everything the pre-push hook runs) without provisioning their host.

Modelled on `setup-prereqs-linux.sh` and `scripts/dev-setup.sh`, pinned to Ubuntu 24.04 to match the cloud/CI VMs.

## What's included

- **`Containerfile`** — Ubuntu 24.04 image with `jq`, `shellcheck`, `python3` + pip, `git`, Node 24 (engines floor, tracks `.nvmrc`), `gh`, all of `requirements-dev.txt`, and the `npm ci` dev-deps. Deps are layered ahead of source for caching; `git safe.directory` is baked in so the bind-mounted repo works without ownership warnings.
- **`.containerignore`** — keeps the build context small and hermetic.
- **`docs/podman-dev-environment.md`** — build/run walkthrough, wired into the mkdocs nav.

## Verification

- `podman build -t agentic-dev-team:dev .` succeeds.
- Inside the image: jq, shellcheck, python 3.12, node v24, npm, gh, git, plus `yaml`/`httpx`/`jsonschema`/`ruff`/`mypy`/`semgrep`/`pytest` all present.
- Against the mounted repo: `pytest plugins/dev-team/tests` → **992 passed, 16 skipped**; `git status` runs clean.

## Usage

```bash
podman build -t agentic-dev-team:dev .
podman run --rm -it -v "$PWD":/workspace:Z agentic-dev-team:dev
podman run --rm -v "$PWD":/workspace:Z agentic-dev-team:dev bash scripts/ci-local.sh
```