### PR TITLE
fix: load plugin hooks via hooks/hooks.json and route subagent models by dispatch alias

### DIFF
--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -41,7 +41,7 @@ The orchestrator classifies incoming requests, routes them to the appropriate pi
 
 ## Resolution Procedure
 
-Each agent declares an **effort band** (`effort: low|medium|high`) in its frontmatter — the reasoning effort its task needs, not a vendor model name. Band-to-model resolution is **enforced by a PreToolUse hook** (`hooks/agent_model_resolve.py`, registered in `settings.json` under `matcher: "Agent"`) backed by the resolver helper (`hooks/lib/model_resolve.py`). The LLM cannot bypass it.
+Each agent declares an **effort band** (`effort: low|medium|high`) in its frontmatter — the reasoning effort its task needs, not a vendor model name. Band-to-model resolution is **enforced by a PreToolUse hook** (`hooks/agent_model_resolve.py`, registered in `hooks/hooks.json` under `matcher: "Agent|Task"`, mirrored in `settings.json` for older CLIs) backed by the resolver helper (`hooks/lib/model_resolve.py`). The LLM cannot bypass it.
 
 When the orchestrator (or any caller) spawns a subagent via the Agent tool, the hook:
 

--- a/plugins/dev-team/docs/model-routing.md
+++ b/plugins/dev-team/docs/model-routing.md
@@ -40,7 +40,7 @@ flowchart LR
     end
 
     subgraph plugin[Plugin enforcement surface]
-        HK[hooks/agent_model_resolve.py<br/>PreToolUse, matcher Agent]
+        HK[hooks/agent_model_resolve.py<br/>PreToolUse, matcher Agent|Task]
         RS[hooks/lib/model_resolve.py<br/>resolver helper]
     end
 
@@ -114,10 +114,18 @@ silent; bumps are logged to disk for `/model-routing-check`.
 ## Contract
 
 Each agent declares `effort: low|medium|high` in its YAML frontmatter. The
