### PR TITLE
fix(project-init): decouple keyless code-lookup pair from key-gated Graphify in Step 4c

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4580,9 +4580,9 @@
       "summary": "Beyond the four static-analysis lanes, other skills and agents depend on a",
       "anchor": "step-4b-install-capability-tools"
     },
-    "Step 4c: Offer the three code-lookup tools (all-or-none)": {
+    "Step 4c: Offer the code-lookup tools (keyless group + key-gated Graphify)": {
       "summary": "Three optional, complementary code-intelligence tools — **CodeGraph**,",
-      "anchor": "step-4c-offer-the-three-code-lookup-tools-all-or-none"
+      "anchor": "step-4c-offer-the-code-lookup-tools-keyless-group-key-gated-graphify"
     },
     "Step 5: Verify — post-install probes": {
       "summary": "Run each configured lane's detection probe exactly as the lane registry",

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -173,32 +173,38 @@ tools**: it installs as an `npm` devDependency (`@playwright/test`), versioned
 with the project like a lane tool — only its Chromium download is machine-level.
 State this explicitly to the user when the capability group installs.
 
-### Step 4c: Offer the three code-lookup tools (all-or-none)
+### Step 4c: Offer the code-lookup tools (keyless group + key-gated Graphify)
 
 Three optional, complementary code-intelligence tools — **CodeGraph**,
 **Repowise**, and **Graphify** — let the review and analysis agents read
 verified skeletons, resolved call graphs, modification risk, and decision
-rationale instead of re-reading whole files. None is required. They are
-offered as **one all-or-none group** rather than three separate prompts, so
-the operator makes a single decision and the agents get a consistent,
-predictable set of lookup capabilities (see issue #1108).
+rationale instead of re-reading whole files. None is required.
 
-Accepting the group both **installs and builds** every missing tool's index in
-this same run — it is not a "print instructions and leave it to the user" step
-(issues #1134, #1135):
+They are offered by **cost profile**, so the operator never has to accept a
+model/API-key cost to get the keyless tools (issue #1141, which relaxes the
+single all-or-none group of #1108):
 
-- **CodeGraph and Repowise are keyless** — they build a purely structural
-  index with **no model/API key** and are safe to build unattended. CodeGraph
-  installs its CLI (`npm install -g @colbymchenry/codegraph`) and runs
-  `codegraph init .`; Repowise installs and runs a `--index-only` index.
-- **Graphify additionally requires a model/API key** to build its graph — its
-  extraction is LLM-driven, heavier, and produces a different kind of graph.
-  Because all three are offered as one all-or-none group, the group prompt
-  **must disclose Graphify's key requirement up front** so accepting is never a
-  surprise key cost. When Graphify is absent the agents that use it fall back
+- **Keyless pair — CodeGraph + Repowise.** Both build a purely structural
+  index with **no model/API key** and are safe to build unattended. They are
+  offered as **one all-or-none group** — a single decision that gives the
+  agents a consistent, predictable lookup set (issue #1108). Accepting the
+  group both **installs and builds** every missing tool's index in this same
+  run — it is not a "print instructions and leave it to the user" step (issues
+  #1134, #1135). CodeGraph installs its CLI (`npm install -g
+  @colbymchenry/codegraph`) and runs `codegraph init .`; Repowise installs and
+  runs a `--index-only` index.
+- **Graphify — separate, key-gated opt-in.** Graphify's extraction is
+  **LLM-driven and REQUIRES a model/API key**; its graph is heavier and its
+  integration is repo-level (a `## graphify` CLAUDE.md section + git hooks —
+  see the sub-section below). It is offered as **its own prompt, after the
+  keyless pair, and only when a model/API key is actually present**. With no
+  key, `graphify extract .` is a guaranteed failure that would leave an **inert
+  repo-level integration** behind (issue #1141) — so Graphify is skipped
+  entirely, its native integration is never written, and the skip is noted in
+  the summary. When Graphify is absent the agents that use it fall back
   gracefully (see `knowledge/codegraph-vs-graphify.md`).
 
-**Detect which are already present** (so re-runs are idempotent and the group
+**Detect which are already present** (so re-runs are idempotent and each offer
 scopes to the *missing* set):
 
 - CodeGraph — `command -v codegraph` succeeds **and** `.codegraph/` exists.
@@ -211,17 +217,16 @@ the "missing" set rather than silently re-offered, and the existing unstick
 instruction still applies (`remove the <tool> key from .claude/init-state.json
 to re-prompt`).
 
-**The group prompt.** Compute the *missing* set = tools that are neither
-already present nor previously declined.
+**The keyless group prompt.** Compute the *missing* set = the keyless tools
+(CodeGraph, Repowise) that are neither already present nor previously declined.
 
 - If the missing set is **empty**: print
-  `Code-lookup tools: all present (or previously declined) — nothing to install.`
+  `Code-lookup tools: keyless pair present (or previously declined) — nothing to install.`
   and continue. No prompt.
 - Otherwise, first show the user the "When to use which" section of
   `${CLAUDE_PLUGIN_ROOT}/knowledge/codegraph-vs-graphify.md`, then prompt
-  **once**, listing the missing tools by name and disclosing Graphify's repo
-  footprint (this is an explicit `y`/`n`, and the recommended default is
-  **yes** when anything is missing):
+  **once**, listing the missing tools by name (this is an explicit `y`/`n`, and
+  the recommended default is **yes** when anything is missing):
 
   ```
   Install the code-lookup tools <missing list> to enable faster, verified
@@ -230,31 +235,59 @@ already present nor previously declined.
                    Keyless: `npm install -g @colbymchenry/codegraph` + `codegraph init .`.
     - Repowise   — local keyless index under .repowise/ (gitignored); MCP server.
                    Keyless: `--index-only`, no API key requested.
-    - Graphify   — repo-level: writes a `## graphify` section into this repo's
-                   CLAUDE.md and installs git hooks (guarded against the known
-                   over-delete bug — see the Graphify sub-section).
-                   REQUIRES a model/API key to build its graph — heavier than
-                   the keyless indexes above; declining the group skips this cost.
   ```
 
-  The prompt copy above must always disclose Graphify's model/API-key
-  requirement (issue #1135) — CodeGraph and Repowise are keyless, Graphify is
-  not, and the operator is accepting all three as one decision.
-
 - On **yes**: install **every** tool in the missing set by running its
-  sub-section below (CodeGraph, Repowise, Graphify), recording each tool's
-  accept in `.claude/init-state.json`.
+  sub-section below (CodeGraph, Repowise), recording each tool's accept in
+  `.claude/init-state.json`.
   - **Partial failure is surfaced, never hidden.** If one tool's install
     errors after another already succeeded, print the failing tool's error,
     record per-tool success/failure in `.claude/init-state.json`, and report
-    the group as *partially installed* — do not claim all three succeeded.
+    the group as *partially installed* — do not claim both succeeded.
 - On **no** (or empty): install nothing, record the group decline for each
   missing tool in `.claude/init-state.json`, and print a terminal-visible
   confirmation so the operator knows the choice was durable and reversible:
   `Code-lookup tools: skipped — agents fall back to Read/Grep/Glob (re-run /project-init to be offered again).`
 
-The per-tool mechanics below are unchanged; the all-or-none group only decides
-*whether* they run. Each remains user-scoped/gitignored exactly as before.
+**The Graphify opt-in (key-gated).** After the keyless pair, offer Graphify
+**only** when it is in the missing set *and* a model/API key is present:
+
+1. **Skip if already present or previously declined** — same missing-set rule
+   as above.
+2. **Detect a model/API key.** Check the environment for any provider key
+   Graphify's extraction accepts — `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`,
+   `MOONSHOT_API_KEY`, `OPENAI_API_KEY` (among the set graphify's own error
+   lists). If **none** is set:
+   - Do **not** prompt for Graphify and do **not** run its sub-section — with
+     no key its build is a guaranteed failure and its repo-level native
+     integration would be left inert (issue #1141).
+   - Merge `{"graphify": {"install_skipped_no_key": true}}` into
+     `.claude/init-state.json` and print a terminal-visible confirmation:
+     `Graphify: skipped — no model/API key detected, and its graph build REQUIRES a model/API key. Set a provider key (e.g. ANTHROPIC_API_KEY) and re-run /project-init to be offered it.`
+3. **If a key IS present**, prompt **once** (recommended default **no**,
+   because — unlike the keyless pair — Graphify writes to this repo):
+
+   ```
+   A model/API key was detected. Also install Graphify for
+   architecture/onboarding-level code intelligence? (y/N)
+     - Graphify — repo-level: writes a `## graphify` section into this repo's
+                  CLAUDE.md and installs git hooks (guarded against the known
+                  over-delete bug — see the Graphify sub-section).
+                  REQUIRES a model/API key to build its graph (detected) —
+                  heavier than the keyless indexes above.
+   ```
+
+   - On **yes**: run the Graphify sub-section below (install, guarded native
+     integration, key-driven build), recording the accept in
+     `.claude/init-state.json`. Its build stays non-fatal (partial-failure
+     rule) if the detected key is later rejected at build time.
+   - On any other response: install nothing and record
+     `{"graphify": {"install_declined": true}}`.
+
+The per-tool mechanics below are unchanged; Step 4c only decides *whether* each
+runs. Each remains user-scoped/gitignored exactly as before, except Graphify's
+documented repo-level native integration — which is now written only on the
+key-gated accept.
 
 #### CodeGraph — strictly personal, never committed
 
@@ -399,8 +432,10 @@ Graphify (`graphifyy` on PyPI) is a multi-modal knowledge graph tool
 skill, PreToolUse nudge hooks into `.claude/settings.json`, and a
 `## graphify` section into the project's own `CLAUDE.md`.
 
-Prompt: `Install graphify for architecture/onboarding-level code intelligence? (y/N)`
-On any response other than `y`/`Y`, skip silently.
+This sub-section runs **only after the key-gated Graphify opt-in in Step 4c
+accepts** — that is, a model/API key was detected *and* the user said yes.
+Because its build needs that key, and its integration is repo-level, it is
+never run (and none of the file writes below happen) when no key is present.
 
 **Install (fallback chain):**
 
@@ -523,11 +558,14 @@ After every configured lane probes green, give the user:
 - **Capability tools** (Step 4b): which were offered, which were installed,
   and which were skipped (signal didn't fire, or the user declined) — noting
   Playwright is repo-level and the rest are user/system-level CLIs.
-- **Graph tools** (Step 4c): CodeGraph state (installed/initialized, MCP
-  registration command printed or skipped) and graphify state (installed,
-  native integration applied, whether the CLAUDE.md corruption guard fired
-  and repaired anything) — noting CodeGraph is strictly user-level/personal
-  and graphify is the repo-level native integration.
+- **Graph tools** (Step 4c): the keyless pair — CodeGraph state
+  (installed/initialized, MCP registration command printed or skipped) and
+  Repowise state — plus Graphify state: installed with native integration
+  applied (and whether the CLAUDE.md corruption guard fired and repaired
+  anything), **or skipped because no model/API key was detected** (its
+  repo-level integration was not written), or declined. Note CodeGraph is
+  strictly user-level/personal and Graphify is the repo-level native
+  integration offered only when a key is present.
 - Files created (greenfield only).
 
 ## Greenfield JS/TS scaffold

--- a/tests/skills/test_project_init_code_lookup_group.py
+++ b/tests/skills/test_project_init_code_lookup_group.py
@@ -1,13 +1,20 @@
-"""#1108 — /project-init Step 4c offers the three code-lookup tools as one
+"""#1108 — /project-init Step 4c offers the keyless code-lookup tools as one
 all-or-none group and installs Repowise (keyless, gitignored, MCP-registered).
 
 #1134 — accepting the group installs *and builds* the keyless CodeGraph and
 Repowise indexes in the same run (CodeGraph via `npm install -g
 @colbymchenry/codegraph` + non-interactive `codegraph init .`).
 
-#1135 — the group stays all-or-none, but the prompt must disclose that Graphify
-(unlike the keyless indexes) requires a model/API key, and Graphify's graph
-build is idempotent (`graphify update .` when a graph exists) and non-fatal.
+#1135 — the prompt must disclose that Graphify (unlike the keyless indexes)
+requires a model/API key, and Graphify's graph build is idempotent
+(`graphify update .` when a graph exists) and non-fatal.
+
+#1141 — the single all-or-none group is split by cost profile. The keyless
+pair (CodeGraph + Repowise) stays all-or-none and can be accepted *alone*.
+Graphify is a separate, key-gated opt-in: it is offered only when a model/API
+key is detected, and when no key is present it is skipped entirely — its
+repo-level native integration is never written, so the repo is not left
+carrying an inert integration.
 
 Content-guard sensor over the shipped project-init SKILL.md prose — a pure text
 grep, no state-mutating operations.
@@ -25,13 +32,15 @@ def _text() -> str:
     return SKILL.read_text(encoding="utf-8")
 
 
-# --- All-or-none group -------------------------------------------------------
+# --- All-or-none keyless group -----------------------------------------------
 
 
-def test_step_4c_is_all_or_none_group():
+def test_step_4c_keyless_pair_is_all_or_none_group():
     text = _text()
     assert "all-or-none" in text
     assert "CodeGraph" in text and "Repowise" in text and "Graphify" in text
+    # #1141: the all-or-none framing now spans only the keyless pair.
+    assert "Keyless pair" in text
 
 
 def test_group_recommends_yes_when_missing():
@@ -132,3 +141,45 @@ def test_graphify_build_is_non_fatal():
     text = _text()
     # Extraction failure (e.g. no key) is reported, not aborting setup.
     assert "build_failed" in text
+
+
+# --- #1141: keyless pair decoupled from key-gated Graphify -------------------
+
+
+def test_keyless_group_prompt_omits_graphify():
+    text = _text()
+    # The keyless group prompt lists only CodeGraph + Repowise, so the pair can
+    # be accepted alone without triggering Graphify's key-required build.
+    prompt = text.split("**The keyless group prompt.**", 1)[1].split(
+        "**The Graphify opt-in", 1
+    )[0]
+    assert "CodeGraph" in prompt and "Repowise" in prompt
+    assert "Graphify" not in prompt
+
+
+def test_graphify_is_separate_key_gated_optin():
+    text = _text()
+    assert "key-gated" in text
+    assert "only when a model/API key is actually present" in text
+
+
+def test_graphify_optin_detects_provider_keys():
+    text = _text()
+    # Detection checks for the provider keys graphify's own error lists.
+    assert "ANTHROPIC_API_KEY" in text
+    assert "GOOGLE_API_KEY" in text
+
+
+def test_graphify_skipped_when_no_key_and_integration_not_written():
+    text = _text()
+    # No key => Graphify is skipped and its repo-level integration is NOT written.
+    assert "install_skipped_no_key" in text
+    assert "guaranteed failure" in text
+    assert "inert" in text
+
+
+def test_graphify_native_integration_gated_on_key_present():
+    text = _text()
+    # The Graphify sub-section documents that its file writes only happen on the
+    # key-gated accept.
+    assert "only after the key-gated Graphify opt-in" in text


### PR DESCRIPTION
## Problem

`project-init` Step 4c offered the three code-lookup tools — CodeGraph, Repowise, Graphify — as a single **all-or-none** group. But the tools have different cost profiles: CodeGraph and Repowise are keyless, while **Graphify's graph build requires a model/API key**. With no key configured, accepting the group triggered a guaranteed Graphify build failure, yet its repo-level native integration (`## graphify` CLAUDE.md section + git hooks) was still written — leaving an **inert integration** behind. There was no way to accept just the keyless pair.

## Fix (issue options 1 + 2)

Split Step 4c by cost profile:

- **Keyless pair (CodeGraph + Repowise)** — stays one all-or-none group, and can now be accepted **alone**. Prompt lists only these two.
- **Graphify** — a separate, **key-gated opt-in** offered *after* the keyless pair, and **only when a provider key is detected** (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `MOONSHOT_API_KEY`, `OPENAI_API_KEY`, …). With no key, Graphify is skipped entirely, its native integration is **never written**, and the skip is recorded (`install_skipped_no_key`) and surfaced to the operator.

The Graphify sub-section now documents that its file writes run only on the key-gated accept. Step 6 summary updated to report the key-gated skip.

## Testing

- Updated the content-guard `tests/skills/test_project_init_code_lookup_group.py` to match the new intent (split framing, key detection, no-key skip, integration-not-written) — strengthened, not weakened.
- Rebuilt `knowledge/index.json`.
- `python3 scripts/check_md_references.py` clean; `python3 -m pytest tests/skills tests/repo tests/docs -q` → 1369 passed.

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)