### PR TITLE
fix: resolve Python 3 across interpreter names so hooks and /version work on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Run `npm ci` as the first step in any new worktree, before committing. An unprov
 
 **Every shipped script under `plugins/dev-team/` is Python 3.8+ using stdlib only.** See [ADR 0014](docs/adr/0014-python-for-cross-os-scripts.md) (the decision) and [ADR 0015](docs/adr/0015-bash-removal-complete.md) (the completion). Concretely:
 
-- **All shipped hooks + scripts are `.py` files.** No `.sh` remains in `plugins/dev-team/` except the `install.sh` trampoline (two-line shell → Python bootstrap so we can detect the shell environment before Python is guaranteed on PATH).
+- **All shipped hooks + scripts are `.py` files.** The only `.sh` in `plugins/dev-team/` are the two pre-Python bootstrap shims, which cannot themselves be Python because they run before an interpreter is guaranteed on PATH: `install.sh` (the `install.py` trampoline) and `hooks/py.sh` (resolves a real Python 3 across `python3`/`py -3`/`python`/`$DEV_TEAM_PYTHON` so hooks and `/version` work on Windows, where `python3` is often absent — see #1078). Every other shipped invocation routes through `py.sh`, not a bare `python3`.
 - **Stdlib only.** No `pip install`, no `requirements.txt` for shipped code. `subprocess`, `signal`, `pathlib`, `argparse`, `json`, `hashlib`, `re` cover the vast majority of shell-script territory portably.
 - **Cross-OS by default.** Python runs natively on macOS, Linux, and Windows — no more Git Bash requirement for plugin hooks. When probing OS-specific paths (DOTNET_ROOT, tool install locations), use runtime probes (`subprocess`, `pathlib`) rather than hard-coding macOS or Linux paths.
 - **Tests are pytest.** New tests land as `test_*.py` under the plugin's `tests/` tree.

--- a/docs/adr/0015-bash-removal-complete.md
+++ b/docs/adr/0015-bash-removal-complete.md
@@ -14,9 +14,9 @@ The parity harness's job is now over — the `.sh` implementations it dispatched
 
 ## Decision
 
-1. **Every shipped script under `plugins/dev-team/` is Python 3.8+ stdlib-only.** The single exception is `plugins/dev-team/install.sh` — a two-line trampoline that detects the shell environment (needed so we can tell users to install Git Bash on Windows *before* running Python).
+1. **Every shipped script under `plugins/dev-team/` is Python 3.8+ stdlib-only.** The exceptions are the two pre-Python bootstrap shims, which run before an interpreter is guaranteed on PATH and therefore cannot be Python: `plugins/dev-team/install.sh` (the `install.py` trampoline) and — added by #1078 — `plugins/dev-team/hooks/py.sh`, which resolves a real Python 3 across `python3`/`py -3`/`python`/`$DEV_TEAM_PYTHON`.
 
-2. **The `sh -c 'if [ "${DEV_TEAM_PY_HOOK_*:-0}" = "1" ]; then python3 …; else bash …; fi'` toggle wrapper is retired** from `plugins/dev-team/settings.json`. Every hook invocation is now a plain `python3 hooks/<name>.py`. Operators no longer need to opt into Python via env var.
+2. **The `sh -c 'if [ "${DEV_TEAM_PY_HOOK_*:-0}" = "1" ]; then python3 …; else bash …; fi'` toggle wrapper is retired** from `plugins/dev-team/settings.json`. Operators no longer need to opt into Python via env var. Hook invocations were originally plain `python3 hooks/<name>.py`; #1078 changed them to `sh hooks/py.sh hooks/<name>.py` so the interpreter name is resolved at run time (a bare `python3` is absent on stock Windows), not hard-coded.
 
 3. **The `plugins/dev-team/tests/hooks/parity/` harness is retired.** The going-forward coverage lives at `plugins/dev-team/tests/hooks/test_*.py` (~23 pytest files, 220+ assertions) and `plugins/dev-team/tests/scripts/test_*.py` (2 files).
 

--- a/plugins/dev-team/hooks/lib/plugin_version.py
+++ b/plugins/dev-team/hooks/lib/plugin_version.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Resolve and print the installed dev-team plugin version (#1078).
+
+Backs the `/version` skill. Reads Claude Code's install record
+(``installed_plugins.json``) and prints a single deterministic line — no
+reasoning, no file-by-file searching, so the answer never depends on the model
+guessing.
+
+Resolution: a project-scoped install whose ``projectPath`` matches the current
+directory wins; otherwise the user-scoped install; otherwise the first entry.
+
+Contract:
+    Output : one line, e.g. ``dev-team@bfinster v10.4.0 (scope: user)``
+    Exit 0 : printed a version line
+    Exit 1 : plugin not recorded as installed (stderr explains)
+    Exit 2 : environment error — install record missing/malformed (stderr)
+
+Honors ``CLAUDE_CONFIG_DIR``. Stdlib only, Python 3.8+ (ADR 0014 / 0015).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Optional
+
+PLUGIN = "dev-team"
+
+
+def config_dir() -> str:
+    """The Claude Code config dir — ``CLAUDE_CONFIG_DIR`` if set, else ~/.claude."""
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(
+        os.path.expanduser("~"), ".claude"
+    )
+
+
+def _record_path(cfg: str) -> str:
+    return os.path.join(cfg, "plugins", "installed_plugins.json")
+
+
+def _dev_team_entries(record: dict):
+    """(marketplace, entry) pairs for every dev-team install, in record order.
+
+    Matches the plugin id ``dev-team@<marketplace>`` exactly on the name part so
+    a sibling like ``aci-dev-team@…`` is never mistaken for it.
+    """
+    out = []
+    for pid, entries in (record.get("plugins") or {}).items():
+        if "@" not in pid or pid.split("@", 1)[0] != PLUGIN:
+            continue
+        market = pid.split("@", 1)[1]
+        for entry in entries or []:
+            if isinstance(entry, dict):
+                out.append((market, entry))
+    return out
+
+
+def _select(entries, cwd: str):
+    """Pick the entry that governs ``cwd``: matching project scope, else user,
+    else the first available. ``entries`` is the list from ``_dev_team_entries``."""
+    cwd = os.path.realpath(cwd)
+
+    def project_match(entry: dict) -> bool:
+        pp = entry.get("projectPath")
+        if entry.get("scope") != "project" or not pp:
+            return False
+        pp = os.path.realpath(pp)
+        # cwd is the project root or nested within it.
+        return cwd == pp or cwd.startswith(pp + os.sep)
+
+    for market, entry in entries:
+        if project_match(entry):
+            return market, entry
+    for market, entry in entries:
+        if entry.get("scope") == "user":
+            return market, entry
+    return entries[0] if entries else (None, None)
+
+
+def resolve(cfg: str, cwd: str):
+    """Return (line, exit_code). ``line`` is None for the non-zero exits."""
+    path = _record_path(cfg)
+    try:
+        with open(path) as f:
+            record = json.load(f)
+    except FileNotFoundError:
+        return None, 2
+    except (json.JSONDecodeError, OSError):
+        return None, 2
+
+    entries = _dev_team_entries(record)
+    if not entries:
+        return None, 1
+
+    market, entry = _select(entries, cwd)
+    version = entry.get("version") or "unknown"
+    scope = entry.get("scope") or "unknown"
+    return f"{PLUGIN}@{market} v{version} (scope: {scope})", 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    cfg = config_dir()
+    line, code = resolve(cfg, os.getcwd())
+    if code == 0:
+        print(line)
+    elif code == 1:
+        print(
+            f"{PLUGIN} is not installed (no record in installed_plugins.json).",
+            file=sys.stderr,
+        )
+    else:  # code == 2
+        print(
+            f"Environment error: cannot read the install record at {_record_path(cfg)}.",
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dev-team/hooks/py.sh
+++ b/plugins/dev-team/hooks/py.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# py.sh — resolve a working Python 3 interpreter and exec it with the given args.
+#
+# Ships as .sh (not .py) by necessity: it runs BEFORE a Python interpreter is
+# guaranteed on PATH, so it cannot itself be Python. This is the same
+# pre-Python bootstrap carve-out ADR 0015 grants install.sh — not a regression
+# on the "shipped scripts are Python" rule.
+#
+# Why it exists: every hook command in settings.json and the /version skill
+# route their Python invocations through this shim so the plugin works on
+# machines where Python 3 exists under a name other than `python3`. Notably
+# Windows, where python.org installs `python.exe`/`py.exe` but NOT
+# `python3.exe`, and the only `python3` on PATH is the WindowsApps
+# app-execution-alias stub that refuses to run non-interactively. Many
+# locked-down corporate users cannot install packages to fix this themselves
+# but do have Python 3 as `python`/`py`.
+#
+# Resolution order: $DEV_TEAM_PYTHON override, then python3, py -3, python.
+# Each candidate is *executed* (not just located with `command -v`) so the
+# Store stub and Python 2 are rejected on behavior, not name. The winner is
+# cached for the session so only the first call pays the probe cost.
+#
+# Usage:  sh hooks/py.sh <script.py> [args...]
+# Exit 2 (environment error) when no Python 3 is found — matches the hook
+# contract's exit-2 semantics.
+
+set -u
+
+# Match version_check.py's cache convention: a bare /tmp literal is portable to
+# Windows Git Bash (MSYS mounts it), so no ${TMPDIR:-/tmp} dance is needed.
+# $DEV_TEAM_PY_CACHE overrides the path (used by tests for isolation).
+CACHE="${DEV_TEAM_PY_CACHE:-/tmp/.dev-team-python}"
+
+# A candidate is valid only if it runs AND reports major version >= 3. All
+# output is discarded so the Store stub's "not found" banner never surfaces and
+# a candidate that prints nothing is judged purely on exit status.
+valid() {
+    command -v "$1" >/dev/null 2>&1 || return 1
+    "$@" -c 'import sys; raise SystemExit(0 if sys.version_info[0] >= 3 else 1)' \
+        >/dev/null 2>&1
+}
+
+# Fast path: trust a cached interpreter if its first token still resolves.
+# Skipped when DEV_TEAM_PYTHON is set so an explicit override always wins over a
+# stale cache.
+if [ -z "${DEV_TEAM_PYTHON:-}" ] && [ -f "$CACHE" ]; then
+    read -r PY <"$CACHE" 2>/dev/null || PY=""
+    if [ -n "$PY" ] && command -v "${PY%% *}" >/dev/null 2>&1; then
+        exec $PY "$@"
+    fi
+fi
+
+PY=""
+# Intentional word-split: DEV_TEAM_PYTHON may be a multi-word command like "py -3".
+# shellcheck disable=SC2086
+if [ -n "${DEV_TEAM_PYTHON:-}" ] && valid ${DEV_TEAM_PYTHON}; then
+    PY="${DEV_TEAM_PYTHON}"
+elif valid python3; then
+    PY="python3"
+elif valid py -3; then
+    PY="py -3"
+elif valid python; then
+    PY="python"
+else
+    echo "dev-team: no Python 3 interpreter found (tried \$DEV_TEAM_PYTHON, python3, py -3, python)." >&2
+    echo "dev-team: install Python 3.8+ or set DEV_TEAM_PYTHON to a working interpreter." >&2
+    exit 2
+fi
+
+# Best-effort cache; a read-only /tmp is non-fatal.
+printf '%s\n' "$PY" >"$CACHE" 2>/dev/null || true
+
+exec $PY "$@"

--- a/plugins/dev-team/install.sh
+++ b/plugins/dev-team/install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# install.sh — thin trampoline that hands off to install.py.
+# install.sh — thin trampoline that resolves a Python 3 interpreter and hands
+# off to install.py.
 #
-# Per ADR 0014, new shipped scripts are Python; this file remains as a
-# .sh only to preserve the well-known `install.sh` command surface AND
-# to detect the shell environment (Git Bash on Windows) before Python
-# is guaranteed on PATH.
+# Per ADR 0014, new shipped scripts are Python; this file remains a .sh only to
+# preserve the well-known `install.sh` command surface AND to bootstrap before
+# Python is guaranteed on PATH.
 #
-# Behavior:
-#   - If `python3` is on PATH, delegate to install.py (which does the
-#     actual prerequisite check).
-#   - Otherwise, fail loudly with an install pointer.
+# Interpreter resolution is delegated to the shared hooks/py.sh shim, which
+# tries $DEV_TEAM_PYTHON, python3, py -3, then python — so install works on
+# Windows, where Python 3 is commonly `python`/`py` and no `python3` exists.
+# py.sh prints an actionable message and exits 2 when no Python 3 is found.
 #
 # Usage:
 #   ./install.sh
@@ -18,12 +18,4 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "[FAIL] python3 — required. Install Python 3.8+."
-  echo "  macOS: brew install python3"
-  echo "  Linux: apt install python3 (or your distro's equivalent)"
-  echo "  Windows: install Git Bash + Python 3 from python.org"
-  exit 1
-fi
-
-exec python3 "$SCRIPT_DIR/install.py" "$@"
+exec sh "$SCRIPT_DIR/hooks/py.sh" "$SCRIPT_DIR/install.py" "$@"

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -21,11 +21,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/session_model_banner.py"
+            "command": "sh hooks/py.sh hooks/session_model_banner.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/codegraph_bootstrap.py"
+            "command": "sh hooks/py.sh hooks/codegraph_bootstrap.py"
           }
         ]
       }
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/telemetry.py"
+            "command": "sh hooks/py.sh hooks/telemetry.py"
           }
         ]
       }
