### PR TITLE
fix: retry once via --resume when /code-review --json narrates instead of JSON

### DIFF
--- a/evals/code-review-benchmark/README.md
+++ b/evals/code-review-benchmark/README.md
@@ -115,8 +115,10 @@ searches for a fenced```json block anywhere in the text (last one first,
 falling back to earlier ones) rather than requiring the whole response to
 be just the fence. If the model's final text has no JSON at all (not just
 a formatting quirk — the payload was never actually emitted in that
-turn), that's unrecoverable and still shows up as "unparseable --json
-output".
+turn), the harness retries once via the same-session `--resume` backstop
+(see "Narration instead of JSON" below, #999/#1002) before giving up; only
+if that retry also fails does it show up as "unparseable --json output
+(after retry)".
 
 ## Usage
 
@@ -168,6 +170,8 @@ python3 cli.py --dataset defects4j --max-cost-usd 50
 | `--workers` | Number of bug cases run concurrently, thread pool (default 2 — lowered from 4 after #974 to bound how many ~14-20-way agent fan-outs run concurrently on one host) |
 | `--max-cost-usd N` | Fail-safe spend cutoff in USD (#1000, default: no cap) — see Cost tracking below |
 | `--no-verify-tests` | Skip building/installing deps and running the project's own test suite per case (on by default; diagnostic only — see below) |
+| `--no-json-retry` | Disable the #999/#1002 retry-once backstop for narration-instead-of-JSON dispatches (on by default — see "Narration instead of JSON" below) |
+| `--json-retry-timeout N` | Subprocess timeout, seconds, for the retry-once follow-up specifically (default: unset, falls back to `min(--timeout, 300)` — deliberately smaller than `--timeout`, since the retry is meant to be a cheap same-session re-emission, not a fresh review) |
 | `--defects4j-home`, `--bugsjs-home` | Dataset home dirs (or the matching env vars) |
 | `--results-dir` | Where `results.jsonl`/`skipped.jsonl`/`report.md`/`raw/` are written (default `./results`) |
 | `--report-only` | Only (re)generate `report.md` from existing results |
@@ -210,25 +214,54 @@ below.
 - `skipped.jsonl` — one record per bug that couldn't be checked out or
   scored: `{dataset, project, bug_id, reason, cost_usd}`. `reason` is one
   of: `checkout failed`, `no ground-truth hunks`, `unparseable --json
