### PR TITLE
fix: repair the integration-eval agent-ablation path

### DIFF
--- a/scripts/eval_ablation.py
+++ b/scripts/eval_ablation.py
@@ -136,8 +136,19 @@ def summarize_arm(expected_dir: Path, trial_actuals: list[dict]) -> dict:
 
     variance = aggregate_trials(expected_dir, trial_actuals)
     by_pair = variance.get("by_pair", {})
-    all_pass = bool(by_pair) and all(
-        d["pass_at_k"] >= 1.0 for d in by_pair.values()
+    # Scope the pass@k bar to the integration pairs this arm actually
+    # dispatched. aggregate_trials grades the WHOLE expected corpus, so the
+    # unit-tier fixtures that an integration arm never runs would otherwise
+    # report pass_at_k 0.0 and force every arm — baseline included — to "fail",
+    # making every ablation "baseline failed — inconclusive". Only the
+    # fixture(s) under ablation gate the arm verdict.
+    scoped_pairs: set[str] = set()
+    for actual in trial_actuals:
+        for pair, _tdata in _flatten_integration_targets(actual):
+            scoped_pairs.add(pair)
+    all_pass = bool(scoped_pairs) and all(
+        pair in by_pair and by_pair[pair]["pass_at_k"] >= 1.0
+        for pair in scoped_pairs
     )
 
     issues_totals: list[int] = []

--- a/scripts/run_integration_eval.py
+++ b/scripts/run_integration_eval.py
@@ -234,8 +234,15 @@ def dispatch_orchestrator(
         env["DEV_TEAM_ABLATE_AGENT"] = ablate_agent
     else:
         env.pop("DEV_TEAM_ABLATE_AGENT", None)
+    # The orchestrator must edit files and run test/build commands to implement
+    # the spec. In headless `claude -p` mode with default permissions those tool
+    # calls are denied ("write was denied by permission settings"), so the build
+    # silently no-ops and every fixture's testCommands fail. The worktree is
+    # ephemeral and torn down unconditionally, so bypass the permission prompts
+    # for this dispatch. (#integration-eval-perms)
     proc = subprocess.run(
-        ["claude", "-p", prompt, "--model", model, "--output-format", "json"],
+        ["claude", "-p", prompt, "--model", model, "--output-format", "json",
+         "--dangerously-skip-permissions"],
         cwd=str(workdir),
         env=env,
         capture_output=True,


### PR DESCRIPTION
## What

Repairs two bugs that left `/agent-eval --ablation` (#868) and the integration tier (#313) non-functional wherever default tool permissions apply. Found while running an ablation of `performance-review` for the 2026-07-20 harness audit.

## Bugs

1. **`run_integration_eval.py` — no edit permission (#1263).** `dispatch_orchestrator` ran `claude -p` with no permission flag, so headless builds were denied file edits ("write was denied by permission settings"), never implemented the spec, and every fixture's `testCommands` failed. A trivial string-calculator build burned 369k tokens and still exited 1. → grant edits with `--dangerously-skip-permissions` (safe: ephemeral, unconditionally-torn-down worktree).
2. **`eval_ablation.py` — unscoped arm grading (#1264).** `summarize_arm` graded the whole 139-fixture corpus against an arm that dispatches only the integration fixture(s); the 138 never-run unit fixtures forced every arm to `fail` and every verdict to `baseline failed — inconclusive`. → scope the pass@k bar to the integration pairs present in the arm's actuals.

## Verification

- `tests/repo/{test_run_integration_eval,test_eval_ablation,test_agent_ablation,test_integration_tier}.py` — 34 passed.
- `ruff` clean on both files.
- End-to-end: re-grading the 6 recorded performance-review ablation trials (all `testCommands` exit 0) now yields `verdict: "no measured impact — supports drop"` instead of a false `baseline failed — inconclusive`.

## Notes

- Touches code (repo-root `scripts/`), so this needs human merge — not doc-only auto-merge.
- Follow-up worth doing (noted in both issues): add regression tests — the existing suite covered neither bug.

Closes #1263
Closes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
