### PR TITLE
feat: add deterministic ship outcome classifier

### DIFF
--- a/plugins/dev-team/hooks/lib/classify_ship_outcome.py
+++ b/plugins/dev-team/hooks/lib/classify_ship_outcome.py
@@ -1,0 +1,129 @@
+"""
+classify_ship_outcome.py — deterministic /ship outcome classifier.
+
+Reads metrics/review-value.jsonl and metrics/verify-log.jsonl since a
+start timestamp and returns one of three outcome strings:
+
+  "convergence_failure" — any review-value entry since `since_iso` has
+                          outcome == "escalated"
+  "success"             — at least one verify-log entry since `since_iso`
+                          has outcome in {"ran", "failed-then-fixed"}
+  "unrecognized"        — neither condition met (or no matching entries)
+
+Files that do not exist are treated as empty (no lines).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+_VERIFY_SUCCESS_OUTCOMES = {"ran", "failed-then-fixed"}
+
+
+def _timestamp_field(record: dict) -> Optional[str]:
+    """Return the timestamp string from a JSONL record, trying common field names."""
+    for key in ("timestamp", "logged_at", "ts"):
+        if key in record:
+            return str(record[key])
+    return None
+
+
+def _read_since(path: Path, since_iso: str) -> List[dict]:
+    """
+    Return all JSON records from *path* whose timestamp >= since_iso.
+
+    Lines that are not valid JSON, or that have no recognisable timestamp
+    field, are skipped silently.
+    """
+    if not path.exists():
+        return []
+
+    results: List[dict] = []
+    with path.open(encoding="utf-8") as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            ts = _timestamp_field(record)
+            if ts is not None and ts < since_iso:
+                continue
+            results.append(record)
+    return results
+
+
+def classify(
+    review_value_path: Path,
+    verify_log_path: Path,
+    since_iso: str,
+) -> str:
+    """
+    Classify the /ship outcome from two JSONL metric files.
+
+    Parameters
+    ----------
+    review_value_path:
+        Path to metrics/review-value.jsonl (may not exist).
+    verify_log_path:
+        Path to metrics/verify-log.jsonl (may not exist).
+    since_iso:
+        ISO-8601 timestamp string.  Only records at or after this time
+        are considered.
+
+    Returns
+    -------
+    One of "convergence_failure", "success", or "unrecognized".
+    """
+    review_records = _read_since(Path(review_value_path), since_iso)
+    if any(r.get("outcome") == "escalated" for r in review_records):
+        return "convergence_failure"
+
+    verify_records = _read_since(Path(verify_log_path), since_iso)
+    if any(r.get("outcome") in _VERIFY_SUCCESS_OUTCOMES for r in verify_records):
+        return "success"
+
+    return "unrecognized"
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Classify /ship outcome from JSONL metric files."
+    )
+    parser.add_argument(
+        "--review-value",
+        required=True,
+        metavar="PATH",
+        help="Path to metrics/review-value.jsonl",
+    )
+    parser.add_argument(
+        "--verify-log",
+        required=True,
+        metavar="PATH",
+        help="Path to metrics/verify-log.jsonl",
+    )
+    parser.add_argument(
+        "--since",
+        required=True,
+        metavar="ISO_TIMESTAMP",
+        help="Consider only records at or after this ISO-8601 timestamp",
+    )
+    args = parser.parse_args()
+
+    result = classify(
+        review_value_path=Path(args.review_value),
+        verify_log_path=Path(args.verify_log),
+        since_iso=args.since,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/test_classify_ship_outcome.py
+++ b/tests/test_classify_ship_outcome.py
@@ -1,0 +1,213 @@
+"""
+Tests for plugins/dev-team/hooks/lib/classify_ship_outcome.py
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Resolve module path without installing the package.
+LIB_DIR = Path(__file__).parent.parent / "plugins" / "dev-team" / "hooks" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+from classify_ship_outcome import classify  # noqa: E402
+
+
+SINCE = "2024-01-15T10:00:00Z"
+BEFORE = "2024-01-15T09:00:00Z"
+AT = "2024-01-15T10:00:00Z"
+AFTER = "2024-01-15T11:00:00Z"
+
+MODULE_PATH = LIB_DIR / "classify_ship_outcome.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def write_jsonl(path: Path, records: list) -> None:
+    with path.open("w") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# (a) convergence_failure when escalated entry present
+# ---------------------------------------------------------------------------
+
+def test_convergence_failure_when_escalated(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"timestamp": AFTER, "outcome": "escalated"}])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "convergence_failure"
+
+
+def test_convergence_failure_takes_priority_over_success(tmp_path):
+    """escalated in review-value wins even when verify-log shows 'ran'."""
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"timestamp": AFTER, "outcome": "escalated"}])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "convergence_failure"
+
+
+# ---------------------------------------------------------------------------
+# (b) success when verify entry with outcome "ran" present
+# ---------------------------------------------------------------------------
+
+def test_success_when_ran(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"timestamp": AFTER, "outcome": "passed"}])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "success"
+
+
+# ---------------------------------------------------------------------------
+# (c) success when outcome is "failed-then-fixed"
+# ---------------------------------------------------------------------------
+
+def test_success_when_failed_then_fixed(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "failed-then-fixed"}])
+
+    assert classify(rv, vl, SINCE) == "success"
+
+
+# ---------------------------------------------------------------------------
+# (d) unrecognized when no matching entries
+# ---------------------------------------------------------------------------
+
+def test_unrecognized_when_no_matching_entries(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"timestamp": AFTER, "outcome": "passed"}])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "skipped"}])
+
+    assert classify(rv, vl, SINCE) == "unrecognized"
+
+
+def test_unrecognized_when_both_files_empty(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [])
+
+    assert classify(rv, vl, SINCE) == "unrecognized"
+
+
+# ---------------------------------------------------------------------------
+# (e) lines before since_iso are ignored
+# ---------------------------------------------------------------------------
+
+def test_lines_before_since_iso_ignored_for_escalated(tmp_path):
+    """An 'escalated' entry timestamped before since_iso must not trigger failure."""
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"timestamp": BEFORE, "outcome": "escalated"}])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "success"
+
+
+def test_lines_before_since_iso_ignored_for_ran(tmp_path):
+    """A 'ran' entry before since_iso must not trigger success."""
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [{"timestamp": BEFORE, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "unrecognized"
+
+
+def test_records_at_since_iso_are_included(tmp_path):
+    """Records with timestamp == since_iso are included (boundary is inclusive)."""
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [{"timestamp": AT, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "success"
+
+
+# ---------------------------------------------------------------------------
+# (f) missing files treated as empty
+# ---------------------------------------------------------------------------
+
+def test_missing_review_value_treated_as_empty(tmp_path):
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    assert classify(tmp_path / "nonexistent.jsonl", vl, SINCE) == "success"
+
+
+def test_missing_verify_log_treated_as_empty(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    write_jsonl(rv, [{"timestamp": AFTER, "outcome": "passed"}])
+
+    assert classify(rv, tmp_path / "nonexistent.jsonl", SINCE) == "unrecognized"
+
+
+def test_both_files_missing(tmp_path):
+    assert classify(
+        tmp_path / "no-rv.jsonl",
+        tmp_path / "no-vl.jsonl",
+        SINCE,
+    ) == "unrecognized"
+
+
+# ---------------------------------------------------------------------------
+# Alternate timestamp field names
+# ---------------------------------------------------------------------------
+
+def test_logged_at_field_respected(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [{"logged_at": BEFORE, "outcome": "escalated"}])
+    write_jsonl(vl, [{"logged_at": AFTER, "outcome": "ran"}])
+
+    # escalated is before since_iso, so should not trigger convergence_failure
+    assert classify(rv, vl, SINCE) == "success"
+
+
+def test_ts_field_respected(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [{"ts": AFTER, "outcome": "ran"}])
+
+    assert classify(rv, vl, SINCE) == "success"
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+def test_cli_prints_result(tmp_path):
+    rv = tmp_path / "review-value.jsonl"
+    vl = tmp_path / "verify-log.jsonl"
+    write_jsonl(rv, [])
+    write_jsonl(vl, [{"timestamp": AFTER, "outcome": "ran"}])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(MODULE_PATH),
+            "--review-value", str(rv),
+            "--verify-log", str(vl),
+            "--since", SINCE,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "success"


### PR DESCRIPTION
Add a stdlib-only Python classifier that reads `metrics/review-value.jsonl`
and `metrics/verify-log.jsonl` since a given timestamp and returns one of
three deterministic outcome strings: `convergence_failure`, `success`, or
`unrecognized`.

Closes #991
Part of #985

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5WPLLGLgkYTswbUmGZcyr)_