### PR TITLE
fix(mutation-testing): detect and surface Stryker coverage-capture failure

### DIFF
--- a/plugins/dev-team/hooks/mutation_adapters/lib.py
+++ b/plugins/dev-team/hooks/mutation_adapters/lib.py
@@ -86,6 +86,35 @@ def emit_block(reason: str) -> str:
     return json.dumps({"decision": "block", "reason": reason})
 
 
+# Canonical coverage-capture-failure signal (see #1156). Verbatim from
+# Stryker.NET's own log: src/Stryker.Core/Stryker.Core/CoverageAnalysis/
+# CoverageAnalyser.cs emits "It looks like the test coverage capture failed.
+# Disable coverage based optimisation." when the initial per-test coverage pass
+# yields zero covered mutations, then calls AssumeAllTestsAreNeeded() —
+# silently falling back to whole-suite-per-mutant. The British "optimisation"
+# spelling matches the source. Kept byte-identical with the copy in the status
+# loop (csharp_stryker_net_status_loop.py); the two live in different import
+# roots (hooks/ vs skills/) so they cannot share a constant — the equivalence
+# is armored by test_coverage_capture_regex_matches_status_loop.
+_COVERAGE_CAPTURE_FAILURE_RE = re.compile(
+    r"test coverage capture failed|disable coverage based optimisation",
+    re.IGNORECASE,
+)
+
+
+def detect_coverage_capture_failure(text: str) -> bool:
+    """True when `text` (Stryker's captured stdout/stderr) shows per-test
+    coverage capture failed and Stryker fell back to whole-suite-per-mutant.
+
+    A pure predicate later slices (#1158's feasibility gate) branch on to
+    decide loop-vs-degrade. Matches either half of 'It looks like the test
+    coverage capture failed. Disable coverage based optimisation.'
+    """
+    if not text:
+        return False
+    return bool(_COVERAGE_CAPTURE_FAILURE_RE.search(text))
+
+
 def emit_advisory(message: str) -> str:
     """Return the PostToolUse additionalContext envelope for an advisory message."""
     return json.dumps(

--- a/plugins/dev-team/hooks/mutation_adapters/stryker_net.py
+++ b/plugins/dev-team/hooks/mutation_adapters/stryker_net.py
@@ -142,10 +142,27 @@ def stryker_net_run(output_file: Path) -> int:
     completed = lib.run_with_timeout(
         timeout_seconds,
         argv,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
     exit_code = completed.returncode
+    run_output = (completed.stdout or b"").decode("utf-8", "replace")
+
+    # Surface the coverage-capture failure (#1156): Stryker disabled per-test
+    # optimisation and fell back to whole-suite-per-mutant. The mutant-kill loop
+    # is infeasible on this suite (xunit.v3); a single-pass advisory with
+    # coverage-analysis off is the way forward. detect_coverage_capture_failure
+    # is the branchable predicate later slices (#1158) consume.
+    if lib.detect_coverage_capture_failure(run_output):
+        print(
+            lib.emit_advisory(
+                "MUTATION GATE ADVISORY: Stryker.NET coverage capture failed — "
+                "per-test optimisation disabled, falling back to "
+                "whole-suite-per-mutant. The mutant-kill loop is infeasible on "
+                "this suite (xunit.v3); prefer a single-pass advisory run with "
+                "coverage-analysis off, or waive. See #1156."
+            )
+        )
 
     if exit_code == 124:
         print(

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_status_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_status_loop.py
@@ -8,6 +8,7 @@ Public API (importable):
     parse_dots_count(logfile: Path) -> int
     parse_summary_count(logfile: Path, key: str) -> Optional[int]
     log_has_completion_marker(logfile: Path) -> bool
+    log_has_coverage_capture_failure(logfile: Path) -> bool
     emit_status_line(logfile: Path) -> str
     check_red_flags(logfile, threshold, stryker_pid, expected_target=None, state_dir=None, drift_threshold=3) -> list[str]
     status_loop_start(logfile, interval, threshold, stryker_pid, expected_target=None, state_dir=None, drift_threshold=3) -> None
@@ -101,6 +102,37 @@ def log_has_completion_marker(logfile: Path) -> bool:
         with logfile.open() as f:
             for line in f:
                 if _COMPLETION_RE.search(line):
+                    return True
+        return False
+    except (OSError, FileNotFoundError):
+        return False
+
+
+# Canonical coverage-capture-failure signal (see #1156). Verbatim from
+# Stryker.NET's own log: src/Stryker.Core/Stryker.Core/CoverageAnalysis/
+# CoverageAnalyser.cs emits "It looks like the test coverage capture failed.
+# Disable coverage based optimisation." when the initial per-test coverage pass
+# yields zero covered mutations, then falls back to whole-suite-per-mutant. The
+# British "optimisation" spelling matches the source. Kept byte-identical with
+# the copy in hooks/mutation_adapters/lib.py; the two live in different import
+# roots (skills/ vs hooks/) so they cannot share a constant — the equivalence
+# is armored by test_coverage_capture_regex_matches_status_loop.
+_COVERAGE_CAPTURE_FAILURE_RE = re.compile(
+    r"test coverage capture failed|disable coverage based optimisation",
+    re.IGNORECASE,
+)
+
+
+def log_has_coverage_capture_failure(logfile: Path) -> bool:
+    """True when the log shows Stryker disabled per-test coverage optimisation
+    and fell back to whole-suite-per-mutant (see #1156). Matches either half of
+    'It looks like the test coverage capture failed. Disable coverage based
+    optimisation.' — resilient to timestamp/log prefixes (search, not match).
+    """
+    try:
+        with logfile.open() as f:
+            for line in f:
+                if _COVERAGE_CAPTURE_FAILURE_RE.search(line):
                     return True
         return False
     except (OSError, FileNotFoundError):
@@ -290,6 +322,15 @@ def check_red_flags(
                 f"[RED-FLAG] Stryker process died mid-run (PID {stryker_pid} "
                 f"no longer running, no completion marker in log) — see #558"
             )
+
+    # --- Red flag 6: coverage capture failed → whole-suite-per-mutant fallback
+    if log_has_coverage_capture_failure(logfile):
+        recognized = True
+        lines.append(
+            "[RED-FLAG] coverage capture failed — Stryker disabled per-test "
+            "coverage optimisation and fell back to whole-suite-per-mutant; the "
+            "mutant-kill loop is infeasible on this suite (xunit.v3) — see #1156"
+        )
 
     # A log with dots or a completion marker is "recognized" even if no
     # summary parser fired — this stops false drift-alerts during a healthy

--- a/plugins/dev-team/tests/hooks/test_mutation_adapters_lib.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_adapters_lib.py
@@ -288,3 +288,33 @@ def test_run_with_timeout_exits_124_when_deadline_hits(tmp_path):
 def test_run_with_timeout_passes_through_exit_code():
     completed = lib.run_with_timeout(5, ["sh", "-c", "exit 3"])
     assert completed.returncode == 3
+
+
+# ---------------------------------------------------------------------------
+# detect_coverage_capture_failure (#1156)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "[13:20:25 ERR] It looks like the test coverage capture failed. Disable coverage based optimisation.",
+        "it looks like the TEST COVERAGE CAPTURE FAILED.",
+        "Disable Coverage Based Optimisation.",
+        "noise\nmore noise\n[ERR] test coverage capture failed\n",
+    ],
+)
+def test_detect_coverage_capture_failure_positive(text: str) -> None:
+    assert lib.detect_coverage_capture_failure(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "Killed:     42\nThe final mutation score is 84.00 %",
+        "coverage analysis: perTest",
+    ],
+)
+def test_detect_coverage_capture_failure_negative(text: str) -> None:
+    assert lib.detect_coverage_capture_failure(text) is False

