### PR TITLE
fix: retry calibration dispatch on unparseable output (#1187)

### DIFF
--- a/scripts/agent_calibrate.py
+++ b/scripts/agent_calibrate.py
@@ -564,7 +564,7 @@ def render_report(results: List[dict], timestamp: str, preflight: Optional[Tuple
 # through eval_grade.run_grading for that one target.
 # ---------------------------------------------------------------------------
 
-def real_dispatch_fn(pair: str, model: str, dirs: Dirs) -> bool:  # pragma: no cover
+def real_dispatch_fn(pair: str, model: str, dirs: Dirs, parse_retries: int = 2) -> bool:  # pragma: no cover
     stem, _, target = pair.partition("::")
     from eval_cache import resolve_fixture_files  # local import, avoids cycle at module load
     spec_path = dirs.expected / f"{stem}.json"
@@ -581,18 +581,27 @@ def real_dispatch_fn(pair: str, model: str, dirs: Dirs) -> bool:  # pragma: no c
         "claude", "-p", f"/review-agent {target} {fixture_path} --json",
         "--output-format", "json", "--model", model,
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    try:
-        envelope = json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        return False
-    # The `--output-format json` envelope carries the agent's answer as free
-    # text in `result`; the structured review is a fenced JSON block inside it.
-    # Extract that block (falling back to the raw stdout if the shape differs).
-    result_text = envelope.get("result") if isinstance(envelope, dict) else None
-    actual = _extract_review_json(result_text if result_text is not None else proc.stdout)
+    # A model occasionally ignores --json and narrates instead of emitting the
+    # bare result object (residual #1199 non-compliance — observed on Sonnet in
+    # ~30% of runs). That is transient output-format noise, NOT the agent's
+    # verdict, so re-dispatch on unparseable output before giving up; only a
+    # PARSED result is ever graded. A genuine fail verdict still parses and is
+    # graded on the first try.
+    actual = None
+    for _ in range(parse_retries + 1):
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            envelope = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            continue  # dispatch produced no envelope — retry
+        # The `--output-format json` envelope carries the agent's answer as
+        # free text in `result`; the structured review is a JSON block inside.
+        result_text = envelope.get("result") if isinstance(envelope, dict) else None
+        actual = _extract_review_json(result_text if result_text is not None else proc.stdout)
+        if actual is not None:
+            break  # got a parseable result — grade it
     if actual is None:
-        return False
+        return False  # never parsed after retries
     actuals = {stem: {"agents": {target: actual}}}
     results, _ = run_grading(dirs.expected, actuals, None, only={target})
     return any(p == pair and ok for p, ok, _ in results)


### PR DESCRIPTION
## What & why

Follow-on robustness fix for #1187, found while validating the a11y-review fixtures merged in #1203.

`real_dispatch_fn` counted an **unparseable dispatch** the same as a **real fail grade**. A model occasionally ignores `--json` and narrates instead of emitting the bare result object (residual #1199 non-compliance — observed on Sonnet in ~30% of runs). So a clean fixture the agent actually grades `pass` was scored as *failing* whenever its output happened not to parse — conflating transient output-format noise with the agent's verdict.

### Evidence
Live validation of the `a11y-clean-form` fixture (which Opus rates `pass` 5/5):

| | Sonnet pass rate |
| --- | --- |
| before (no retry) | 2/5 — the 3 misses were **parse failures**, not over-flagging (when Sonnet emitted JSON it correctly said `pass` with 0 issues) |
| **after (2 retries)** | **4/5** |

## Change

Re-dispatch on unparseable output (default `parse_retries=2`) and grade **only** a parsed result. A genuine fail verdict still parses and is graded on the first try, so this separates output-format noise from the agent's actual verdict. With ~70% first-try compliance and 2 retries, ~97% of dispatches yield a gradeable result; combined with `--samples 5` majority voting (#1203), the clean form now grades correctly ~94% of the time at Sonnet.

## Testing
- 25 calibrate tests pass (the retry is on the `# pragma: no cover` real-dispatch adapter; `_extract_review_json` and the grading path it wraps are covered).
- Live: a11y-clean-form Sonnet pass rate 2/5 → 4/5.

## Not chasing the last 1/5
Residual model non-determinism is what `--samples` majority-vote + flapping-detection (both #1203) exist to absorb — no retry count eliminates it.

Part of #1187
Part of #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX)_