### PR TITLE
fix: raise benchmark timeout, lower workers after fan-out finding

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -131,9 +131,11 @@ python3 cli.py --dataset bugsjs --project Bower --resume
 python3 cli.py --dataset defects4j --limit-projects 2 --full-repo
 
 # Full sweep: every project in both datasets (same --results-dir, so
-# results.jsonl accumulates across both runs and report.md covers both)
-python3 cli.py --dataset defects4j --workers 4
-python3 cli.py --dataset bugsjs --workers 4
+# results.jsonl accumulates across both runs and report.md covers both).
+# --workers left at its default (2) here deliberately — see #974 below on
+# why a higher value multiplies concurrent nested `claude -p` dispatches.
+python3 cli.py --dataset defects4j
+python3 cli.py --dataset bugsjs
 
 # Regenerate report.md from existing results.jsonl without re-dispatching
 python3 cli.py --report-only
@@ -151,8 +153,8 @@ python3 cli.py --report-only
 | `--limit-projects N` | Cap the number of projects processed |
 | `--tolerance N` | Line-range tolerance for hit scoring (default 3) |
 | `--model` | Model tier passed to the `/code-review` dispatch (default `sonnet`) |
-| `--timeout` | Per-case dispatch timeout in seconds (default 900) |
-| `--workers` | Number of bug cases run concurrently, thread pool (default 4) |
+| `--timeout` | Per-case dispatch timeout in seconds (default 1800 — raised from 900 after #974: a "single file" review still fans out to the full ~14-agent roster, not a lightweight pass; see `runner.make_isolated_dispatch_fn`'s docstring for the measured evidence) |
+| `--workers` | Number of bug cases run concurrently, thread pool (default 2 — lowered from 4 after #974 to bound how many ~14-20-way agent fan-outs run concurrently on one host) |
 | `--no-verify-tests` | Skip building/installing deps and running the project's own test suite per case (on by default; diagnostic only — see below) |
 | `--defects4j-home`, `--bugsjs-home` | Dataset home dirs (or the matching env vars) |
 | `--results-dir` | Where `results.jsonl`/`skipped.jsonl`/`report.md`/`raw/` are written (default `./results`) |
@@ -200,11 +202,14 @@ reproduced-vs-not when any case ran verification.
 
 ## Parallel execution
 
-Cases run concurrently across a thread pool (`--workers`, default 4) — each
-case does its own checkout into a private temp dir and its own subprocess
-calls (git/defects4j/npm/`claude`), so cases don't share mutable state.
-Raise `--workers` for a faster full sweep; keep it low if you're worried
-about hitting rate limits on the underlying `claude -p` dispatches.
+Cases run concurrently across a thread pool (`--workers`, default 2 (#974))
+— each case does its own checkout into a private temp dir and its own
+subprocess calls (git/defects4j/npm/`claude`), so cases don't share mutable
+state. Raise `--workers` for a faster full sweep; keep it low if you're
+worried about hitting rate limits on the underlying `claude -p` dispatches:
+each "case" is itself a ~14-20-way parallel agent fan-out (see
+`runner.make_isolated_dispatch_fn`'s docstring), so `--workers 4` means up
+to ~60-80 concurrent nested `claude -p` dispatches, not 4.
 
 ## Layout
 

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -223,7 +223,11 @@ def run(args: argparse.Namespace) -> int:
     return 0
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def _build_parser() -> argparse.ArgumentParser:
+    """Build this CLI's `argparse.ArgumentParser`, isolated from `main()` so
+    tests can assert defaults/overrides (e.g. `--timeout`/`--workers`, #974)
+    via `_build_parser().parse_args([...])` without exercising `run()`'s
+    dataset auto-provisioning/detection."""
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -257,13 +261,32 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Model tier passed to the /code-review dispatch.",
     )
     parser.add_argument(
-        "--timeout", type=int, default=900, help="Per-case dispatch timeout, seconds."
+        "--timeout",
+        type=int,
+        default=1800,
+        help=(
+            "Per-case dispatch timeout, seconds (default 1800). Raised from "
+            "900 after #974: a live single-file /code-review dispatch still "
+            "fans out to the full ~14-agent review roster (scope narrows "
+            "which files are reviewed, not how many agents run), measured "
+            "at up to 58 turns / 846s cumulative API time / $4.48 for one "
+            "real Defects4J case even at low concurrency — 900s was too "
+            "tight a ceiling for that real cost, not evidence of a hang."
+        ),
     )
     parser.add_argument(
         "--workers",
         type=int,
-        default=4,
-        help="Number of bug cases to run concurrently (thread pool).",
+        default=2,
+        help=(
+            "Number of bug cases to run concurrently, thread pool (default "
+            "2). Lowered from 4 after #974: each case is really a ~14-20-"
+            "way parallel agent fan-out under the hood, so 4 concurrent "
+            "cases means up to ~60-80 concurrent nested `claude -p` "
+            "dispatches sharing one host's CPU/network/rate limits — a "
+            "plausible contributor to the 900s timeouts that motivated "
+            "this change."
+        ),
     )
     parser.add_argument(
         "--no-verify-tests",
@@ -290,6 +313,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         action="store_true",
         help="Only (re)generate report.md from existing results.",
     )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
     args = parser.parse_args(argv)
 
     if not args.report_only and not args.dataset:

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -300,7 +300,7 @@ def _load_isolated_dispatch():
 
 
 def make_isolated_dispatch_fn(
-    model: str = "sonnet", timeout: int = 900
+    model: str = "sonnet", timeout: int = 1800
 ) -> Callable[[str, str], Dict[str, Any]]:
     """Build the real, production `dispatch_fn` for `run_case`.
 
@@ -312,6 +312,32 @@ def make_isolated_dispatch_fn(
     unconditionally, unlike the standalone script's opt-in `--preserve-auth`
     — since running this harness at all presupposes the operator's own
     subscription rather than an `ANTHROPIC_API_KEY`.
+
+    `timeout`'s default was raised 900 -> 1800 after #974 (a 900s single-
+    file timeout on `defects4j-Lang-23`/`defects4j-Lang-56` reported against
+    #967). Investigated live rather than guessed at: a real, uncontended-
+    by-design `/code-review --path <dir> --json` dispatch against a
+    deliberately trivial 15-line single-file directory (this module's own
+    `isolated_dispatch.py`/`copy_auth_state()` machinery, no artificial
+    speedup) still cost 28 turns, 1.28M input tokens, and $1.29 — because
+    `skills/code-review/SKILL.md` step 3 dispatches its full ~14-agent
+    review roster regardless of file count ("fix-only" scope narrows which
+    *files* get reviewed, not how many *agents* run); step 4 hands every
+    dispatched agent the complete file content. A real Defects4J case
+    (`defects4j-Lang-29`, sampled independently the same session) measured
+    even higher: 58 turns, 846s of cumulative nested-call API time (vs.
+    368s wall clock — only possible with heavy fan-out), $4.48. Neither run
+    hit 900s at the concurrency each happened to run under, but the
+    numbers make clear that a larger real ground-truth file (Lang-23's is
+    536 lines, Lang-56's 1744) reviewed by the same full roster, especially
+    under this harness's `--workers` concurrency multiplying the nested
+    `claude -p` dispatch count further, can plausibly exceed the old 900s
+    ceiling without any hang — the aggregation step itself
+    (`skills/code-review/SKILL.md` step 5) is deterministic parsing with no
+    LLM call and no loop, ruled out as a hang source. 1800s is deliberate
+    headroom for that now-measured real cost, not an arbitrary bump; see
+    `cli.py`'s `--timeout` help text and `plans/issue-974-benchmark-
+    timeout-fanout.md` for the full investigation.
     """
     isolated_dispatch = _load_isolated_dispatch()
 

--- a/tests/scripts/test_code_review_benchmark_cli.py
+++ b/tests/scripts/test_code_review_benchmark_cli.py
@@ -1,0 +1,44 @@
+"""Unit tests for the #821 benchmark harness's CLI argument parsing (#974).
+
+#974 investigated a 900s single-case timeout in the harness (see
+`runner.make_isolated_dispatch_fn`'s docstring for the full finding); the
+fix raised `--timeout`'s default 900 -> 1800 and lowered `--workers`'s
+default 4 -> 2. These tests pin both new defaults and confirm explicit
+overrides still take effect, via `cli._build_parser()` — the parser-only
+extraction added by this same change so tests don't need to exercise
+`cli.run()`'s dataset auto-provisioning/detection just to check argparse
+defaults.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HARNESS_DIR = Path(__file__).resolve().parents[2] / "evals" / "code-review-benchmark"
+if str(_HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_DIR))
+
+import cli  # noqa: E402
+
+
+def test_timeout_default_is_1800() -> None:
+    args = cli._build_parser().parse_args(["--dataset", "defects4j"])
+    assert args.timeout == 1800
+
+
+def test_workers_default_is_2() -> None:
+    args = cli._build_parser().parse_args(["--dataset", "defects4j"])
+    assert args.workers == 2
+
+
+def test_timeout_override_still_works() -> None:
+    args = cli._build_parser().parse_args(
+        ["--dataset", "defects4j", "--timeout", "600"]
+    )
+    assert args.timeout == 600
+
+
+def test_workers_override_still_works() -> None:
+    args = cli._build_parser().parse_args(["--dataset", "defects4j", "--workers", "4"])
+    assert args.workers == 4


### PR DESCRIPTION
## Summary

Investigated GitHub issue #974 — a 900s single-file `/code-review` timeout in `evals/code-review-benchmark/` on `defects4j-Lang-23`/`defects4j-Lang-56` — via a live dispatch experiment rather than guessing at a cause.

**Root cause (confirmed, not hypothesized):** `/code-review`'s `SKILL.md` step 3 dispatches its full ~14-agent review roster regardless of file count — the harness's `fix-only` scope narrows which *files* are reviewed, not how many *agents* run. Every dispatched agent gets the complete file content (step 4). I confirmed this live: a trivial 15-line single-file review (via `runner.py`'s own `isolated_dispatch.py`/`copy_auth_state()` machinery, no shortcuts, real Claude Code OAuth dispatch) still cost **28 turns, 1.28M input tokens, $1.29, 234s**. A real Defects4J case sampled independently the same session (`defects4j-Lang-29`) measured even higher: **58 turns, 846s cumulative nested-call API time (vs. 368s wall clock), $4.48**. Neither hit 900s at the concurrency each happened to run under, but the numbers make clear that Lang-23's (536-line) and Lang-56's (1744-line) real ground-truth files, reviewed by the same full roster under the harness's original `--workers 4`, can plausibly exceed 900s without any hang — the aggregation step itself (`SKILL.md` step 5) is deterministic parsing with no LLM call, ruled out as a hang source.

**Fix:** raise `cli.py`'s `--timeout` default 900→1800 and lower `--workers` default 4→2 to reflect this now-measured real cost, and document the finding in code/README so it isn't rediscovered blind. Deliberately does **not** touch `/code-review`'s agent roster or `SKILL.md` — trimming the roster to "fix" the timeout would change what the benchmark measures.

## Quality Gate
- [x] New unit tests (`tests/scripts/test_code_review_benchmark_cli.py`) pin the new defaults + confirm overrides still work, via a new `cli._build_parser()` extraction
- [x] Full plugin test suite: 2999 passed, 1 skipped (pre-existing, documented opt-in skip unrelated to this change)
- [x] `scripts/citation_lint.py`, `scripts/check_registry_sync.py`, `scripts/check-python-only.py`, `scripts/check_md_references.py` — clean
- [x] `scripts/ci-local.sh` (full local CI mirror) — all checks passed
- [x] Plan reviewed by Acceptance Test Critic + Design & Architecture Critic before implementation (both approved with fixes folded in); `doc-review` + `arch-review` dispatched against the final diff (doc-review found and I fixed two real issues — a markdown-heading-breaking line wrap and a stale `--workers 4` usage example; arch-review passed with two non-blocking suggestions, already noted as deferred follow-ups below)

## Decisions & Assumptions

- **This is a benchmark-harness-only change.** No production `/code-review` behavior changed — the roster fan-out this investigation found is real, intended production behavior; the harness's defaults were simply undercounting its real cost.
- **Not reproducing Lang-23/Lang-56 in full isolation** against a live `--workers 1` Defects4J run — the two live experiments run this session (a deliberately trivial single-file case, plus an independently-running real sweep's `Lang-29` case landing mid-investigation) already gave a confident, evidence-backed root cause without needing that heavier infra investment.
- **A new, separate finding surfaced during this investigation, explicitly out of scope for this PR:** the concurrently-running live sweep's `Lang-29` case reproduced issue #967's finding #1 (a completion claiming JSON was emitted with none present in the final text) — after PR #975 was merged specifically to fix that pattern. This suggests #975's fix isn't fully holding and deserves its own follow-up issue/investigation; not folded into this PR since #974 is specifically about the empty-stdout timeout, not the narration-instead-of-emission pattern.
- **Two non-blocking suggestions from arch-review, deferred rather than addressed here:** (1) `cli.py`'s and `runner.py`'s timeout/workers defaults are two independently-maintained literals rather than a single shared constant (the file already has this same pattern for `--model`'s default, so it's consistent with existing local convention, not a new inconsistency); (2) no total-sweep cost budget/warning exists despite now-measured $1.29–$4.48/case real costs — worth a future `--max-cost-usd`-style guardrail.

## Test Plan
- [x] `pytest tests/scripts/test_code_review_benchmark_cli.py tests/scripts/test_code_review_benchmark_runner.py` — 27 passed
- [x] `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` (excluding the two known C# subprocess-heavy exclusions) — 2999 passed, 1 skipped
- [x] `scripts/ci-local.sh` — all local CI checks passed

## Evidence Bundle
**Checks run**
- Full test suite (see above)
- `doc-review`, `arch-review` dispatched directly against the diff — both pass after two doc-review findings were fixed (README markdown-heading line wrap, stale `--workers 4` usage example)
- Two live, real `/code-review` dispatches used as investigation evidence (not simulated): a controlled trivial single-file case, and an independently-running real Defects4J sweep's `Lang-29` case

**Scope notes**
- No `/code-review` skill/agent/roster files changed — this diff is entirely benchmark-harness config + docs + a new unit test

**Untested regions**
- The new `--timeout`/`--workers` defaults are not re-verified against a live Defects4J sweep in this PR (would require the same heavy infra this investigation deliberately avoided provisioning) — the values are evidence-based, not re-confirmed empirically at scale

**Residual risks**
- A future sweep could still occasionally exceed even 1800s for an unusually large/complex file under real concurrency — this is a headroom increase grounded in measured evidence, not a guarantee. The two arch-review-flagged follow-ups (shared-constant refactor, cost-budget guardrail) and the newly-discovered #967-finding-#1 recurrence are known, tracked residual items for separate follow-up, not silently dropped.

Closes #974