--- a/plugins/dev-team/tests/hooks/test_stryker_net_adapter.py
+++ b/plugins/dev-team/tests/hooks/test_stryker_net_adapter.py
@@ -1,0 +1,64 @@
+"""Tests for the Stryker.NET adapter's coverage-capture wiring (#1156).
+
+The pure predicate lib.detect_coverage_capture_failure is unit-tested in
+test_mutation_adapters_lib.py. These tests armor the production consumer:
+stryker_net_run captures the subprocess stdout and emits the #1156 advisory
+when the capture-failure signal is present — the exact path #1158 branches on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "dev-team"
+sys.path.insert(0, str(_PLUGIN_ROOT / "hooks"))
+
+from mutation_adapters import stryker_net as sn  # noqa: E402
+
+
+def _stub_run(stdout_bytes: bytes):
+    def fake_run(_seconds, argv, **_kwargs):
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=stdout_bytes)
+
+    return fake_run
+
+
+def test_run_emits_advisory_on_capture_failure(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sn, "_changed_cs_file", lambda: "")
+    monkeypatch.setattr(
+        sn.lib,
+        "run_with_timeout",
+        _stub_run(
+            b"[13:20:25 ERR] It looks like the test coverage capture failed. "
+            b"Disable coverage based optimisation.\n"
+        ),
+    )
+    monkeypatch.setattr(sn.lib, "parse_stryker_kills", lambda _rp, _of: None)
+
+    rc = sn.stryker_net_run(tmp_path / "out.json")
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "#1156" in out
+    assert "coverage capture failed" in out.lower()
+
+
+def test_run_no_advisory_on_clean_output(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sn, "_changed_cs_file", lambda: "")
+    monkeypatch.setattr(
+        sn.lib,
+        "run_with_timeout",
+        _stub_run(b"Killed:     42\nThe final mutation score is 84.00 %\n"),
+    )
+    monkeypatch.setattr(sn.lib, "parse_stryker_kills", lambda _rp, _of: None)
+
+    rc = sn.stryker_net_run(tmp_path / "out.json")
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "#1156" not in out

--- a/tests/fixtures/stryker-net-logs/coverage-capture-failed.log
+++ b/tests/fixtures/stryker-net-logs/coverage-capture-failed.log
@@ -1,0 +1,15 @@
+Stryker.NET v4.16.0
+
+[13:20:14 INF] Analyzing project 'Aci.Speedpay.SDK.Async.Tests.csproj'
+[13:20:20 INF] Building project 'Aci.Speedpay.SDK.Async.Tests.csproj'
+[13:20:25 ERR] It looks like the test coverage capture failed. Disable coverage based optimisation.
+[13:20:26 INF] Testing 100 mutants
+
+Testing mutants:
+.........................................................
+Killed:     42
+Survived:    8
+Timeout:     0
+No coverage: 0
+
+The final mutation score is 84.00 %

--- a/tests/scripts/test_csharp_stryker_net_status_loop.py
+++ b/tests/scripts/test_csharp_stryker_net_status_loop.py
@@ -352,3 +352,60 @@ class TestCLI:
         assert result.returncode == 0
         assert "[RED-FLAG]" in result.stdout
         assert "#554" in result.stdout
+
+
+# =============================================================================
+# Red flag 6 — coverage capture failure (#1156)
+# =============================================================================
+class TestRedFlagCoverageCapture:
+    def test_fires_on_coverage_capture_failure(self, state_dir, alive_pid):
+        flags = loop.check_red_flags(
+            FIXTURES / "coverage-capture-failed.log",
+            threshold=25,
+            stryker_pid=alive_pid,
+            state_dir=state_dir,
+        )
+        capture = [f for f in flags if "coverage capture failed" in f]
+        assert len(capture) == 1
+        assert "#1156" in capture[0]
+
+    def test_silent_on_healthy_log(self, state_dir, alive_pid):
+        flags = loop.check_red_flags(
+            FIXTURES / "healthy-dots.log",
+            threshold=25,
+            stryker_pid=alive_pid,
+            state_dir=state_dir,
+        )
+        assert not any("coverage capture failed" in f for f in flags)
+
+    def test_helper_matches_either_half_case_insensitively(self, tmp_path):
+        first = tmp_path / "first.log"
+        first.write_text("[13:20:25 ERR] it looks like the TEST COVERAGE CAPTURE FAILED.\n")
+        second = tmp_path / "second.log"
+        second.write_text("[13:20:25 ERR] Disable Coverage Based Optimisation.\n")
+        clean = tmp_path / "clean.log"
+        clean.write_text("Killed:     42\nThe final mutation score is 84.00 %\n")
+        assert loop.log_has_coverage_capture_failure(first) is True
+        assert loop.log_has_coverage_capture_failure(second) is True
+        assert loop.log_has_coverage_capture_failure(clean) is False
+
+    def test_missing_file_is_false(self, tmp_path):
+        assert loop.log_has_coverage_capture_failure(tmp_path / "nope.log") is False
+
+
+def test_coverage_capture_regex_matches_adapter_copy():
+    """The signal regex is duplicated across the status loop (skills/) and the
+    adapter lib (hooks/) because they have no shared import root. This armors
+    the 'kept byte-identical' comment so a drift or spelling 'fix' in one copy
+    cannot pass unnoticed. See #1156."""
+    hooks_dir = Path(__file__).resolve().parents[2] / "plugins" / "dev-team" / "hooks"
+    sys.path.insert(0, str(hooks_dir))
+    from mutation_adapters import lib  # noqa: E402
+
+    assert (
+        loop._COVERAGE_CAPTURE_FAILURE_RE.pattern
+        == lib._COVERAGE_CAPTURE_FAILURE_RE.pattern
+    )
+    assert (
+        loop._COVERAGE_CAPTURE_FAILURE_RE.flags == lib._COVERAGE_CAPTURE_FAILURE_RE.flags
+    )