-PreToolUse hook `hooks/agent_model_resolve.py`, registered in `settings.json`
-under `matcher: "Agent"`, intercepts every sub-agent dispatch, strips any
-`<plugin>:` prefix from `subagent_type`, reads the agent's effort band, and
-resolves it to a concrete model before the harness sees the call.
+PreToolUse hook `hooks/agent_model_resolve.py`, registered in
+`hooks/hooks.json` (the plugin-hook mechanism Claude Code actually loads;
+`settings.json` mirrors the registrations for older CLIs) under
+`matcher: "Agent|Task"` — the subagent-dispatch tool was named `Task` before
+Claude Code 2.1.63 and `Agent` after, and both names are covered so a
+harness rename can't silently kill routing (#1178) — intercepts every
+sub-agent dispatch, strips any `<plugin>:` prefix from `subagent_type`,
+reads the agent's effort band, and resolves it to a concrete model before
+the harness sees the call. The rewrite emits the dispatch-layer **alias**
+(`haiku|sonnet|opus`), not the resolved snapshot ID: the Agent/Task tool's
+`model` parameter silently ignores full snapshot IDs (#1178), while the
+routing map and bump log keep full IDs for ladder/pricing purposes.
 
 Resolution inputs:
 

--- a/plugins/dev-team/hooks/agent_model_resolve.py
+++ b/plugins/dev-team/hooks/agent_model_resolve.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Python port of hooks/agent-model-resolve.sh (#585 / #572 Phase 2).
 
-PreToolUse hook on the `Agent` matcher. Resolves an agent's effort band to
-a concrete model before any sub-agent dispatch reaches the harness, then
-rewrites `tool_input.model` so the harness dispatches on it.
+PreToolUse hook on the `Agent|Task` matcher (the subagent-dispatch tool:
+`Task` before Claude Code 2.1.63, `Agent` after the rename — both names are
+accepted so a harness rename can't silently kill routing, #1178). Resolves
+an agent's effort band to a concrete model before any sub-agent dispatch
+reaches the harness, then rewrites `tool_input.model` so the harness
+dispatches on it. The rewrite value is the dispatch-layer ALIAS
+(haiku|sonnet|opus|fable), not the resolved snapshot ID: the Agent/Task
+tool's `model` parameter validates against an alias enum and silently
+ignores full snapshot IDs (#1178), while the routing map keeps full IDs
+for ladder/pricing purposes.
 
 Emits one of:
   - rewrite:      {"hookSpecificOutput":{"hookEventName":"PreToolUse",
@@ -248,6 +255,24 @@ def _emit_pass_through() -> None:
     sys.stdout.write("{}\n")
 
 
+# The Agent/Task tool's `model` parameter accepts alias names only — a full
+# snapshot ID placed in updatedInput is accepted by the hook layer but
+# silently ignored at dispatch, billing the session model (#1178). Rewrites
+# therefore translate the resolved ID to its family alias at the last
+# moment; the routing map and bump log keep full IDs.
+_DISPATCH_ALIAS_RE = re.compile(r"haiku|sonnet|opus|fable")
+
+
+def _dispatch_alias(model_id: str) -> str:
+    """Return the dispatch-layer alias for a model ID.
+
+    An ID with no recognizable family (or an already-alias value) passes
+    through unchanged — fail-open, matching this hook's posture.
+    """
+    m = _DISPATCH_ALIAS_RE.search(model_id)
+    return m.group(0) if m else model_id
+
+
 def _emit_rewrite(payload: dict, new_model: str) -> None:
     """Print the updatedInput envelope rewriting tool_input.model.
 
@@ -260,7 +285,7 @@ def _emit_rewrite(payload: dict, new_model: str) -> None:
         _emit_pass_through()
         return
     updated = dict(tool_input)
-    updated["model"] = new_model
+    updated["model"] = _dispatch_alias(new_model)
     envelope = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
@@ -291,7 +316,7 @@ def main() -> int:
         return 0
 
     tool_name = payload.get("tool_name") or ""
-    if tool_name != "Agent":
+    if tool_name not in ("Agent", "Task"):
         return 0
 
     if not _MODEL_RESOLVE_AVAILABLE:  # pragma: no cover

--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -107,9 +107,11 @@ _RECOVERY_SKILLS = frozenset(
     }
 )
 
-# Only these two tool matchers trigger the ceiling — everything else is a
-# silent pass. Keeps the guard scoped to capability-loading calls.
-_GATED_TOOLS = frozenset({"Agent", "Skill"})
+# Only capability-loading tools trigger the ceiling — everything else is a
+# silent pass. "Agent" and "Task" are the same subagent-dispatch tool
+# (renamed Task → Agent in Claude Code 2.1.63; both live on as payload
+# tool_names, #1178).
+_GATED_TOOLS = frozenset({"Agent", "Task", "Skill"})
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -1,0 +1,252 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/session_model_banner.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_bootstrap.py\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/telemetry.py\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_tool_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/contract_version_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/refactor_test_freeze_guard.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/verify_guard_edit_marker.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/destructive_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/refactor_test_bash_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_commit_review.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_commit_knowledge_index.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/telemetry.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/verify_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/bash_retry_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/stryker_xunit_shim_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/mutation_testing_smoke_gate.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/telemetry.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/context_ceiling_guard.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_nudge.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_nudge.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_nudge.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/agent_model_resolve.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/context_ceiling_guard.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/js_fp_review.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/token_efficiency_review.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/eval_compliance_check.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/tdd_guard.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/knowledge_index.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/skills_index.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/mutation_gate.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/refactor_test_revert_guard.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/version_check.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__codegraph__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_turn_mark.py\""
+          }
+        ]
+      }
+    ],
+    "SessionStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/session_learning_trigger.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/cost_meter.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/task_completion_metrics.py\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/cost_meter.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/task_completion_metrics.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -149,7 +149,7 @@
         ]
       },
       {
-        "matcher": "Agent",
+        "matcher": "Agent|Task",
         "hooks": [
           {
             "type": "command",

--- a/plugins/dev-team/tests/hooks/test_agent_model_resolve.py
+++ b/plugins/dev-team/tests/hooks/test_agent_model_resolve.py
@@ -13,6 +13,9 @@ Covers two independent #732 fixes:
 from __future__ import annotations
 
 import inspect
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -108,3 +111,101 @@ def test_read_effort_uses_descriptive_frontmatter_flag_name():
     source = inspect.getsource(agent_model_resolve._read_effort)
     assert "infm" not in source
     assert "in_frontmatter" in source
+
+
+# ---------------------------------------------------------------------------
+# #1178 — dispatch tool name coverage + dispatch-layer alias translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model_id", "alias"),
+    [
+        ("claude-haiku-4-5-20251001", "haiku"),
+        ("claude-sonnet-4-6", "sonnet"),
+        ("claude-opus-4-8", "opus"),
+        ("claude-fable-5", "fable"),
+        ("haiku", "haiku"),  # already an alias — unchanged
+    ],
+)
+def test_dispatch_alias_translates_model_family(model_id: str, alias: str) -> None:
+    assert agent_model_resolve._dispatch_alias(model_id) == alias
+
+
+def test_dispatch_alias_passes_unknown_ids_through() -> None:
+    # Fail-open: a ladder entry with no recognizable family is emitted
+    # as-is rather than guessed at.
+    assert (
+        agent_model_resolve._dispatch_alias("some-custom-model")
+        == "some-custom-model"
+    )
+
+
+def _run_hook(payload: dict, env_overrides: dict) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / "agent_model_resolve.py")],
+        input=json.dumps(payload).encode("utf-8"),
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def _dispatch_env(tmp_path: Path) -> dict:
+    """Isolated path seams: one high-effort agent, the shipped default map,
+    no ladder, no session model."""
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    (agents / "correctness-review.md").write_text(
+        "---\neffort: high\n---\n", encoding="utf-8"
+    )
+    routing = tmp_path / "model-routing.json"
+    routing.write_text(
+        '{"low": "claude-haiku-4-5-20251001", "medium": "claude-sonnet-4-6", '
+        '"high": "claude-opus-4-8"}',
+        encoding="utf-8",
+    )
+    return {
+        "MODEL_AGENTS_DIR": str(agents),
+        "MODEL_ROUTING_JSON": str(routing),
+        "MODEL_LADDER_JSON": str(tmp_path / "no-ladder.json"),
+        "SESSION_MODEL_FILE": str(tmp_path / "no-session-model"),
+        "MODEL_BUMP_LOG": str(tmp_path / "bump.log"),
+    }
+
+
+@pytest.mark.parametrize("tool_name", ["Agent", "Task"])
+def test_rewrite_fires_for_both_dispatch_tool_names(
+    tmp_path: Path, tool_name: str
+) -> None:
+    """#1178: the subagent-dispatch tool is "Task" before Claude Code 2.1.63
+    and "Agent" after — the hook must rewrite under either payload name."""
+    result = _run_hook(
+        {
+            "session_id": "s1",
+            "tool_name": tool_name,
+            "tool_input": {"subagent_type": "dev-team:correctness-review"},
+        },
+        _dispatch_env(tmp_path),
+    )
+    assert result.returncode == 0
+    envelope = json.loads(result.stdout)
+    updated = envelope["hookSpecificOutput"]["updatedInput"]
+    # #1178 alias bug: the Agent/Task tool's `model` parameter silently
+    # ignores full snapshot IDs — the rewrite must carry the alias.
+    assert updated["model"] == "opus"
+
+
+def test_non_dispatch_tool_names_pass_through_silently(tmp_path: Path) -> None:
+    result = _run_hook(
+        {
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "true"},
+        },
+        _dispatch_env(tmp_path),
+    )
+    assert result.returncode == 0
+    assert result.stdout == b""

--- a/tests/hooks/test_plugin_hooks_json.py
+++ b/tests/hooks/test_plugin_hooks_json.py
@@ -1,0 +1,122 @@
+"""Structural guards for plugins/dev-team/hooks/hooks.json (#1178).
+
+Current Claude Code loads plugin hooks from `hooks/hooks.json` (the
+documented plugin-hooks mechanism), NOT from a plugin-root `settings.json`
+— so a registration that exists only in settings.json is silently dead.
+These tests pin three things:
+
+  1. hooks.json exists, is valid, and every command routes through
+     ${CLAUDE_PLUGIN_ROOT} (plugin hooks run with the project dir as CWD,
+     so CWD-relative script paths would break).
+  2. hooks.json and settings.json register the same scripts at the same
+     lifecycle points (settings.json is kept as an older-CLI mirror; the
+     two must never drift).
+  3. The subagent-dispatch matcher covers BOTH dispatch tool names —
+     "Task" (pre-2.1.63) and "Agent" (post-rename) — so a harness rename
+     can't silently kill model routing again.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+HOOKS_JSON = PLUGIN / "hooks" / "hooks.json"
+SETTINGS_JSON = PLUGIN / "settings.json"
+
+DISPATCH_TOOL_NAMES = ("Agent", "Task")
+DISPATCH_HOOK_SCRIPTS = ("agent_model_resolve.py", "context_ceiling_guard.py")
+
+
+def _load_hooks(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))["hooks"]
+
+
+def _script_names(entry: dict) -> list[str]:
+    """Basenames of the .py scripts an entry's commands invoke."""
+    names = []
+    for hook in entry.get("hooks", []):
+        found = re.findall(r"([A-Za-z0-9_]+\.py)", hook.get("command", ""))
+        assert found, f"no .py script in command: {hook.get('command')!r}"
+        names.append(found[-1])
+    return names
+
+
+def _shape(hooks: dict) -> dict:
+    """Comparable shape: event -> [(matcher, [script, ...]), ...]."""
+    return {
+        event: [(entry.get("matcher"), _script_names(entry)) for entry in entries]
+        for event, entries in hooks.items()
+    }
+
+
+def test_hooks_json_exists_and_has_hooks_key() -> None:
+    assert HOOKS_JSON.is_file(), (
+        "plugins/dev-team/hooks/hooks.json is missing — plugin hooks are "
+        "only loaded from this file on current Claude Code (#1178); a "
+        "settings.json-only registration ships a dead hook layer."
+    )
+    assert isinstance(_load_hooks(HOOKS_JSON), dict)
+
+
+def test_every_hooks_json_command_routes_through_plugin_root() -> None:
+    for event, entries in _load_hooks(HOOKS_JSON).items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                cmd = hook["command"]
+                assert "${CLAUDE_PLUGIN_ROOT}" in cmd, (
+                    f"{event}: command must be anchored to "
+                    f"${{CLAUDE_PLUGIN_ROOT}} (plugin hooks run from the "
+                    f"project dir, not the plugin root): {cmd!r}"
+                )
+                assert "py.sh" in cmd, (
+                    f"{event}: command must route through the py.sh "
+                    f"interpreter shim (#1078): {cmd!r}"
+                )
+
+
+def test_hooks_json_mirrors_settings_json_registrations() -> None:
+    """settings.json stays as the older-CLI mirror — same events, same
+    matchers, same scripts in the same order. Only the path anchoring
+    differs."""
+    assert _shape(_load_hooks(HOOKS_JSON)) == _shape(_load_hooks(SETTINGS_JSON))
+
+
+def _dispatch_entries(hooks: dict) -> list[dict]:
+    """PreToolUse entries that register the model-routing dispatch hook."""
+    return [
+        entry
+        for entry in hooks.get("PreToolUse", [])
+        if "agent_model_resolve.py" in _script_names(entry)
+    ]
+
+
+def test_dispatch_matcher_covers_both_dispatch_tool_names() -> None:
+    """The regression guard #1178 asked for: whichever name the harness
+    uses for subagent dispatch ("Task" pre-2.1.63, "Agent" after), the
+    routing hooks must fire."""
+    for path in (HOOKS_JSON, SETTINGS_JSON):
+        entries = _dispatch_entries(_load_hooks(path))
+        assert entries, f"{path.name}: agent_model_resolve.py not registered"
+        for entry in entries:
+            matcher = entry["matcher"]
+            for tool_name in DISPATCH_TOOL_NAMES:
+                assert re.fullmatch(matcher, tool_name), (
+                    f"{path.name}: PreToolUse matcher {matcher!r} does not "
+                    f"match dispatch tool name {tool_name!r} — model "
+                    f"routing would silently never fire (#1178)"
+                )
+
+
+def test_dispatch_entry_registers_both_dispatch_hooks() -> None:
+    for path in (HOOKS_JSON, SETTINGS_JSON):
+        entries = _dispatch_entries(_load_hooks(path))
+        scripts = [s for entry in entries for s in _script_names(entry)]
+        for script in DISPATCH_HOOK_SCRIPTS:
+            assert script in scripts, (
+                f"{path.name}: {script} missing from the subagent-dispatch "
+                f"PreToolUse entry"
+            )


### PR DESCRIPTION
## Summary

Effort-band model routing (and the entire shipped hook layer) was dead on current Claude Code. Three layered defects, each validated against the official plugin/hooks/subagent docs:

1. **Wrong loading mechanism.** Current Claude Code loads plugin hooks from `hooks/hooks.json`, not a plugin-root `settings.json` — so every shipped hook registration was silently ignored. This PR ships `plugins/dev-team/hooks/hooks.json` mirroring all registrations with `${CLAUDE_PLUGIN_ROOT}`-anchored commands (plugin hooks run with the project dir as CWD, so the old CWD-relative paths would also have broken). `settings.json` stays as the older-CLI mirror.
2. **Dispatch tool name drift.** The subagent-dispatch tool was named `Task` before Claude Code 2.1.63 and `Agent` after the rename; both names live on in hook payloads. The dispatch matcher is widened to `Agent|Task` (in both registration files), and `agent_model_resolve.py` / `context_ceiling_guard.py` now accept both `tool_name`s, so a harness rename can't silently kill routing again.
3. **Alias-only model parameter.** The Agent/Task tool's `model` parameter validates against an alias enum and silently ignores full snapshot IDs — a rewrite to `claude-opus-4-8` was accepted into `updatedInput` but the subagent billed the session model. Rewrites now translate the resolved ID to its family alias (`haiku|sonnet|opus|fable`) at emit time; the routing map and bump log keep full IDs for ladder/pricing purposes.

Living docs (`docs/model-routing.md`, `agents/orchestrator.md`) updated to describe the real mechanism.

## Regression guards

- New `tests/hooks/test_plugin_hooks_json.py`: `hooks.json` exists, every command routes through `${CLAUDE_PLUGIN_ROOT}` + `py.sh`, registrations never drift from `settings.json`, and the dispatch matcher regex-fullmatches both `Agent` and `Task`.
- New unit tests in `plugins/dev-team/tests/hooks/test_agent_model_resolve.py`: end-to-end rewrite under both tool names (asserting the alias lands in `updatedInput`), silent pass-through for non-dispatch tools, and `_dispatch_alias` translation cases.

## Verification

- Piping live PreToolUse payloads through the hook yields `"model":"opus"` for `dev-team:correctness-review` under both `tool_name: "Task"` and `"Agent"`; other tools pass through silently.
- Full pre-push gate green: 3,893 passed / 9 skipped across the complete pytest dir list, plus `scripts/check_md_references.py` and `build_knowledge_index.py` with no drift.

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBYrKHv4kDgSxuFYcjybyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBYrKHv4kDgSxuFYcjybyK)_