### PR TITLE
fix: scope /pr code-review gate to branch diff instead of full repo

### DIFF
--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -71,7 +71,13 @@ Run each check sequentially. Stop on first failure:
    - `golangci-lint` available: `golangci-lint run`
 
 4. **Code review** (unless `--skip-review`):
-   - Run `/code-review --json`. `/pr` owns the human gate, so code-review runs non-interactively: it skips its own "fix or report?" prompt and applies its fix loop automatically (up to 5 iterations), then returns an aggregated status.
+   - Scope the review to this branch's diff against the base branch, not the whole repo. At PR time the working tree is clean (Step 1 requires it), so a bare `/code-review --json` would auto-scope to the **full repository** — expensive, wrongly scoped, and on a large repo it can trigger the sliced-review path. Compute the merge base and pass it via `--since`:
+
+     ```bash
+     BASE=$(git merge-base HEAD "origin/<base>")   # <base> defaults to main, or the --base arg
+     ```
+
+   - Run `/code-review --since "$BASE" --json`. `/pr` owns the human gate, so code-review runs non-interactively: it skips its own "fix or report?" prompt and applies its fix loop automatically (up to 5 iterations), then returns an aggregated status.
    - Read the returned status field. A normal review returns `{"overall": "pass|warn|fail", ...}`; a documentation-only changeset short-circuits with `{"status": "skipped", ...}`:
      - `overall` of `pass` / `warn`, or `status` of `skipped` → continue to step 3.
      - `overall` of `fail` → show the remaining findings and ask the user whether to proceed anyway or stop and fix.
@@ -104,7 +110,7 @@ Analyze the diff against the base branch (`git diff <base>...HEAD`) and commit h
   from the Step 2 quality-gate results plus on-disk pipeline data — **no new
   checks, no re-execution**:
   - **Checks run**: the exact Step 2 commands (test/typecheck/lint/`/code-review
-    --json`) and their results.
+    --since <base> --json`) and their results.
   - **Scope notes**: gates skipped as not-applicable in Step 2 (e.g. no
     `tsconfig.json` → type check skipped), plus `--skip-review` if passed.
   - **Untested regions**: read `baseline-coverage.json` / `coverage-history.json`


### PR DESCRIPTION
## Summary
- `/pr` Step 2's code-review gate ran a bare `/code-review --json`. Because Step 1 requires a clean working tree, at PR time `/code-review`'s auto-scope rule ("uncommitted changes if any, else full repository") selects the **entire repo** — expensive, wrongly scoped, and on a large repo it can trigger the sliced-review path.
- The gate now scopes to the branch diff: compute `BASE=$(git merge-base HEAD origin/<base>)` (base defaults to `main`, or the `--base` arg) and dispatch `/code-review --since "$BASE" --json`.
- The `--json` non-interactive contract and the `overall`/`status` pass/warn/skipped/fail handling are unchanged. The evidence-bundle "Checks run" reference is updated to match the scoped invocation.

## Quality Gate
- [x] `python3 scripts/check_md_references.py` — exit 0
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — exit 0, no index change (description unchanged)
- [x] Content-guard suites `tests/skills tests/repo tests/commands plugins/dev-team/tests` — 2534 passed, 5 skipped
- [x] `--since <ref>` flag confirmed supported by `skills/code-review/SKILL.md` (`git diff --name-only <ref>...HEAD`)

## Test Plan
- [ ] Confirm the `--since <base>` dispatch text renders correctly and preserves the `--json` non-interactive contract.

## Evidence Bundle
**Checks run**
- `python3 scripts/check_md_references.py` — exit 0
- `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — exit 0, no diff
- `python3 -m pytest tests/skills tests/repo tests/commands plugins/dev-team/tests` (hermetic env) — 2534 passed, 5 skipped, 13 failed

**Scope notes**
- Documentation/skill-content change only (one markdown file). No code, hook, or agent logic changed.

**Untested regions**
- Not applicable — markdown skill instruction change; no runtime surface.

**Residual risks**
- The 13 failures in `plugins/dev-team/tests/hooks/test_cost_meter_lib.py` are **pre-existing and unrelated** to this change: they reproduce identically on the clean `origin/main` tree (stash + full-suite run) and pass in isolation, indicating a test-ordering / module-name-collision issue in the existing suite, not a regression from this PR.

Closes #1122