@@ -46,15 +46,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/pre_tool_guard.py"
+            "command": "sh hooks/py.sh hooks/pre_tool_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/contract_version_guard.py"
+            "command": "sh hooks/py.sh hooks/contract_version_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/refactor_test_freeze_guard.py"
+            "command": "sh hooks/py.sh hooks/refactor_test_freeze_guard.py"
           }
         ]
       },
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/verify_guard_edit_marker.py"
+            "command": "sh hooks/py.sh hooks/verify_guard_edit_marker.py"
           }
         ]
       },
@@ -72,35 +72,35 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/destructive_guard.py"
+            "command": "sh hooks/py.sh hooks/destructive_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/refactor_test_bash_guard.py"
+            "command": "sh hooks/py.sh hooks/refactor_test_bash_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/pre_commit_review.py"
+            "command": "sh hooks/py.sh hooks/pre_commit_review.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/pre_commit_knowledge_index.py"
+            "command": "sh hooks/py.sh hooks/pre_commit_knowledge_index.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/telemetry.py"
+            "command": "sh hooks/py.sh hooks/telemetry.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/verify_guard.py"
+            "command": "sh hooks/py.sh hooks/verify_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/bash_retry_guard.py"
+            "command": "sh hooks/py.sh hooks/bash_retry_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/mutation_testing_smoke_gate.py"
+            "command": "sh hooks/py.sh hooks/mutation_testing_smoke_gate.py"
           }
         ]
       },
