### PR TITLE
fix(setup): write stryker.config.mjs directly instead of interactive init

### DIFF
--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -322,14 +322,40 @@ test -f stryker.config.js -o -f stryker.config.mjs -o -f stryker.config.ts \
   -o -f stryker.config.cjs -o -f .strykerrc.json && echo "config exists" || echo "no config"
 ```
 
-If no config exists, run:
+If no config exists, **write `stryker.config.mjs` directly** — do not run
+`npx stryker init`, which is interactive (it prompts for the test runner,
+reporters, and package manager) and hangs a non-interactive `/setup` run.
+You already detected the test runner above, so emit the config with
+`testRunner` set to that runner. Write the file with this shape, substituting
+the detected runner (`vitest` / `jest` / `mocha` / `jasmine`; use `vitest`
+when none was detected):
 
-```bash
-npx stryker init
+```js
+// stryker.config.mjs
+export default {
+  packageManager: "npm",
+  testRunner: "jest", // <- the runner detected above
+  coverageAnalysis: "perTest",
+  reporters: ["html", "clear-text", "progress"],
+  mutate: ["src/**/*.{js,ts}", "!src/**/*.{test,spec}.{js,ts}"],
+};
 ```
 
-This generates a `stryker.config.mjs` interactively. Tell the user it will ask
-a few questions; they should accept defaults unless they have a specific setup.
+Runner-specific notes when substituting `testRunner`:
+
+- **jest** — add a `jest` block so Stryker finds the project config, e.g.
+  `jest: { projectType: "custom", configFile: "jest.config.js" }` (point
+  `configFile` at the repo's actual Jest config). Angular repos also want
+  `"!src/**/*.module.ts"` appended to `mutate`.
+- **vitest / mocha / jasmine** — no extra runner block is required; the
+  `testRunner` value alone wires up the installed runner plugin.
+
+Keep `mutate` scoped to the repo's real source layout — adjust the globs if
+sources live somewhere other than `src/`.
+
+> If you'd rather configure interactively, `npx stryker init` walks through
+> the same choices with prompts — but only run it in an interactive shell, not
+> as part of an automated `/setup`.
 
 **Verify:**
 


### PR DESCRIPTION
## Problem

`/setup` Step 6 (JS/TS — Stryker) instructed operators to run `npx stryker init`, which is **interactive** — it prompts for the test runner, reporters, and package manager. In a non-interactive/agent `/setup` run the command hangs on stdin, with no documented non-interactive path (surfaced on a real Angular 21 + Jest run).

## Fix

Step 6 now **writes `stryker.config.mjs` directly**, parameterized by the test runner the step already detects (vitest/jest/mocha/jasmine; defaults to vitest when none detected). Includes a concrete config template plus runner-specific notes (the jest `configFile` block and the Angular `!src/**/*.module.ts` exclude generalized from the issue example). `npx stryker init` is kept only as an optional "if you'd rather configure interactively" note.

## Testing

- `python3 scripts/check_md_references.py` — clean
- `python3 -m pytest tests/skills tests/repo tests/docs -q` — 1369 passed
- `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — no changes

This PR touches a skill, so it requires human merge (no auto-merge armed).

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)