### PR TITLE
chore: gitignore .gitattributes written by graphify hook install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ graphify-out/
 # committed — like .git/hooks. The portable wiring under .claude/ IS committed.
 .husky/post-commit
 .husky/post-checkout
+# Graphify's merge-driver .gitattributes is written per-clone by `graphify hook
+# install` (points at the gitignored graphify-out/graph.json), so it's not committed.
+.gitattributes
 
 # Runtime joern / CPG cache + workspace
 memory/cpg/


### PR DESCRIPTION
## Summary
Add `.gitattributes` to `.gitignore` since it is generated per-clone by the `graphify hook install` command and should not be committed to the repository.

## Changes
- Added `.gitattributes` to the gitignore list with explanatory comment noting that graphify's merge-driver configuration is written per-clone and points to the gitignored `graphify-out/graph.json`

## Details
The `.gitattributes` file is machine-specific and generated during local setup (similar to `.husky/post-commit` and `.husky/post-checkout` which are already gitignored). It should not be committed since each clone will regenerate it with paths appropriate to that machine's environment.

https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX