### PR TITLE
docs(adr): reject 0006; record #1178 enforcement gap in 0008/0011

### DIFF
--- a/docs/adr/0006-per-increment-trunk-integration-topology.md
+++ b/docs/adr/0006-per-increment-trunk-integration-topology.md
@@ -4,7 +4,7 @@ Date: 2026-06-07
 
 ## Status
 
-Review
+Rejected
 
 > Proposed for feedback (issue #112). This ADR records a *direction under
 > consideration*, not an accepted decision. It is deliberately written before
@@ -17,6 +17,32 @@ Review
 > evidence prerequisite (#111) returned its first signal: bypassing the
 > review gate correlated with ~2.6× the rework. Moving to **Accepted** still
 > needs the cross-repo validation spike (see *Migration path*, step 3).
+
+> **2026-07-20 — Rejected.** This ADR never left Proposed/Review; it was never
+> moved to **Accepted** and no part of the topology was built. Its own gate for
+> acceptance — the step-3 cross-repo validation spike in *Migration path*
+> (validate the Flag Capability Contract across a vendor repo, a greenfield
+> OpenFeature + flagd-file repo, and a no-flag degraded repo) — never landed,
+> so the integrate-dark-per-increment thesis was never evidenced. In the
+> interim its premises have been overtaken:
+>
+> - [ADR 0013](0013-llm-driven-orchestration-over-deterministic-workflow-scripts.md)
+>   settled orchestration as LLM-driven rather than the deterministic
+>   integrate-dark / monitor-and-revert topology this ADR assumed.
+> - [ADR 0017](0017-single-build-cadence-remove-classic-tdd-opt-in.md) collapsed
+>   `/build` to a single cadence, removing the "one green TDD step / one flagged
+>   increment" trust-unit this ADR was framed around.
+> - [ADR 0022](0022-reject-delegation-only-sweep-dispatch.md) established the
+>   measure-a-win-before-shipping rule for dispatch changes, and recorded in
+>   passing that the shipped PreToolUse hook layer did not load at all until
+>   #1178 — the auto-revert/monitor enforcement substrate this topology depends
+>   on had no working hook layer to build on.
+>
+> The Gate-vs-monitor split above is also stale: two of the agents it names
+> (`test-modernization-review`, and the `/test-modernize` phase it gate-kept) no
+> longer exist in the agents/skills trees. Rejected rather than superseded — no
+> single later ADR replaces it; the direction was abandoned unbuilt. Body
+> preserved verbatim above for the historical record.
 
 ## Context
 

--- a/docs/adr/0008-use-effort-bands-instead-of-model-names-in-agent-frontmatter.md
+++ b/docs/adr/0008-use-effort-bands-instead-of-model-names-in-agent-frontmatter.md
@@ -104,3 +104,21 @@ the allowed set, so the contract cannot silently rot the way `model: mid` did.
   `high` agent can run above the session model. Mitigated by the SessionStart
   banner flagging every upgrade; deferred decision on whether to also warn
   per-dispatch.
+
+## Amendment (2026-07-20)
+
+The effort-band routing this ADR introduces is enforced by the PreToolUse
+model-resolution hook it inherits from
+[ADR 0004](0004-pre-dispatch-model-resolution.md): the hook is what maps a
+declared `effort:` band to a concrete model before dispatch. That enforcement
+guarantee was **inert as shipped**. The plugin's PreToolUse hook layer did not
+load at all on current Claude Code, so the resolver never ran and effort bands
+were never mapped pre-dispatch — agents ran on the session model regardless of
+their declared band. This is the finding
+[ADR 0022](0022-reject-delegation-only-sweep-dispatch.md) recorded in passing
+while running the #1099 orchestration benchmark: "the shipped hook layer
+(including effort-band routing) does not load at all on current Claude Code
+(#1178) … Shipped band-routing economics had never actually been exercised."
+The gap was closed in **v10.12.1** ("load plugin hooks via hooks/hooks.json …
+closes #1178"); before that fix, the vendor-neutral band vocabulary was correct
+but had no working enforcer. See #1178 and ADR 0022.

--- a/docs/adr/0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md
+++ b/docs/adr/0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md
@@ -68,3 +68,18 @@ default. This preserves the original warn-by-default posture's asymmetry:
 over-nudging a large-window session is a minor false alarm, while
 under-nudging a small-window session risks running well past the real
 ceiling — so an unknown model is never assumed large.
+
+## Amendment (2026-07-20)
+
+The enforcement this ADR adds — the `context-ceiling-guard` PreToolUse hook
+registered on `Agent`/`Skill` — was **inert as shipped**. The plugin's
+PreToolUse hook layer did not load at all on current Claude Code, so the guard
+never fired and the 40% Context Window Rule reverted to unenforced prose — the
+very "measured backstop, not just prose" state this ADR set out to replace.
+This is the same finding
+[ADR 0022](0022-reject-delegation-only-sweep-dispatch.md) recorded in passing
+while running the #1099 orchestration benchmark: "the shipped hook layer …
+does not load at all on current Claude Code (#1178)." The gap was closed in
+**v10.12.1** ("load plugin hooks via hooks/hooks.json … closes #1178"); before
+that fix, capability loads over the ceiling surfaced no nudge or block. See
+#1178 and ADR 0022.


### PR DESCRIPTION
## Summary

Reconciles three ADRs with what actually shipped.

**Change 1 — ADR 0006 (per-increment trunk integration topology): Rejected.**
Status changed `Review → Rejected`. Body preserved verbatim; a dated
(2026-07-20) status note explains it never left Proposed/Review, its step-3
cross-repo validation spike never landed, and its premises are overtaken —
citing ADR 0013 (LLM-driven orchestration), ADR 0017 (single build cadence),
and ADR 0022 (measure-a-win + the #1178 hook-layer finding).

**Change 2 — ADRs 0008 and 0011: dated amendments (2026-07-20).**
Each records that its PreToolUse-hook enforcement guarantee (effort-band
routing in 0008; the context-ceiling guard in 0011) was inert as shipped
because the plugin hook layer did not load on current Claude Code, until
#1178 was fixed in v10.12.1 ("load plugin hooks via hooks/hooks.json …
closes #1178"). Both cross-reference ADR 0022 and #1178.

Existing ADR bodies are preserved verbatim; only status/notes appended. No
renumbering. ADR TOC regenerated (`adr generate toc`, byte-identical).

## Verification results

1. `grep -rl "test-modernization-review|/test-modernize"` over `agents/` and
   `skills/` → **no matches** (those agents/phases are gone, confirming 0006's
   Gate-vs-monitor split is stale).
2. ADR 0017 removes the Classic TDD cadence opt-in (Decision: "Remove the
   Classic TDD opt-in from the build workflow") and ADR 0022 records the
   solo-arm dominance + dispatch-ceremony rejection — **confirmed** by reading
   both.
3. `gh issue view 1178 --json state` → **CLOSED**; the #1178 finding text
   ("the shipped hook layer … does not load at all on current Claude Code")
   is present in ADR 0022 — **confirmed**.

Out of scope (untouched): bash/.bats references in ADRs 0002/0004/0005, and all
other ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)