### PR TITLE
feat: right-size security-assessment agents and complete cross-plugin documentation automation

### DIFF
--- a/plugins/security-assessment/agents/authorization-logic-review.md
+++ b/plugins/security-assessment/agents/authorization-logic-review.md
@@ -3,6 +3,7 @@ effort: high
 name: authorization-logic-review
 description: Top-down authorization review. Maps the access-control model (RBAC/ABAC/ACL/tenancy), then verifies enforcement at every layer. Phase 1b peer agent.
 tools: Read, Grep, Glob
+cites: [severity-floors]
 ---
 
 # Authorization Logic Review

--- a/plugins/security-assessment/agents/compliance-edge-annotator.md
+++ b/plugins/security-assessment/agents/compliance-edge-annotator.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: compliance-edge-annotator
 description: Edge annotator for compliance findings whose pattern row has llm_review_trigger=true. Refines pattern-table citations; never invents new ones.
 tools: Read, Grep

--- a/plugins/security-assessment/agents/cross-repo-synthesizer.md
+++ b/plugins/security-assessment/agents/cross-repo-synthesizer.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: cross-repo-synthesizer
 description: Synthesizes attack-chain narratives from multi-repo RECON + shared-cred matches + service-comm diagram. Produces named attack chains citing findings by ID. Does not detect.
 tools: Read, Grep, Glob
@@ -13,7 +13,7 @@ explicitly. Cite findings; do not invent.
 Invoked by `/cross-repo-analysis` after `service-comm-parser.py` and
 `shared-cred-hash-match.py` have produced their outputs.
 
-Context needs: project-structure
+Context needs: artifact-stream
 
 ## Inputs
 

--- a/plugins/security-assessment/agents/exec-report-generator.md
+++ b/plugins/security-assessment/agents/exec-report-generator.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: exec-report-generator
 description: Synthesizes the publication-ready executive report from upstream artifacts. Emits a 7-section per-repo report (plus cross-repo summary for multi-repo runs).
 tools: Read, Write, Glob, Grep
@@ -11,7 +11,7 @@ Final agent in `/security-assessment`. Synthesizes narrative from upstream
 artifacts. Does not detect, disposition, or score. Maps presentational
 severity (CRITICAL/HIGH/MEDIUM/LOW) per primitives contract v1.1.0.
 
-Context needs: project-structure
+Context needs: artifact-stream
 
 ## Inputs (per target repo)
 

--- a/plugins/security-assessment/agents/fp-reduction.md
+++ b/plugins/security-assessment/agents/fp-reduction.md
@@ -3,6 +3,7 @@ effort: high
 name: fp-reduction
 description: Applies the 5-stage FP-reduction rubric to a unified-finding stream, producing a disposition register. Consumes findings + RECON (+ CPG when joern is available).
 tools: Read, Grep, Glob, Bash
+cites: [severity-floors]
 ---
 
 # FP-Reduction Agent

--- a/plugins/security-assessment/agents/recon-driven-scan.md
+++ b/plugins/security-assessment/agents/recon-driven-scan.md
@@ -3,6 +3,7 @@ effort: high
 name: recon-driven-scan
 description: Bridges RECON narrative risk claims to file/line evidence. Emits findings only when the source actually exhibits the described pattern. Phase 1b peer agent.
 tools: Read, Grep, Glob, Bash
+cites: [severity-floors]
 ---
 
 # RECON-Driven Scan Agent

--- a/plugins/security-assessment/agents/redteam-evasion-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-evasion-analyzer.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: redteam-evasion-analyzer
 description: Interprets probe 05 (evasion) alongside probe 03 (sensitivity) and probe 04 (boundaries). Rates adversarial realism, explains evasion mechanism, recommends defenses.
 tools: Read, Grep
@@ -12,7 +12,7 @@ realistic (a fraud actor could actually submit them), which succeed
 because of model brittleness, and what defenses raise the cost of
 evasion.
 
-Context needs: full-file
+Context needs: artifact-stream
 
 ## Inputs
 

--- a/plugins/security-assessment/agents/redteam-extraction-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-extraction-analyzer.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: redteam-extraction-analyzer
 description: Interprets probe 07 (model extraction) alongside probe 03 (sensitivity). Translates R² into extraction fidelity, extracts decision-rule structure, names IP-theft implications.
 tools: Read, Grep
@@ -11,7 +11,7 @@ Translate probe 07's surrogate-model R² scores into business-actionable
 language: what does R² = 0.87 mean for IP, can the surrogate make business
 decisions, what has the attacker actually stolen.
 