@@ -109,11 +109,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/telemetry.py"
+            "command": "sh hooks/py.sh hooks/telemetry.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/context_ceiling_guard.py"
+            "command": "sh hooks/py.sh hooks/context_ceiling_guard.py"
           }
         ]
       },
@@ -122,7 +122,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/codegraph_nudge.py"
+            "command": "sh hooks/py.sh hooks/codegraph_nudge.py"
           }
         ]
       },
@@ -131,7 +131,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/codegraph_nudge.py"
+            "command": "sh hooks/py.sh hooks/codegraph_nudge.py"
           }
         ]
       },
@@ -140,7 +140,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/codegraph_nudge.py"
+            "command": "sh hooks/py.sh hooks/codegraph_nudge.py"
           }
         ]
       },
@@ -149,11 +149,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/agent_model_resolve.py"
+            "command": "sh hooks/py.sh hooks/agent_model_resolve.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/context_ceiling_guard.py"
+            "command": "sh hooks/py.sh hooks/context_ceiling_guard.py"
           }
         ]
       }
@@ -164,27 +164,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/js_fp_review.py"
+            "command": "sh hooks/py.sh hooks/js_fp_review.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/token_efficiency_review.py"
+            "command": "sh hooks/py.sh hooks/token_efficiency_review.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/eval_compliance_check.py"
+            "command": "sh hooks/py.sh hooks/eval_compliance_check.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/tdd_guard.py"
+            "command": "sh hooks/py.sh hooks/tdd_guard.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/knowledge_index.py"
+            "command": "sh hooks/py.sh hooks/knowledge_index.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/skills_index.py"
+            "command": "sh hooks/py.sh hooks/skills_index.py"
           }
         ]
       },
