### PR TITLE
fix: match metrics/ runtime logs at any depth in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,16 +15,18 @@ _mkdocs_src/
 # EnterWorktree tool scratch dirs (per-agent git worktrees, not repo content)
 .claude/worktrees/
 
+# Runtime metrics logs — leading **/ so they match whether hooks write to the
+# repo-root metrics/ or plugins/dev-team/metrics/ (cwd-dependent) — #1081.
 # Session-review trend digest (per-run runtime data; consumed locally — #129)
-metrics/session-digest.jsonl
+**/metrics/session-digest.jsonl
 # Opt-in telemetry beacon event log (local-only; never checked in — #135)
-metrics/telemetry.jsonl
+**/metrics/telemetry.jsonl
 # Per-checkpoint review-value meter (runtime data; counts-only — #348)
-metrics/review-value.jsonl
+**/metrics/review-value.jsonl
 # Per-slice /verify evidence log (runtime data; counts-only — #727)
-metrics/verify-log.jsonl
+**/metrics/verify-log.jsonl
 # Boundary-level policy-gateway event log (runtime data; rule-IDs-only — #859)
-metrics/boundary-events.jsonl
+**/metrics/boundary-events.jsonl
 
 # Effort-band model routing (per-user, never checked in)
 # - ladder: optional ordered model list (.claude/model-ladder.json), hand-written by users behind restricted endpoints


### PR DESCRIPTION
The five `metrics/*.jsonl` runtime-log ignore patterns were anchored to the repo root by their mid-pattern slash, so hooks writing to `plugins/dev-team/metrics/` (when the plugin dir is cwd — e.g. during the plugin's own test runs) produced untracked files that could be committed by accident. Prefix each with `**/` so they match `metrics/` at any depth (verified: both `metrics/telemetry.jsonl` and `plugins/dev-team/metrics/boundary-events.jsonl` are now ignored).

Metadata-only (`.gitignore`); no shipping code changes — armed for auto-merge.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)