-Context needs: full-file
+Context needs: artifact-stream
 
 ## Inputs
 

--- a/plugins/security-assessment/agents/redteam-recon-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-recon-analyzer.md
@@ -1,8 +1,9 @@
 ---
-effort: high
+effort: medium
 name: redteam-recon-analyzer
 description: Interprets probe 01 (API recon). Severity-rates info leaks, identifies the framework, recommends a feature-discovery strategy for probe 02.
 tools: Read, Grep
+cites: [severity-floors]
 ---
 
 # Red-Team Recon Analyzer
@@ -12,7 +13,7 @@ endpoints, HTTP method matrices, and server headers — judging which leaks
 matter and what an attacker would do next requires reasoning the probe
 cannot do.
 
-Context needs: full-file
+Context needs: artifact-stream
 
 ## Input
 

--- a/plugins/security-assessment/agents/redteam-report-generator.md
+++ b/plugins/security-assessment/agents/redteam-report-generator.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: redteam-report-generator
 description: Refines the red-team adversarial-report.md into an executive document. Assigns RED/AMBER/GREEN rating; produces remediation with effort estimates.
 tools: Read, Write, Grep
@@ -12,7 +12,7 @@ Final agent in the red-team pipeline. Synthesize the raw report from probe
 rating, severity-calibrated findings, narrative flow, actionable
 remediation.
 
-Context needs: project-structure
+Context needs: artifact-stream
 
 ## Inputs
 

--- a/plugins/security-assessment/agents/tool-finding-narrative-annotator.md
+++ b/plugins/security-assessment/agents/tool-finding-narrative-annotator.md
@@ -1,5 +1,5 @@
 ---
-effort: high
+effort: medium
 name: tool-finding-narrative-annotator
 description: Weaves findings into four narrative domains (PII flow, ML edge cases, messaging auth, crypto). Prose for the exec report. Synthesizes; does not detect.
 tools: Read, Grep, Glob
@@ -11,7 +11,7 @@ Read related findings, weave them into a coherent per-domain story.
 Consumed by `exec-report-generator` to populate the "Findings by domain"
 section.
 
-Context needs: project-structure
+Context needs: artifact-stream, full-file
 
 ## Inputs
 

--- a/tests/agents/test_agent_effort_frontmatter.py
+++ b/tests/agents/test_agent_effort_frontmatter.py
@@ -37,7 +37,7 @@ AGENTS_DIRS = [
 ]
 ALLOWED_BANDS = ("low", "medium", "high")
 DEPRECATED_MODEL_TIERS = ("haiku", "sonnet", "opus")
-ALLOWED_CONTEXT_NEEDS = ("diff-only", "full-file", "project-structure")
+ALLOWED_CONTEXT_NEEDS = ("diff-only", "full-file", "project-structure", "artifact-stream")
 
 
 def _agent_files_to_check(agent_files: str | None = None) -> List[Path]:
@@ -195,7 +195,8 @@ def test_description_has_no_colon() -> None:
 def test_every_agent_declares_context_needs() -> None:
     """FAIL if any agent body is missing a 'Context needs:' declaration.
 
-    Every agent must declare one of: diff-only, full-file, project-structure.
+    Every agent must declare one of: diff-only, full-file, project-structure,
+    artifact-stream (or a comma-separated combination of recognized values).
     This tells the orchestrator how much context to load before dispatching
     (agent-audit SKILL.md check 9).
     """
@@ -208,9 +209,11 @@ def test_every_agent_declares_context_needs() -> None:
         if not value:
             missing.append(str(rel))
             continue
