### PR TITLE
feat(test-review): detect reflection-based private-member access

### DIFF
--- a/evals/expected/test-reflection-private-member-java.json
+++ b/evals/expected/test-reflection-private-member-java.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-reflection-private-member-java",
+  "description": "Test reaches into a private method via getDeclaredMethod + setAccessible instead of the class's public API (Java reflection-into-private-member pattern, issue #959), where the private computation has no existing public entry point of its own -- the 'extract collaborator' branch of the 3-way fix menu. Should be flagged as an encapsulation/architecture issue, not a hygiene nit.",
+  "applicableAgents": ["test-review"],
+  "agents": {
+    "test-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 3 },
+      "severities": { "warning": { "min": 1, "max": 2 } },
+      "mustMention": ["encapsulation"],
+      "mustNotMention": ["public API surface needs expanding"]
+    }
+  }
+}

--- a/evals/expected/test-reflection-private-member-py.json
+++ b/evals/expected/test-reflection-private-member-py.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-reflection-private-member-py",
+  "description": "Test reaches into a name-mangled private attribute via getattr instead of the class's public API (Python reflection-into-private-member pattern, issue #959) — should be flagged as an encapsulation/architecture issue, not a hygiene nit, with a suggested fix naming one of the three specific remedies.",
+  "applicableAgents": ["test-review"],
+  "agents": {
+    "test-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 3 },
+      "severities": { "warning": { "min": 1, "max": 2 } },
+      "mustMention": ["encapsulation"],
+      "mustNotMention": ["public API surface needs expanding"]
+    }
+  }
+}

--- a/evals/expected/test-reflection-private-member.test.json
+++ b/evals/expected/test-reflection-private-member.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-reflection-private-member.test",
+  "description": "Test reaches into a private method via bracket-notation access instead of the class's public API (JS/TS reflection-into-private-member pattern, issue #959) — should be flagged as an encapsulation/architecture issue, not a hygiene nit, with a suggested fix naming one of the three specific remedies.",
+  "applicableAgents": ["test-review"],
+  "agents": {
+    "test-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 3 },
+      "severities": { "warning": { "min": 1, "max": 2 } },
+      "mustMention": ["encapsulation"],
+      "mustNotMention": ["public API surface needs expanding"]
+    }
+  }
+}

--- a/evals/fixtures/test-reflection-private-member-java.java
+++ b/evals/fixtures/test-reflection-private-member-java.java
@@ -1,0 +1,25 @@
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SurchargeCalculatorTest {
+
+    @Test
+    public void computesSurchargeMultiplierViaReflection() throws Exception {
+        SurchargeCalculator calculator = new SurchargeCalculator();
+
+        // No public method exposes this standalone computation on its own --
+        // it's buried inside a much larger public workflow. The test reaches
+        // around encapsulation via reflection instead of extracting the
+        // computation into its own testable collaborator.
+        Method method = SurchargeCalculator.class.getDeclaredMethod(
+                "computeSurchargeMultiplier", int.class);
+        method.setAccessible(true);
+
+        double multiplier = (double) method.invoke(calculator, 12);
+
+        assertEquals(1.12, multiplier, 0.0001);
+    }
+}

--- a/evals/fixtures/test-reflection-private-member-py.py
+++ b/evals/fixtures/test-reflection-private-member-py.py
@@ -1,0 +1,20 @@
+import unittest
+
+from pricing.engine import PricingEngine
+
+
+class TestPricingEngine(unittest.TestCase):
+    def test_computes_discount_tier_via_name_mangled_attribute(self):
+        engine = PricingEngine()
+
+        # Reaches around encapsulation instead of testing through the public API
+        tier = getattr(engine, "_PricingEngine__compute_discount_tier")(450)
+
+        self.assertEqual(tier, "gold")
+
+    def test_applies_discount_through_public_api(self):
+        engine = PricingEngine()
+
+        total = engine.apply_discount(450)
+
+        self.assertAlmostEqual(total, 382.5)

