### PR TITLE
fix(setup): stack-gate Step 6 mutation-tool install so wrong-stack probes can't fire

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5065,7 +5065,7 @@
       "anchor": "5-record-the-stack-signal-for-dev-teams-own-use"
     },
     "6. Install per-language mutation tooling": {
-      "summary": "Determine which of the language sections below to run from the stack signal",
+      "summary": "Mutation-tool installation is **strictly relative to the detected stack**.",
       "anchor": "6-install-per-language-mutation-tooling"
     },
     "7. Select agent templates": {

--- a/plugins/dev-team/scripts/mutation_stack_sections.py
+++ b/plugins/dev-team/scripts/mutation_stack_sections.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Select which /setup Step 6 mutation-tooling sections to run (#1152).
+
+`/setup` Step 6 installs per-language mutation tooling (Stryker for JS/TS,
+pitest for Java/Kotlin, Stryker.NET for C#/.NET). Which sections run must be
+strictly relative to the repo's detected stack — a JS-only or Python-only
+repo must never probe for `dotnet`, `mvn`, or `node` outside its own stack.
+
+This helper makes that decision deterministically instead of leaving it to
+prose the agent can skip. It reads `.claude/project-stack.json`'s `stacks`
+array once and maps stack tokens to sections:
+
+    typescript / node   -> js       (Stryker)
+    java / kotlin        -> java     (pitest)
+    csharp / dotnet      -> csharp   (Stryker.NET)
+
+Output is a single JSON object on stdout:
+
+    {
+      "sections": ["js"],        # sections to run, in canonical order
+      "stacks": ["typescript"],  # the stacks array that was read
+      "ambiguous": false,        # true ONLY when the stack signal is empty/missing
+      "note": null               # one-line note when a stack matched no section
+    }
+
+Three distinct outcomes:
+
+- Definite stack that maps to sections -> run ONLY those sections
+  (`ambiguous` false, `note` null).
+- Definite stack that maps to NO section (e.g. pure Python — no Python
+  mutation tool is wired in) -> `sections` empty, `ambiguous` false, `note`
+  set to `no mutation tooling for detected stack (<stacks>)`. Install
+  nothing; probe nothing.
+- Empty / missing / stacks-less signal -> `ambiguous` true. This is the ONLY
+  outcome that authorizes the interactive "which languages?" fallback.
+
+Usage:
+    mutation_stack_sections.py [PROJECT_DIR]
+    mutation_stack_sections.py --stacks typescript,node   # for testing
+
+PROJECT_DIR defaults to the current directory; the stack file is read from
+`<PROJECT_DIR>/.claude/project-stack.json`.
+
+Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Canonical section order — polyglot repos run matching sections in this order.
+SECTION_ORDER = ["js", "java", "csharp"]
+
+# Stack token (lowercased) -> section key.
+STACK_TO_SECTION: Dict[str, str] = {
+    "typescript": "js",
+    "node": "js",
+    "javascript": "js",
+    "java": "java",
+    "kotlin": "java",
+    "csharp": "csharp",
+    "dotnet": "csharp",
+}
+
+
+def select_sections(stacks: Optional[List[str]]) -> Dict[str, object]:
+    """Map a `stacks` array to the sections /setup Step 6 should run.
+
+    Returns a dict with `sections`, `stacks`, `ambiguous`, and `note`.
+
+    `stacks` None or empty -> ambiguous (the interactive fallback is allowed).
+    A non-empty `stacks` that maps to no section is NOT ambiguous — it is a
+    definite "no mutation tooling for this stack" outcome.
+    """
+    normalized = [str(s).strip().lower() for s in (stacks or []) if str(s).strip()]
+
+    if not normalized:
+        return {
+            "sections": [],
+            "stacks": normalized,
+            "ambiguous": True,
+            "note": None,
+        }
+
+    matched = {STACK_TO_SECTION[s] for s in normalized if s in STACK_TO_SECTION}
+    sections = [s for s in SECTION_ORDER if s in matched]
+
+    note = None
+    if not sections:
+        note = f"no mutation tooling for detected stack ({', '.join(normalized)})"
+
+    return {
+        "sections": sections,
+        "stacks": normalized,
+        "ambiguous": False,
+        "note": note,
+    }
+
+
+def read_stacks(project_dir: Path) -> Optional[List[str]]:
+    """Return the `stacks` array from `<project_dir>/.claude/project-stack.json`.
+
+    Returns None when the file is missing, unreadable, not valid JSON, or has
+    no `stacks` key — all of which collapse to the ambiguous outcome.
+    """
+    stack_file = project_dir / ".claude" / "project-stack.json"
+    try:
+        data = json.loads(stack_file.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    stacks = data.get("stacks")
+    if not isinstance(stacks, list):
+        return None
+    return stacks
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "project_dir",
+        nargs="?",
+        default=".",
+        help="Project directory (default: current directory).",
+    )
+    parser.add_argument(
+        "--stacks",
+        default=None,
+        help="Comma-separated stacks to use directly, bypassing the file (testing).",
+    )
+    args = parser.parse_args(argv[1:])
+
+    if args.stacks is not None:
+        stacks: Optional[List[str]] = [s for s in args.stacks.split(",") if s.strip()]
+    else:
+        stacks = read_stacks(Path(args.project_dir))
+
+    print(json.dumps(select_sections(stacks)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -220,15 +220,41 @@ Write findings to `.claude/project-stack.json`:
 
 ### 6. Install per-language mutation tooling
 
-Determine which of the language sections below to run from the stack signal
-just recorded in Step 5 (`.claude/project-stack.json`'s `stacks` array —
-`typescript`/`node` maps to the JS/TS section, `csharp`/`dotnet` maps to the
-C# section, `java`/`kotlin` maps to the Java section). Run every matching
-section; more than one may apply in a polyglot repo.
+Mutation-tool installation is **strictly relative to the detected stack**.
+Do not decide which language sections to run by hand — the mapping is a
+deterministic helper, so the wrong-stack probe (e.g. `dotnet` on a JS repo)
+cannot fire. Call it once:
 
-If the signal is empty or ambiguous (e.g. `--dry-run` scanning a repo with
-no recognizable stack, or a layout project-init's detection table doesn't
-cleanly classify), fall back to asking:
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mutation_stack_sections.py" .
+```
+
+It reads `.claude/project-stack.json`'s `stacks` array (recorded in Step 5)
+and prints one JSON object:
+
+```json
+{ "sections": ["js"], "stacks": ["typescript", "node"], "ambiguous": false, "note": null }
+```
+
+- `sections` — the sections to run, from `js` (JS/TS — Stryker), `java`
+  (Java/Kotlin — pitest), `csharp` (C#/.NET — Stryker.NET). The mapping is
+  `typescript`/`node`/`javascript` → `js`, `java`/`kotlin` → `java`,
+  `csharp`/`dotnet` → `csharp`. **Run every section in `sections` and no
+  others.** More than one may apply in a polyglot repo.
+- `ambiguous` — `true` **only** when the stack signal is genuinely empty or
+  missing (no `.claude/project-stack.json`, unreadable/invalid, or an empty
+  `stacks` array). This is the **only** outcome that authorizes the
+  interactive fallback below.
+- `note` — set when a definite stack matched no section (e.g. a pure-Python
+  repo — there is no Python mutation tool wired into this step). When `note`
+  is non-null, `sections` is empty and `ambiguous` is `false`: install
+  **nothing**, probe **nothing** (no `dotnet`, `node`, or `mvn`), print the
+  `note` line verbatim, and skip the rest of this step.
+
+**Interactive fallback — only when `ambiguous` is `true`.** When a definite
+stack was detected (`ambiguous` is `false`), never prompt; honor `sections`
+exactly. Only when `ambiguous` is `true` (e.g. `--dry-run` scanning a repo
+with no recognizable stack) fall back to asking:
 
 > "Which languages do you need mutation testing for? (Select all that apply)"
 >
@@ -238,14 +264,22 @@ cleanly classify), fall back to asking:
 > 4. **All of the above**
 > 5. **None — skip mutation tooling**
 
-Parse the response. If they choose 4, treat it as selecting 1, 2, and 3. If
-5 (or the signal maps to none of the above, e.g. a pure-Python repo — there
-is no Python mutation tool wired into this step), skip the rest of this
+Parse the response. If they choose 4, treat it as selecting 1, 2, and 3
+(i.e. `sections` = `["js", "java", "csharp"]`). If 5, skip the rest of this
 step.
+
+Each language subsection below **re-asserts its own gate as its literal
+first step** — a section whose key is not in `sections` returns immediately,
+before any `command -v` / tool probe. The guard is therefore robust even if
+a section is reached out of order.
 
 ---
 
 #### JS/TS — Stryker
+
+**Stack gate (first step — hard precondition):** if `js` is not in the
+Step 6 helper's `sections`, return immediately. Do **not** run the
+prerequisites probe below. Only proceed when `js` is in `sections`.
 
 **Prerequisites check:**
 
@@ -428,6 +462,10 @@ the final `ready`/`meaningful`/`patched` state for the Step 12 report.
 
 #### Java / Kotlin — pitest
 
+**Stack gate (first step — hard precondition):** if `java` is not in the
+Step 6 helper's `sections`, return immediately. Do **not** run the
+prerequisites probe below. Only proceed when `java` is in `sections`.
+
 **Prerequisites check:**
 
 ```bash
@@ -517,6 +555,11 @@ mvn pitest:mutationCoverage -DtimestampedReports=false -DoutputFormats=XML --hel
 ---
 
 #### C# / .NET — Stryker.NET
+
+**Stack gate (first step — hard precondition):** if `csharp` is not in the
+Step 6 helper's `sections`, return immediately. Do **not** run the
+prerequisites probe below (no `command -v dotnet`, no `dotnet tool list`).
+Only proceed when `csharp` is in `sections`.
 
 **Prerequisites check:**
 
@@ -657,7 +700,14 @@ Display a summary of everything installed and created:
 ### Prerequisites
 - jq:       ✓ <version>
 - python3:  ✓ <version>
-- Mutation testing (Stryker): ✓ <version>   [or: ✗ skipped | ✗ failed]
+- Mutation testing: ✓ <tool> <version>   [or: ✗ skipped | ✗ failed]
+
+Report a mutation-testing line **only for sections actually in scope** — the
+`sections` the Step 6 helper returned (Stryker for `js`, pitest for `java`,
+Stryker.NET for `csharp`). Never list a tool for a stack that was not
+detected. When the helper's `note` was set (a detected stack with no
+mutation tool wired in, e.g. pure Python), report that one line verbatim —
+`no mutation tooling for detected stack (<stacks>)` — and no tool line.
 
 ### Coverage baseline readiness (JS/TS only)
 - ✓ json-summary + coverage scope present   [ready + meaningful]

--- a/tests/skills/test_setup_mutation_stack_gate.py
+++ b/tests/skills/test_setup_mutation_stack_gate.py
@@ -1,0 +1,230 @@
+"""#1152 — /setup Step 6 mutation-tool install is strictly stack-gated.
+
+Two layers of contract:
+
+1. Behavioral — the `mutation_stack_sections.py` helper maps a repo's
+   `stacks` array to the sections /setup runs. A JS-only signal selects only
+   `js` (never a `dotnet` probe); a pure-Python/unrecognized signal selects
+   nothing and is NOT ambiguous (installs/probes nothing); a C#/.NET signal
+   selects `csharp`; polyglot selects each matching section; and only an
+   empty/missing signal is `ambiguous` (the sole path to the interactive
+   fallback).
+
+2. Doc-shape — the SKILL.md prose calls the helper, each language subsection
+   re-asserts its own gate as its literal first step, the interactive
+   fallback fires only when `ambiguous`, and the Step 12 summary reports only
+   in-scope tools.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from skill_doc_helpers import PLUGIN_ROOT, grep, section
+
+# --- import the helper under test -------------------------------------------
+
+_SCRIPT_DIR = PLUGIN_ROOT / "scripts"
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import mutation_stack_sections as mss  # type: ignore[import-not-found]  # noqa: E402
+
+_SCRIPT_PY = _SCRIPT_DIR / "mutation_stack_sections.py"
+SKILL = PLUGIN_ROOT / "skills" / "setup" / "SKILL.md"
+
+
+def _text() -> str:
+    return SKILL.read_text()
+
+
+# ---------------------------------------------------------------------------
+# select_sections() — the deterministic stack -> section mapping
+# ---------------------------------------------------------------------------
+
+
+def test_js_only_signal_runs_only_js_section() -> None:
+    """A JS-only stack selects the JS/TS section and emits no C#/.NET probe."""
+    result = mss.select_sections(["typescript", "node"])
+    assert result["sections"] == ["js"]
+    assert result["ambiguous"] is False
+    assert result["note"] is None
+    # The dotnet probe belongs to the csharp section — it must not be selected.
+    assert "csharp" not in result["sections"]
+    assert "java" not in result["sections"]
+
+
+def test_python_only_signal_installs_and_probes_nothing() -> None:
+    """A definite-but-unsupported stack (pure Python) selects nothing, is not
+    ambiguous, and carries the one-line note — so no fallback, no probes."""
+    result = mss.select_sections(["python"])
+    assert result["sections"] == []
+    assert result["ambiguous"] is False
+    assert result["note"] == "no mutation tooling for detected stack (python)"
+
+
+def test_unrecognized_signal_installs_nothing_not_ambiguous() -> None:
+    """An unrecognized-but-present stack behaves like Python: nothing, no
+    fallback (it is a definite signal, just unsupported here)."""
+    result = mss.select_sections(["ruby", "elixir"])
+    assert result["sections"] == []
+    assert result["ambiguous"] is False
+    assert result["note"] == "no mutation tooling for detected stack (ruby, elixir)"
+
+
+def test_csharp_signal_runs_stryker_net_section() -> None:
+    result = mss.select_sections(["csharp"])
+    assert result["sections"] == ["csharp"]
+    assert result["ambiguous"] is False
+    assert mss.select_sections(["dotnet"])["sections"] == ["csharp"]
+
+
+def test_polyglot_signal_runs_each_matching_section() -> None:
+    """Polyglot repo runs every matching section, in canonical order."""
+    result = mss.select_sections(["csharp", "typescript", "java"])
+    assert result["sections"] == ["js", "java", "csharp"]
+    assert result["ambiguous"] is False
+    assert result["note"] is None
+
+
+def test_empty_signal_is_the_only_ambiguous_path() -> None:
+    """Empty / missing stacks is the ONLY outcome that authorizes the
+    interactive fallback."""
+    for signal in ([], None):
+        result = mss.select_sections(signal)
+        assert result["sections"] == []
+        assert result["ambiguous"] is True
+        assert result["note"] is None
+
+
+def test_definite_signals_are_never_ambiguous() -> None:
+    """No non-empty stack ever flips ambiguous — the fallback never fires when
+    a definite stack was detected."""
+    for signal in (["typescript"], ["python"], ["csharp"], ["java"], ["ruby"]):
+        assert mss.select_sections(signal)["ambiguous"] is False
+
+
+def test_tokens_are_case_and_whitespace_insensitive() -> None:
+    result = mss.select_sections([" TypeScript ", "Node"])
+    assert result["sections"] == ["js"]
+
+
+# ---------------------------------------------------------------------------
+# CLI — reads .claude/project-stack.json, prints one JSON object
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT_PY), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+    )
+
+
+def _write_stack(project_dir: Path, stacks) -> None:
+    claude = project_dir / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "project-stack.json").write_text(json.dumps({"stacks": stacks}))
+
+
+def test_cli_reads_stack_file_js_only(tmp_path: Path) -> None:
+    _write_stack(tmp_path, ["typescript", "node"])
+    r = _run_cli(".", cwd=tmp_path)
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["sections"] == ["js"]
+    assert out["ambiguous"] is False
+
+
+def test_cli_missing_stack_file_is_ambiguous(tmp_path: Path) -> None:
+    """No project-stack.json at all -> ambiguous (fallback allowed)."""
+    r = _run_cli(".", cwd=tmp_path)
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["sections"] == []
+    assert out["ambiguous"] is True
+
+
+def test_cli_python_only_note(tmp_path: Path) -> None:
+    _write_stack(tmp_path, ["python"])
+    r = _run_cli(".", cwd=tmp_path)
+    out = json.loads(r.stdout)
+    assert out["sections"] == []
+    assert out["ambiguous"] is False
+    assert out["note"] == "no mutation tooling for detected stack (python)"
+
+
+def test_cli_invalid_json_is_ambiguous(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    claude.mkdir(parents=True)
+    (claude / "project-stack.json").write_text("{ not json")
+    r = _run_cli(".", cwd=tmp_path)
+    out = json.loads(r.stdout)
+    assert out["ambiguous"] is True
+
+
+def test_cli_stacks_flag_bypasses_file() -> None:
+    r = _run_cli("--stacks", "csharp")
+    out = json.loads(r.stdout)
+    assert out["sections"] == ["csharp"]
+
+
+# ---------------------------------------------------------------------------
+# Doc-shape — SKILL.md wires the helper and gates every section
+# ---------------------------------------------------------------------------
+
+
+def _step6() -> str:
+    return section(_text(), r"^### 6\. Install per-language mutation tooling")
+
+
+def test_step6_calls_the_helper() -> None:
+    step6 = _step6()
+    assert grep(r"mutation_stack_sections\.py", step6)
+
+
+def test_step6_fallback_gated_on_ambiguous() -> None:
+    """The interactive fallback must be explicitly conditioned on `ambiguous`
+    being true — never on a definite stack."""
+    step6 = _step6()
+    assert grep(r"only when `ambiguous` is `true`", step6, ignore_case=True)
+
+
+def test_each_section_reasserts_its_gate_first() -> None:
+    """Each language subsection's literal first step is a `sections`-membership
+    precondition that returns before any probe."""
+    js = section(_text(), r"^#### JS/TS", boundary_pattern=r"^#### ")
+    java = section(_text(), r"^#### Java / Kotlin", boundary_pattern=r"^#### ")
+    csharp = section(_text(), r"^#### C# / .NET", boundary_pattern=r"^#### ")
+
+    for body, key in ((js, "js"), (java, "java"), (csharp, "csharp")):
+        assert grep(r"Stack gate \(first step", body), f"{key} missing gate header"
+        assert grep(rf"`{key}` is not in", body), f"{key} gate missing membership check"
+        assert grep(r"return immediately", body), f"{key} gate missing early-return"
+
+
+def test_csharp_gate_precedes_dotnet_probe() -> None:
+    """The C#/.NET gate must come before the `command -v dotnet` probe so a
+    non-C# repo never probes dotnet."""
+    csharp = section(_text(), r"^#### C# / .NET", boundary_pattern=r"^#### ")
+    gate_idx = csharp.find("Stack gate")
+    probe_idx = csharp.find("command -v dotnet")
+    assert gate_idx != -1 and probe_idx != -1
+    assert gate_idx < probe_idx
+
+
+def test_summary_reports_only_in_scope_tools() -> None:
+    """The Step 12 summary line must scope the mutation-testing report to the
+    sections actually selected, and surface the no-stack note. (The Report
+    section embeds a fenced example whose lines break `section()` boundary
+    detection, so assert against the full body — these phrases are unique to
+    Step 12's guidance.)"""
+    body = _text()
+    assert grep(r"only for sections actually in scope", body, ignore_case=True)
+    assert grep(r"When the helper's `note` was set", body)


### PR DESCRIPTION
## What

`/setup` Step 6 ("Install per-language mutation tooling") ran the C#/.NET Stryker.NET probes (`command -v dotnet`, `dotnet tool list --local | grep stryker`) on repos that are not C#/.NET. The per-stack gate was prose only, and each language subsection opened with its own unconditional prerequisites probe that fired regardless of the detected stack.

## Fix

- **New deterministic helper** `plugins/dev-team/scripts/mutation_stack_sections.py` (stdlib-only, Python 3.8+). Reads `.claude/project-stack.json`'s `stacks` array once and maps tokens to sections: `typescript`/`node`/`javascript` → `js` (Stryker), `java`/`kotlin` → `java` (pitest), `csharp`/`dotnet` → `csharp` (Stryker.NET). Emits one JSON object with `sections`, `stacks`, `ambiguous`, and `note`.
- **Three distinct outcomes.** Definite match → run only those sections. Definite-but-unsupported (e.g. pure Python — no Python mutation tool wired in) → `sections` empty, `ambiguous` false, one-line `no mutation tooling for detected stack (<stacks>)` note; install nothing, probe nothing. Genuinely empty/missing signal → `ambiguous` true, the **only** path that authorizes the interactive "which languages?" fallback.
- **Each language subsection re-asserts its own gate as its literal first step**, returning before any `command -v` / tool probe — robust even if reached out of order. The C#/.NET gate precedes the `dotnet` probe.
- **Step 12 summary** reports a mutation-testing line only for sections actually in scope, and surfaces the no-stack note.

## Tests

`tests/skills/test_setup_mutation_stack_gate.py` (18 cases): helper behavior (JS-only → only `js`, no dotnet; Python/unrecognized → nothing, not ambiguous; C#/.NET → `csharp`; polyglot → each matching section; only empty/missing → ambiguous), CLI reading the stack file, and doc-shape guards (helper wired, per-section gate-first preconditions, fallback gated on `ambiguous`, summary scoped).

Ran `python3 scripts/check_md_references.py` (clean) and `python3 -m pytest plugins/dev-team/tests tests/skills tests/repo tests/docs -q` (2684 passed, 5 pre-existing env-gated npm-ci skips). Rebuilt `knowledge/index.json`.

## Overlap note

Sibling PR #1148 (issue #1142, npm ERESOLVE `--legacy-peer-deps`) also touches Step 6 (the JS/TS npm-install block). If it lands after this, a rebase may be needed; edits here are localized to the stack-gating intro, per-section gate preconditions, and the summary line, so conflicts should be minimal. #1147 (stryker config) is already on main and included in this branch.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
