### PR TITLE
test: run the env-gated opt-in tests in CI so they can't silently rot

### DIFF
--- a/.github/workflows/opt-in-tests.yml
+++ b/.github/workflows/opt-in-tests.yml
@@ -1,0 +1,122 @@
+name: Opt-in tests
+
+# Issue #1222: three env-gated opt-in tests are correctly skipped in the default
+# local / pre-push run (they need host-specific prerequisites), but until now no
+# CI lane set their opt-in flags, so they never executed *anywhere* — a
+# regression in the code they cover would go undetected. This workflow runs them
+# where their prerequisites can be provisioned, so they can't silently rot:
+#
+#   1. Stryker.NET POSIX signal tests — need a real .NET SDK on PATH.
+#      Gated by MUTATION_WRAPPER_SIGNAL_TESTS=1. Cheap + keyless, so they run on
+#      every PR that touches the wrapper (path-filtered) and on a schedule.
+#   2. Orchestrator real-subprocess test — shells out to the real `claude` CLI
+#      (30s timeout; outcome/latency/cost vary by host). Gated by
+#      ORCHESTRATOR_REAL_SUBPROCESS_TESTS=1. Because it is pricey/host-variant it
+#      runs only on a schedule and manual dispatch, NOT on every PR — mirroring
+#      the opt-in posture of the "Eval live regression" lane.
+#
+# The default local/pre-push run keeps skipping all three: this workflow imposes
+# no new requirement on any dev machine. A failure here is a real red run
+# (surfaced on the PR for the wrapper job; a failed scheduled run for the
+# orchestrator job, which GitHub notifies the repo admins about) — never a
+# silent green.
+
+on:
+  # path-filtered: fires the wrapper job only when the wrapper / its tests / this
+  # workflow change. The schedule + workflow_dispatch triggers below ignore
+  # `paths`, so the scheduled orchestrator lane still runs on time.
+  push:
+    branches: [main]
+    paths:
+      - "plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py"
+      - "tests/scripts/test_csharp_stryker_net_wrapper.py"
+      - ".github/workflows/opt-in-tests.yml"
+  pull_request:
+    paths:
+      - "plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py"
+      - "tests/scripts/test_csharp_stryker_net_wrapper.py"
+      - ".github/workflows/opt-in-tests.yml"
+  # Weekly heartbeat (Mondays 06:17 UTC) so both lanes exercise their code even
+  # when nothing in the paths above changed.
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: opt-in-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stryker-net-signals:
+    name: Stryker.NET POSIX signal tests
+    # Not on schedule-only? It IS cheap, so run it on schedule too as a rot
+    # check. Skip only the pricey orchestrator lane's exclusive triggers.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      # The opt-in gate: MUTATION_WRAPPER_SIGNAL_TESTS=1 + `dotnet` on PATH.
+      # -ra surfaces the exact assertion/reason on any non-pass in the log.
+      - name: Run POSIX signal tests (opt-in flag set, real .NET SDK on PATH)
+        env:
+          MUTATION_WRAPPER_SIGNAL_TESTS: "1"
+        run: |
+          dotnet --version
+          python -m pytest \
+            "tests/scripts/test_csharp_stryker_net_wrapper.py::TestSignalHandlingPOSIX" \
+            -v -ra --tb=short
+
+  orchestrator-real-subprocess:
+    name: Orchestrator real-subprocess test
+    # Pricey / host-variant: schedule + manual dispatch only, never per-PR.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Set up Node (for the claude CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pytest + pytest-asyncio
+        run: python -m pip install --upgrade pip pytest pytest-asyncio
+
+      - name: Install the claude CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          command -v claude
+
+      # The opt-in gate: ORCHESTRATOR_REAL_SUBPROCESS_TESTS=1 + `claude` on PATH.
+      # ANTHROPIC_API_KEY (when configured as a secret) lets the CLI actually
+      # classify; without it classify() still exercises the real subprocess path
+      # and falls back to the safe default, so the test runs (not skips) either
+      # way. The 30s timeout inside classify() bounds any hang.
+      - name: Run orchestrator real-subprocess test (opt-in flag set, claude on PATH)
+        env:
+          ORCHESTRATOR_REAL_SUBPROCESS_TESTS: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python -m pytest \
+            "tests/scripts/test_orchestrator.py::test_classify_real_subprocess_returns_valid_size" \
+            -v -ra --tb=short

