### PR TITLE
fix: add /test-improve to /code-review's step-6 non-interactive exception list

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -239,7 +239,7 @@ Otherwise present the Review Findings prompt (template: [`output-format.md`](out
 **Exception — non-interactive mode**: skip this prompt when the run is non-interactive.
 
 - (a) If `--json` (or `--yes`), **default to report only** — proceed to step 7 and emit the aggregated JSON; **never modify code** without an explicit caller opt-in. `--json` is contractually non-interactive (CI-safe): it never blocks on this prompt.
-- (b) If running inside `/build` or `/pr`, proceed to the fix loop. The caller owns the human gate (the orchestrator's Phase 3 approval for `/build`; the pre-PR confirmation for `/pr`).
+- (b) If running inside `/build`, `/pr`, or `/test-improve`, proceed to the fix loop. The caller owns the human gate (the orchestrator's Phase 3 approval for `/build`; the pre-PR confirmation for `/pr`; for `/test-improve`, the Phase 3 Story-set approval gating entry to Phase 4 and the `[r]evise/[w]aive/[q]uit` prompt raised after 2 failed iterations of its own end-of-phase review loop — see `../test-improve/SKILL.md`'s Phase 4/5 "End-of-phase review loop" sections).
 
 ### 6a. Review-fix loop
 


### PR DESCRIPTION
Closes #995

## Summary

#982's PR (#996) wired `/test-improve`'s Phase 4/5 end-of-phase review loop
to pass `--internal` to its `/code-review` dispatches — but `--internal`
only suppresses the `DEV_TEAM_REPORTS/code-review.md` write. It has no
effect on Step 6's separate interactive "Fix these issues automatically, or
save as report only?" prompt gate, whose non-interactive exception (b) list
named only `/build` and `/pr`. `/test-improve`'s automated round-trip
(dispatch → `/apply-fixes corrections/` → re-run `--internal` → cap at 2
iterations before an operator prompt) could therefore stall at Step 6 with
no human present. #996 deliberately deferred this exact gap to a fast-follow
(this issue), since it's orthogonal to #982's write-suppression scope.

This PR adds `/test-improve` to Step 6 exception (b), naming its actual
human gates (the Phase 3 Story-set approval that must precede Phase 4, and
the `[r]evise/[w]aive/[q]uit` prompt raised after 2 failed review-loop
iterations) instead of its post-hoc evidence file, mirroring the existing
`/build`/`/pr` parenthetical shape.

## Decisions & Assumptions

- **Exception-list addition, not a new flag.** The issue offered two paths:
  extend Step 6's exception (b), or have `/test-improve` pass an explicit
  non-interactive signal (e.g. `--yes`) alongside `--internal`. Chose the
  former: `code-review/SKILL.md`'s own `--internal` flags-table row and
  `knowledge/report-output-location.md` already documented `/test-improve`
  as a sanctioned `--internal` caller expecting the fix loop to run — Step
  6's exception (b) was simply the one place not yet updated to match. A
  new flag would duplicate what this one-line addition already grants,
  while leaving that inconsistency in place.
- **Cited the real human gates, not the evidence file.** An earlier draft of
  this fix cited `/test-improve`'s per-phase evidence JSON
  (`phase-4-review.json`/`phase-5-review.json`) as the "human gate," mirroring
  the shape of the `/build`/`/pr` parenthetical too literally. Both dispatched
  plan reviewers (Acceptance Test Critic, Design & Architecture Critic) caught
  that the evidence file is a post-hoc output written at the *end* of the
  loop — it authorizes nothing. Corrected to cite the actual gates: the Phase
  3 Story-set approval before Phase 4 runs, and the `[r/w/q]` prompt after 2
  failed iterations.
- **Not fixed here (flagged by arch-review, non-blocking):** the sanctioned
  `--internal`-caller identity is now maintained as three independently
  hand-edited prose lists (the flags table, Step 6(b), and
  `report-output-location.md`) — the exact fragility that produced #995 in
  the first place. Left as a hardening follow-up rather than expanding this
  PR's scope. arch-review also flagged a pre-existing, unrelated
  inconsistency between `/pr/SKILL.md`'s described `--json` behavior and
  `/code-review`'s own `--json` contract — out of scope for this diff, not
  introduced by it, noted as a residual risk below.

## Quality Gate

- [x] Tests: 3022 passed, 1 skipped (pre-existing, opt-in) —
  `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands
  tests/docs tests/knowledge tests/bats tests/skills tests/scripts`
- [x] Knowledge index rebuilt;
  `pytest tests/repo/test_knowledge_index_current.py` passes
- [x] `python3 scripts/check_registry_sync.py` — in sync
- [x] `/agent-audit`-equivalent scoped checks on the touched file: markdown
  reference integrity, registry sync, and the 3 known pre-existing
  `claude_setup_review.py` false positives on `CLAUDE.md` (unrelated,
  documented gotcha) — clean
- [x] Local CI mirror (`scripts/ci-local.sh` via pre-push hook, 18 checks) —
  all green
- [x] Plan review: Acceptance Test Critic (`needs-revision` → revised →
  `approve`) and Design & Architecture Critic (`approve`) dispatched
  pre-build; doc-review (pass, no findings) and arch-review (pass, 1
  suggestion + 1 non-blocking pre-existing warning) dispatched post-build
  against the full diff

## Test Plan

- [x] Full canonical test suite green (see above)
- [x] Markdown reference integrity test
  (`tests/repo/test_md_reference.py`) — verifies the new
  `../test-improve/SKILL.md` cross-reference resolves correctly
- [x] Manual read-through confirming Step 6's exception (b), the
  `--internal` flags-table row, and `knowledge/report-output-location.md`
  are now mutually consistent

## Evidence Bundle

**Checks run**
- `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` — 3022 passed, 1 skipped
- `pytest tests/repo/test_knowledge_index_current.py` — passed
- `pytest tests/repo/test_md_reference.py` — 16 passed
- `scripts/check_registry_sync.py` — in sync
- `scripts/ci-local.sh` (pre-push, 18 checks) — all green
- doc-review, arch-review — both pass

**Scope notes**
- Documentation-only change: one sentence edited in
  `plugins/dev-team/skills/code-review/SKILL.md` Step 6. No application
  code, agents, hooks, or eval fixtures touched.
- No other review agents dispatched — this diff doesn't touch code,
  security surface, or a UI.

**Untested regions**
- Step 6's caller identification is prose interpreted by an LLM at run
  time, not a flag or code path a test harness can drive — verification is
  manual read-through plus the plan-review/code-review agent passes above,
  not an automated test. Disclosed in the plan
  (`plans/issue-995-code-review-step6-test-improve-exception.md`) rather
  than silently assumed.

**Residual risks**
- The sanctioned-`--internal`-caller identity remains a hand-maintained,
  triplicated prose enumeration (flags table, Step 6(b),
  `report-output-location.md`) — a future new caller could repeat this same
  gap by being added to one list and not the others (arch-review
  suggestion, non-blocking).
- arch-review separately flagged that `/pr/SKILL.md` describes its `--json`
  dispatch as running the fix loop automatically, which appears to
  contradict `/code-review`'s own `--json` contract (report-only, never
  modifies code). Pre-existing, not introduced by this PR, and out of
  scope — worth its own follow-up issue.