### PR TITLE
fix: sync orchestrator.md effort-band routing docs with frontmatter and guard against drift

### DIFF
--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -248,12 +248,14 @@ Do **not** dispatch `security-engineer` on every task — its `effort: high` cos
 - **Output**: An implementation plan with explicit file changes, test expectations, and acceptance criteria
 - **Automated plan review**: Before the human gate, dispatch **four plan review personas in parallel** as sub-agents. Each reviewer independently challenges the plan from a different critical perspective:
 
-  | Reviewer | Template | Model | What it challenges |
-  |----------|----------|-------|--------------------|
-  | Acceptance Test Critic | `prompts/plan-review-acceptance.md` | `sonnet` | Criteria verifiability, scenario completeness, error paths, TDD traceability |
-  | Design & Architecture Critic | `prompts/plan-review-design.md` | `sonnet` | Coupling, abstraction quality, structural risks, pattern consistency |
-  | UX Critic | `prompts/plan-review-ux.md` | `sonnet` | User journey, error experience, cognitive load, accessibility |
-  | Strategic Critic | `prompts/plan-review-strategic.md` | `sonnet` | Problem-solution fit, scope, risk, opportunity cost |
+  | Reviewer | Template | Effort | What it challenges |
+  |----------|----------|--------|--------------------|
+  | Acceptance Test Critic | `prompts/plan-review-acceptance.md` | `medium` | Criteria verifiability, scenario completeness, error paths, TDD traceability |
+  | Design & Architecture Critic | `prompts/plan-review-design.md` | `medium` | Coupling, abstraction quality, structural risks, pattern consistency |
+  | UX Critic | `prompts/plan-review-ux.md` | `medium` | User journey, error experience, cognitive load, accessibility |
+  | Strategic Critic | `prompts/plan-review-strategic.md` | `medium` | Problem-solution fit, scope, risk, opportunity cost |
+
+  The **Effort** column is a reasoning-effort band, not a pinned model. These personas are prompt templates with no frontmatter, so the resolver hook cannot route them — resolve the band yourself before dispatch (`python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/model_resolve.py medium --caller plan-review`) exactly as the plan skill's [Run plan review personas step](../skills/plan/SKILL.md#5-run-plan-review-personas) does. Never hard-code a model alias, so the personas honor the same ladder and per-environment overrides as every other agent.
 
   Each returns a `verdict` of `approve` or `needs-revision`. If **any** reviewer returns `needs-revision`, address the blocker issues before presenting to the human. Aggregate all findings (including warnings from approving reviewers) into the plan review summary.
 

--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -57,11 +57,11 @@ Legacy `model: haiku|sonnet|opus` agents still resolve (tier→band) for this de
 
 ### Effort-band guidance (informational)
 
-Each agent's `effort:` band is the authoritative routing input. Below is the rationale by band, so new agents have a guide for which band to declare:
+Each agent's `effort:` band is the authoritative routing input. Pick a band by the *kind* of reasoning the task needs — not by naming a model, and not by copying a peer agent. This guide names no agents on purpose: a per-agent list drifts out of sync with frontmatter the moment a band changes. For the live band→model map and which band each agent actually declares, run `/model-routing-check`; to validate that a declared band clears its eval floor, run `/agent-eval --calibrate`.
 
-- `low` — lexical/structural pattern matching, checklist-style verification (naming-review, complexity-review, claude-setup-review, token-efficiency-review, a11y-review, svelte-review, js-fp-review, progress-guardian).
-- `medium` — semantic analysis with balanced cost/quality (spec-compliance-review, test-review, structure-review, concurrency-review, doc-review, refactor-opportunity-review, data-flow-tracer, performance-review, orchestrator, software-engineer, qa-engineer, tech-writer, platform-engineer, product-manager, ui-ux-designer, adr).
-- `high` — cross-file reasoning, high-stakes decisions, design synthesis, threat modeling, broad reconnaissance (security-review, domain-review, arch-review, architect, security-engineer, codebase-recon).
+- `low` — lexical/structural pattern matching and checklist-style verification: threshold counting, config/style/markup checks, and single-file lints that need no cross-file context.
+- `medium` — semantic analysis with balanced cost/quality: reading intent within a file or a small neighborhood, spec-to-code matching, and most review and persona work.
+- `high` — cross-file reasoning, high-stakes decisions, design synthesis, threat modeling, and broad reconnaissance: work where a missed finding or a wrong call is expensive and the relevant context spans many files.
 
 ## Wave-Aware Build Dispatch
 