-        # Strip inline notes (e.g. "full-file (reads plan + git state)")
-        bare = value.split()[0]
-        if bare not in ALLOWED_CONTEXT_NEEDS:
+        # Strip inline notes (e.g. "full-file (reads plan + git state)").
+        # Support comma-separated combined values like "artifact-stream, full-file".
+        # canonical source: agent-audit/SKILL.md check 9
+        tokens = [t.strip().split()[0] for t in value.split(",")]
+        if any(t not in ALLOWED_CONTEXT_NEEDS for t in tokens):
             invalid.append(f"{rel}: Context needs: {value}")
 
     assert not missing and not invalid, (

--- a/tests/repo/test_skills_index_current.py
+++ b/tests/repo/test_skills_index_current.py
@@ -232,6 +232,32 @@ def test_missing_categories_file_produces_ungrouped_section(
     assert "## Other" not in rendered
 
 
+def test_security_assessment_skills_md_is_current() -> None:
+    """CI freshness gate: security-assessment/docs/skills.md must match a fresh build."""
+    sa_dir = REPO_ROOT / "plugins" / "security-assessment"
+    if not sa_dir.is_dir():
+        return  # plugin not present in this checkout
+    res = _run_builder(["--check", "--plugin-dir", str(sa_dir)])
+    assert res.returncode == 0, (
+        "security-assessment/docs/skills.md is out of date. "
+        "Rebuild with: python3 plugins/dev-team/hooks/lib/build_skills_index.py "
+        f"--plugin-dir {sa_dir}\n" + res.stdout + res.stderr
+    )
+
+
+def test_marketplace_dev_skills_md_is_current() -> None:
+    """CI freshness gate: marketplace-dev/docs/skills.md must match a fresh build."""
+    md_dir = REPO_ROOT / "plugins" / "marketplace-dev"
+    if not md_dir.is_dir():
+        return  # plugin not present in this checkout
+    res = _run_builder(["--check", "--plugin-dir", str(md_dir)])
+    assert res.returncode == 0, (
+        "marketplace-dev/docs/skills.md is out of date. "
+        "Rebuild with: python3 plugins/dev-team/hooks/lib/build_skills_index.py "
+        f"--plugin-dir {md_dir}\n" + res.stdout + res.stderr
+    )
+
+
 def test_plugin_dir_flag_points_to_security_assessment(tmp_path: Path) -> None:
     """--plugin-dir with security-assessment unions skills/ (3) and commands/ (5) = 8 entries."""
     sa_dir = REPO_ROOT / "plugins" / "security-assessment"


### PR DESCRIPTION
## Summary

Two related changes landing together on this branch:

### 1. Right-size security-assessment agent effort bands (Closes #1037)

- Migrates all 13 `security-assessment` agents from legacy `model: opus` frontmatter to right-sized `effort:` bands per ADR 0008
- Extends `ALLOWED_CONTEXT_NEEDS` in `tests/agents/test_agent_effort_frontmatter.py` with `artifact-stream` and adds combined-value validation (e.g. `artifact-stream, full-file`)
- Sets `Context needs:` accurately per each agent's actual input consumption pattern
- Adds `cites: [severity-floors]` to 4 agents whose bodies reference severity thresholds backed by `plugins/security-assessment/knowledge/severity-floors.json`

**Effort band changes:**

| Agent | Before | After |
|---|---|---|
| `authorization-logic-review` | high | **high** (unchanged) |
| `business-logic-domain-review` | high | **high** (unchanged) |
| `compliance-edge-annotator` | high | **medium** ⬇ |
| `cross-repo-synthesizer` | high | **medium** ⬇ |
| `deep-code-reasoning` | high | **high** (unchanged) |
| `exec-report-generator` | high | **medium** ⬇ |
| `fp-reduction` | high | **high** (unchanged) |
| `recon-driven-scan` | high | **high** (unchanged) |
| `redteam-evasion-analyzer` | high | **medium** ⬇ |
| `redteam-extraction-analyzer` | high | **medium** ⬇ |
| `redteam-recon-analyzer` | high | **medium** ⬇ |
| `redteam-report-generator` | high | **medium** ⬇ |
| `tool-finding-narrative-annotator` | high | **medium** ⬇ |

**AC3 — Agents downgraded from `high` to `medium` (8 total — flagged for eval scrutiny before merge):**
`compliance-edge-annotator`, `cross-repo-synthesizer`, `exec-report-generator`, `redteam-evasion-analyzer`, `redteam-extraction-analyzer`, `redteam-recon-analyzer`, `redteam-report-generator`, `tool-finding-narrative-annotator`

These agents consume pre-generated pipeline artifacts (JSON results, memory/ files) without reading source files directly. Moderate synthesis fits `medium`. Agents that use Read/Grep/Glob on the target codebase retain `high`.

---

### 2. Add CI freshness gates for security-assessment and marketplace-dev skills catalogs (Closes #1018)

- Adds `test_security_assessment_skills_md_is_current` and `test_marketplace_dev_skills_md_is_current` to `tests/repo/test_skills_index_current.py`
- Each runs `build_skills_index.py --check --plugin-dir <plugin>` — if a skill or command is added/removed/renamed without rebuilding the catalog, CI now fails
- Previously only `dev-team/docs/skills.md` had this gate; the other two plugins had generated catalogs but no enforcement
- Both new tests pass on a clean checkout (16 tests pass, up from 14)

Closes #1037
Closes #1018