### PR TITLE
fix: skill-only calibration targets + missing reactivity fixtures

### DIFF
--- a/docs/adr/0023-calibrate-effort-bands-from-the-1184-eval-baseline.md
+++ b/docs/adr/0023-calibrate-effort-bands-from-the-1184-eval-baseline.md
@@ -116,7 +116,14 @@ before this result is treated as rock-solid.
   are untouched pending fixture/floor work, each blocking its own apply.
 - **Excluded as harness gaps** (not calibration results): reactivity agents
   with missing fixtures (#1209) and `test-design-advisor`, a skill that
-  `/review-agent` cannot dispatch (#1210).
+  `/review-agent` cannot dispatch (#1210). Both are now fixed at the code
+  level: `calibrate_target`/`target_universe` in `scripts/agent_calibrate.py`
+  report a skill-only target as `uncalibratable` instead of forcing every
+  cell to a false 0% floor-failure (#1210), and `ang/react/vue-reactivity-*`
+  each gained a real clean + positive fixture pair so their fixtures resolve
+  to files on disk (#1209). A follow-up calibration run against the new
+  fixtures still needs to happen to replace this baseline's forced-0%
+  numbers with a real hit distribution.
 - **Verification debt**: per-agent re-calibration (`/agent-eval --calibrate
   --agent <name>` → `aligned`) after each applied change is still pending; the
   #1184 baseline is the supporting evidence in the interim.

--- a/evals/expected/ang-reactivity-issues.json
+++ b/evals/expected/ang-reactivity-issues.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "ang-reactivity-issues.ts",
+  "description": "OnPush component mutating an @Input array in place, unclosed RxJS subscription, and an effect() that writes the signal it reads",
+  "applicableAgents": ["angular-reactivity-review"],
+  "agents": {
+    "angular-reactivity-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 5 },
+      "severities": { "error": { "min": 2, "max": 5 } },
+      "mustMention": ["OnPush"],
+      "mustNotMention": ["async pipe"]
+    }
+  }
+}

--- a/evals/expected/react-reactivity-issues.json
+++ b/evals/expected/react-reactivity-issues.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "react-reactivity-issues.tsx",
+  "description": "setState called during render, a stale-closure dependency array, and a timer effect with no cleanup",
+  "applicableAgents": ["react-reactivity-review"],
+  "agents": {
+    "react-reactivity-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 5 },
+      "severities": { "error": { "min": 2, "max": 5 } },
+      "mustMention": ["dependency"],
+      "mustNotMention": ["useMemo"]
+    }
+  }
+}

--- a/evals/expected/vue-reactivity-issues.json
+++ b/evals/expected/vue-reactivity-issues.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "vue-reactivity-issues.vue",
+  "description": "Destructured reactive() object, an untracked watchEffect dependency, and a resize listener with no unmount cleanup",
+  "applicableAgents": ["vue-reactivity-review"],
+  "agents": {
+    "vue-reactivity-review": {
+      "expectedStatus": "fail",
+      "issueCount": { "min": 2, "max": 5 },
+      "severities": { "error": { "min": 2, "max": 5 } },
+      "mustMention": ["reactive"],
+      "mustNotMention": ["Vue.set"]
+    }
+  }
+}

--- a/evals/fixtures/ang-reactivity-clean.ts
+++ b/evals/fixtures/ang-reactivity-clean.ts
@@ -1,0 +1,49 @@
+// PASS: OnPush + immutable updates, takeUntilDestroyed cleanup, correct Signal usage
+
+import { Component, ChangeDetectionStrategy, Input, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { signal, computed, effect } from "@angular/core";
+import { interval } from "rxjs";
+
+interface Config {
+  multiplier: number;
+}
+
+@Component({
+  selector: "app-counter",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<span>{{ doubled() }}</span>`,
+})
+export class CounterComponent {
+  @Input() config!: Config;
+
+  private destroyRef = inject(DestroyRef);
+
+  // Correct: signal wraps a primitive, updated via set()/update() with a new value
+  count = signal(0);
+  doubled = computed(() => this.count() * (this.config?.multiplier ?? 1));
+
+  // Correct: effect only reads `count`, writes to a *different* signal
+  lastUpdated = signal<number | null>(null);
+  private logEffect = effect(() => {
+    const value = this.count();
+    this.lastUpdated.set(Date.now());
+    void value;
+  });
+
+  // Correct: RxJS subscription cleaned up via takeUntilDestroyed — no manual
+  // ngOnDestroy bookkeeping needed
+  constructor() {
+    interval(1000)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.count.update((c) => c + 1);
+      });
+  }
+
+  // Correct: replaces the reference instead of mutating in place, so OnPush
+  // change detection sees a new identity
+  addItem(items: readonly string[], next: string): string[] {
+    return [...items, next];
+  }
+}

--- a/evals/fixtures/ang-reactivity-issues.ts
+++ b/evals/fixtures/ang-reactivity-issues.ts
@@ -1,0 +1,41 @@
+// FAIL: OnPush + in-place mutation, unclosed RxJS subscription, effect self-write
+
+import { Component, ChangeDetectionStrategy, Input, OnInit, OnDestroy } from "@angular/core";
+import { signal, effect } from "@angular/core";
+import { interval, Subscription } from "rxjs";
+
+@Component({
+  selector: "app-feed",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<span>{{ items.length }}</span>`,
+})
+export class FeedComponent implements OnInit, OnDestroy {
+  @Input() items: string[] = [];
+
+  // ISSUE: mutating the @Input array in place inside an OnPush component —
+  // change detection only checks reference identity and will never re-render
+  addItem(next: string) {
+    this.items.push(next);
+  }
+
+  private sub?: Subscription;
+
+  // ISSUE: subscribe() in ngOnInit with no unsubscribe() in ngOnDestroy —
+  // subscription leak on every component destroy/recreate
+  ngOnInit() {
+    this.sub = interval(1000).subscribe(() => {
+      this.addItem(`tick-${Date.now()}`);
+    });
+  }
+
+  ngOnDestroy() {
+    // no this.sub.unsubscribe() here
+  }
+
+  // ISSUE: effect() reads `counter` and writes back to `counter` unconditionally
+  // -> infinite update loop
+  counter = signal(0);
+  private loopingEffect = effect(() => {
+    this.counter.set(this.counter() + 1);
+  });
+}

--- a/evals/fixtures/react-reactivity-clean.tsx
+++ b/evals/fixtures/react-reactivity-clean.tsx
@@ -1,0 +1,59 @@
+// PASS: correct dependency arrays, cleanup functions, no setState-during-render
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Props {
+  userId: string;
+  onLoaded?: (name: string) => void;
+}
+
+export function UserStatus({ userId, onLoaded }: Props) {
+  const [name, setName] = useState("");
+  const [online, setOnline] = useState(false);
+
+  // Correct: onLoaded is a dep, guards against stale closure
+  const notify = useCallback(
+    (value: string) => {
+      onLoaded?.(value);
+    },
+    [onLoaded],
+  );
+
+  // Correct: full dependency array, cleanup returned
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/users/${userId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled) {
+          setName(data.name);
+          notify(data.name);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, notify]);
+
+  // Correct: subscription cleaned up in the returned teardown function
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  // Correct: ref used for a mutable value that shouldn't trigger re-render
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  return (
+    <div>
+      {name} — {online ? "online" : "offline"}
+    </div>
+  );
+}

--- a/evals/fixtures/react-reactivity-issues.tsx
+++ b/evals/fixtures/react-reactivity-issues.tsx
@@ -1,0 +1,33 @@
+// FAIL: stale closure (missing dep), setState during render, subscription leak
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  step: number;
+}
+
+export function Ticker({ step }: Props) {
+  const [count, setCount] = useState(0);
+  const [ready, setReady] = useState(false);
+
+  // ISSUE: setState called directly in the render body, not inside a handler
+  // or effect — triggers a synchronous re-render loop
+  if (!ready) {
+    setReady(true);
+  }
+
+  // ISSUE: `step` is read inside the effect but omitted from the dependency
+  // array — the interval callback captures a stale `step` from the first render
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount((c) => c + step);
+    }, 1000);
+    // ISSUE: no cleanup function returned — timer keeps running after unmount
+  }, []);
+
+  return (
+    <div>
+      {count} (step {step})
+    </div>
+  );
+}

--- a/evals/fixtures/vue-reactivity-clean.vue
+++ b/evals/fixtures/vue-reactivity-clean.vue
@@ -1,0 +1,37 @@
+<!-- PASS: correct ref/reactive usage, tracked watchEffect deps, cleanup on unmount -->
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watchEffect } from "vue";
+
+const props = defineProps<{ multiplier: number }>();
+
+// Correct: primitive wrapped in ref, accessed via .value in script
+const count = ref(0);
+const doubled = computed(() => count.value * props.multiplier);
+
+// Correct: watchEffect reads `count.value` directly inside the effect body,
+// so the dependency is tracked
+let intervalId: ReturnType<typeof setInterval> | undefined;
+watchEffect((onCleanup) => {
+  intervalId = setInterval(() => {
+    count.value += 1;
+  }, 1000);
+  onCleanup(() => clearInterval(intervalId));
+});
+
+// Correct: whole reactive object passed through, not destructured or spread
+const state = ref({ x: 0, y: 0 });
+function updatePosition(e: MouseEvent) {
+  state.value = { x: e.clientX, y: e.clientY };
+}
+
+window.addEventListener("mousemove", updatePosition);
+onUnmounted(() => {
+  window.removeEventListener("mousemove", updatePosition);
+});
+
+defineExpose({ count, doubled, state });
+</script>
+
+<template>
+  <div>{{ doubled }} — {{ state.x }},{{ state.y }}</div>
+</template>

--- a/evals/fixtures/vue-reactivity-issues.vue
+++ b/evals/fixtures/vue-reactivity-issues.vue
@@ -1,0 +1,36 @@
+<!-- FAIL: destructured reactive(), untracked watchEffect dep, missing cleanup -->
+<script setup lang="ts">
+import { reactive, watchEffect } from "vue";
+
+// ISSUE: destructuring a reactive() object breaks reactivity — `x` and `y`
+// become plain, non-reactive copies
+const state = reactive({ x: 0, y: 0, multiplier: 2 });
+const { x, y } = state;
+
+// ISSUE: watchEffect calls a plain function that reads `state.multiplier`
+// internally instead of accessing it directly inside the effect body — the
+// dependency is never tracked, so the effect won't re-run when it changes
+function computeArea() {
+  return x * y * getMultiplier();
+}
+function getMultiplier() {
+  return state.multiplier;
+}
+
+let area = 0;
+watchEffect(() => {
+  area = computeArea();
+});
+
+// ISSUE: event listener added with no onUnmounted/cleanup teardown
+function handleResize() {
+  state.x = window.innerWidth;
+}
+window.addEventListener("resize", handleResize);
+
+defineExpose({ state, area });
+</script>
+
+<template>
+  <div>{{ area }}</div>
+</template>

--- a/scripts/agent_calibrate.py
+++ b/scripts/agent_calibrate.py
@@ -229,15 +229,22 @@ def load_quarantine(path: Path) -> Set[str]:
 # ---------------------------------------------------------------------------
 
 def target_universe(dirs: Dirs) -> List[str]:
-    """Every agent/skill name on disk — the full set `--calibrate` (no
-    `--agent`) sweeps, so a fixture-less target still surfaces as
-    uncalibratable rather than silently being skipped."""
-    names: Set[str] = set()
-    if dirs.agents.is_dir():
-        names.update(p.stem for p in dirs.agents.glob("*.md"))
-    if dirs.skills.is_dir():
-        names.update(p.parent.name for p in dirs.skills.glob("*/SKILL.md"))
-    return sorted(names)
+    """Every review agent name on disk — the full set `--calibrate` (no
+    `--agent`) sweeps, so a fixture-less agent still surfaces as
+    uncalibratable rather than silently being skipped.
+
+    Skills are deliberately excluded, even when they carry an eval fixture
+    (`applicableSkills`) or a `calibration-floors.json` entry: `real_dispatch_
+    fn` grades exclusively by shelling out to `/review-agent <target>`, which
+    loads `agents/<name>.md` and can never dispatch a skill. Sweeping skills
+    in here forced a fixture-bearing skill (e.g. test-design-advisor) to a
+    false 0% every run -- a harness mis-classification, not a routing result
+    (#1210). `calibrate_target`'s own agent-file guard covers the same case
+    for a direct `--agent <skill>` invocation that bypasses this sweep.
+    """
+    if not dirs.agents.is_dir():
+        return []
+    return sorted(p.stem for p in dirs.agents.glob("*.md"))
 
 
 def fixtures_for_target(target: str, dirs: Dirs) -> List[str]:
