### PR TITLE
feat: add opt-in CI_LOCAL_TIMING profiling to ci-local.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ The local gates (`scripts/ci-local.sh`, run by the `pre-push` hook) need these t
 
 `ci-local.sh` checks these up front and exits with an actionable message (pointing at `dev-setup.sh`) if any are missing.
 
+**Profiling the gate:** set `CI_LOCAL_TIMING=1` to append a timing section — each check's individual wall-clock (in declared order, regardless of completion order under the parallel pool) plus the total run wall-clock, followed by an uncolored machine-parseable block (`label<TAB>seconds`) for scripting. It is off by default and changes nothing when unset; a `--changed-only`-skipped check reads `skipped`, never `0.00s`. Use it to find the slowest gates before optimizing (issue #1118).
+
 **The pre-push pytest gate spans more than `plugins/dev-team/tests`.** `ci-local.sh`'s unit-test step runs pytest over `plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` (with `-n auto --dist loadfile`; two csharp-stryker files `--ignore`d). Editing agent/skill markdown can break repo-level content-guards that live **outside** `plugins/dev-team/tests` — e.g. `tests/skills/test_code_review_frontend_dispatch.py` asserts specific agent names appear verbatim in `code-review/SKILL.md`, and `tests/repo` runs `check_md_references.py` (a backticked cross-skill path must be file-relative, e.g. `../code-review/SKILL.md`). Before pushing plugin-content changes, run that **full dir list** — not just the plugin subdir — plus `python3 scripts/check_md_references.py` and `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py`, or the `pre-push` hook / CI will catch what a plugin-only run missed.
 
 ### Worktrees — run `npm ci` first

--- a/scripts/check-python-only.py
+++ b/scripts/check-python-only.py
@@ -57,6 +57,12 @@ ALLOWLIST_EXACT_PATHS = {
     ".claude/install-dev-team.sh",
     # Named out-of-scope-here in #700; owned by #677 (retire bats-core).
     "tests/lib/hermetic_tests.bats",
+    # Curated repo-root orchestration lib sourced by scripts/ci-local.sh (itself
+    # a sanctioned repo-root shell gate, not shipped plugin code). Kept as a
+    # bash-sourced pure helper alongside its sibling scripts/lib/ci-changed-only.sh
+    # so ci-local.sh can source it without a subprocess — #1118 / ADR 0014-0015
+    # scope the Python rule to plugins/dev-team/.
+    "scripts/lib/ci-timing.sh",
 }
 
 # Directory prefixes the allowlist exempts wholesale (trailing "/").

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -122,6 +122,10 @@ JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
 case "$JOBS" in ''|*[!0-9]*) JOBS=2 ;; esac
 [ "$JOBS" -ge 1 ] || JOBS=2
 
+# --- timing helper (opt-in per-step timing; pure renderer, sourced) ---------
+# shellcheck source=scripts/lib/ci-timing.sh
+. scripts/lib/ci-timing.sh
+
 # --- --changed-only resolution ---------------------------------------------
 # Source the suite->path mapping + matcher (pure logic, unit-tested separately),
 # then resolve the changed-file set once. Any failure or an empty set disables
@@ -284,12 +288,31 @@ if [ -n "$ONLY" ]; then
   CHECKS=(${filtered[@]+"${filtered[@]}"})
 fi
 
+# _render_timing_if_enabled — opt-in (CI_LOCAL_TIMING=1 exactly). Renders the
+# timing section from the per-index files in $RUNDIR, labels in declared CHECKS
+# order (index-aligned with the aggregation loop below). Any other flag value —
+# 0, false, empty, unset — returns immediately and prints nothing.
+_render_timing_if_enabled() {
+  [ "${CI_LOCAL_TIMING:-}" = "1" ] || return 0
+  local labels=() e
+  for e in ${CHECKS[@]+"${CHECKS[@]}"}; do labels+=("${e%%::*}"); done
+  ci_render_timing "$RUNDIR" ${labels[@]+"${labels[@]}"}
+}
+
 # --- dispatch (bounded FIFO pool; no `wait -n`, so portable to bash 3.2) ----
 RUNDIR="$(mktemp -d)"
 trap 'rm -rf "$RUNDIR"' EXIT
 
 printf '%srunning %d checks, up to %d in parallel…%s\n' "$bold" "${#CHECKS[@]}" "$JOBS" "$reset"
 