@@ -193,11 +193,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/mutation_gate.py"
+            "command": "sh hooks/py.sh hooks/mutation_gate.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/refactor_test_revert_guard.py"
+            "command": "sh hooks/py.sh hooks/refactor_test_revert_guard.py"
           }
         ]
       },
@@ -206,7 +206,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/version_check.py"
+            "command": "sh hooks/py.sh hooks/version_check.py"
           }
         ]
       },
@@ -215,7 +215,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/codegraph_turn_mark.py"
+            "command": "sh hooks/py.sh hooks/codegraph_turn_mark.py"
           }
         ]
       }
@@ -225,7 +225,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/session_learning_trigger.py"
+            "command": "sh hooks/py.sh hooks/session_learning_trigger.py"
           }
         ]
       }
@@ -236,11 +236,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/cost_meter.py"
+            "command": "sh hooks/py.sh hooks/cost_meter.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/task_completion_metrics.py"
+            "command": "sh hooks/py.sh hooks/task_completion_metrics.py"
           }
         ]
       }
@@ -251,11 +251,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 hooks/cost_meter.py"
+            "command": "sh hooks/py.sh hooks/cost_meter.py"
           },
           {
             "type": "command",
-            "command": "python3 hooks/task_completion_metrics.py"
+            "command": "sh hooks/py.sh hooks/task_completion_metrics.py"
           }
         ]
       }

--- a/plugins/dev-team/skills/version/SKILL.md
+++ b/plugins/dev-team/skills/version/SKILL.md
@@ -20,8 +20,12 @@ Arguments: none.
 Run the resolver and report its output verbatim:
 
 ```bash
-"$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin_version.py"
+sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin_version.py"
 ```
+
+Invoking through `hooks/py.sh` (not `python3` directly) is what lets this work
+on Windows, where Python 3 is often installed as `python`/`py` and no
+`python3` is on PATH. The shim resolves a real interpreter or exits 2.
 
 The script reads `~/.claude/plugins/installed_plugins.json` (Claude Code's
 install record) and resolves the version deterministically: a project-scoped

