### PR TITLE
fix(mutation-testing): harden the v2 shim path and add the -t mtp coverage-off floor

### DIFF
--- a/plugins/dev-team/hooks/stryker_xunit_shim_guard.py
+++ b/plugins/dev-team/hooks/stryker_xunit_shim_guard.py
@@ -96,6 +96,18 @@ def _is_v3(csproj: Path) -> bool:
     return "xunit.v3" in _read(csproj)
 
 
+_MTP_RUNNER_RE = re.compile(r"""(?:^|\s)(?:-t|--test-runner)[ =]+["']?mtp\b""")
+
+
+def _uses_mtp_runner(command: str) -> bool:
+    """True when the command explicitly selects Stryker's Microsoft Testing
+    Platform runner (`-t mtp` / `--test-runner mtp`) — the sanctioned no-shim
+    floor (#1156/#1159): it drives the real xunit.v3 suite and yields a real
+    (if slow, whole-suite-per-mutant) score, so the false-~0% premise this gate
+    guards against does not apply."""
+    return bool(_MTP_RUNNER_RE.search(command))
+
+
 def _resolve_run_dir(command: str, cwd: str) -> Path:
     """Honour a leading `cd <dir> && ...` so the gate reasons about where Stryker
     actually runs, not where the shell started."""
@@ -211,6 +223,12 @@ def main() -> int:
         return 0
     command = (event.get("tool_input") or {}).get("command", "") or ""
     if not _STRYKER_TRIGGER.search(command):
+        return 0
+
+    # Sanctioned no-shim floor (#1156/#1159): an explicit MTP-runner run drives
+    # the real xunit.v3 suite and produces a real score, so it must not be
+    # blocked or shimmed. Let it through before any v3-project detection.
+    if _uses_mtp_runner(command):
         return 0
 
     cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5276,6 +5276,10 @@
       "summary": "Stryker.NET (through at least 4.15/4.16) **cannot observe mutant kills through",
       "anchor": "why-this-exists"
     },
