### PR TITLE
docs: wire new-page nav and annotate superseded ADRs

### DIFF
--- a/docs/adr/0002-use-sentinel-file-and-argument-shape-heuristic-for-codegraph-nudge-hook.md
+++ b/docs/adr/0002-use-sentinel-file-and-argument-shape-heuristic-for-codegraph-nudge-hook.md
@@ -8,6 +8,8 @@ Accepted
 
 Tooling documented by [3. Document ADR tooling workflow as a skill](0003-document-adr-tooling-workflow-as-a-skill.md)
 
+> **Path and tooling note (2026-07-20):** the plugin was renamed `agentic-dev-team` → `dev-team` in the bfinster marketplace; substitute `plugins/dev-team/` for `plugins/agentic-dev-team/` to locate current files. Separately, the bash-removal effort (ADR 0014, completed by ADR 0015) rewrote every shipped hook under `plugins/dev-team/` — including `codegraph-nudge.sh`, `codegraph-turn-mark.sh`, and `destructive-guard.sh` — as Python (`.py`), and their `.bats` tests as pytest `test_*.py` files. This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 We added a `PreToolUse` hook (`codegraph-nudge.sh`) that fires on every `Read`, `Grep`, and `Glob` tool call in projects with a CodeGraph index (`.codegraph/` in cwd). When the call looks like exploration, the hook should recommend the indexed `codegraph_*` MCP tools instead. Two implementation questions had non-obvious answers:

--- a/docs/adr/0003-document-adr-tooling-workflow-as-a-skill.md
+++ b/docs/adr/0003-document-adr-tooling-workflow-as-a-skill.md
@@ -8,6 +8,8 @@ Accepted
 
 Documents tooling used by [2. Use sentinel file and argument-shape heuristic for CodeGraph nudge hook](0002-use-sentinel-file-and-argument-shape-heuristic-for-codegraph-nudge-hook.md)
 
+> **Path note (2026-07-20):** the plugin was renamed `agentic-dev-team` → `dev-team` in the bfinster marketplace; substitute `plugins/dev-team/` for `plugins/agentic-dev-team/` to locate the `adr-tools` skill and other files named below. The "31 → 32 skills" count in the Decision section is a point-in-time snapshot, not a current total. This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 We started using [npryce/adr-tools](https://github.com/npryce/adr-tools) to manage Architecture Decision Records under `docs/adr/` (project convention; `.adr-dir` at the project root points adr-tools at it). ADR-0002 was the first decision recorded with the tool, and writing it surfaced a non-obvious failure mode: `adr new` opens `$VISUAL`/`$EDITOR` (defaulting to `vi`), which hangs in non-interactive shells — the file is created but empty, and the command exits non-zero. Without documented guidance, every future ADR run will hit the same wall and either:

--- a/docs/adr/0004-pre-dispatch-model-resolution.md
+++ b/docs/adr/0004-pre-dispatch-model-resolution.md
@@ -8,6 +8,8 @@ Accepted
 
 Amended by [8. Use effort bands instead of model names in agent frontmatter](0008-use-effort-bands-instead-of-model-names-in-agent-frontmatter.md)
 
+> **Path and command note (2026-07-20):** the bash-removal effort (ADR 0014, completed by ADR 0015) rewrote `hooks/agent-model-resolve.sh` and `hooks/lib/model-resolve.sh` as Python (`.py`) files. Separately, the `/init-dev-team` command referenced below was split into `/setup` and `/project-init`, and `/model-routing-check` is now a skill (`plugins/dev-team/skills/model-routing-check/`), not a `commands/*.md` command. This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 The plugin's agents declare a tier alias (`haiku`, `sonnet`, `opus`) in their

--- a/docs/adr/0005-on-demand-knowledge-indexing.md
+++ b/docs/adr/0005-on-demand-knowledge-indexing.md
@@ -6,6 +6,8 @@ Date: 2026-06-02
 
 Accepted
 
+> **Bash-removal note (2026-07-20):** the bash-removal effort (ADR 0014, completed by ADR 0015) rewrote `build-knowledge-index.sh` as Python, and retired `tests/repo/knowledge_index_current.bats` and `tests/agents/agent_knowledge_anchor_tests.bats` in favor of pytest `test_*.py` files. Separately, `/init-dev-team` was split into `/setup` and `/project-init`, and `/model-routing-check` is now a skill, not a command. (See the separate 2026-06-02 path note further below for the plugin rename.) This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 Agents in this plugin reference markdown files under `knowledge/` and skill

--- a/docs/adr/0009-human-consent-gate-for-learning-loop.md
+++ b/docs/adr/0009-human-consent-gate-for-learning-loop.md
@@ -6,6 +6,8 @@ Date: 2026-06-23
 
 Accepted
 
+> **Bash-removal note (2026-07-20):** the bash-removal effort (ADR 0014, completed by ADR 0015) rewrote `session-model-banner.sh` as a Python (`.py`) hook. This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 The closed learning loop automatically analyzes session transcripts and generates

--- a/docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md
+++ b/docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md
@@ -8,6 +8,8 @@ Accepted
 
 Builds on [2. Use sentinel file and argument-shape heuristic for CodeGraph nudge hook](0002-use-sentinel-file-and-argument-shape-heuristic-for-codegraph-nudge-hook.md).
 
+> **Path and command note (2026-07-20):** the bash-removal effort (ADR 0014, completed by ADR 0015) rewrote `codegraph-bootstrap.sh` and `init-dev-team-linux.sh` as Python (`.py`) files, and retired their `.bats` tests in favor of pytest `test_*.py` files. Separately, `/init-dev-team` was split into `/setup` and `/project-init`. This ADR is preserved verbatim as a historical record.
+
 ## Context
 
 CodeGraph gives agents code intelligence over an index of the repo. That index is a SQLite database (`.codegraph/codegraph.db`) **derived from source and machine-local** — `.codegraph/.gitignore` excludes `*.db`, so it is never committed. A team that adopts CodeGraph therefore faces a sharing problem: how does every teammate's clone get a working index without each developer remembering to run `codegraph init` by hand?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,12 +90,14 @@ nav:
           - Agent Info: plugins/dev-team/docs/agent_info.md
       - Workflows & Skills:
           - Workflows: plugins/dev-team/docs/workflows.md
+          - Test Improve: plugins/dev-team/docs/test-improve.md
           - Skills: plugins/dev-team/docs/skills.md
           - Code Review Process: plugins/dev-team/docs/code-review-process.md
           - Triage Workflow: plugins/dev-team/docs/triage-workflow.md
       - Model Routing:
           - Model Routing: plugins/dev-team/docs/model-routing.md
           - Model Routing Overrides: plugins/dev-team/docs/model-routing-overrides.md
+          - Band Calibration: plugins/dev-team/docs/band-calibration.md
       - Evaluation:
           - Eval System: plugins/dev-team/docs/eval-system.md
           - Eval Running Guide: plugins/dev-team/docs/eval-running-guide.md


### PR DESCRIPTION
## Summary

Coordinator step of the documentation overhaul (epic #1238) — the serialized changes reserved out of the six file-disjoint fix lanes.

- **`mkdocs.yml` nav**: adds the two pages the fix lanes extracted — **Test Improve** (`plugins/dev-team/docs/test-improve.md`) under *Workflows & Skills*, and **Band Calibration** (`plugins/dev-team/docs/band-calibration.md`) under *Model Routing*. Both source files landed via #1247 and #1249.
- **ADR superseded sweep**: dated (2026-07-20) annotation notes added to ADRs **0002, 0003, 0004, 0005, 0009, 0012** for the bash-removal (ADR 0014/0015 → `.sh`→`.py`, `.bats`→pytest), the `agentic-dev-team`→`dev-team` rename, and the `/init-dev-team`→`/setup` + `/project-init` command split. **Bodies preserved verbatim** (ADRs are immutable records). **0011** already carried an equivalent note and was left untouched.
- The two cross-lane link fixes (CONTRIBUTING→marketplace-dev entry point, eval-system relative ref) were already made within their lanes — verified, no change needed here.

## Verification

- `assemble-docs.sh` (nav integrity) + `check_md_references.py` pass; both new nav targets resolve to real files.
- `pytest tests/docs tests/repo` → 603 passed.

Closes #1245
Part of #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)