--- a/plugins/dev-team/tests/hooks/test_py_sh.py
+++ b/plugins/dev-team/tests/hooks/test_py_sh.py
@@ -1,0 +1,189 @@
+"""Behavioral tests for hooks/py.sh (#1078).
+
+py.sh is a POSIX bootstrap shim (it runs before Python is guaranteed on PATH,
+so it cannot itself be Python). Driven here via subprocess with a controlled
+PATH of fake interpreters so we can assert: it resolves python3, falls back to
+py -3 / python, rejects the Windows Store stub and Python 2, honors
+$DEV_TEAM_PYTHON, and exits 2 with a message when nothing works.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+PY_SH = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "py.sh"
+
+# A real interpreter the fakes delegate to when running an actual script.
+_REAL_PY = sys.executable
+
+# Absolute path to sh — the sandbox sets PATH to only the fake bindir, so the
+# subprocess launcher can't rely on PATH to locate the shell itself.
+_SH = shutil.which("sh") or "/bin/sh"
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _fake_valid(path: Path, name: str, *, launcher_flag: str | None = None) -> None:
+    """A fake python-3 interpreter.
+
+    For the version probe (`-c ...`) it reports success (exit 0). For anything
+    else it records its own name to $MARKER then delegates to the real Python so
+    the target script actually runs. ``launcher_flag`` emulates the Windows `py`
+    launcher, whose real first argument is a version selector like ``-3``.
+    """
+    shift = 'shift\n' if launcher_flag else ""
+    _write(
+        path,
+        f"""#!/bin/sh
+{shift}if [ "$1" = "-c" ]; then exit 0; fi
+printf '{name}\\n' >> "$MARKER"
+exec "{_REAL_PY}" "$@"
+""",
+    )
+
+
+def _fake_py2(path: Path) -> None:
+    """A Python-2-like interpreter: the probe reports major < 3 (exit 1)."""
+    _write(
+        path,
+        f"""#!/bin/sh
+if [ "$1" = "-c" ]; then exit 1; fi
+exec "{_REAL_PY}" "$@"
+""",
+    )
+
+
+def _fake_stub(path: Path) -> None:
+    """The WindowsApps app-execution-alias stub: refuses to run, exit non-zero."""
+    _write(
+        path,
+        """#!/bin/sh
+echo "Python was not found; run without arguments to install from the Microsoft Store" >&2
+exit 9009
+""",
+    )
+
+
+@pytest.fixture()
+def sandbox(tmp_path):
+    """A private bin dir on an isolated PATH, an isolated cache, and a target
+    script that prints a sentinel. Returns (env, run)."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    marker = tmp_path / "marker"
+    target = tmp_path / "target.py"
+    target.write_text("print('SENTINEL')\n")
+
+    env = dict(os.environ)
+    env["PATH"] = str(bindir)  # only our fakes are resolvable
+    env["MARKER"] = str(marker)
+    env["DEV_TEAM_PY_CACHE"] = str(tmp_path / "cache")
+    env.pop("DEV_TEAM_PYTHON", None)
+
+    def run():
+        return subprocess.run(
+            [_SH, str(PY_SH), str(target)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    return bindir, marker, env, run
+
+
+def test_prefers_python3(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_valid(bindir / "python3", "python3")
+    _fake_valid(bindir / "python", "python")  # present but should not win
+    r = run()
+    assert r.returncode == 0
+    assert "SENTINEL" in r.stdout
+    assert marker.read_text().strip() == "python3"
+
+
+def test_falls_back_to_python_when_no_python3(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_valid(bindir / "python", "python")
+    r = run()
+    assert r.returncode == 0
+    assert "SENTINEL" in r.stdout
+    assert marker.read_text().strip() == "python"
+
+
+def test_falls_back_to_py_launcher(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_valid(bindir / "py", "py", launcher_flag="-3")
+    r = run()
+    assert r.returncode == 0
+    assert "SENTINEL" in r.stdout
+    assert marker.read_text().strip() == "py"
+
+
+def test_rejects_windows_store_stub(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_stub(bindir / "python3")  # the stub masquerades as python3
+    _fake_valid(bindir / "python", "python")
+    r = run()
+    assert r.returncode == 0
+    assert "SENTINEL" in r.stdout
+    assert marker.read_text().strip() == "python"  # stub skipped, python won
+
+
+def test_rejects_python2(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_py2(bindir / "python3")  # a py2 masquerading as python3
+    _fake_valid(bindir / "python", "python")
+    r = run()
+    assert r.returncode == 0
+    assert marker.read_text().strip() == "python"
+
+
+def test_exit_2_when_nothing_valid(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_stub(bindir / "python3")  # only a stub, nothing else
+    r = run()
+    assert r.returncode == 2
+    assert "no Python 3 interpreter found" in r.stderr
+
+
+def test_dev_team_python_override_wins(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_valid(bindir / "python3", "python3")
+    _fake_valid(bindir / "custompy", "custompy")
+    env["DEV_TEAM_PYTHON"] = "custompy"
+    r = run()
+    assert r.returncode == 0
+    assert marker.read_text().strip() == "custompy"
+
+
+def test_cache_short_circuits_second_call(sandbox):
+    bindir, marker, env, run = sandbox
+    _fake_valid(bindir / "python", "python")
+    assert run().returncode == 0
+    # Cache now records `python`. A second call must reuse it without re-probing
+    # (the marker gains a second line from the cached exec).
+    assert run().returncode == 0
+    assert marker.read_text().split() == ["python", "python"]
+
+
+def test_resolves_with_real_interpreter_no_path_override():
+    """Smoke test against the actual environment (real python3 present)."""
+    if shutil.which("python3") is None and shutil.which("python") is None:
+        pytest.skip("no Python on PATH to smoke-test against")
+    r = subprocess.run(
+        [_SH, str(PY_SH), "-c", "print('OK')"],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0
+    assert "OK" in r.stdout

--- a/plugins/dev-team/tests/lib/test_plugin_version.py
+++ b/plugins/dev-team/tests/lib/test_plugin_version.py
@@ -1,0 +1,119 @@
+"""Unit tests for hooks/lib/plugin_version.py (#1078).
+
+Covers scope resolution (project-for-cwd wins, else user, else first), exact
+plugin-id matching (a sibling like aci-dev-team is never mistaken for it), and
+the exit-code contract (0 printed / 1 not-installed / 2 record missing or
+malformed).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(
+    0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib")
+)
+
+import plugin_version  # noqa: E402
+
+
+def _seed(cfg: Path, record) -> None:
+    plugins = cfg / "plugins"
+    plugins.mkdir(parents=True, exist_ok=True)
+    (plugins / "installed_plugins.json").write_text(json.dumps(record))
+
+
+def _user(version="10.4.0"):
+    return {"scope": "user", "version": version}
+
+
+def _project(project_path, version="9.9.9"):
+    return {"scope": "project", "projectPath": str(project_path), "version": version}
+
+
+def test_user_scope_resolves(tmp_path):
+    _seed(tmp_path, {"plugins": {"dev-team@bfinster": [_user("10.4.0")]}})
+    line, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 0
+    assert line == "dev-team@bfinster v10.4.0 (scope: user)"
+
+
+def test_project_scope_wins_for_matching_cwd(tmp_path):
+    proj = tmp_path / "work"
+    proj.mkdir()
+    _seed(
+        tmp_path,
+        {"plugins": {"dev-team@bfinster": [_user("10.4.0"), _project(proj, "9.9.9")]}},
+    )
+    line, code = plugin_version.resolve(str(tmp_path), str(proj))
+    assert code == 0
+    assert line == "dev-team@bfinster v9.9.9 (scope: project)"
+
+
+def test_project_scope_matches_nested_cwd(tmp_path):
+    proj = tmp_path / "work"
+    nested = proj / "src" / "deep"
+    nested.mkdir(parents=True)
+    _seed(tmp_path, {"plugins": {"dev-team@bfinster": [_project(proj, "9.9.9"), _user()]}})
+    line, code = plugin_version.resolve(str(tmp_path), str(nested))
+    assert code == 0 and "scope: project" in line
+
+
+def test_project_scope_ignored_when_cwd_elsewhere(tmp_path):
+    proj = tmp_path / "work"
+    other = tmp_path / "other"
+    proj.mkdir()
+    other.mkdir()
+    _seed(
+        tmp_path,
+        {"plugins": {"dev-team@bfinster": [_project(proj, "9.9.9"), _user("10.4.0")]}},
+    )
+    line, code = plugin_version.resolve(str(tmp_path), str(other))
+    assert code == 0
+    assert line == "dev-team@bfinster v10.4.0 (scope: user)"
+
+
+def test_sibling_plugin_not_matched(tmp_path):
+    _seed(tmp_path, {"plugins": {"aci-dev-team@tools": [_user("0.1.0")]}})
+    line, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 1 and line is None
+
+
+def test_not_installed_exit_1(tmp_path):
+    _seed(tmp_path, {"plugins": {"other@market": [_user()]}})
+    _, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 1
+
+
+def test_missing_record_exit_2(tmp_path):
+    # No installed_plugins.json written at all.
+    _, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 2
+
+
+def test_malformed_record_exit_2(tmp_path):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir(parents=True)
+    (plugins / "installed_plugins.json").write_text("{not json")
+    _, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 2
+
+
+def test_missing_version_falls_back_to_unknown(tmp_path):
+    _seed(tmp_path, {"plugins": {"dev-team@bfinster": [{"scope": "user"}]}})
+    line, code = plugin_version.resolve(str(tmp_path), str(tmp_path))
+    assert code == 0
+    assert line == "dev-team@bfinster vunknown (scope: user)"
+
+
+def test_config_dir_honors_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert plugin_version.config_dir() == str(tmp_path)
+
+
+def test_config_dir_defaults_to_home_claude(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    assert plugin_version.config_dir().endswith(".claude")

--- a/plugins/dev-team/tests/structure/test_script_references.py
+++ b/plugins/dev-team/tests/structure/test_script_references.py
@@ -1,0 +1,88 @@
+"""Structural guard: scripts referenced by skills, agents, and hooks must exist.
+
+This is the coverage gap that let #1078 ship — `skills/version/SKILL.md`
+invoked `$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin_version.py`, a file that did not
+exist, and nothing in the suite noticed because skills are agent-followed prose
+that CI never executes and no unit test referenced the missing file.
+
+Two high-signal, low-false-positive checks:
+
+1. Every ``$CLAUDE_PLUGIN_ROOT``-relative ``.py``/``.sh`` reference in any
+   SKILL.md or agent .md resolves to a real file (those paths unambiguously
+   point at plugin-internal files, unlike bare example commands that may target
+   the user's own project).
+2. Every script path in a ``settings.json`` hook command exists.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+
+# $CLAUDE_PLUGIN_ROOT/... or ${CLAUDE_PLUGIN_ROOT}/... ending in .py or .sh.
+_PLUGIN_ROOT_REF = re.compile(
+    r"\$\{?CLAUDE_PLUGIN_ROOT\}?/([^\s\"'`)]+?\.(?:py|sh))(?![a-zA-Z0-9])"
+)
+
+
+def _doc_files():
+    yield from PLUGIN_ROOT.glob("skills/**/SKILL.md")
+    yield from PLUGIN_ROOT.glob("agents/*.md")
+
+
+def test_plugin_root_script_references_exist():
+    missing = []
+    for doc in _doc_files():
+        text = doc.read_text(encoding="utf-8")
+        for rel in _PLUGIN_ROOT_REF.findall(text):
+            if not (PLUGIN_ROOT / rel).is_file():
+                missing.append(f"{doc.relative_to(PLUGIN_ROOT)} -> {rel}")
+    assert not missing, "Referenced scripts do not exist:\n" + "\n".join(sorted(missing))
+
+
+def _hook_commands():
+    settings = json.loads((PLUGIN_ROOT / "settings.json").read_text())
+    found = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            cmd = node.get("command")
+            if isinstance(cmd, str):
+                found.append(cmd)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(settings.get("hooks", {}))
+    return found
+
+
+def test_hook_command_scripts_exist():
+    missing = []
+    for cmd in _hook_commands():
+        for tok in shlex.split(cmd):
+            if tok.startswith("-") or "=" in tok:
+                continue
+            if tok.endswith((".py", ".sh")):
+                # Hook commands run with the plugin root as cwd, so relative
+                # paths resolve against it.
+                if not (PLUGIN_ROOT / tok).is_file():
+                    missing.append(f"{cmd!r} -> {tok}")
+    assert not missing, "Hook command scripts do not exist:\n" + "\n".join(sorted(missing))
+
+
+def test_scanner_actually_finds_references():
+    """Guard the guard: the regex must match a known-good reference, so a
+    silently-broken pattern can't turn this suite into a no-op."""
+    version_skill = (PLUGIN_ROOT / "skills" / "version" / "SKILL.md").read_text()
+    refs = _PLUGIN_ROOT_REF.findall(version_skill)
+    assert "hooks/py.sh" in refs
+    assert "hooks/lib/plugin_version.py" in refs

--- a/scripts/check-python-only.py
+++ b/scripts/check-python-only.py
@@ -49,6 +49,9 @@ TRACKED_EXTENSIONS = (".sh", ".bats")
 ALLOWLIST_EXACT_PATHS = {
     # Shell trampoline that must run before Python is guaranteed on PATH.
     "plugins/dev-team/install.sh",
+    # POSIX interpreter-resolver shim; must be shell because it runs before a
+    # Python 3 is guaranteed on PATH (resolves python3/py -3/python) — #1078.
+    "plugins/dev-team/hooks/py.sh",
     # Cloud SessionStart / setup-script install trampolines — same rationale.
     ".claude/cloud-setup.sh",
     ".claude/install-dev-team.sh",

--- a/tests/scripts/test_install.py
+++ b/tests/scripts/test_install.py
@@ -5,7 +5,7 @@ Covers:
   - one required missing → exit 1 with `[FAIL] <cmd>`
   - one optional missing → exit 0 with warn line + "X optional dependency missing"
   - trampoline .sh finds python3 → delegates to install.py byte-identically
-  - trampoline .sh cannot find python3 → exit 1 with a clear pointer
+  - trampoline .sh cannot find any Python 3 → delegates to hooks/py.sh, exit 2
   - Windows-path detection: OS=Windows_NT + non-MSYS uname → informational
     [ok], never a hard failure (ADR 0015 retired the Git Bash requirement)
 """
@@ -108,26 +108,38 @@ def test_trampoline_delegates_to_py(tmp_path: Path) -> None:
 
 
 def test_trampoline_fails_when_no_python3(tmp_path: Path) -> None:
-    """No python3 on PATH → the .sh emits an install pointer and exits 1."""
-    # subprocess needs bash on PATH to run the .sh at all, but python3 must
-    # NOT be there. Symlink bash into the shim, leave python3 out.
-    shim = tmp_path / "shim"
-    shim.mkdir()
+    """No Python 3 under any name → install.sh delegates to hooks/py.sh, which
+    exits 2 with an actionable pointer (#1078).
+
+    install.sh no longer probes `python3` directly; it execs the shared
+    interpreter-resolver shim (`hooks/py.sh`). With no python3/py/python on
+    PATH, the shim finds nothing and exits 2, printing its guidance to stderr.
+    """
     import shutil as _shutil
 
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    # The shim needs bash (to launch install.sh), sh (install.sh execs
+    # `sh hooks/py.sh`), and dirname (install.sh resolves its own dir to locate
+    # py.sh) — but deliberately NO python3/py/python.
+    for tool in ("bash", "sh", "dirname"):
+        src = _shutil.which(tool)
+        if src:
+            os.symlink(src, shim / tool)
     bash_path = _shutil.which("bash")
-    if bash_path:
-        os.symlink(bash_path, shim / "bash")
     r = subprocess.run(
         [bash_path or "bash", str(_INSTALL_SH)],
         capture_output=True,
         text=True,
         check=False,
-        env={"PATH": str(shim), "HOME": "/tmp"},
+        env={
+            "PATH": str(shim),
+            "HOME": "/tmp",
+            "DEV_TEAM_PY_CACHE": str(tmp_path / "py-cache"),
+        },
     )
-    assert r.returncode == 1
-    assert "python3" in r.stdout
-    assert "required" in r.stdout
+    assert r.returncode == 2
+    assert "no Python 3 interpreter found" in r.stderr
 
 
 def test_windows_without_git_bash_does_not_hard_fail(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

A Windows user ran `/dev-team:version` and got *"No python3 interpreter is available in this environment (only a Windows Store app-execution-alias stub that refuses to run)."* Two stacked defects (see #1078):

1. **The `/version` resolver was never shipped.** `skills/version/SKILL.md` invoked `$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin_version.py`, a file absent from the tree and the v10.4.0 release. `/version` only appeared to work on macOS/Linux because the agent improvised the lookup with an available `python3` — non-deterministic for a purely mechanical command.
2. **The whole hook layer hard-codes `python3`.** All 37 `settings.json` hook commands (plus `install.sh`) invoke the literal name `python3`. Stock Windows installs Python 3 as `python`/`py`, not `python3`; the only `python3` on PATH is the WindowsApps stub that refuses to run. So on such machines the entire hook layer fails — and locked-down corporate users often can't install packages to fix it.

## Fix

- **`hooks/py.sh`** — a POSIX bootstrap shim (ADR-0015 pre-Python carve-out, same as `install.sh`) that resolves a real Python 3 across `$DEV_TEAM_PYTHON` → `python3` → `py -3` → `python`, **executing** each candidate so the Store stub and Python 2 are rejected on behavior, and caching the winner per session.
- **`hooks/lib/plugin_version.py`** — the missing `/version` resolver (project-scope-for-cwd via `projectPath` wins, else user scope; exit 0/1/2 contract).
- Routed all 37 `settings.json` hook commands, `/version`, and `install.sh` through `py.sh`.
- **`tests/structure/test_script_references.py`** — the structural guard that closes the coverage gap that hid the missing resolver: every `$CLAUDE_PLUGIN_ROOT` script reference in skills/agents and every hook-command script must exist on disk.
- Unit tests for both new files; updated `test_install.py` for the new exit-2 trampoline contract; allowlisted `py.sh` in `check-python-only.py`; updated the ADR-0015 / CLAUDE.md carve-out wording.

## Scope note

Skill `SKILL.md` prose that invokes `python3` directly (~30 files) is agent-followed and lower-risk; tracked as follow-up hardening. The **hard floor** remains: a machine with no Python 3 under any name still can't run the plugin (it *is* Python) — this closes the far more common gap where Python exists but isn't named `python3`.

## Verification

- New: 20 unit tests (`test_py_sh.py`, `test_plugin_version.py`) + 3 structural (`test_script_references.py`), all green.
- Full ci-local scoped suite: 3231 passed, 1 skipped (pre-existing).
- `shellcheck` clean on `py.sh`/`install.sh`; python-only audit passes.
- End-to-end: `/version` resolver returns `dev-team@bfinster v10.4.0 (scope: user)` both directly and via the shim.

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)