### PR TITLE
fix: bump ui-ux-designer effort band to high

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,9 @@ export default tseslint.config(
       "node_modules/**",
       "**/build/**",
       "**/dist/**",
+      // Per-agent scratch worktrees (EnterWorktree tool), gitignored and
+      // not repo content — see .gitignore's ".claude/worktrees/" entry.
+      ".claude/worktrees/**",
       "**/knowledge/rule-fixtures/**/*.js",
       "**/tests/fixtures/agent-readiness/**/*.js",
       // Parity harness fixtures for the token-efficiency-review hook are

--- a/plugins/dev-team/agents/ui-ux-designer.md
+++ b/plugins/dev-team/agents/ui-ux-designer.md
@@ -2,7 +2,7 @@
 name: ui-ux-designer
 description: User interface design, UX optimization, and accessibility compliance
 tools: Read, Grep, Glob, Skill
-effort: medium
+effort: high
 ---
 
 # UI/UX Designer Agent


### PR DESCRIPTION
## Summary
- Bumps `ui-ux-designer`'s reasoning-effort band from `medium` to `high` — designing and reviewing UX requires reasoning about flows, friction points, accessibility tradeoffs, and cognitive load, not surface-level pattern application.
- Also excludes gitignored `.claude/worktrees/**` scratch checkouts from the eslint scan; they were causing spurious failures unrelated to any real change (blocked this push).

## Test plan
- [x] `/agent-audit`-equivalent structural checks (`scripts/check_registry_sync.py`) pass
- [x] `scripts/ci-local.sh` full local CI mirror passes
- [x] `npx eslint` clean

Closes #1013
Closes #1014