### PR TITLE
feat(mutation-testing): detect and classify xunit.v3 shim-breaking test constructs

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -69,6 +69,23 @@ If detected, take **all four** steps below. Missing any one recreates the fake-s
 
 The four steps above defend against the *fake-100 %-via-Timeout* variant of the MTP-runner incompatibility. The **complementary** *fake-0 %-via-Survived* variant (mutation-switch not observing mutations at runtime; every mutant reported `Survived`; final score `0.00 %`) is caught by [`SKILL.md`](../../SKILL.md) **Step 1c smoke gate** — run a single-file probe before any full run and parse `mutation-report.json` for `Killed > 0`. Do not skip Step 1c on xunit.v3 configurations; it is the specific safety net for issues [#554](https://github.com/bdfinst/agentic-dev-team/issues/554) and [#557](https://github.com/bdfinst/agentic-dev-team/issues/557). Inside a Claude Code session the [`mutation_testing_smoke_gate`](../../../../hooks/mutation_testing_smoke_gate.py) PreToolUse hook enforces this step automatically — see SKILL.md § Step 1c for the operator-facing contract.
 
+## xunit.v3 shim-breaking features — detect and human-gate (before building the shim)
+
+The v2 shim is the only path that gives the mutant-kill **loop** per-test coverage on an xunit.v3 suite (under v2/VSTest `perTest` works, ~5–6× faster than `off` — see [#669](https://github.com/bdfinst/agentic-dev-team/issues/669)). Its weakness is compile fragility: any xunit-v3-only API breaks the shim's compile before Stryker runs a mutant (the `[Fact(Explicit = true)]` break that motivated [#1156](https://github.com/bdfinst/agentic-dev-team/issues/1156)). Rather than hand the operator an opaque C# compile error, scan for the breaking constructs first and let a human decide.
+
+**Detector.** [`../../scripts/xunit_v3_feature_detector.py`](../../scripts/xunit_v3_feature_detector.py) scans the real xunit.v3 test `.cs` files for shim-breaking v3-only constructs (`[Fact/Theory(Explicit = true)]`, `Assert.Skip`/`SkipWhen`/`SkipUnless`, `TestContext.Current`/`ITestContext`, `ValueTask` async-lifetime signatures, `TheoryDataRow`) and classifies each on two axes:
+
+- **compile-ability** — `clean-translatable` (a mechanical v2 equivalent exists) vs `no-v2-equivalent` (cannot compile under v2).
+- **coverage impact** — `neutral` (excluding the test from the shim changes no coverage — e.g. `Explicit=true` tests are skipped by default, **provided the run does not enable explicit tests** via `-explicit` / `xunit.runner.json` `explicit=on`) vs `bearing` (the test runs and covers code, so excluding it inflates the loop's survivor set and makes it generate redundant tests).
+
+```bash
+python3 scripts/xunit_v3_feature_detector.py <test-project>/**/*.cs --json
+```
+
+**Human gate — always ask, never auto-drop.** Present the full classified list every run, even when every hit is coverage-neutral. For each test the operator chooses whether to exclude it from the shim for the duration of the loop; nothing is deactivated silently. Coverage-bearing tests are flagged with the lines that go dark if excluded. The detector's `summary.recommendation` is **advisory** sizing only (few + neutral → shim path is reasonable; many or coverage-bearing → prefer skipping the loop for a single-pass `coverage-analysis: off` advisory) — the human always decides.
+
+**"Deactivate" means exclude from the shim's `<Compile Include>` set, never edit the real test suite** — so there is no crash-unsafe "restore after the loop" step. The operator-selected exclusions are applied to the shim project by the shim-generation path (see [#1159](https://github.com/bdfinst/agentic-dev-team/issues/1159)); the loop-vs-degrade decision that consumes this gate's outcome lives in [#1158](https://github.com/bdfinst/agentic-dev-team/issues/1158).
+
 ## .NET 10 targets: default `vstest` runner can silently fake a 0% score
 
 On **.NET 10** test-project targets (and possibly .NET 9), Stryker.NET's bundled default `vstest` test runner can silently fail to capture coverage — it ships a `net8.0` `vstest.console.dll` that cannot correctly execute newer-TFM test assemblies. The observable symptom is a **fake `Killed: 0` / `Survived: N` / 0.00 % score**, even though the same tests pass fine under a direct `dotnet test`. This is the complementary failure mode to the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section above (that one produces a fake **100 %** via `Timeout`; this one produces a fake **0 %** via `Survived`) — both are caught by [`SKILL.md`](../../SKILL.md) **Step 1c smoke gate**, but this one is easy to mistake for a legitimately weak test suite rather than a broken runner.

--- a/plugins/dev-team/skills/mutation-testing/scripts/xunit_v3_feature_detector.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/xunit_v3_feature_detector.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Detect xunit.v3-only constructs that break the v2 mutation-shim compile,
+and classify each so a human can decide how to handle it (#1160, part of #1156).
+
+The v2 shim is the only path that gives the mutant-kill loop per-test coverage
+on an xunit.v3 suite (validated in #669). Its weakness is compile fragility:
+any xunit-v3-only API breaks the shim's compile before Stryker runs a mutant.
+This module turns that opaque C# compile error into a classified list the
+mutation-kill agent presents at an **always-ask, never-auto-drop** human gate.
+
+Two classification axes:
+
+- ``compile_ability`` — ``clean-translatable`` (a mechanical v2 equivalent
+  exists) or ``no-v2-equivalent`` (the construct cannot compile under v2).
+- ``coverage_impact`` — ``neutral`` (excluding the test from the shim changes
+  no coverage, e.g. ``[Fact(Explicit = true)]`` tests are skipped by default)
+  or ``bearing`` (the test runs and covers code, so excluding it inflates the
+  loop's survivor set — the operator must be told which lines go dark).
+
+Pure and stdlib-only. The interactive gate and the actual shim-exclusion wiring
+(#1159) consume this module's structured output; this module never edits a file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+CLEAN_TRANSLATABLE = "clean-translatable"
+NO_V2_EQUIVALENT = "no-v2-equivalent"
+COVERAGE_NEUTRAL = "neutral"
+COVERAGE_BEARING = "bearing"
+
+
+@dataclass(frozen=True)
+class Construct:
+    name: str
+    pattern: "re.Pattern[str]"
+    compile_ability: str
+    coverage_impact: str
+    note: str
+
+
+# Each entry's classification is grounded in xunit.v3's documented surface —
+# xunit.net/docs/getting-started/v3/whats-new (Explicit property, Assert.Skip*,
+# TestContext, IAsyncLifetime→ValueTask, TheoryDataRow) — validated against real
+# xunit behavior in #1156. C# attribute/keyword casing is fixed, so patterns are
+# case-sensitive (no re.IGNORECASE).
+_CONSTRUCTS: List[Construct] = [
+    Construct(
+        name="fact-explicit",
+        # [Fact(Explicit = true)] / [Theory(Explicit=true)] — the property does
+        # not exist on v2's FactAttribute. `[^\]"]*` stops the property match
+        # from crossing into a quoted argument (e.g. DisplayName="Explicit = true").
+        pattern=re.compile(r"\[\s*(?:Fact|Theory)\s*\([^\]\"]*\bExplicit\s*=\s*true"),
+        compile_ability=NO_V2_EQUIVALENT,
+        coverage_impact=COVERAGE_NEUTRAL,
+        note="Explicit tests are skipped unless the run opts in (-explicit / "
+        "xunit.runner.json explicit=on), so under a normal mutation run they "
+        "contribute zero coverage — excluding them from the shim changes nothing. "
+        "Neutral ONLY while the run does not enable explicit tests.",
+    ),
+    Construct(
+        name="assert-skip",
+        # Assert.Skip / Assert.SkipWhen / Assert.SkipUnless — dynamic skip is v3-only.
+        pattern=re.compile(r"\bAssert\.(?:Skip|SkipWhen|SkipUnless)\s*\("),
+        compile_ability=NO_V2_EQUIVALENT,
+        coverage_impact=COVERAGE_BEARING,
+        note="Dynamic skip has no v2 equivalent (v2 skip is a static attribute). "
+        "The test runs and covers code; excluding it hides that coverage.",
+    ),
+    Construct(
+        name="test-context",
+        pattern=re.compile(r"\b(?:TestContext\.Current|ITestContext)\b"),
+        compile_ability=NO_V2_EQUIVALENT,
+        coverage_impact=COVERAGE_BEARING,
+        note="TestContext/ITestContext is v3-only with no v2 equivalent; the "
+        "test runs and covers code.",
+    ),
+    Construct(
+        name="async-lifetime-valuetask",
+        # v3's IAsyncLifetime uses ValueTask InitializeAsync/DisposeAsync;
+        # v2 uses Task. Mechanically translatable but changes signatures.
+        pattern=re.compile(
+            r"\bValueTask\s+(?:InitializeAsync|DisposeAsync)\s*\("
+        ),
+        compile_ability=CLEAN_TRANSLATABLE,
+        coverage_impact=COVERAGE_BEARING,
+        note="v3's IAsyncLifetime returns ValueTask (and extends IAsyncDisposable); "
+        "v2's returns Task. Translatable for the common CompletedTask case but not "
+        "purely a return-type swap — the interface surface differs and cached "
+        "ValueTask / IValueTaskSource bodies don't map trivially. Coverage-bearing "
+        "(runs real setup/teardown).",
+    ),
+    Construct(
+        name="theory-data-row",
+        pattern=re.compile(r"\bTheoryDataRow\b"),
+        compile_ability=CLEAN_TRANSLATABLE,
+        coverage_impact=COVERAGE_BEARING,
+        note="v3's TheoryDataRow maps to v2's TheoryData<> for value-only rows; "
+        "rows carrying per-row metadata (Skip/Explicit/Traits/TestDisplayName) "
+        "lose it in translation. Coverage-bearing (the test runs and covers code).",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    line: int
+    construct: str
+    compile_ability: str
+    coverage_impact: str
+    snippet: str
+
+
+def scan_text(path: str, text: str) -> List[Finding]:
+    """Return the v3-only constructs found in ``text``, attributed to ``path``.
+
+    Line-oriented so each finding carries a 1-based line number and the source
+    snippet the operator will see at the gate.
+    """
+    findings: List[Finding] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        # Skip fully commented-out lines so a `// [Fact(Explicit = true)]` in
+        # dead code isn't flagged as a shim-breaker. A trailing comment on a
+        # real code line is left alone (the code before `//` still matters).
+        if line.lstrip().startswith("//"):
+            continue
+        for construct in _CONSTRUCTS:
+            if construct.pattern.search(line):
+                findings.append(
+                    Finding(
+                        file=path,
+                        line=lineno,
+                        construct=construct.name,
+                        compile_ability=construct.compile_ability,
+                        coverage_impact=construct.coverage_impact,
+                        snippet=line.strip(),
+                    )
+                )
+    return findings
+
+
+def scan_file(path: Path) -> List[Finding]:
+    """Scan a single .cs file. Missing/unreadable files yield no findings."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, FileNotFoundError):
+        return []
+    return scan_text(str(path), text)
+
+
+def scan_files(paths: Iterable[Path]) -> List[Finding]:
+    findings: List[Finding] = []
+    for p in paths:
+        findings.extend(scan_file(p))
+    return findings
+
+
+def files_with_findings(findings: Sequence[Finding]) -> List[str]:
+    """Distinct files carrying at least one shim-breaking construct — the
+    candidate exclusion set the human gate offers (dedup, stable order)."""
+    seen: List[str] = []
+    for f in findings:
+        if f.file not in seen:
+            seen.append(f.file)
+    return seen
+
+
+@dataclass(frozen=True)
+class Summary:
+    total: int
+    files: int
+    neutral: int
+    bearing: int
+    recommendation: str
+
+
+def summarize(findings: Sequence[Finding]) -> Summary:
+    """Roll findings up into counts plus an advisory sizing recommendation.
+
+    The recommendation is advisory only — the gate is always-ask (#1160). It
+    never auto-excludes; it tells the operator which way the blast radius leans.
+    """
+    neutral = sum(1 for f in findings if f.coverage_impact == COVERAGE_NEUTRAL)
+    bearing = sum(1 for f in findings if f.coverage_impact == COVERAGE_BEARING)
+    files = len(files_with_findings(findings))
+
+    if not findings:
+        rec = (
+            "No shim-breaking xunit.v3 constructs found — the v2 shim path is "
+            "viable as-is."
+        )
+    elif bearing == 0:
+        rec = (
+            f"{neutral} coverage-neutral hit(s) across {files} file(s) "
+            "(Explicit tests skipped by default). Excluding them from the shim "
+            "is safe PROVIDED the run does not enable explicit tests "
+            "(-explicit / xunit.runner.json explicit=on) — confirm that, then "
+            "proceeding on the shim path is reasonable."
+        )
+    else:
+        rec = (
+            f"{bearing} coverage-bearing hit(s) across {files} file(s): "
+            "excluding these from the shim blinds the loop to their coverage. "
+            "If few and acceptable, exclude and proceed; if many, skip the loop "
+            "and run a single-pass advisory with coverage-analysis off."
+        )
+    return Summary(
+        total=len(findings),
+        files=files,
+        neutral=neutral,
+        bearing=bearing,
+        recommendation=rec,
+    )
+
+
+def _cli(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect and classify xunit.v3-only, shim-breaking test constructs."
+    )
+    parser.add_argument("paths", nargs="+", help="test .cs files to scan")
+    parser.add_argument(
+        "--json", action="store_true", help="emit JSON instead of a table"
+    )
+    args = parser.parse_args(list(argv))
+
+    findings = scan_files(Path(p) for p in args.paths)
+    summary = summarize(findings)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "findings": [asdict(f) for f in findings],
+                    "summary": asdict(summary),
+                },
+                indent=2,
+            )
+        )
+    else:
+        for f in findings:
+            print(
+                f"{f.file}:{f.line}  {f.construct}  "
+                f"[{f.compile_ability} / coverage-{f.coverage_impact}]  {f.snippet}"
+            )
+        print(f"\n{summary.recommendation}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_cli(sys.argv[1:]))

--- a/tests/fixtures/xunit-v3/V3FeaturesTests.cs
+++ b/tests/fixtures/xunit-v3/V3FeaturesTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+// Fixture for xunit_v3_feature_detector — exercises each shim-breaking v3-only
+// construct PLUS near-miss negatives that must NOT be flagged. See #1160.
+public class V3FeaturesTests : IAsyncLifetime
+{
+    [Fact(Explicit = true)]
+    public void ExplicitFact()
+    {
+        Assert.True(true);
+    }
+
+    [Theory(Explicit = true)]
+    [InlineData(1)]
+    public void ExplicitTheory(int x)
+    {
+        Assert.Equal(1, x);
+    }
+
+    [Fact]
+    public void DynamicSkip()
+    {
+        Assert.SkipWhen(DateTime.Now.Hour < 0, "never");
+        Assert.Skip("bare skip");
+        Assert.SkipUnless(true, "unless");
+        Assert.Equal(4, 2 + 2);
+    }
+
+    [Fact]
+    public void UsesTestContext()
+    {
+        var name = TestContext.Current.Test.TestDisplayName;
+        Assert.NotNull(name);
+    }
+
+    public static TheoryDataRow<int> RowData() => new(1);
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    // --- Near-miss negatives: none of these must be flagged ---
+
+    // [Fact(Explicit = true)]  <- commented-out attribute, must be ignored
+
+    [Fact(Explicit = false)]
+    public void NotActuallyExplicit()
+    {
+        Assert.Equal(2, 1 + 1);
+    }
+
+    [Fact]
+    public void PlainV2CompatibleTest()
+    {
+        var tail = new[] { 1, 2, 3 }.Skip(1).ToArray(); // LINQ .Skip, not Assert.Skip
+        Assert.Equal(2, tail.Length);
+    }
+}

--- a/tests/scripts/test_xunit_v3_feature_detector.py
+++ b/tests/scripts/test_xunit_v3_feature_detector.py
@@ -1,0 +1,202 @@
+"""Tests for xunit_v3_feature_detector.py — detects and classifies the
+xunit.v3-only constructs that break the v2 mutation-shim compile (#1160,
+part of #1156)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import xunit_v3_feature_detector as det  # noqa: E402
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "xunit-v3"
+    / "V3FeaturesTests.cs"
+)
+
+
+def _by_construct(findings):
+    out = {}
+    for f in findings:
+        out.setdefault(f.construct, []).append(f)
+    return out
+
+
+def test_detects_every_construct_in_fixture():
+    names = {f.construct for f in det.scan_file(FIXTURE)}
+    assert names == {
+        "fact-explicit",
+        "assert-skip",
+        "test-context",
+        "async-lifetime-valuetask",
+        "theory-data-row",
+    }
+
+
+def test_fact_explicit_is_neutral_and_no_equivalent():
+    findings = _by_construct(det.scan_file(FIXTURE))["fact-explicit"]
+    # Both [Fact(Explicit=true)] and [Theory(Explicit=true)] are caught.
+    assert len(findings) == 2
+    for f in findings:
+        assert f.compile_ability == det.NO_V2_EQUIVALENT
+        assert f.coverage_impact == det.COVERAGE_NEUTRAL
+
+
+def test_assert_skip_matches_all_three_alternations():
+    fs = _by_construct(det.scan_file(FIXTURE))["assert-skip"]
+    # Assert.SkipWhen, Assert.Skip, Assert.SkipUnless.
+    assert len(fs) == 3
+    for f in fs:
+        assert f.compile_ability == det.NO_V2_EQUIVALENT
+        assert f.coverage_impact == det.COVERAGE_BEARING
+
+
+def test_test_context_is_bearing_and_no_equivalent():
+    f = _by_construct(det.scan_file(FIXTURE))["test-context"][0]
+    assert f.compile_ability == det.NO_V2_EQUIVALENT
+    assert f.coverage_impact == det.COVERAGE_BEARING
+
+
+def test_async_lifetime_valuetask_is_translatable_and_bearing():
+    fs = _by_construct(det.scan_file(FIXTURE))["async-lifetime-valuetask"]
+    assert len(fs) == 2  # InitializeAsync + DisposeAsync
+    for f in fs:
+        assert f.compile_ability == det.CLEAN_TRANSLATABLE
+        assert f.coverage_impact == det.COVERAGE_BEARING
+
+
+def test_theory_data_row_detected():
+    text = "public static TheoryDataRow<int> Cases() => new(1);"
+    findings = det.scan_text("Cases.cs", text)
+    assert len(findings) == 1
+    assert findings[0].construct == "theory-data-row"
+    assert findings[0].compile_ability == det.CLEAN_TRANSLATABLE
+    assert findings[0].coverage_impact == det.COVERAGE_BEARING
+
+
+# --- near-miss negatives: none of these may be flagged ---------------------
+
+
+def test_explicit_false_not_flagged():
+    findings = det.scan_text("N.cs", "[Fact(Explicit = false)]")
+    assert findings == []
+
+
+def test_commented_out_attribute_not_flagged():
+    findings = det.scan_text("N.cs", "    // [Fact(Explicit = true)]")
+    assert findings == []
+
+
+def test_linq_skip_not_flagged():
+    findings = det.scan_text("N.cs", "var tail = items.Skip(1).ToArray();")
+    assert findings == []
+
+
+def test_display_name_containing_explicit_not_flagged():
+    # `[^\]"]*` must stop the property match at the opening quote.
+    findings = det.scan_text("N.cs", '[Fact(DisplayName="Explicit = true story")]')
+    assert findings == []
+
+
+def test_fixture_negatives_not_flagged():
+    findings = det.scan_file(FIXTURE)
+    snippets = [f.snippet for f in findings]
+    # LINQ .Skip and the Explicit=false / commented-out lines never appear.
+    assert not any(".Skip(1)" in s for s in snippets)
+    assert not any("Explicit = false" in s for s in snippets)
+    assert not any(s.lstrip().startswith("//") for s in snippets)
+
+
+def test_findings_carry_line_numbers():
+    findings = det.scan_text("F.cs", "line1\n[Fact(Explicit = true)]\nline3")
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_missing_file_yields_no_findings(tmp_path):
+    assert det.scan_file(tmp_path / "nope.cs") == []
+
+
+def test_files_with_findings_dedups_stable():
+    findings = det.scan_file(FIXTURE)
+    files = det.files_with_findings(findings)
+    assert files == [str(FIXTURE)]
+
+
+def test_files_with_findings_multi_file_first_seen_order():
+    # Interleave two files; expect first-seen order, deduped.
+    findings = (
+        det.scan_text("b.cs", "[Fact(Explicit = true)]")
+        + det.scan_text("a.cs", "TestContext.Current.Test")
+        + det.scan_text("b.cs", "Assert.Skip(\"x\")")
+    )
+    assert det.files_with_findings(findings) == ["b.cs", "a.cs"]
+
+
+# --- summarize / sizing recommendation --------------------------------------
+
+
+def test_summary_no_findings_says_viable():
+    s = det.summarize([])
+    assert s.total == 0
+    assert "viable" in s.recommendation.lower()
+
+
+def test_summary_neutral_only_recommends_safe_exclude():
+    findings = det.scan_text(
+        "N.cs", "[Fact(Explicit = true)]\n[Theory(Explicit=true)]"
+    )
+    s = det.summarize(findings)
+    assert s.bearing == 0
+    assert s.neutral == 2
+    assert "safe" in s.recommendation.lower()
+
+
+def test_summary_bearing_warns_about_hidden_coverage():
+    findings = det.scan_file(FIXTURE)
+    s = det.summarize(findings)
+    assert s.bearing > 0
+    assert "coverage-analysis off" in s.recommendation.lower()
+
+
+def test_cli_json_output(capsys):
+    rc = det._cli([str(FIXTURE), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    import json
+
+    payload = json.loads(out)
+    assert "findings" in payload and "summary" in payload
+    assert payload["summary"]["total"] == len(payload["findings"])
+    assert payload["summary"]["total"] > 0  # FIXTURE is non-empty
+    # The finding record shape the #1159 gate/exclusion wiring consumes.
+    assert set(payload["findings"][0]) == {
+        "file",
+        "line",
+        "construct",
+        "compile_ability",
+        "coverage_impact",
+        "snippet",
+    }
+
+
+def test_cli_table_output(capsys):
+    rc = det._cli([str(FIXTURE)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # The per-finding table line shape plus the recommendation footer.
+    assert "fact-explicit" in out
+    assert "coverage-" in out
+    assert "/" in out  # the "[compile / coverage-...]" bracket
+    # summarize() recommendation footer is present (bearing hits in fixture).
+    assert "coverage-analysis off" in out.lower()


### PR DESCRIPTION
## What

Slice 2 of epic #1156. Adds `xunit_v3_feature_detector.py` — a pure, stdlib scanner that finds the xunit.v3-only constructs that break the v2 mutation-shim compile and **classifies** each on two axes so a human can decide how to handle it:

- **compile-ability** — `clean-translatable` vs `no-v2-equivalent`
- **coverage impact** — `neutral` (excluding changes no coverage, e.g. `Explicit=true` tests are skipped by default) vs `bearing` (excluding hides real coverage)

Plus an advisory sizing recommendation. Constructs covered: `[Fact/Theory(Explicit=true)]`, `Assert.Skip`/`SkipWhen`/`SkipUnless`, `TestContext.Current`/`ITestContext`, `ValueTask` async-lifetime, `TheoryDataRow`.

The detector feeds an **always-ask, never-auto-drop** human gate (protocol documented in `csharp-stryker-net.md`): the operator picks which tests to exclude from the shim; "exclude" means dropping the file from the shim's `<Compile Include>` set — **the real test suite is never edited**, so there's no crash-unsafe restore. #1158 consumes the gate outcome (loop vs degrade); #1159 applies the selected exclusions to shim generation.

## Review outcome (reviewed before opening)

- **correctness: pass** after fix — the `fact-explicit` regex over-matched into string literals (`DisplayName="Explicit = true"`); now quote-guarded (`[^\]"]*`) and case-sensitive.
- **test-review: pass** after fixes — added the missing half of two constructs' classification assertions, near-miss negatives (`Explicit=false`, LINQ `.Skip(`, commented-out attribute), the CLI table-branch test, a non-tautological JSON assertion, and multi-file ordering.
- **ai-provenance: pass** after fixes — classifications confirmed correct (no coverage-bearing test misclassified as neutral); grounded the table in xunit.v3's documented surface, downgraded the two `clean-translatable` overclaims (async-lifetime interface-shape, TheoryDataRow per-row metadata), and surfaced the neutral case's explicit-off precondition in both the note and the recommendation. Fully-commented lines are now skipped.

## Tests

Full pre-push suite green: **3731 passed, 3 skipped** (pre-existing env-gated). 20 detector tests cover every construct's full classification, the near-miss negatives, line numbers, missing-file, multi-file dedup order, `summarize()`'s three branches, and both CLI output modes.

Closes #1160
Part of #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)