### PR TITLE
feat: expand concurrency-review eval fixtures 1 → 3 (#1187)

### DIFF
--- a/evals/expected/cc-clean-idempotent.json
+++ b/evals/expected/cc-clean-idempotent.json
@@ -1,0 +1,16 @@
+{
+  "fixture": "cc-clean-idempotent",
+  "description": "Concurrency-safe code: no shared mutable module state, an idempotent full-resource PUT keyed by id, independent parallel reads via an awaited Promise.all, and every async operation awaited with error handling — should pass review",
+  "applicableAgents": [
+    "concurrency-review"
+  ],
+  "agents": {
+    "concurrency-review": {
+      "expectedStatus": "pass",
+      "issueCount": {
+        "min": 0,
+        "max": 1
+      }
+    }
+  }
+}

--- a/evals/expected/cc-unhandled-races.json
+++ b/evals/expected/cc-unhandled-races.json
@@ -1,0 +1,22 @@
+{
+  "fixture": "cc-unhandled-races",
+  "description": "Three distinct concurrency hazards: a database read-modify-write with no transaction, a shared-file read-modify-write with no lock, and an event handler mutating shared array state across a non-atomic check-then-splice — should fail review",
+  "applicableAgents": [
+    "concurrency-review"
+  ],
+  "agents": {
+    "concurrency-review": {
+      "expectedStatus": "fail",
+      "issueCount": {
+        "min": 2,
+        "max": 6
+      },
+      "severities": {
+        "error": {
+          "min": 1,
+          "max": 4
+        }
+      }
+    }
+  }
+}

--- a/evals/fixtures/cc-clean-idempotent.ts
+++ b/evals/fixtures/cc-clean-idempotent.ts
@@ -1,0 +1,40 @@
+// Concurrency-safe by construction: no shared mutable module state, every async
+// operation is awaited with error handling, and mutations are idempotent.
+
+interface Store {
+  get(key: string): Promise<unknown>;
+  put(key: string, value: unknown): Promise<void>;
+}
+interface Profile {
+  displayName: string;
+}
+interface Dashboard {
+  profile: unknown;
+  settings: unknown;
+  notifications: unknown;
+}
+
+declare function logError(message: string, err: unknown): void;
+
+// Idempotent by construction: a full-resource PUT keyed by id yields the same
+// state on retry, so a duplicated/retried request is safe with no dedup needed.
+// No shared mutable state; the async op is awaited and errors propagate.
+export async function upsertProfile(store: Store, id: string, profile: Profile): Promise<void> {
+  try {
+    await store.put(`profile:${id}`, profile);
+  } catch (err) {
+    logError("upsertProfile failed", err);
+    throw err;
+  }
+}
+
+// Independent parallel reads with no shared writes; the Promise.all is awaited,
+// so a rejection is not swallowed and there is no fire-and-forget path.
+export async function loadDashboard(store: Store, userId: string): Promise<Dashboard> {
+  const [profile, settings, notifications] = await Promise.all([
+    store.get(`profile:${userId}`),
+    store.get(`settings:${userId}`),
+    store.get(`notifications:${userId}`),
+  ]);
+  return { profile, settings, notifications };
+}

--- a/evals/fixtures/cc-unhandled-races.ts
+++ b/evals/fixtures/cc-unhandled-races.ts
@@ -1,0 +1,33 @@
+// Distinct concurrency hazards: a database read-modify-write with no
+// transaction, a file read-modify-write with no lock, and an event handler
+// mutating shared state across a non-atomic check-then-splice.
+
+import { readFile, writeFile } from "fs/promises";
+
+interface DB {
+  query(sql: string, params: unknown[]): Promise<{ views: number }>;
+}
+
+// Read-modify-write with no transaction or optimistic lock: two concurrent
+// increments both read the same `views` and one update is lost.
+export async function incrementViews(db: DB, postId: string): Promise<void> {
+  const row = await db.query("SELECT views FROM posts WHERE id = ?", [postId]);
+  await db.query("UPDATE posts SET views = ? WHERE id = ?", [row.views + 1, postId]);
+}
+
+// Open-read-modify-write on a shared file with no lock: concurrent callers read
+// the same contents and the last writer clobbers the others' appends.
+export async function appendAudit(entry: string): Promise<void> {
+  const existing = await readFile("audit.log", "utf8");
+  await writeFile("audit.log", existing + entry + "\n");
+}
+
+// Shared mutable state mutated from concurrent event callbacks with no guard:
+// the length check and the splice are not atomic across interleaved events.
+const pending: string[] = [];
+export function onMessage(msg: string, flush: (items: string[]) => void): void {
+  pending.push(msg);
+  if (pending.length >= 100) {
+    flush(pending.splice(0));
+  }
+}


### PR DESCRIPTION
## What & why

Continues the #1187 fixture-coverage work (a11y-review was expanded in #1203). concurrency-review had a **single fixture against a 1.0 floor** — too thin to calibrate stably, since one flaky dispatch flips the verdict (exactly what the pre-fix validation showed: `0/1` swinging to `1/1`).

## Changes

Two new fixtures + expected specs, taking concurrency-review from **1 → 3**:

- **`cc-clean-idempotent.ts`** (expect `pass`) — no shared mutable module state, an idempotent full-resource PUT keyed by id, independent parallel reads via an awaited `Promise.all`, every async op awaited with error handling. A **precision** case: an agent that over-flags clean concurrency code fails it.
- **`cc-unhandled-races.ts`** (expect `fail`) — three hazards **distinct** from the existing check-then-act fixture: a DB read-modify-write with no transaction, a shared-file RMW with no lock, and an unguarded check-then-splice on shared array state across concurrent events.

## Testing

- Structural: `--check-corpus` reports 123 valid fixtures (up from 121); floors-sync + calibrate guards green (33 tests).
- **Live-validated** (with the merged parse-retry): both fixtures grade correctly **3/3 at Haiku and 3/3 at Opus** — perfectly clean signal at both bookend bands.

Combined with `--samples` majority-vote + flapping detection (#1203), concurrency-review is now stably calibratable rather than a coin flip.

Part of #1187
Part of #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX)_