### PR TITLE
fix(setup): add --legacy-peer-deps fallback for npm install ERESOLVE

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4605,7 +4605,7 @@
       "anchor": "scaffold-step-2-initialize-packagejson"
     },
     "Scaffold step 3: Install dependencies": {
-      "summary": "`eslint-config-prettier` disables ESLint rules that conflict with Prettier.",
+      "summary": "If this (or the Playwright install below) fails with `npm error code",
       "anchor": "scaffold-step-3-install-dependencies"
     },
     "Scaffold step 4: Create config files": {

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -117,6 +117,11 @@ pipx install, never `npm install -g`.
   npm install --save-dev oxlint
   ```
 
+  If this fails with `npm error code ERESOLVE`, the peer conflict is
+  pre-existing in the repo's tree (not with `oxlint`) — retry once with
+  `--legacy-peer-deps` and note to the user that you did so, rather than
+  aborting.
+
 - **Python** — add `ruff` and `mypy` — plus `pytest` if no test runner is
   present — to the project's own dev-dependency mechanism: the
   `pyproject.toml` dev group or `requirements-dev.txt`, whichever the
@@ -171,7 +176,12 @@ docker scanners, so they install via the OS package manager (or pipx / user
 pip on Linux). **Playwright is the repo-level exception among capability
 tools**: it installs as an `npm` devDependency (`@playwright/test`), versioned
 with the project like a lane tool — only its Chromium download is machine-level.
-State this explicitly to the user when the capability group installs.
+State this explicitly to the user when the capability group installs. If the
+Playwright `npm` install fails with `npm error code ERESOLVE`, the peer
+conflict is pre-existing in the repo's tree (`@playwright/test` has no
+framework peer relationship) — retry that install once with
+`--legacy-peer-deps` and note to the user that you did so, rather than
+aborting.
 
 ### Step 4c: Offer the three code-lookup tools (all-or-none)
 
@@ -605,6 +615,11 @@ Frontend projects also add: `"test:e2e": "playwright test"`.
 ```bash
 npm install -D eslint prettier vitest @eslint/js eslint-config-prettier husky lint-staged oxlint
 ```
+
+If this (or the Playwright install below) fails with `npm error code
+ERESOLVE`, the peer conflict is pre-existing in the repo's tree, not with the
+tooling being added — retry the failing command once with `--legacy-peer-deps`
+and note to the user that you did so, rather than aborting.
 
 `eslint-config-prettier` disables ESLint rules that conflict with Prettier. Do NOT install `eslint-plugin-prettier` — run Prettier as a separate step (`npm run format:check`), not through ESLint.
 

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -315,6 +315,14 @@ Install the appropriate runner plugin:
 | jasmine | `npm install --save-dev @stryker-mutator/jasmine-runner` |
 | none detected | Install vitest runner as default: `npm install --save-dev @stryker-mutator/vitest-runner` and note to the user they may need to swap this for their runner |
 
+**If any Stryker install above fails with `npm error code ERESOLVE`**, the
+conflict is a peer-dependency clash already present in the repo's tree — not
+between it and `@stryker-mutator/*`, which carries no such peer relationship.
+Retry that command once with `--legacy-peer-deps` (e.g. `npm install
+--save-dev @stryker-mutator/core --legacy-peer-deps`), and add a one-line note
+to the user that you fell back to `--legacy-peer-deps` because of a
+pre-existing peer conflict. Don't abort on the first ERESOLVE.
+
 **Initialize Stryker config if not already present:**
 
 ```bash


### PR DESCRIPTION
## Problem

The `npm install --save-dev <pkg>` commands in `skills/setup/SKILL.md` (Step 6 — Stryker) and `skills/project-init/SKILL.md` (Step 4b — Playwright, JS/TS lane, and the greenfield scaffold) had no handling for an `ERESOLVE` peer-dependency conflict. In repos carrying a pre-existing peer conflict (unrelated to the tool being added), these installs failed outright with no fallback and the skill would simply stop.

## Fix

Wherever a tool-installing `npm install` appears in those two skills, add guidance: on an `npm error code ERESOLVE` failure, retry that command once with `--legacy-peer-deps` (the conflict is in the repo's existing tree, not the tool being added — Stryker/Playwright/oxlint carry no such peer relationship) and surface a one-line note that it did so, rather than aborting. Edits are localized to the install lines and match the surrounding markdown idiom.

Covered:
- setup Step 6 — Stryker core + runner-plugin installs
- project-init Step 4 — JS/TS lane (`oxlint`)
- project-init Step 4b — Playwright capability install
- project-init greenfield scaffold — JS/TS devDependency + Playwright installs

Knowledge index rebuilt (`build_knowledge_index.py`); `check_md_references.py` clean; `pytest tests/skills tests/repo tests/docs` green (1364 passed, 5 pre-existing env-gated skips).

## Overlapping PRs

#1140 also edits `setup/SKILL.md` Step 6 and #1141 edits `project-init/SKILL.md` Step 4c — both touch lines near these edits. This PR keeps its changes localized to the `npm install` lines to minimize textual conflicts, but may need a rebase depending on merge order.

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
