### PR TITLE
fix(mutation-kill): shim-first feasibility gate before the loop

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -150,11 +150,7 @@ assertion-only fixes once you reach Statement/Block.
 
 ## Speed: scoped + per-test coverage analysis
 
-The scoped-run config the loop builds sets per-test coverage analysis (Stryker:
-`coverageAnalysis: "perTest"`; pitest: `withHistory`) so per-mutation execution
-drops from full-suite time to the time of the tests covering the mutated line
-(observed 10–50× speedup). Scoped + per-test is for the development loop; the
-full run (coverage-analysis off) is reserved for the CI gate only.
+The loop's scoped config sets per-test coverage (Stryker `coverageAnalysis: "perTest"`; pitest `withHistory`) so each mutant runs only its covering tests, not the full suite (observed 10–50× speedup). Scoped+per-test is the dev loop; the full run (coverage-analysis off) is the CI gate only.
 
 ## Fresh build before a run
 
@@ -222,6 +218,10 @@ generated code that this test surface cannot reach?
 
 This is the same `EXCLUDED` log format used for the [structurally unkillable
 files](#structurally-unkillable-files) section — a single audit trail either way.
+
+## Pre-loop feasibility gate (xunit.v3 shim-first)
+
+On **xunit.v3** the loop is viable only through the v2 shim, because it re-runs mutation every round and that is affordable only with **per-test** coverage. Prove per-test capture works before entering — measured, not assumed. Plain xunit.v2 / other stacks skip this gate. Steps: (1) run [`xunit_v3_feature_detector.py`](../skills/mutation-testing/scripts/xunit_v3_feature_detector.py) and resolve its **always-ask** human gate (#1160 — operator excludes shim-breaking tests or declines the shim path); (2) build the shim and run **one timed one-file probe** under `coverage-analysis: perTest`, scanning its output for the #1157 capture-failure signal; (3) arbitrate with [`mutation_feasibility_gate.py`](../skills/mutation-testing/scripts/mutation_feasibility_gate.py) (`--probe-seconds --scope-files [--capture-failed] [--shim-declined]`). **`enter-loop`** → proceed to the scripted loop. **`degrade`** (declined, capture failed, or estimated round over budget) → do **not** loop; run a single advisory `/mutation-testing` pass with `coverage-analysis: off` and record the waiver verbatim: *"mutant-kill loop not feasible on this suite (xunit.v3); ran single-pass advisory instead."* The round estimate is derived from the probe (`probe_seconds × scope files`), so a merely-slow environment degrades too. **Never grind for hours; never fabricate a score.**
 
 ## The loop is scripted — invoke it, don't re-run its steps by hand
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Pre-loop feasibility gate for the mutant-kill loop (#1158, part of #1156).
+
+The mutant-kill loop re-runs mutation after every generation round, so it is
+only viable when a scoped run gets **per-test** coverage (covering-subset per
+mutant). On an xunit.v3 suite that requires the v2 shim; if the shim path is
+declined, or per-test coverage capture fails (#1157) so Stryker degrades to
+whole-suite-per-mutant, or a single round would blow a wall-clock budget, then
+looping is infeasible — pay the cost once as a single advisory pass, never loop.
+
+This module is the pure, testable **arbiter**: given the shim-first one-file
+probe's results it returns ``enter-loop`` or ``degrade`` with a reason. The
+agent runs the probe (reusing the wrapper + #1157's capture detection) and
+feeds the measurements here; applying the shim exclusions is #1159's job.
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from typing import Optional, Sequence
+
+
+ENTER_LOOP = "enter-loop"
+DEGRADE = "degrade"
+
+# Wall-clock ceiling for a single estimated loop round. Not a magic constant on
+# the probe side — the round estimate is *derived from the measured probe*
+# (probe_seconds × scope files); this ceiling is the operator-tolerable maximum,
+# overridable so slow-but-working environments degrade rather than grind.
+DEFAULT_ROUND_BUDGET_SECONDS = 1800.0
+_BUDGET_ENV = "DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS"
+
+WAIVER_MESSAGE = (
+    "mutant-kill loop not feasible on this suite (xunit.v3); ran single-pass "
+    "advisory instead"
+)
+
+
+def resolve_budget_seconds(env: Optional[dict] = None) -> float:
+    """The per-round wall-clock ceiling — ``DEFAULT_ROUND_BUDGET_SECONDS``
+    unless ``DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS`` overrides it. A
+    non-positive or unparseable override falls back to the default."""
+    src = os.environ if env is None else env
+    raw = src.get(_BUDGET_ENV)
+    if raw is None:
+        return DEFAULT_ROUND_BUDGET_SECONDS
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_ROUND_BUDGET_SECONDS
+    return val if val > 0 else DEFAULT_ROUND_BUDGET_SECONDS
+
+
+def estimate_round_seconds(probe_seconds: float, scope_file_count: int) -> float:
+    """Estimate one full loop round from the one-file probe. Under working
+    per-test coverage each file costs ~the probe's wall-clock, so a round over
+    N files is ~probe × N. Derived from the probe, never hardcoded."""
+    if probe_seconds < 0:
+        probe_seconds = 0.0
+    return probe_seconds * max(1, scope_file_count)
+
+
+@dataclass(frozen=True)
+class Decision:
+    outcome: str  # ENTER_LOOP | DEGRADE
+    reason: str
+    estimated_round_seconds: Optional[float] = None
+    budget_seconds: Optional[float] = None
+
+    @property
+    def waiver(self) -> Optional[str]:
+        """The precise waiver line to record when degrading; None when the
+        loop is entered."""
+        return None if self.outcome == ENTER_LOOP else WAIVER_MESSAGE
+
+
+def decide(
+    *,
+    shim_declined: bool,
+    capture_failed: bool,
+    probe_seconds: float,
+    scope_file_count: int,
+    budget_seconds: Optional[float] = None,
+) -> Decision:
+    """Arbitrate loop-vs-degrade from the shim-first probe.
+
+    Order matters: an operator's decline and a hard capture failure both make
+    the loop infeasible regardless of timing, so they short-circuit before the
+    (timing-based) budget check — which itself only means anything once per-test
+    capture is known to work.
+    """
+    if budget_seconds is None:
+        budget_seconds = resolve_budget_seconds()
+
+    if shim_declined:
+        return Decision(
+            DEGRADE,
+            "operator declined the shim path at the v3-feature gate (#1160)",
+        )
+    if capture_failed:
+        return Decision(
+            DEGRADE,
+            "per-test coverage capture failed on the probe (#1157) — Stryker "
+            "fell back to whole-suite-per-mutant, so each loop round pays the "
+            "full-suite cost",
+        )
+
+    estimated = estimate_round_seconds(probe_seconds, scope_file_count)
+    if estimated > budget_seconds:
+        return Decision(
+            DEGRADE,
+            f"estimated round {estimated:.0f}s exceeds the {budget_seconds:.0f}s "
+            "budget (per-test works but the suite is too slow to iterate)",
+            estimated_round_seconds=estimated,
+            budget_seconds=budget_seconds,
+        )
+    return Decision(
+        ENTER_LOOP,
+        f"per-test capture works and the estimated round {estimated:.0f}s is "
+        f"within the {budget_seconds:.0f}s budget",
+        estimated_round_seconds=estimated,
+        budget_seconds=budget_seconds,
+    )
+
+
+def _cli(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Arbitrate the mutant-kill loop's shim-first feasibility gate."
+    )
+    parser.add_argument(
+        "--shim-declined",
+        action="store_true",
+        help="operator declined the shim path at the #1160 v3-feature gate",
+    )
+    parser.add_argument(
+        "--capture-failed",
+        action="store_true",
+        help="the #1157 coverage-capture-failure signal fired on the probe",
+    )
+    parser.add_argument(
+        "--probe-seconds", type=float, default=0.0, help="measured one-file probe wall-clock"
+    )
+    parser.add_argument(
+        "--scope-files", type=int, default=1, help="number of files in the loop scope"
+    )
+    parser.add_argument(
+        "--budget-seconds",
+        type=float,
+        default=None,
+        help="override the per-round wall-clock budget",
+    )
+    args = parser.parse_args(list(argv))
+
+    decision = decide(
+        shim_declined=args.shim_declined,
+        capture_failed=args.capture_failed,
+        probe_seconds=args.probe_seconds,
+        scope_file_count=args.scope_files,
+        budget_seconds=args.budget_seconds,
+    )
+    payload = asdict(decision)
+    payload["waiver"] = decision.waiver
+    print(json.dumps(payload, indent=2))
+    # Exit 0 either way — this is an advisory arbiter, not a gate that fails a run.
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_cli(sys.argv[1:]))

--- a/tests/scripts/test_mutation_feasibility_gate.py
+++ b/tests/scripts/test_mutation_feasibility_gate.py
@@ -1,0 +1,201 @@
+"""Tests for mutation_feasibility_gate.py — the mutant-kill loop's shim-first
+feasibility arbiter (#1158, part of #1156)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mutation_feasibility_gate as gate  # noqa: E402
+
+
+# --- decide: the happy path (loop entered) ---------------------------------
+
+
+def test_fast_pertest_probe_enters_loop():
+    d = gate.decide(
+        shim_declined=False,
+        capture_failed=False,
+        probe_seconds=10.0,
+        scope_file_count=5,
+        budget_seconds=1800.0,
+    )
+    assert d.outcome == gate.ENTER_LOOP
+    assert d.waiver is None
+    assert d.estimated_round_seconds == 50.0
+
+
+def test_healthy_v2_repo_enters_loop_no_regression(monkeypatch):
+    # No shim decline, no capture failure, trivially fast — the plain xunit.v2
+    # path must be unchanged. Strip the budget env so the default applies
+    # regardless of the host shell (hermetic).
+    monkeypatch.delenv("DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS", raising=False)
+    d = gate.decide(
+        shim_declined=False,
+        capture_failed=False,
+        probe_seconds=1.0,
+        scope_file_count=1,
+    )
+    assert d.outcome == gate.ENTER_LOOP
+
+
+# --- decide: degrade paths --------------------------------------------------
+
+
+def test_capture_failure_degrades_regardless_of_timing():
+    d = gate.decide(
+        shim_declined=False,
+        capture_failed=True,
+        probe_seconds=0.1,  # would be "fast" but capture failed
+        scope_file_count=1,
+        budget_seconds=1800.0,
+    )
+    assert d.outcome == gate.DEGRADE
+    assert "#1157" in d.reason
+    assert d.waiver == gate.WAIVER_MESSAGE
+
+
+def test_shim_declined_degrades():
+    d = gate.decide(
+        shim_declined=True,
+        capture_failed=False,
+        probe_seconds=1.0,
+        scope_file_count=1,
+    )
+    assert d.outcome == gate.DEGRADE
+    assert "#1160" in d.reason
+    assert d.waiver == gate.WAIVER_MESSAGE
+
+
+def test_over_budget_degrades():
+    d = gate.decide(
+        shim_declined=False,
+        capture_failed=False,
+        probe_seconds=100.0,
+        scope_file_count=40,  # 4000s estimated
+        budget_seconds=1800.0,
+    )
+    assert d.outcome == gate.DEGRADE
+    assert "budget" in d.reason
+    assert d.estimated_round_seconds == 4000.0
+
+
+def test_shim_decline_takes_precedence_over_capture_and_budget():
+    d = gate.decide(
+        shim_declined=True,
+        capture_failed=True,
+        probe_seconds=100.0,
+        scope_file_count=40,
+    )
+    assert d.outcome == gate.DEGRADE
+    assert "#1160" in d.reason  # decline reason wins the short-circuit
+
+
+def test_capture_failure_takes_precedence_over_budget():
+    d = gate.decide(
+        shim_declined=False,
+        capture_failed=True,
+        probe_seconds=100.0,
+        scope_file_count=40,
+    )
+    assert d.outcome == gate.DEGRADE
+    assert "#1157" in d.reason
+
+
+# --- estimate_round_seconds -------------------------------------------------
+
+
+def test_estimate_scales_with_scope():
+    assert gate.estimate_round_seconds(10.0, 5) == 50.0
+
+
+def test_estimate_floors_scope_at_one():
+    assert gate.estimate_round_seconds(10.0, 0) == 10.0
+
+
+def test_estimate_clamps_negative_probe():
+    assert gate.estimate_round_seconds(-5.0, 3) == 0.0
+
+
+# --- resolve_budget_seconds -------------------------------------------------
+
+
+def test_budget_default_when_unset():
+    assert gate.resolve_budget_seconds({}) == gate.DEFAULT_ROUND_BUDGET_SECONDS
+
+
+def test_budget_reads_real_environ_when_no_dict(monkeypatch):
+    # The env is None path reads os.environ; strip then set to pin the branch.
+    monkeypatch.delenv("DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS", raising=False)
+    assert gate.resolve_budget_seconds() == gate.DEFAULT_ROUND_BUDGET_SECONDS
+    monkeypatch.setenv("DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS", "600")
+    assert gate.resolve_budget_seconds() == 600.0
+
+
+def test_budget_env_override():
+    assert gate.resolve_budget_seconds(
+        {"DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS": "300"}
+    ) == 300.0
+
+
+def test_budget_ignores_nonpositive_and_garbage():
+    assert (
+        gate.resolve_budget_seconds({"DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS": "0"})
+        == gate.DEFAULT_ROUND_BUDGET_SECONDS
+    )
+    assert (
+        gate.resolve_budget_seconds({"DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS": "nan?"})
+        == gate.DEFAULT_ROUND_BUDGET_SECONDS
+    )
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_enter_loop_json(capsys):
+    rc = gate._cli(["--probe-seconds", "5", "--scope-files", "3"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["outcome"] == gate.ENTER_LOOP
+    assert payload["waiver"] is None
+
+
+def test_cli_capture_failed_json(capsys):
+    rc = gate._cli(["--capture-failed"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["outcome"] == gate.DEGRADE
+    assert payload["waiver"] == gate.WAIVER_MESSAGE
+
+
+def test_cli_shim_declined_flag_wiring(capsys):
+    rc = gate._cli(["--shim-declined"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["outcome"] == gate.DEGRADE
+    assert "#1160" in payload["reason"]
+
+
+def test_cli_budget_flag_wiring(capsys):
+    # Small budget + slow probe drives the over-budget degrade through argparse.
+    rc = gate._cli(
+        ["--probe-seconds", "100", "--scope-files", "40", "--budget-seconds", "10"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["outcome"] == gate.DEGRADE
+    assert "budget" in payload["reason"]


### PR DESCRIPTION
## What

Slice 3 of epic #1156. Adds `mutation_feasibility_gate.py` — the pure arbiter that decides, per run, whether the mutant-kill loop is viable or must degrade to a single advisory pass. The loop re-runs mutation every generation round, so on xunit.v3 it's affordable only when the v2 shim delivers per-test coverage.

`decide()` returns **`enter-loop`** or **`degrade`**, degrading when:
- the operator declined the shim path at the #1160 v3-feature gate,
- the #1157 capture-failure signal fired (whole-suite-per-mutant), or
- the estimated round exceeds a configurable wall-clock budget.

The round estimate is `probe_seconds × scope files` — **derived from the probe, not a magic constant** — so a merely-slow environment degrades too, not just the v3 bug. Budget default 1800s, overridable via `DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS`.

Wired into the mutation-kill agent as a **pre-loop gate** (before "The loop is scripted"): run the #1160 detector + always-ask gate → shim-first one-file `perTest` probe → arbitrate → enter loop, or run a single `/mutation-testing` advisory with `coverage-analysis: off` and record the verbatim waiver *"mutant-kill loop not feasible on this suite (xunit.v3); ran single-pass advisory instead."* Never grind for hours; never fabricate a score. Plain xunit.v2 / other stacks skip the gate — no regression.

## Review outcome (reviewed before opening)

- **correctness: pass** — short-circuit order (declined → capture → budget) correct so a fast probe can't override a decline/capture-failure; clamps and budget fallbacks (None/garbage/non-positive/NaN → default) sound; waiver logic right.
- **test-review: pass** after fixes — added an explicit outcome assertion to the precedence test, made the no-regression test hermetic (`monkeypatch.delenv`) plus a dedicated `env is None` branch test, and drove the `--shim-declined` / `--budget-seconds` CLI flag wiring end-to-end.

## Tests

Full pre-push suite green: **3749 passed, 3 skipped**. 18 gate tests cover all `decide()` branches, the full declined>capture>budget precedence chain, estimate clamps, all budget fallbacks, the healthy-v2 no-regression case, and every CLI outcome. Agent stays under the 500-line budget.

Closes #1158
Part of #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)