### PR TITLE
feat: extend Context needs vocabulary with artifact-stream value

### DIFF
--- a/plugins/dev-team/hooks/eval_compliance_check.py
+++ b/plugins/dev-team/hooks/eval_compliance_check.py
@@ -205,13 +205,27 @@ def _agent_checks(
         )
 
     # 9. Context needs (WARN)
-    if not _grep_i_matches(
-        content,
-        r"context needs:\s*(diff-only|full-file|project-structure)",
-    ):
+    # Valid standalone values: diff-only, full-file, project-structure,
+    # artifact-stream.  Comma-separated combinations are allowed only when
+    # every token is one of the four valid values (e.g. "artifact-stream,
+    # full-file").  A declaration containing any unknown token still warns.
+    _VALID_CTX = {"diff-only", "full-file", "project-structure", "artifact-stream"}
+    _ctx_match = re.search(
+        r"context needs:\s*(.+)", content, re.IGNORECASE
+    )
+    if _ctx_match:
+        _tokens = [t.strip() for t in _ctx_match.group(1).split(",")]
+        _invalid = [t for t in _tokens if t not in _VALID_CTX]
+        if _invalid:
+            warn(
+                f"{agent_name}: 'Context needs' contains invalid token(s): "
+                f"{', '.join(_invalid)}. "
+                f"Valid values: diff-only, full-file, project-structure, artifact-stream."
+            )
+    else:
         warn(
             f"{agent_name}: Missing 'Context needs' field "
-            f"(must be diff-only, full-file, or project-structure)."
+            f"(must be diff-only, full-file, project-structure, or artifact-stream)."
         )
 
     # 6. File scope for language-specific agents (WARN)

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -106,11 +106,23 @@ review agents. Check:
      that the tier name is deprecated and name the band to use
      (`haiku` → `low`, `sonnet` → `medium`, `opus` → `high`)
 
-9. **Context needs**: Does the agent declare
-   `Context needs: diff-only|full-file|project-structure`?
+9. **Context needs**: Does the agent declare a `Context needs:` field?
    - All agents MUST declare what input context they need
-   - Valid values: `diff-only`, `full-file`, `project-structure`
-   - WARN if missing
+   - Valid standalone values:
+     - `diff-only` — agent reads only the unified diff
+     - `full-file` — agent needs the complete file content
+     - `project-structure` — agent needs directory/project layout
+     - `artifact-stream` — agent consumes upstream JSON artifact streams
+       (prior-phase findings, RECON output) and does **not** read source
+       files directly; qualifies when the agent's only input is an artifact
+       produced by an earlier pipeline phase
+   - **Combinability**: a comma-separated list of two or more values is
+     valid when every token is one of the four values above (e.g.
+     `artifact-stream, full-file` is valid for an agent that reads both
+     upstream artifacts **and** full source files). An unknown token in a
+     combined declaration still WARNs on that token specifically.
+   - WARN if the field is missing entirely
+   - WARN if the declaration contains an unrecognised token
 
 10. **No colons in description**: Does the `description:` frontmatter field contain a colon?
     - The `description` field MUST NOT contain colons — they break argument-hints and other tooling

--- a/plugins/dev-team/tests/hooks/test_eval_compliance_check.py
+++ b/plugins/dev-team/tests/hooks/test_eval_compliance_check.py
@@ -155,3 +155,64 @@ def test_hook_exits_zero_even_with_eval_required(project: Path):
     }
     result = _run(payload, {"CLAUDE_PROJECT_DIR": str(project)})
     assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# _agent_checks — Context needs: artifact-stream (issue #1038)
+# ---------------------------------------------------------------------------
+
+_AGENT_TEMPLATE = """\
+---
+name: test-agent
+role: worker
+model tier: mid
+context needs: {ctx}
+---
+
+# Test Agent
+
+## Detect
+Checks something.
+
+## Skip
+Skip generated files.
+
+Output JSON with status/issues/summary.
+Severity: error, warning, suggestion.
+"""
+
+
+def _ctx_warnings(ctx_value: str) -> str:
+    """Return the _agent_checks output for an agent with the given context needs value."""
+    content = _AGENT_TEMPLATE.format(ctx=ctx_value)
+    return ecc._agent_checks(content, "test-agent", "agents/test-agent.md")
+
+
+def test_context_needs_artifact_stream_alone_passes():
+    out = _ctx_warnings("artifact-stream")
+    assert "Context needs" not in out or "invalid" not in out
+
+
+def test_context_needs_combined_artifact_stream_full_file_passes():
+    out = _ctx_warnings("artifact-stream, full-file")
+    assert "Context needs" not in out or "invalid" not in out
+
+
+def test_context_needs_unknown_token_warns():
+    out = _ctx_warnings("unknown-value")
+    assert "Context needs" in out
+    assert "invalid" in out
+    assert "unknown-value" in out
+
+
+def test_context_needs_combined_with_invalid_token_warns_on_bad_token():
+    out = _ctx_warnings("artifact-stream, bogus-value")
+    assert "bogus-value" in out
+
+
+def test_context_needs_existing_values_still_pass():
+    for value in ("diff-only", "full-file", "project-structure"):
+        out = _ctx_warnings(value)
+        assert "Context needs" not in out or "invalid" not in out, (
+            f"Value {value!r} should pass but got: {out}"
+        )


### PR DESCRIPTION
## Summary

- Adds `artifact-stream` as a fourth valid `Context needs:` value in `agent-audit/SKILL.md` with combinability rules (comma-separated list; all tokens validated)
- Updates `eval_compliance_check.py` hook to tokenise on commas, validate each token against the four-value set, and emit targeted warnings naming invalid tokens
- Adds 5 new unit tests covering artifact-stream alone, combined values, and invalid token cases

Closes #1038


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5WPLLGLgkYTswbUmGZcyr)_