--- a/evals/fixtures/test-reflection-private-member.test.ts
+++ b/evals/fixtures/test-reflection-private-member.test.ts
@@ -1,0 +1,20 @@
+import { PricingEngine } from "../services/PricingEngine";
+
+describe("PricingEngine", () => {
+  it("computes the discount tier by reaching into the private method", () => {
+    const engine = new PricingEngine();
+
+    // Reaches around encapsulation instead of testing through the public API
+    const tier = (engine as any)["_computeDiscountTier"](450);
+
+    expect(tier).toBe("gold");
+  });
+
+  it("applies a discount through the public API", () => {
+    const engine = new PricingEngine();
+
+    const total = engine.applyDiscount(450);
+
+    expect(total).toBeCloseTo(382.5);
+  });
+});

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -53,6 +53,7 @@ coverage gaps) and detects the deferred signals only when running solo.
 Run in two phases — enumerate first, classify second. This stabilizes finding counts across runs by forcing a full pass before applying judgment.
 
 **Phase 1 — Enumerate**: List every test case in scope with:
+
 - Test name / description string
 - Assertion method(s) used (or explicit note that no assertion is present)
 - Observable setup tier (unit / integration / e2e)
@@ -64,11 +65,12 @@ Run in two phases — enumerate first, classify second. This stabilizes finding 
 Calibrate against these worked examples before flagging real code:
 
 | Severity | Pattern | Violation | Fix |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `error` | `it('renders', () => { render(<Comp />) })` | No assertion — zero regression protection | Add `expect(screen.getByRole('heading')).toBeInTheDocument()` |
 | `error` | `expect(result).toBeTruthy()` | Truthiness-only check; passes on any non-null value | `expect(result).toEqual({ id: 1, name: 'Alice' })` |
 | `warning` | `const now = new Date()` inside test body | Unstubbed clock — flaky on midnight, DST transitions | `jest.useFakeTimers()` or inject a clock dependency |
 | `warning` | Three tests asserting `expect(output).toContain('success')` identically | No boundary condition distinguishes them — redundant coverage | Collapse or add boundary cases |
+| `warning` | Java: `field.setAccessible(true); field.get(obj)` on a private field | Test reaches around encapsulation via reflection — this is a design issue, not a test-hygiene nit | Extract the logic into a collaborator with its own public seam (if standalone); relax visibility to package-private/internal only if a production collaborator independently needs it (never solely for test access); or test the behavior through the existing public API (if already reachable) |
 | `suggestion` | Copy-pasted arrange block across 4 tests | Duplication above extraction threshold | Extract to `beforeEach` |
 | `suggestion` | `it('test 1', ...)` | Description reveals nothing about behavior | Rename to describe the scenario and expected outcome |
 
@@ -128,7 +130,7 @@ Testability blockers:
 
 - Code under test that cannot be constructed with known values (static factories, singletons, no injectable constructor) — flag as error; per `knowledge/testability-patterns.md#pattern-1-constructor-injection-replace-static-factories-singletons`, the production code must change, not the test approach
 - Mocking of concrete classes (not interfaces) — flag as warning; extract an interface for the dependency
-- Tests using reflection into private members as primary strategy — flag as warning; the public API surface needs expanding
+- Tests using reflection into private members as primary strategy — flag as warning. This is an architecture/encapsulation issue the test is reaching around, not a test-hygiene nit. Detection signatures: Java: `getDeclaredMethod`/`getDeclaredField` + `setAccessible(true)`, `Method.invoke` on a private/protected member; C#: `Type.GetMethod(..., BindingFlags.NonPublic | BindingFlags.Instance)`, `Type.InvokeMember`; Python: `getattr`/`setattr`/`hasattr` targeting a name-mangled (`_ClassName__attr`) or underscore-prefixed attribute; JS/TS: bracket-notation access into a `private`/non-exported member (e.g. `(obj as any)['_privateMethod']()`), `Object.getOwnPropertyDescriptor`/`Object.defineProperty` used to reach a non-exported member. Suggested fix — pick by shape of the code, never the generic "expand the public API": (1) extract the private logic into a collaborator with its own public seam, when it's standalone logic worth testing independently; (2) relax visibility to package-private/internal, only when a production collaborator in the same module/assembly independently needs the access (the language must have that tier) — never as a grant solely so the test can reach in, which recreates the `InternalsVisibleTo`/`@VisibleForTesting` anti-pattern below; (3) test the behavior through the class's existing public API, when the private method is already an implementation detail of a public behavior
 
 ## Self-Challenge
 