-  output`, `ground truth touches no recognized source files` (the fix's
-  own commit bundled with its tests touched nothing but a
-  changelog/manifest/CI-config file — e.g. `History.md`, `package.json`,
+  output` (or `unparseable --json output (after retry)` — see "Narration
+  instead of JSON" below), `ground truth touches no recognized source
+  files` (the fix's own commit bundled with its tests touched nothing but
+  a changelog/manifest/CI-config file — e.g. `History.md`, `package.json`,
   `.travis.yml` — so there was no source change for `/code-review` to have
   found; scored as a skip, not a recall miss), or a message naming
   `--max-cost-usd` (#1000 — the sweep's budget was reached before this
   case could be dispatched).
 - `cost_usd` (#1000, both files above) — the dispatch's `total_cost_usd`
-  from the underlying `claude -p --output-format json` wrapper, or `None`
-  when no dispatch happened (checkout failure, no ground truth, budget cut
-  off before this case started) or the wrapper never reported one (e.g. a
-  timeout).
+  from the underlying `claude -p --output-format json` wrapper (summed
+  across both attempts when the #999/#1002 retry-once backstop fired), or
+  `None` when no dispatch happened (checkout failure, no ground truth,
+  budget cut off before this case started) or the wrapper never reported
+  one (e.g. a timeout).
 - `raw/<dataset>-<project>-<bug_id>.txt` — the dispatch's raw stdout,
-  verbatim, saved before any parsing (so a parser bug never loses data).
+  verbatim, saved before any parsing (so a parser bug never loses data). If
+  the #999/#1002 retry-once backstop fired, this file has BOTH attempts:
+  the primary dispatch's raw stdout, then a `--- #999/#1002 JSON-retry
+  follow-up (--resume) ---` delimiter, then the retry's raw stdout (or a
+  placeholder noting the retry subprocess itself failed/timed out).
 - `report.md` — overall/per-dataset/per-project recall, a **Missed Defects**
   section (the actionable part), a noise summary (average unmatched
   findings per hit run — "unmatched," not "false positive": the review may
   have found a real, different issue), and a total-cost line (#1000)
   summed across `results.jsonl` + `skipped.jsonl`.
+
+### Narration instead of JSON (#967, #975, #999, #1002)
+
+A completed, otherwise-successful `/code-review --json` dispatch
+occasionally narrates having emitted its JSON payload instead of actually
+emitting it (e.g. "Aggregated JSON emitted to stdout per `--json` contract;
+run stops here" — no `{...}` object anywhere in the text). PR #975 hardened
+the skill's step-7 wording specifically to forbid this, but #999 and #1002
+each independently reproduced it again afterward, on cases at opposite ends
+of the harness's turn-count range (58 turns and 15 turns) — evidence that a
+wording-only fix doesn't reliably close the gap; see
+`plans/issue-999-1002-json-narration.md` for the full investigation.
+
+`make_isolated_dispatch_fn` (this is where `--no-json-retry` and
+`--json-retry-timeout` apply) now retries exactly once when this happens:
+it resumes the SAME session (`claude -p --resume <session_id>`, not a fresh
+dispatch) with a short instruction to re-emit only the JSON, since the
+review's findings are already in that session's context and don't need to
+be redone. If the retry succeeds, the case scores normally. If it also
+fails, the case is skipped with reason `unparseable --json output (after
+retry)` so it's distinguishable in `skipped.jsonl`/`report.md` from a case
+where no retry was ever attempted (e.g. the first dispatch itself errored
+or timed out — retrying a broken run's session isn't expected to help).
 
 ## Test verification (diagnostic, not a gate)
 

--- a/evals/code-review-benchmark/cli.py
+++ b/evals/code-review-benchmark/cli.py
@@ -228,7 +228,10 @@ def run(args: argparse.Namespace) -> int:
 
     already = runner.already_processed(results_dir) if args.resume else set()
     dispatch_fn = runner.make_isolated_dispatch_fn(
-        model=args.model, timeout=args.timeout
+        model=args.model,
+        timeout=args.timeout,
+        retry_on_unparseable=not args.no_json_retry,
+        retry_timeout=args.json_retry_timeout,
     )
 
     pending = []
@@ -373,6 +376,33 @@ def _build_parser() -> argparse.ArgumentParser:
             "Skip building/installing deps and running the project's own "
             "test suite per case (on by default; diagnostic only, never "
             "gates scoring)."
+        ),
+    )
+    parser.add_argument(
+        "--no-json-retry",
+        action="store_true",
+        help=(
+            "Disable the #999/#1002 retry-once backstop: a `/code-review "
+            "--json` dispatch that completes normally but narrates instead "
+            "of emitting the required JSON is, by default, retried exactly "
+            "once via a cheap `--resume` follow-up on the same session. "
+            "Pass this flag to disable it (e.g. for a retry-on vs. "
+            "retry-off recurrence-rate comparison, or a cost-sensitive "
+            "sweep)."
+        ),
+    )
+    parser.add_argument(
+        "--json-retry-timeout",
+        type=int,
+        default=None,
+        help=(
+            "Subprocess timeout, seconds, for the #999/#1002 retry-once "
+            "follow-up dispatch specifically (default: unset, which falls "
+            "back to `min(--timeout, 300)` in "
+            "`runner.make_isolated_dispatch_fn` — deliberately NOT the "
+            "same, much larger --timeout budget as the primary dispatch, "
+            "since the retry is meant to be a cheap same-session "
+            "re-emission, not a fresh review)."
         ),
     )
     parser.add_argument(

--- a/evals/code-review-benchmark/runner.py
+++ b/evals/code-review-benchmark/runner.py
@@ -228,9 +228,10 @@ def run_case(
 
         review_json = _extract_review_json(dispatch_result.get("result_text"))
         if review_json is None:
-            return skip_record(
-                case, "unparseable --json output", str(raw_path), cost_usd=cost_usd
-            )
+            reason = "unparseable --json output"
+            if dispatch_result.get("retry_attempted"):
+                reason += " (after retry)"
+            return skip_record(case, reason, str(raw_path), cost_usd=cost_usd)
 
         findings = _flatten_findings(review_json)
         scored = scorer.score(ground_truth_hunks, findings, tolerance=tolerance)
@@ -313,8 +314,60 @@ def _load_isolated_dispatch():
     return module
 
 
+# #999/#1002: a completed `/code-review --json` dispatch occasionally
+# narrates having emitted the JSON instead of actually emitting it, even
+# after PR #975 hardened the skill's step-7 wording to specifically forbid
+# this — confirmed independently on two more cases post-#975 (58-turn and
+# 15-turn runs, so not cleanly explained by turn count/context pressure
+# alone). A skill-file wording instruction cannot deterministically force
+# what the model's literal final turn contains, so this is a harness-side
+# backstop instead of a third wording attempt: one cheap follow-up dispatch
+# that RESUMES the same session (`--resume`, not a fresh `--session-id`) and
+# asks it to restate the already-computed result as raw JSON only. See
+# `plans/issue-999-1002-json-narration.md` for the full investigation.
+_JSON_RETRY_PROMPT = (
+    "Your previous response completed the /code-review --json review, but "
+    "its final text did not contain the required JSON object — a narration "
+    "or prose summary was returned instead of the payload. Re-emit the "
+    "exact same review result you already computed. Your entire response "
+    "must be the raw JSON object itself, per the aggregated JSON schema — "
+    "no preamble, no markdown fence, no trailing commentary."
+)
+
+# Delimiter joining the primary dispatch's raw stdout to the #999/#1002
+# retry's raw stdout in the value `run_case` persists to `raw/*.txt` — so a
+# retried case's raw-output file still shows both attempts verbatim (never
+# silently discards the retry's own output, matching this file's existing
+# "never lose data" contract for raw-output persistence).
+_RETRY_RAW_DELIMITER = "\n\n--- #999/#1002 JSON-retry follow-up (--resume) ---\n\n"
+
+
+def _parse_dispatch_wrapper(raw_stdout: str) -> Dict[str, Any]:
+    """Parse one dispatch's `--output-format json` wrapper stdout into the
+    fields `make_isolated_dispatch_fn`'s closure needs: the model's final
+    `result` text, whether the run itself reported an error, and its
+    `total_cost_usd` (#1000). Shared by both the primary dispatch and the
+    #999/#1002 retry-once follow-up so neither duplicates the other's
+    parse/extract logic (Design & Architecture Critic finding during this
+    plan's review)."""
+    result_text = None
+    is_error = True
+    cost_usd = None
+    try:
+        wrapper = json.loads(raw_stdout)
+        result_text = wrapper.get("result")
+        is_error = bool(wrapper.get("is_error"))
+        cost_usd = wrapper.get("total_cost_usd")
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return {"result_text": result_text, "is_error": is_error, "cost_usd": cost_usd}
+
+
 def make_isolated_dispatch_fn(
-    model: str = "sonnet", timeout: int = 1800
+    model: str = "sonnet",
+    timeout: int = 1800,
+    retry_on_unparseable: bool = True,
+    retry_timeout: Optional[int] = None,
 ) -> Callable[[str, str], Dict[str, Any]]:
     """Build the real, production `dispatch_fn` for `run_case`.
 
@@ -352,8 +405,32 @@ def make_isolated_dispatch_fn(
     headroom for that now-measured real cost, not an arbitrary bump; see
     `cli.py`'s `--timeout` help text and `plans/issue-974-benchmark-
     timeout-fanout.md` for the full investigation.
+
+    `retry_on_unparseable` (#999/#1002, default `True`): when a completed,
+    non-error dispatch's `result` text has no parseable `--json` payload
+    (per `_extract_review_json()`), issue exactly ONE follow-up dispatch
+    that resumes the SAME session (cheap — no work is redone) asking it to
+    re-emit only the JSON. Set `False` to disable this backstop (e.g. for a
+    retry-on vs. retry-off recurrence-rate comparison, or a cost-sensitive
+    sweep) via `cli.py --no-json-retry`.
+
+    `retry_timeout` (#999/#1002, default `None` -> `min(timeout, 300)`):
+    the follow-up retry dispatch's own subprocess timeout, deliberately
+    NOT the same (large, 1800s-by-default) budget as the primary dispatch.
+    The retry's whole premise is that it's a cheap restatement of an
+    already-computed result within the same session, not a fresh review —
+    reusing the full primary timeout would let a stuck/looping retry cost
+    nearly as much wall-clock as the original dispatch, undermining that
+    premise (Design & Architecture Critic finding during this plan's
+    review). 300s is a reasonable, deliberately conservative ceiling for
+    that — not an empirically measured number (no live retry-cost data
+    exists yet); override via `cli.py --json-retry-timeout` if a live
+    sweep later shows it's too tight or too loose.
     """
     isolated_dispatch = _load_isolated_dispatch()
+    effective_retry_timeout = (
+        retry_timeout if retry_timeout is not None else min(timeout, 300)
+    )
 
     def dispatch(prompt: str, cwd: str) -> Dict[str, Any]:
         home = isolated_dispatch.make_cell_home()
@@ -372,22 +449,70 @@ def make_isolated_dispatch_fn(
                 timeout=timeout,
             )
         except subprocess.TimeoutExpired:
-            return {"raw_stdout": "", "result_text": None, "is_error": True}
-        finally:
             shutil.rmtree(str(home), ignore_errors=True)
+            return {
+                "raw_stdout": "",
+                "result_text": None,
+                "is_error": True,
+                "retry_attempted": False,
+            }
 
         raw_stdout = proc.stdout or ""
-        result_text = None
-        cost_usd = None
-        try:
-            wrapper = json.loads(raw_stdout)
-            result_text = wrapper.get("result")
-            cost_usd = wrapper.get("total_cost_usd")
-        except (json.JSONDecodeError, ValueError):
-            pass
+        parsed = _parse_dispatch_wrapper(raw_stdout)
+        result_text = parsed["result_text"]
+        cost_usd = parsed["cost_usd"]
+        retry_attempted = False
+
+        if (
+            retry_on_unparseable
+            and not parsed["is_error"]
+            and _extract_review_json(result_text) is None
+        ):
+            retry_attempted = True
+            retry_cmd = isolated_dispatch.build_cmd(
+                _JSON_RETRY_PROMPT, session_id, model, cwd=cwd, resume=True
+            )
+            try:
+                retry_proc = subprocess.run(
+                    retry_cmd,
+                    cwd=cwd,
+                    env=env,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=effective_retry_timeout,
+                )
+            except subprocess.TimeoutExpired:
+                retry_proc = None
+            except Exception:  # noqa: BLE001 - a broken retry must not crash the case
+                retry_proc = None
+
+            if retry_proc is not None:
+                retry_raw_stdout = retry_proc.stdout or ""
+                retry_parsed = _parse_dispatch_wrapper(retry_raw_stdout)
+                if (
+                    not retry_parsed["is_error"]
+                    and _extract_review_json(retry_parsed["result_text"]) is not None
+                ):
+                    result_text = retry_parsed["result_text"]
+                    # #1000's cost tracking must reflect the real total
+                    # spend for this case, including the retry's own cost —
+                    # not just the primary dispatch's.
+                    if retry_parsed["cost_usd"] is not None:
+                        cost_usd = (cost_usd or 0) + retry_parsed["cost_usd"]
+            else:
+                retry_raw_stdout = "<retry subprocess failed: timeout or exception, no stdout captured>"
+            # #999/#1002 doc-review finding: the retry's own raw stdout must
+            # not be silently discarded — raw_dir/*.txt's whole purpose (see
+            # `run_case`) is "never lose data even on a parser bug," and a
+            # retried case is exactly the scenario this feature targets.
+            raw_stdout = raw_stdout + _RETRY_RAW_DELIMITER + retry_raw_stdout
+
+        shutil.rmtree(str(home), ignore_errors=True)
         return {
             "raw_stdout": raw_stdout,
             "result_text": result_text,
+            "retry_attempted": retry_attempted,
             "cost_usd": cost_usd,
         }
 

--- a/plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py
+++ b/plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py
@@ -11,7 +11,9 @@ Nested inside a live Remote session, a plain `claude -p` reuses the parent
   * a fresh temp HOME + CLAUDE_CONFIG_DIR (no shared config/memory/telemetry);
   * a SCRUBBED env with inherited CLAUDE_* session/Remote identity vars removed;
   * a fresh `--session-id <uuid>` per invocation (the key fix for the reused
-    session_id) with NO `--resume`;
+    session_id) with NO `--resume` by default (see `build_cmd(resume=...)`
+    for the harness's opt-in, same-session #999/#1002 retry exception —
+    this script's own CLI/`run()` entry point never sets it);
   * `--output-format json` so the caller reads the verified session_id/cost;
   * a hard subprocess timeout.
 
@@ -232,27 +234,34 @@ def build_cmd(
     model: str,
     cwd: Optional[str] = None,  # accepted for symmetry; cwd is applied at run time
     skip_permissions: Optional[bool] = None,
+    resume: bool = False,
 ) -> List[str]:
     """The `claude -p` argv for one isolated dispatch.
 
-    Always carries `--session-id <uuid>` (the reused-session fix) and
-    `--output-format json`; NEVER `--resume`/`--fork-session` (those would
-    re-adopt an existing session). `--dangerously-skip-permissions` is added
-    only when not running as root (the CLI blocks it under root), matching
-    run_tdd_experiment's `os.getuid() == 0` guard."""
+    Default (`resume=False`): always carries `--session-id <uuid>` (the
+    reused-session fix) and `--output-format json`; NEVER `--resume`/
+    `--fork-session` (those would re-adopt an existing session).
+    `--dangerously-skip-permissions` is added only when not running as root
+    (the CLI blocks it under root), matching run_tdd_experiment's
+    `os.getuid() == 0` guard.
+
+    `resume=True` (#999/#1002's harness-side retry-once backstop, see
+    `evals/code-review-benchmark/runner.py::make_isolated_dispatch_fn`):
+    targets an EXISTING session via `--resume <session_id>` instead of
+    starting a fresh one — used for a cheap same-session follow-up dispatch
+    when the primary dispatch's `/code-review --json` response narrated
+    instead of emitting its required JSON payload, so the retry doesn't
+    redo the (expensive) review, only asks the same session to re-state its
+    already-computed result. Mutually exclusive with `--session-id` by
+    construction (the CLI only accepts one or the other)."""
     if skip_permissions is None:
         skip_permissions = not _is_root()
-    cmd = [
-        "claude",
-        "-p",
-        prompt,
-        "--session-id",
-        session_id,
-        "--output-format",
-        "json",
-        "--model",
-        model,
-    ]
+    cmd = ["claude", "-p", prompt]
+    if resume:
+        cmd += ["--resume", session_id]
+    else:
+        cmd += ["--session-id", session_id]
+    cmd += ["--output-format", "json", "--model", model]
     if skip_permissions:
         cmd.append("--dangerously-skip-permissions")
     return cmd

--- a/tests/scripts/test_code_review_benchmark_cli.py
+++ b/tests/scripts/test_code_review_benchmark_cli.py
@@ -68,6 +68,33 @@ def test_workers_rejects_negative() -> None:
         cli._build_parser().parse_args(["--dataset", "defects4j", "--workers", "-1"])
 
 
+def test_no_json_retry_defaults_off_so_retry_backstop_stays_on() -> None:
+    """#999/#1002: the retry-once backstop (`runner.make_isolated_dispatch_fn`'s
+    `retry_on_unparseable`) defaults ON — `--no-json-retry` must default to
+    `False` so an operator opts OUT, not opts in."""
+    args = cli._build_parser().parse_args(["--dataset", "defects4j"])
+    assert args.no_json_retry is False
+
+
+def test_no_json_retry_flag_disables_the_backstop() -> None:
+    args = cli._build_parser().parse_args(["--dataset", "defects4j", "--no-json-retry"])
+    assert args.no_json_retry is True
+
+
+def test_json_retry_timeout_defaults_to_none() -> None:
+    """`None` lets `runner.make_isolated_dispatch_fn` fall back to its own
+    `min(timeout, 300)` default rather than cli.py hard-coding a number."""
+    args = cli._build_parser().parse_args(["--dataset", "defects4j"])
+    assert args.json_retry_timeout is None
+
+
+def test_json_retry_timeout_override_still_works() -> None:
+    args = cli._build_parser().parse_args(
+        ["--dataset", "defects4j", "--json-retry-timeout", "120"]
+    )
+    assert args.json_retry_timeout == 120
+
+
 class _FakeCase:
     def __init__(self, bug_id: str) -> None:
         self.bug_id = bug_id

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -562,6 +564,395 @@ def test_make_isolated_dispatch_fn_cost_usd_none_when_wrapper_unparseable(
     result = dispatch_fn("/code-review --json", str(tmp_path))
 
     assert result["cost_usd"] is None
+
+
+class _RetryFakeIsolatedDispatch:
+    """A `_load_isolated_dispatch()` fake that supports the `resume` kwarg
+    `build_cmd()` gained in Slice 1 — the pre-existing
+    `_FakeIsolatedDispatch` above predates that and deliberately isn't
+    reused here, so this class's `build_cmd` signature exactly matches the
+    real `isolated_dispatch.build_cmd`'s post-Slice-1 shape."""
+
+    SESSION_ID = "22222222-2222-2222-2222-222222222222"
+
+    @staticmethod
+    def make_cell_home():
+        return Path(tempfile.mkdtemp(prefix="crb-retry-fake-home-"))
+
+    @staticmethod
+    def copy_auth_state(home):
+        return True
+
+    @classmethod
+    def new_session_id(cls):
+        return cls.SESSION_ID
+
+    @staticmethod
+    def build_env(home):
+        return {}
+
+    @staticmethod
+    def build_cmd(prompt, session_id, model, cwd=None, resume=False):
+        cmd = ["claude", "-p", prompt]
+        cmd += ["--resume", session_id] if resume else ["--session-id", session_id]
+        cmd += ["--output-format", "json", "--model", model]
+        return cmd
+
+
+def _wrapper_stdout(result_text: Optional[str], is_error: bool = False) -> str:
+    return json.dumps({"result": result_text, "is_error": is_error})
+
+
+def test_make_isolated_dispatch_fn_retries_once_on_unparseable_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#999/#1002: a completed, non-error dispatch whose result_text has no
+    parseable --json payload gets exactly ONE follow-up dispatch, resuming
+    the SAME session — not a fresh one — asking it to re-emit the JSON."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            stdout = _wrapper_stdout("Aggregated JSON emitted per contract.")
+        else:
+            stdout = _wrapper_stdout(json.dumps(_REVIEW_JSON))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 2
+    retry_cmd = calls[1]
+    assert "--resume" in retry_cmd
+    assert (
+        retry_cmd[retry_cmd.index("--resume") + 1]
+        == _RetryFakeIsolatedDispatch.SESSION_ID
+    )
+    assert "--session-id" not in retry_cmd
+    # The retry sends the short re-emission instruction, NOT a repeat of the
+    # original /code-review prompt (which would defeat the "cheap, no work
+    # redone" premise the retry is built on).
+    assert retry_cmd[2] == runner._JSON_RETRY_PROMPT
+    assert retry_cmd[2] != "/code-review --json"
+
+    assert result["retry_attempted"] is True
+    assert json.loads(result["result_text"]) == _REVIEW_JSON
+    # doc-review finding: the retry's own raw stdout must be persisted
+    # alongside the primary dispatch's, not silently discarded — raw/*.txt
+    # exists specifically so a parser bug never loses data, and a retried
+    # case is exactly the scenario this feature targets.
+    assert "Aggregated JSON emitted per contract." in result["raw_stdout"]
+    assert "missing assignment" in result["raw_stdout"]
+
+
+def test_make_isolated_dispatch_fn_retry_also_fails_keeps_original_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the retry ALSO comes back unparseable, the ORIGINAL (still
+    unparseable) result_text is preserved for raw-output/debugging
+    purposes, and retry_attempted is still True."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    original_text = "Review complete: FAIL overall, no JSON here."
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        text = original_text if len(calls) == 1 else "still just prose"
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=_wrapper_stdout(text)
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 2
+    assert result["retry_attempted"] is True
+    assert result["result_text"] == original_text
+
+
+def test_make_isolated_dispatch_fn_no_retry_when_first_call_errored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first dispatch that itself reports is_error: true is not retried —
+    resuming a broken run's session isn't expected to help."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=_wrapper_stdout("something went wrong", is_error=True),
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 1
+    assert result["retry_attempted"] is False
+
+
+def test_make_isolated_dispatch_fn_no_retry_when_first_result_already_parses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first dispatch whose result_text already parses as the --json
+    payload triggers no retry at all — the common, non-failure case."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=_wrapper_stdout(json.dumps(_REVIEW_JSON))
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 1
+    assert result["retry_attempted"] is False
+    assert json.loads(result["result_text"]) == _REVIEW_JSON
+
+
+def test_make_isolated_dispatch_fn_no_retry_when_first_dispatch_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The FIRST dispatch timing out (subprocess.TimeoutExpired) must not
+    attempt a retry — there is no completed session to resume. Explicit
+    regression coverage for this path (Acceptance Test Critic finding),
+    not just the structural guarantee of an early return."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 1
+    assert result["retry_attempted"] is False
+    assert result["is_error"] is True
+
+
+def test_make_isolated_dispatch_fn_retry_follow_up_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The RETRY dispatch itself timing out must not crash the case — the
+    original (still-unparseable) result_text is preserved and
+    retry_attempted stays True (Acceptance + Design critic finding: AC3's
+    'times out' sub-mode had no test)."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    original_text = (
+        "Per the --json contract, that JSON object is the run's only output."
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=_wrapper_stdout(original_text)
+            )
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 2
+    assert result["retry_attempted"] is True
+    assert result["result_text"] == original_text
+    # The retry subprocess itself never produced usable stdout (it raised),
+    # but that must still be visible in the persisted raw output rather
+    # than silently vanishing — a debugging-time distinction between "the
+    # retry ran and also narrated" and "the retry never completed at all."
+    assert original_text in result["raw_stdout"]
+    assert "retry subprocess failed" in result["raw_stdout"]
+
+
+def test_make_isolated_dispatch_fn_retry_follow_up_raises_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry dispatch that raises something other than TimeoutExpired
+    (e.g. an OSError spawning the subprocess) must not propagate and crash
+    the case — same "never let a broken retry sink the case" contract as
+    the timeout path, and the same contract cli.py already applies at the
+    batch level for `run_case` itself."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    original_text = "Review complete: FAIL overall, no JSON emitted."
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=_wrapper_stdout(original_text)
+            )
+        raise OSError("could not spawn subprocess")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 2
+    assert result["retry_attempted"] is True
+    assert result["result_text"] == original_text
+
+
+def test_make_isolated_dispatch_fn_retry_follow_up_wrapper_is_error_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry whose own wrapper JSON reports is_error: true (the resumed
+    session itself errored, distinct from merely being unparseable) must
+    not be treated as a successful retry — the ORIGINAL text is kept."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    original_text = (
+        "Aggregated JSON emitted to stdout per --json contract; run stops here."
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            stdout = _wrapper_stdout(original_text)
+        else:
+            stdout = _wrapper_stdout(json.dumps(_REVIEW_JSON), is_error=True)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn()
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 2
+    assert result["retry_attempted"] is True
+    assert result["result_text"] == original_text
+
+
+def test_make_isolated_dispatch_fn_retry_on_unparseable_false_suppresses_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`retry_on_unparseable=False` (the `--no-json-retry` path) must
+    suppress the retry at the dispatch-closure level, not just at CLI
+    argument parsing — proves the flag is actually wired through and
+    honored (Acceptance Test Critic finding: AC6 had no end-to-end test)."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=_wrapper_stdout("Aggregated JSON emitted per contract."),
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn(retry_on_unparseable=False)
+    result = dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert len(calls) == 1
+    assert result["retry_attempted"] is False
+
+
+def test_make_isolated_dispatch_fn_retry_timeout_override_reaches_subprocess_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`retry_timeout=` must reach the actual retry `subprocess.run` call's
+    `timeout=` kwarg — not just be accepted by argparse (Design &
+    Architecture Critic finding on the second review pass). The primary
+    dispatch keeps the larger `timeout=` budget; only the retry call uses
+    the smaller, independently-overridable `retry_timeout`."""
+    monkeypatch.setattr(
+        runner, "_load_isolated_dispatch", lambda: _RetryFakeIsolatedDispatch
+    )
+
+    seen_timeouts = []
+
+    def fake_run(cmd, **kwargs):
+        seen_timeouts.append(kwargs.get("timeout"))
+        if len(seen_timeouts) == 1:
+            stdout = _wrapper_stdout("Aggregated JSON emitted per contract.")
+        else:
+            stdout = _wrapper_stdout(json.dumps(_REVIEW_JSON))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    dispatch_fn = runner.make_isolated_dispatch_fn(timeout=1800, retry_timeout=5)
+    dispatch_fn("/code-review --json", "/tmp/some-dir")
+
+    assert seen_timeouts == [1800, 5]
+
+
+def test_run_case_skip_reason_notes_retry_when_retry_attempted(tmp_path: Path) -> None:
+    """`run_case`'s skip reason distinguishes a retried-but-still-failed
+    dispatch from one where no retry was ever attempted (#999/#1002)."""
+
+    def checkout_fn(workdir: str) -> bool:
+        _seed_checkout(workdir, ["src/Foo.java"])
+        return True
+
+    def dispatch_fn(prompt: str, cwd: str) -> Dict[str, Any]:
+        return {
+            "raw_stdout": json.dumps({"result": "still prose"}),
+            "result_text": "still prose",
+            "retry_attempted": True,
+        }
+
+    record = runner.run_case(
+        _CASE,
+        checkout_fn=checkout_fn,
+        dispatch_fn=dispatch_fn,
+        results_dir=tmp_path,
+    )
+    assert record["skipped"] is True
+    assert record["reason"] == "unparseable --json output (after retry)"
 
 
 def test_append_and_resume_roundtrip(tmp_path: Path) -> None:

--- a/tests/skills/test_isolated_dispatch.py
+++ b/tests/skills/test_isolated_dispatch.py
@@ -100,6 +100,27 @@ def test_build_cmd_contains_session_id_uuid_and_no_resume():
     assert "--fork-session" not in cmd
 
 
+def test_build_cmd_resume_true_uses_resume_flag_not_session_id():
+    """#999/#1002's harness-side retry-once backstop resumes the SAME
+    session (`--resume <session_id>`) for a cheap follow-up dispatch,
+    rather than starting a fresh one (`--session-id`)."""
+    mod = _load()
+    sid = mod.new_session_id()
+    cmd = mod.build_cmd(
+        prompt="re-emit the JSON only",
+        session_id=sid,
+        model="sonnet",
+        skip_permissions=True,
+        resume=True,
+    )
+    assert "--resume" in cmd
+    passed = cmd[cmd.index("--resume") + 1]
+    assert passed == sid
+    assert "--session-id" not in cmd
+    assert "--output-format" in cmd and "json" in cmd
+    assert "--model" in cmd and "sonnet" in cmd
+
+
 def test_build_cmd_skip_permissions_flag_is_gated():
     mod = _load()
     sid = mod.new_session_id()


### PR DESCRIPTION
## Summary

- Fixes #999 and #1002 — both are the same failure mode (a completed, otherwise-successful `/code-review --json` dispatch narrates having emitted its JSON payload instead of actually emitting it), reproduced independently on cases at opposite ends of the harness's turn-count range (58 turns / 15 turns) **after** PR #975's wording-only fix.
- Ships a harness-side detect-and-retry-once backstop in `evals/code-review-benchmark/runner.py`'s `make_isolated_dispatch_fn`: when the primary dispatch completes without error but its result text has no parseable `--json` payload, one cheap follow-up dispatch resumes the SAME Claude Code session (`claude -p --resume <session_id>`) asking it to re-emit only the JSON — no re-review, no fresh session.
- `plugins/dev-team/skills/headless-run/scripts/isolated_dispatch.py`'s `build_cmd()` gains a backward-compatible `resume` kwarg (default `False`) to support this.
- `cli.py` gains `--no-json-retry` (disable the backstop) and `--json-retry-timeout` (independent, smaller-by-default timeout budget for the retry specifically).
- Persists the retry's own raw stdout alongside the primary dispatch's in `raw/*.txt` (doc-review finding — the retry's output was initially silently discarded).

Closes #999
Closes #1002
Part of #970

## Decisions & Assumptions

**Root cause investigation — turn-count/context-pressure dependent, or genuinely unpredictable?** Neither cleanly. #999's case (`defects4j-Lang-29`) is at the harness's high end (58 turns). #1002's case (`defects4j-Lang-23`) is only 15 turns — near the harness's *low* end (the trivial single-file baseline from #974 was 28 turns). If the failure were purely "context pressure from a long run," a 15-turn run completing normally should be one of the *safest* cases, not a reproduction. What both cases (and #967's original `Lang-7` finding) share instead: each is the terminal turn of a multi-agent aggregation step, immediately after the model has spent many nested subagent dispatches producing prose findings — a hard pivot from sustained prose-summarizing to a single raw JSON blob, competing against a very strong, very recent generation pattern regardless of total turn count.

**Why not another wording tweak.** PR #975 already shipped the strongest reasonable version of that approach (explicit anti-pattern example, "non-negotiable, not model discretion," "there is no valid end state... that consists of prose alone") and it did not close the gap on a second, independent, *lower*-turn-count case. A skill file is a system-prompt instruction; it cannot deterministically force what the model's literal final turn contains. Repeating "the wording still wasn't strong enough" a third time, with no new evidence, would not be a responsible fix — this PR does not touch `skills/code-review/SKILL.md`'s step 7 wording at all.

**Why a harness-side retry instead of a skill-side forced-tool-call self-check.** Both issues explicitly asked this be considered. A "validate your own JSON via a tool call before finishing" instruction is still fundamentally a *prompt instruction* asking the model to take an extra step before ending its turn — the same class of thing #975 already tried and which failed a second time on independent evidence. The harness-side retry is different in kind: it's deterministic control flow (detect via the existing `_extract_review_json()`, dispatch once more, parse again), fully testable with dependency injection, and doesn't depend on the model choosing to comply with anything new.

**Retry cost design.** The retry does NOT reuse the primary dispatch's full timeout budget (1800s default) — that would let a stuck retry cost nearly as much wall-clock as the original review, contradicting the "cheap re-emission" premise (Design & Architecture Critic finding during plan review). It gets its own `retry_timeout` (default `min(timeout, 300)`, independently overridable via `--json-retry-timeout`) — a deliberately conservative, not empirically-measured, ceiling; a future live sweep may show it needs adjusting.

**Confidence this closes the gap.** Moderate, not certain — and stated honestly. The mechanism is real and tested (see below), but its actual real-world recurrence-reduction rate is unverified without a live Defects4J sweep (infra not available in this session — no `svn` confirmed in worktree, consistent with the fork handoff's note). Unlike PR #975, though, this fix does not *depend* on the model's wording compliance to activate — it fires on the deterministic post-hoc signal ("is there parseable JSON in the text yes/no"), which is the structural difference the issues asked for.

**Plan review**: two-pass review by Acceptance Test Critic + Design & Architecture Critic (`plans/issue-999-1002-json-narration.md`). First pass: both `needs-revision` (AC3's three retry-failure sub-modes — unparseable/timeout/error — only had one test; retry reused the full primary timeout). Second pass, after adding the missing tests and the independent `retry_timeout`: both `approve`.

## Test Plan

- [x] New unit tests for `build_cmd(resume=True)` (backward-compat regression guard for the default `no --resume` path kept passing).
- [x] New unit tests for `make_isolated_dispatch_fn`'s retry branch: retry succeeds, retry also fails (unparseable/timeout/arbitrary-exception/retry-itself-`is_error:true`), no retry when the first dispatch itself errored or timed out, no retry when the first result already parses, `retry_on_unparseable=False` suppresses the retry at the closure level (not just CLI parsing), `retry_timeout` reaches the actual `subprocess.run(timeout=...)` call.
- [x] New unit tests for `cli.py`'s `--no-json-retry`/`--json-retry-timeout` argparse defaults and overrides.
- [x] `run_case`'s skip reason distinguishes `"unparseable --json output (after retry)"` from the unretried case, byte-for-byte unchanged when no retry occurred.
- [ ] A live Defects4J sweep re-run — the natural next step to measure the retry's actual recurrence-reduction rate — is out of scope here (infra constraint, see Decisions above).

## Quality Gate

- [x] Full suite: `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py -n auto --dist loadfile -q` — 3038 passed, 1 skipped (expected opt-in skip).
- [x] `scripts/ci-local.sh` — all local CI checks passed.
- [x] `doc-review` — 1 error (stale "unrecoverable" claim contradicting the new retry section) + 1 warning (retry's raw stdout silently discarded) — both fixed.
- [x] `arch-review` — pass; 1 suggestion (module docstring caveat in `isolated_dispatch.py`) — fixed.

## Evidence Bundle

**Checks run**
- `pytest` (targeted): `tests/scripts/test_code_review_benchmark_runner.py`, `tests/scripts/test_code_review_benchmark_cli.py`, `tests/skills/test_isolated_dispatch.py` — all green, no regressions to pre-existing tests.
- Full repo suite + `scripts/ci-local.sh` — all green.

**Scope notes**
- No changes to `skills/code-review/SKILL.md` (deliberate — see Decisions above).
- No live Defects4J re-run in this session (infra constraint).

**Residual risks**
- The retry's real-world success rate is unmeasured; tracked as a known gap, not silently dropped — a future live sweep is the natural verification step.
- `retry_timeout`'s `min(timeout, 300)` default is a reasoned-but-unmeasured ceiling.