### PR TITLE
fix: verify Vitest coverage provider in coverage-baseline readiness

### DIFF
--- a/plugins/dev-team/scripts/coverage_readiness.py
+++ b/plugins/dev-team/scripts/coverage_readiness.py
@@ -28,12 +28,15 @@ Report schema (stdout, one JSON object):
       "config_kind": "json" | "js" | "none",
       "has_json_summary": bool,   # json-summary reporter enabled
       "has_scope": bool,          # collectCoverageFrom / coverage.include set
-      "ready": bool,              # has_json_summary (hard requirement to parse)
+      "coverage_provider": <str or null>,  # Vitest provider pkg / "istanbul (built-in)"
+      "has_provider": bool,       # Jest: always true; Vitest: provider installed
+      "ready": bool,              # summary parseable AND (Vitest) provider present
       "meaningful": bool,         # has_scope (baseline reflects whole tree)
       "patchable": bool,          # --patch can add the reporter unaided
       "patched": bool,            # --patch actually wrote a change
       "reporter_hint": <str or null>,   # exact edit for a js/ts config
       "scope_hint": <str or null>,      # exact edit when scope is missing
+      "provider_hint": <str or null>,   # install cmd when Vitest lacks a provider
       "notes": [<str>, ...]
     }
 
@@ -79,6 +82,12 @@ VITEST_CONFIG_FILES = (
     "vite.config.js",
     "vite.config.mjs",
 )
+
+# Vitest emits no coverage at all unless one of these provider packages is a
+# dependency — the analog to Jest's built-in Istanbul. Without it, `vitest run
+# --coverage` errors, so the baseline can never be captured regardless of the
+# reporter config (issue #1086, Vitest arm).
+VITEST_COVERAGE_PROVIDERS = ("@vitest/coverage-v8", "@vitest/coverage-istanbul")
 
 _JSON_SUFFIXES = frozenset({".json"})
 
@@ -158,6 +167,21 @@ def resolve_config_source(root: Path, runner: str, pkg: Optional[dict]) -> Tuple
     if runner == "jest" and isinstance((pkg or {}).get("jest"), dict):
         return "package.json#jest", "json"
     return None, "none"
+
+
+def detect_vitest_provider(pkg: Optional[dict]) -> Optional[str]:
+    """Return the installed Vitest coverage provider package, or None.
+
+    Jest ships Istanbul, so this is Vitest-only; for Jest the provider is
+    always considered present.
+    """
+    if pkg is None:
+        return None
+    deps = _all_deps(pkg)
+    for provider in VITEST_COVERAGE_PROVIDERS:
+        if provider in deps:
+            return provider
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -314,8 +338,11 @@ def build_report(root: Path, patch: bool) -> Report:
         meaningful=False,
         patchable=False,
         patched=False,
+        coverage_provider=None,
+        has_provider=True,
         reporter_hint=None,
         scope_hint=None,
+        provider_hint=None,
         notes=[],
     )
 
@@ -341,9 +368,28 @@ def build_report(root: Path, patch: bool) -> Report:
         except (OSError, json.JSONDecodeError) as exc:
             report.note(f"Could not patch {config_source}: {exc}")
 
+    # Vitest emits no coverage without a provider package; Jest ships Istanbul.
+    if runner == "vitest":
+        provider = detect_vitest_provider(pkg)
+        report["coverage_provider"] = provider
+        report["has_provider"] = provider is not None
+        if provider is None:
+            report["provider_hint"] = (
+                "Install a Vitest coverage provider so it can emit coverage "
+                f"(e.g. `npm install --save-dev {VITEST_COVERAGE_PROVIDERS[0]}`)."
+            )
+            report.note(
+                "Vitest has no coverage provider installed; `vitest run --coverage` "
+                "will error before any report is written. Offer to install "
+                f"{VITEST_COVERAGE_PROVIDERS[0]} (confirm first)."
+            )
+    else:
+        report["coverage_provider"] = "istanbul (built-in)"
+
     report["has_json_summary"] = has_json_summary
     report["has_scope"] = has_scope
