### PR TITLE
feat: extend agent-audit effort-frontmatter gate to security-assessment plugin

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1619,7 +1619,7 @@
       "anchor": "1-parse-arguments"
     },
     "2. Audit agents": {
-      "summary": "Read each file in `.claude/agents/*.md` whose body contains a structured JSON",
+      "summary": "**Scope**: this audit covers agents from all plugins in the repository, not just",
       "anchor": "2-audit-agents"
     },
     "2b. Audit agent tool declarations (all agents)": {

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -48,6 +48,16 @@ Arguments: $ARGUMENTS
 
 ### 2. Audit agents
 
+**Scope**: this audit covers agents from all plugins in the repository, not just
+`plugins/dev-team/agents/`. Currently audited directories:
+
+- `plugins/dev-team/agents/` — the primary dev-team plugin agents
+- `plugins/security-assessment/agents/` — the security-assessment plugin agents
+
+The automated effort-band gate (`tests/agents/test_agent_effort_frontmatter.py`)
+discovers and checks agents from both directories; add new plugin agent directories
+to `AGENTS_DIRS` in that test file when a new plugin is introduced.
+
 Read each file in `.claude/agents/*.md` whose body contains a structured JSON
 output schema (a line with `"status": "pass|warn|fail|skip"`) — these are
 review agents. Check:

--- a/plugins/security-assessment/agents/authorization-logic-review.md
+++ b/plugins/security-assessment/agents/authorization-logic-review.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: authorization-logic-review
 description: Top-down authorization review. Maps the access-control model (RBAC/ABAC/ACL/tenancy), then verifies enforcement at every layer. Phase 1b peer agent.
 tools: Read, Grep, Glob

--- a/plugins/security-assessment/agents/business-logic-domain-review.md
+++ b/plugins/security-assessment/agents/business-logic-domain-review.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: business-logic-domain-review
 description: Business-logic review for ML/fraud services. Detects the 9 patterns in knowledge/domain-logic-patterns.md (fail-open, score manipulation, emulation bypass, etc.). Phase 1b peer agent.
 tools: Read, Grep, Glob

--- a/plugins/security-assessment/agents/compliance-edge-annotator.md
+++ b/plugins/security-assessment/agents/compliance-edge-annotator.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: compliance-edge-annotator
 description: Edge annotator for compliance findings whose pattern row has llm_review_trigger=true. Refines pattern-table citations; never invents new ones.
 tools: Read, Grep

--- a/plugins/security-assessment/agents/cross-repo-synthesizer.md
+++ b/plugins/security-assessment/agents/cross-repo-synthesizer.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: cross-repo-synthesizer
 description: Synthesizes attack-chain narratives from multi-repo RECON + shared-cred matches + service-comm diagram. Produces named attack chains citing findings by ID. Does not detect.
 tools: Read, Grep, Glob

--- a/plugins/security-assessment/agents/deep-code-reasoning.md
+++ b/plugins/security-assessment/agents/deep-code-reasoning.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: deep-code-reasoning
 description: Context-aware vulnerability detection beyond static patterns. RECON-scoped freeform reasoning about IDOR, confused deputy, TOCTOU, privilege escalation, workflow bypass. Phase 1b peer agent.
 tools: Read, Grep, Glob

--- a/plugins/security-assessment/agents/exec-report-generator.md
+++ b/plugins/security-assessment/agents/exec-report-generator.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: exec-report-generator
 description: Synthesizes the publication-ready executive report from upstream artifacts. Emits a 7-section per-repo report (plus cross-repo summary for multi-repo runs).
 tools: Read, Write, Glob, Grep

--- a/plugins/security-assessment/agents/fp-reduction.md
+++ b/plugins/security-assessment/agents/fp-reduction.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: fp-reduction
 description: Applies the 5-stage FP-reduction rubric to a unified-finding stream, producing a disposition register. Consumes findings + RECON (+ CPG when joern is available).
 tools: Read, Grep, Glob, Bash

--- a/plugins/security-assessment/agents/recon-driven-scan.md
+++ b/plugins/security-assessment/agents/recon-driven-scan.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: recon-driven-scan
 description: Bridges RECON narrative risk claims to file:line evidence. Emits findings only when the source actually exhibits the described pattern. Phase 1b peer agent.
 tools: Read, Grep, Glob, Bash

--- a/plugins/security-assessment/agents/redteam-evasion-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-evasion-analyzer.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: redteam-evasion-analyzer
 description: Interprets probe 05 (evasion) alongside probe 03 (sensitivity) and probe 04 (boundaries). Rates adversarial realism, explains evasion mechanism, recommends defenses.
 tools: Read, Grep

--- a/plugins/security-assessment/agents/redteam-extraction-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-extraction-analyzer.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: redteam-extraction-analyzer
 description: Interprets probe 07 (model extraction) alongside probe 03 (sensitivity). Translates R² into extraction fidelity, extracts decision-rule structure, names IP-theft implications.
 tools: Read, Grep

--- a/plugins/security-assessment/agents/redteam-recon-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-recon-analyzer.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: redteam-recon-analyzer
 description: Interprets probe 01 (API recon). Severity-rates info leaks, identifies the framework, recommends a feature-discovery strategy for probe 02.
 tools: Read, Grep

--- a/plugins/security-assessment/agents/redteam-report-generator.md
+++ b/plugins/security-assessment/agents/redteam-report-generator.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: redteam-report-generator
 description: Refines the red-team adversarial-report.md into an executive document. Assigns RED/AMBER/GREEN rating; produces remediation with effort estimates.
 tools: Read, Write, Grep

--- a/plugins/security-assessment/agents/tool-finding-narrative-annotator.md
+++ b/plugins/security-assessment/agents/tool-finding-narrative-annotator.md
@@ -1,4 +1,5 @@
 ---
+effort: high
 name: tool-finding-narrative-annotator
 description: Weaves findings into four narrative domains (PII flow, ML edge cases, messaging auth, crypto). Prose for the exec report. Synthesizes; does not detect.
 tools: Read, Grep, Glob

--- a/tests/agents/test_agent_effort_frontmatter.py
+++ b/tests/agents/test_agent_effort_frontmatter.py
@@ -19,26 +19,37 @@ from typing import List
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-AGENTS_DIR = REPO_ROOT / "plugins" / "dev-team" / "agents"
+AGENTS_DIRS = [
+    REPO_ROOT / "plugins" / "dev-team" / "agents",
+    REPO_ROOT / "plugins" / "security-assessment" / "agents",
+]
 ALLOWED_BANDS = ("low", "medium", "high")
 
 
 def _agent_files_to_check(agent_files: str | None = None) -> List[Path]:
     """Resolve which agent files to check.
 
-    - Default: every *.md directly under agents/.
-    - With agent_files: only the named basenames (each must exist).
+    - Default: every *.md directly under any agents/ directory in AGENTS_DIRS.
+    - With agent_files: only the named basenames (each must exist in one of the dirs).
     """
     if agent_files:
         raw = agent_files.replace(",", " ").split()
         result = []
         for name in raw:
-            candidate = AGENTS_DIR / name
-            if not candidate.is_file():
+            found = None
+            for agents_dir in AGENTS_DIRS:
+                candidate = agents_dir / name
+                if candidate.is_file():
+                    found = candidate
+                    break
+            if found is None:
                 raise ValueError(f"AGENT_FILES contains an unknown agent: {name}")
-            result.append(candidate)
+            result.append(found)
         return result
-    return sorted(AGENTS_DIR.glob("*.md"))
+    files: List[Path] = []
+    for agents_dir in AGENTS_DIRS:
+        files.extend(agents_dir.glob("*.md"))
+    return sorted(files)
 
 
 def _effort_value(agent_file: Path) -> str:


### PR DESCRIPTION
## Summary

- Parametrize `AGENTS_DIRS` in `tests/agents/test_agent_effort_frontmatter.py` to discover and enforce the `effort:` frontmatter contract against both `plugins/dev-team/agents/` and `plugins/security-assessment/agents/`
- Add `effort: high` to all 13 `plugins/security-assessment/agents/*.md` files (all had `model: opus`, which maps to `high` per ADR 0008)
- Document multi-plugin audit scope in `plugins/dev-team/skills/agent-audit/SKILL.md` — the new "Scope" note in Step 2 explains which directories are covered and how to add future plugins

## Test plan

- [ ] `python3 -m pytest tests/agents/test_agent_effort_frontmatter.py -v` passes (2 tests, both green)
- [ ] All 13 security-assessment agents now carry `effort: high` in frontmatter
- [ ] No changes to `main`; PR targets `claude/open-issues-plan-9ptovp`

Closes #1040
Part of #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5WPLLGLgkYTswbUmGZcyr

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5WPLLGLgkYTswbUmGZcyr)_