### PR TITLE
fix: verify coverage-baseline readiness during /setup for JS/TS repos

### DIFF
--- a/plugins/dev-team/scripts/coverage_readiness.py
+++ b/plugins/dev-team/scripts/coverage_readiness.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""coverage_readiness.py — assess (and optionally patch) a JS/TS repo's
+coverage config so `/coverage-baseline` can capture a line+branch floor.
+
+`/coverage-baseline` (used by `/test-improve` Phase 2) parses
+`coverage/coverage-summary.json` (`total.lines.pct` / `total.branches.pct`)
+for Istanbul-family runners. Jest and Vitest only write that file when the
+**`json-summary`** coverage reporter is enabled, and the baseline is only
+meaningful when the runner measures the whole source tree rather than just
+files already imported by a test (Jest `collectCoverageFrom` / Vitest
+`coverage.include`). A repo can pass `/setup` and still miss both, aborting
+Phase 2 (issue #1086).
+
+This probe reports readiness as JSON and, in `--patch` mode, adds the
+`json-summary` reporter to configs it can edit **deterministically and
+safely** — JSON-shaped configs only (`package.json`'s `jest` block, or a
+`jest.config.json`). JS/TS config files (`jest.config.js`, `vitest.config.ts`,
+…) are never rewritten here; the report names the file and the exact edit so
+the caller can apply it through the operator-confirmed edit path instead.
+
+Detection is text/JSON based — no runner is executed and no JS is evaluated.
+
+Report schema (stdout, one JSON object):
+
+    {
+      "runner": "jest" | "vitest" | null,
+      "config_source": <repo-relative file, "package.json#jest", or null>,
+      "config_kind": "json" | "js" | "none",
+      "has_json_summary": bool,   # json-summary reporter enabled
+      "has_scope": bool,          # collectCoverageFrom / coverage.include set
+      "ready": bool,              # has_json_summary (hard requirement to parse)
+      "meaningful": bool,         # has_scope (baseline reflects whole tree)
+      "patchable": bool,          # --patch can add the reporter unaided
+      "patched": bool,            # --patch actually wrote a change
+      "reporter_hint": <str or null>,   # exact edit for a js/ts config
+      "scope_hint": <str or null>,      # exact edit when scope is missing
+      "notes": [<str>, ...]
+    }
+
+Exit status: 0 when `ready` (after any patch), 1 when a JS/TS repo is not
+ready, 2 when the repo is not a JS/TS project (no package.json) — callers
+treat 2 as "not applicable, skip".
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+JSON_SUMMARY = "json-summary"
+
+# Jest config files, highest precedence first. Jest ignores a package.json
+# `jest` key when any of these exist.
+JEST_CONFIG_FILES = (
+    "jest.config.ts",
+    "jest.config.mts",
+    "jest.config.cts",
+    "jest.config.js",
+    "jest.config.mjs",
+    "jest.config.cjs",
+    "jest.config.json",
+)
+
+# Vitest config files, highest precedence first (a dedicated vitest.config.*
+# wins over a shared vite.config.*).
+VITEST_CONFIG_FILES = (
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "vitest.config.js",
+    "vitest.config.mjs",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vite.config.js",
+    "vite.config.mjs",
+)
+
+_JSON_SUFFIXES = frozenset({".json"})
+
+
+class Report(dict):
+    """Thin dict subclass so callers can build the JSON report incrementally."""
+
+    def note(self, message: str) -> None:
+        self.setdefault("notes", []).append(message)
+
+
+# ---------------------------------------------------------------------------
+# package.json helpers
+# ---------------------------------------------------------------------------
+
+def _load_package_json(root: Path) -> Optional[dict]:
+    path = root / "package.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _all_deps(pkg: dict) -> dict:
+    deps: dict = {}
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        section = pkg.get(key)
+        if isinstance(section, dict):
+            deps.update(section)
+    return deps
+
+
+def detect_runner(root: Path, pkg: Optional[dict]) -> Optional[str]:
+    """Return "jest", "vitest", or None.
+
+    Config files are the strongest signal; dependency names (including the
+    Angular Jest presets) are the fallback.
+    """
+    for name in JEST_CONFIG_FILES:
+        if (root / name).is_file():
+            return "jest"
+    for name in VITEST_CONFIG_FILES:
+        # vite.config.* only counts as a vitest signal when vitest is a dep;
+        # a plain Vite app without vitest has no coverage config to assess.
+        if (root / name).is_file():
+            if name.startswith("vitest.") or (pkg and "vitest" in _all_deps(pkg)):
+                return "vitest"
+    if pkg is None:
+        return None
+    deps = _all_deps(pkg)
+    if "vitest" in deps:
+        return "vitest"
+    jest_signals = ("jest", "@angular-builders/jest", "jest-preset-angular", "ts-jest")
+    if isinstance(pkg.get("jest"), dict) or any(dep in deps for dep in jest_signals):
+        return "jest"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Config source resolution
+# ---------------------------------------------------------------------------
+
+def resolve_config_source(root: Path, runner: str, pkg: Optional[dict]) -> Tuple[Optional[str], str]:
+    """Return (config_source, config_kind).
+
+    config_source is a repo-relative filename, the sentinel "package.json#jest",
+    or None when the runner has no coverage config anywhere. config_kind is
+    "json" (safely patchable), "js" (edit via the confirmed path), or "none".
+    """
+    candidates = JEST_CONFIG_FILES if runner == "jest" else VITEST_CONFIG_FILES
+    for name in candidates:
+        if (root / name).is_file():
+            kind = "json" if Path(name).suffix in _JSON_SUFFIXES else "js"
+            return name, kind
+    if runner == "jest" and isinstance((pkg or {}).get("jest"), dict):
+        return "package.json#jest", "json"
+    return None, "none"
+
+
+# ---------------------------------------------------------------------------
+# Reporter / scope detection
+# ---------------------------------------------------------------------------
+
+def _reporters_from_obj(config: dict, runner: str) -> Optional[list]:
+    if runner == "jest":
+        reporters = config.get("coverageReporters")
+        return reporters if isinstance(reporters, list) else None
+    coverage = (config.get("test") or {}).get("coverage") if isinstance(config.get("test"), dict) else None
+    if isinstance(coverage, dict):
+        reporter = coverage.get("reporter")
+        return reporter if isinstance(reporter, list) else None
+    return None
+
+
+def _scope_from_obj(config: dict, runner: str) -> bool:
+    if runner == "jest":
+        return isinstance(config.get("collectCoverageFrom"), list) and bool(config["collectCoverageFrom"])
+    test = config.get("test")
+    coverage = test.get("coverage") if isinstance(test, dict) else None
+    return isinstance(coverage, dict) and bool(coverage.get("include"))
+
+
+# Text-scan fallbacks for JS/TS config files, which we can read but not eval.
+_REPORTER_KEY = re.compile(r"coverageReporters|\breporter\b")
+_SCOPE_JEST = re.compile(r"collectCoverageFrom")
+_SCOPE_VITEST = re.compile(r"include\s*:")
+
+
+def _has_json_summary_text(text: str) -> bool:
+    return bool(re.search(r"['\"]json-summary['\"]", text)) and bool(_REPORTER_KEY.search(text))
+
+
+def _has_scope_text(text: str, runner: str) -> bool:
+    if runner == "jest":
+        return bool(_SCOPE_JEST.search(text))
+    return bool(_SCOPE_VITEST.search(text))
+
+
+def assess_source(
+    root: Path, runner: str, config_source: Optional[str], config_kind: str
+) -> Tuple[bool, bool]:
+    """Return (has_json_summary, has_scope) for the resolved config source."""
+    if config_source is None:
+        return False, False
+    if config_source == "package.json#jest":
+        pkg = _load_package_json(root) or {}
+        config = pkg.get("jest", {})
+        reporters = _reporters_from_obj(config, runner) or []
+        return JSON_SUMMARY in reporters, _scope_from_obj(config, runner)
+    path = root / config_source
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False, False
+    if config_kind == "json":
+        try:
+            config = json.loads(text)
+        except json.JSONDecodeError:
+            return _has_json_summary_text(text), _has_scope_text(text, runner)
+        reporters = _reporters_from_obj(config, runner) or []
+        return JSON_SUMMARY in reporters, _scope_from_obj(config, runner)
+    return _has_json_summary_text(text), _has_scope_text(text, runner)
+
+
+# ---------------------------------------------------------------------------
+# Patch (JSON configs only)
+# ---------------------------------------------------------------------------
+
+def _add_reporter_to_config(config: dict, runner: str) -> bool:
+    """Add json-summary to the config dict in place. Return True if changed."""
+    if runner == "jest":
+        reporters = config.get("coverageReporters")
+        if not isinstance(reporters, list):
+            reporters = []
+        if JSON_SUMMARY in reporters:
+            return False
+        # Preserve any existing reporters; Istanbul writes all of them.
+        config["coverageReporters"] = reporters + [JSON_SUMMARY] if reporters else ["text", JSON_SUMMARY]
+        return True
+    test = config.setdefault("test", {})
+    coverage = test.setdefault("coverage", {})
+    reporter = coverage.get("reporter")
+    if not isinstance(reporter, list):
+        reporter = []
+    if JSON_SUMMARY in reporter:
+        return False
+    coverage["reporter"] = reporter + [JSON_SUMMARY] if reporter else ["text", JSON_SUMMARY]
+    return True
+
+
+def patch_json_config(root: Path, runner: str, config_source: str) -> bool:
+    """Add the json-summary reporter to a JSON-shaped config. Return True if
+    the file was changed. Only ``package.json#jest`` and ``*.json`` configs are
+    handled; anything else is a no-op (the caller keeps config_kind == "js")."""
+    if config_source == "package.json#jest":
+        path = root / "package.json"
+        pkg = json.loads(path.read_text(encoding="utf-8"))
+        if not _add_reporter_to_config(pkg.setdefault("jest", {}), runner):
+            return False
+        path.write_text(json.dumps(pkg, indent=2) + "\n", encoding="utf-8")
+        return True
+    path = root / config_source
+    config = json.loads(path.read_text(encoding="utf-8"))
+    if not _add_reporter_to_config(config, runner):
+        return False
+    path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Hints for the caller's confirmed-edit path (JS/TS configs)
+# ---------------------------------------------------------------------------
+
+def _reporter_hint(runner: str, config_source: str) -> str:
+    if runner == "jest":
+        return (
+            f"Add '{JSON_SUMMARY}' to `coverageReporters` in {config_source} "
+            f"(e.g. ['lcov', 'clover', 'json', '{JSON_SUMMARY}'])."
+        )
+    return (
+        f"Add '{JSON_SUMMARY}' to `test.coverage.reporter` in {config_source} "
+        f"(e.g. reporter: ['text', '{JSON_SUMMARY}'])."
+    )
+
+
+def _scope_hint(runner: str, config_source: Optional[str]) -> str:
+    where = config_source or "the runner config"
+    if runner == "jest":
+        return (
+            f"Set `collectCoverageFrom` in {where} so coverage measures the whole "
+            "source tree (e.g. ['src/**/*.{js,ts}', '!**/*.spec.*'])."
+        )
+    return (
+        f"Set `test.coverage.include` in {where} so coverage measures the whole "
+        "source tree (e.g. ['src/**/*.{js,ts}'])."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def build_report(root: Path, patch: bool) -> Report:
+    report = Report(
+        runner=None,
+        config_source=None,
+        config_kind="none",
+        has_json_summary=False,
+        has_scope=False,
+        ready=False,
+        meaningful=False,
+        patchable=False,
+        patched=False,
+        reporter_hint=None,
+        scope_hint=None,
+        notes=[],
+    )
+
+    pkg = _load_package_json(root)
+    runner = detect_runner(root, pkg)
+    report["runner"] = runner
+    if runner is None:
+        report.note("No Jest or Vitest runner detected; coverage-baseline readiness is not applicable.")
+        return report
+
+    config_source, config_kind = resolve_config_source(root, runner, pkg)
+    report["config_source"] = config_source
+    report["config_kind"] = config_kind
+
+    has_json_summary, has_scope = assess_source(root, runner, config_source, config_kind)
+
+    if patch and not has_json_summary and config_kind == "json":
+        try:
+            if patch_json_config(root, runner, config_source):
+                report["patched"] = True
+                report.note(f"Added '{JSON_SUMMARY}' reporter to {config_source}.")
+                has_json_summary = True
+        except (OSError, json.JSONDecodeError) as exc:
+            report.note(f"Could not patch {config_source}: {exc}")
+
+    report["has_json_summary"] = has_json_summary
+    report["has_scope"] = has_scope
+    report["ready"] = has_json_summary
+    report["meaningful"] = has_scope
+    report["patchable"] = (config_kind == "json")
+
+    if not has_json_summary:
+        if config_kind == "none":
+            report["reporter_hint"] = (
+                f"No coverage config found for {runner}; add one that includes "
+                f"the '{JSON_SUMMARY}' reporter."
+            )
+            report.note(
+                f"{runner} has no coverage config; /coverage-baseline cannot parse a summary."
+            )
+        elif config_kind == "js":
+            report["reporter_hint"] = _reporter_hint(runner, config_source)
+            report.note(
+                f"{config_source} is a JS/TS config; apply the reporter edit through the "
+                "confirmed edit path (this probe does not rewrite JS config files)."
+            )
+        else:  # json but patch was not requested or failed
+            report["reporter_hint"] = _reporter_hint(runner, config_source)
+
+    if not has_scope:
+        report["scope_hint"] = _scope_hint(runner, config_source)
+        report.note(
+            "Coverage scope is unset; the baseline would reflect only already-tested "
+            "files. Offer to add a whole-tree scope so the floor is meaningful."
+        )
+
+    return report
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("repo", nargs="?", default=".", help="Repo root (default: cwd)")
+    parser.add_argument(
+        "--patch",
+        action="store_true",
+        help="Add the json-summary reporter to JSON-shaped configs (package.json#jest / *.json).",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo).resolve()
+    if not (root / "package.json").is_file():
+        print(
+            json.dumps(
+                {
+                    "runner": None,
+                    "config_kind": "none",
+                    "ready": False,
+                    "notes": ["No package.json; not a JS/TS project."],
+                },
+                indent=2,
+            )
+        )
+        return 2
+
+    report = build_report(root, patch=args.patch)
+    print(json.dumps(report, indent=2))
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/coverage-baseline/SKILL.md
+++ b/plugins/dev-team/skills/coverage-baseline/SKILL.md
@@ -61,6 +61,11 @@ If the run fails:
 For each tool, parse the report into `{ "line": <pct>, "branch": <pct>, "tool": "<name>", "raw_path": "<file>" }`:
 
 - Istanbul / Jest / Vitest → `coverage/coverage-summary.json` → `total.lines.pct` + `total.branches.pct`.
+  - **If `coverage-summary.json` is absent** (the `json-summary` reporter wasn't enabled — see #1086), do not abort. Fall back, in order, to another emitted report and derive the two percentages from it:
+    - `coverage/coverage-final.json` (Istanbul `json` reporter) → sum each file's statement/branch hit counts (`s`/`b`) into totals, then `line = covered_statements / total_statements * 100`, `branch = covered_branches / total_branches * 100`.
+    - `coverage/lcov.info` → tally `LF`/`LH` for lines and `BRF`/`BRH` for branches across all records; `line = ΣLH/ΣLF * 100`, `branch = ΣBRH/ΣBRF * 100` (branch `null` when `BRF` totals 0).
+    - `coverage/clover.xml` → read the project-level `<metrics>` element: `line = coveredstatements/statements * 100`, `branch = coveredconditionals/conditionals * 100`.
+  - Note in the persisted baseline which report was used (`raw_report`). Recommend the operator run `/setup` (which now checks coverage readiness) or add the `json-summary` reporter so future runs use the canonical summary.
 - pytest-cov → `coverage.json` → `totals.percent_covered` (and branch via `--branch`).
 - JaCoCo → `target/site/jacoco/jacoco.csv` → sum line/branch missed+covered.
 - Coverlet → `coverage.json` → `summary.linecoverage`, `summary.branchcoverage`.

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -337,6 +337,47 @@ a few questions; they should accept defaults unless they have a specific setup.
 npx stryker --version
 ```
 
+**Coverage baseline readiness (Jest/Vitest):**
+
+`/coverage-baseline` (Phase 2 of `/test-improve`) parses
+`coverage/coverage-summary.json` for `total.lines.pct` / `total.branches.pct`.
+Jest and Vitest only emit that file when the **`json-summary`** reporter is
+enabled, and the floor is only meaningful when coverage measures the whole
+source tree (Jest `collectCoverageFrom` / Vitest `coverage.include`). Without
+both, a repo that otherwise passes `/setup` still aborts `/test-improve`
+Phase 2 (issue #1086). Probe and repair it now:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/coverage_readiness.py" .
+```
+
+Read the JSON report. `ready` is the hard requirement (the summary can be
+parsed); `meaningful` is whether the baseline reflects the whole tree.
+
+- **`ready` is `true`** → record it for the Step 11 report and continue.
+- **`ready` is `false` and `patchable` is `true`** (config lives in
+  `package.json`'s `jest` block or a `*.json` config) → tell the operator
+  exactly which reporter will be added, and on confirmation re-run with
+  `--patch`:
+
+  ```bash
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/coverage_readiness.py" . --patch
+  ```
+
+  The patch only appends `json-summary`, preserving existing reporters.
+- **`ready` is `false` and `patchable` is `false`** (config is a JS/TS file
+  like `jest.config.js` or `vitest.config.ts` — the probe never rewrites
+  these) → show the operator `reporter_hint` and, on confirmation, apply that
+  one-line edit with the Edit tool. Re-run the probe (no `--patch`) to confirm
+  `ready` flipped to `true`.
+- **`meaningful` is `false`** → show `scope_hint` and offer to add the
+  suggested `collectCoverageFrom`/`coverage.include` (confirm first; never
+  overwrite an existing scope). This is advisory — a missing scope doesn't
+  block the baseline, it just inflates it.
+
+Never write or patch coverage config without operator confirmation. Record
+the final `ready`/`meaningful`/`patched` state for the Step 11 report.
+
 ---
 
 #### Java / Kotlin — pitest
@@ -534,6 +575,12 @@ Display a summary of everything installed and created:
 - jq:       ✓ <version>
 - python3:  ✓ <version>
 - Mutation testing (Stryker): ✓ <version>   [or: ✗ skipped | ✗ failed]
+
+### Coverage baseline readiness (JS/TS only)
+- ✓ json-summary + coverage scope present   [ready + meaningful]
+- ✓ patched (added json-summary reporter to <config>)   [was not ready, now fixed]
+- ⚠ manual action needed — <reporter_hint>   [JS/TS config the operator declined or must edit]
+- ⚠ coverage scope unset — baseline will be inflated (<scope_hint>)   [not meaningful]
 
 ### Created
 - `.claude/project-stack.json` — stack detection results

--- a/plugins/dev-team/tests/scripts/test_coverage_readiness.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_readiness.py
@@ -1,0 +1,234 @@
+"""Tests for scripts/coverage_readiness.py (issue #1086)."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from coverage_readiness import (  # noqa: E402
+    build_report,
+    detect_runner,
+    main,
+    resolve_config_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def write(path: Path, content) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, (dict, list)):
+        path.write_text(json.dumps(content, indent=2), encoding="utf-8")
+    else:
+        path.write_text(content, encoding="utf-8")
+
+
+def pkg(root: Path, data: dict) -> None:
+    write(root / "package.json", data)
+
+
+# ---------------------------------------------------------------------------
+# runner detection
+# ---------------------------------------------------------------------------
+
+def test_detect_runner_none_without_package_json(tmp_path):
+    assert detect_runner(tmp_path, None) is None
+
+
+def test_detect_runner_jest_from_dependency(tmp_path):
+    data = {"devDependencies": {"jest": "^29"}}
+    assert detect_runner(tmp_path, data) == "jest"
+
+
+def test_detect_runner_angular_jest_preset(tmp_path):
+    data = {"devDependencies": {"@angular-builders/jest": "^18", "jest-preset-angular": "^14"}}
+    assert detect_runner(tmp_path, data) == "jest"
+
+
+def test_detect_runner_vitest_from_dependency(tmp_path):
+    assert detect_runner(tmp_path, {"devDependencies": {"vitest": "^2"}}) == "vitest"
+
+
+def test_detect_runner_config_file_beats_absent_dep(tmp_path):
+    write(tmp_path / "jest.config.js", "module.exports = {}")
+    assert detect_runner(tmp_path, {}) == "jest"
+
+
+def test_detect_runner_vite_config_needs_vitest_dep(tmp_path):
+    write(tmp_path / "vite.config.ts", "export default {}")
+    assert detect_runner(tmp_path, {}) is None
+    assert detect_runner(tmp_path, {"devDependencies": {"vitest": "^2"}}) == "vitest"
+
+
+# ---------------------------------------------------------------------------
+# config source resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_prefers_config_file_over_package_json(tmp_path):
+    write(tmp_path / "jest.config.js", "module.exports = {}")
+    src, kind = resolve_config_source(tmp_path, "jest", {"jest": {}})
+    assert src == "jest.config.js"
+    assert kind == "js"
+
+
+def test_resolve_package_json_jest_key(tmp_path):
+    src, kind = resolve_config_source(tmp_path, "jest", {"jest": {"coverageReporters": []}})
+    assert src == "package.json#jest"
+    assert kind == "json"
+
+
+def test_resolve_json_config_is_patchable_kind(tmp_path):
+    write(tmp_path / "jest.config.json", {"coverageReporters": ["lcov"]})
+    src, kind = resolve_config_source(tmp_path, "jest", None)
+    assert (src, kind) == ("jest.config.json", "json")
+
+
+def test_resolve_none_when_no_config(tmp_path):
+    assert resolve_config_source(tmp_path, "jest", {}) == (None, "none")
+
+
+# ---------------------------------------------------------------------------
+# the reproduction case from #1086 — Angular/Jest, no json-summary, no scope
+# ---------------------------------------------------------------------------
+
+def test_angular_jest_not_ready(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"@angular-builders/jest": "^18"}})
+    write(
+        tmp_path / "jest.config.js",
+        "module.exports = { coverageReporters: ['lcov', 'clover', 'json'] };",
+    )
+    report = build_report(tmp_path, patch=False)
+    assert report["runner"] == "jest"
+    assert report["config_kind"] == "js"
+    assert report["has_json_summary"] is False
+    assert report["ready"] is False
+    assert report["has_scope"] is False
+    assert report["reporter_hint"] and "json-summary" in report["reporter_hint"]
+    assert report["scope_hint"] and "collectCoverageFrom" in report["scope_hint"]
+    # JS configs are never auto-rewritten, even with --patch.
+    patched = build_report(tmp_path, patch=True)
+    assert patched["patched"] is False
+    assert patched["ready"] is False
+
+
+def test_js_config_with_json_summary_is_ready(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}})
+    write(
+        tmp_path / "jest.config.js",
+        "module.exports = { coverageReporters: ['json-summary'], collectCoverageFrom: ['src/**/*.ts'] };",
+    )
+    report = build_report(tmp_path, patch=False)
+    assert report["ready"] is True
+    assert report["meaningful"] is True
+    assert report["reporter_hint"] is None
+    assert report["scope_hint"] is None
+
+
+# ---------------------------------------------------------------------------
+# patching JSON-shaped configs
+# ---------------------------------------------------------------------------
+
+def test_patch_package_json_jest_key(tmp_path):
+    pkg(
+        tmp_path,
+        {
+            "devDependencies": {"jest": "^29"},
+            "jest": {"coverageReporters": ["lcov", "clover", "json"]},
+        },
+    )
+    report = build_report(tmp_path, patch=True)
+    assert report["patched"] is True
+    assert report["ready"] is True
+    data = json.loads((tmp_path / "package.json").read_text())
+    reporters = data["jest"]["coverageReporters"]
+    assert "json-summary" in reporters
+    # existing reporters preserved
+    assert reporters[:3] == ["lcov", "clover", "json"]
+
+
+def test_patch_jest_config_json(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}})
+    write(tmp_path / "jest.config.json", {"coverageReporters": ["lcov"]})
+    report = build_report(tmp_path, patch=True)
+    assert report["patched"] is True
+    assert report["ready"] is True
+    data = json.loads((tmp_path / "jest.config.json").read_text())
+    assert "json-summary" in data["coverageReporters"]
+
+
+def test_patch_creates_reporters_when_absent(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}, "jest": {}})
+    report = build_report(tmp_path, patch=True)
+    assert report["patched"] is True
+    data = json.loads((tmp_path / "package.json").read_text())
+    assert "json-summary" in data["jest"]["coverageReporters"]
+
+
+def test_patch_idempotent_when_already_present(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}, "jest": {"coverageReporters": ["json-summary"]}})
+    report = build_report(tmp_path, patch=True)
+    assert report["patched"] is False
+    assert report["ready"] is True
+
+
+def test_patch_vitest_json_is_reported_not_written(tmp_path):
+    # Vitest config is always JS/TS in practice; a hypothetical JSON path still
+    # patches deterministically, but the common case is a JS file left to the
+    # confirmed edit path.
+    pkg(tmp_path, {"devDependencies": {"vitest": "^2"}})
+    write(tmp_path / "vitest.config.ts", "export default { test: { coverage: { reporter: ['text'] } } }")
+    report = build_report(tmp_path, patch=True)
+    assert report["config_kind"] == "js"
+    assert report["patched"] is False
+    assert report["ready"] is False
+    assert "json-summary" in report["reporter_hint"]
+
+
+# ---------------------------------------------------------------------------
+# vitest object detection
+# ---------------------------------------------------------------------------
+
+def test_vitest_scope_detected_from_include(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"vitest": "^2"}})
+    write(
+        tmp_path / "vitest.config.ts",
+        "export default { test: { coverage: { reporter: ['json-summary'], include: ['src/**'] } } }",
+    )
+    report = build_report(tmp_path, patch=False)
+    assert report["runner"] == "vitest"
+    assert report["ready"] is True
+    assert report["meaningful"] is True
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes
+# ---------------------------------------------------------------------------
+
+def test_main_exit_2_when_not_js(tmp_path, capsys):
+    rc = main([str(tmp_path)])
+    assert rc == 2
+    assert json.loads(capsys.readouterr().out)["ready"] is False
+
+
+def test_main_exit_1_when_not_ready(tmp_path, capsys):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}})
+    write(tmp_path / "jest.config.js", "module.exports = { coverageReporters: ['lcov'] }")
+    assert main([str(tmp_path)]) == 1
+
+
+def test_main_exit_0_after_patch(tmp_path, capsys):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}, "jest": {"coverageReporters": ["lcov"]}})
+    assert main([str(tmp_path), "--patch"]) == 0
+    assert json.loads(capsys.readouterr().out)["ready"] is True
+
+
+def test_main_exit_1_no_runner(tmp_path, capsys):
+    pkg(tmp_path, {"dependencies": {"left-pad": "^1"}})
+    assert main([str(tmp_path)]) == 1
+    assert json.loads(capsys.readouterr().out)["runner"] is None


### PR DESCRIPTION
## Summary

JS/TS repos (verified against Angular 21 + Jest) could complete `/setup` yet abort `/test-improve` Phase 2. The coverage-baseline worker parses `coverage/coverage-summary.json`, which Jest/Vitest only emit when the **`json-summary`** reporter is enabled — and the floor is meaningless without whole-tree coverage scope (`collectCoverageFrom` / `coverage.include`). `/setup` never checked either.

## Changes

- **`scripts/coverage_readiness.py`** (new) — detects the runner (Jest/Vitest, incl. Angular Jest presets), resolves the *effective* coverage config, and reports `ready` (json-summary present) / `meaningful` (scope present) as JSON. `--patch` safely appends `json-summary` to **JSON-shaped configs only** (`package.json#jest`, `*.json`), preserving existing reporters. JS/TS config files are reported with an exact `reporter_hint` and never rewritten by the probe.
- **`/setup`** — new coverage-readiness step in the JS/TS path: runs the probe, patches JSON configs on confirmation, hands JS/TS configs to the operator-confirmed Edit path, and offers a whole-tree scope when missing. Step 11 report now states readiness explicitly. No config is written without operator confirmation.
- **`/coverage-baseline`** — defense-in-depth: Step 3 now falls back to `coverage-final.json` / `lcov.info` / `clover.xml` when `coverage-summary.json` is absent, instead of aborting.

## Tests

`tests/scripts/test_coverage_readiness.py` — 22 cases covering runner detection, config resolution/precedence, the exact #1086 Angular/Jest reproduction, JSON patching (idempotent, reporter-preserving), JS-config no-rewrite, Vitest object detection, and `main()` exit codes. Full plugin suite: 1149 passed.

## Acceptance criteria

- [x] `/setup` on a JS/Jest (incl. Angular) or Vitest repo leaves coverage config able to capture a line+branch baseline without manual edits (auto-patch for JSON configs; guided one-line edit for JS/TS configs).
- [x] Step 11 report states coverage-baseline readiness explicitly.
- [x] No coverage config overwritten without operator confirmation.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)