### PR TITLE
feat: add cost budget/visibility to the code-review benchmark harness

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -144,6 +144,11 @@ python3 cli.py --report-only
 # e.g. re-running the exact cases a prior sweep flagged, for a reproducible
 # regression check (#970) instead of --sample's unseeded random selection
 python3 cli.py --dataset defects4j --project Lang --bug-ids 36,44,7,23,56
+
+# Cap real spend on a long unattended sweep — stops dispatching NEW cases
+# once the running total meets/exceeds $50 (already in-flight cases still
+# finish; nothing is silently dropped, see Cost tracking below)
+python3 cli.py --dataset defects4j --max-cost-usd 50
 ```
 
 ### Flags
@@ -161,30 +166,69 @@ python3 cli.py --dataset defects4j --project Lang --bug-ids 36,44,7,23,56
 | `--model` | Model tier passed to the `/code-review` dispatch (default `sonnet`) |
 | `--timeout` | Per-case dispatch timeout in seconds (default 1800 — raised from 900 after #974: a "single file" review still fans out to the full ~14-agent roster, not a lightweight pass; see `runner.make_isolated_dispatch_fn`'s docstring for the measured evidence) |
 | `--workers` | Number of bug cases run concurrently, thread pool (default 2 — lowered from 4 after #974 to bound how many ~14-20-way agent fan-outs run concurrently on one host) |
+| `--max-cost-usd N` | Fail-safe spend cutoff in USD (#1000, default: no cap) — see Cost tracking below |
 | `--no-verify-tests` | Skip building/installing deps and running the project's own test suite per case (on by default; diagnostic only — see below) |
 | `--defects4j-home`, `--bugsjs-home` | Dataset home dirs (or the matching env vars) |
 | `--results-dir` | Where `results.jsonl`/`skipped.jsonl`/`report.md`/`raw/` are written (default `./results`) |
 | `--report-only` | Only (re)generate `report.md` from existing results |
 
+## Cost tracking (#1000)
+
+Real per-case dispatch cost is real money — #974 measured $1.29 (a
+deliberately trivial single file) to $4.48 (a real Defects4J case) per
+`/code-review --json` dispatch. Three things make spend visible and
+boundable instead of a surprise at the end of a long sweep:
+
+- **A running total on every progress line**: `[3/10] defects4j:Lang:23:
+  HIT ($6.12 total)` — sourced from `total_cost_usd` in the underlying
+  `claude -p --output-format json` wrapper.
+- **A pre-sweep estimate**, printed to stderr before any dispatch begins:
+  `case_count * $4.50` (a conservative hardcoded constant, not
+  extrapolated from live cases — see the plan's Decisions & Assumptions
+  for why). Skipped when there's nothing to dispatch (`--report-only`, or
+  a `--resume` run that already covers every case).
+- **`--max-cost-usd <N>`**, a fail-safe cutoff, not an exact ceiling: it's
+  checked only *after* a case completes — never before the initial
+  `--workers`-sized batch is primed — so realized spend can exceed `N` by
+  up to `workers - 1` extra in-flight cases' cost. Once the running total
+  meets/exceeds `N`, no further case is submitted; cases already in flight
+  are never cancelled and always finish normally. Cases that never got to
+  start are recorded to `skipped.jsonl` with a reason naming
+  `--max-cost-usd` (never silently dropped), and a stderr message
+  explains the stop. `report.md`'s summary line also sums the total spent
+  across `results.jsonl` + `skipped.jsonl` (a case skipped for
+  "unparseable --json output" still paid for a real dispatch).
+
+The scheduling itself lives in `scheduler.py`, not `cli.py` — see Layout
+below.
+
 ## Output artifacts (`results/`, gitignored)
 
 - `results.jsonl` — one record per attempted bug: `{dataset, project, bug_id,
   hit, ground_truth_hunks, findings, unmatched_findings, raw_output_path,
-  test_verification}`.
+  test_verification, cost_usd}`.
 - `skipped.jsonl` — one record per bug that couldn't be checked out or
