### PR TITLE
fix: correct invalid hook schema that broke plugin load

### DIFF
--- a/docs/adr/0010-per-session-analysis-granularity.md
+++ b/docs/adr/0010-per-session-analysis-granularity.md
@@ -12,7 +12,7 @@ The closed learning loop must decide how frequently to run session analysis. Two
 candidates were considered:
 
 1. **Per conversation turn** — trigger analysis after every model response.
-2. **Per session** — trigger analysis when a session ends (SessionStop event).
+2. **Per session** — trigger analysis when a session ends (SessionEnd event).
 
 Per-turn analysis would provide the highest freshness but runs the extractor and
 dispatches a background agent after every single response, multiplying API cost
@@ -20,13 +20,13 @@ and adding latency to every interaction.
 
 ## Decision
 
-The analysis trigger fires on **SessionStop**, not per conversation turn. A
+The analysis trigger fires on **SessionEnd**, not per conversation turn. A
 configurable counter (`DEV_TEAM_AUTO_REVIEW_THRESHOLD`, default 5) controls how
 many sessions accumulate before analysis runs — amortizing the background dispatch
 cost across multiple sessions. The counter is persisted in
 `metrics/learning-loop-state.json` and reset to zero when the threshold is reached.
 
-The session-id from the SessionStop payload is passed to the background `claude`
+The session-id from the SessionEnd payload is passed to the background `claude`
 subprocess via `--session-id` to enable prompt-cache reuse, reducing background
 API cost.
 

--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -208,7 +208,7 @@
         ]
       }
     ],