+# Time the entire concurrent dispatch region for the opt-in timing summary. The
+# `time` keyword (TIMEFORMAT='%R' -> bare real seconds) is a shell builtin — no
+# subprocess, portable to macOS bash 3.2 — and its report is redirected to a file
+# in $RUNDIR, so a run with timing disabled pays only the keyword and prints
+# nothing extra. `wait` stays inside the timed block so the total is true
+# wall-clock, not the sum of per-check times.
+TIMEFORMAT='%R'
+{ time {
 pids=()
 idx=0
 for entry in "${CHECKS[@]}"; do
@@ -302,7 +325,14 @@ for entry in "${CHECKS[@]}"; do
     idx=$((idx + 1))
     continue
   fi
-  ( "$fn" >"$RUNDIR/$idx.out" 2>&1; echo $? >"$RUNDIR/$idx.rc" ) &
+  # Time each check with the `time` keyword (TIMEFORMAT='%R' -> bare real
+  # seconds) inside its own subshell, writing the real time to a per-index file
+  # alongside .out/.rc. One subshell owns each index, so concurrent checks cannot
+  # corrupt each other's timing — the same isolation .out/.rc already rely on.
+  # $? after the timed group is the check's own exit status (time is transparent).
+  ( TIMEFORMAT='%R'
+    { time "$fn" >"$RUNDIR/$idx.out" 2>&1; } 2>"$RUNDIR/$idx.time"
+    echo $? >"$RUNDIR/$idx.rc" ) &
   pids+=("$!")
   idx=$((idx + 1))
   # Throttle: once JOBS are in flight, block on the oldest before launching more.
@@ -312,6 +342,7 @@ for entry in "${CHECKS[@]}"; do
   fi
 done
 wait  # drain the remainder
+}; } 2>"$RUNDIR/.total.time"
 
 # --- aggregate in declared order -------------------------------------------
 FAILURES=()
@@ -334,8 +365,10 @@ done
 section "summary"
 if [ "${#FAILURES[@]}" -eq 0 ]; then
   printf '%s%sAll local CI checks passed.%s\n' "$bold" "$green" "$reset"
+  _render_timing_if_enabled
   exit 0
 fi
 printf '%s%s%d check(s) failed:%s\n' "$bold" "$red" "${#FAILURES[@]}" "$reset" >&2
 for f in "${FAILURES[@]}"; do printf '  %s✗ %s%s\n' "$red" "$f" "$reset" >&2; done
+_render_timing_if_enabled
 exit 1

--- a/scripts/lib/ci-timing.sh
+++ b/scripts/lib/ci-timing.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# ci-timing.sh — opt-in per-step timing renderer for ci-local.sh. SOURCED, not
+# executed.
+#
+# Pure formatting/aggregation: it reads the per-index timing files ci-local.sh
+# writes into $RUNDIR and prints (1) a human-readable timing section and
+# (2) an uncolored, machine-parseable block. No git, no side effects beyond
+# stdout — so it is unit-testable by seeding a $RUNDIR without running the real
+# suite (tests/scripts/test_ci_local_timing.py), mirroring the sourced-pure
+# design of scripts/lib/ci-changed-only.sh.
+#
+# The decision of *whether* to render (the CI_LOCAL_TIMING gate) stays in
+# ci-local.sh; this file only knows *how* to format. bash 3.2 safe.
+
+# ci_timing_format_seconds <raw>
+# Normalize a raw bash `time`/TIMEFORMAT='%R' value (e.g. "0.007", "1.234") to a
+# fixed two-decimal string. Returns non-zero on empty/non-numeric input so the
+# caller can substitute a sentinel rather than print a bogus number.
+ci_timing_format_seconds() {
+  case "$1" in
+    '' | *[!0-9.]*) return 1 ;;
+  esac
+  printf '%.2f' "$1"
+}
+
+# ci_timing_seconds_at <time_file>
+# Read a per-index (or total) .time file and echo its value formatted to two
+# decimals. Echoes '?' when the file is absent or its content is non-numeric.
+# Single source of the read-and-format step shared by the human and machine rows.
+ci_timing_seconds_at() {
+  local raw
+  # tail -1: the timed region's stderr may carry stray lines; the %R value is the
+  # last line the `time` keyword emits.
+  raw="$(tail -n 1 "$1" 2>/dev/null | tr -d '[:space:]')"
+  ci_timing_format_seconds "$raw" 2>/dev/null || printf '?'
+}
+
+# ci_timing_value_for <rundir> <index>
+# The machine value for one check: its formatted seconds when it ran, the literal
+# 'skipped' when it was skipped (a --changed-only skip writes <index>.rc but never
+# forks a timed subshell, so no <index>.time exists — never report 0.00s, which
+# would misread as a real fast pass), or '?' when neither file is present.
+ci_timing_value_for() {
+  local rundir="$1" i="$2"
+  if [ -f "$rundir/$i.time" ]; then
+    ci_timing_seconds_at "$rundir/$i.time"
+  elif [ -f "$rundir/$i.rc" ]; then
+    printf 'skipped'
+  else
+    printf '?'
+  fi
+}
+
+# ci_timing_human <value>
+# Human rendering of a machine value: numeric -> "<n>s"; any sentinel (skipped,
+# ?) is passed through unchanged so it never becomes e.g. "skippeds".
+ci_timing_human() {
+  case "$1" in
+    '' | *[!0-9.]*) printf '%s' "$1" ;;
+    *) printf '%ss' "$1" ;;
+  esac
+}
+
+# ci_render_timing <rundir> [<label0> <label1> ...]
+# Print the timing section. <rundir> is ci-local.sh's per-run temp dir: the total
+# wall-clock lives at <rundir>/.total.time and each check's own time at
+# <rundir>/<i>.time, index-aligned with the declared CHECKS labels passed in
+# order. Emits a human-readable section (per-check lines in declared order plus a
+# total) and, below it, an uncolored machine-parseable block (label<TAB>seconds)
+# so the ranking follow-up need not scrape the human text.
+ci_render_timing() {
+  local rundir="$1"
+  shift
+  local labels=("$@")
+  local total_val
+  total_val="$(ci_timing_seconds_at "$rundir/.total.time")"
+
+  # Read each check's value once, index-aligned with the labels, so the human and
+  # machine renderings below share one source of values (a real time, 'skipped',
+  # or '?').
+  local vals=() i=0
+  for _label in ${labels[@]+"${labels[@]}"}; do
+    vals+=("$(ci_timing_value_for "$rundir" "$i")")
+    i=$((i + 1))
+  done
+
+  printf '\n== timing ==\n'
+  i=0
+  for _label in ${labels[@]+"${labels[@]}"}; do
+    printf '  %s  %s\n' "$_label" "$(ci_timing_human "${vals[$i]}")"
+    i=$((i + 1))
+  done
+  printf '  %s  %s\n' "total" "$(ci_timing_human "$total_val")"
+
+  printf '\n-- machine-readable --\n'
+  i=0
+  for _label in ${labels[@]+"${labels[@]}"}; do
+    printf '%s\t%s\n' "$_label" "${vals[$i]}"
+    i=$((i + 1))
+  done
+  printf '%s\t%s\n' "total" "$total_val"
+}

--- a/tests/scripts/test_ci_local_timing.py
+++ b/tests/scripts/test_ci_local_timing.py
@@ -1,0 +1,331 @@
+"""Tests for scripts/ci-local.sh's opt-in per-step timing instrument
+(CI_LOCAL_TIMING) and its pure render helper scripts/lib/ci-timing.sh.
+
+Issue #1118. scripts/ci-local.sh stays bash (a sanctioned repo-root orchestration
+script, out of the Python-only rule per ADR 0014/0015); only the test harness is
+pytest, matching tests/scripts/test_ci_local_hermetic.py.
+
+Two layers of coverage:
+  * End-to-end: invoke ci-local.sh with a fast, hermetic --only selection and
+    assert the timing section appears/does not appear and exit codes/summary are
+    unchanged. chk_oe_staleness is advisory (--warn-only, always exit 0).
+  * Unit: source scripts/lib/ci-timing.sh in bash and seed a fake $RUNDIR to test
+    the pure renderer deterministically — no real suite run, no timing flakiness.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_LOCAL = REPO_ROOT / "scripts" / "ci-local.sh"
+CI_TIMING_LIB = REPO_ROOT / "scripts" / "lib" / "ci-timing.sh"
+
+TIMING_HEADER = "== timing =="
+TOTAL_RE = re.compile(r"^\s*total\s+(\d+\.\d{2})s\s*$", re.MULTILINE)
+
+
+def _base_env() -> dict:
+    """Minimal, deterministic env. PATH so real tools resolve; HOME for tools
+    that read it; C locale for stable output. CI_LOCAL_PROBE_ENV must be absent
+    or ci-local short-circuits before running anything."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "LANG": "C",
+        "LC_ALL": "C",
+    }
+    return env
+
+
+def _run_ci_local(*args: str, timing: str | None) -> subprocess.CompletedProcess:
+    """Run ci-local.sh with the given args. `timing` sets CI_LOCAL_TIMING to that
+    value, or leaves it unset when None."""
+    env = _base_env()
+    if timing is not None:
+        env["CI_LOCAL_TIMING"] = timing
+    return subprocess.run(
+        ["bash", str(CI_LOCAL), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- Step 1.1: total run wall-clock, strict flag semantics -----------------
+
+
+def test_timing_absent_when_flag_unset() -> None:
+    proc = _run_ci_local("--only=chk_oe_staleness", timing=None)
+    assert proc.returncode == 0, proc.stderr
+    assert TIMING_HEADER not in proc.stdout
+    assert "All local CI checks passed." in proc.stdout
+
+
+def test_timing_absent_for_non_enabling_values() -> None:
+    # Criterion 1: any value other than exactly "1" is off (0, false, empty).
+    for value in ("0", "false", ""):
+        proc = _run_ci_local("--only=chk_oe_staleness", timing=value)
+        assert proc.returncode == 0, f"value={value!r}: {proc.stderr}"
+        assert TIMING_HEADER not in proc.stdout, f"value={value!r} rendered timing"
+        assert "All local CI checks passed." in proc.stdout
+
+
+def test_timing_section_reports_positive_total_when_enabled() -> None:
+    proc = _run_ci_local("--only=chk_oe_staleness", timing="1")
+    assert proc.returncode == 0, proc.stderr
+    assert TIMING_HEADER in proc.stdout
+    match = TOTAL_RE.search(proc.stdout)
+    assert match is not None, f"no well-formed total line in:\n{proc.stdout}"
+    assert float(match.group(1)) > 0.0
+
+
+def test_enabling_timing_does_not_change_exit_or_summary() -> None:
+    off = _run_ci_local("--only=chk_oe_staleness", timing=None)
+    on = _run_ci_local("--only=chk_oe_staleness", timing="1")
+    assert off.returncode == on.returncode == 0
+    assert "All local CI checks passed." in off.stdout
+    assert "All local CI checks passed." in on.stdout
+
+
+# --- Step 1.2: per-check wall-clock in declared order + machine block -------
+
+PER_CHECK_RE = re.compile(r"^\s*(\S.*?)\s+(\d+\.\d{2})s\s*$")
+
+
+def _render_helper(rundir: Path, *labels: str) -> str:
+    """Source ci-timing.sh and invoke the pure renderer against a seeded rundir."""
+    script = f'source "{CI_TIMING_LIB}"; ci_render_timing "{rundir}" ' + " ".join(labels)
+    proc = subprocess.run(
+        ["bash", "-c", script], env=_base_env(), capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_helper_renders_each_label_with_its_own_seeded_time(tmp_path: Path) -> None:
+    # Distinct values, seeded so index i -> i.time; proves the label<->time mapping
+    # is by index and that no per-check value is copied from the total (no swap).
+    (tmp_path / ".total.time").write_text("9.99\n")
+    (tmp_path / "0.time").write_text("1.11\n")
+    (tmp_path / "1.time").write_text("2.22\n")
+    (tmp_path / "2.time").write_text("3.33\n")
+
+    out = _render_helper(tmp_path, "chk_a", "chk_b", "chk_c")
+
+    human, _, machine = out.partition("-- machine-readable --")
+
+    # Human section: labels appear in the declared (argument) order, each with its
+    # own seeded value; none copies the total.
+    assert human.index("chk_a") < human.index("chk_b") < human.index("chk_c")
+    assert re.search(r"^\s*chk_a\s+1\.11s$", human, re.MULTILINE)
+    assert re.search(r"^\s*chk_b\s+2\.22s$", human, re.MULTILINE)
+    assert re.search(r"^\s*chk_c\s+3\.33s$", human, re.MULTILINE)
+    assert re.search(r"^\s*total\s+9\.99s$", human, re.MULTILINE)
+
+    # Machine block: uncolored label<TAB>seconds (no 's' suffix, no ANSI), one per
+    # check plus total, same declared order.
+    assert "chk_a\t1.11" in machine
+    assert "chk_b\t2.22" in machine
+    assert "chk_c\t3.33" in machine
+    assert "total\t9.99" in machine
+    assert "\x1b[" not in machine  # no ANSI colour codes in the machine block
+
+
+def test_two_concurrent_checks_appear_once_in_declared_order(tmp_path: Path) -> None:
+    # Integration: two fast, always-exit-0 checks that dispatch concurrently. Each
+    # gets a well-formed per-check time in declared CHECKS order; total > 0. (A
+    # near-instant check may legitimately read 0.00s, so per-check is asserted
+    # well-formed, not > 0 — the > 0 / distinctness proof lives in the unit test.)
+    proc = _run_ci_local("--only=chk_oe_staleness,chk_eval_semver", timing="1")
+    assert proc.returncode == 0, proc.stderr
+    section = proc.stdout.split(TIMING_HEADER, 1)[1]
+
+    oe_label = "OE scoring staleness (advisory; oe_scoring_staleness.py)"
+    semver_label = "eval-corpus semver contract"
+    # Declared CHECKS order places OE staleness before the semver contract.
+    assert section.index(oe_label) < section.index(semver_label)
+
+    per_check = {
+        m.group(1): m.group(2)
+        for m in (PER_CHECK_RE.match(line) for line in section.splitlines())
+        if m
+    }
+    assert oe_label in per_check and re.fullmatch(r"\d+\.\d{2}", per_check[oe_label])
+    assert semver_label in per_check and re.fullmatch(r"\d+\.\d{2}", per_check[semver_label])
+
+    total_match = TOTAL_RE.search(section)
+    assert total_match is not None and float(total_match.group(1)) > 0.0
+
+
+def test_check_set_and_order_identical_with_and_without_flag() -> None:
+    off = _run_ci_local("--only=chk_oe_staleness,chk_eval_semver", timing=None)
+    on = _run_ci_local("--only=chk_oe_staleness,chk_eval_semver", timing="1")
+    assert off.returncode == on.returncode == 0
+    # The section headers (one per check, printed by the aggregation loop) are the
+    # check set + order; they must be identical whether or not timing is enabled.
+    headers = lambda text: [ln for ln in text.splitlines() if ln.startswith("\x1b[1m== ")]
+    assert headers(off.stdout) == headers(on.stdout)
+
+
+# --- Step 1.3: skip sentinel, failure (exit code), empty selection ---------
+
+
+def _fabricate_range(*paths: str) -> tuple[str, str]:
+    """Create two commit objects (no ref/HEAD/index/worktree mutation) whose diff
+    is exactly `paths`, and return (base_sha, head_sha). Lets --changed-only run
+    against a deterministic change set regardless of the (dirty) working tree."""
+
+    # Explicit committer/author identity so `git commit-tree` works in a hermetic
+    # CI clone that has no user.name/user.email configured (locally it would fall
+    # back to the developer's global identity; CI has none → exit 128).
+    git_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "ci-timing-test",
+        "GIT_AUTHOR_EMAIL": "ci-timing-test@example.invalid",
+        "GIT_COMMITTER_NAME": "ci-timing-test",
+        "GIT_COMMITTER_EMAIL": "ci-timing-test@example.invalid",
+    }
+
+    def git(*args: str, stdin: str | None = None) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=git_env,
+        ).stdout.strip()
+
+    blob = git("hash-object", "-w", "--stdin", stdin="x\n")
+    tree_spec = "".join(f"100644 blob {blob}\t{p}\n" for p in paths)
+    tree = git("mktree", stdin=tree_spec)
+    empty_tree = git("mktree", stdin="")
+    base = git("commit-tree", empty_tree, "-m", "base")
+    head = git("commit-tree", tree, "-p", base, "-m", "head")
+    return base, head
+
+
+def test_helper_shows_skipped_sentinel_and_still_times_failures(tmp_path: Path) -> None:
+    # index 0: ran & passed; index 1: ran & FAILED (rc=1) but still timed;
+    # index 2: skipped (rc present, no .time) — must read 'skipped', never 0.00s.
+    (tmp_path / ".total.time").write_text("5.00\n")
+    (tmp_path / "0.time").write_text("1.00\n")
+    (tmp_path / "0.rc").write_text("0\n")
+    (tmp_path / "1.time").write_text("2.00\n")
+    (tmp_path / "1.rc").write_text("1\n")
+    (tmp_path / "2.rc").write_text("0\n")  # deliberately no 2.time
+
+    out = _render_helper(tmp_path, "chk_a", "chk_b", "chk_c")
+    human, _, machine = out.partition("-- machine-readable --")
+
+    assert re.search(r"^\s*chk_a\s+1\.00s$", human, re.MULTILINE)
+    assert re.search(r"^\s*chk_b\s+2\.00s$", human, re.MULTILINE)  # failing, still timed
+    assert re.search(r"^\s*chk_c\s+skipped$", human, re.MULTILINE)  # not 0.00s
+    assert "0.00" not in human
+    assert "chk_c\tskipped" in machine
+
+
+def test_helper_normalizes_seconds_and_falls_back_to_question_mark(tmp_path: Path) -> None:
+    # Pin the renderer's reason to exist — %R normalization to exactly two
+    # decimals — and its sentinel/robustness branches:
+    #   index 0: under-precision "1.2"      -> "1.20s"
+    #   index 1: over-precision  "0.007"    -> "0.01s" (rounds)
+    #   index 2: garbage .time (has .rc)    -> "?"      (non-numeric, not "skipped")
+    #   index 3: neither .time nor .rc      -> "?"
+    #   total:   stray leading line         -> tail -1 picks the real value
+    (tmp_path / ".total.time").write_text("junk line\n3.5\n")
+    (tmp_path / "0.time").write_text("1.2\n")
+    (tmp_path / "0.rc").write_text("0\n")
+    (tmp_path / "1.time").write_text("0.007\n")
+    (tmp_path / "1.rc").write_text("0\n")
+    (tmp_path / "2.time").write_text("notanumber\n")
+    (tmp_path / "2.rc").write_text("0\n")
+    # index 3: deliberately no files at all
+
+    out = _render_helper(tmp_path, "chk_a", "chk_b", "chk_c", "chk_d")
+    human, _, machine = out.partition("-- machine-readable --")
+
+    assert re.search(r"^\s*chk_a\s+1\.20s$", human, re.MULTILINE)  # padded
+    assert re.search(r"^\s*chk_b\s+0\.01s$", human, re.MULTILINE)  # rounded
+    assert re.search(r"^\s*chk_c\s+\?$", human, re.MULTILINE)  # garbage -> ?
+    assert re.search(r"^\s*chk_d\s+\?$", human, re.MULTILINE)  # missing -> ?
+    assert re.search(r"^\s*total\s+3\.50s$", human, re.MULTILINE)  # tail -1 of a stray line
+    assert "chk_c\t?" in machine
+    assert "chk_d\t?" in machine
+
+
+def test_failing_check_preserves_nonzero_exit_and_shows_timing(tmp_path: Path) -> None:
+    # A shellcheck stub that exits 1 makes chk_shellcheck_helpers fail deterministically
+    # on every OS. The appended timing section must not swallow the non-zero verdict.
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    (stub / "shellcheck").write_text("#!/bin/sh\nexit 1\n")
+    (stub / "shellcheck").chmod(0o755)
+
+    env = _base_env()
+    env["PATH"] = f"{stub}{os.pathsep}{env['PATH']}"
+    env["CI_LOCAL_TIMING"] = "1"
+    proc = subprocess.run(
+        ["bash", str(CI_LOCAL), "--only=chk_shellcheck_helpers"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    section = proc.stdout.split(TIMING_HEADER, 1)
+    assert len(section) == 2, "timing section missing on a failing run"
+    assert PER_CHECK_RE.search(
+        [ln for ln in section[1].splitlines() if "shellcheck" in ln][0]
+    ), "failing check has no timing line"
+
+
+def test_empty_only_selection_exits_2_without_timing() -> None:
+    proc = _run_ci_local("--only=chk_does_not_exist", timing="1")
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert TIMING_HEADER not in proc.stdout
+
+
+def test_changed_only_skip_renders_sentinel_and_keeps_selection() -> None:
+    # Change set touches only foo.txt: chk_eslint (watches plugins/dev-team, *.js/…)
+    # is skipped; chk_oe_staleness (no watched path) always runs.
+    base, head = _fabricate_range("foo.txt")
+    args = ("--only=chk_oe_staleness,chk_eslint", "--changed-only", base, head)
+    on = _run_ci_local(*args, timing="1")
+    off = _run_ci_local(*args, timing=None)
+    assert on.returncode == off.returncode == 0, on.stderr
+
+    section = on.stdout.split(TIMING_HEADER, 1)[1]
+    assert re.search(r"^\s*eslint\s+skipped$", section, re.MULTILINE)
+    assert "0.00" not in section  # the skip is never a zero duration
+    oe = "OE scoring staleness (advisory; oe_scoring_staleness.py)"
+    oe_line = [ln for ln in section.splitlines() if oe in ln][0]
+    assert re.search(r"\d+\.\d{2}s$", oe_line)  # oe actually ran
+
+    # Selection (the per-check section headers) is identical with/without timing.
+    headers = lambda t: [ln for ln in t.splitlines() if ln.startswith("\x1b[1m== ")]
+    assert headers(on.stdout) == headers(off.stdout)
+
+
+def test_base_head_is_a_distinct_mode_from_changed_only() -> None:
+    # With a BASE/HEAD range (no --changed-only, no --only filter interplay),
+    # chk_eval_semver runs its real classifier; without a range it takes its own
+    # internal skip-print. Isolates BASE/HEAD from --changed-only.
+    base, head = _fabricate_range("foo.txt")
+    with_range = _run_ci_local("--only=chk_eval_semver", base, head, timing="1")
+    no_range = _run_ci_local("--only=chk_eval_semver", timing="1")
+
+    skip_msg = "skipped (no BASE/HEAD range supplied)"
+    assert with_range.returncode == 0, with_range.stdout  # classifier ran clean
+    assert skip_msg not in with_range.stdout  # it actually executed
+    assert skip_msg in no_range.stdout  # it took the internal skip-print
+
+    section = with_range.stdout.split(TIMING_HEADER, 1)[1]
+    semver_line = [ln for ln in section.splitlines() if "eval-corpus semver" in ln][0]
+    assert re.search(r"\d+\.\d{2}s$", semver_line)  # real timing, not a sentinel


### PR DESCRIPTION
## Summary
Adds an opt-in, off-by-default per-step timing instrument to the local CI gate (`scripts/ci-local.sh`) so the gate's cost is measurable before anyone optimizes it. `CI_LOCAL_TIMING=1` appends a timing section after the summary: each check's own wall-clock in declared `CHECKS` order (regardless of completion order under the parallel pool) plus the total run wall-clock, followed by an uncolored machine-parseable block (`label<TAB>seconds`). Off by default; output is unchanged when unset.

Spec + findings live on the issue (issue-first convention): the [findings comment](https://github.com/bdfinst/agentic-dev-team/issues/1118#issuecomment-4995376587) reports real per-step timings and ranked contributors from the shipped instrument.

## How it works
- Timing uses the bash `time` keyword with `TIMEFORMAT='%R'` — a shell builtin, **no subprocess inside the timed region**, portable to macOS bash 3.2.
- Per-check times are captured at each dispatch subshell into per-index `$RUNDIR/<i>.time` files (one subshell per index → concurrent checks can't corrupt each other's timing, same isolation `.out`/`.rc` already rely on).
- A `--changed-only`-skipped check renders `skipped`, never a misleading `0.00s`.
- The existing exit-code logic is untouched — a failing run still exits non-zero with the section present (proven by an end-to-end test).
- Rendering is a sourced pure helper (`scripts/lib/ci-timing.sh`), sibling to `ci-changed-only.sh`, unit-tested by seeding a `$RUNDIR`.

## Testing
- New `tests/scripts/test_ci_local_timing.py` (13 tests): flag semantics (unset/`0`/`false`/empty/`1`), per-check declared order, concurrent-dispatch distinctness, skip sentinel, failing-check exit-code preservation, empty `--only` (exit 2), `%R` normalization/fallback, and BASE/HEAD-vs-`--changed-only` isolation.
- Full local gate green (`pre-push`): 3385 passed, 1 skipped, "All local CI checks passed".

## Decisions & Assumptions
- **Scope (narrow, human-confirmed):** this PR ships the instrument + produces the findings; the speedups it surfaced are follow-up issues (#1128, #1129, #1130), not implemented here.
- **`scripts/lib/ci-timing.sh` kept as bash and allowlisted** in `check-python-only.py`: the plan assumed repo-root `.sh` was out of the Python-only rule (per CLAUDE.md prose), but the enforcement gate blocks *new* repo-root `.sh`. Surfaced the CLAUDE.md-vs-gate inconsistency; per maintainer decision, allowlisted the curated lib (sourced without a subprocess, sibling to `ci-changed-only.sh`) rather than porting to Python. Note: prose/enforcement wording remains slightly inconsistent (not reconciled in this PR).
- **Overhead** within the max(2%, 1s) bar on the reference machine (the `time` keyword adds no measurable cost); verified manually, not automated (machine-dependent).
- Diff-scoping the pytest gate was **not** recommended in the findings — it risks the #1116 content-guard blind spot.

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)