-  scored: `{dataset, project, bug_id, reason}`. `reason` is one of:
-  `checkout failed`, `no ground-truth hunks`, `unparseable --json output`, or
-  `ground truth touches no recognized source files` (the fix's own commit
-  bundled with its tests touched nothing but a changelog/manifest/CI-config
-  file — e.g. `History.md`, `package.json`, `.travis.yml` — so there was no
-  source change for `/code-review` to have found; scored as a skip, not a
-  recall miss).
+  scored: `{dataset, project, bug_id, reason, cost_usd}`. `reason` is one
+  of: `checkout failed`, `no ground-truth hunks`, `unparseable --json
+  output`, `ground truth touches no recognized source files` (the fix's
+  own commit bundled with its tests touched nothing but a
+  changelog/manifest/CI-config file — e.g. `History.md`, `package.json`,
+  `.travis.yml` — so there was no source change for `/code-review` to have
+  found; scored as a skip, not a recall miss), or a message naming
+  `--max-cost-usd` (#1000 — the sweep's budget was reached before this
+  case could be dispatched).
+- `cost_usd` (#1000, both files above) — the dispatch's `total_cost_usd`
+  from the underlying `claude -p --output-format json` wrapper, or `None`
+  when no dispatch happened (checkout failure, no ground truth, budget cut
+  off before this case started) or the wrapper never reported one (e.g. a
+  timeout).
 - `raw/<dataset>-<project>-<bug_id>.txt` — the dispatch's raw stdout,
   verbatim, saved before any parsing (so a parser bug never loses data).
 - `report.md` — overall/per-dataset/per-project recall, a **Missed Defects**
-  section (the actionable part), and a noise summary (average unmatched
+  section (the actionable part), a noise summary (average unmatched
   findings per hit run — "unmatched," not "false positive": the review may
-  have found a real, different issue).
+  have found a real, different issue), and a total-cost line (#1000)
+  summed across `results.jsonl` + `skipped.jsonl`.
 
 ## Test verification (diagnostic, not a gate)
 
@@ -228,6 +272,7 @@ adapters/
 runner.py                 # checkout -> scope -> dispatch -> parse -> score -> JSONL
 scorer.py                 # hit/miss/tolerance/unmatched-findings
 report.py                 # results.jsonl + skipped.jsonl -> report.md
+scheduler.py              # #1000: budget-aware, submit-as-you-go case scheduling (--max-cost-usd)
 cli.py                    # argparse entry point
 fixtures/                 # real (trimmed) sample data used by the unit tests
 ```

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -6,6 +6,7 @@ Usage:
     python3 cli.py --dataset bugsjs --project Bower --resume
     python3 cli.py --dataset defects4j --limit-projects 2 --full-repo
     python3 cli.py --dataset defects4j --project Lang --bug-ids 36,44,7
+    python3 cli.py --dataset defects4j --max-cost-usd 50
     python3 cli.py --report-only
 
 Both dataset homes are auto-provisioned into a gitignored
@@ -20,7 +21,6 @@ import argparse
 import os
 import random
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -28,9 +28,29 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import report
 import runner
+import scheduler
 from adapters import bootstrap, bugsjs_adapter, defects4j_adapter
 
 DEFAULT_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+# #1000: conservative, hardcoded per-case cost estimate for the pre-sweep
+# warning — rounded up from the $4.48 real-case high measured in #974, not
+# extrapolated from live cases (see the plan's Decisions & Assumptions for
+# why extrapolation was deferred).
+DEFAULT_COST_PER_CASE_ESTIMATE_USD = 4.50
+
+
+def _positive_float(raw: str) -> float:
+    """`argparse` `type=` validator for `--max-cost-usd`: rejects `<= 0`
+    rather than silently accepting an ambiguous "zero (or negative)
+    budget" — mirrors `--dataset`'s `choices=` validation style (an
+    `argparse` error, not a custom exception)."""
+    value = float(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(
+            f"--max-cost-usd must be a positive number, got {raw!r}"
+        )
+    return value
 
 
 def _parse_bug_ids(raw: Optional[str]) -> Optional[set]:
@@ -202,54 +222,43 @@ def run(args: argparse.Namespace) -> int:
             continue
         pending.append((case, case_dict))
 
-    processed = 0
-    total = len(pending)
-    workers = max(1, args.workers)
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {
-            executor.submit(
-                runner.run_case,
-                case_dict,
-                checkout_fn=_make_checkout_fn(
-                    args.dataset, case, home, defects4j_bin, defects4j_env
-                ),
-                ground_truth_fn=_make_ground_truth_fn(args.dataset, case),
-                test_fn=_make_test_fn(
-                    args.dataset,
-                    case,
-                    not args.no_verify_tests,
-                    defects4j_bin,
-                    defects4j_env,
-                ),
-                dispatch_fn=dispatch_fn,
-                results_dir=results_dir,
-                scope="full-repo" if args.full_repo else "fix-only",
-                tolerance=args.tolerance,
-            ): case_dict
-            for case, case_dict in pending
-        }
-        # Drain in the main thread as futures complete: keeps append_result()/
-        # print() single-threaded (no lock needed) and isolates one case's
-        # crash from aborting the rest of the batch.
-        for future in as_completed(futures):
-            case_dict = futures[future]
-            key = runner.case_key(case_dict)
-            try:
-                record = future.result()
-            except Exception as exc:  # noqa: BLE001 - one case's crash must not abort the batch
-                record = runner.skip_record(case_dict, f"internal error: {exc}")
+    if pending:
+        estimate = len(pending) * DEFAULT_COST_PER_CASE_ESTIMATE_USD
+        print(
+            f"code-review-benchmark: about to dispatch {len(pending)} case(s); "
+            "prior measured per-case cost $1.29-$4.48 (#974) — conservative "
+            f"estimate ${estimate:.2f} total. Use --max-cost-usd to cap spend.",
+            file=sys.stderr,
+        )
 
-            runner.append_result(record, results_dir)
-            processed += 1
-            status = (
-                "HIT"
-                if record.get("hit")
-                else ("SKIP" if record.get("skipped") else "MISS")
-            )
-            print(f"[{processed}/{total}] {key}: {status}")
+    def _make_kwargs(case: Any) -> Dict[str, Any]:
+        return {
+            "checkout_fn": _make_checkout_fn(
+                args.dataset, case, home, defects4j_bin, defects4j_env
+            ),
+            "ground_truth_fn": _make_ground_truth_fn(args.dataset, case),
+            "test_fn": _make_test_fn(
+                args.dataset,
+                case,
+                not args.no_verify_tests,
+                defects4j_bin,
+                defects4j_env,
+            ),
+            "scope": "full-repo" if args.full_repo else "fix-only",
+            "tolerance": args.tolerance,
+        }
+
+    total_cost = scheduler.run_pending(
+        pending,
+        make_kwargs=_make_kwargs,
+        dispatch_fn=dispatch_fn,
+        results_dir=results_dir,
+        workers=args.workers,
+        max_cost_usd=args.max_cost_usd,
+    )
 
     path = report.write_report(results_dir)
-    print(f"Wrote {path}")
+    print(f"Wrote {path} (total cost: ${total_cost:.2f})")
     return 0
 
 
@@ -324,6 +333,21 @@ def _build_parser() -> argparse.ArgumentParser:
             "dispatches sharing one host's CPU/network/rate limits — a "
             "plausible contributor to the 900s timeouts that motivated "
             "this change."
+        ),
+    )
+    parser.add_argument(
+        "--max-cost-usd",
+        type=_positive_float,
+        default=None,
+        help=(
+            "Fail-safe spend cutoff, USD (#1000, default: no cap). Checked "
+            "only AFTER a case completes — not before the initial "
+            "--workers-sized batch is primed — so realized spend can "
+            "exceed this by up to `workers - 1` extra in-flight cases' "
+            "cost; the executor never cancels an in-flight case. Once "
+            "reached, no further case is submitted; still-queued cases "
+            "are recorded to skipped.jsonl (never silently dropped) and a "
+            "clear message is printed to stderr. Must be > 0."
         ),
     )
     parser.add_argument(

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -53,6 +53,22 @@ def _positive_float(raw: str) -> float:
     return value
 
 
+def _positive_int(raw: str) -> int:
+    """`argparse` `type=` validator for `--workers`: fails loud on `<= 0`
+    at the CLI boundary rather than `scheduler.run_pending()`'s internal
+    `max(1, workers)` silently clamping an invalid value (flagged by
+    arch-review on #1000 as an inconsistency with `--max-cost-usd`'s own
+    fail-fast validation). The `max(1, workers)` clamp in `scheduler.py`
+    stays as a defense-in-depth default for direct/test callers that don't
+    go through this parser."""
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(
+            f"--workers must be a positive integer, got {raw!r}"
+        )
+    return value
+
+
 def _parse_bug_ids(raw: Optional[str]) -> Optional[set]:
     """Parse `--bug-ids`' comma-separated string into a set of bug-id strings.
 
@@ -323,7 +339,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--workers",
-        type=int,
+        type=_positive_int,
         default=2,
         help=(
             "Number of bug cases to run concurrently, thread pool (default "

--- a/evals/code-review-benchmark/report.py
+++ b/evals/code-review-benchmark/report.py
@@ -69,6 +69,13 @@ def build_report(results_dir: Any) -> str:
     lines.append(f"Overall recall: {_fmt_recall(overall)}")
     if skipped:
         lines.append(f"Skipped: {len(skipped)} (see Skipped section below)")
+    # #1000: sum cost_usd across BOTH results.jsonl and skipped.jsonl — a
+    # case skipped for "unparseable --json output" still paid for a real
+    # dispatch, so its cost counts too. `.get("cost_usd") or 0.0` treats a
+    # missing/None field (a case that never dispatched, or an older record
+    # from before this field existed) as $0.00 rather than raising.
+    total_cost = sum((r.get("cost_usd") or 0.0) for r in list(results) + list(skipped))
+    lines.append(f"Total cost: ${total_cost:.2f}")
     lines.append("")
 
     lines.append("## Recall by dataset")

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -135,8 +135,17 @@ def _build_scoped_dir(checkout_dir: str, files: List[str]) -> str:
 
 
 def skip_record(
-    case: Dict[str, Any], reason: str, raw_output_path: Optional[str] = None
+    case: Dict[str, Any],
+    reason: str,
+    raw_output_path: Optional[str] = None,
+    cost_usd: Optional[float] = None,
 ) -> Dict[str, Any]:
+    """`cost_usd` is `None` (the default) for every skip reason that fires
+    before a dispatch happens (checkout failure, no ground truth, no
+    recognized source) — nothing was spent. The one skip reason that fires
+    *after* a real dispatch ("unparseable --json output", #1000) passes the
+    dispatch's actual `cost_usd` through explicitly, since that case still
+    cost real money even though it couldn't be scored."""
     return {
         "dataset": case["dataset"],
         "project": case["project"],
@@ -144,6 +153,7 @@ def skip_record(
         "skipped": True,
         "reason": reason,
         "raw_output_path": raw_output_path,
+        "cost_usd": cost_usd,
     }
 
 
@@ -211,13 +221,16 @@ def run_case(
 
         prompt = f"/code-review --path {review_dir} --json"
         dispatch_result = dispatch_fn(prompt, review_dir) or {}
+        cost_usd = dispatch_result.get("cost_usd")
 
         raw_path = raw_dir / f"{case['dataset']}-{case['project']}-{case['bug_id']}.txt"
         raw_path.write_text(dispatch_result.get("raw_stdout") or "", encoding="utf-8")
 
         review_json = _extract_review_json(dispatch_result.get("result_text"))
         if review_json is None:
-            return skip_record(case, "unparseable --json output", str(raw_path))
+            return skip_record(
+                case, "unparseable --json output", str(raw_path), cost_usd=cost_usd
+            )
 
         findings = _flatten_findings(review_json)
         scored = scorer.score(ground_truth_hunks, findings, tolerance=tolerance)
@@ -233,6 +246,7 @@ def run_case(
             "unmatched_findings": scored["unmatched"],
             "raw_output_path": str(raw_path),
             "test_verification": test_verification,
+            "cost_usd": cost_usd,
         }
     finally:
         shutil.rmtree(checkout_dir, ignore_errors=True)
@@ -364,12 +378,18 @@ def make_isolated_dispatch_fn(
 
         raw_stdout = proc.stdout or ""
         result_text = None
+        cost_usd = None
         try:
             wrapper = json.loads(raw_stdout)
             result_text = wrapper.get("result")
+            cost_usd = wrapper.get("total_cost_usd")
         except (json.JSONDecodeError, ValueError):
             pass
-        return {"raw_stdout": raw_stdout, "result_text": result_text}
+        return {
+            "raw_stdout": raw_stdout,
+            "result_text": result_text,
+            "cost_usd": cost_usd,
+        }
 
     return dispatch
 

--- a/evals/code-review-benchmark/scheduler.py
+++ b/evals/code-review-benchmark/scheduler.py
@@ -1,0 +1,155 @@
+"""Bounded, budget-aware case scheduler for the /code-review benchmark
+harness (#1000).
+
+Runs a list of pending cases through a `ThreadPoolExecutor`, submitting at
+most `workers` cases at a time and topping up as each completes — rather
+than submitting every case upfront and draining via `as_completed()` (the
+harness's original shape, still visible in git history). That "submit all,
+then drain" shape cannot give `--max-cost-usd` a real "stop new dispatch"
+guarantee: `Future.cancel()` only succeeds for futures the pool hasn't
+started yet, a race that can't be tested deterministically. This module
+makes "no case is submitted after the cutoff" an actual invariant instead:
+a case is only ever handed to the executor from this module's own
+`submit_one()` closure, so once submission stops, it stays stopped.
+
+`concurrent.futures.as_completed()` is deliberately NOT used here — it
+snapshots its input set at call time and cannot accept futures added after
+iteration starts. Instead this loops on `concurrent.futures.wait(in_flight,
+return_when=FIRST_COMPLETED)`, rebuilding the `in_flight` set each pass.
+
+Extracted out of `cli.py` (rather than grown inside it) because `cli.py`
+already carries argparse wiring, dataset/adapter selection, and bootstrap
+— a fourth responsibility (cost accounting + budget scheduling) belongs in
+its own single-purpose module. `run_pending()` has no adapter/dataset
+knowledge of its own (see `make_kwargs`), mirroring `cli.py`'s existing
+`_make_checkout_fn`/`_make_test_fn` factory pattern.
+"""
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import runner
+
+CaseAndDict = Tuple[Any, Dict[str, Any]]
+
+
+def run_pending(
+    pending: List[CaseAndDict],
+    make_kwargs: Callable[[Any], Dict[str, Any]],
+    dispatch_fn: Callable[[str, str], Dict[str, Any]],
+    results_dir: Any,
+    workers: int,
+    max_cost_usd: Optional[float] = None,
+    run_case_fn: Callable[..., Dict[str, Any]] = runner.run_case,
+) -> float:
+    """Run every `(case, case_dict)` pair in `pending` to completion.
+
+    Submits up to `workers` cases before the first completion — so
+    `max_cost_usd` is checked only *after* a completion, never before that
+    initial batch, meaning realized spend can exceed it by up to
+    `workers - 1` extra in-flight cases' cost (disclosed, not a bug — see
+    the plan's Decisions & Assumptions). Once the running total meets or
+    exceeds `max_cost_usd`, no further case is submitted; already
+    in-flight futures are never cancelled and always finish normally.
+    Cases still queued when the cutoff engages are recorded to
+    `results_dir` as skip records (never silently dropped) and a single,
+    clear message is printed to stderr explaining why.
+
+    `make_kwargs(case) -> dict` supplies the per-case `run_case_fn` keyword
+    arguments (checkout_fn/ground_truth_fn/test_fn/scope/tolerance) — this
+    function itself has no adapter/dataset knowledge.
+
+    Returns the final running cost total (USD).
+    """
+    results_dir = Path(results_dir)
+    queue: List[CaseAndDict] = list(pending)
+    total = len(queue)
+    processed = 0
+    running_total = 0.0
+    budget_stopped = False
+    workers = max(1, workers)
+
+    def _print_progress(record: Dict[str, Any], key: str) -> None:
+        nonlocal processed
+        processed += 1
+        status = (
+            "HIT"
+            if record.get("hit")
+            else ("SKIP" if record.get("skipped") else "MISS")
+        )
+        print(f"[{processed}/{total}] {key}: {status} (${running_total:.2f} total)")
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        in_flight: Dict[Future, Dict[str, Any]] = {}
+
+        def submit_one() -> None:
+            case, case_dict = queue.pop(0)
+            future = executor.submit(
+                run_case_fn,
+                case_dict,
+                dispatch_fn=dispatch_fn,
+                results_dir=results_dir,
+                **make_kwargs(case),
+            )
+            in_flight[future] = case_dict
+
+        while queue and len(in_flight) < workers:
+            submit_one()
+
+        while in_flight:
+            done, _ = wait(list(in_flight), return_when=FIRST_COMPLETED)
+            for future in done:
+                case_dict = in_flight.pop(future)
+                key = runner.case_key(case_dict)
+                try:
+                    record = future.result()
+                except Exception as exc:  # noqa: BLE001 - one case's crash must not abort the batch
+                    record = runner.skip_record(case_dict, f"internal error: {exc}")
+
+                runner.append_result(record, results_dir)
+                running_total += record.get("cost_usd") or 0.0
+                _print_progress(record, key)
+
+                if (
+                    not budget_stopped
+                    and max_cost_usd is not None
+                    and running_total >= max_cost_usd
+                    and queue
+                ):
+                    budget_stopped = True
+                    print(
+                        f"code-review-benchmark: --max-cost-usd {max_cost_usd} "
+                        f"reached (running total ${running_total:.2f}) — stopping "
+                        f"new dispatch; {len(queue)} not-yet-started case(s) will "
+                        "be recorded as skipped. Cases already in flight will "
+                        "still finish.",
+                        file=sys.stderr,
+                    )
+
+                if queue and not budget_stopped:
+                    submit_one()
+
+        # Only reached when the budget cutoff tripped while cases were
+        # still queued — record each as an explicit, visible skip rather
+        # than silently dropping it.
+        while queue:
+            _, case_dict = queue.pop(0)
+            record = runner.skip_record(
+                case_dict,
+                f"--max-cost-usd {max_cost_usd} reached before dispatch "
+                f"(running total ${running_total:.2f})",
+                cost_usd=None,
+            )
+            runner.append_result(record, results_dir)
+            _print_progress(record, runner.case_key(case_dict))
+
+    return running_total
+
+
+if __name__ == "__main__":
+    sys.stderr.write("scheduler.py is a library — invoke via cli.py\n")
+    raise SystemExit(1)

--- a/tests/scripts/test_code_review_benchmark_cli.py
+++ b/tests/scripts/test_code_review_benchmark_cli.py
@@ -56,6 +56,18 @@ def test_workers_override_still_works() -> None:
     assert args.workers == 4
 
 
+def test_workers_rejects_zero() -> None:
+    """arch-review finding on #1000: --workers must fail loud at the CLI
+    boundary, like --max-cost-usd, rather than silently clamping."""
+    with pytest.raises(SystemExit):
+        cli._build_parser().parse_args(["--dataset", "defects4j", "--workers", "0"])
+
+
+def test_workers_rejects_negative() -> None:
+    with pytest.raises(SystemExit):
+        cli._build_parser().parse_args(["--dataset", "defects4j", "--workers", "-1"])
+
+
 class _FakeCase:
     def __init__(self, bug_id: str) -> None:
         self.bug_id = bug_id

--- a/tests/scripts/test_code_review_benchmark_cli.py
+++ b/tests/scripts/test_code_review_benchmark_cli.py
@@ -19,9 +19,10 @@ previously-problematic bug IDs without it).
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest
@@ -137,3 +138,149 @@ def test_parse_bug_ids_arg_splits_comma_separated_string():
 
 def test_parse_bug_ids_arg_none_stays_none():
     assert cli._parse_bug_ids(None) is None
+
+
+def test_max_cost_usd_default_is_none() -> None:
+    args = cli._build_parser().parse_args(["--dataset", "defects4j"])
+    assert args.max_cost_usd is None
+
+
+def test_max_cost_usd_override_still_works() -> None:
+    args = cli._build_parser().parse_args(
+        ["--dataset", "defects4j", "--max-cost-usd", "12.5"]
+    )
+    assert args.max_cost_usd == 12.5
+
+
+def test_max_cost_usd_rejects_zero() -> None:
+    with pytest.raises(SystemExit):
+        cli._build_parser().parse_args(
+            ["--dataset", "defects4j", "--max-cost-usd", "0"]
+        )
+
+
+def test_max_cost_usd_rejects_negative() -> None:
+    with pytest.raises(SystemExit):
+        cli._build_parser().parse_args(
+            ["--dataset", "defects4j", "--max-cost-usd", "-1"]
+        )
+
+
+class _FullFakeCase:
+    """Unlike `_FakeCase` above (which only needs `.bug_id` for
+    `_list_cases`' filtering tests), `cli.run()`'s dispatch path calls
+    `.to_dict()` on every case — this stand-in supports that."""
+
+    def __init__(self, bug_id: str) -> None:
+        self.bug_id = bug_id
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dataset": "defects4j",
+            "project": "Lang",
+            "bug_id": self.bug_id,
+            "language": "java",
+            "ground_truth_files": [],
+            "ground_truth_hunks": [],
+            "description": None,
+            "extra": {},
+        }
+
+
+def _fake_list_bugs_full(project: str, home: str) -> List[_FullFakeCase]:
+    return [_FullFakeCase(str(n)) for n in range(1, 6)]  # bug ids "1".."5"
+
+
+@pytest.fixture
+def _patch_run_dependencies(monkeypatch: pytest.MonkeyPatch):
+    """Stand in for everything `cli.run()` needs besides case selection —
+    dataset bootstrap/detection and the actual dispatch loop — so tests can
+    drive `cli.run()`/`cli.main()` end to end without real Defects4J/claude."""
+    monkeypatch.setattr(
+        cli.bootstrap,
+        "ensure_defects4j_home",
+        lambda explicit_home: {"home": "fake-home", "bin": "defects4j", "env": {}},
+    )
+    monkeypatch.setattr(cli.defects4j_adapter, "detect", lambda home, bin: True)
+    monkeypatch.setattr(cli.defects4j_adapter, "list_bugs", _fake_list_bugs_full)
+    monkeypatch.setattr(cli.defects4j_adapter, "list_projects", lambda home: ["Lang"])
+    monkeypatch.setattr(
+        cli.report, "write_report", lambda results_dir: Path(results_dir) / "report.md"
+    )
+
+
+def test_pre_sweep_estimate_warning_printed_before_dispatch(
+    tmp_path: Path,
+    _patch_run_dependencies,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(cli.scheduler, "run_pending", lambda *a, **k: 0.0)
+    args = cli._build_parser().parse_args(
+        ["--dataset", "defects4j", "--project", "Lang", "--results-dir", str(tmp_path)]
+    )
+    exit_code = cli.run(args)
+    assert exit_code == 0
+    err = capsys.readouterr().err
+    assert "about to dispatch 5 case(s)" in err
+    assert "$22.50" in err  # 5 * DEFAULT_COST_PER_CASE_ESTIMATE_USD (4.50)
+
+
+def test_pre_sweep_estimate_skipped_when_report_only(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = cli._build_parser().parse_args(
+        ["--report-only", "--results-dir", str(tmp_path)]
+    )
+    exit_code = cli.run(args)
+    assert exit_code == 0
+    err = capsys.readouterr().err
+    assert "about to dispatch" not in err
+
+
+def test_pre_sweep_estimate_skipped_when_resume_leaves_zero_pending(
+    tmp_path: Path,
+    _patch_run_dependencies,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Drives the real --resume pending-computation path down to zero by
+    pre-seeding results.jsonl with every case _fake_list_bugs_full produces."""
+    results_dir = tmp_path
+    with open(results_dir / "results.jsonl", "w", encoding="utf-8") as fh:
+        for n in range(1, 6):
+            fh.write(
+                json.dumps(
+                    {
+                        "dataset": "defects4j",
+                        "project": "Lang",
+                        "bug_id": str(n),
+                        "skipped": False,
+                        "hit": True,
+                    }
+                )
+                + "\n"
+            )
+
+    called = []
+    monkeypatch.setattr(
+        cli.scheduler,
+        "run_pending",
+        lambda pending, **k: (called.append(len(pending)), 0.0)[1],
+    )
+    args = cli._build_parser().parse_args(
+        [
+            "--dataset",
+            "defects4j",
+            "--project",
+            "Lang",
+            "--resume",
+            "--results-dir",
+            str(results_dir),
+        ]
+    )
+    exit_code = cli.run(args)
+    assert exit_code == 0
+    assert called == [0]  # every case was already processed
+    err = capsys.readouterr().err
+    assert "about to dispatch" not in err

--- a/tests/scripts/test_code_review_benchmark_report.py
+++ b/tests/scripts/test_code_review_benchmark_report.py
@@ -143,6 +143,85 @@ def test_report_no_results_is_well_formed(tmp_path: Path) -> None:
     assert "No hit runs to compute noise from." in text
 
 
+def test_report_total_cost_sums_results_and_skipped(tmp_path: Path) -> None:
+    """#1000: total cost is a sum across BOTH results.jsonl and
+    skipped.jsonl — a case skipped for "unparseable --json output" still
+    paid for a real dispatch."""
+    _write_jsonl(
+        tmp_path / "results.jsonl",
+        [
+            {
+                "dataset": "defects4j",
+                "project": "Lang",
+                "bug_id": "29",
+                "hit": True,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r1.txt",
+                "cost_usd": 4.48,
+            },
+            {
+                "dataset": "bugsjs",
+                "project": "Bower",
+                "bug_id": "1",
+                "hit": False,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r2.txt",
+                "cost_usd": 1.29,
+            },
+        ],
+    )
+    _write_jsonl(
+        tmp_path / "skipped.jsonl",
+        [
+            {
+                "dataset": "defects4j",
+                "project": "Lang",
+                "bug_id": "23",
+                "skipped": True,
+                "reason": "unparseable --json output",
+                "cost_usd": 0.75,
+            },
+            {
+                "dataset": "defects4j",
+                "project": "Lang",
+                "bug_id": "9",
+                "skipped": True,
+                "reason": "checkout failed",
+                "cost_usd": None,
+            },
+        ],
+    )
+
+    text = report.build_report(tmp_path)
+    assert "Total cost: $6.52" in text
+
+
+def test_report_total_cost_defaults_missing_field_to_zero(tmp_path: Path) -> None:
+    """Records with no `cost_usd` key at all (older results, pre-#1000)
+    must not crash the report — they contribute $0.00."""
+    _write_jsonl(
+        tmp_path / "results.jsonl",
+        [
+            {
+                "dataset": "bugsjs",
+                "project": "Bower",
+                "bug_id": "1",
+                "hit": True,
+                "ground_truth_hunks": [],
+                "findings": [],
+                "unmatched_findings": [],
+                "raw_output_path": "r1.txt",
+            }
+        ],
+    )
+    text = report.build_report(tmp_path)
+    assert "Total cost: $0.00" in text
+
+
 def test_write_report_creates_results_dir(tmp_path: Path) -> None:
     target = tmp_path / "nested" / "results"
     path = report.write_report(target)

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -61,14 +61,19 @@ def _seed_checkout(workdir: str, files) -> None:
         path.write_text("stub\n", encoding="utf-8")
 
 
-def _dispatch_result(review_json: Dict[str, Any] = _REVIEW_JSON) -> Dict[str, Any]:
+def _dispatch_result(
+    review_json: Dict[str, Any] = _REVIEW_JSON, cost_usd: Any = 4.48
+) -> Dict[str, Any]:
     """A dispatch_fn return value shaped like the real `make_isolated_dispatch_fn`
     output: both the raw wrapper stdout AND the already-extracted `result_text`
-    (the runner reads `result_text` directly; it does not re-parse `raw_stdout`)."""
+    (the runner reads `result_text` directly; it does not re-parse `raw_stdout`),
+    plus `cost_usd` (#1000) — defaults to a real measured value (#974) so tests
+    exercise cost propagation by default rather than opting in."""
     result_text = json.dumps(review_json)
     return {
         "raw_stdout": json.dumps({"result": result_text}),
         "result_text": result_text,
+        "cost_usd": cost_usd,
     }
 
 
@@ -95,6 +100,7 @@ def test_run_case_hit(tmp_path: Path) -> None:
     assert len(record["findings"]) == 1
     assert record["unmatched_findings"] == []
     assert Path(record["raw_output_path"]).is_file()
+    assert record["cost_usd"] == 4.48
 
 
 def test_run_case_checkout_failure_is_skipped(tmp_path: Path) -> None:
@@ -106,6 +112,8 @@ def test_run_case_checkout_failure_is_skipped(tmp_path: Path) -> None:
     )
     assert record["skipped"] is True
     assert record["reason"] == "checkout failed"
+    # No dispatch ever happened for this case — nothing was spent (#1000).
+    assert record["cost_usd"] is None
 
 
 def test_run_case_no_ground_truth_is_skipped(tmp_path: Path) -> None:
@@ -261,6 +269,7 @@ def test_run_case_unparseable_json_is_skipped(tmp_path: Path) -> None:
         return {
             "raw_stdout": json.dumps({"result": "not json at all"}),
             "result_text": "not json at all",
+            "cost_usd": 1.29,
         }
 
     record = runner.run_case(
@@ -273,6 +282,25 @@ def test_run_case_unparseable_json_is_skipped(tmp_path: Path) -> None:
     assert record["reason"] == "unparseable --json output"
     # Raw output is still saved verbatim even on a parse failure.
     assert Path(record["raw_output_path"]).is_file()
+    # #1000: the dispatch happened and cost real money even though its
+    # output couldn't be parsed/scored — that cost must not be lost.
+    assert record["cost_usd"] == 1.29
+
+
+def test_skip_record_defaults_cost_usd_to_none() -> None:
+    """Direct unit coverage: every skip reason that fires before a dispatch
+    (the overwhelming majority of call sites) gets `cost_usd=None` for free
+    by simply not passing the keyword — this is the contract that makes
+    that safe."""
+    record = runner.skip_record(_CASE, "checkout failed")
+    assert record["cost_usd"] is None
+
+
+def test_skip_record_carries_explicit_cost_usd() -> None:
+    record = runner.skip_record(
+        _CASE, "unparseable --json output", "raw.txt", cost_usd=3.33
+    )
+    assert record["cost_usd"] == 3.33
 
 
 def test_run_case_full_repo_scope_passes_full_checkout(tmp_path: Path) -> None:
@@ -419,14 +447,10 @@ def test_extract_review_json_no_fence_parses_raw_json() -> None:
     assert runner._extract_review_json(json.dumps(_REVIEW_JSON)) == _REVIEW_JSON
 
 
-def test_make_isolated_dispatch_fn_carries_over_auth_state(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """`make_isolated_dispatch_fn()`'s dispatch closure must call
-    `copy_auth_state()` (#957) so the harness's own runs keep the
-    operator's real Claude Code login — unlike the standalone
-    `isolated_dispatch.py` script/skill, where this is opt-in."""
-    calls = []
+def _make_fake_isolated_dispatch(tmp_path: Path, calls: list):
+    """Shared fake `isolated_dispatch` module stand-in for
+    `make_isolated_dispatch_fn()` tests (#957 auth-carry-over, #1000
+    cost extraction) — avoids redefining the same four-method stub per test."""
 
     class _FakeIsolatedDispatch:
         @staticmethod
@@ -452,8 +476,21 @@ def test_make_isolated_dispatch_fn_carries_over_auth_state(
         def build_cmd(prompt, session_id, model, cwd=None):
             return ["claude", "-p", prompt]
 
+    return _FakeIsolatedDispatch
+
+
+def test_make_isolated_dispatch_fn_carries_over_auth_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`make_isolated_dispatch_fn()`'s dispatch closure must call
+    `copy_auth_state()` (#957) so the harness's own runs keep the
+    operator's real Claude Code login — unlike the standalone
+    `isolated_dispatch.py` script/skill, where this is opt-in."""
+    calls: list = []
     monkeypatch.setattr(
-        runner, "_load_isolated_dispatch", lambda: _FakeIsolatedDispatch
+        runner,
+        "_load_isolated_dispatch",
+        lambda: _make_fake_isolated_dispatch(tmp_path, calls),
     )
 
     import subprocess as subprocess_module
@@ -469,6 +506,62 @@ def test_make_isolated_dispatch_fn_carries_over_auth_state(
     dispatch_fn("/code-review --json", str(tmp_path))
 
     assert calls == [("copy_auth_state", tmp_path / "cell-home")]
+
+
+def test_make_isolated_dispatch_fn_extracts_cost_usd_from_wrapper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#1000: the wrapper JSON's `total_cost_usd` (already reported by the
+    underlying `claude -p --output-format json` call) must be surfaced as
+    `cost_usd` in the dispatch result, so the harness can track real spend."""
+    monkeypatch.setattr(
+        runner,
+        "_load_isolated_dispatch",
+        lambda: _make_fake_isolated_dispatch(tmp_path, []),
+    )
+
+    import subprocess as subprocess_module
+
+    def fake_run(cmd, **kwargs):
+        return subprocess_module.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps({"result": "{}", "total_cost_usd": 2.5}),
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", str(tmp_path))
+
+    assert result["cost_usd"] == 2.5
+
+
+def test_make_isolated_dispatch_fn_cost_usd_none_when_wrapper_unparseable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A malformed wrapper (or a case where the process was killed before
+    printing) must not crash — `cost_usd` is simply `None`, mirroring
+    `result_text`'s existing None-on-failure contract."""
+    monkeypatch.setattr(
+        runner,
+        "_load_isolated_dispatch",
+        lambda: _make_fake_isolated_dispatch(tmp_path, []),
+    )
+
+    import subprocess as subprocess_module
+
+    def fake_run(cmd, **kwargs):
+        return subprocess_module.CompletedProcess(
+            args=cmd, returncode=0, stdout="not json at all"
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", str(tmp_path))
+
+    assert result["cost_usd"] is None
 
 
 def test_append_and_resume_roundtrip(tmp_path: Path) -> None:

--- a/tests/scripts/test_code_review_benchmark_scheduler.py
+++ b/tests/scripts/test_code_review_benchmark_scheduler.py
@@ -1,0 +1,238 @@
+"""Unit tests for the #1000 benchmark harness's budget-aware scheduler.
+
+`scheduler.run_pending()` is exercised entirely through fake `run_case_fn`
+callables — no real subprocess, no real `ThreadPoolExecutor` work beyond
+what Python itself provides — mirroring the dependency-injection style
+`test_code_review_benchmark_runner.py` already uses for `dispatch_fn`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+_HARNESS_DIR = Path(__file__).resolve().parents[2] / "evals" / "code-review-benchmark"
+if str(_HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_DIR))
+
+import runner  # noqa: E402
+import scheduler  # noqa: E402
+
+
+def _noop_kwargs(case: Any) -> Dict[str, Any]:
+    return {}
+
+
+def _pending(bug_ids: List[str]):
+    """Build `(case, case_dict)` pairs `run_pending()` expects — `case` is
+    unused when `make_kwargs` is `_noop_kwargs`, so a bare dict stands in."""
+    return [
+        (bug_id, {"dataset": "defects4j", "project": "Lang", "bug_id": bug_id})
+        for bug_id in bug_ids
+    ]
+
+
+def test_run_pending_prints_progress_and_returns_total(tmp_path: Path) -> None:
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 1.0}
+
+    total = scheduler.run_pending(
+        _pending(["1", "2"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=1,
+        run_case_fn=fake_run_case_fn,
+    )
+    assert total == 2.0
+    seen = runner.already_processed(tmp_path)
+    assert seen == {"defects4j:Lang:1", "defects4j:Lang:2"}
+
+
+def test_run_pending_running_total_accumulates_across_cases(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    costs = {"1": 1.00, "2": 2.00, "3": 0.50}
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        return {
+            **case_dict,
+            "skipped": False,
+            "hit": True,
+            "cost_usd": costs[case_dict["bug_id"]],
+        }
+
+    total = scheduler.run_pending(
+        _pending(["1", "2", "3"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=1,  # deterministic completion order
+        run_case_fn=fake_run_case_fn,
+    )
+    assert total == 3.50
+    out = capsys.readouterr().out
+    assert "($1.00 total)" in out
+    assert "($3.00 total)" in out
+    assert "($3.50 total)" in out
+
+
+def test_scheduler_no_max_cost_usd_dispatches_everything(tmp_path: Path) -> None:
+    called: List[str] = []
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        called.append(case_dict["bug_id"])
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 5.0}
+
+    scheduler.run_pending(
+        _pending(["1", "2", "3"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=2,
+        max_cost_usd=None,
+        run_case_fn=fake_run_case_fn,
+    )
+    assert sorted(called) == ["1", "2", "3"]
+
+
+def test_scheduler_stops_new_dispatch_once_budget_reached(tmp_path: Path) -> None:
+    """workers=1: cases complete one at a time, so the budget check after
+    case 1 ($5.00 >= $5.00 budget) must stop cases 2 and 3 from ever
+    calling run_case_fn — they land in skipped.jsonl instead."""
+    called: List[str] = []
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        called.append(case_dict["bug_id"])
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 5.0}
+
+    scheduler.run_pending(
+        _pending(["1", "2", "3"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=1,
+        max_cost_usd=5.0,
+        run_case_fn=fake_run_case_fn,
+    )
+    assert called == ["1"]
+
+    lines = (tmp_path / "skipped.jsonl").read_text(encoding="utf-8").splitlines()
+    skipped_records = [json.loads(line) for line in lines]
+    skipped_ids = {r["bug_id"] for r in skipped_records}
+    assert skipped_ids == {"2", "3"}
+    assert all("--max-cost-usd" in r["reason"] for r in skipped_records)
+
+
+def test_scheduler_initial_batch_can_exceed_budget_before_first_check(
+    tmp_path: Path,
+) -> None:
+    """workers=3: cases 1, 2, and 3 are all primed before any completion,
+    so all three run to completion even though their combined cost ($15)
+    exceeds the $5 budget — only case 4 (queued behind them) is skipped."""
+    called: List[str] = []
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        called.append(case_dict["bug_id"])
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 5.0}
+
+    scheduler.run_pending(
+        _pending(["1", "2", "3", "4"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=3,
+        max_cost_usd=5.0,
+        run_case_fn=fake_run_case_fn,
+    )
+    assert sorted(called) == ["1", "2", "3"]
+
+    lines = (tmp_path / "skipped.jsonl").read_text(encoding="utf-8").splitlines()
+    skipped_records = [json.loads(line) for line in lines]
+    assert {r["bug_id"] for r in skipped_records} == {"4"}
+
+
+def test_scheduler_in_flight_case_finishes_after_budget_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """workers=2: case A completes immediately and trips the budget; case
+    B must already be genuinely blocked (its worker thread has not
+    returned) at that moment, and must still be allowed to finish rather
+    than being treated as skipped. Deterministic synchronization: B's fake
+    run_case_fn blocks on `a_appended` — an Event only set by a wrapped
+    `runner.append_result` right after A's real result is appended, which
+    happens on the main thread strictly after A's future is drained. B's
+    worker thread therefore cannot return before that point, proving B was
+    still in flight (not done) at the moment the budget check for A ran."""
+    a_appended = threading.Event()
+
+    original_append_result = runner.append_result
+
+    def wrapped_append_result(record, results_dir):
+        original_append_result(record, results_dir)
+        if record.get("bug_id") == "A":
+            a_appended.set()
+
+    monkeypatch.setattr(scheduler.runner, "append_result", wrapped_append_result)
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        if case_dict["bug_id"] == "A":
+            return {**case_dict, "skipped": False, "hit": True, "cost_usd": 5.0}
+        # Case B: block until A has genuinely been appended by the main
+        # thread — guarantees B's future is still un-done at that instant.
+        assert a_appended.wait(timeout=5), "A was never appended — test setup broken"
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 0.0}
+
+    scheduler.run_pending(
+        [
+            ("A", {"dataset": "defects4j", "project": "Lang", "bug_id": "A"}),
+            ("B", {"dataset": "defects4j", "project": "Lang", "bug_id": "B"}),
+        ],
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=2,
+        max_cost_usd=5.0,
+        run_case_fn=fake_run_case_fn,
+    )
+
+    seen = runner.already_processed(tmp_path)
+    # Both A and B completed and were scored (hit) — B was never skipped
+    # despite the budget tripping while it was still in flight.
+    assert seen == {"defects4j:Lang:A", "defects4j:Lang:B"}
+
+    results_path = tmp_path / "results.jsonl"
+    records = [
+        json.loads(line)
+        for line in results_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert {r["bug_id"] for r in records} == {"A", "B"}
+
+
+def test_scheduler_tops_up_queue_as_futures_complete_when_under_budget(
+    tmp_path: Path,
+) -> None:
+    """workers=2, no budget: submitting case 3 only once one of the first
+    two slots frees up proves the top-up mechanism runs (not just the
+    stop condition) — all 4 cases must complete."""
+    called: List[str] = []
+
+    def fake_run_case_fn(case_dict, **kwargs) -> Dict[str, Any]:
+        called.append(case_dict["bug_id"])
+        return {**case_dict, "skipped": False, "hit": True, "cost_usd": 1.0}
+
+    total = scheduler.run_pending(
+        _pending(["1", "2", "3", "4"]),
+        make_kwargs=_noop_kwargs,
+        dispatch_fn=lambda prompt, cwd: {},
+        results_dir=tmp_path,
+        workers=2,
+        run_case_fn=fake_run_case_fn,
+    )
+    assert sorted(called) == ["1", "2", "3", "4"]
+    assert total == 4.0


### PR DESCRIPTION
## Summary

Closes #1000
Part of #970

`evals/code-review-benchmark/cli.py` dispatched real `/code-review --json` headless runs with zero cost visibility. #974's live investigation measured $1.29 (trivial single file) to $4.48 (real Defects4J case) per case — an unbounded sweep (`cli.py --dataset defects4j`, no `--sample`/`--limit-projects`) could rack up uncapped real spend with no signal until it finished or was killed.

This PR ships all four "consider" items from the issue:

- **Running cost total** on every progress line: `[3/10] defects4j:Lang:23: HIT ($6.12 total)`.
- **`--max-cost-usd <N>`**, a fail-safe cutoff: checked only after a case completes (never before the initial `--workers`-sized batch is primed, so realized spend can exceed `N` by up to `workers - 1` extra in-flight cases' cost — disclosed, not a bug). Already-in-flight cases always finish; cases that never got to start are recorded to `skipped.jsonl` (never silently dropped), with a clear stderr message. Rejects `<= 0` at the parser.
- **Pre-sweep cost estimate**: `case_count * $4.50` (a hardcoded conservative constant — not extrapolated from live cases, see Decisions & Assumptions below), printed as a stderr warning before dispatch begins.
- **`report.md` total cost**: a new summary line summing `cost_usd` across `results.jsonl` + `skipped.jsonl` (a case skipped for "unparseable --json output" still paid for a real dispatch).

The dispatch loop is extracted into a new `evals/code-review-benchmark/scheduler.py` module rather than grown inside `cli.py` (which already carried argparse wiring, dataset bootstrap, and dispatch orchestration). `scheduler.run_pending()` replaces "submit every case upfront, drain via `as_completed`, rely on `Future.cancel()` to stop unstarted ones" (a race that can't give `--max-cost-usd` a real guarantee, or be tested deterministically) with "submit up to `--workers` cases, top up as each completes" via `concurrent.futures.wait(in_flight, return_when=FIRST_COMPLETED)` over a mutable in-flight set — `as_completed` can't accept futures added mid-iteration, so it isn't usable here.

## Quality Gate

- [x] Full repo test suite green: `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py -n auto --dist loadfile -q` → 3044 passed, 1 skipped (expected, unrelated opt-in skip from `test_orchestrator.py`).
- [x] Benchmark harness's own suite: `tests/scripts/test_code_review_benchmark_*.py` → 117 passed (including a new `test_code_review_benchmark_scheduler.py`, 9 tests).
- [x] `doc-review`: pass, no issues — README/docstrings/`--help` all verified consistent with the implementation.
- [x] `arch-review`: pass — sound design, no ADR conflicts, clean import DAG (no circularity), correct concurrency (verified by reading, not assumed); one low-severity suggestion (align `--workers` validation with `--max-cost-usd`'s fail-fast style) applied in a follow-up commit; one theoretical `BaseException`-vs-`Exception` edge case noted, no action needed (matches the pre-existing pattern this code was extracted from).
- [x] Real, unmocked end-to-end verification (not just unit tests): ran `scheduler.run_pending()` directly with fake case functions to observe the real budget-trip/top-up/skip behavior and progress-line format; ran `cli.py --report-only` against hand-built `results.jsonl`/`skipped.jsonl` fixtures to confirm `report.md`'s `Total cost: $5.77` line renders correctly from real code (not asserted-only); ran `cli.py --max-cost-usd 0`/`--help` to confirm real parser validation and help text.

## Decisions & Assumptions

- **All four "consider" items shipped** — the running total and `report.md` total are near-zero-risk plumbing; the fail-safe cutoff and pre-sweep estimate both directly address the issue's stated risk (uncapped real spend with zero visibility).
- **Pre-sweep estimate uses a hardcoded `$4.50`/case constant**, not extrapolation from live cases. Extrapolation needs a warm-up window and adds real complexity (how many samples is "enough"? what about out-of-order completion with `workers > 1`?) for a feature whose only job is a rough heads-up before spending real money. Deferred, not abandoned — revisit only if the constant proves materially wrong against real sweep data.
- **`--max-cost-usd` is a fail-safe backstop, not an exact ceiling.** Because the budget is checked only after a completion, up to `workers - 1` extra in-flight cases can complete past the limit. An exact ceiling would require either `workers=1` (defeats the point of concurrency) or aborting in-flight API calls mid-request (real risk of losing a finished-but-unread result — worse than a few dollars of bounded, disclosed overspend). Documented in the flag's help text, the README, and the plan.
- **Fixed-size batching was considered and rejected** as a simpler alternative to submit-as-you-go scheduling: it gives the same real stop guarantee but stalls an entire batch behind one slow straggler (a 58-turn, 846s Defects4J case, per #974), idling other workers even when budget hasn't been reached — defeating the point of `--workers` on a real sweep.
- **Extracted a new `scheduler.py` module** rather than growing `cli.py` (369 lines, 3 existing responsibilities pre-change) with a 4th — verified by the dispatched Design & Architecture Critic during planning.
- Full plan with Gherkin scenarios, two rounds of dispatched plan review (Acceptance Test Critic + Design & Architecture Critic — both `needs-revision` → `approve`), and the reasoning above lives at `plans/issue-1000-benchmark-cost-budget.md` (gitignored, not part of this diff).

## Test Plan

- `tests/scripts/test_code_review_benchmark_runner.py` — `cost_usd` extraction/threading through `make_isolated_dispatch_fn`, `run_case`, `skip_record` (success, post-dispatch skip, pre-dispatch skip, timeout).
- `tests/scripts/test_code_review_benchmark_scheduler.py` (new) — running total, no-cap regression, budget-stop, initial-batch-can-overspend, in-flight-case-survives-budget-trip (real `threading.Event` synchronization, not a sleep-based race), top-up-under-budget.
- `tests/scripts/test_code_review_benchmark_cli.py` — `--max-cost-usd`/`--workers` parser validation (default/override/reject-zero/reject-negative), pre-sweep estimate printed/skipped (`--report-only`, `--resume`-to-zero-pending).
- `tests/scripts/test_code_review_benchmark_report.py` — total-cost summation across both JSONL files, missing-field defaulting to $0.00.

## Evidence Bundle

- Full suite: 3044 passed, 1 skipped.
- Benchmark harness suite: 117 passed.
- Manual verification transcript (real code, no mocks) — `scheduler.run_pending()` with `workers=2, max_cost_usd=8.0` against 4 fake $5 cases: cases 1 & 2 primed, case 1 completes ($5 < $8, tops up case 3), case 2 completes ($10 ≥ $8, budget trips, case 4 skipped), case 3 (already in flight) finishes normally → final total $15.00, matching the disclosed overspend bound exactly.
- `cli.py --report-only` against hand-built fixtures → real `report.md` rendered `Total cost: $5.77` ($4.48 + $1.29).