### PR TITLE
fix: stop /project-init gating keyless Graphify build behind an API key

### DIFF
--- a/plugins/dev-team/knowledge/codegraph-vs-graphify.md
+++ b/plugins/dev-team/knowledge/codegraph-vs-graphify.md
@@ -97,14 +97,16 @@ function."
 - A repo-level tool with its own native `/graphify` skill
   (`.claude/skills/graphify/SKILL.md` in this repo), not part of the
   `dev-team` plugin's shipped skill set.
-- Also offered opt-in during `/project-init`'s Step 4c as part of the
-  CodeGraph + Repowise + Graphify all-or-none group. **Unlike the keyless
-  CodeGraph/Repowise indexes, graphify's extraction requires a model/API
-  key** — the group prompt discloses this up front so accepting the group is
-  never a surprise key cost (issue #1135). When accepted, the skill builds the
-  graph (`graphify extract .`, or `graphify update .` when a graph already
-  exists); when graphify is absent, consuming agents fall back to
-  `Read`/`Grep`/`Glob`.
+- Also offered opt-in during `/project-init`'s Step 4c, after the keyless
+  CodeGraph + Repowise pair. **Graphify's AST structural graph builds keyless**
+  — `graphify extract .` runs the AST pass with no model/API key, exits 0, and
+  produces the `graph.json` the agents traverse (issue #1224). A model/API key
+  is required **only** for the semantic-enrichment layer: human-readable
+  community names (`graphify label`) and inferred edges (`extract --mode
+  deep`). When accepted, the skill builds the keyless graph (`graphify extract
+  .`, or `graphify update .` when a graph already exists) and offers enrichment
+  only when a key is present; when graphify is absent, consuming agents fall
+  back to `Read`/`Grep`/`Glob`.
 - Build a graph with `graphify extract .` (or the full `/graphify` pipeline),
   which writes `graphify-out/graph.json` (gitignored) plus
   `graphify-out/GRAPH_REPORT.md` and an HTML visualization.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -4660,9 +4660,9 @@
       "summary": "Beyond the four static-analysis lanes, other skills and agents depend on a",
       "anchor": "step-4b-install-capability-tools"
     },
-    "Step 4c: Offer the code-lookup tools (keyless group + key-gated Graphify)": {
+    "Step 4c: Offer the code-lookup tools (keyless group + keyless Graphify build)": {
       "summary": "Three optional, complementary code-intelligence tools — **CodeGraph**,",
-      "anchor": "step-4c-offer-the-code-lookup-tools-keyless-group-key-gated-graphify"
+      "anchor": "step-4c-offer-the-code-lookup-tools-keyless-group-keyless-graphify-build"
     },
     "Step 5: Verify — post-install probes": {
       "summary": "Run each configured lane's detection probe exactly as the lane registry",

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -183,7 +183,7 @@ framework peer relationship) — retry that install once with
 `--legacy-peer-deps` and note to the user that you did so, rather than
 aborting.
 
-### Step 4c: Offer the code-lookup tools (keyless group + key-gated Graphify)
+### Step 4c: Offer the code-lookup tools (keyless group + keyless Graphify build)
 
 Three optional, complementary code-intelligence tools — **CodeGraph**,
 **Repowise**, and **Graphify** — let the review and analysis agents read
@@ -203,16 +203,20 @@ single all-or-none group of #1108):
   #1134, #1135). CodeGraph installs its CLI (`npm install -g
   @colbymchenry/codegraph`) and runs `codegraph init .`; Repowise installs and
   runs a `--index-only` index.
-- **Graphify — separate, key-gated opt-in.** Graphify's extraction is
-  **LLM-driven and REQUIRES a model/API key**; its graph is heavier and its
-  integration is repo-level (a `## graphify` CLAUDE.md section + git hooks —
-  see the sub-section below). It is offered as **its own prompt, after the
-  keyless pair, and only when a model/API key is actually present**. With no
-  key, `graphify extract .` is a guaranteed failure that would leave an **inert
-  repo-level integration** behind (issue #1141) — so Graphify is skipped
-  entirely, its native integration is never written, and the skip is noted in
-  the summary. When Graphify is absent the agents that use it fall back
-  gracefully (see `knowledge/codegraph-vs-graphify.md`).
+- **Graphify — keyless AST build, with an optional key-gated enrichment
+  add-on.** Graphify's **AST structural graph builds with no model/API key** —
+  `graphify extract .` (and `graphify update .`) run keyless, exit 0, and
+  produce the `graph.json` that `graphify query`/`path`/`explain` traverse. A
+  model/API key is required **only** for the *semantic-enrichment layer*:
+  inferred edges (`extract --mode deep`) and human-readable community names
+  (`graphify label`; without it communities stay `Community N` placeholders).
+  Graphify is offered as **its own opt-in prompt after the keyless pair** —
+  separate not because of a key, but because its integration is **repo-level**
+  (it writes a `## graphify` CLAUDE.md section + git hooks; see the sub-section
+  below). On accept, always build the keyless AST graph; then, **only when a
+  provider key is present**, additionally offer semantic enrichment. When
+  Graphify is absent the agents that use it fall back gracefully (see
+  `knowledge/codegraph-vs-graphify.md`).
 
 **Detect which are already present** (so re-runs are idempotent and each offer
 scopes to the *missing* set):
@@ -259,45 +263,42 @@ to re-prompt`).
   confirmation so the operator knows the choice was durable and reversible:
   `Code-lookup tools: skipped — agents fall back to Read/Grep/Glob (re-run /project-init to be offered again).`
 
-**The Graphify opt-in (key-gated).** After the keyless pair, offer Graphify
-**only** when it is in the missing set *and* a model/API key is present:
+**The Graphify opt-in.** After the keyless pair, offer Graphify whenever it is
+in the missing set (regardless of key presence — its AST graph builds keyless):
 
 1. **Skip if already present or previously declined** — same missing-set rule
    as above.
-2. **Detect a model/API key.** Check the environment for any provider key
-   Graphify's extraction accepts — `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`,
-   `MOONSHOT_API_KEY`, `OPENAI_API_KEY` (among the set graphify's own error
-   lists). If **none** is set:
-   - Do **not** prompt for Graphify and do **not** run its sub-section — with
-     no key its build is a guaranteed failure and its repo-level native
-     integration would be left inert (issue #1141).
-   - Merge `{"graphify": {"install_skipped_no_key": true}}` into
-     `.claude/init-state.json` and print a terminal-visible confirmation:
-     `Graphify: skipped — no model/API key detected, and its graph build REQUIRES a model/API key. Set a provider key (e.g. ANTHROPIC_API_KEY) and re-run /project-init to be offered it.`
-3. **If a key IS present**, prompt **once** (recommended default **no**,
-   because — unlike the keyless pair — Graphify writes to this repo):
+2. **Prompt once** (recommended default **no**, because — unlike the keyless
+   pair — Graphify writes to this repo):
 
    ```
-   A model/API key was detected. Also install Graphify for
-   architecture/onboarding-level code intelligence? (y/N)
+   Also install Graphify for architecture/onboarding-level code intelligence? (y/N)
      - Graphify — repo-level: writes a `## graphify` section into this repo's
                   CLAUDE.md and installs git hooks (guarded against the known
                   over-delete bug — see the Graphify sub-section).
-                  REQUIRES a model/API key to build its graph (detected) —
-                  heavier than the keyless indexes above.
+                  Its AST structural graph builds WITHOUT an API key.
    ```
 
-   - On **yes**: run the Graphify sub-section below (install, guarded native
-     integration, key-driven build), recording the accept in
-     `.claude/init-state.json`. Its build stays non-fatal (partial-failure
-     rule) if the detected key is later rejected at build time.
-   - On any other response: install nothing and record
-     `{"graphify": {"install_declined": true}}`.
+3. **On yes:** run the Graphify sub-section below (install + guarded native
+   integration + **keyless** `graphify extract .`), recording the accept in
+   `.claude/init-state.json`.
+4. **Semantic enrichment (key-gated add-on).** After the keyless graph is
+   built, detect a provider key — `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`,
+   `MOONSHOT_API_KEY`, `OPENAI_API_KEY` (among the set graphify's own error
+   lists):
+   - **Key present:** offer `graphify label` (community naming) and/or
+     `extract --mode deep` (inferred edges) on top of the keyless graph. Its
+     build stays non-fatal (partial-failure rule) if the key is rejected at
+     build time.
+   - **No key:** the keyless graph stands as-is; print `Graphify: keyless AST graph built — set a provider key (e.g. ANTHROPIC_API_KEY) and re-run /project-init for semantic enrichment (community names + inferred edges).` Merge
+     `{"graphify": {"enrichment_skipped_no_key": true}}` into
+     `.claude/init-state.json`.
+5. **On no:** install nothing, record `{"graphify": {"install_declined": true}}`.
 
 The per-tool mechanics below are unchanged; Step 4c only decides *whether* each
 runs. Each remains user-scoped/gitignored exactly as before, except Graphify's
-documented repo-level native integration — which is now written only on the
-key-gated accept.
+documented repo-level native integration — which is written on any Graphify
+accept (it does not require a key).
 
 #### CodeGraph — strictly personal, never committed
 
@@ -442,10 +443,10 @@ Graphify (`graphifyy` on PyPI) is a multi-modal knowledge graph tool
 skill, PreToolUse nudge hooks into `.claude/settings.json`, and a
 `## graphify` section into the project's own `CLAUDE.md`.
 
-This sub-section runs **only after the key-gated Graphify opt-in in Step 4c
-accepts** — that is, a model/API key was detected *and* the user said yes.
-Because its build needs that key, and its integration is repo-level, it is
-never run (and none of the file writes below happen) when no key is present.
+This sub-section runs **only after the Graphify opt-in in Step 4c accepts** —
+that is, the user said yes. Its integration is repo-level, so none of the file
+writes below happen unless that opt-in was accepted; no model/API key is
+required to reach or complete this sub-section — the AST build is keyless.
 
 **Install (fallback chain):**
 
@@ -488,30 +489,40 @@ over-delete, taking unrelated pre-existing content with it. Guard every run:
 5. **On no corruption detected:** leave the installer's output as-is —
    nothing further to do.
 
-**Build the graph (requires a model/API key — issue #1135).** Unlike the
-keyless CodeGraph/Repowise indexes, graphify's extraction is LLM-driven and
-needs a model/API key — this is the cost the group prompt discloses.
+**Build the graph — keyless AST pass (issue #1224).** Graphify's AST
+structural graph builds with **no model/API key**: `graphify extract .` runs
+the AST pass, skips the semantic pass gracefully when no key is present, and
+exits 0 with a valid `graph.json`. This is the graph the agents actually
+traverse (`graphify query`/`path`/`explain`).
 
 - **Idempotent:** if `graphify-out/graph.json` already exists, skip extraction
-  and offer the incremental, no-key refresh instead:
+  and offer the incremental, keyless refresh instead:
 
   ```bash
   graphify update .
   ```
 
-- **Otherwise build it:**
+- **Otherwise build it (keyless):**
 
   ```bash
   graphify extract .
   ```
 
   This writes `graphify-out/graph.json` (gitignored) plus `GRAPH_REPORT.md`.
-- **Non-fatal:** if extraction fails (e.g. no model/API key is configured),
-  print the error, merge `{"graphify": {"build_failed": true}}` into
-  `.claude/init-state.json`, and continue — never abort the rest of setup, and
-  never claim the group fully installed (the partial-failure rule). Agents that
-  consume graphify fall back to `Read`/`Grep`/`Glob` when `graphify-out/` is
-  absent (see `knowledge/codegraph-vs-graphify.md`).
+  Without a provider key it structurally clusters communities but leaves them
+  unlabeled (`Community N`) and skips inferred edges — the structure is intact.
+- **Non-fatal:** if extraction fails, print the error, merge
+  `{"graphify": {"build_failed": true}}` into `.claude/init-state.json`, and
+  continue — never abort the rest of setup, and never claim the group fully
+  installed (the partial-failure rule). Agents that consume graphify fall back
+  to `Read`/`Grep`/`Glob` when `graphify-out/` is absent (see
+  `knowledge/codegraph-vs-graphify.md`).
+
+**Semantic enrichment (key-gated add-on).** Only when a provider key is present
+(per Step 4c step 4), enrich the keyless graph: `graphify label` names the
+structural communities, and `graphify extract . --mode deep` adds INFERRED
+semantic edges. Both stay non-fatal — if the key is rejected at build time the
+keyless graph stands as-is. With no key, skip this step entirely.
 
 **Gitignore advice.** `graphify hook install` creates machine-specific
 generated git hooks. Tell the user to gitignore them the same way this
@@ -572,10 +583,11 @@ After every configured lane probes green, give the user:
   (installed/initialized, MCP registration command printed or skipped) and
   Repowise state — plus Graphify state: installed with native integration
   applied (and whether the CLAUDE.md corruption guard fired and repaired
-  anything), **or skipped because no model/API key was detected** (its
-  repo-level integration was not written), or declined. Note CodeGraph is
-  strictly user-level/personal and Graphify is the repo-level native
-  integration offered only when a key is present.
+  anything) and its keyless AST graph built, **whether semantic enrichment ran
+  or was skipped because no provider key was detected**, or declined. Note
+  CodeGraph is strictly user-level/personal and Graphify is the repo-level
+  native integration; its AST build is keyless, with semantic enrichment as a
+  key-gated add-on.
 - Files created (greenfield only).
 
 ## Greenfield JS/TS scaffold

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -720,7 +720,7 @@ mutation tool wired in, e.g. pure Python), report that one line verbatim —
 ### Code-intelligence indexes (project-init Step 4c — all-or-none group)
 - CodeGraph: ✓ installed + `.codegraph/` built (keyless)   [or: ✗ declined | ✗ failed]
 - Repowise:  ✓ installed + `.repowise/` indexed (keyless)   [or: ✗ declined | ✗ failed]
-- Graphify:  ✓ `graphify-out/` built (required a model/API key)   [or: ✗ declined | ✗ failed]
+- Graphify:  ✓ `graphify-out/` built (keyless AST; enrichment key-gated)   [or: ✗ declined | ✗ failed]
 
 The separate "run index-codebase first" step is no longer required — accepting
 the group installs and builds all three indexes in the same run.

--- a/tests/skills/test_project_init_code_lookup_group.py
+++ b/tests/skills/test_project_init_code_lookup_group.py
@@ -5,16 +5,20 @@ all-or-none group and installs Repowise (keyless, gitignored, MCP-registered).
 Repowise indexes in the same run (CodeGraph via `npm install -g
 @colbymchenry/codegraph` + non-interactive `codegraph init .`).
 
-#1135 — the prompt must disclose that Graphify (unlike the keyless indexes)
-requires a model/API key, and Graphify's graph build is idempotent
-(`graphify update .` when a graph exists) and non-fatal.
+#1135 — Graphify's graph build is idempotent (`graphify update .` when a graph
+exists) and non-fatal.
 
 #1141 — the single all-or-none group is split by cost profile. The keyless
 pair (CodeGraph + Repowise) stays all-or-none and can be accepted *alone*.
-Graphify is a separate, key-gated opt-in: it is offered only when a model/API
-key is detected, and when no key is present it is skipped entirely — its
-repo-level native integration is never written, so the repo is not left
-carrying an inert integration.
+Graphify is a separate opt-in (its footprint is repo-level, not because of a
+key).
+
+#1224 — Graphify's AST structural graph builds keyless: it is offered
+regardless of key presence, and on accept its keyless AST graph always builds.
+A provider key gates only the semantic-enrichment add-on (community names via
+`graphify label`, inferred edges via `extract --mode deep`). When no key is
+present, enrichment is skipped and recorded as `enrichment_skipped_no_key` —
+the graph still builds and the repo-level integration is still written.
 
 Content-guard sensor over the shipped project-init SKILL.md prose — a pure text
 grep, no state-mutating operations.
@@ -121,13 +125,15 @@ def test_group_states_codegraph_repowise_are_keyless():
     assert "keyless" in text.lower()
 
 
-# --- #1135: Graphify's model/API-key requirement is disclosed ----------------
+# --- #1224: Graphify's AST build is keyless; only enrichment is key-gated -----
 
 
-def test_group_prompt_discloses_graphify_key_requirement():
+def test_graphify_optin_discloses_keyless_ast_build():
     text = _text()
-    # The all-or-none prompt must warn that Graphify needs a model/API key.
-    assert "REQUIRES a model/API key" in text
+    # The Graphify prompt must state the AST structural graph builds without a key.
+    assert "builds WITHOUT an API key" in text
+    # And the semantic-enrichment layer is the only key-gated part.
+    assert "key-gated add-on" in text
 
 
 def test_graphify_build_is_idempotent_with_update_fallback():
@@ -157,10 +163,12 @@ def test_keyless_group_prompt_omits_graphify():
     assert "Graphify" not in prompt
 
 
-def test_graphify_is_separate_key_gated_optin():
+def test_graphify_is_separate_optin_after_keyless_pair():
     text = _text()
-    assert "key-gated" in text
-    assert "only when a model/API key is actually present" in text
+    # Graphify is a separate opt-in (repo-level footprint), offered after the pair.
+    assert "its own opt-in prompt after the keyless pair" in text
+    # Enrichment — not the build — is the key-gated part.
+    assert "key-gated add-on" in text
 
 
 def test_graphify_optin_detects_provider_keys():
@@ -170,16 +178,17 @@ def test_graphify_optin_detects_provider_keys():
     assert "GOOGLE_API_KEY" in text
 
 
-def test_graphify_skipped_when_no_key_and_integration_not_written():
+def test_graphify_keyless_build_offered_without_key():
     text = _text()
-    # No key => Graphify is skipped and its repo-level integration is NOT written.
-    assert "install_skipped_no_key" in text
-    assert "guaranteed failure" in text
-    assert "inert" in text
+    # No key => Graphify is still offered and its keyless AST graph still builds;
+    # only enrichment is skipped, recorded as enrichment_skipped_no_key (#1224).
+    assert "enrichment_skipped_no_key" in text
+    assert "install_skipped_no_key" not in text  # the old skip-entirely flag is gone
+    assert "regardless of key presence" in text
 
 
-def test_graphify_native_integration_gated_on_key_present():
+def test_graphify_native_integration_gated_on_optin_accept():
     text = _text()
-    # The Graphify sub-section documents that its file writes only happen on the
-    # key-gated accept.
-    assert "only after the key-gated Graphify opt-in" in text
+    # The Graphify sub-section documents that its file writes only happen when
+    # the opt-in is accepted — not when a key is present.
+    assert "only after the Graphify opt-in in Step 4c accepts" in text


### PR DESCRIPTION
## Problem

`/project-init` Step 4c skipped Graphify **entirely** when no provider key was present, on the false premise that `graphify extract .` requires a model/API key. Graphify's AST structural graph builds **keyless** (exit 0, valid `graph.json`) — a key gates only the semantic-enrichment layer (community names via `graphify label`, inferred edges via `extract --mode deep`).

## Change

- **project-init `SKILL.md`** — Graphify is now offered regardless of key presence; on accept it always builds the keyless AST graph, then offers semantic enrichment **only when a provider key is present**. Records `enrichment_skipped_no_key` instead of the old `install_skipped_no_key`; drops the "guaranteed failure / skip entirely" logic. Description, opt-in flow, and native-integration sub-section all corrected.
- **setup `SKILL.md`** — summary line no longer claims Graphify "required a model/API key".
- **`knowledge/codegraph-vs-graphify.md`** — keyless-AST correction.
- **`tests/skills/test_project_init_code_lookup_group.py`** — content-guards updated to the new wording (keyless build disclosed, enrichment is the only key-gated part).
- `CLAUDE.md:51` already implied no key — left unchanged.

## Acceptance criteria

- [x] `/project-init` offers and builds a keyless Graphify AST graph with no provider key.
- [x] Semantic enrichment (labels / inferred edges) is the only key-gated step.
- [x] No user-facing text claims Graphify's build requires an API key.
- [x] `init-state.json` records `enrichment_skipped_no_key`, not `install_skipped_no_key`, on a keyless machine.
- [x] Content-guard tests updated; `tests/skills` + `tests/knowledge` green (900 passed).

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)