### PR TITLE
perf: speed up ci-local.sh (semgrep single-pass, pytest worker cap)

### DIFF
--- a/scripts/audit-semgrep-fixtures.py
+++ b/scripts/audit-semgrep-fixtures.py
@@ -94,8 +94,13 @@ def audit():
     fatal = []
     known_broken = _load_known_broken()
     seen_broken = set()
+    # One semgrep invocation over the whole rules directory instead of one per
+    # ruleset file (#1130): semgrep parses each fixture once and applies every
+    # rule, rather than re-parsing all fixtures N times and paying N process
+    # startups. Results are keyed by (rule-id, path) and errors by rule id, so
+    # combining all rulesets in a single scan preserves per-rule attribution.
+    fired, errored = _run_semgrep(RULES_DIR)
     for ruleset in sorted(RULES_DIR.glob("*.yaml")):
-        fired, errored = _run_semgrep(ruleset)
         spec = yaml.safe_load(ruleset.read_text())
         for rule in spec.get("rules", []) or []:
             rid = rule["id"]

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -240,9 +240,27 @@ chk_hook_units() {
   # --dist loadfile keeps every test from one file on a single worker, preserving
   # intra-file execution order — the git-subprocess suites (e.g. progress_guardian)
   # are order-sensitive and race when their tests are split across workers.
+  # Worker count (#1129): `-n auto` spawns one worker per core. In a FULL local
+  # run (no --only) this check is dispatched inside ci-local.sh's outer parallel
+  # pool alongside ~17 other checks, so `auto` oversubscribes every core and
+  # starves the co-runners — eslint measured 2.3s solo but 34.7s here while
+  # pytest's workers held the cores. This suite is coordination-bound (~2.7 cores
+  # of real work even at -n auto), so leaving ~1/3 of the cores for the pool
+  # barely moves its own wall-clock while letting the light co-runners finish in
+  # the freed headroom. Under --only (CI shards each gate into its own job) pytest
+  # is effectively the sole heavy check, so keep -n auto there — no co-runners to
+  # protect, and small CI runners want every core.
   parallel=()
   if python3 -c 'import xdist' >/dev/null 2>&1; then
-    parallel=(-n auto --dist loadfile)
+    local workers="auto"
+    if [ -z "$ONLY" ]; then
+      local cores
+      cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+      case "$cores" in '' | *[!0-9]*) cores=4 ;; esac
+      workers=$(( cores - cores / 3 ))
+      [ "$workers" -ge 2 ] || workers=2
+    fi
+    parallel=(-n "$workers" --dist loadfile)
   fi
   python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands \
     tests/docs tests/knowledge tests/bats tests/skills tests/scripts \


### PR DESCRIPTION
## Summary
Two coverage-preserving speedups to the local CI gate, both surfaced by the `CI_LOCAL_TIMING` instrument from #1118. Companion issue #1128 (eslint) was **closed as a false premise** — measurement showed eslint is 2.3s solo (its 34.7s in-gate was pure oversubscription, i.e. the same root cause as #1129), so there was no eslint change to make.

## #1130 — semgrep fixtures audit: one scan instead of seven `Closes #1130`
`audit-semgrep-fixtures.py` ran a **separate semgrep process per ruleset YAML** (7 files), re-parsing every fixture 7× and paying 7 rule-compilation startups. Now runs semgrep **once** over the whole rules directory (parses each fixture once, applies all rules). Per-rule attribution is preserved (results keyed by rule-id + path; errors by rule-id).
- **Verified verdicts identical**: all 36 rules unchanged (27 WORKING / 8 PARSE-ERROR / 1 NO-FIRE), 0 fatal, before vs after.
- **Measured** (`CI_LOCAL_TIMING`): ~18s → ~7s solo; **15.8s → 3.4s** in-gate.

## #1129 — cap pytest workers in full runs `Closes #1129`
In a full `ci-local.sh` run (no `--only`), the pytest check is dispatched inside the outer core-capped pool alongside ~17 other checks, yet also ran xdist at `-n auto` (one worker per core) — double-parallelism that oversubscribes every core and starves co-runners (**eslint: 2.3s solo → 34.7s in-gate**). This caps xdist to ~2/3 of the cores **only in a full run**; the suite is coordination-bound (~2.7 cores of real work at `-n auto`) so its own wall-clock barely moves while the light co-runners finish in the freed headroom.

**Scope guardrail:** under `--only` (how CI shards every gate into its own job) `-n auto` is kept, so this is a **no-op on every CI path** — it can neither regress nor be exercised by CI. It only affects the developer full pre-push run.

## Testing
- `pre-push` full gate (which exercises the **capped** `-n 7` full-run path + the single-pass semgrep audit): **3425 passed, 1 skipped, "All local CI checks passed."**
- #1130 before/after verdict diff: identical.
- No new unit tests: #1130 is a behaviour-preserving refactor covered by the existing `chk_semgrep_fixtures` gate (verified identical output); #1129 changes only the xdist `-n` value, validated by the full gate running green with the cap.

## Decisions & Assumptions (measure-first, per #1118)
- **#1129 speedup not benchmarked locally.** Microsoft Defender for Endpoint was thrashing the dev machine (xdist repeatedly failed to bring up workers under the CPU spike), making local timing unreliable. The change is low-risk by construction (no-op on CI; coordination-bound pytest ⇒ negligible self-slowdown; only relieves starved co-runners). **Confirm the local speedup with `CI_LOCAL_TIMING=1 bash scripts/ci-local.sh` on a quiet machine.**
- #1128 closed (not-planned) with the solo-vs-contended measurement rather than shipping a spurious eslint change.

Part of #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)