+    "Scope — one path, not the only one": {
+      "summary": "The shim is the path that keeps the **mutant-kill loop** viable on xunit.v3, because it restores per-test coverage (fast covering-subset per mutant).",
+      "anchor": "scope-one-path-not-the-only-one"
+    },
     "When to build it": {
       "summary": "Detection is one check: a test `.csproj` contains `Include=\"xunit.v3\"`.",
       "anchor": "when-to-build-it"

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -86,11 +86,25 @@ python3 scripts/xunit_v3_feature_detector.py <test-project>/**/*.cs --json
 
 **"Deactivate" means exclude from the shim's `<Compile Include>` set, never edit the real test suite** — so there is no crash-unsafe "restore after the loop" step. The operator-selected exclusions are applied to the shim project by the shim-generation path (see [#1159](https://github.com/bdfinst/agentic-dev-team/issues/1159)); the loop-vs-degrade decision that consumes this gate's outcome lives in [#1158](https://github.com/bdfinst/agentic-dev-team/issues/1158).
 
+### No-shim floor — `-t mtp` + `coverage-analysis: off`
+
+When the feasibility gate degrades (operator declined the shim, per-test capture failed, or the estimated round is over budget), the sanctioned fallback is to run the **real xunit.v3 suite** through the Microsoft Testing Platform runner with coverage off:
+
+```bash
+dotnet stryker -t mtp --config-file stryker-config.json   # coverage-analysis: off
+```
+
+No shim is built, so there are no v3-only-syntax compile breaks. **`-t mtp` is the floor, not a fast path** — it does not restore per-test coverage (stryker-net#3629 is closed-unfixed), so the run is still whole-suite-per-mutant and slow; use it for a single advisory pass, not the iterating loop. The `stryker_xunit_shim_guard.py` gate **exempts** an explicit `-t mtp` run (it produces a real score, so the false-~0% block does not apply).
+
+**Trigger is xunit.v3, not the TFM.** Decide `off`-vs-`perTest` from xunit.v3 in the **real** test suite, never from a csproj that may be the v2 shim — a shim's `xunit` v2 marker must not mask the real v3 project. **Runtime:** current Stryker.NET requires the **.NET 10 runtime to run** (even for older target projects); if `dotnet --version` is below 10, install/select it before any Stryker invocation.
+
 ## .NET 10 targets: default `vstest` runner can silently fake a 0% score
 
-On **.NET 10** test-project targets (and possibly .NET 9), Stryker.NET's bundled default `vstest` test runner can silently fail to capture coverage — it ships a `net8.0` `vstest.console.dll` that cannot correctly execute newer-TFM test assemblies. The observable symptom is a **fake `Killed: 0` / `Survived: N` / 0.00 % score**, even though the same tests pass fine under a direct `dotnet test`. This is the complementary failure mode to the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section above (that one produces a fake **100 %** via `Timeout`; this one produces a fake **0 %** via `Survived`) — both are caught by [`SKILL.md`](../../SKILL.md) **Step 1c smoke gate**, but this one is easy to mistake for a legitimately weak test suite rather than a broken runner.
+> **Distinct from the xunit.v3 coverage-capture failure** (see the "No-shim floor" and xunit.v3 sections above). That one is a **per-test coverage-capture** problem keyed on **xunit.v3** (breaks even under VSTest), where `-t mtp` is only the slow *floor*. The one below is a **runner-execution** problem keyed on the **TFM**: the bundled vstest runner cannot execute the assemblies at all. `-t mtp` genuinely fixes *this* one (it swaps in a runner that can execute the tests) but still does **not** restore fast per-test coverage. Do not read this TFM-keyed runner bug as licence to decide `off`-vs-`perTest` from the TFM — that decision keys on xunit.v3.
 
-**Recommend `-t mtp` (the Microsoft Testing Platform runner) as the default for .NET 10+ targets, not an afterthought:**
+On **.NET 10** test-project targets (and possibly .NET 9), Stryker.NET's bundled default `vstest` test runner can silently fail to **execute** newer-TFM test assemblies — it ships a `net8.0` `vstest.console.dll` that cannot correctly run them. The observable symptom is a **fake `Killed: 0` / `Survived: N` / 0.00 % score**, even though the same tests pass fine under a direct `dotnet test`. This is a **complementary** failure mode to the [xunit.v3 detection](#xunitv3-detection-do-this-before-configuring-runs) section above (that one produces a fake **100 %** via `Timeout`; this one produces a fake **0 %** via `Survived`) — both are caught by [`SKILL.md`](../../SKILL.md) **Step 1c smoke gate**, but this one is easy to mistake for a legitimately weak test suite rather than a broken runner.
+
+**Recommend `-t mtp` (the Microsoft Testing Platform runner) for .NET 10+ targets to fix the runner-execution failure — but note it does not restore per-test coverage (that is the separate xunit.v3 constraint above):**
 
 ```bash
 export DOTNET_ROOT="${DOTNET_ROOT:-/opt/homebrew/opt/dotnet/libexec}"
@@ -98,7 +112,7 @@ dotnet build <solution> -c Debug --nologo
 dotnet stryker -t mtp --mutate "**/ChangedFile.cs" -O StrykerOutput/probe
 ```
 
-If a smoke probe (Step 1c) or full run reports `Killed: 0` alongside `Survived > 0` on a .NET 10 target using the default runner, retry with `-t mtp` before assuming the test suite doesn't cover the mutated code — a real coverage-capture bug, not a real test gap, is the more likely explanation on this TFM.
+If a smoke probe (Step 1c) or full run reports `Killed: 0` alongside `Survived > 0` on a .NET 10 target using the default runner, retry with `-t mtp` before assuming the test suite doesn't cover the mutated code — a broken runner (can't execute the assemblies), not a real test gap, is the more likely explanation on this TFM.
 
 ## Default `coverage-analysis: perTest` for xunit.v2 / non-MTP projects
 

--- a/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
+++ b/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
@@ -28,6 +28,10 @@ of truth. Stryker is then run **from the shim directory** in project mode.
 [`references/shim-howto.md`](references/shim-howto.md) has the full reference build
 and any edge case not covered here.
 
+## Scope — one path, not the only one
+
+The shim is the path that keeps the **mutant-kill loop** viable on xunit.v3, because it restores per-test coverage (fast covering-subset per mutant). It is not mandatory for every xunit.v3 run. Within `mutation-kill` the shim-first feasibility gate ([#1158](https://github.com/bdfinst/agentic-dev-team/issues/1158)) decides per run: build the shim and probe under `perTest`; if per-test capture works and a round fits the budget, enter the loop; otherwise **degrade** to the no-shim floor — the real v3 suite via `-t mtp` + `coverage-analysis: off` (a real but slow, whole-suite-per-mutant single advisory pass; see [`csharp-stryker-net.md`](../mutation-testing/references/languages/csharp-stryker-net.md)). Before building, [`xunit_v3_feature_detector.py`](../mutation-testing/scripts/xunit_v3_feature_detector.py) classifies the shim-breaking v3-only constructs for an always-ask human gate; pass the operator's selections to `generate_shim.py --compile-exclude` to drop them from the shim's compile set.
+
 ## When to build it
 
 Detection is one check: a test `.csproj` contains `Include="xunit.v3"`. Build the
@@ -36,7 +40,7 @@ shim **proactively, before the first Stryker run** — because the failure is si
 possibly hours-long run. As a backstop the `stryker_xunit_shim_guard.py` PreToolUse
 hook auto-scaffolds the shim (and reports what it wrote) when you run
 `dotnet-stryker` against a xunit.v3 project without one, then blocks so you re-run
-from the shim dir — but build it proactively rather than relying on the interception.
+from the shim dir — but build it proactively rather than relying on the interception. (The guard **exempts** an explicit `-t mtp` run — the no-shim floor — so it is not forced into a shim; see the Scope section.) Within `mutation-kill` the feasibility gate may still degrade to that floor after the shim is built and probed.
 
 One precondition decides whether the shim is cheap: source compatibility with
 xunit.v2. `[Fact]`, `[Theory]`, `[InlineData]`, `TheoryData<>`, `MemberData`,

--- a/plugins/dev-team/skills/stryker-xunit-v2-shim/scripts/generate_shim.py
+++ b/plugins/dev-team/skills/stryker-xunit-v2-shim/scripts/generate_shim.py
@@ -35,6 +35,10 @@ def main():
     ap.add_argument("csproj", help="path to the real xunit.v3 test .csproj")
     ap.add_argument("--mutate-exclude", action="append", default=[],
                     help="extra mutate exclude glob (repeatable), e.g. '**/gRPC/**/*.cs'")
+    ap.add_argument("--compile-exclude", action="append", default=[],
+                    help="operator-selected v3-feature test file to drop from the shim's "
+                         "<Compile> set (repeatable), from the #1160 always-ask gate. Path "
+                         "relative to the real project, e.g. '..\\Foo.Tests\\ExplicitTests.cs'")
     args = ap.parse_args()
 
     real = os.path.abspath(args.csproj)
@@ -88,9 +92,14 @@ def main():
         lines += ["  <ItemGroup>"]
         lines += ["    " + " ".join(pr.split()) for pr in projrefs]
         lines += ["  </ItemGroup>", ""]
+    # Always exclude build output; append operator-selected v3-feature files
+    # (#1160) so the shim compiles without the constructs that break under v2.
+    compile_excludes = [f"..\\{name}\\obj\\**\\*.cs", f"..\\{name}\\bin\\**\\*.cs"]
+    compile_excludes += [g.strip() for g in args.compile_exclude if g.strip()]
+    exclude_attr = ";".join(compile_excludes)
     lines += ["  <ItemGroup>",
               f'    <Compile Include="..\\{name}\\**\\*.cs"',
-              f'             Exclude="..\\{name}\\obj\\**\\*.cs;..\\{name}\\bin\\**\\*.cs">',
+              f'             Exclude="{exclude_attr}">',
               "      <Link>Linked\\%(RecursiveDir)%(FileName)%(Extension)</Link>",
               "    </Compile>",
               "  </ItemGroup>", "", "</Project>", ""]
@@ -100,7 +109,12 @@ def main():
         fh.write("\n".join(lines))
 
     mutate = ["**/*.cs", "!obj/**/*.cs"] + [f"!{g}" for g in args.mutate_exclude]
+    # Pin test-projects to the shim and deliberately set NO SolutionPath: with
+    # both set, Stryker enumerates the solution and prefers the real xunit.v3
+    # project over the shim (the SolutionPath trap, #557/#1156) — so the shim's
+    # kills never register. test-projects alone keeps Stryker on the shim.
     config = {"stryker-config": {
+        "test-projects": [f"{name}.Mutation.csproj"],
         "mutate": mutate,
         "mutation-level": "Standard",
         "coverage-analysis": "perTest",

--- a/plugins/dev-team/tests/hooks/test_stryker_xunit_shim_guard.py
+++ b/plugins/dev-team/tests/hooks/test_stryker_xunit_shim_guard.py
@@ -109,6 +109,45 @@ def test_dotnet_dash_stryker_also_triggers(tmp_path):
     assert proc.returncode == 2
 
 
+def test_mtp_floor_run_is_exempt(tmp_path):
+    # The sanctioned no-shim floor (#1156/#1159): an explicit -t mtp run drives
+    # the real v3 suite and yields a real score, so it must NOT be blocked or
+    # scaffolded.
+    d = _v3_project(tmp_path)
+    proc = _run({"tool_name": "Bash", "cwd": str(d),
+                 "tool_input": {"command": "dotnet stryker -t mtp --reporter json"}})
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+    # No shim was scaffolded by the floor path.
+    assert not (tmp_path / "tests" / "Acme.Widgets.Tests.Mutation").exists()
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "dotnet stryker --test-runner mtp",
+        "dotnet stryker -t=mtp",
+        "dotnet stryker --test-runner=mtp",
+        'dotnet stryker --test-runner "mtp"',
+    ],
+)
+def test_mtp_runner_variants_exempt(tmp_path, cmd):
+    d = _v3_project(tmp_path)
+    proc = _run({"tool_name": "Bash", "cwd": str(d),
+                 "tool_input": {"command": cmd}})
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+    assert not (tmp_path / "tests" / "Acme.Widgets.Tests.Mutation").exists()
+
+
+def test_vstest_runner_still_blocks(tmp_path):
+    # An explicit non-mtp runner is NOT the floor — the false-score block stands.
+    d = _v3_project(tmp_path)
+    proc = _run({"tool_name": "Bash", "cwd": str(d),
+                 "tool_input": {"command": "dotnet stryker -t vstest"}})
+    assert proc.returncode == 2
+
+
 def test_v3_only_constructs_refuse_scaffold(tmp_path):
     d = _v3_project(tmp_path)
     (d / "AutoTests.cs").write_text(

--- a/tests/scripts/test_generate_shim.py
+++ b/tests/scripts/test_generate_shim.py
@@ -1,0 +1,135 @@
+"""Tests for the xunit.v2 shim generator's #1159 hardening — operator-selected
+compile exclusions and the SolutionPath-trap-avoiding config."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN = (
+    _REPO_ROOT
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "stryker-xunit-v2-shim"
+    / "scripts"
+    / "generate_shim.py"
+)
+
+_V3_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Acme.Widgets.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\Acme.Widgets\\Acme.Widgets.csproj" />
+  </ItemGroup>
+</Project>
+"""
+
+
+def _make_project(root: Path) -> Path:
+    d = root / "tests" / "Acme.Widgets.Tests"
+    d.mkdir(parents=True)
+    csproj = d / "Acme.Widgets.Tests.csproj"
+    csproj.write_text(_V3_CSPROJ)
+    return csproj
+
+
+def _run_gen(csproj: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_GEN), str(csproj), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _shim_dir(root: Path) -> Path:
+    return root / "tests" / "Acme.Widgets.Tests.Mutation"
+
+
+def test_config_pins_test_projects_and_omits_solution_path(tmp_path):
+    csproj = _make_project(tmp_path)
+    proc = _run_gen(csproj)
+    assert proc.returncode == 0, proc.stderr
+    config = json.loads((_shim_dir(tmp_path) / "stryker-config.json").read_text())
+    sc = config["stryker-config"]
+    # test-projects pins the shim; SolutionPath must be absent (the #557/#1156 trap).
+    assert sc["test-projects"] == ["Acme.Widgets.Tests.Mutation.csproj"]
+    assert "SolutionPath" not in sc
+    assert "solution-path" not in sc
+
+
+def test_compile_exclude_appends_to_shim_compile_set(tmp_path):
+    csproj = _make_project(tmp_path)
+    proc = _run_gen(
+        csproj,
+        "--compile-exclude",
+        "..\\Acme.Widgets.Tests\\ExplicitTests.cs",
+        "--compile-exclude",
+        "..\\Acme.Widgets.Tests\\TestContextUsage.cs",
+    )
+    assert proc.returncode == 0, proc.stderr
+    shim_csproj = (_shim_dir(tmp_path) / "Acme.Widgets.Tests.Mutation.csproj").read_text()
+    assert "ExplicitTests.cs" in shim_csproj
+    assert "TestContextUsage.cs" in shim_csproj
+    # Still inside the <Compile ... Exclude="..."> attribute alongside obj/bin.
+    assert "obj\\**\\*.cs" in shim_csproj
+
+
+def test_compile_exclude_single_value(tmp_path):
+    csproj = _make_project(tmp_path)
+    proc = _run_gen(csproj, "--compile-exclude", "..\\Acme.Widgets.Tests\\OneFile.cs")
+    assert proc.returncode == 0, proc.stderr
+    shim_csproj = (_shim_dir(tmp_path) / "Acme.Widgets.Tests.Mutation.csproj").read_text()
+    assert "OneFile.cs" in shim_csproj
+    # Appended after the two defaults with a single separator, no doubled ';'.
+    assert "bin\\**\\*.cs;..\\Acme.Widgets.Tests\\OneFile.cs" in shim_csproj
+    assert ";;" not in shim_csproj
+
+
+def test_compile_exclude_drops_empty_and_trims(tmp_path):
+    csproj = _make_project(tmp_path)
+    proc = _run_gen(
+        csproj,
+        "--compile-exclude", "",
+        "--compile-exclude", "   ",
+        "--compile-exclude", "  ..\\Acme.Widgets.Tests\\Padded.cs  ",
+    )
+    assert proc.returncode == 0, proc.stderr
+    exclude_line = next(
+        ln for ln in (_shim_dir(tmp_path) / "Acme.Widgets.Tests.Mutation.csproj")
+        .read_text().splitlines() if "Exclude=" in ln
+    )
+    # Empty/whitespace entries dropped → no doubled/trailing separators.
+    assert ";;" not in exclude_line
+    assert not exclude_line.rstrip('">').endswith(";")
+    # The padded path is present, trimmed.
+    assert "..\\Acme.Widgets.Tests\\Padded.cs" in exclude_line
+    assert "Padded.cs  " not in exclude_line
+
+
+def test_no_compile_exclude_keeps_default_excludes_only(tmp_path):
+    csproj = _make_project(tmp_path)
+    proc = _run_gen(csproj)
+    assert proc.returncode == 0
+    shim_csproj = (_shim_dir(tmp_path) / "Acme.Widgets.Tests.Mutation.csproj").read_text()
+    assert 'Exclude="..\\Acme.Widgets.Tests\\obj\\**\\*.cs;..\\Acme.Widgets.Tests\\bin\\**\\*.cs"' in shim_csproj
+
+
+def test_non_v3_csproj_refuses(tmp_path):
+    d = tmp_path / "tests" / "Plain"
+    d.mkdir(parents=True)
+    csproj = d / "Plain.csproj"
+    csproj.write_text('<Project><ItemGroup><PackageReference Include="xunit" Version="2.9.2" /></ItemGroup></Project>')
+    proc = _run_gen(csproj)
+    assert proc.returncode != 0
+    assert "xunit.v3" in proc.stderr


### PR DESCRIPTION
## What

Slice 4 (final) of epic #1156. Makes the shim path reliable so #1158's probe reflects its real capability, and gives an honest floor when the shim path isn't taken.

- **`generate_shim.py`** — new `--compile-exclude` (repeatable) drops the operator-selected v3-feature files from #1160's always-ask gate out of the shim's `<Compile>` set; the generated config now pins `test-projects` to the shim and sets **no** `SolutionPath`, so Stryker can't enumerate the solution and prefer the real v3 project (the SolutionPath trap, #557/#1156 — the likely reason "shim compiled but capture still failed").
- **`stryker_xunit_shim_guard.py`** — exempts an explicit `-t mtp` / `--test-runner mtp` run: the sanctioned no-shim floor drives the real v3 suite and yields a real score, so the false-~0% block must not fire. A non-mtp runner still blocks.
- **Docs** — `csharp-stryker-net.md` gains the no-shim floor (`-t mtp` + `coverage-analysis: off` is the **floor, not a fast path** — still whole-suite-per-mutant), the xunit.v3-not-TFM trigger, and the .NET 10 runtime requirement; disambiguates the older ".NET 10 targets" section (a distinct *runner-execution* bug) from the xunit.v3 *coverage-capture* failure. The shim `SKILL.md` gains a scope note tying it to the #1158 feasibility gate.

## Review outcome (reviewed before opening)

- **correctness: pass** — the mtp regex matches all four forms and rejects `-t vstest` / `--other mtp` / `-t mtpx`; Exclude string well-formed for 0/1/N. Applied its one suggestion (quote-tolerant `--test-runner "mtp"`).
- **test-review: pass** after fixes — added the whitespace/empty `--compile-exclude` filter test, the `=`-form + quoted mtp variants, strengthened the long-flag exemption assertions, and a 1-value boundary.
- **doc-review: pass** after fix — reconciled the new xunit.v3/floor framing with the older ".NET 10 targets" section (distinct failure modes, cross-referenced) and pointed the shim "When to build it" at the degrade path.

## Tests

Full pre-push suite green: **3761 passed, 3 skipped**. New tests cover the mtp exemption (all flag forms + no-shim negative + non-mtp-still-blocks) and the shim generator (compile-exclude 0/1/N + whitespace filter, test-projects pin, SolutionPath absence, non-v3 refusal).

Closes #1159
Part of #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)