@@ -322,6 +329,24 @@ def calibrate_target(
     """
     pairs = fixtures_for_target(target, dirs)
     if not pairs:
+        return {
+            "target": target,
+            "verdict": "uncalibratable",
+            "declared_band": read_declared_band(target, dirs),
+            "calibrated_band": None,
+            "floor": None,
+            "band_results": {},
+            "quarantined": [],
+            "fixture_gap": 0,
+        }
+
+    if not (dirs.agents / f"{target}.md").is_file():
+        # A skill-only target (no agents/<target>.md): real_dispatch_fn grades
+        # exclusively by shelling out to `/review-agent <target>`, which loads
+        # `agents/<name>.md` and can never dispatch a skill. Without this guard
+        # every cell is forced to a false 0% ("floor-failure"), which reads as
+        # a routing problem when it's actually a harness mis-classification
+        # (#1210 -- e.g. test-design-advisor).
         return {
             "target": target,
             "verdict": "uncalibratable",

--- a/tests/repo/test_agent_calibrate.py
+++ b/tests/repo/test_agent_calibrate.py
@@ -200,6 +200,45 @@ def test_uncalibratable_when_no_fixtures(corpus: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Scenario 4b — a skill-only target (no agents/<name>.md) is uncalibratable,
+# never a forced floor-failure (#1210).
+# ---------------------------------------------------------------------------
+
+def _write_skill_fixture(corpus: Path, stem: str, target: str) -> None:
+    (corpus / "evals" / "expected" / f"{stem}.json").write_text(json.dumps({
+        "fixture": f"{stem}.ts",
+        "applicableSkills": [target],
+        "skills": {target: {"expectedStatus": "fail", "issueCount": {"min": 1, "max": 5}}},
+    }))
+    (corpus / "evals" / "fixtures" / f"{stem}.ts").write_text("const x = 1\n")
+
+
+def test_skill_only_target_is_uncalibratable_not_floor_failure(corpus: Path) -> None:
+    skill_dir = corpus / "plugins" / "dev-team" / "skills" / "test-design-advisor"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: test-design-advisor\n---\n# Test Design Advisor\n")
+    _write_skill_fixture(corpus, "tlg-01", "test-design-advisor")
+    _write_floors(corpus, {"test-design-advisor": {"riskClass": "advisory", "floor": 0.8}})
+
+    dirs = _dirs(corpus)
+    routing_path, ladder_path = _routing_paths(corpus)
+
+    def dispatch_fn(pair: str, model: str) -> bool:
+        raise AssertionError("dispatch must never be called for a skill /review-agent can't load")
+
+    pass_rate_fn = ac.make_pass_rate_fn(dispatch_fn)
+    floors = ac.load_floors(corpus / "plugins" / "dev-team" / "knowledge" / "calibration-floors.json")
+    result = ac.calibrate_target("test-design-advisor", dirs, floors, set(), pass_rate_fn, routing_path, ladder_path)
+
+    assert result["verdict"] == "uncalibratable"
+    assert result["calibrated_band"] is None
+
+    # A full sweep never admits the skill into the dispatchable target list.
+    all_targets = ac.target_universe(dirs)
+    assert "test-design-advisor" not in all_targets
+
+
+# ---------------------------------------------------------------------------
 # Scenario 5 — in-session dispatch is refused.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `target_universe()`/`calibrate_target()` in `scripts/agent_calibrate.py` no longer sweep skill-only names (e.g. `test-design-advisor`) into real dispatch. `/review-agent` can only load `agents/<name>.md`, so a fixture-bearing skill was forced to a false 0% ("floor-failure") on every calibration run instead of reporting `uncalibratable`. Added a regression test covering both the full-sweep and direct `--agent <skill>` paths.
- `angular/react/vue-reactivity-review` each declared a `*-reactivity-clean` fixture in `evals/expected/*.json` whose source file never existed on disk, so `resolve_fixture_files()` returned nothing and every calibration cell was forced to 0/5. Added the missing clean fixtures plus a new positive `*-reactivity-issues` fixture per framework with a planted, agent-detectable defect (OnPush in-place mutation + unclosed RxJS subscription + effect self-write for Angular; setState-during-render + stale closure + missing cleanup for React; destructured `reactive()` + untracked `watchEffect` dependency + missing unmount cleanup for Vue).
- Updated ADR 0023 to record both fixes (previously only flagged as harness gaps in the #1184 baseline narrative).

## Test plan

- [x] `pytest tests/repo/test_agent_calibrate.py tests/repo/test_calibration_floors_sync.py -q` — 34 passed
- [x] `python3 scripts/check_calibration_floors_sync.py` — in sync
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Verified all 6 new/existing reactivity fixtures resolve to real files via `resolve_fixture_files()`
- [ ] Follow-up (not in this PR): a real `/agent-eval --calibrate` run against the new reactivity fixtures to replace the forced-0% baseline numbers with a real hit distribution

Closes #1210
Closes #1209


---
_Generated by [Claude Code](https://claude.ai/code/session_012unNQsojSFDD639b9KKAe6)_