-    "SessionStop": [
+    "SessionEnd": [
       {
         "hooks": [
           {
@@ -220,7 +220,6 @@
     ],
     "Stop": [
       {
-        "matcher": null,
         "hooks": [
           {
             "type": "command",
@@ -235,7 +234,6 @@
     ],
     "SubagentStop": [
       {
-        "matcher": null,
         "hooks": [
           {
             "type": "command",

--- a/plugins/dev-team/hooks/session_learning_trigger.py
+++ b/plugins/dev-team/hooks/session_learning_trigger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""session_learning_trigger.py — SessionStop hook (Python port of session-learning-trigger.sh).
+"""session_learning_trigger.py — SessionEnd hook (Python port of session-learning-trigger.sh).
 
 Counts sessions and dispatches background session-analysis at threshold.
 

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -224,7 +224,7 @@
         ]
       }
     ],
-    "SessionStop": [
+    "SessionEnd": [
       {
         "hooks": [
           {
@@ -236,7 +236,6 @@
     ],
     "Stop": [
       {
-        "matcher": null,
         "hooks": [
           {
             "type": "command",
@@ -251,7 +250,6 @@
     ],
     "SubagentStop": [
       {
-        "matcher": null,
         "hooks": [
           {
             "type": "command",

--- a/tests/docs/test_learning_loop_adr.py
+++ b/tests/docs/test_learning_loop_adr.py
@@ -63,8 +63,8 @@ def test_adr_0010_has_accepted_status_and_required_sections() -> None:
     assert re.search(r"^## Consequences", text, re.MULTILINE)
 
 
-def test_adr_0010_decision_contains_sessionstop_not_per_turn() -> None:
+def test_adr_0010_decision_contains_sessionend_not_per_turn() -> None:
     text = ADR_0010.read_text(encoding="utf-8")
     decision = _section(text, "## Decision")
-    assert "SessionStop" in decision
+    assert "SessionEnd" in decision
     assert "per turn" not in decision.lower()

--- a/tests/hooks/test_settings_registration.py
+++ b/tests/hooks/test_settings_registration.py
@@ -46,9 +46,9 @@ def test_mutation_gate_is_in_post_tool_use_not_pre_tool_use() -> None:
     assert not any("mutation_gate.py" in cmd for cmd in commands)
 
 
-def test_session_learning_trigger_py_is_registered_in_session_stop_hooks() -> None:
+def test_session_learning_trigger_py_is_registered_in_session_end_hooks() -> None:
     data = _load()
-    commands = _commands(data["hooks"]["SessionStop"])
+    commands = _commands(data["hooks"]["SessionEnd"])
     assert any("session_learning_trigger.py" in cmd for cmd in commands)
 
 

--- a/tests/hooks/test_settings_schema.py
+++ b/tests/hooks/test_settings_schema.py
@@ -1,0 +1,97 @@
+"""Guard the shipped hook config against the Claude Code hook-config schema.
+
+Regression test for #1227: v10.14.x shipped `settings.json`/`hooks.json` with
+an invalid hook event (`SessionStop`) and `"matcher": null` on the `Stop` and
+`SubagentStop` groups. The CLI's schema rejected both, so the whole plugin
+`failed to load` — no hooks, agents, or skills available.
+
+These two checks reproduce the CLI's two rejection classes without needing the
+CLI itself:
+
+1. every top-level key under `hooks` must be a known Claude Code hook event;
+2. no hook group may carry `matcher: null` — the schema wants a string or the
+   key omitted entirely.
+
+Both the plugin-local `settings.json` and the marketplace `hooks/hooks.json`
+are validated, since they are hand-maintained mirrors and drift silently.
+
+If Claude Code adds a new hook event, extend VALID_HOOK_EVENTS below — this is
+a deliberate known-good allowlist, not an auto-derived one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+HOOK_FILES = [PLUGIN / "settings.json", PLUGIN / "hooks" / "hooks.json"]
+
+# The hook events Claude Code's hook-config schema accepts. Sourced from the
+# CLI's own error enum (#1227). Add new events here when the CLI adds them.
+VALID_HOOK_EVENTS = frozenset(
+    {
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PostToolBatch",
+        "Notification",
+        "UserPromptSubmit",
+        "UserPromptExpansion",
+        "SessionStart",
+        "SessionEnd",
+        "Stop",
+        "StopFailure",
+        "SubagentStart",
+        "SubagentStop",
+        "PreCompact",
+        "PostCompact",
+        "PermissionRequest",
+        "PermissionDenied",
+        "Setup",
+        "TeammateIdle",
+        "TaskCreated",
+        "TaskCompleted",
+        "Elicitation",
+        "ElicitationResult",
+        "ConfigChange",
+        "WorktreeCreate",
+        "WorktreeRemove",
+        "InstructionsLoaded",
+        "CwdChanged",
+        "FileChanged",
+        "MessageDisplay",
+    }
+)
+
+
+def _hooks(path: Path) -> dict:
+    return json.loads(path.read_text()).get("hooks", {})
+
+
+@pytest.mark.parametrize("path", HOOK_FILES, ids=lambda p: p.name)
+def test_every_hook_event_key_is_valid(path: Path) -> None:
+    invalid = sorted(set(_hooks(path)) - VALID_HOOK_EVENTS)
+    assert not invalid, (
+        f"{path.relative_to(REPO_ROOT)} registers unknown hook event(s) "
+        f"{invalid}; the CLI schema will reject the plugin. Valid events: "
+        f"{sorted(VALID_HOOK_EVENTS)}"
+    )
+
+
+@pytest.mark.parametrize("path", HOOK_FILES, ids=lambda p: p.name)
+def test_no_hook_group_has_null_matcher(path: Path) -> None:
+    offenders = [
+        event
+        for event, groups in _hooks(path).items()
+        for group in groups
+        if "matcher" in group and group["matcher"] is None
+    ]
+    assert not offenders, (
+        f"{path.relative_to(REPO_ROOT)} has `\"matcher\": null` under "
+        f"{sorted(set(offenders))}; the schema requires a string or an omitted "
+        f"key. Remove the matcher key for non-tool events."
+    )


### PR DESCRIPTION
## Problem

`dev-team@bfinster` **fails to load** in current Claude Code — `claude plugin list` shows `Status: ✘ failed to load`, `Error: Hook load failed`. Reproduced on installed v10.14.0 and v10.14.1. Because load fails, none of the plugin's hooks, agents, or skills are available.

Two schema violations in `plugins/dev-team/settings.json` and its mirror `plugins/dev-team/hooks/hooks.json`:

1. **`SessionStop` is not a valid hook event.** Validated against the official docs (https://code.claude.com/docs/en/hooks): the event enum has `SessionEnd`, not `SessionStop`. Session-end semantics (ADR 0010) map to `SessionEnd`, which provides `session_id` in its payload — exactly what `session_learning_trigger.py` consumes.
2. **`Stop` and `SubagentStop` carried `"matcher": null`.** The docs state these events "don't support matchers and always fire on every occurrence"; the schema wants a string or an omitted key, so `null` is rejected. Removed (2 per file).

## Fix

- `SessionStop` → `SessionEnd` in both hook files.
- Drop the `matcher: null` key from `Stop` and `SubagentStop` in both files.
- Update the `session_learning_trigger.py` docstring, ADR 0010, and the two tests that pinned the old name.

## Prevention

New `tests/hooks/test_settings_schema.py` validates **both** hook files against:
1. the documented Claude Code hook-event allowlist (all 30 events, verified against the docs), and
2. a no-`matcher: null` rule.

This reproduces the CLI's two rejection classes without the CLI, catching both before release. Verified it flags the pre-fix content and passes on the fix.

## Verification

- `tests/hooks` + `tests/docs` — 196 passed.
- Both JSON files parse; no residual `SessionStop` or `matcher: null` in shipped files.
- Negative-checked the new guard against the original shape.

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)