### PR TITLE
fix: harness-audit + code-review accuracy follow-ups from 2026-07-20 audit

### DIFF
--- a/plugins/dev-team/hooks/task_completion_metrics.py
+++ b/plugins/dev-team/hooks/task_completion_metrics.py
@@ -31,8 +31,11 @@ The hook consumes that file and clears it after writing.
 }
 ```
 
-All fields are optional. If the file is absent or empty, the hook writes a
-minimal heartbeat entry recording session cost fields from the stop payload.
+All fields are optional. If the scratch file is absent or empty, the hook
+writes **nothing** and exits — a Stop/SubagentStop with no task-local payload
+carries no signal worth recording, and a bare heartbeat only produces
+`task_type:"unknown"` noise that dilutes `/harness-audit` Step 3 (see #1258;
+a single 2026-07-20 audit run emitted 172 empty heartbeats vs 10 real rows).
 
 ## Output files
 
@@ -184,10 +187,12 @@ def main() -> int:
 
     scratch = _load_scratch(cwd)
 
-    # If neither a scratch file nor any useful payload exists, skip writing
-    # a hollow entry.  The hook is advisory — do nothing rather than generate
-    # noise.
-    if not scratch and not payload:
+    # Suppress empty heartbeats (#1258). A Stop/SubagentStop with no scratch
+    # payload has nothing task-local to record — writing an entry would only
+    # emit a hollow task_type:"unknown" row that dilutes downstream analysis
+    # (harness-audit Step 3). The stop payload alone (stop_reason, cost) is not
+    # enough to justify a row; a skill that wants a row populates the scratch.
+    if not scratch:
         return 0
 
     try:

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -199,11 +199,14 @@ counts and outcomes only, never code or file content.
 | `complexity` | string enum | `standard` \| `complex` |
 | `agents_run` | array of string | Review agents dispatched |
 | `issues_found`, `issues_fixed`, `fix_iterations` | integer | Counts |
+| `severity_breakdown` | object | `{errors, warnings, suggestions}` counts (same enum as `/code-review`); the three sum to `issues_found`. Lets `/harness-audit` Step 3 flag mostly-minor lenses (#1256). Absent on pre-#1256 rows |
+| `source` | string enum | Row provenance: `build-checkpoint` (fix-applying `/build` checkpoint) \| `code-review` (read-only standalone review). **Absent = `build-checkpoint`** (back-compat). `/harness-audit` Step 4 excludes `code-review` rows from fix-rate drop-candidate logic (#1257) |
 | `outcome` | string enum | `no-op` \| `fixed` \| `escalated` |
 
-- **Emitter:** `/build` skill (model-authored append, sub-step 7). Disable with `DEV_TEAM_REVIEW_VALUE=off`.
+- **Emitter:** `/build` skill (model-authored append, sub-step 7) writes `source: "build-checkpoint"`. Disable with `DEV_TEAM_REVIEW_VALUE=off`.
 - **Consent:** unconditional when enabled (no code/file content recorded).
 - **Consumers:** `skills/cost-report/SKILL.md`, `skills/harness-audit/SKILL.md`.
+- **Provenance (#1257):** fix-rate ROI is only meaningful for fix-applying rows. A read-only review that never applies fixes (`source: "code-review"`) always has `issues_fixed: 0`; Step 4 must not read that as a zero-value drop candidate — it reports finding-rate for those instead.
 
 ---
 

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -197,10 +197,10 @@ Work each step **one behavior at a time** — never all the code then all the te
 7. **Record review value (#348).** For **each** checkpoint that runs (per-step `complex` in sub-step 4, and per-slice in sub-step 6), append one JSON line to `metrics/review-value.jsonl` capturing whether review actually changed anything — counts and outcomes only, never code or file content (consistent with the cost meter's privacy boundary). Schema in `performance-metrics`:
 
    ```json