-    report["ready"] = has_json_summary
+    # Readiness needs a parseable summary AND, for Vitest, an installed provider.
+    report["ready"] = has_json_summary and report["has_provider"]
     report["meaningful"] = has_scope
     report["patchable"] = (config_kind == "json")
 

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -352,8 +352,20 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/coverage_readiness.py" .
 ```
 
 Read the JSON report. `ready` is the hard requirement (the summary can be
-parsed); `meaningful` is whether the baseline reflects the whole tree.
+parsed **and**, for Vitest, a coverage provider is installed); `meaningful`
+is whether the baseline reflects the whole tree.
 
+- **Vitest with `has_provider` `false`** (no `@vitest/coverage-v8` or
+  `@vitest/coverage-istanbul` — Vitest emits no coverage at all without one,
+  unlike Jest's built-in Istanbul) → show `provider_hint` and, on
+  confirmation, install it as a devDependency:
+
+  ```bash
+  npm install --save-dev @vitest/coverage-v8
+  ```
+
+  Then re-run the probe. This is orthogonal to the reporter/scope checks
+  below — both must be satisfied for `ready` to flip to `true`.
 - **`ready` is `true`** → record it for the Step 11 report and continue.
 - **`ready` is `false` and `patchable` is `true`** (config lives in
   `package.json`'s `jest` block or a `*.json` config) → tell the operator
@@ -579,7 +591,9 @@ Display a summary of everything installed and created:
 ### Coverage baseline readiness (JS/TS only)
 - ✓ json-summary + coverage scope present   [ready + meaningful]
 - ✓ patched (added json-summary reporter to <config>)   [was not ready, now fixed]
+- ✓ installed @vitest/coverage-v8   [Vitest provider was missing, now present]
 - ⚠ manual action needed — <reporter_hint>   [JS/TS config the operator declined or must edit]
+- ⚠ Vitest coverage provider missing — <provider_hint>   [not ready]
 - ⚠ coverage scope unset — baseline will be inflated (<scope_hint>)   [not meaningful]
 
 ### Created

--- a/plugins/dev-team/tests/scripts/test_coverage_readiness.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_readiness.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from coverage_readiness import (  # noqa: E402
     build_report,
     detect_runner,
+    detect_vitest_provider,
     main,
     resolve_config_source,
 )
@@ -191,11 +192,21 @@ def test_patch_vitest_json_is_reported_not_written(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# vitest object detection
+# vitest object detection + coverage provider (Vitest arm of #1086)
 # ---------------------------------------------------------------------------
 
+def test_detect_vitest_provider():
+    assert detect_vitest_provider(None) is None
+    assert detect_vitest_provider({"devDependencies": {}}) is None
+    assert detect_vitest_provider({"devDependencies": {"@vitest/coverage-v8": "^2"}}) == "@vitest/coverage-v8"
+    assert (
+        detect_vitest_provider({"devDependencies": {"@vitest/coverage-istanbul": "^2"}})
+        == "@vitest/coverage-istanbul"
+    )
+
+
 def test_vitest_scope_detected_from_include(tmp_path):
-    pkg(tmp_path, {"devDependencies": {"vitest": "^2"}})
+    pkg(tmp_path, {"devDependencies": {"vitest": "^2", "@vitest/coverage-v8": "^2"}})
     write(
         tmp_path / "vitest.config.ts",
         "export default { test: { coverage: { reporter: ['json-summary'], include: ['src/**'] } } }",
@@ -204,6 +215,32 @@ def test_vitest_scope_detected_from_include(tmp_path):
     assert report["runner"] == "vitest"
     assert report["ready"] is True
     assert report["meaningful"] is True
+    assert report["coverage_provider"] == "@vitest/coverage-v8"
+
+
+def test_vitest_missing_provider_blocks_ready(tmp_path):
+    # Reporter + scope are correct, but no coverage provider is installed, so
+    # `vitest run --coverage` would error before writing any report.
+    pkg(tmp_path, {"devDependencies": {"vitest": "^2"}})
+    write(
+        tmp_path / "vitest.config.ts",
+        "export default { test: { coverage: { reporter: ['json-summary'], include: ['src/**'] } } }",
+    )
+    report = build_report(tmp_path, patch=False)
+    assert report["has_json_summary"] is True
+    assert report["has_provider"] is False
+    assert report["coverage_provider"] is None
+    assert report["ready"] is False
+    assert report["provider_hint"] and "@vitest/coverage-v8" in report["provider_hint"]
+
+
+def test_jest_provider_always_present(tmp_path):
+    pkg(tmp_path, {"devDependencies": {"jest": "^29"}, "jest": {"coverageReporters": ["json-summary"]}})
+    report = build_report(tmp_path, patch=False)
+    assert report["has_provider"] is True
+    assert report["coverage_provider"] == "istanbul (built-in)"
+    assert report["provider_hint"] is None
+    assert report["ready"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1086 (merged in `f2a8240e`). That fix added the `/setup` coverage-baseline readiness check and handled Jest + Vitest **reporter/scope** config, but not Vitest's coverage **provider**. The Vitest arm was written during the same session but stranded off the merged PR when its branch auto-deleted; this lands it.

## Gap

Vitest emits no coverage unless `@vitest/coverage-v8` or `@vitest/coverage-istanbul` is installed (analog to Jest's built-in Istanbul). `vitest run --coverage` errors before writing any report when it's absent, so a Vitest repo with `json-summary` + `coverage.include` correctly set can still abort `/test-improve` Phase 2.

## Changes

- **`scripts/coverage_readiness.py`** — detect the Vitest provider; `ready` now requires a parseable summary **and** (Vitest only) an installed provider. New report fields: `coverage_provider`, `has_provider`, `provider_hint`. Jest keeps `has_provider: true` (Istanbul is built in).
- **`/setup`** — offers to install `@vitest/coverage-v8` on confirmation before the reporter/scope checks; Step 11 report surfaces the provider state.

## Tests

`test_coverage_readiness.py` — 3 new cases (provider detection, missing-provider blocks `ready`, Jest provider always present); 25 total, all green.

## Acceptance criteria

- [x] A Vitest repo with no provider is `ready: false` with an install hint.
- [x] `/setup` offers to install the provider on confirmation; Jest repos unaffected.

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)