### PR TITLE
feat: add skills/commands catalogs for security-assessment and marketplace-dev plugins

### DIFF
--- a/plugins/dev-team/hooks/lib/build_skills_index.py
+++ b/plugins/dev-team/hooks/lib/build_skills_index.py
@@ -4,15 +4,21 @@
 docs/skills.md is the human-readable skills catalog. It used to be hand-edited,
 which drifted: skills were added on disk with no catalog row (14 missing at the
 time this generator was introduced). This builder makes the catalog a derived
-artifact — one row per skills/<name>/SKILL.md, sourced from that file's `name`
-and `description` frontmatter, split into the two sub-types the frontmatter
-already encodes (`user-invocable: true` → slash command, else agent-loaded). No
+artifact — one row per skills/<name>/SKILL.md (and commands/<name>.md when the
+plugin has a commands/ directory), sourced from that file's `name` and
+`description` frontmatter, split into the two sub-types the frontmatter already
+encodes (`user-invocable: true` → slash command, else agent-loaded). No
 hand-curation survives in the output, so it can never silently drift.
 
-Modes (argv[1]):
+Modes:
   (none) / write   rebuild docs/skills.md in place (atomic write)
   --check          diff a fresh build against the on-disk file; exit non-zero
                    with a unified diff on stderr if they differ. Writes nothing.
+
+Flags:
+  --plugin-dir <path>   target a plugin other than dev-team. Derives skills_dir,
+                        commands_dir, output path, and categories file from <path>.
+                        The categories file is expected at <path>/skill_categories.yaml.
 
 Env (TEST-ONLY injection seams — production callers must NOT set these):
   SKILLS_INDEX_SKILLS_DIR   override the skills/ corpus root
