### PR TITLE
feat: install + build code-intelligence indexes in setup, disclose graphify key cost

### DIFF
--- a/plugins/dev-team/knowledge/codegraph-vs-graphify.md
+++ b/plugins/dev-team/knowledge/codegraph-vs-graphify.md
@@ -51,10 +51,13 @@ function."
 ### CodeGraph
 
 - Offered opt-in during `/project-init`'s "Step 4c — Offer graph-tools"
-  ([`skills/project-init/SKILL.md`](../skills/project-init/SKILL.md)):
-  the skill checks `command -v codegraph` and the presence of `.codegraph/`,
-  then prompts to install and/or run `codegraph init -i`, recording the
-  choice in `.claude/init-state.json`.
+  ([`skills/project-init/SKILL.md`](../skills/project-init/SKILL.md)) as part
+  of the CodeGraph + Repowise + Graphify all-or-none group: the skill checks
+  `command -v codegraph` and the presence of `.codegraph/`, and when the group
+  is accepted **installs the CLI keylessly** (`npm install -g
+  @colbymchenry/codegraph`) and builds the index non-interactively
+  (`codegraph init .`, no `-i`), recording the choice in
+  `.claude/init-state.json` (issue #1134).
 - **Strictly personal, user-level tooling — never committed.** Once
   initialized, the skill prints the manual command
   (`claude mcp add codegraph -- codegraph serve --mcp`) for the user to
@@ -94,6 +97,14 @@ function."
 - A repo-level tool with its own native `/graphify` skill
   (`.claude/skills/graphify/SKILL.md` in this repo), not part of the
   `dev-team` plugin's shipped skill set.
+- Also offered opt-in during `/project-init`'s Step 4c as part of the
+  CodeGraph + Repowise + Graphify all-or-none group. **Unlike the keyless
+  CodeGraph/Repowise indexes, graphify's extraction requires a model/API
+  key** — the group prompt discloses this up front so accepting the group is
+  never a surprise key cost (issue #1135). When accepted, the skill builds the
+  graph (`graphify extract .`, or `graphify update .` when a graph already
+  exists); when graphify is absent, consuming agents fall back to
+  `Read`/`Grep`/`Glob`.
 - Build a graph with `graphify extract .` (or the full `/graphify` pipeline),
   which writes `graphify-out/graph.json` (gitignored) plus
   `graphify-out/GRAPH_REPORT.md` and an HTML visualization.

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -183,6 +183,21 @@ offered as **one all-or-none group** rather than three separate prompts, so
 the operator makes a single decision and the agents get a consistent,
 predictable set of lookup capabilities (see issue #1108).
 
+Accepting the group both **installs and builds** every missing tool's index in
+this same run — it is not a "print instructions and leave it to the user" step
+(issues #1134, #1135):
+
+- **CodeGraph and Repowise are keyless** — they build a purely structural
+  index with **no model/API key** and are safe to build unattended. CodeGraph
+  installs its CLI (`npm install -g @colbymchenry/codegraph`) and runs
+  `codegraph init .`; Repowise installs and runs a `--index-only` index.
+- **Graphify additionally requires a model/API key** to build its graph — its
+  extraction is LLM-driven, heavier, and produces a different kind of graph.
+  Because all three are offered as one all-or-none group, the group prompt
+  **must disclose Graphify's key requirement up front** so accepting is never a
+  surprise key cost. When Graphify is absent the agents that use it fall back
+  gracefully (see `knowledge/codegraph-vs-graphify.md`).
+
 **Detect which are already present** (so re-runs are idempotent and the group
 scopes to the *missing* set):
 
@@ -212,11 +227,19 @@ already present nor previously declined.
   Install the code-lookup tools <missing list> to enable faster, verified
   code navigation for the review and analysis agents? [Y/n]
     - CodeGraph  — personal, user-level MCP; nothing committed to the repo.
+                   Keyless: `npm install -g @colbymchenry/codegraph` + `codegraph init .`.
     - Repowise   — local keyless index under .repowise/ (gitignored); MCP server.
+                   Keyless: `--index-only`, no API key requested.
     - Graphify   — repo-level: writes a `## graphify` section into this repo's
                    CLAUDE.md and installs git hooks (guarded against the known
                    over-delete bug — see the Graphify sub-section).
+                   REQUIRES a model/API key to build its graph — heavier than
+                   the keyless indexes above; declining the group skips this cost.
   ```
+
+  The prompt copy above must always disclose Graphify's model/API-key
+  requirement (issue #1135) — CodeGraph and Repowise are keyless, Graphify is
+  not, and the operator is accepting all three as one decision.
 
 - On **yes**: install **every** tool in the missing set by running its
   sub-section below (CodeGraph, Repowise, Graphify), recording each tool's
@@ -272,10 +295,22 @@ filesystem/PATH check supersedes the recorded preference.
   `CodeGraph: previously declined install (remove the codegraph key from .claude/init-state.json to re-prompt)`
   and continue.
 - Otherwise prompt: `Install CodeGraph for code intelligence? (y/N)`
-  - On `y`/`Y`: print
-    `CodeGraph install instructions: https://github.com/colbymchenry/codegraph#installation`.
-    Merge `{"codegraph": {"install_accepted": true}}` into
-    `.claude/init-state.json`.
+  - On `y`/`Y`: install the CodeGraph CLI (machine-level, keyless — nothing is
+    committed to the repo):
+
+    ```bash
+    npm install -g @colbymchenry/codegraph
+    ```
+
+    - On success: merge `{"codegraph": {"install_accepted": true}}` into
+      `.claude/init-state.json` and **fall through to the init step below**
+      (`codegraph init .`) so the index is built in this same run — this is
+      what issue #1134 requires (install *and* build, not just instructions).
+    - **Non-fatal on failure** (npm missing, or the install errors): print
+      `CodeGraph install failed — install it manually: https://github.com/colbymchenry/codegraph#installation`,
+      merge `{"codegraph": {"install_failed": true}}`, and continue. Per the
+      group's partial-failure rule, report the tool as failed rather than
+      aborting the rest of setup.
   - On any other response (including empty): merge
     `{"codegraph": {"install_declined": true}}` and continue silently.
 
@@ -287,9 +322,10 @@ filesystem/PATH check supersedes the recorded preference.
 - Otherwise prompt:
   `CodeGraph is installed but not initialized in this project. Initialize now? (y/N)`
   - On `y`/`Y`:
-    1. Print: `Running 'codegraph init -i' in this project...`
-    2. Execute `codegraph init -i` with the current working directory as
-       cwd. Surface its stdout/stderr to the user.
+    1. Print: `Running 'codegraph init .' in this project...`
+    2. Execute `codegraph init .` — **non-interactive** (no `-i`; issue #1134),
+       targeting the current working directory. Surface its stdout/stderr to
+       the user.
     3. On exit 0: print `CodeGraph: initialized ✓`, merge
        `{"codegraph": {"init_accepted": true}}` into
        `.claude/init-state.json`, then register the MCP server (below).
@@ -406,6 +442,31 @@ over-delete, taking unrelated pre-existing content with it. Guard every run:
    repo already carries).
 5. **On no corruption detected:** leave the installer's output as-is —
    nothing further to do.
+
+**Build the graph (requires a model/API key — issue #1135).** Unlike the
+keyless CodeGraph/Repowise indexes, graphify's extraction is LLM-driven and
+needs a model/API key — this is the cost the group prompt discloses.
+
+- **Idempotent:** if `graphify-out/graph.json` already exists, skip extraction
+  and offer the incremental, no-key refresh instead:
+
+  ```bash
+  graphify update .
+  ```
+
+- **Otherwise build it:**
+
+  ```bash
+  graphify extract .
+  ```
+
+  This writes `graphify-out/graph.json` (gitignored) plus `GRAPH_REPORT.md`.
+- **Non-fatal:** if extraction fails (e.g. no model/API key is configured),
+  print the error, merge `{"graphify": {"build_failed": true}}` into
+  `.claude/init-state.json`, and continue — never abort the rest of setup, and
+  never claim the group fully installed (the partial-failure rule). Agents that
+  consume graphify fall back to `Read`/`Grep`/`Glob` when `graphify-out/` is
+  absent (see `knowledge/codegraph-vs-graphify.md`).
 
 **Gitignore advice.** `graphify hook install` creates machine-specific
 generated git hooks. Tell the user to gitignore them the same way this

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -633,6 +633,14 @@ Display a summary of everything installed and created:
 - ⚠ Vitest coverage provider missing — <provider_hint>   [not ready]
 - ⚠ coverage scope unset — baseline will be inflated (<scope_hint>)   [not meaningful]
 
+### Code-intelligence indexes (project-init Step 4c — all-or-none group)
+- CodeGraph: ✓ installed + `.codegraph/` built (keyless)   [or: ✗ declined | ✗ failed]
+- Repowise:  ✓ installed + `.repowise/` indexed (keyless)   [or: ✗ declined | ✗ failed]
+- Graphify:  ✓ `graphify-out/` built (required a model/API key)   [or: ✗ declined | ✗ failed]
+
+The separate "run index-codebase first" step is no longer required — accepting
+the group installs and builds all three indexes in the same run.
+
 ### Created
 - `.claude/project-stack.json` — stack detection results
 - `.claude/CLAUDE.md` — project conventions

--- a/tests/skills/test_project_init_code_lookup_group.py
+++ b/tests/skills/test_project_init_code_lookup_group.py
@@ -1,6 +1,14 @@
 """#1108 — /project-init Step 4c offers the three code-lookup tools as one
 all-or-none group and installs Repowise (keyless, gitignored, MCP-registered).
 
+#1134 — accepting the group installs *and builds* the keyless CodeGraph and
+Repowise indexes in the same run (CodeGraph via `npm install -g
+@colbymchenry/codegraph` + non-interactive `codegraph init .`).
+
+#1135 — the group stays all-or-none, but the prompt must disclose that Graphify
+(unlike the keyless indexes) requires a model/API key, and Graphify's graph
+build is idempotent (`graphify update .` when a graph exists) and non-fatal.
+
 Content-guard sensor over the shipped project-init SKILL.md prose — a pure text
 grep, no state-mutating operations.
 """
@@ -82,3 +90,45 @@ def test_repowise_registers_mcp_and_flags_server_name_coupling():
 def test_repowise_has_detection_probe():
     text = _text()
     assert "command -v repowise" in text
+
+
+# --- #1134: CodeGraph + Repowise install AND build keyless indexes -----------
+
+
+def test_codegraph_installs_keyless_package():
+    # Accepting the group installs the CLI, not just prints instructions.
+    assert "npm install -g @colbymchenry/codegraph" in _text()
+
+
+def test_codegraph_builds_index_non_interactively():
+    text = _text()
+    assert "codegraph init ." in text
+    assert "codegraph init -i" not in text  # no interactive flag (#1134)
+
+
+def test_group_states_codegraph_repowise_are_keyless():
+    text = _text()
+    # Both keyless tools must be labeled as needing no API key.
+    assert "keyless" in text.lower()
+
+
+# --- #1135: Graphify's model/API-key requirement is disclosed ----------------
+
+
+def test_group_prompt_discloses_graphify_key_requirement():
+    text = _text()
+    # The all-or-none prompt must warn that Graphify needs a model/API key.
+    assert "REQUIRES a model/API key" in text
+
+
+def test_graphify_build_is_idempotent_with_update_fallback():
+    text = _text()
+    assert "graphify extract ." in text  # fresh build
+    assert "graphify update ." in text  # incremental refresh when graph exists
+    assert "graphify-out/graph.json" in text  # idempotency probe
+
+
+def test_graphify_build_is_non_fatal():
+    text = _text()
+    # Extraction failure (e.g. no key) is reported, not aborting setup.
+    assert "build_failed" in text

--- a/tests/skills/test_project_init_codegraph.py
+++ b/tests/skills/test_project_init_codegraph.py
@@ -49,7 +49,13 @@ def test_install_prompt_text_present(text: str) -> None:
 
 
 def test_install_accept_url_present(text: str) -> None:
+    # Kept as the non-fatal manual-install hint when npm install fails.
     assert "https://github.com/colbymchenry/codegraph#installation" in text
+
+
+def test_install_runs_npm_package(text: str) -> None:
+    # #1134: accepting installs the CLI keylessly rather than only printing a URL.
+    assert "npm install -g @colbymchenry/codegraph" in text
 
 
 # ---------------------------------------------------------------------------
@@ -65,11 +71,17 @@ def test_init_prompt_text_present(text: str) -> None:
 
 
 def test_init_run_command_documented(text: str) -> None:
-    assert "codegraph init -i" in text
+    # #1134: non-interactive init targeting the repo dir (no -i flag).
+    assert "codegraph init ." in text
+
+
+def test_init_run_command_is_non_interactive(text: str) -> None:
+    # The interactive `-i` form must not reappear anywhere in the spec.
+    assert "codegraph init -i" not in text
 
 
 def test_init_run_announcement_present(text: str) -> None:
-    assert "Running 'codegraph init -i' in this project..." in text
+    assert "Running 'codegraph init .' in this project..." in text
 
 
 def test_init_success_message_present(text: str) -> None:


### PR DESCRIPTION
## What

Folds the `index-codebase` behavior into the setup workflow's tool-install path and makes Graphify's cost explicit — implementing #1134 and #1135 as **one all-or-none group** (per operator direction: keep it all-or-none, don't split Graphify out).

`/project-init` Step 4c (the CodeGraph + Repowise + Graphify all-or-none group) now:

- **#1134 — installs *and builds* the keyless indexes in the same run**, not just prints instructions:
  - CodeGraph: `npm install -g @colbymchenry/codegraph` then `codegraph init .` (non-interactive, no `-i`). Non-fatal on failure (falls back to the manual-install URL hint).
  - Repowise: keyless `--index-only` (unchanged).
- **#1135 — the group prompt discloses Graphify's model/API-key requirement** up front so accepting is never a surprise key cost; Graphify's build is idempotent (`graphify update .` when `graphify-out/graph.json` exists) and non-fatal, and consuming agents fall back to Read/Grep/Glob when it's absent.

The separate "run `index-codebase` first" step is no longer required — accepting the group builds `.codegraph/`, `.repowise/`, and `graphify-out/` in one run.

## Also

- Setup report (Step 12) now surfaces the three indexes' build state.
- `knowledge/codegraph-vs-graphify.md` updated to match (keyless CodeGraph install/init, Graphify key requirement).
- Content-guard tests updated to the new contract (`test_project_init_codegraph.py`, `test_project_init_code_lookup_group.py`).

## Testing

`tests/skills tests/repo tests/knowledge tests/docs` — 1433 passed. `check_md_references.py` clean.

Closes #1134
Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)