--- a/plugins/dev-team/knowledge/testability-patterns.md
+++ b/plugins/dev-team/knowledge/testability-patterns.md
@@ -142,7 +142,7 @@ orders = OrderFaker.generateBatch(100)
 Constructor Injection (Pattern 1) is the common case, but it is one of a named family of seams from *xUnit Test Patterns* Ch. 26. Pick by *how* the dependency reaches the SUT and *why* it's hard to test.
 
 | Seam | The change | Use when | Cost |
-|------|-----------|----------|------|
+| ------ | ----------- | ---------- | ------ |
 | **Dependency Injection** (Pattern 1) | Pass collaborators in (constructor/setter) | You control construction and can thread the dependency through | Low; the default |
 | **Dependency Lookup** | SUT asks a broker/service-locator for the collaborator; the test configures the broker | The DOC is buried deep and threading it through every caller would be messy (e.g. a Fake DB behind a service facade) | Medium; hides the dependency, but far easier to **retrofit onto legacy** code than DI |
 | **Humble Object** | Extract logic out of a hard-to-instantiate shell into a plain, synchronously-testable object | Logic is trapped in a UI control, framework callback, thread, or transaction boundary | Medium; the shell becomes a thin adapter |
@@ -221,9 +221,9 @@ Prefer, in order: Dependency Injection → Dependency Lookup → Test-Specific S
 ## Anti-Patterns Table
 
 | Anti-Pattern | Why It's Wrong | Correct Alternative |
-|---|---|---|
+| --- | --- | --- |
 | `InternalsVisibleTo` + `internal set` for tests | Weakens encapsulation for test convenience | Add a public constructor that accepts values |
-| Reflection into private members as primary strategy | Fragile; breaks on rename; masks coupling | Extract to public API or create a proper test entry point |
+| Reflection into private members as primary strategy — Java: `getDeclaredMethod`/`getDeclaredField` + `setAccessible(true)`, `Method.invoke` on a private/protected member; C#: `Type.GetMethod(..., BindingFlags.NonPublic \| BindingFlags.Instance)`, `Type.InvokeMember`; Python: `getattr`/`setattr`/`hasattr` on a name-mangled (`_ClassName__attr`) or underscore-prefixed attribute; JS/TS: bracket-notation into a `private`/non-exported member, or `Object.getOwnPropertyDescriptor`/`Object.defineProperty` to reach one | Fragile; breaks on rename; masks coupling — this is an architecture/encapsulation issue the test is reaching around, not a test-hygiene nit | Pick by shape of the code: extract the logic into a collaborator with its own public seam; relax visibility to package-private/internal only when a production collaborator in the same module/assembly independently needs it — never as a grant solely so the test can reach in (that recreates the `InternalsVisibleTo`/`@VisibleForTesting` rows above); or test the behavior through the existing public API (if already reachable) |
 | Static test helper that mutates private state | Bypasses object invariants | Use Test Data Builder with public construction |
 | Mocking concrete classes | Fragile; requires virtual/open methods; masks design issues | Extract interface; mock the interface |
 | Tests configuring global/static state | Shared state causes order-dependent failures | Inject dependencies through constructors |


### PR DESCRIPTION
## Summary
- Replaces `test-review`'s generic "reflection into private members ... the public API surface needs expanding" Detect bullet with per-language detection signatures (Java `getDeclaredMethod`/`setAccessible`, C# `BindingFlags.NonPublic`, Python name-mangled/underscore attrs, JS/TS bracket-notation) and a 3-way suggested-fix menu (extract collaborator / relax visibility, gated to production-need-only, never solely for test access / test through existing public API), framed explicitly as an encapsulation/architecture issue rather than a test-hygiene nit. Adds a worked calibration row to the Severity Anchors table.
- Syncs `knowledge/testability-patterns.md`'s matching Anti-Patterns table row so the agent's citation of that file stays accurate, with the same gating language reconciling the new "relax visibility" option against the file's existing `InternalsVisibleTo`/`@VisibleForTesting` anti-pattern rows.
- Adds three eval fixture/expected pairs (JS/TS, Python, Java) under `evals/` closing the "does the agent actually behave this way" verification gap that pure prose review can't cover — spanning 3 of 4 languages and 2 of the 3 fix-menu branches (test-through-public-API and extract-collaborator).