@@ -60,6 +66,62 @@ knowledge modules — shown as a plain `name` — that agents read for domain ex
 """
 
 
+def _plugin_header(plugin_dir: Path) -> str:
+    """Return a generated-file header for the given plugin directory."""
+    try:
+        rel = plugin_dir.relative_to(Path.cwd())
+    except ValueError:
+        rel = plugin_dir
+    return (
+        "# Skills\n"
+        "\n"
+        "<!-- GENERATED FILE — do not edit by hand.\n"
+        f"     Rows: each {rel}/skills/<name>/SKILL.md"
+        f" (and {rel}/commands/<name>.md if present).\n"
+        f"     Grouping: {rel}/skill_categories.yaml (by capability).\n"
+        f"     Regenerate: python3 plugins/dev-team/hooks/lib/build_skills_index.py"
+        f" --plugin-dir {rel}\n"
+        "     A CI freshness gate (--check) fails if this file drifts from the"
+        " skills on disk. -->\n"
+        "\n"
+        "Skills are the unified reusable capability layer in this plugin. "
+        "Skills live in `skills/<name>/SKILL.md`; user-invocable commands live "
+        "in `commands/<name>.md`. This catalog groups them **by capability** (the "
+        "sections below); each row's description is the file's own frontmatter "
+        "`description`, verbatim.\n"
+        "\n"
+        "Most skills are **user-invocable** as slash commands — shown as `/name`; "
+        "run them directly or let the Orchestrator dispatch them. The rest are "
+        "**agent-loaded** knowledge modules — shown as a plain `name` — that agents "
+        "read for domain expertise.\n"
+    )
+
+
+def _parse_argv(argv: list) -> tuple:
+    """Returns (mode: str, plugin_dir: Path | None).
+
+    Accepts: [--plugin-dir <path>] [--check | write]
+    """
+    args = list(argv[1:])
+    mode = "write"
+    plugin_dir = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--plugin-dir":
+            if i + 1 >= len(args):
+                sys.stderr.write("--plugin-dir requires a path argument\n")
+                sys.exit(2)
+            plugin_dir = Path(args[i + 1]).resolve()
+            i += 2
+        elif args[i] in ("--check", "write"):
+            mode = args[i]
+            i += 1
+        else:
+            sys.stderr.write(f"Unknown mode: {args[i]}\n")
+            sys.exit(2)
+    return mode, plugin_dir
+
+
 class FrontmatterError(ValueError):
     """A SKILL.md whose frontmatter can't be parsed — fail loudly, never emit a
     silent empty/miscategorized catalog row."""
@@ -88,23 +150,34 @@ def _cell(text: str) -> str:
     return " ".join(str(text).split()).replace("|", "\\|")
 
 
-def _load_categories():
+def _load_categories(categories_file: Path | None = None) -> list:
     """Ordered [(category_name, [skill, ...]), ...] from skill_categories.yaml."""
-    data = parse_yaml(CATEGORIES_FILE.read_text(encoding="utf-8")) or {}
+    path = categories_file if categories_file is not None else CATEGORIES_FILE
+    data = parse_yaml(path.read_text(encoding="utf-8")) or {}
     return [
         (c["name"], list(c.get("skills") or [])) for c in (data.get("categories") or [])
     ]
 
 
-def _collect():
-    """Group skills by capability. Returns ordered [(category, rows), ...] where each
-    row is (name, folder, link, desc, slash). A skill whose folder isn't in the
-    taxonomy lands in a trailing `Other` section so it stays visible in the diff."""
-    cats = _load_categories()
+def _collect(
+    skills_dir: Path | None = None,
+    commands_dir: Path | None = None,
+    categories_file: Path | None = None,
+) -> list:
+    """Group skills and commands by capability.
+
+    Returns ordered [(category, rows), ...] where each row is
+    (name, sort_key, link, desc, slash). A skill whose key isn't in the
+    taxonomy lands in a trailing `Other` section so it stays visible in the diff.
+    """
+    effective_skills_dir = skills_dir if skills_dir is not None else SKILLS_DIR
+    cats = _load_categories(categories_file)
     order = [name for name, _ in cats]
     lookup = {skill: name for name, skills in cats for skill in skills}
     buckets = {name: [] for name in order}
-    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+
+    # Scan skills/<name>/SKILL.md
+    for skill_md in sorted(effective_skills_dir.glob("*/SKILL.md")):
         folder = skill_md.parent.name
         fm = _frontmatter(skill_md)
         if not fm.get("description"):
@@ -116,6 +189,22 @@ def _collect():
         buckets.setdefault(lookup.get(folder, OTHER), []).append(
             (name, folder, link, desc, slash)
         )
+
+    # Scan commands/<name>.md (only when the plugin has a commands/ dir)
+    if commands_dir is not None and commands_dir.is_dir():
+        for cmd_md in sorted(commands_dir.glob("*.md")):
+            key = cmd_md.stem
+            fm = _frontmatter(cmd_md)
+            if not fm.get("description"):
+                raise FrontmatterError(f"{cmd_md}: frontmatter has no `description`")
+            name = str(fm.get("name") or key)
+            desc = _cell(fm["description"])
+            link = f"[`commands/{cmd_md.name}`](../commands/{cmd_md.name})"
+            slash = fm.get("user-invocable") is True
+            buckets.setdefault(lookup.get(key, OTHER), []).append(
+                (name, key, link, desc, slash)
+            )
+
     display = [(name, buckets[name]) for name in order if buckets.get(name)]
     if buckets.get(OTHER):
         display.append((OTHER, buckets[OTHER]))
@@ -127,15 +216,21 @@ def _collect():
 def _table(rows) -> str:
     head = "| Skill | File | Description |\n| --- | --- | --- |\n"
     body = []
-    for name, _folder, link, desc, slash in rows:
+    for name, _sort_key, link, desc, slash in rows:
         label = f"`/{name}`" if slash else name
         body.append(f"| {label} | {link} | {desc} |")
     return head + "\n".join(body) + "\n"
 
 
-def build() -> str:
-    parts = [HEADER]
-    for cat_name, rows in _collect():
+def build(
+    header: str | None = None,
+    skills_dir: Path | None = None,
+    commands_dir: Path | None = None,
+    categories_file: Path | None = None,
+) -> str:
+    effective_header = header if header is not None else HEADER
+    parts = [effective_header]
+    for cat_name, rows in _collect(skills_dir, commands_dir, categories_file):
         parts += ["", f"## {cat_name}", "", _table(rows)]
     return "\n".join(parts).rstrip("\n") + "\n"
 
@@ -151,35 +246,61 @@ def _atomic_write(output: Path, text: str) -> None:
 
 
 def main(argv: list) -> int:
-    mode = argv[1] if len(argv) > 1 else "write"
+    mode, plugin_dir_override = _parse_argv(argv)
+
+    if plugin_dir_override is not None:
+        skills_dir = plugin_dir_override / "skills"
+        commands_dir = plugin_dir_override / "commands"
+        output = plugin_dir_override / "docs" / "skills.md"
+        categories_file = plugin_dir_override / "skill_categories.yaml"
+        header = _plugin_header(plugin_dir_override)
+    else:
+        skills_dir = None  # use module-level SKILLS_DIR (env-override aware)
+        commands_dir = None  # dev-team has no commands/ dir
+        output = OUTPUT
+        categories_file = None  # use module-level CATEGORIES_FILE
+        header = None  # use module-level HEADER
+
     try:
-        actual = build()
+        actual = build(
+            header=header,
+            skills_dir=skills_dir,
+            commands_dir=commands_dir,
+            categories_file=categories_file,
+        )
     except FrontmatterError as e:
         sys.stderr.write(f"[skills-index] {e}\n")
         return 1
 
     if mode == "--check":
-        if not OUTPUT.exists():
-            sys.stderr.write(f"[skills-index] index file missing: {OUTPUT}\n")
+        if not output.exists():
+            sys.stderr.write(f"[skills-index] index file missing: {output}\n")
             return 1
-        current = OUTPUT.read_text(encoding="utf-8")
+        current = output.read_text(encoding="utf-8")
         if current == actual:
             return 0
         diff = difflib.unified_diff(
             current.splitlines(keepends=True),
             actual.splitlines(keepends=True),
-            fromfile=str(OUTPUT),
+            fromfile=str(output),
             tofile="<fresh build>",
         )
         sys.stderr.writelines(diff)
+        regen = "python3 plugins/dev-team/hooks/lib/build_skills_index.py"
+        if plugin_dir_override is not None:
+            try:
+                rel = plugin_dir_override.relative_to(Path.cwd())
+            except ValueError:
+                rel = plugin_dir_override
+            regen += f" --plugin-dir {rel}"
         sys.stderr.write(
-            "\n[skills-index] docs/skills.md is stale. Regenerate: "
-            "python3 plugins/dev-team/hooks/lib/build_skills_index.py\n"
+            f"\n[skills-index] docs/skills.md is stale. Regenerate: {regen}\n"
         )
         return 1
 
     if mode in ("write", ""):
-        _atomic_write(OUTPUT, actual)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write(output, actual)
         return 0
 
     sys.stderr.write(f"Unknown mode: {mode}\n")

--- a/plugins/marketplace-dev/docs/skills.md
+++ b/plugins/marketplace-dev/docs/skills.md
@@ -1,0 +1,39 @@
+# Skills
+
+<!-- GENERATED FILE — do not edit by hand.
+     Rows: each plugins/marketplace-dev/skills/<name>/SKILL.md (and plugins/marketplace-dev/commands/<name>.md if present).
+     Grouping: plugins/marketplace-dev/skill_categories.yaml (by capability).
+     Regenerate: python3 plugins/dev-team/hooks/lib/build_skills_index.py --plugin-dir plugins/marketplace-dev
+     A CI freshness gate (--check) fails if this file drifts from the skills on disk. -->
+
+Skills are the unified reusable capability layer in this plugin. Skills live in `skills/<name>/SKILL.md`; user-invocable commands live in `commands/<name>.md`. This catalog groups them **by capability** (the sections below); each row's description is the file's own frontmatter `description`, verbatim.
+
+Most skills are **user-invocable** as slash commands — shown as `/name`; run them directly or let the Orchestrator dispatch them. The rest are **agent-loaded** knowledge modules — shown as a plain `name` — that agents read for domain expertise.
+
+
+## Plugin Scaffolding
+
+| Skill | File | Description |
+| --- | --- | --- |
+| init-plugin-eval | [`init-plugin-eval/SKILL.md`](../skills/init-plugin-eval/SKILL.md) | Scaffold the eval directory structure for a plugin's review agents and advisory skills. Use after creating a plugin or adding its first review agent, or when the user says "set up evals for this plugin", "init plugin evals", "scaffold eval fixtures", or "create the eval harness for <plugin>". Creates the fixtures/ and expected/ dirs plus a README describing the grading contract. |
+| scaffold-marketplace | [`scaffold-marketplace/SKILL.md`](../skills/scaffold-marketplace/SKILL.md) | Create a Claude Code plugin-marketplace root with a valid catalog, release automation, and at least one plugin slot. Use when starting a new marketplace monorepo, or when the user says "scaffold a marketplace", "set up a plugin marketplace", "create a marketplace catalog", or "bootstrap a marketplace repo". |
+| scaffold-plugin | [`scaffold-plugin/SKILL.md`](../skills/scaffold-plugin/SKILL.md) | Create a new Claude Code plugin directory with the correct, audit-clean structure. Use when starting a new plugin in a marketplace monorepo, or when the user says "scaffold a plugin", "create a new plugin", "add a plugin to this marketplace", or "new plugin skeleton". Produces a directory that passes /plugin-audit with zero findings on a clean install. |
+
+
+## Agent Authoring
+
+| Skill | File | Description |
+| --- | --- | --- |
+| `/agent-add` | [`agent-add/SKILL.md`](../skills/agent-add/SKILL.md) | Create a new Claude Code agent file (review or team type) following the official sub-agent schema and token-efficiency budgets. Use when the user wants to add a new review agent, detect a new category of code issue, create a team agent persona, or says things like "add an agent for X", "create a reviewer for Y", "new team agent for Z". Also use when given a URL to a coding standard that should become a review agent. |
+| `/agent-create` | [`agent-create/SKILL.md`](../skills/agent-create/SKILL.md) | Create new Claude Code sub-agent files following the official schema and token-efficiency budgets. Handles both review agents (JSON output, read-only tools, ≤ 40-line body) and team agents (prose output, action tools, ≤ 75-line body). Use when the user says "add an agent", "create a reviewer for X", "new team agent for Y", or when /agent-add is invoked. Validates against /plugin-audit before writing. Updates the agent registry and plugin CLAUDE.md after success. |
+| `/agent-remove` | [`agent-remove/SKILL.md`](../skills/agent-remove/SKILL.md) | Remove an agent from the system — deletes the agent file, cleans up all registry entries, removes cross-references, and updates documentation. Use when the user says "remove the X agent", "delete X-review", "retire the X role", or "we no longer need X". Handles both team agents and review agents. Always confirms before deleting. |
+| `/agent-skill-authoring` | [`agent-skill-authoring/SKILL.md`](../skills/agent-skill-authoring/SKILL.md) | Conventions, anti-patterns, and meta-patterns for writing skills (and the shared agent/skill philosophy). Use when creating or editing a SKILL.md file, or when reviewing the agent-vs-skill separation. For the procedural workflow that generates a new agent file, use the agent-create skill (invoked by /agent-add). |
+| `/agent-type-advisor` | [`agent-type-advisor/SKILL.md`](../skills/agent-type-advisor/SKILL.md) | Recommend whether a plugin capability should be a markdown (LLM-interpreted) unit or a deterministic script. Use when designing a new agent/skill ("should this be markdown or a script?"), or when auditing an existing agent/skill file for a type mismatch. Accepts either a prose use-case description (forward- looking, new unit) or a path to an existing agent/skill file (retrospective). |
+
+
+## Plugin Maintenance
+
+| Skill | File | Description |
+| --- | --- | --- |
+| `/add-plugin` | [`add-plugin/SKILL.md`](../skills/add-plugin/SKILL.md) | Install a Claude Code plugin and register it in settings.json so the full team can replicate the install. Use this whenever adding a new plugin to the project — it keeps settings.json in sync with what is actually installed. |
+| plugin-audit | [`plugin-audit/SKILL.md`](../skills/plugin-audit/SKILL.md) | Generalized structural compliance check for any Claude Code plugin. Audits architectural decisions only — agent type appropriateness (markdown vs script), frontmatter compliance, eval coverage, and body line-count budgets. Use when adding or modifying any agent or skill in a plugin, after scaffolding a new plugin, before a migration PR lands, or for a periodic health check. Accepts any plugin directory path; not hardcoded to one plugin's internal structure. |

--- a/plugins/marketplace-dev/skill_categories.yaml
+++ b/plugins/marketplace-dev/skill_categories.yaml
@@ -1,0 +1,32 @@
+# Capability taxonomy for plugins/marketplace-dev/docs/skills.md.
+#
+# build_skills_index.py groups the skills catalog by these capabilities, in this
+# order. Each entry's row (name, description) is derived from the file's own
+# frontmatter — this file only decides *which capability section* it lands in.
+# A skill on disk that is not listed here falls into a trailing "Other" section;
+# the freshness gate then shows it as a diff, prompting you to file it under the
+# right capability and regenerate.
+#
+# Regenerate after editing:
+#   python3 plugins/dev-team/hooks/lib/build_skills_index.py \
+#     --plugin-dir plugins/marketplace-dev
+
+categories:
+  - name: Plugin Scaffolding
+    skills:
+      - scaffold-marketplace
+      - scaffold-plugin
+      - init-plugin-eval
+
+  - name: Agent Authoring
+    skills:
+      - agent-create
+      - agent-add
+      - agent-remove
+      - agent-skill-authoring
+      - agent-type-advisor
+
+  - name: Plugin Maintenance
+    skills:
+      - add-plugin
+      - plugin-audit

--- a/plugins/security-assessment/docs/skills.md
+++ b/plugins/security-assessment/docs/skills.md
@@ -1,0 +1,49 @@
+# Skills
+
+<!-- GENERATED FILE — do not edit by hand.
+     Rows: each plugins/security-assessment/skills/<name>/SKILL.md (and plugins/security-assessment/commands/<name>.md if present).
+     Grouping: plugins/security-assessment/skill_categories.yaml (by capability).
+     Regenerate: python3 plugins/dev-team/hooks/lib/build_skills_index.py --plugin-dir plugins/security-assessment
+     A CI freshness gate (--check) fails if this file drifts from the skills on disk. -->
+
+Skills are the unified reusable capability layer in this plugin. Skills live in `skills/<name>/SKILL.md`; user-invocable commands live in `commands/<name>.md`. This catalog groups them **by capability** (the sections below); each row's description is the file's own frontmatter `description`, verbatim.
+
+Most skills are **user-invocable** as slash commands — shown as `/name`; run them directly or let the Orchestrator dispatch them. The rest are **agent-loaded** knowledge modules — shown as a plain `name` — that agents read for domain expertise.
+
+
+## Assessment Pipelines
+
+| Skill | File | Description |
+| --- | --- | --- |
+| `/cross-repo-analysis` | [`commands/cross-repo-analysis.md`](../commands/cross-repo-analysis.md) | Run cross-repo security analysis across two or more target paths. Composes service-comm-parser + shared-cred-hash-match + cross-repo-synthesizer to produce a named-attack-chain report. |
+| `/security-assessment` | [`commands/security-assessment.md`](../commands/security-assessment.md) | Full security assessment pipeline — recon, SARIF-first tool detection, judgment review, FP-reduction, narrative + compliance, service-comm diagram, exec report. Single-repo or multi-repo. |
+
+
+## Adversarial Testing
+
+| Skill | File | Description |
+| --- | --- | --- |
+| `/redteam-model` | [`commands/redteam-model.md`](../commands/redteam-model.md) | Adversarial ML red-team harness against a self-owned model endpoint. 7 probes + report. Rate-limited, budget-bounded, audit-logged. |
+
+
+## Finding Management
+
+| Skill | File | Description |
+| --- | --- | --- |
+| compliance-mapping | [`compliance-mapping/SKILL.md`](../skills/compliance-mapping/SKILL.md) | Pattern-table mapping from unified findings to regulatory citations (PCI-DSS, GDPR, HIPAA, SOC2). LLM edge annotator invoked only for llm_review_trigger=true rows. |
+| false-positive-reduction | [`false-positive-reduction/SKILL.md`](../skills/false-positive-reduction/SKILL.md) | Hybrid FP-reduction — joern when present, LLM fallback when absent. Six-stage rubric (Stage 0 + Stages 1-5) applied to every finding; emits the disposition register. |
+
+
+## Pipeline Infrastructure
+
+| Skill | File | Description |
+| --- | --- | --- |
+| security-assessment-pipeline | [`security-assessment-pipeline/SKILL.md`](../skills/security-assessment-pipeline/SKILL.md) | Declarative phase graph for /security-assessment. Phases run in fixed order with dependency enforcement; per-phase artifacts land in memory/ and feed the next phase. |
+
+
+## Tooling & Maintenance
+
+| Skill | File | Description |
+| --- | --- | --- |
+| `/export-pdf` | [`commands/export-pdf.md`](../commands/export-pdf.md) | Convert a Markdown report to PDF via pandoc (preferred) or weasyprint (fallback). Skips gracefully if neither is installed. |
+| `/upgrade` | [`commands/upgrade.md`](../commands/upgrade.md) | Check for and apply security-assessment plugin updates using the official Claude Code plugin update mechanism. |

--- a/plugins/security-assessment/skill_categories.yaml
+++ b/plugins/security-assessment/skill_categories.yaml
@@ -1,0 +1,36 @@
+# Capability taxonomy for plugins/security-assessment/docs/skills.md.
+#
+# build_skills_index.py groups the skills catalog by these capabilities, in this
+# order. Each entry's row (name, description) is derived from the file's own
+# frontmatter — this file only decides *which capability section* it lands in.
+# A skill or command on disk that is not listed here falls into a trailing
+# "Other" section; the freshness gate then shows it as a diff, prompting you to
+# file it under the right capability and regenerate.
+#
+# Regenerate after editing:
+#   python3 plugins/dev-team/hooks/lib/build_skills_index.py \
+#     --plugin-dir plugins/security-assessment
+
+categories:
+  - name: Assessment Pipelines
+    skills:
+      - security-assessment
+      - cross-repo-analysis
+
+  - name: Adversarial Testing
+    skills:
+      - redteam-model
+
+  - name: Finding Management
+    skills:
+      - false-positive-reduction
+      - compliance-mapping
+
+  - name: Pipeline Infrastructure
+    skills:
+      - security-assessment-pipeline
+
+  - name: Tooling & Maintenance
+    skills:
+      - export-pdf
+      - upgrade

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -167,7 +167,13 @@ chk_eval_corpus()     { python3 scripts/eval_grade.py --check-corpus; }
 chk_oe_staleness()    { python3 scripts/oe_scoring_staleness.py --warn-only; }
 chk_citation_lint()   { python3 scripts/citation_lint.py --all; }  # advisory (#312)
 chk_md_references()   { python3 scripts/check_md_references.py; }
-chk_skills_index()    { python3 plugins/dev-team/hooks/lib/build_skills_index.py --check; }
+chk_skills_index() {
+  local script=plugins/dev-team/hooks/lib/build_skills_index.py
+  python3 "$script" --check || return 1
+  for plugin_dir in plugins/security-assessment plugins/marketplace-dev; do
+    python3 "$script" --plugin-dir "$plugin_dir" --check || return 1
+  done
+}
 chk_rules_vs_prompts() { bash scripts/audit-rules-vs-prompts.sh; }
 chk_python_only() {
   if [ -n "$BASE" ]; then


### PR DESCRIPTION
## Summary

- Extend `build_skills_index.py` with `--plugin-dir <path>` flag so it can generate catalogs for any plugin directory (not just dev-team); adds `commands/*.md` scanning to include slash commands in the output
- Add `plugins/security-assessment/skill_categories.yaml` — 5 capability groups covering 5 commands + 3 skills
- Generate `plugins/security-assessment/docs/skills.md` — slash commands + agent-loaded skills catalog
- Add `plugins/marketplace-dev/skill_categories.yaml` — 3 capability groups covering 10 skills
- Generate `plugins/marketplace-dev/docs/skills.md` — slash commands + agent-loaded skills catalog
- Extend `scripts/ci-local.sh` `chk_skills_index` to loop over all three plugin dirs; `--check` exits 0 for all three

## Test plan

- [ ] `bash scripts/ci-local.sh --only=chk_skills_index` exits 0 for dev-team, security-assessment, and marketplace-dev
- [ ] `python3 plugins/dev-team/hooks/lib/build_skills_index.py` (no flag) still works for dev-team (backward-compatible)
- [ ] `python3 plugins/dev-team/hooks/lib/build_skills_index.py --plugin-dir plugins/security-assessment` generates security-assessment/docs/skills.md
- [ ] All 832 hook unit tests pass

Closes #1035
Part of #879

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5WPLLGLgkYTswbUmGZcyr)_