--- a/tests/agents/test_orchestrator_effort_band_guidance_no_agent_names.py
+++ b/tests/agents/test_orchestrator_effort_band_guidance_no_agent_names.py
@@ -1,0 +1,67 @@
+"""Drift guard for the "Effort-band guidance" section of orchestrator.md (#1182).
+
+The guidance section used to carry a per-band list of example agent names
+(``low`` — ...(naming-review, complexity-review, ...)). That list drifted out
+of sync with agent frontmatter — agents were listed under the wrong band and
+new agents were never added — and nothing caught it.
+
+The fix removes the agent-name examples entirely (the three rubric definitions
+are the actual decision criteria; ``/model-routing-check`` is the live band→model
+map). This test keeps the section agent-name-free so the drifting list cannot be
+reintroduced: if a future edit re-adds an agent basename under a band, the list
+can silently disagree with frontmatter again, so it fails here instead.
+
+The band a given agent declares is guarded separately by
+``test_agent_effort_frontmatter.py`` (the frontmatter is the single source of
+truth); this test only guards the prose from re-mirroring it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_DIR = REPO_ROOT / "plugins" / "dev-team" / "agents"
+ORCH = AGENTS_DIR / "orchestrator.md"
+
+GUIDANCE_HEADING = "### Effort-band guidance"
+
+
+def _guidance_section() -> str:
+    """Return the body of the Effort-band guidance section.
+
+    From the ``### Effort-band guidance`` heading up to (but not including) the
+    next ``##``/``###`` heading. Raises if the section is missing so the guard
+    fails loudly rather than vacuously passing on an empty string.
+    """
+    text = ORCH.read_text(encoding="utf-8")
+    start = text.find(GUIDANCE_HEADING)
+    assert start != -1, (
+        f"'{GUIDANCE_HEADING}' section not found in {ORCH.relative_to(REPO_ROOT)}. "
+        "If it was renamed, update GUIDANCE_HEADING here."
+    )
+    body_start = start + len(GUIDANCE_HEADING)
+    next_heading = re.search(r"^#{2,3} ", text[body_start:], re.MULTILINE)
+    end = body_start + next_heading.start() if next_heading else len(text)
+    return text[body_start:end]
+
+
+def _agent_basenames() -> list[str]:
+    return sorted(p.stem for p in AGENTS_DIR.glob("*.md"))
+
+
+def test_effort_band_guidance_names_no_agents() -> None:
+    section = _guidance_section()
+    offenders = [
+        name
+        for name in _agent_basenames()
+        if re.search(rf"\b{re.escape(name)}\b", section)
+    ]
+    assert not offenders, (
+        "The Effort-band guidance section in orchestrator.md must not name "
+        "specific agents — a per-agent list drifts out of sync with frontmatter "
+        "(the drift #1182 fixed). Describe the *kind* of work per band instead, "
+        "and point readers at `/model-routing-check` for the live map.\n"
+        f"Agent names found in the section: {', '.join(offenders)}"
+    )


### PR DESCRIPTION
## Summary

Removes specific agent names from the "Effort-band guidance" section of `orchestrator.md` to prevent the list from drifting out of sync with agent frontmatter declarations, and stops the plan-review persona table from hard-coding a model. Adds a test to enforce the no-agent-names constraint going forward.

## Changes

- **orchestrator.md — effort-band guidance**: Rewrote the section to describe the *kind* of reasoning each band requires (lexical/structural, semantic, cross-file) rather than listing example agent names. Directs readers to `/model-routing-check` for the live band→model map and agent declarations, and `/agent-eval --calibrate` for validation.

- **orchestrator.md — plan review personas table**: Renamed the "Model" column to "Effort" and replaced hard-coded model aliases (`sonnet`) with the effort band (`medium`). Added a note explaining these are prompt templates without frontmatter, so the resolver hook cannot route them — callers must resolve the band themselves via `model_resolve.py` before dispatch, exactly as the plan skill's existing [Run plan review personas step](https://github.com/bdfinst/agentic-dev-team/blob/main/plugins/dev-team/skills/plan/SKILL.md) does.

- **New test** (`tests/agents/test_orchestrator_effort_band_guidance_no_agent_names.py`): Drift guard that fails if any agent basename appears in the Effort-band guidance section. Prevents the per-agent list from being reintroduced and silently diverging from frontmatter again. Per-agent band validation stays with `test_agent_effort_frontmatter.py` (frontmatter is the single source of truth).

## Rationale

The previous guidance section listed agents under each band (e.g., `low` — naming-review, complexity-review, ...). This list drifted out of sync with agent frontmatter — agents were listed under the wrong band and new agents were never added — and nothing caught it. The plan-review table's hard-coded `sonnet` similarly diverged from `skills/plan/SKILL.md`, which resolves those personas through the effort-band resolver and forbids hard-coding a model.

## Issues

Closes #1182
Closes #1183
Part of #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnSSUCmsnARKhaq6Qz9j3R