### PR TITLE
docs: correct code-intelligence terms, attribute marketplace-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-How to develop, test, and release the `dev-team` and `security-assessment` plugins. To *use* the plugins, see the [README](README.md) and the [Getting Started](GETTING-STARTED.md) tutorial.
+How to develop, test, and release the `dev-team`, `security-assessment`, and `marketplace-dev` plugins. To *use* the plugins, see the [README](README.md) and the [Getting Started](GETTING-STARTED.md) tutorial.
 
 ## Repository layout
 
@@ -8,6 +8,7 @@ How to develop, test, and release the `dev-team` and `security-assessment` plugi
 .claude-plugin/marketplace.json    # marketplace catalog (the published plugin list)
 plugins/dev-team/                  # the dev-team plugin source
 plugins/security-assessment/       # the security companion plugin
+plugins/marketplace-dev/           # the plugin-author's toolkit (scaffold/audit/agent authoring)
 docs/                              # repo-level documentation
 evals/                            # eval fixtures and harnesses (not shipped)
 ```
@@ -73,19 +74,21 @@ See [comparative testing](plugins/security-assessment/docs/comparative-testing.m
 
 ## Adding agents and skills
 
+The agent-authoring commands — `/agent-add`, `/agent-create`, `/agent-remove` — and the `agent-skill-authoring` skill ship in the **`marketplace-dev`** plugin, not `dev-team`. Install `marketplace-dev` (see [Getting Started](GETTING-STARTED.md#install-marketplace-dev-optional)) before using them.
+
 Scaffold a new agent (review or team) with the authoring command:
 
 ```text
 /agent-add <description or URL to a coding standard>
 ```
 
-`/agent-add` scaffolds the file, checks for scope overlap with existing agents, runs `/agent-audit`, creates eval fixtures, and registers the agent. For the templates, schema, and registration steps, see:
+`/agent-add` scaffolds the file, checks for scope overlap with existing agents, runs `/agent-audit`, creates eval fixtures, and registers the agent. `/agent-create` builds one from scratch and `/agent-remove` deletes an agent and its registrations. For the templates, schema, and registration steps, see:
 
 - [Agents](plugins/dev-team/docs/agent_info.md) — team-agent and review-agent templates; add, remove, or customize agents
 - [Skills & Commands](plugins/dev-team/docs/skills.md) — skill template; add a knowledge or user-invocable (slash-command) skill
-- the `agent-skill-authoring` skill — conventions, anti-patterns, and the agent-vs-skill philosophy
+- the `agent-skill-authoring` skill (marketplace-dev) — conventions, anti-patterns, and the agent-vs-skill philosophy
 
-Every new or changed agent/skill/hook must pass `/agent-audit`.
+Every new or changed agent/skill/hook must pass `/agent-audit` (which ships in `dev-team`).
 
 ## Documentation diagrams
 
@@ -97,10 +100,4 @@ The docs use three diagram formats, each for a distinct purpose — match the co
 
 ## Releasing
 
-Releases are managed by [release-please](https://github.com/googleapis/release-please). Push [conventional commits](https://www.conventionalcommits.org/) to `main`:
-
-- `feat:` → minor version bump
-- `fix:` → patch version bump
-- `feat!:` or `BREAKING CHANGE:` → major version bump
-
-A release PR is opened automatically; merging it creates a GitHub Release with a version tag. The marketplace catalog serves only tagged releases.
+Releases are managed by [release-please](https://github.com/googleapis/release-please): push [conventional commits](https://www.conventionalcommits.org/) to `main` and merge the release PR it opens. The full rules — the version-bump mapping, why every commit that lands on `main` must be conventional under rebase-merge, and how to recover a missed release with a `Release-As:` footer — are in [`CLAUDE.md`](CLAUDE.md#releasing).

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -2,18 +2,21 @@
 
 This project gives you an AI development team — specialized agents with distinct roles, reusable skills they draw on, and slash commands for skills and workflows. You talk to the team in natural language. The system figures out who should do the work and what knowledge they need.
 
+On this page:
+
+- [Installation](#installation)
+- [Key Concepts](#key-concepts)
+- [How to Use It](#how-to-use-it)
+- [Common Workflows](#common-workflows)
+- [Diagnostic & Audit Workflows](#diagnostic--audit-workflows)
+- [Available Agents and Skills](#available-agents-and-skills)
+- [Rules to Know](#rules-to-know)
+
 ## Installation
 
 ### Install `dev-team`
 
-Start here — most users install only this plugin. Required tools (`jq`, `gh`) are listed in the [Plugins](README.md#plugins) table.
-
-```bash
-claude plugin marketplace add bdfinst/agentic-dev-team
-claude plugin install dev-team@bfinster
-```
-
-The `owner/repo` shorthand and the full `https://github.com/bdfinst/agentic-dev-team` URL are equivalent. For self-hosted or other git hosts, install scopes (`user`/`project`/`local`), and the upgrade/re-point commands, see the [plugin install guide](plugins/dev-team/README.md#install).
+Start here — most users install only this plugin. The core install one-liner is canonical in the [README](README.md#getting-started); required tools (`jq`, `gh`) are listed in its [Plugins](README.md#plugins) table. The `owner/repo` shorthand and the full `https://github.com/bdfinst/agentic-dev-team` URL are equivalent. For self-hosted or other git hosts, install scopes (`user`/`project`/`local`), and the upgrade/re-point commands, see the [plugin install guide](plugins/dev-team/README.md#install).
 
 Then, in your project, run one command to install tool dependencies and generate config:
 
@@ -21,7 +24,12 @@ Then, in your project, run one command to install tool dependencies and generate
 /setup
 ```
 
-**`/setup`** installs the plugin's tool dependencies — `jq`, `python3`, and language-specific mutation tooling (Stryker, pitest, Stryker.NET) — then detects your stack and generates project-level config and hooks, including the automated pre-commit review gate. (CodeGraph/Graphify code-intelligence indexing is offered separately by `/project-init`, which `/setup` invokes for stack detection.)
+**`/setup`** installs the plugin's tool dependencies — `jq`, `python3`, and language-specific mutation tooling (Stryker, pitest, Stryker.NET) — then detects your stack and generates project-level config and hooks, including the automated pre-commit review gate. Code-intelligence indexing — the keyless CodeGraph + Repowise pair plus Graphify — is offered separately by `/project-init`, which `/setup` invokes for stack detection.
+
+Two flags control how it runs:
+
+- `--dry-run` reports what would be installed and generated without writing any files or installing anything.
+- `--yes` runs unattended, auto-confirming every prompt with its safe default and passing `--yes` through to `/project-init`. If both flags are passed, `--dry-run` wins.
 
 After `/setup`, run `/specs` to start a feature, or ask a question and let the Orchestrator route it.
 
@@ -115,7 +123,7 @@ The structured lifecycle has real slash commands. These are the primary entry po
 /triage  Investigate a bug and file an issue with a fix plan
 ```
 
-Run `/help` to see every available command.
+The [dev-team workflow table in the README](README.md#dev-team-workflow) is canonical for what each step produces; the [supporting-commands table](README.md#supporting-commands) covers the rest. Run `/help` to see every available command.
 
 ### Invoke a skill directly
 


### PR DESCRIPTION
Root-prose documentation lane (#1239) of the docs refresh epic.

## GETTING-STARTED.md
- Fix the code-intelligence description to the keyless **CodeGraph + Repowise** pair plus **Graphify** (was "CodeGraph/Graphify"), matching `/project-init` Step 4c.
- Document `/setup --yes` and `/setup --dry-run`, including the "`--dry-run` wins when both are passed" precedence.
- Trim the duplicated core `dev-team` install one-liner to a pointer to the canonical README; the optional-plugin installs stay here.
- Add an on-page quick-nav (bullet list of the page's H2 sections).
- Point the workflow-commands block at the canonical README workflow + supporting-commands tables.
- Both `plugins/dev-team/README.md#install` links preserved.

## CONTRIBUTING.md
- Add `marketplace-dev` to the scope sentence and the repo-layout block.
- Attribute `/agent-add`, `/agent-create`, `/agent-remove`, and the `agent-skill-authoring` skill to the **marketplace-dev** plugin (they no longer live in `dev-team`) and note it must be installed first.
- Trim the release-please rules to a pointer to `CLAUDE.md#releasing`.

## Files
- `GETTING-STARTED.md`
- `CONTRIBUTING.md`

## Gates
- `scripts/assemble-docs.sh` — OK
- `scripts/check_md_references.py` — OK (all cross-refs + anchors resolve)
- `pytest tests/docs tests/repo` — 598 passed, 5 skipped

docs-only lane; auto-merge armed.

Closes #1239
Part of #1238