### PR TITLE
docs: add ADRs for epic-label criterion and orchestration/choreography split

### DIFF
--- a/docs/adr/0018-native-sub-issues-determine-the-epic-label.md
+++ b/docs/adr/0018-native-sub-issues-determine-the-epic-label.md
@@ -1,0 +1,80 @@
+# 18. Native sub-issues determine the epic label
+
+Date: 2026-07-08
+
+## Status
+
+Accepted
+
+## Context
+
+This repo's issue-first workflow already treats specs as epic issues and plan
+slices as sub-issues, using GitHub's native sub-issues feature (queried via
+GraphQL `subIssuesSummary`, linked via the `addSubIssue` mutation) rather than
+a body-text list. A separate `epic-auto-close` GitHub Action (issue #987)
+closes the parent epic once every one of its native sub-issues closes —
+GitHub's own tracking only ever computes a completion percentage, it never
+closes the parent as a side effect.
+
+None of that wiring defines when an issue should carry the `epic` **label**.
+An audit of the repo's open issues needed a concrete, repeatable rule to
+apply it consistently. Two candidate criteria surfaced:
+
+1. **Prose shape** — label an issue `epic` if its body reads like one: an
+   Architecture Specification, Acceptance Criteria, an Ambiguity Log, or
+   similar spec-shaped sections, as produced by `/specs`.
+2. **Native sub-issue linkage** — label an issue `epic` only once it has at
+   least one sub-issue linked through the native GitHub relationship
+   (`subIssuesSummary.total > 0`).
+
+Applying both during the audit surfaced a concrete divergence: #1020 and
+#1042 have sub-issues linked via `addSubIssue` and clearly belong under
+`epic`. #1018 is a large `/specs`-style issue — it has an Architecture
+Specification, Acceptance Criteria, and an Ambiguity Log, and reads exactly
+like an epic — but it has not yet been sliced into sub-issues
+(`subIssuesSummary.total` is `0`). Labeling it `epic` on prose shape alone
+would produce a label that a later `gh api graphql` re-audit could not
+reproduce from the same rule, and that stays accurate only as long as
+someone remembers to re-check it by eye.
+
+Prose shape is necessary but not sufficient — a `/specs` issue is written as
+a future epic, not yet an operational one. The native sub-issue relationship
+is the point at which an issue actually starts behaving like an epic: it has
+children whose completion `epic-auto-close` will track, and whose count
+`subIssuesSummary` can report on demand.
+
+## Decision
+
+An issue gets the `epic` label if and only if it has at least one linked
+native GitHub sub-issue (`subIssuesSummary.total > 0`). Prose content — even
+unambiguous `/specs`-style epic shape (Architecture Specification,
+Acceptance Criteria, Ambiguity Log) — is not sufficient on its own.
+
+Concretely:
+
+- Apply the label the same moment sub-issues are linked (typically when
+  `/issues-from-plan` or `/issues-from-assessment` runs `addSubIssue` against
+  the parent), not earlier.
+- A `/specs` issue with zero linked sub-issues stays unlabeled until it is
+  actually sliced. It does not retroactively need the label just because its
+  body is epic-shaped — see #1018 as the reference case.
+- Re-auditing the label is a single GraphQL query per issue
+  (`subIssuesSummary { total }`), the same query used to apply it, so the
+  label can be verified mechanically rather than by re-reading issue bodies.
+
+## Consequences
+
+- The `epic` label stays a reliable filter: `is:open label:epic` will always
+  match issues that actually have tracked children, matching what
+  `epic-auto-close` acts on.
+- Re-auditing the label after any bulk issue review is cheap and
+  deterministic — one batched GraphQL query, not a manual re-read of every
+  issue body.
+- A spec issue that is clearly headed toward becoming an epic (like #1018)
+  goes unlabeled for a period between being filed and being sliced into
+  sub-issues. Anyone scanning `label:epic` for "epics in flight, including
+  ones not yet sliced" needs a second signal (e.g. the `/specs` issue
+  template) to catch these — this ADR does not introduce one.
+- If a future workflow wants to distinguish "planned epic, not yet sliced"
+  from "no epic intent at all," that is a new label or convention layered on
+  top of this one, not a reason to loosen this criterion.

--- a/docs/adr/0019-orchestrate-the-phase-pipeline-choreograph-the-safety-layer.md
+++ b/docs/adr/0019-orchestrate-the-phase-pipeline-choreograph-the-safety-layer.md
@@ -1,0 +1,120 @@
+# 19. Orchestrate the phase pipeline, choreograph the safety layer
+
+Date: 2026-07-08
+
+## Status
+
+Accepted
+
+## Context
+
+Microservice architecture distinguishes two coordination styles.
+**Orchestration**: a central coordinator holds the full-flow view, decides
+what runs next, and can compensate when a step fails. **Choreography**:
+independent components react to events with no central coordinator; each
+knows only its own trigger and its own action.
+
+The dev-team plugin already runs both patterns side by side without having
+named the split:
+
+- **Orchestrated**: `agents/orchestrator.md` (`Role: orchestrator`) and the
+  higher-level skills that declare the same role
+  (`code-review`, `competitive-analysis`, and other multi-agent skills)
+  dispatch specialized agents by task classification, sequence
+  Research → Plan → Implement phases, and decide what happens after each
+  agent returns — retry, escalate, or move to the next phase. There is one
+  place that holds the flow.
+- **Choreographed**: the `PreToolUse`/`PostToolUse` hooks
+  (`plugins/dev-team/hooks/*.py` — `context_ceiling_guard.py`,
+  `destructive_guard.py`, `pre_tool_guard.py`,
+  `mutation_testing_smoke_gate.py`, `tdd_guard.py`,
+  `refactor_test_freeze_guard.py`, and the rest of the ~25-file hook roster)
+  each fire independently off a tool-call event. None of them knows the
+  others exist, none of them knows what phase the session is in, and none of
+  them can compensate for another hook's decision. They just react.
+
+Neither pattern is "the architecture" — the plugin is both, layered. The
+question this ADR answers is not "which pattern should we use" but "what
+decides which pattern a given piece of coordination gets." Applying the
+orchestration/choreography distinction concretely surfaced the operative
+rule already implicit in the existing design:
+
+- Coordination that needs a **full-flow view** to make its decision — what
+  phase are we in, what did the last agent return, does this warrant a
+  retry or a human escalation, which specialized agents does this task
+  classification need — has nowhere to live except a central coordinator.
+  Distributing that logic into independent reactive components would mean
+  no component has enough context to make the call, and failures could only
+  be diagnosed by reconstructing state no single place held.
+- Coordination that is a **narrow, local, always-applicable check** —
+  "is this a destructive bash command," "did context cross the ceiling,"
+  "does this diff touch a frozen refactor file" — needs no knowledge of the
+  broader flow to decide, and benefits from running the same way regardless
+  of which orchestrator or skill triggered the tool call. Routing every one
+  of these checks through the central orchestrator would mean the
+  orchestrator carries every guard's logic and every future guard requires
+  an orchestrator change, when the check has no actual dependency on
+  orchestration state.
+
+That is: orchestration cost buys coordinated, context-aware decisions;
+choreography cost buys independent, uniformly-applied guards that scale by
+adding a file, not by editing a central dispatcher. The plugin already
+sorted its coordination logic along this line — this ADR names the line so
+future additions land on the correct side of it on purpose, not by
+accident.
+
+## Decision
+
+Coordination logic in this plugin is orchestrated if, and only if, making
+the right call requires cross-phase or cross-agent context that no single
+reactive component holds. Everything else — a check that is local to one
+tool call and whose answer doesn't depend on what phase, task, or agent
+triggered it — is choreographed as a hook, never folded into the
+orchestrator or a `role: orchestrator` skill.
+
+Concretely, when adding new coordination:
+
+- **Add to the orchestrator or an orchestrator-role skill** when the logic
+  needs to know what happened in a prior phase or agent call, needs to
+  decide what runs next among several options, or needs the ability to
+  compensate (retry, escalate, roll back) based on another component's
+  outcome. Example: deciding which review agents to dispatch based on
+  changed file types, or deciding whether a failed phase should retry or
+  escalate to the human.
+- **Add as a `PreToolUse`/`PostToolUse` hook** when the logic is a
+  self-contained check against a single tool call's inputs or the
+  session's own measurable state (context size, file path, command
+  string), and the same answer applies no matter which orchestrator, skill,
+  or phase triggered the call. Example: `destructive_guard.py` blocking an
+  `rm -rf` regardless of which agent issued it.
+- A hook must never assume it runs after or before another specific hook,
+  and must never reach into orchestrator state to make its decision — if it
+  needs that, it is miscategorized and belongs in the orchestrated layer
+  instead.
+- An orchestrator-role skill must not reimplement a check a hook already
+  covers uniformly (e.g. re-checking for destructive commands inside
+  `/build`) — that duplicates enforcement in a place that can drift out of
+  sync with the hook.
+
+## Consequences
+
+- Future contributors get a concrete test for "does this new guard go in a
+  hook or in the orchestrator" instead of guessing by precedent: ask
+  whether the decision needs cross-phase/cross-agent context.
+- The hook layer stays composable — each hook can be added, removed, or
+  reordered independently, and none of them can be broken by another hook's
+  internal changes, because none of them depend on each other.
+- The orchestrated layer stays the single place to look for "what happens
+  next" logic — anyone tracing a phase transition or a retry/escalation
+  decision knows to look at `agents/orchestrator.md` or the relevant
+  `role: orchestrator` skill, not to go hunting through the hook roster.
+- Risk: as the hook roster grows (already ~25 files), a hook author could
+  be tempted to smuggle in a small piece of cross-cutting state (e.g. a
+  hook that reads what phase a skill is in from a shared file) to avoid an
+  orchestrator change. That reintroduces implicit coordination between
+  supposedly-independent hooks and defeats the point of this split — reviews
+  of new hooks should watch for it.
+- This ADR does not require refactoring any existing hook or orchestrator
+  logic — the current split already matches this rule; it formalizes the
+  boundary so it holds going forward rather than eroding as new
+  coordination needs appear.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,3 +17,5 @@
 * [15. Bash removal complete — plugins/dev-team is Python-native](0015-bash-removal-complete.md)
 * [16. Rely on harness-native compaction; the plugin performs structured summarization only](0016-rely-on-harness-native-compaction-the-plugin-performs-structured-summarization-only.md)
 * [17. Single build cadence — remove the Classic TDD opt-in](0017-single-build-cadence-remove-classic-tdd-opt-in.md)
+* [18. Native sub-issues determine the epic label](0018-native-sub-issues-determine-the-epic-label.md)
+* [19. Orchestrate the phase pipeline, choreograph the safety layer](0019-orchestrate-the-phase-pipeline-choreograph-the-safety-layer.md)


### PR DESCRIPTION
## Summary
- ADR 0018: the `epic` label tracks native GitHub sub-issue linkage (`subIssuesSummary.total > 0`), not prose shape — codifies the criterion applied when auditing open issues (#1020/#1042 labeled, #1018 left unlabeled).
- ADR 0019: new coordination logic is orchestrated (goes through `agents/orchestrator.md` or a `role: orchestrator` skill) only when it needs cross-phase/cross-agent context; otherwise it's a self-contained `PreToolUse`/`PostToolUse` hook.

No code, agent, skill, or hook behavior changes — documentation only.

## Test plan
- [x] `scripts/ci-local.sh` passed via pre-push hook (includes markdown reference integrity, ADR-adjacent checks, full pytest suite)
- [x] `adr generate toc` regenerated `docs/adr/README.md`