### PR TITLE
fix: /setup gitignores dev-team runtime artifact folders in target repos

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5048,9 +5048,13 @@
       "summary": "Create a project-specific `skills/pr/SKILL.md` if one doesn't exist, referencing the project's test/lint/typecheck commands.",
       "anchor": "10-generate-pr-command"
     },
-    "11. Report": {
+    "11. Ensure `.gitignore` covers dev-team runtime artifacts": {
+      "summary": "**Downstream projects only** — skip this step entirely when Step 2 detected",
+      "anchor": "11-ensure-gitignore-covers-dev-team-runtime-artifacts"
+    },
+    "12. Report": {
       "summary": "Display a summary of everything installed and created:",
-      "anchor": "11-report"
+      "anchor": "12-report"
     }
   },
   "plugins/dev-team/skills/ship/SKILL.md": {

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -366,7 +366,7 @@ is whether the baseline reflects the whole tree.
 
   Then re-run the probe. This is orthogonal to the reporter/scope checks
   below — both must be satisfied for `ready` to flip to `true`.
-- **`ready` is `true`** → record it for the Step 11 report and continue.
+- **`ready` is `true`** → record it for the Step 12 report and continue.
 - **`ready` is `false` and `patchable` is `true`** (config lives in
   `package.json`'s `jest` block or a `*.json` config) → tell the operator
   exactly which reporter will be added, and on confirmation re-run with
@@ -388,7 +388,7 @@ is whether the baseline reflects the whole tree.
   block the baseline, it just inflates it.
 
 Never write or patch coverage config without operator confirmation. Record
-the final `ready`/`meaningful`/`patched` state for the Step 11 report.
+the final `ready`/`meaningful`/`patched` state for the Step 12 report.
 
 ---
 
@@ -573,7 +573,44 @@ the user and re-point them at `/project-init` rather than installing it here.
 
 Create a project-specific `skills/pr/SKILL.md` if one doesn't exist, referencing the project's test/lint/typecheck commands.
 
-### 11. Report
+### 11. Ensure `.gitignore` covers dev-team runtime artifacts
+
+**Downstream projects only** — skip this step entirely when Step 2 detected
+`in-repo` (the plugin-dev repo curates its own `.gitignore`, and it tracks
+deliverables under `memory/` such as `decisions.md` and eval fixtures that
+this blanket ignore would wrongly hide).
+
+`/test-improve`, `/build`, and the review workflows write per-run resume
+state, progress bookkeeping, reports, and metrics into `memory/`, `reports/`,
+`metrics/`, and `plans/`. These are regeneratable runtime artifacts, not
+deliverables — but `/build` commits the working tree per completed step, so
+without an ignore rule they land in the project's history (issue #1101).
+
+In a downstream project, `memory/` is exclusively dev-team runtime state, so
+the whole folder is safe to ignore. Idempotently append the block (create
+`.gitignore` if absent; do nothing if the marker is already present):
+
+```bash
+MARKER="# dev-team workflow runtime artifacts"
+if ! grep -qF "$MARKER" .gitignore 2>/dev/null; then
+  printf '\n%s\n%s\n' \
+    "$MARKER (regeneratable; not deliverables — issue #1101)" \
+    "memory/
+reports/
+metrics/
+plans/" >> .gitignore
+  echo "gitignore-updated"
+else
+  echo "gitignore-already-covered"
+fi
+```
+
+If the project relocated `reports/` via `DEV_TEAM_REPORTS` or `metrics/` via
+`DEV_TEAM_TASK_METRICS`, add that path instead of the default. Record whether
+the block was added for the Step 12 report. Under `--dry-run`, report what
+would be appended without writing.
+
+### 12. Report
 
 Display a summary of everything installed and created:
 
@@ -600,6 +637,7 @@ Display a summary of everything installed and created:
 - `.claude/project-stack.json` — stack detection results
 - `.claude/CLAUDE.md` — project conventions
 - `.claude/settings.json` — PostToolUse formatting hook (prettier + eslint)
+- `.gitignore` — dev-team runtime artifacts (memory/, reports/, metrics/, plans/)   [downstream only; omit if already covered]
 - Activated templates: ts-enforcer, esm-enforcer, react-testing
 
 ### Recommendations


### PR DESCRIPTION
## What

Adds a downstream-only **Step 11** to `/setup` that idempotently appends a dev-team runtime-artifacts block to the target repo's `.gitignore`:

```gitignore
# dev-team workflow runtime artifacts (regeneratable; not deliverables — issue #1101)
memory/
reports/
metrics/
plans/
```

## Why

`/test-improve` and the `/build` it invokes (Phases 4/5) write per-run resume state, progress bookkeeping, reports, and metrics into `memory/`, `reports/`, `metrics/`, and `plans/`. `/build` commits the working tree per completed step (enforced by `progress_guardian.py` `check_commit_discipline`) without a path-scoped `git add`, so these regeneratable runtime artifacts get swept into the downstream project's git history. Nothing in `/setup` protected the target repo the way this repo's own curated `.gitignore` protects itself.

## Notes

- **Gated to downstream repos only.** Skips when Step 2 detects `in-repo`, because the plugin-dev repo tracks deliverables under `memory/` (`decisions.md`, eval fixtures) that a blanket `memory/` ignore would wrongly hide.
- Idempotent via a marker-grep; honors `--dry-run`; notes the `DEV_TEAM_REPORTS` / `DEV_TEAM_TASK_METRICS` relocations.
- Report step (now Step 12) lists the `.gitignore` update.
- Knowledge index rebuilt.

A follow-up (scoped `git add` in `/build`) is noted in the issue as an optional secondary fix; not included here.

Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
