### PR TITLE
fix: grant code-intelligence MCP tools to read-only review agents

### DIFF
--- a/plugins/dev-team/agents/a11y-review.md
+++ b/plugins/dev-team/agents/a11y-review.md
@@ -2,7 +2,7 @@
 
 name: a11y-review
 description: WCAG 2.1 AA compliance, semantic HTML, ARIA, keyboard navigation, focus management
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/ai-provenance-review.md
+++ b/plugins/dev-team/agents/ai-provenance-review.md
@@ -2,7 +2,7 @@
 
 name: ai-provenance-review
 description: Checks whether AI-authored test assertions and non-obvious production decisions carry human-verification evidence, flags verification debt and regeneration-risk candidates
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: high
 cites: [adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/angular-reactivity-review.md
+++ b/plugins/dev-team/agents/angular-reactivity-review.md
@@ -2,7 +2,7 @@
 
 name: angular-reactivity-review
 description: Angular Zone.js change-detection pitfalls, OnPush + immutability violations, RxJS subscription leaks, async-pipe alternatives
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/arch-review.md
+++ b/plugins/dev-team/agents/arch-review.md
@@ -2,7 +2,7 @@
 
 name: arch-review
 description: Architectural alignment — ADR compliance, layer boundary violations, dependency direction, pattern consistency
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: high
 cites: [architecture-assessment, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/claude-setup-review.md
+++ b/plugins/dev-team/agents/claude-setup-review.md
@@ -2,7 +2,7 @@
 
 name: claude-setup-review
 description: CLAUDE.md completeness, rules, skills, path accuracy, and agent frontmatter schema compliance
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol, directory-enumeration]
 enforcement: script

--- a/plugins/dev-team/agents/complexity-review.md
+++ b/plugins/dev-team/agents/complexity-review.md
@@ -2,7 +2,7 @@
 
 name: complexity-review
 description: Cyclomatic complexity, nesting depth, function size, parameter count
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [object-calisthenics, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/component-architecture-review.md
+++ b/plugins/dev-team/agents/component-architecture-review.md
@@ -2,7 +2,7 @@
 
 name: component-architecture-review
 description: Reusable component extraction and frontend duplication — repeated UI patterns, prop drilling, component granularity, inconsistent component APIs
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [frontend-component-architecture, adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/concurrency-review.md
+++ b/plugins/dev-team/agents/concurrency-review.md
@@ -2,7 +2,7 @@
 
 name: concurrency-review
 description: Race conditions, async pitfalls, idempotency, shared state safety
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/correctness-review.md
+++ b/plugins/dev-team/agents/correctness-review.md
@@ -2,7 +2,7 @@
 
 name: correctness-review
 description: Functional/behavioral defects where implementation diverges from evident intent (missing assignments, wrong operators, inverted conditions, missing guard clauses, off-by-one/boundary errors)
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: high
 cites: [adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/doc-review.md
+++ b/plugins/dev-team/agents/doc-review.md
@@ -2,7 +2,7 @@
 
 name: doc-review
 description: Documentation accuracy, README staleness, API doc alignment, inline comment drift, ADR update triggers
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/domain-review.md
+++ b/plugins/dev-team/agents/domain-review.md
@@ -2,7 +2,7 @@
 
 name: domain-review
 description: Domain boundaries, abstraction leaks, business logic placement
-tools: Read, Grep, Glob, Skill
+tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: high
 cites: [domain-modeling, ubiquitous-language, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/js-fp-review.md
+++ b/plugins/dev-team/agents/js-fp-review.md
@@ -2,7 +2,7 @@
 
 name: js-fp-review
 description: Array mutations, parameter mutations, global state, impure patterns in JS/TS
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/naming-review.md
+++ b/plugins/dev-team/agents/naming-review.md
@@ -2,7 +2,7 @@
 
 name: naming-review
 description: Naming clarity, conventions, magic values, and consistency
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [design-smells, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/performance-review.md
+++ b/plugins/dev-team/agents/performance-review.md
@@ -2,7 +2,7 @@
 
 name: performance-review
 description: Resource leaks, N+1 queries, unbounded growth, timeouts, algorithmic issues
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/react-reactivity-review.md
+++ b/plugins/dev-team/agents/react-reactivity-review.md
@@ -2,7 +2,7 @@
 
 name: react-reactivity-review
 description: React hook rules violations, stale closures in useEffect, missing dependency arrays, setState-during-render, subscription leaks
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/refactor-opportunity-review.md
+++ b/plugins/dev-team/agents/refactor-opportunity-review.md
@@ -2,7 +2,7 @@
 
 name: refactor-opportunity-review
 description: Assesses refactoring opportunities after tests pass (TDD REFACTOR phase), distinguishing semantic duplication from structural similarity
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [design-smells, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/security-review.md
+++ b/plugins/dev-team/agents/security-review.md
@@ -2,7 +2,7 @@
 
 name: security-review
 description: Injection, auth/authz, data exposure, security headers, crypto
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: high
 cites: [owasp-detection, accepted-risks-schema, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/spec-compliance-review.md
+++ b/plugins/dev-team/agents/spec-compliance-review.md
@@ -2,7 +2,7 @@
 
 name: spec-compliance-review
 description: Verify implementation matches specification before quality review agents run
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [adversarial-review-protocol, directory-enumeration]
 scope: always

--- a/plugins/dev-team/agents/structure-review.md
+++ b/plugins/dev-team/agents/structure-review.md
@@ -2,7 +2,7 @@
 
 name: structure-review
 description: SRP violations, DRY, coupling, nesting depth, file organization
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [design-smells, object-calisthenics, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/svelte-review.md
+++ b/plugins/dev-team/agents/svelte-review.md
@@ -2,7 +2,7 @@
 
 name: svelte-review
 description: Svelte reactivity pitfalls, closure state leaks, $state proxy issues, store subscription leaks
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -2,7 +2,7 @@
 
 name: test-review
 description: Test quality, coverage gaps, assertion quality, and test hygiene
-tools: Read, Grep, Glob, Skill
+tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [testability-patterns, result-verification, test-automation-maturity, adversarial-review-protocol, oracle-provenance]
 scope: always

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -2,7 +2,7 @@
 
 name: test-smell-review
 description: xUnit test smells, test double selection, and test-pyramid layer placement
-tools: Read, Grep, Glob, Skill
+tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: medium
 cites: [test-smells, test-automation-principles, test-doubles, value-patterns, test-pyramid, fixture-construction, test-organization, test-refactoring, testability-patterns, result-verification, database-test-patterns, cd-test-architecture, microservice-testing, adversarial-review-protocol]
 scope: always

--- a/plugins/dev-team/agents/token-efficiency-review.md
+++ b/plugins/dev-team/agents/token-efficiency-review.md
@@ -2,7 +2,7 @@
 
 name: token-efficiency-review
 description: Token usage optimization, file length, CLAUDE.md size, LLM anti-patterns
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 enforcement: script

--- a/plugins/dev-team/agents/vue-reactivity-review.md
+++ b/plugins/dev-team/agents/vue-reactivity-review.md
@@ -2,7 +2,7 @@
 
 name: vue-reactivity-review
 description: Vue ref/reactive unwrapping pitfalls, watchEffect dependency tracking, reactive proxy escapes, composition API subscription leaks
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 effort: low
 cites: [adversarial-review-protocol]
 scope:

--- a/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Validate that every read-only *-review agent grants the code-intelligence MCP tools.
+
+Review agents (agents/*-review.md) do structural and behavioral review. When a
+target repo has a CodeGraph index (.codegraph/) and/or a Repowise MCP server, the
+agents should call those tools for verified skeletons and resolved call graphs
+instead of re-reading whole files. That only works if the tool names are present
+in each agent's `tools:` frontmatter allowlist. This check enforces that, and
+--fix appends any missing names (merge, never replace — Read/Grep/Glob/Skill are
+preserved). A granted tool whose MCP server is absent is simply unavailable at
+runtime (no error); agents fall back to Read/Grep/Glob.
+
+It also verifies the code-review skill documents detecting the index and
+preferring it over full-file reads (the guidance that makes the grant useful).
+
+Exit 0 if every review agent grants all five tools and the skill prose is present.
+Exit 1 (detection) or applies fixes (--fix) otherwise.
+
+Usage:
+    python3 check_review_agent_mcp_tools.py [--agents-dir <path>] [--skill-file <path>]
+    python3 check_review_agent_mcp_tools.py --fix        # append missing tool names
+    python3 check_review_agent_mcp_tools.py --json        # machine-readable report
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Single source of truth for the five code-intelligence MCP tool names granted to
+# read-only review agents. The pytest wrapper and any --fix logic import this list
+# so the canonical set has one home (frontmatter itself must duplicate it per-agent).
+MCP_TOOL_NAMES = [
+    "mcp__codegraph__codegraph_explore",
+    "mcp__plugin_repowise_repowise__get_context",
+    "mcp__plugin_repowise_repowise__get_symbol",
+    "mcp__plugin_repowise_repowise__search_codebase",
+    "mcp__plugin_repowise_repowise__get_risk",
+]
+
+# Phrases the code-review skill must contain so the granted tools are actually used:
+# detection of each index, the preference instruction, and the documented fallback.
+SKILL_REQUIRED_PHRASES = [
+    "mcp__codegraph__codegraph_explore",
+    ".codegraph/",
+    "get_context",
+    "get_symbol",
+    "search_codebase",
+    "get_risk",
+]
+
+_TOOLS_RE = re.compile(r"^(tools:\s*)(.*?)(\s*)$", re.MULTILINE)
+
+
+def _agents_dir_default() -> Path:
+    # scripts/ is one level below plugins/dev-team/
+    return Path(__file__).parent.parent / "agents"
+
+
+def _skill_file_default() -> Path:
+    return Path(__file__).parent.parent / "skills" / "code-review" / "SKILL.md"
+
+
+def find_review_agents(agents_dir: Path) -> list[Path]:
+    """Return the read-only review agent files (agents/*-review.md), sorted."""
+    return sorted(agents_dir.glob("*-review.md"))
+
+
+def parse_tools(text: str) -> list[str] | None:
+    """Return the comma-separated tokens on the `tools:` frontmatter line, or None."""
+    m = _TOOLS_RE.search(text)
+    if not m:
+        return None
+    return [tok.strip() for tok in m.group(2).split(",") if tok.strip()]
+
+
+def missing_mcp_tools(text: str) -> list[str]:
+    """Return the MCP tool names absent from the agent's tools: line (all five if no line)."""
+    tokens = parse_tools(text)
+    if tokens is None:
+        return list(MCP_TOOL_NAMES)
+    present = set(tokens)
+    return [name for name in MCP_TOOL_NAMES if name not in present]
+
+
+def fix_tools_line(text: str) -> tuple[str, list[str]]:
+    """Append any missing MCP tool names to the tools: line. Idempotent.
+
+    Returns (new_text, added_names). Order-preserving: existing tokens keep their
+    order; missing MCP names are appended in MCP_TOOL_NAMES order. A line already
+    containing all five is returned unchanged (added == []).
+    """
+    m = _TOOLS_RE.search(text)
+    if not m:
+        return text, []
+    tokens = [tok.strip() for tok in m.group(2).split(",") if tok.strip()]
+    present = set(tokens)
+    added = [name for name in MCP_TOOL_NAMES if name not in present]
+    if not added:
+        return text, []
+    new_tokens = tokens + added
+    new_line = m.group(1) + ", ".join(new_tokens)
+    new_text = text[: m.start()] + new_line + text[m.end() - len(m.group(3)) :]
+    return new_text, added
+
+
+def check_skill(skill_text: str) -> list[str]:
+    """Return the required phrases absent from the code-review skill prose."""
+    return [phrase for phrase in SKILL_REQUIRED_PHRASES if phrase not in skill_text]
+
+
+def _skill_missing(skill_file: Path) -> list[str]:
+    if skill_file.is_file():
+        return check_skill(skill_file.read_text(encoding="utf-8"))
+    return list(SKILL_REQUIRED_PHRASES)
+
+
+def apply_fixes(agents: list[Path]) -> tuple[dict[str, list[str]], list[str]]:
+    """Append missing MCP tools to each review agent. Returns (fixed, unfixable).
+
+    `unfixable` names agents with no inline `tools:` line the regex can append
+    to (a missing line, or a block-list form) — these are reported and cause a
+    non-zero exit rather than a silent false "OK" (they can't be auto-fixed).
+    """
+    fixed: dict[str, list[str]] = {}
+    unfixable: list[str] = []
+    for agent_file in agents:
+        text = agent_file.read_text(encoding="utf-8")
+        if parse_tools(text) is None:
+            unfixable.append(agent_file.stem)
+            continue
+        new_text, added = fix_tools_line(text)
+        if added:
+            agent_file.write_text(new_text, encoding="utf-8")
+            fixed[agent_file.stem] = added
+    return fixed, unfixable
+
+
+def find_offenders(agents: list[Path]) -> dict[str, list[str]]:
+    """Return {agent: missing tool names} for review agents lacking any of the five."""
+    offenders: dict[str, list[str]] = {}
+    for agent_file in agents:
+        missing = missing_mcp_tools(agent_file.read_text(encoding="utf-8"))
+        if missing:
+            offenders[agent_file.stem] = missing
+    return offenders
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agents-dir", type=Path, default=None)
+    parser.add_argument("--skill-file", type=Path, default=None)
+    parser.add_argument("--fix", action="store_true", help="append missing MCP tool names")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    agents_dir = args.agents_dir or _agents_dir_default()
+    skill_file = args.skill_file or _skill_file_default()
+
+    if not agents_dir.is_dir():
+        print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
+        return 1
+
+    agents = find_review_agents(agents_dir)
+    skill_missing = _skill_missing(skill_file)
+
+    if args.fix:
+        fixed, unfixable = apply_fixes(agents)
+        rc = 1 if (unfixable or skill_missing) else 0
+        if args.json:
+            # --json owns stdout: emit ONLY the JSON object, nothing else.
+            print(json.dumps({
+                "reviewed": [a.stem for a in agents],
+                "fixed": fixed,
+                "unfixable": unfixable,
+                "skill_missing_phrases": skill_missing,
+            }, indent=2))
+            return rc
+        if fixed:
+            for name, added in fixed.items():
+                print(f"FIXED: {name} — added {', '.join(added)}")
+        else:
+            print(f"OK: all {len(agents)} review agents already grant the MCP tools.")
+        if unfixable:
+            print("WARN: review agents with no inline tools: line (fix by hand): "
+                  + ", ".join(unfixable), file=sys.stderr)
+        if skill_missing:
+            print("WARN: code-review SKILL.md is missing phrases (fix by hand): "
+                  + ", ".join(skill_missing), file=sys.stderr)
+        return rc
+
+    offenders = find_offenders(agents)
+    rc = 1 if (offenders or skill_missing) else 0
+    if args.json:
+        # --json owns stdout: emit ONLY the JSON object, nothing else.
+        print(json.dumps({
+            "reviewed": [a.stem for a in agents],
+            "offenders": offenders,
+            "skill_missing_phrases": skill_missing,
+        }, indent=2))
+        return rc
+    if offenders:
+        print("FAIL: review agents missing code-intelligence MCP tools in tools::")
+        for name, missing in offenders.items():
+            print(f"  - {name}: missing {', '.join(missing)}")
+        print("\nRun: python3 scripts/check_review_agent_mcp_tools.py --fix")
+    if skill_missing:
+        print("FAIL: code-review SKILL.md missing required phrases: " + ", ".join(skill_missing))
+    if rc == 0:
+        print(f"OK: all {len(agents)} review agents grant the five MCP tools; skill prose present.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -152,6 +152,15 @@ Include the result in the agent report table under a `Skills-Tool` column.
 
 **Fix (when `--fix` is passed)**: Append `, Skill` to the `tools:` frontmatter line. Report `FIXED: <agent> — Added Skill to tools:`.
 
+2. **Code-intelligence MCP invariant (review agents)**: Every read-only `*-review` agent MUST grant the five code-intelligence MCP tools in `tools:` — `mcp__codegraph__codegraph_explore` and `mcp__plugin_repowise_repowise__{get_context,get_symbol,search_codebase,get_risk}` — so a review on a repo with a CodeGraph/Repowise index uses verified skeletons and resolved call graphs instead of raw whole-file reads (the grant is inert when the server is absent; agents fall back to Read/Grep/Glob). This mirrors the Skills-Skill invariant: it self-extends to future `*-review` agents.
+   - FAIL if any `*-review` agent's `tools:` line is missing one or more of the five names.
+   - PASS if every `*-review` agent grants all five.
+   - Delegated to `scripts/check_review_agent_mcp_tools.py` (with `MCP_TOOL_NAMES` as the single source of truth); it also checks that [`code-review/SKILL.md`](../code-review/SKILL.md) still contains the code-intelligence phrases (the five tool names and `.codegraph/`) as a proxy for the detection/preference guidance — it asserts the phrases are present, not the instruction wording itself.
+
+Include the result in the agent report table under a `Code-Intel` column.
+
+**Fix (when `--fix` is passed)**: run `python3 scripts/check_review_agent_mcp_tools.py --fix`, which appends the missing names (merge, never replacing `Read, Grep, Glob`/`Skill`). Report `FIXED: <agent> — added code-intelligence MCP tools`.
+
 ### 2c. Audit team agent personas
 
 A file is a **team agent** when its body contains a `## Behavioral Guidelines` section. **Exemption**: an agent that declares `enforcement: script` in its frontmatter is a script-enforced **prose spec**, not a persona-driven team agent — skip the persona checks below for it and instead verify it carries a `> **Implemented by:** <script>` pointer immediately after the H1. For each remaining team agent, check:

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -129,11 +129,12 @@ If `REVIEW-CONTEXT.md` exists at the repo root, read it and pass its contents to
 | Tool | Check | Use |
 | --- | --- | --- |
 | RoslynMCP | `get_code_metrics` / `search_symbols` available | C# metrics, compiler diagnostics |
-| Code knowledge graph | `list_repos` available | Cross-repo dependency mapping |
+| CodeGraph | `.codegraph/` present / `mcp__codegraph__codegraph_explore` available | Verified structural skeletons, resolved callers/callees/impact |
+| Repowise | `get_context` / `get_symbol` / `search_codebase` / `get_risk` available | Verified file/symbol context + modification-risk lookups |
 | Documentation MCP | wiki/docs search available | Architecture docs |
 | Semgrep | `which semgrep` | SAST context for security-review |
 
-Pass availability info to each agent so they can use enhanced tools or fall back to Glob/Grep/Read. Include in the final report per `knowledge/review-template.md`.
+Pass availability info to each agent so they can use enhanced tools or fall back to Glob/Grep/Read. When CodeGraph or Repowise is available, instruct agents to **prefer `get_context` (verified skeleton) first, then `get_symbol`/`codegraph_explore` for bodies**, and use `Read`/`Grep` only to confirm a specific line or when the index can't serve a file — this cuts token cost and gives resolved call graphs instead of grep heuristics. All read-only review agents grant these MCP tools; the grant is inert (no error) when the server is absent. Include availability in the final report per `knowledge/review-template.md`.
 
 ### 2. Pre-flight gates
 
@@ -201,7 +202,7 @@ Spawn agents as parallel subagents in a single message using the Agent tool.
 - **Static analysis context**: if step 2b produced findings, inject into every agent's prompt using the format in `skills/static-analysis-integration/SKILL.md`: "These issues were detected by static analysis. Do not re-report them. Focus on semantic concerns."
 - **Per-agent output**: `{"agentName": "<name>", "status": "pass|warn|fail", "issues": [], "summary": "..."}` (full schema in `output-format.md`).
 
-**Graph-assisted architectural review**: if the target repo has `.codegraph/` (CodeGraph MCP server, `mcp__codegraph__*` tools — fast callers/callees/impact lookups) and/or `graphify-out/graph.json` (Graphify CLI — `graphify query`/`path`/`explain` — architecture and cross-artifact questions), pass availability to agents doing structural/architectural review (`arch-review`, `component-architecture-review`, `structure-review`, `domain-review`) so they may consult the graph for impact/dependency context before flagging findings. See `knowledge/codegraph-vs-graphify.md` for when to use which. Never assume either tool exists — agents fall back to Read/Grep/Glob when absent.
+**Graph-assisted review**: if the target repo has `.codegraph/` (CodeGraph MCP server, `mcp__codegraph__codegraph_explore` — fast callers/callees/impact lookups), a Repowise MCP server (`get_context`/`get_symbol`/`search_codebase`/`get_risk` — verified context + modification risk), and/or `graphify-out/graph.json` (Graphify CLI — `graphify query`/`path`/`explain` — architecture and cross-artifact questions), pass availability to **all read-only review agents** — the structural lenses (`arch-review`, `component-architecture-review`, `structure-review`, `domain-review`) benefit most from resolved call graphs, but every lens gains cheaper verified reads — so they may consult the index for impact/dependency context before flagging findings. When CodeGraph or Repowise is present, prefer `get_context` for a verified skeleton, then `get_symbol`/`codegraph_explore` for bodies, using `Read`/`Grep` only to confirm a specific line or when the index can't serve a file. See `knowledge/codegraph-vs-graphify.md` for when to use which. Never assume any tool exists — agents fall back to Read/Grep/Glob when absent, and the granted MCP tools are simply unavailable (no error) on repos without an index.
 
 Wait for all agents to complete before aggregating.
 

--- a/plugins/dev-team/tests/scripts/test_check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/tests/scripts/test_check_review_agent_mcp_tools.py
@@ -1,0 +1,226 @@
+"""Tests for scripts/check_review_agent_mcp_tools.py."""
+
+import sys
+from pathlib import Path
+
+# Make the scripts directory importable
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from check_review_agent_mcp_tools import (  # noqa: E402
+    MCP_TOOL_NAMES,
+    SKILL_REQUIRED_PHRASES,
+    _agents_dir_default,
+    _skill_file_default,
+    check_skill,
+    find_review_agents,
+    fix_tools_line,
+    main,
+    missing_mcp_tools,
+    parse_tools,
+)
+
+_SKILL_TEXT = " ".join(SKILL_REQUIRED_PHRASES)  # a skill body containing every required phrase
+
+REAL_AGENTS_DIR = _agents_dir_default()
+REAL_SKILL_FILE = _skill_file_default()
+
+# Sample of well-known non-review agents that must NOT gain the MCP grants.
+NON_REVIEW_SAMPLE = ["software-engineer", "orchestrator", "product-manager"]
+
+
+# ---------------------------------------------------------------------------
+# Contract pin — independent oracle for the canonical tool-name strings.
+# Without this, every other assertion references MCP_TOOL_NAMES as its own
+# oracle, so a typo in the constant would propagate through --fix undetected.
+# ---------------------------------------------------------------------------
+
+def test_mcp_tool_names_are_the_expected_literals():
+    assert MCP_TOOL_NAMES == [
+        "mcp__codegraph__codegraph_explore",
+        "mcp__plugin_repowise_repowise__get_context",
+        "mcp__plugin_repowise_repowise__get_symbol",
+        "mcp__plugin_repowise_repowise__search_codebase",
+        "mcp__plugin_repowise_repowise__get_risk",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests (synthetic content — pass independent of migration)
+# ---------------------------------------------------------------------------
+
+def test_fix_appends_all_five_when_absent():
+    text = "---\nname: foo-review\ntools: Read, Grep, Glob\n---\n# Body\n"
+    new_text, added = fix_tools_line(text)
+    assert added == MCP_TOOL_NAMES
+    tokens = parse_tools(new_text)
+    assert tokens[:3] == ["Read", "Grep", "Glob"]
+    for name in MCP_TOOL_NAMES:
+        assert name in tokens
+
+
+def test_fix_preserves_skill_token():
+    text = "---\ntools: Read, Grep, Glob, Skill\n---\n"
+    new_text, _ = fix_tools_line(text)
+    tokens = parse_tools(new_text)
+    assert "Skill" in tokens
+    assert tokens[:4] == ["Read", "Grep", "Glob", "Skill"]
+
+
+def test_fix_does_not_add_skill_when_absent():
+    text = "---\ntools: Read, Grep, Glob\n---\n"
+    new_text, _ = fix_tools_line(text)
+    assert "Skill" not in parse_tools(new_text)
+
+
+def test_fix_is_idempotent():
+    text = "---\ntools: Read, Grep, Glob\n---\n"
+    once, _ = fix_tools_line(text)
+    twice, added_again = fix_tools_line(once)
+    assert added_again == []
+    assert once == twice
+
+
+def test_missing_reports_all_when_no_tools_line():
+    assert missing_mcp_tools("---\nname: x\n---\n") == MCP_TOOL_NAMES
+
+
+def test_fix_no_ops_when_no_tools_line():
+    text = "---\nname: x\n---\n# Body\n"
+    assert fix_tools_line(text) == (text, [])
+
+
+def test_parse_tools_returns_none_without_line_and_tokens_with():
+    assert parse_tools("---\nname: x\n---\n") is None
+    assert parse_tools("---\ntools: Read, Grep\n---\n") == ["Read", "Grep"]
+
+
+def test_check_skill_reports_absent_phrases():
+    assert check_skill("nothing relevant here") == SKILL_REQUIRED_PHRASES
+    assert check_skill(_SKILL_TEXT) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against the real repo (regression protection)
+# ---------------------------------------------------------------------------
+
+def test_every_review_agent_grants_all_five_mcp_tools():
+    agents = find_review_agents(REAL_AGENTS_DIR)
+    assert agents, "expected to find *-review agents"
+    for agent_file in agents:
+        text = agent_file.read_text(encoding="utf-8")
+        assert missing_mcp_tools(text) == [], f"{agent_file.stem} missing MCP tools"
+
+
+def test_review_agents_preserve_read_grep_glob():
+    for agent_file in find_review_agents(REAL_AGENTS_DIR):
+        tokens = parse_tools(agent_file.read_text(encoding="utf-8"))
+        assert tokens is not None, f"{agent_file.stem} has no tools: line"
+        for base in ("Read", "Grep", "Glob"):
+            assert base in tokens, f"{agent_file.stem} lost {base}"
+
+
+def test_grant_does_not_leak_into_non_review_agents():
+    for name in NON_REVIEW_SAMPLE:
+        agent_file = REAL_AGENTS_DIR / f"{name}.md"
+        assert agent_file.is_file(), f"expected sample agent {name}"
+        tokens = parse_tools(agent_file.read_text(encoding="utf-8")) or []
+        for mcp_name in MCP_TOOL_NAMES:
+            assert mcp_name not in tokens, f"{name} unexpectedly granted {mcp_name}"
+
+
+def test_code_review_skill_documents_detection_and_preference():
+    assert REAL_SKILL_FILE.is_file()
+    assert check_skill(REAL_SKILL_FILE.read_text(encoding="utf-8")) == []
+
+
+# ---------------------------------------------------------------------------
+# main() CLI / exit-code tests (the gate layer CI depends on)
+# ---------------------------------------------------------------------------
+
+def _call_main(agents_dir: Path, skill_file: Path, *extra: str) -> int:
+    old_argv = sys.argv[:]
+    sys.argv = [
+        "check_review_agent_mcp_tools.py",
+        "--agents-dir", str(agents_dir),
+        "--skill-file", str(skill_file),
+        *extra,
+    ]
+    try:
+        return main()
+    except SystemExit as exc:  # pragma: no cover - main returns rather than exits
+        return int(exc.code) if exc.code is not None else 0
+    finally:
+        sys.argv = old_argv
+
+
+def _agent(directory: Path, name: str, tools_line: str) -> None:
+    (directory / f"{name}.md").write_text(
+        f"---\nname: {name}\ntools: {tools_line}\n---\n# {name}\n", encoding="utf-8"
+    )
+
+
+def _tmp_env(tmp_path: Path, skill_ok: bool = True):
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(_SKILL_TEXT if skill_ok else "empty", encoding="utf-8")
+    return agents_dir, skill_file
+
+
+def test_main_passes_when_compliant(tmp_path):
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "foo-review", "Read, Grep, Glob, " + ", ".join(MCP_TOOL_NAMES))
+    assert _call_main(agents_dir, skill_file) == 0
+
+
+def test_main_fails_and_names_offender(tmp_path, capsys):
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "bar-review", "Read, Grep, Glob")
+    assert _call_main(agents_dir, skill_file) == 1
+    assert "bar-review" in capsys.readouterr().out
+
+
+def test_main_fix_writes_and_is_idempotent(tmp_path):
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "baz-review", "Read, Grep, Glob")
+    assert _call_main(agents_dir, skill_file, "--fix") == 0
+    assert missing_mcp_tools((agents_dir / "baz-review.md").read_text()) == []
+    # detection now clean, and a second --fix changes nothing
+    assert _call_main(agents_dir, skill_file) == 0
+    assert _call_main(agents_dir, skill_file, "--fix") == 0
+
+
+def test_main_fix_reports_unfixable_agent_without_tools_line(tmp_path, capsys):
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    (agents_dir / "notools-review.md").write_text(
+        "---\nname: notools-review\n---\n# body\n", encoding="utf-8"
+    )
+    # --fix cannot append to a missing tools: line — must fail loudly, not false-OK
+    assert _call_main(agents_dir, skill_file, "--fix") == 1
+    assert "notools-review" in capsys.readouterr().err
+
+
+def test_main_missing_agents_dir_returns_one(tmp_path, capsys):
+    _, skill_file = _tmp_env(tmp_path)
+    assert _call_main(tmp_path / "nope", skill_file) == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_main_fails_when_skill_prose_missing(tmp_path):
+    agents_dir, skill_file = _tmp_env(tmp_path, skill_ok=False)
+    _agent(agents_dir, "foo-review", "Read, Grep, Glob, " + ", ".join(MCP_TOOL_NAMES))
+    assert _call_main(agents_dir, skill_file) == 1
+
+
+def test_main_json_emits_only_json_on_stdout(tmp_path, capsys):
+    import json
+
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "bar-review", "Read, Grep, Glob")
+    rc = _call_main(agents_dir, skill_file, "--json")
+    out = capsys.readouterr().out
+    # stdout must be parseable JSON with no trailing prose (structure-review finding)
+    parsed = json.loads(out)
+    assert rc == 1
+    assert "bar-review" in parsed["offenders"]


### PR DESCRIPTION
## Summary
- The 24 read-only `*-review` agents were declared `tools: Read, Grep, Glob` only, so on a repo with a CodeGraph (`.codegraph/`) or Repowise MCP index they could not call it — every lens re-read whole files and guessed call graphs via grep, and the `code-review` skill's "graph-assisted review" note was dead code.
- Append the five code-intelligence MCP tools (`mcp__codegraph__codegraph_explore` + `mcp__plugin_repowise_repowise__{get_context,get_symbol,search_codebase,get_risk}`) to all 24 read-only `*-review` agents (merge — `Read`/`Grep`/`Glob`/`Skill` preserved), and update `code-review` SKILL.md Step 1c (detection rows) and Step 4 (prefer `get_context` → bodies, `Read`/`Grep` only to confirm a line; broadened from the four structural agents to all read-only review agents).
- Enforce it with `scripts/check_review_agent_mcp_tools.py` (single `MCP_TOOL_NAMES` source of truth, `--fix`) + a pytest wrapper, wired into `/agent-audit` as a §2b-style invariant mirroring the Skills-Skill check so future `*-review` agents are caught the same way. Grants are inert when the server is absent; agents fall back to `Read`/`Grep`/`Glob`.

## Quality Gate
- [x] Tests: 1172 passed, 0 failed, 0 skipped
- [x] Lint: `ruff` clean on new Python
- [x] Type check: not applicable (no `tsconfig.json`; stdlib-only Python)
- [x] Code review: Phase 5 panel (correctness / test-review / structure / claude-setup) converged clean after one fix iteration

## Decisions & Assumptions
- **Scope: all read-only `*-review` agents** (not just the four structural ones) — confirmed with the requester upfront; cheaper verified reads help every lens.
- **Merge, not replace**, on each `tools:` line — reversible; preserves existing `Read`/`Grep`/`Glob`/`Skill` and the invariants `/agent-audit` already checks.
- **Exact tool-name literals, not `mcp__…__*` wildcards** — frontmatter grants are literal, and this deliberately excludes code-mutating-adjacent Repowise tools from read-only reviewers.
- **Repowise server-name coupling** (`mcp__plugin_repowise_repowise__*`) accepted — frontmatter cannot discover the server dynamically; the grant is inert (no error) when absent and the `Read`/`Grep`/`Glob` fallback is documented.
- **Graphify deferred to #1108** — it is a Bash-invoked CLI and review agents have no `Bash` grant.
- **Deferred follow-ups (latent-only, all agents use inline `tools:`):** a shared review-agent-definition helper between `check_agent_scope.py` and this script, and block-list `tools:` parsing. The `--fix` path now fails loudly (WARN + exit 1) on a no-inline-`tools:`-line agent rather than a silent false "OK".

## Test Plan
- [ ] `python3 -m pytest plugins/dev-team/tests/scripts/test_check_review_agent_mcp_tools.py` — 20 passed.
- [ ] `python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py` — exits 0 ("all 24 review agents grant the five MCP tools; skill prose present").
- [ ] `python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py --json` — emits parseable JSON only (no trailing prose).
- [ ] On a repo with `.codegraph/` and/or a Repowise MCP server, run `/code-review` and confirm the agents can call the MCP tools (and fall back cleanly where neither is present).

## Evidence Bundle
**Checks run**
- `python3 -m pytest tests/` (plugin suite) — 1172 passed, 0 failed, 0 skipped.
- `ruff check` on the new script + test — all checks passed.
- `python3 scripts/progress_guardian.py --pre-pr` — pass (plan steps `[x]`, commit discipline, verify-log present).
- Phase 5 `/code-review` panel on this HEAD — converged clean after one fix iteration.

**Scope notes**
- Type check not applicable (Python stdlib-only, no `tsconfig.json`).
- Change is plugin content (agent/skill markdown) + one stdlib Python check script and its test; no runtime service surface beyond the CLI, which was exercised end-to-end.

**Untested regions**
- Not measured — no coverage tool configured for the plugin's Python; regression protection is the new guard test + `/agent-audit` invariant.

**Residual risks**
- None escalated. Repowise/CodeGraph grants are inert when the index is absent (documented fallback). Server-name coupling noted above.

Closes #1102