Closes #959

## Quality Gate
- [x] Tests: 2995 passed, 1 skipped (pre-existing opt-in skip, `test_orchestrator.py` — unrelated to this change)
- [x] Type check: not applicable (no TypeScript source changed; the new `.test.ts` eval fixture is a review-corpus input, not shipped/compiled code)
- [x] Lint: not applicable (no shipped JS/TS/Python source changed)
- [x] Code review: pass — `doc-review` (pass, no findings) and `arch-review` (pass, one suggestion-tier finding addressed by adding the Java fixture) dispatched against the full diff

## Decisions & Assumptions
- Severity stays `warning`, per the issue's own "Decisions" section (matches the sibling testability-blocker rule; design-integrity findings that don't compromise test effectiveness stay at `warning`).
- Language scope is JS/TS, C#, Java, Python, per the issue.
- Out of scope, per the issue: no new JSON schema field (`category`), no cross-agent dispatch to `arch-review`/`domain-review`, no cross-file "is this the only test" reasoning.
- Plan review (Acceptance Test Critic + Design & Architecture Critic) surfaced two real findings, both fixed before merge:
  1. `/agent-audit` checks structure, not semantics, so it can't confirm the agent's runtime behavior matches the new Detect text — added eval fixtures (JS/TS, Python) to close the gap.
  2. The "relax visibility to package-private/internal" fix option, as first drafted, would have contradicted `testability-patterns.md`'s existing `InternalsVisibleTo`/`@VisibleForTesting` anti-pattern rows (which treat relaxed-visibility-for-test-access as itself the anti-pattern). Fixed by gating the option to "only when a production collaborator independently needs it, never solely to grant test access" in both files.
  3. A follow-up `arch-review` pass found the first two eval fixtures both exercised only the "test through public API" branch — added a third (Java) fixture exercising "extract collaborator" for broader fix-menu coverage.
- This diff has no shipped runtime surface (agent/knowledge markdown + eval-corpus fixtures only), so `/verify` was recorded as `skipped` with a reason in the local (gitignored) `metrics/verify-log.jsonl`, satisfying `progress_guardian.py --pre-pr`.

## Test Plan
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py` — 2995 passed, 1 skipped
- [x] `python3 scripts/eval_grade.py --check-corpus` — 111 expected fixtures valid (new corpus entries pair correctly)
- [x] `python3 -m pytest tests/repo/test_knowledge_index_current.py` — passes (no knowledge-index rebuild needed; the prose edit didn't move any indexed section)
- [x] `python3 scripts/check_registry_sync.py` — in sync
- [x] `bash scripts/ci-local.sh` (via `git push`'s pre-push hook) — all local CI checks passed

## Evidence Bundle
**Checks run**
- Full pytest suite (see Test Plan) — 2995 passed, 1 skipped
- `python3 scripts/eval_grade.py --check-corpus` — corpus structurally valid
- `/code-review` equivalent: `doc-review` + `arch-review` dispatched against the full diff, both pass
- `python3 scripts/plan_waves.py` — no collisions, no scope mismatches
- `python3 scripts/progress_guardian.py --pre-pr` — pass

**Scope notes**
- No TypeScript/JS/Python/C#/Java *shipped* source changed — type check and lint (eslint/tsc) not applicable; the eval fixtures are review-corpus test inputs, not compiled/shipped code
- The live eval gate (paid, `run-eval` label) was not run for this PR — the always-on structural gate (`eval_grade.py --check-corpus`) validates the new fixture/expected pairs at zero cost; the live gate can confirm actual agent behavior on a future labeled run

**Untested regions**
- The "relax visibility to package-private/internal" fix-menu branch has no dedicated eval fixture (JS/TS and Python fixtures exercise "test through public API"; the new Java fixture exercises "extract collaborator") — a proportionate scope call per the plan's Decisions section, not a blocking gap
- C# has no dedicated eval fixture (JS/TS, Python, Java do) — the per-language signature text itself is verified by direct diff/citation read, not by fixture, for all four languages

**Residual risks**
- None identified beyond the two disclosed scope notes above — no escalations, no non-interactive gate bypasses, no `/verify` failures (this diff has no shipped runtime surface to drive)