### PR DESCRIPTION
## What

Slice 1 of epic #1156. Makes Stryker.NET's coverage-capture failure — `It looks like the test coverage capture failed. Disable coverage based optimisation.` (verbatim from `CoverageAnalyser.cs`) — a **detected, surfaced signal**, the foundation the feasibility gate (#1158) will branch on.

Two runtime layers that actually see Stryker's output:

- **Status loop** (`csharp_stryker_net_status_loop.py`): new `[RED-FLAG]` (red flag 6) + `log_has_coverage_capture_failure` helper — fires off the wrapper's real log.
- **Adapter** (`mutation_adapters`): `detect_coverage_capture_failure` pure predicate in `lib` (the branchable result #1158 consumes) + an advisory in the adapter, which now captures stdout/stderr (`PIPE`+`STDOUT`) to scan it.

The signal regex is grounded on the verbatim Stryker source string; the two copies (skills/ vs hooks/ — no shared import root) are armored **byte-identical** by a regex-equivalence test.

## Review outcome (this branch was reviewed before opening)

- **security-review: pass** — the `DEVNULL`→`PIPE` capture is bounded (trusted local tool under a 600s timeout); captured output is never interpolated, only fed to the pure regex; the JSON decision channel is preserved.
- **correctness-review: pass** — deadlock-free (`subprocess.run` drains pipes); all exit branches yield valid bytes.
- **test-review + ai-provenance: applied.** Two changes made in response:
  1. **Descoped the smoke-gate fail-fast.** A PreToolUse hook can't see the current run's output; the report looks healthy when capture degrades; and no log is produced at the scanned path (Step 1c uses `-O`, not a log, and log-tail parsing is forbidden). It was test-green but production-inert, so it's removed — detection lives in the runtime layers here, and the "don't proceed" decision belongs to **#1158**.
  2. **Grounded the regex** against the real Stryker source (was self-referential) and added the wiring test (adapter capture→advisory), the helper's missing-file test, and the regex-equivalence test.

## Tests

Full pre-push suite green: **3711 passed, 3 skipped** (pre-existing env-gated skips). New/changed tests cover the predicate (positive/negative), the status-loop red flag + helper (either-half, case-insensitive, missing-file), the adapter capture→advisory wiring, and the two-copy regex equivalence.

## Follow-up

Grounding the log line in `csharp-stryker-net.md` (provenance suggestion) rides with **#1159**, which already owns that reference-doc update.

Closes #1157
Part of #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)