### PR TITLE
chore: gitignore #1184 baseline calibration temp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ graphify-out/
 # deliberate baseline run is meant to commit them.
 .claude/evals/reports/
 .claude/evals/calibration-records.json
+.claude/evals/baseline-1184/
 
 # Runtime joern / CPG cache + workspace
 memory/cpg/


### PR DESCRIPTION
The parallel #1184 baseline driver writes intermediate per-target calibration records and reports under `.claude/evals/baseline-1184/` before merging them into the (already-ignored) `.claude/evals/calibration-records.json`. Ignore the temp dir too so ad-hoc baseline runs don't leave untracked files in the tree.

`.gitignore`-only, no code change.

Part of #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty2ScpEiqFjcedmzsRj4JX)_