--- a/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -714,6 +714,21 @@ class TestSignalHandlingPOSIX:
         stryker_pid_file = hermetic.root / "stryker.pid"
         fake_stryker = self._make_fake_stryker(hermetic)
 
+        # This class spawns the REAL wrapper subprocess, so the monkeypatched
+        # build_project does NOT apply — the wrapper runs a real `dotnet build
+        # <sln>`. main() aborts before spawning Stryker if that build returns
+        # non-zero (see the wrapper's `if rc != 0: return rc`), so the `.sln`
+        # must be a VALID solution the SDK builds clean. The global fixture's
+        # "solution stub" is not — a real build fails it with MSB5010. Write a
+        # validly-formatted empty solution instead: the SDK builds it with a
+        # harmless "no project to restore" warning and exits 0, which is all
+        # the signal path needs (it never inspects the build output). This is
+        # why the class requires a real .NET SDK on PATH (#1222).
+        hermetic.sln.write_text(
+            "Microsoft Visual Studio Solution File, Format Version 12.00\n"
+            "# Visual Studio Version 17\n"
+        )
+
         env = os.environ.copy()
         env["STRYKER_BLOCK_SENTINEL"] = str(sentinel_path)
         env["STRYKER_PID_FILE"] = str(stryker_pid_file)
@@ -728,7 +743,7 @@ class TestSignalHandlingPOSIX:
                 "--sln",
                 str(hermetic.sln),
                 "--shim-project",
-                "",  # skip shim; the sln build fails silently
+                "",  # skip shim; only the .sln is built
                 "--stryker-bin",
                 sys.executable,
                 "--logfile",
@@ -745,9 +760,9 @@ class TestSignalHandlingPOSIX:
             if stryker_pid_file.exists():
                 break
             time.sleep(0.05)
-        # Note: if the wrapper failed before spawning stryker (e.g. dotnet
-        # build failed because we're not fixing PATH here), the PID file
-        # will be absent. Surface that clearly.
+        # Note: if the wrapper failed before spawning stryker (e.g. no .NET SDK
+        # on PATH, or `dotnet build` returned non-zero), the PID file will be
+        # absent. Surface that clearly.
         if not stryker_pid_file.exists():
             proc.terminate()
             out, err = proc.communicate(timeout=5)


### PR DESCRIPTION
## Problem

The pre-push pytest sweep reports **3 skipped** tests — all intentional, host-dependent opt-in tests, but gated behind flags **no CI lane set**, so they never executed anywhere. A regression in the code they cover would go undetected.

## Change

New workflow `.github/workflows/opt-in-tests.yml` with two lanes:

| Lane | Prereq + flag | Triggers |
|---|---|---|
| **Stryker.NET POSIX signal tests** | real .NET SDK (`setup-dotnet`) + `MUTATION_WRAPPER_SIGNAL_TESTS=1` | wrapper-path-filtered PR/push + weekly schedule (cheap, keyless) |
| **Orchestrator real-subprocess test** | `claude` CLI (`npm i -g @anthropic-ai/claude-code`) + `ORCHESTRATOR_REAL_SUBPROCESS_TESTS=1` | schedule + manual dispatch only (pricey/host-variant); `ANTHROPIC_API_KEY` passed when configured |

### Latent-bug fix (required to make the lane green)

The signal tests could **never** have passed even with the flag set: `TestSignalHandlingPOSIX` spawns the wrapper as a **real subprocess**, so the monkeypatched `build_project` doesn't apply and the real `dotnet build` runs against the `"solution stub"` fixture — which fails a real build (MSB5010), so `main()` aborted before spawning Stryker (`if rc != 0: return rc`). Fix: write a validly-formatted **empty** solution just before the spawn; the SDK builds it clean (exit 0), which is all the signal path needs. Verified locally with .NET 10 SDK — both signal tests pass; default run still skips them.

## Acceptance criteria

- [x] Each of the 3 opt-in tests executes (not skipped) in at least one CI lane with its prerequisite installed and its flag set.
- [x] The default local/pre-push run keeps skipping them (no new host requirement on dev machines) — verified: `70 passed, 3 skipped`.
- [x] Failures are visible: red PR check (wrapper lane) / failed scheduled run the repo admins are notified of (orchestrator lane), never silently green.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)