-   {"timestamp":"<ISO8601>","plan":"<plan-file>","slice":"<N>","step":"<N.M or all>","checkpoint":"step|slice","complexity":"standard|complex","agents_run":["spec-compliance-review","..."],"issues_found":0,"issues_fixed":0,"fix_iterations":0,"outcome":"no-op|fixed|escalated"}
+   {"timestamp":"<ISO8601>","plan":"<plan-file>","slice":"<N>","step":"<N.M or all>","checkpoint":"step|slice","complexity":"standard|complex","source":"build-checkpoint","agents_run":["spec-compliance-review","..."],"issues_found":0,"severity_breakdown":{"errors":0,"warnings":0,"suggestions":0},"issues_fixed":0,"fix_iterations":0,"outcome":"no-op|fixed|escalated"}
    ```
 
-   `outcome` is `no-op` when the checkpoint passed clean (found nothing), `fixed` when it found and auto-fixed actionable issues, `escalated` when the loop didn't converge. This is the sensor that tells a build where review caught a real defect from one where every loop passed no-op — it turns the pipeline's "value untested" into "value measured" and feeds the plan/step tiering decisions. Disable with `DEV_TEAM_REVIEW_VALUE=off`.
+   `outcome` is `no-op` when the checkpoint passed clean (found nothing), `fixed` when it found and auto-fixed actionable issues, `escalated` when the loop didn't converge. `severity_breakdown` splits `issues_found` by severity (`errors`/`warnings`/`suggestions`, the same enum as `/code-review`), so `/harness-audit` Step 3 can flag a lens producing mostly minor findings — the three counts must sum to `issues_found` (#1256). This is the sensor that tells a build where review caught a real defect from one where every loop passed no-op — it turns the pipeline's "value untested" into "value measured" and feeds the plan/step tiering decisions. Disable with `DEV_TEAM_REVIEW_VALUE=off`.
 
 ### 4.9. Verify runtime behavior before the slice is done (issue #727)
 

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -204,6 +204,27 @@ This replaces any hardcoded per-agent dispatch rules. Adding or changing a revie
 
 If `review-config.json` exists at the repo root, honor its per-agent `"enabled": false` flags.
 
+**Change-shape gate for low-yield lenses (#1254).** After the eligible roster is
+known, drop the two low-yield code lenses (`performance-review`,
+`correctness-review`) when the changeset has **no runtime surface** — every
+target file is documentation or config, so those lenses would only no-op. Decide
+deterministically with the shared helper (not by eyeballing the file list):
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/change_shape.py" --files <target files>
+```
+
+It prints `{"hasRuntimeSurface": <bool>, "skipLenses": [...]}`. When `skipLenses`
+is non-empty, exclude those agents from this run and note the skip in the report
+(they were gated by change shape, not by `scope:`). The gate is **fail-safe**: any
+file it cannot prove is doc/config (source, an unknown extension, or functional
+Claude-config markdown under `agents/`, `skills/`, `knowledge/`, `.claude/`, …)
+counts as runtime surface and keeps every lens. This never fires on a pure-docs
+changeset — that is already handled earlier by the documentation-only
+short-circuit; this gate covers the doc/config-**mixed** and config-only diffs
+the short-circuit does not. Bypassed by `--force` and by `--agent <name>` (an
+explicit single-agent request always runs that agent).
+
 ### 4. Run each enabled agent
 
 Spawn agents as parallel subagents in a single message using the Agent tool.

--- a/plugins/dev-team/skills/code-review/output-format.md
+++ b/plugins/dev-team/skills/code-review/output-format.md
@@ -111,6 +111,26 @@ reads these back for the final report.
   `consolidate.py` merge reporting agents per `file:line` and roll up recurring
   themes — omitting it yields empty `agents[]` arrays and no themes.
 
+### Schema-drift tolerance (#1261)
+
+Real review-agent output drifts from this schema — agents return the native
+`{status, issues, summary}` shape, key the list as `issues` (the per-agent key)
+instead of `findings` (the section key), or add extra top-level keys. The
+aggregator absorbs these variants deterministically rather than miscounting:
+
+- `consolidate.py`'s `consolidate()` reads a section's findings from `findings`
+  **or** `issues` (canonical first), so a mis-keyed list is aggregated, never
+  silently counted as zero. A value present but not a list degrades to "no
+  findings" rather than crashing.
+- `consolidate.normalize_agent_result(raw, agent_name=None)` is the extraction
+  contract for folding one agent's raw result into a section's flat `findings[]`:
+  it pulls the list from either key, ignores extra keys (`status`, `summary`),
+  and tags each finding with its reporting `agent` (`raw["agentName"]`, else the
+  passed `agent_name`). Non-dict input degrades to `[]`; it never raises.
+
+This tolerance is a safety net for silent drift, **not** a licence to emit the
+wrong shape — the per-agent contract above (`issues[]`) remains authoritative.
+
 ## Progress ledger (sliced mode)
 
 Written by `init_ledger` to `DEV_TEAM_REPORTS/code-review/ledger.json`, updated to

--- a/plugins/dev-team/skills/code-review/scripts/change_shape.py
+++ b/plugins/dev-team/skills/code-review/scripts/change_shape.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Classify a changeset's shape to gate low-yield review lenses (#1254).
+
+Running the full review panel unconditionally wastes tokens on diffs with no
+runtime/logic surface. The 2026-07-20 audit found `performance-review` fired
+0/10 and `correctness-review` 1/10 — on doc/config-dominated commits most lenses
+no-op. `/code-review` (invoked directly) applies no complexity gate the way
+`/build` and `/plan` do, so every lens runs on every changed file regardless of
+change shape.
+
+This module is the deterministic gate. Given the changed-file list it decides
+whether the changeset has any **runtime surface** — a file that could hold
+executable logic. When it does not (every file is documentation or config),
+the two low-yield code lenses (`performance-review`, `correctness-review`) are
+skipped; the rest of the panel still runs.
+
+**Fail-safe by construction.** A file is "no runtime surface" only when it is
+*provably* documentation or config (matches an explicit allowlist). Anything
+else — an unknown extension, a source file, functional Claude-config markdown —
+counts as runtime surface, so the lenses run. A misclassification can only ever
+*add* a lens, never silently drop one on real code.
+
+Pure policy — no filesystem, no globals. Mirrors the documentation-only
+short-circuit's classification in `code-review/SKILL.md` (this gate is the
+weaker sibling: the short-circuit skips *everything* when every file is
+documentation; this skips only the two low-yield lenses when every file is
+documentation *or* config, which the doc-only short-circuit does not cover).
+
+Scope note: this is a filename-shape gate. Annotation-only edits *inside* a
+source file (e.g. adding a C# attribute) still count as runtime surface — that
+would require diff parsing and is deliberately out of scope for v1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import PurePosixPath
+from typing import Iterable, List
+
+# The lenses this gate can skip. Both are code-only lenses that no-op on diffs
+# with no executable logic to reason about.
+LOW_YIELD_LENSES = ["performance-review", "correctness-review"]
+
+# Documentation extensions (lower-cased). Mirrors SKILL.md's doc-only rule.
+_DOC_EXTENSIONS = {".md", ".mdx", ".markdown", ".rst", ".txt", ".adoc"}
+
+# Documentation root-file stems (matched case-insensitively on the stem prefix).
+_DOC_ROOT_PREFIXES = (
+    "readme", "changelog", "contributing", "license", "notice",
+    "authors", "code_of_conduct",
+)
+
+# Config / data extensions with no executable logic surface (lower-cased).
+_CONFIG_EXTENSIONS = {
+    ".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf",
+    ".properties", ".lock", ".csv", ".tsv",
+}
+
+# Config dotfiles carry no suffix (``PurePosixPath(".gitignore").suffix == ""``),
+# so they are matched by full name instead (lower-cased).
+_CONFIG_NAMES = {
+    ".gitignore", ".gitattributes", ".editorconfig", ".env", ".dockerignore",
+    ".npmignore", ".prettierignore",
+}
+
+# Path segments marking **functional Claude-config**: markdown/paths here drive
+# agent/skill/command behavior and are never "just docs or config" — they always
+# count as runtime surface (must be reviewed). Same exclusion as SKILL.md.
+_FUNCTIONAL_CONFIG_SEGMENTS = {
+    ".claude", "agents", "skills", "prompts", "knowledge", "templates",
+}
+
+# Functional-config filenames anywhere in the tree.
+_FUNCTIONAL_CONFIG_NAMES = {"claude.md", "agents.md"}
+
+
+def _is_functional_config(path: PurePosixPath) -> bool:
+    """True when the path drives agent/skill/command behavior (always reviewed)."""
+    if path.name.lower() in _FUNCTIONAL_CONFIG_NAMES:
+        return True
+    return any(seg in _FUNCTIONAL_CONFIG_SEGMENTS for seg in path.parts)
+
+
+def _is_documentation(path: PurePosixPath) -> bool:
+    if path.suffix.lower() in _DOC_EXTENSIONS:
+        return True
+    if "docs" in path.parts:
+        return True
+    stem = path.name.lower()
+    return any(stem.startswith(prefix) for prefix in _DOC_ROOT_PREFIXES)
+
+
+def _is_config(path: PurePosixPath) -> bool:
+    return (
+        path.suffix.lower() in _CONFIG_EXTENSIONS
+        or path.name.lower() in _CONFIG_NAMES
+    )
+
+
+def _has_runtime_surface_file(file: str) -> bool:
+    """True when a single file could hold executable logic (fail-safe default)."""
+    path = PurePosixPath(str(file).strip())
+    if not path.name:
+        return False  # empty entry contributes nothing
+    if _is_functional_config(path):
+        return True
+    # Provably non-runtime only when documentation or config; anything else
+    # (source, unknown extension) is treated as runtime surface.
+    return not (_is_documentation(path) or _is_config(path))
+
+
+def has_runtime_surface(files: Iterable[str]) -> bool:
+    """True when *any* changed file could hold executable logic.
+
+    An empty changeset has no runtime surface (returns False).
+    """
+    return any(_has_runtime_surface_file(f) for f in files if str(f).strip())
+
+
+def lenses_to_skip(files: Iterable[str]) -> List[str]:
+    """Return the low-yield lenses to skip for this changeset.
+
+    Empty when the changeset has any runtime surface (run every lens). Otherwise
+    the doc/config-only changeset skips `performance-review` and
+    `correctness-review`.
+    """
+    file_list = [f for f in files if str(f).strip()]
+    if not file_list:
+        return []  # nothing to review — the caller handles empty scope
+    return [] if has_runtime_surface(file_list) else list(LOW_YIELD_LENSES)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--files", nargs="*", default=[],
+        help="changed file paths (space-separated)",
+    )
+    parser.add_argument(
+        "--files-from", default=None,
+        help="read newline-separated file paths from this file ('-' for stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    files = list(args.files)
+    if args.files_from:
+        text = sys.stdin.read() if args.files_from == "-" else open(args.files_from).read()
+        files.extend(line for line in text.splitlines() if line.strip())
+
+    skip = lenses_to_skip(files)
+    result = {
+        "hasRuntimeSurface": has_runtime_surface(files),
+        "skipLenses": skip,
+    }
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/dev-team/skills/code-review/scripts/consolidate.py
+++ b/plugins/dev-team/skills/code-review/scripts/consolidate.py
@@ -34,9 +34,57 @@ _SEVERITY_BUCKET = {"error": "errors", "warning": "warnings", "suggestion": "sug
 # A review dimension recurring across at least this many slices is a theme.
 _THEME_MIN_SLICES = 2
 
+# Real-world review-agent output drifts from the documented schema (#1261): some
+# agents return their findings list under `issues` (the per-agent key in
+# output-format.md) instead of `findings` (the section-artifact key). Accept
+# either so a mis-keyed list is aggregated, never silently counted as zero. The
+# canonical key is tried first; the alias is a fallback.
+_FINDINGS_KEYS = ("findings", "issues")
+
 
 def _rank(severity: str) -> int:
     return _SEVERITY_RANK.get(severity, 0)
+
+
+def _findings_of(container: dict) -> list:
+    """Return the findings list from ``container`` tolerating key drift (#1261).
+
+    Prefers ``findings`` (section-artifact key), falls back to ``issues``
+    (per-agent key). A value that is present but not a list is treated as no
+    findings rather than crashing the aggregation.
+    """
+    for key in _FINDINGS_KEYS:
+        value = container.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def normalize_agent_result(raw: dict, agent_name: Optional[str] = None) -> list:
+    """Coerce one review agent's result into a flat, ``agent``-tagged findings list.
+
+    Absorbs the schema drift observed in real runs (#1261): the native per-agent
+    ``{status, issues, summary}`` shape, findings keyed as ``issues`` **or**
+    ``findings``, and any extra top-level keys (e.g. ``summary``) — all of which
+    are ignored except the findings list. Each returned finding is tagged with
+    its reporting ``agent`` (from ``raw["agentName"]``, else ``agent_name``) so
+    ``consolidate()`` can merge reporters per ``file:line`` and roll up themes.
+
+    Non-dict input, or a findings entry that is not a dict, yields an empty list
+    / is skipped — this never raises, so a malformed agent result degrades to
+    "reported nothing" rather than aborting the whole aggregation.
+    """
+    if not isinstance(raw, dict):
+        return []
+    agent = raw.get("agentName") or agent_name
+    out = []
+    for finding in _findings_of(raw):
+        if not isinstance(finding, dict):
+            continue
+        tagged = dict(finding)
+        tagged.setdefault("agent", agent)
+        out.append(tagged)
+    return out
 
 
 def _dedupe_key(finding: dict):
@@ -94,7 +142,7 @@ def consolidate(sections: List[dict]) -> dict:
         slice_id = section.get("id")
         if section.get("is_declarative"):
             reduced_panel_slices.append(slice_id)
-        for finding in section.get("findings", []):
+        for finding in _findings_of(section):
             severity = finding.get("severity", "suggestion")
             totals[_SEVERITY_BUCKET.get(severity, "suggestions")] += 1
             agent = finding.get("agent")

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -114,7 +114,22 @@ For each review agent in the registry (`knowledge/agent-registry.md`):
 1. **Finding rate**: How often does this agent produce findings (fail or warn) vs. pass?
 2. **Zero-fail agents**: Flag agents that have never returned `fail` across all logged reviews. These are removal candidates — they may not be catching real issues.
 3. **False positive rate**: If correction data exists (from `/apply-fixes`), check how often findings were dismissed vs. applied. Agents with >50% dismissed findings have a high false positive rate.
-4. **Finding severity distribution**: Is the agent producing mostly minor findings? If >80% of findings are minor severity, consider whether the agent justifies its token cost.
+4. **Finding severity distribution**: Is the agent producing mostly minor findings? If >80% of findings are minor severity, consider whether the agent justifies its token cost. Compute this from the `severity_breakdown` object on `metrics/review-value.jsonl` rows (`{errors, warnings, suggestions}`, added in #1256) — aggregate per `agents_run` and treat `suggestions` as the minor bucket. Rows written before #1256 lack the field; count them as "no severity data" and exclude them from the ratio rather than assuming a mix (small-N honesty, consistent with Step 5). If **no** row carries `severity_breakdown`, report this analysis as dark ("severity breakdown unavailable — pre-#1256 metrics") rather than fabricating a distribution.
+
+   ```bash
+   [ -f metrics/review-value.jsonl ] && jq -s '
+     map(select(.severity_breakdown != null))
+     | group_by(.agents_run | sort | join(","))
+     | map({
+         agents:      (.[0].agents_run | sort | join(", ")),
+         errors:      (map(.severity_breakdown.errors)      | add // 0),
+         warnings:    (map(.severity_breakdown.warnings)    | add // 0),
+         suggestions: (map(.severity_breakdown.suggestions) | add // 0)
+       })
+     | map(. + {total: (.errors + .warnings + .suggestions)})
+     | map(select(.total > 0) | . + {minor_pct: (.suggestions / .total * 100 | round)})' \
+     metrics/review-value.jsonl
+   ```
 
 ### 4. Analyze review-value fix rates
 
@@ -122,9 +137,18 @@ Read `metrics/review-value.jsonl` (written by `/build` per #348, schema in `perf
 
 For each **checkpoint type** (the `checkpoint` field: `step` or `slice`) and each **agent combination** (`agents_run` list, treated as a set-key), compute:
 
+**Exclude read-only rows first (#1257).** Fix-rate ROI is only meaningful for
+fix-applying `/build` checkpoints. A read-only review (`source: "code-review"`)
+never applies fixes, so **every** row it produces has `issues_fixed: 0` and a 0%
+fix rate — feeding those to the drop-candidate logic falsely flags a whole panel
+that may be surfacing real defects (the 2026-07-20 run mislabeled all 7 agents
+this way). The `jq` filters to `source == "build-checkpoint"` (treating an absent
+`source` as `build-checkpoint`, back-compat) **before** grouping:
+
 ```bash
 [ -f metrics/review-value.jsonl ] && jq -s '
-  group_by(.checkpoint + "|" + (.agents_run | sort | join(",")))
+  map(select((.source // "build-checkpoint") == "build-checkpoint"))
+  | group_by(.checkpoint + "|" + (.agents_run | sort | join(",")))
   | map({
       checkpoint:    .[0].checkpoint,
       agents:        (.[0].agents_run | sort | join(", ")),
@@ -140,7 +164,29 @@ For each **checkpoint type** (the `checkpoint` field: `step` or `slice`) and eac
   metrics/review-value.jsonl
 ```
 
-Flag **drop candidates**: any checkpoint+agents combination with `fix_rate == 0` across **N ≥ 5** logged runs is a drop candidate — it consistently adds overhead without catching defects.
+For **read-only `code-review` rows**, report **finding-rate** (how often the
+panel surfaced any issue) instead of fix-rate, and state plainly in the report
+that these rows are excluded from the fix-rate drop-candidate logic because they
+apply no fixes by design — a 0% fix rate there is expected, not a signal:
+
+```bash
+[ -f metrics/review-value.jsonl ] && jq -s '
+  map(select(.source == "code-review"))
+  | if length == 0 then "no read-only rows" else
+    group_by(.agents_run | sort | join(","))
+    | map({
+        agents:       (.[0].agents_run | sort | join(", ")),
+        total:        length,
+        found_issues: (map(select(.issues_found > 0)) | length),
+        finding_rate: ((map(select(.issues_found > 0)) | length) / length * 100 | round)
+      })
+    end' \
+  metrics/review-value.jsonl
+```
+
+Flag **drop candidates**: any checkpoint+agents combination (from the
+fix-applying rows only) with `fix_rate == 0` across **N ≥ 5** logged runs is a
+drop candidate — it consistently adds overhead without catching defects.
 
 Flag **high-value checkpoints**: `fix_rate ≥ 50%` — these are earning their cost and should be retained.
 

--- a/plugins/dev-team/skills/performance-metrics/SKILL.md
+++ b/plugins/dev-team/skills/performance-metrics/SKILL.md
@@ -168,8 +168,10 @@ right-sized with evidence rather than guessed.
   "step": "all",
   "checkpoint": "slice",
   "complexity": "standard",
+  "source": "build-checkpoint",
   "agents_run": ["spec-compliance-review", "security-review"],
   "issues_found": 1,
+  "severity_breakdown": {"errors": 1, "warnings": 0, "suggestions": 0},
   "issues_fixed": 1,
   "fix_iterations": 1,
   "outcome": "fixed"
@@ -179,9 +181,11 @@ right-sized with evidence rather than guessed.
 | Field | Type | Description |
 | --- | --- | --- |
 | `checkpoint` | string | `step` (per-step `complex` review) or `slice` (batched slice-boundary review) |
+| `source` | string | Row provenance — `build-checkpoint` (fix-applying `/build` checkpoint, the default when absent) or `code-review` (read-only standalone review). `/harness-audit` Step 4 excludes `code-review` rows from fix-rate drop-candidate logic (#1257) |
 | `step` | string | `N.M` for a per-step checkpoint; `all` for a batched slice checkpoint |
 | `agents_run` | string[] | Review agents and static-analysis lane tools run at this checkpoint |
 | `issues_found` | number | Actionable issues the checkpoint surfaced (semantic review + static lanes) |
+| `severity_breakdown` | object | `{errors, warnings, suggestions}` counts (same enum as `/code-review`); the three sum to `issues_found`. Lets `/harness-audit` Step 3 flag low-value (mostly-minor) lenses (#1256) |
 | `issues_fixed` | number | Of those, how many were auto-fixed |
 | `fix_iterations` | number | Review-fix and static self-heal fix-loop iterations consumed |
 | `outcome` | string | `no-op` (passed clean), `fixed` (found + fixed), `escalated` (a fix loop didn't converge — including a static lane capping out) |

--- a/plugins/dev-team/tests/hooks/test_task_completion_metrics.py
+++ b/plugins/dev-team/tests/hooks/test_task_completion_metrics.py
@@ -46,18 +46,16 @@ class TestNoScratch:
         assert result.returncode == 0
         assert not (tmp_path / "metrics").exists()
 
-    def test_stop_payload_writes_task_log(self, tmp_path):
-        """A minimal Stop payload with no scratch file still writes a task entry."""
+    def test_stop_payload_no_scratch_writes_nothing(self, tmp_path):
+        """A Stop payload with no scratch file writes no task entry (#1258).
+
+        A bare heartbeat carries no task-local signal — recording one only
+        produces task_type:"unknown" noise that dilutes harness-audit Step 3.
+        """
         payload = json.dumps({"stop_reason": "end_turn"})
         result = _run(payload, cwd=tmp_path)
         assert result.returncode == 0
-        metrics = tmp_path / "metrics"
-        logs = list(metrics.glob("*-task-log.jsonl"))
-        assert len(logs) == 1
-        entry = json.loads(logs[0].read_text().strip())
-        assert entry["stop_reason"] == "end_turn"
-        assert entry["hallucination_detected"] is False
-        assert entry["rework_cycles"] == 0
+        assert not (tmp_path / "metrics").exists()
 
 
 class TestScratchFile:
@@ -134,7 +132,14 @@ class TestFailOpen:
         assert result.returncode == 0
 
     def test_metrics_dir_creation_failure_exits_zero(self, tmp_path):
-        """Simulate metrics dir being a file (cannot mkdir) — hook must exit 0."""
+        """Simulate metrics dir being a file (cannot mkdir) — hook must exit 0.
+
+        Populates the scratch so the hook reaches the mkdir (an empty scratch
+        now short-circuits before any write, per #1258).
+        """
         (tmp_path / "metrics").write_text("file")
+        dot_claude = tmp_path / ".claude"
+        dot_claude.mkdir()
+        (dot_claude / "session-metrics.json").write_text(json.dumps({"task_type": "fix"}))
         result = _run(json.dumps({"stop_reason": "end_turn"}), cwd=tmp_path)
         assert result.returncode == 0

--- a/plugins/dev-team/tests/scripts/test_change_shape.py
+++ b/plugins/dev-team/tests/scripts/test_change_shape.py
@@ -1,0 +1,98 @@
+"""Unit tests for skills/code-review/scripts/change_shape.py (#1254).
+
+Covers the deterministic change-shape gate: when a changeset has no runtime
+surface (docs/config only), the low-yield lenses (performance, correctness) are
+skipped; any runtime surface (source, unknown extension, functional Claude
+config) keeps them. Fail-safe: unknown = runtime surface.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(
+    0,
+    str(_REPO_ROOT / "plugins" / "dev-team" / "skills" / "code-review" / "scripts"),
+)
+
+import change_shape  # noqa: E402
+
+
+class TestHasRuntimeSurface:
+    def test_source_file_has_runtime_surface(self):
+        assert change_shape.has_runtime_surface(["src/app.py"]) is True
+        assert change_shape.has_runtime_surface(["src/app.ts", "README.md"]) is True
+
+    def test_docs_only_has_no_runtime_surface(self):
+        assert change_shape.has_runtime_surface(["README.md", "docs/guide.rst"]) is False
+
+    def test_config_only_has_no_runtime_surface(self):
+        assert change_shape.has_runtime_surface(
+            ["config.json", "app.yaml", ".gitignore", "settings.toml"]
+        ) is False
+
+    def test_docs_and_config_mixed_has_no_runtime_surface(self):
+        assert change_shape.has_runtime_surface(["CHANGELOG.md", "ci.yml"]) is False
+
+    def test_unknown_extension_is_runtime_surface_failsafe(self):
+        # A file we cannot prove is doc/config must count as runtime surface,
+        # so the code lenses still run (fail-safe).
+        assert change_shape.has_runtime_surface(["Makefile"]) is True
+        assert change_shape.has_runtime_surface(["thing.rb"]) is True
+
+    def test_functional_claude_config_is_runtime_surface(self):
+        # Markdown under agents/skills/etc. drives behavior — never "just docs".
+        for f in [
+            "agents/security-review.md",
+            "skills/plan/SKILL.md",
+            "knowledge/agent-registry.md",
+            ".claude/settings.json",
+            "CLAUDE.md",
+            "AGENTS.md",
+            "templates/agents/python.md",
+        ]:
+            assert change_shape.has_runtime_surface([f]) is True, f
+
+    def test_empty_changeset_has_no_runtime_surface(self):
+        assert change_shape.has_runtime_surface([]) is False
+        assert change_shape.has_runtime_surface(["", "  "]) is False
+
+
+class TestLensesToSkip:
+    def test_docs_only_skips_low_yield_lenses(self):
+        skip = change_shape.lenses_to_skip(["README.md", "config.json"])
+        assert skip == ["performance-review", "correctness-review"]
+
+    def test_runtime_surface_skips_nothing(self):
+        assert change_shape.lenses_to_skip(["src/app.py", "README.md"]) == []
+
+    def test_empty_changeset_skips_nothing(self):
+        assert change_shape.lenses_to_skip([]) == []
+
+
+class TestCli:
+    def test_cli_docs_only_reports_skip(self, capsys):
+        rc = change_shape.main(["--files", "README.md", "config.yaml"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hasRuntimeSurface"] is False
+        assert out["skipLenses"] == ["performance-review", "correctness-review"]
+
+    def test_cli_runtime_surface_reports_no_skip(self, capsys):
+        rc = change_shape.main(["--files", "src/main.go"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hasRuntimeSurface"] is True
+        assert out["skipLenses"] == []
+
+    def test_cli_files_from_stdin(self, capsys, monkeypatch):
+        import io
+
+        monkeypatch.setattr(sys, "stdin", io.StringIO("docs/a.md\nb.json\n"))
+        rc = change_shape.main(["--files-from", "-"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["skipLenses"] == ["performance-review", "correctness-review"]

--- a/plugins/dev-team/tests/scripts/test_consolidate.py
+++ b/plugins/dev-team/tests/scripts/test_consolidate.py
@@ -134,3 +134,91 @@ def test_main_treats_wrong_shape_json_as_malformed(tmp_path, capsys):
     assert "section-0002.json" in captured.err
     out = json.loads(captured.out)
     assert out["sliceCount"] == 1
+
+
+# --- schema-drift tolerance (#1261) -------------------------------------------
+
+
+def test_section_findings_under_issues_key_are_aggregated():
+    """A section whose findings landed under `issues` (per-agent key) instead of
+    `findings` (section key) is still aggregated — not silently counted as zero."""
+    section = {
+        "schema": "code-review-section/v1",
+        "id": "0001",
+        "files": ["src/a.ts"],
+        "is_declarative": False,
+        "panel": ["structure-review"],
+        "issues": [_f("src/a.ts", 10, "error", "structure-review")],
+    }
+    result = consolidate.consolidate([section])
+    assert result["totals"]["errors"] == 1
+    assert len(result["topFindings"]) == 1
+    assert result["topFindings"][0]["agents"] == ["structure-review"]
+
+
+def test_findings_key_wins_when_both_present():
+    section = _section("0001", [_f("src/a.ts", 1, "warning", "x")])
+    section["issues"] = [_f("src/b.ts", 2, "error", "y")]
+    result = consolidate.consolidate([section])
+    # `findings` is canonical and takes precedence over the `issues` alias.
+    assert [f["file"] for f in result["topFindings"]] == ["src/a.ts"]
+
+
+def test_non_list_findings_value_degrades_to_empty():
+    section = _section("0001", [])
+    section["findings"] = "oops"  # wrong type, not a list
+    section["issues"] = [_f("src/a.ts", 1, "warning", "x")]
+    # `findings` present-but-not-a-list falls through to the `issues` alias.
+    result = consolidate.consolidate([section])
+    assert result["totals"]["warnings"] == 1
+
+
+def test_normalize_native_agent_shape_with_extra_keys():
+    """Native per-agent {status, issues, summary} shape → agent-tagged findings."""
+    raw = {
+        "agentName": "security-review",
+        "status": "fail",
+        "summary": "1 issue",
+        "issues": [{"severity": "error", "file": "src/x.ts", "line": 5, "message": "sqli"}],
+    }
+    findings = consolidate.normalize_agent_result(raw)
+    assert len(findings) == 1
+    assert findings[0]["agent"] == "security-review"
+    assert findings[0]["severity"] == "error"
+
+
+def test_normalize_findings_key_variant_and_fallback_agent_name():
+    raw = {"status": "warn", "findings": [{"severity": "warning", "file": "a", "line": 1}]}
+    findings = consolidate.normalize_agent_result(raw, agent_name="naming-review")
+    # No agentName in payload → fall back to the passed agent_name.
+    assert findings[0]["agent"] == "naming-review"
+
+
+def test_normalize_preserves_explicit_agent_over_fallback():
+    raw = {"issues": [{"severity": "error", "file": "a", "line": 1, "agent": "js-fp-review"}]}
+    findings = consolidate.normalize_agent_result(raw, agent_name="naming-review")
+    # A finding that already names its agent keeps it (setdefault, not overwrite).
+    assert findings[0]["agent"] == "js-fp-review"
+
+
+def test_normalize_malformed_inputs_never_raise():
+    assert consolidate.normalize_agent_result(None) == []
+    assert consolidate.normalize_agent_result("not-a-dict") == []
+    assert consolidate.normalize_agent_result({}) == []
+    # A non-dict entry inside the findings list is skipped, not crashed on.
+    assert consolidate.normalize_agent_result({"issues": ["bogus", {"file": "a"}]}) == [
+        {"file": "a", "agent": None}
+    ]
+
+
+def test_normalized_findings_feed_consolidate_end_to_end():
+    """The normalize→section→consolidate path an orchestrator would follow."""
+    agent_a = {"agentName": "structure-review", "status": "warn",
+               "issues": [{"severity": "warning", "file": "src/a.ts", "line": 10, "message": "m"}]}
+    agent_b = {"agentName": "complexity-review", "status": "fail",
+               "findings": [{"severity": "error", "file": "src/a.ts", "line": 10, "message": "m"}]}
+    findings = consolidate.normalize_agent_result(agent_a) + consolidate.normalize_agent_result(agent_b)
+    result = consolidate.consolidate([_section("0001", findings)])
+    entry = result["topFindings"][0]
+    assert entry["severity"] == "error"
+    assert sorted(entry["agents"]) == ["complexity-review", "structure-review"]

--- a/tests/knowledge/test_review_value_schema.py
+++ b/tests/knowledge/test_review_value_schema.py
@@ -1,0 +1,84 @@
+"""Content contract for the `review-value.jsonl` schema (#1256, #1257).
+
+The stream gained two fields in the 2026-07-20 audit follow-up:
+- `severity_breakdown` — `{errors, warnings, suggestions}` counts so
+  `/harness-audit` Step 3 can flag mostly-minor lenses (#1256).
+- `source` — row provenance (`build-checkpoint` vs read-only `code-review`) so
+  `/harness-audit` Step 4 excludes read-only rows from fix-rate drop-candidate
+  logic (#1257).
+
+The schema is documented in three places that must stay in sync: the
+`telemetry-schema.md` reference, the `performance-metrics` skill, and the
+`/build` emitter that writes the rows. This test pins all three.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+
+TELEMETRY = _PLUGIN / "knowledge" / "telemetry-schema.md"
+PERF_METRICS = _PLUGIN / "skills" / "performance-metrics" / "SKILL.md"
+BUILD = _PLUGIN / "skills" / "build" / "SKILL.md"
+HARNESS_AUDIT = _PLUGIN / "skills" / "harness-audit" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def telemetry() -> str:
+    return TELEMETRY.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def perf() -> str:
+    return PERF_METRICS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def build() -> str:
+    return BUILD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def audit() -> str:
+    return HARNESS_AUDIT.read_text(encoding="utf-8")
+
+
+class TestSeverityBreakdown:
+    def test_documented_in_telemetry_schema(self, telemetry):
+        assert "severity_breakdown" in telemetry
+
+    def test_documented_in_performance_metrics(self, perf):
+        assert "severity_breakdown" in perf
+
+    def test_emitted_by_build(self, build):
+        # The /build emitter JSON must carry the field, split into the three
+        # severity buckets of the /code-review enum.
+        assert "severity_breakdown" in build
+        for bucket in ("errors", "warnings", "suggestions"):
+            assert bucket in build
+
+    def test_harness_audit_consumes_it(self, audit):
+        assert "severity_breakdown" in audit
+
+
+class TestSourceProvenance:
+    def test_documented_in_telemetry_schema(self, telemetry):
+        assert "source" in telemetry
+        assert "build-checkpoint" in telemetry
+        assert "code-review" in telemetry
+
+    def test_documented_in_performance_metrics(self, perf):
+        assert "build-checkpoint" in perf
+
+    def test_emitted_by_build(self, build):
+        assert "build-checkpoint" in build
+
+    def test_harness_audit_excludes_readonly_from_fix_rate(self, audit):
+        # Step 4 filters to build-checkpoint rows before the drop-candidate
+        # fix-rate computation, and reports finding-rate for read-only rows.
+        assert 'select((.source // "build-checkpoint") == "build-checkpoint")' in audit
+        assert "finding-rate" in audit or "finding_rate" in audit


### PR DESCRIPTION
Five follow-ups from the 2026-07-20 harness audit (`reports/harness-audit-2026-07-20-nextgen-code-review.md`). They cluster around one theme — the audit's own instruments were miscounting — and touch overlapping files (`review-value.jsonl` schema, `harness-audit`, `code-review`), so they land together.

## Changes

- **#1258 — empty heartbeats.** `task_completion_metrics.py` no longer writes a hollow `task_type:"unknown"` row on a Stop/SubagentStop with an empty scratch (172 such rows vs 10 real ones in the audit run). Skips the write unless the scratch carries a task-local payload.
- **#1261 — aggregator schema drift.** `consolidate()` reads a section's findings from `findings` **or** `issues` (canonical first) so a mis-keyed list is never silently counted as zero; new `normalize_agent_result()` is the extraction contract for the native `{status, issues, summary}` per-agent shape. Regression fixtures + `output-format.md` note.
- **#1254 — change-shape lens gate.** New deterministic `change_shape.py` drops `performance-review` + `correctness-review` when the changeset has no runtime surface (all files provably doc/config). Fail-safe: anything not provably doc/config keeps every lens. Wired into `/code-review` step 3.
- **#1256 — severity in `review-value.jsonl`.** New `severity_breakdown {errors, warnings, suggestions}` alongside `issues_found`; `/harness-audit` Step 3 now flags mostly-minor lenses instead of running dark.
- **#1257 — fix-rate provenance.** New `source` field (`build-checkpoint` | `code-review`, absent = `build-checkpoint`); `/harness-audit` Step 4 excludes read-only rows from the fix-rate drop-candidate logic (they're always `issues_fixed=0` by design — the flaw that mislabeled all 7 agents) and reports finding-rate for them instead.

## Testing

- New: `test_change_shape.py`, `test_review_value_schema.py`; extended `test_consolidate.py`, `test_task_completion_metrics.py`.
- Full pre-push pytest dir list green: **3937 passed, 3 skipped** (pre-existing env-gated skips).
- jq snippets in `harness-audit` validated against sample data.

Touches code, skills, and a hook → requires explicit human merge (not doc-only auto-merge).

Closes #1258
Closes #1261
Closes #1254
Closes #1256
Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)