### PR TITLE
feat: weekly action to detect stale pinned models in model-routing.json

### DIFF
--- a/.github/workflows/model-staleness.yml
+++ b/.github/workflows/model-staleness.yml
@@ -1,0 +1,43 @@
+name: Model staleness
+
+# model-routing.json pins exact model IDs (claude-haiku-4-5, claude-sonnet-5,
+# claude-opus-4-8). Anthropic deprecates/retires models on a timeline, so a
+# pinned ID can silently go stale. This weekly job asks the Models API which
+# models are actually served and files a deduped tracking issue when a pinned
+# ID has disappeared. It is intentionally NOT a PR gate: keeping the external
+# API call off PR CI avoids flakiness and never exposes ANTHROPIC_API_KEY to
+# fork PRs. See scripts/check_model_staleness.py (#1271).
+
+on:
+  schedule:
+    # Sundays 13:00 UTC.
+    - cron: "0 13 * * 0"
+  # On-demand: "Run workflow" button in the Actions tab, or
+  # `gh workflow run model-staleness.yml`.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: model-staleness-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  check-model-staleness:
+    name: Detect stale pinned models
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Check pinned models against the live catalog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/check_model_staleness.py --repo "${{ github.repository }}"

--- a/scripts/check_model_staleness.py
+++ b/scripts/check_model_staleness.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Detect pinned models in model-routing.json that are no longer served (#1271).
+
+`plugins/dev-team/knowledge/model-routing.json` pins exact model IDs. Anthropic
+deprecates and retires models on a timeline, so a pinned ID can silently go
+stale. This script is invoked by `.github/workflows/model-staleness.yml` on a
+weekly cron: it reads the pinned IDs, fetches the live catalog from the Models
+API (`GET /v1/models`), and opens (or leaves alone, if already open) a single
+deduped tracking issue when any pinned ID has disappeared from the catalog.
+
+Auth: `ANTHROPIC_API_KEY` in the environment. Endpoint host is `ANTHROPIC_BASE_URL`
+if set (so a self-hosted-runner/proxy variant is a config change, not a rewrite),
+else api.anthropic.com. GitHub calls go through `gh` (needs `GH_TOKEN`), mirroring
+scripts/epic_auto_close.py.
+
+Usage: check_model_staleness.py --repo OWNER/REPO [--routing PATH] [--dry-run]
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+DEFAULT_ROUTING = "plugins/dev-team/knowledge/model-routing.json"
+DEFAULT_BASE_URL = "https://api.anthropic.com"
+ANTHROPIC_VERSION = "2023-06-01"
+ISSUE_TITLE = "chore: pinned model(s) in model-routing.json are no longer served"
+
+
+def pinned_model_ids(routing: dict) -> list:
+    """Distinct model IDs pinned in routing.json, sorted.
+
+    Only values that look like model IDs (start with `claude-`) are returned,
+    so convention markers such as `rounding: round_half_up` are skipped. Keys
+    are irrelevant — a model listed under several keys collapses to one entry.
+    """
+    ids = {
+        v for v in routing.values() if isinstance(v, str) and v.startswith("claude-")
+    }
+    return sorted(ids)
+
+
+def stale_models(pinned: list, live_ids) -> list:
+    """Pinned IDs absent from the live catalog, order-preserved."""
+    live = set(live_ids)
+    return [model for model in pinned if model not in live]
+
+
+def issue_body(stale: list, live_ids: list) -> str:
+    """Markdown body for the tracking issue."""
+    stale_lines = "\n".join(f"- `{m}`" for m in stale)
+    active = "\n".join(f"- `{m}`" for m in sorted(live_ids) if m.startswith("claude-"))
+    return (
+        "The weekly model-staleness check found pinned model ID(s) in "
+        "`plugins/dev-team/knowledge/model-routing.json` that the Models API "
+        "(`GET /v1/models`) no longer returns — they are deprecated or "
+        "retired.\n\n"
+        "## No longer served\n\n"
+        f"{stale_lines}\n\n"
+        "## Fix\n\n"
+        "Repoint each stale band in `model-routing.json` to a current, "
+        "bare canonical ID (no dated snapshot suffix — see ADR 0024), then "
+        "run the routing tests:\n\n"
+        "```\n"
+        "pytest tests/knowledge/test_model_routing_defaults.py \\\n"
+        "  plugins/dev-team/tests/hooks/test_model_resolve.py\n"
+        "```\n\n"
+        "## Currently served `claude-*` models\n\n"
+        f"{active}\n\n"
+        "---\n"
+        "_Filed automatically by `scripts/check_model_staleness.py` "
+        "(`.github/workflows/model-staleness.yml`)._"
+    )
+
+
+def fetch_live_model_ids(base_url: str, api_key: str) -> list:
+    """Every served model ID via `GET /v1/models`, following pagination.
+
+    Raises on transport/auth failure so an infra problem surfaces as a
+    non-zero process exit (CI red) rather than being mistaken for "nothing
+    stale".
+    """
+    ids: list = []
+    after: str = ""
+    while True:
+        url = f"{base_url.rstrip('/')}/v1/models?limit=100"
+        if after:
+            url += f"&after_id={after}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": ANTHROPIC_VERSION,
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        ids.extend(model["id"] for model in payload.get("data", []))
+        if not payload.get("has_more"):
+            break
+        after = payload.get("last_id") or ""
+        if not after:
+            break
+    return ids
+
+
+def find_open_issue(repo: str, title: str) -> int:
+    """Number of an open issue whose title matches exactly, or 0 if none."""
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            f'"{title}" in:title',
+            "--json",
+            "number,title",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for issue in json.loads(result.stdout):
+        if issue.get("title") == title:
+            return int(issue["number"])
+    return 0
+
+
+def create_issue(repo: str, title: str, body: str) -> None:
+    subprocess.run(
+        ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
+        check=True,
+    )
+
+
+def main(argv: list) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="OWNER/REPO")
+    parser.add_argument(
+        "--routing", default=DEFAULT_ROUTING, help="Path to routing.json"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report staleness but do not open an issue.",
+    )
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ANTHROPIC_API_KEY is not set.", file=sys.stderr)
+        return 2
+    base_url = os.environ.get("ANTHROPIC_BASE_URL") or DEFAULT_BASE_URL
+
+    with open(args.routing, "r", encoding="utf-8") as fh:
+        routing = json.load(fh)
+    pinned = pinned_model_ids(routing)
+    if not pinned:
+        print(f"No pinned model IDs found in {args.routing}; nothing to check.")
+        return 0
+
+    live_ids = fetch_live_model_ids(base_url, api_key)
+    stale = stale_models(pinned, live_ids)
+
+    print(f"Pinned: {', '.join(pinned)}")
+    print(f"Live catalog: {len(live_ids)} models")
+
+    if not stale:
+        print("All pinned models are currently served. Nothing to do.")
+        return 0
+
+    print(f"STALE (no longer served): {', '.join(stale)}")
+    if args.dry_run:
+        print("Dry run — not opening an issue.")
+        return 0
+
+    existing = find_open_issue(args.repo, ISSUE_TITLE)
+    if existing:
+        print(f"Tracking issue already open (#{existing}); not filing a duplicate.")
+        return 0
+
+    create_issue(args.repo, ISSUE_TITLE, issue_body(stale, live_ids))
+    print("Opened tracking issue.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/scripts/test_check_model_staleness.py
+++ b/tests/scripts/test_check_model_staleness.py
@@ -1,0 +1,176 @@
+"""Tests for scripts/check_model_staleness.py (#1271).
+
+Covers the pure comparison logic (pinned-ID extraction, staleness diff, issue
+body) against fixtures, plus the main() control flow with the network
+(`fetch_live_model_ids`) and GitHub (`find_open_issue`/`create_issue`)
+boundaries monkeypatched. No network, no `gh`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_model_staleness.py"
+
+_spec = importlib.util.spec_from_file_location("check_model_staleness", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+# --- pinned_model_ids ------------------------------------------------------
+
+
+def test_pinned_ids_current_shape() -> None:
+    routing = {
+        "low": "claude-haiku-4-5",
+        "medium": "claude-sonnet-5",
+        "high": "claude-opus-4-8",
+        "rounding": "round_half_up",
+    }
+    assert mod.pinned_model_ids(routing) == [
+        "claude-haiku-4-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+    ]
+
+
+def test_pinned_ids_dedupes_legacy_alias_keys() -> None:
+    # Pre-#1269 shape: the same three IDs listed under bands AND aliases.
+    routing = {
+        "low": "claude-haiku-4-5",
+        "medium": "claude-sonnet-5",
+        "high": "claude-opus-4-8",
+        "haiku": "claude-haiku-4-5",
+        "sonnet": "claude-sonnet-5",
+        "opus": "claude-opus-4-8",
+        "rounding": "round_half_up",
+    }
+    assert mod.pinned_model_ids(routing) == [
+        "claude-haiku-4-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+    ]
+
+
+def test_pinned_ids_skips_non_model_values() -> None:
+    assert mod.pinned_model_ids({"rounding": "round_half_up"}) == []
+
+
+# --- stale_models ----------------------------------------------------------
+
+
+def test_stale_none_when_all_served() -> None:
+    pinned = ["claude-haiku-4-5", "claude-opus-4-8"]
+    live = ["claude-haiku-4-5", "claude-opus-4-8", "claude-sonnet-5"]
+    assert mod.stale_models(pinned, live) == []
+
+
+def test_stale_flags_missing_and_preserves_order() -> None:
+    pinned = ["claude-haiku-4-5", "claude-opus-4-8", "claude-sonnet-5"]
+    live = ["claude-sonnet-5"]
+    assert mod.stale_models(pinned, live) == [
+        "claude-haiku-4-5",
+        "claude-opus-4-8",
+    ]
+
+
+# --- issue_body ------------------------------------------------------------
+
+
+def test_issue_body_lists_stale_ids() -> None:
+    body = mod.issue_body(["claude-opus-4-8"], ["claude-sonnet-5", "gpt-ignored"])
+    assert "`claude-opus-4-8`" in body
+    assert "no longer" in body.lower()
+    # Only claude-* live models are echoed under "currently served".
+    assert "gpt-ignored" not in body
+
+
+# --- main() flow (boundaries monkeypatched) --------------------------------
+
+
+def _write_routing(tmp_path: Path) -> Path:
+    p = tmp_path / "model-routing.json"
+    p.write_text(
+        json.dumps(
+            {
+                "low": "claude-haiku-4-5",
+                "medium": "claude-sonnet-5",
+                "high": "claude-opus-4-8",
+                "rounding": "round_half_up",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_main_no_api_key_returns_2(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    routing = _write_routing(tmp_path)
+    assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 2
+
+
+def test_main_all_served_does_not_file_issue(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        mod,
+        "fetch_live_model_ids",
+        lambda base, key: ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-4-8"],
+    )
+    called = {"create": 0}
+    monkeypatch.setattr(
+        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
+    )
+    routing = _write_routing(tmp_path)
+    assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
+    assert called["create"] == 0
+
+
+def test_main_stale_files_issue_when_none_open(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
+    )
+    monkeypatch.setattr(mod, "find_open_issue", lambda repo, title: 0)
+    created = {}
+    monkeypatch.setattr(
+        mod,
+        "create_issue",
+        lambda repo, title, body: created.update(title=title, body=body),
+    )
+    routing = _write_routing(tmp_path)
+    assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
+    assert "claude-haiku-4-5" in created["body"]
+    assert "claude-opus-4-8" in created["body"]
+
+
+def test_main_stale_skips_when_issue_already_open(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
+    )
+    monkeypatch.setattr(mod, "find_open_issue", lambda repo, title: 42)
+    called = {"create": 0}
+    monkeypatch.setattr(
+        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
+    )
+    routing = _write_routing(tmp_path)
+    assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
+    assert called["create"] == 0
+
+
+def test_main_dry_run_never_files(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
+    )
+    called = {"create": 0}
+    monkeypatch.setattr(
+        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
+    )
+    routing = _write_routing(tmp_path)
+    assert mod.main(["--repo", "o/r", "--routing", str(routing), "--dry-run"]) == 0
+    assert called["create"] == 0


### PR DESCRIPTION
## What

A weekly GitHub Action that flags when a model pinned in `plugins/dev-team/knowledge/model-routing.json` (`claude-haiku-4-5` / `claude-sonnet-5` / `claude-opus-4-8`) is no longer served by Anthropic — closing the gap where those IDs were updated only manually and reactively.

## How

- **`scripts/check_model_staleness.py`** — stdlib-only Python 3.8+ (mirrors `scripts/epic_auto_close.py`). Reads the pinned IDs, fetches the live catalog via `GET /v1/models`, diffs, and opens a single **deduped** tracking issue when any pinned ID has disappeared. `gh`-driven issue creation; pure comparison logic separated from the network + `gh` boundaries.
- **`.github/workflows/model-staleness.yml`** — weekly `schedule` cron + `workflow_dispatch`, `issues: write` + `contents: read`, `ANTHROPIC_API_KEY` from repo secrets against `api.anthropic.com`.
- **`tests/scripts/test_check_model_staleness.py`** — 11 tests over the diff logic and `main()` flow, network + `gh` monkeypatched (no network, no `gh`).

## Decisions

- **Repo secret → api.anthropic.com** (not the internal proxy — a GitHub-hosted runner can't reach `10.99.21.15`). `GET /v1/models` is a metadata endpoint: **zero token cost**, only rate-limited. `ANTHROPIC_BASE_URL` is overridable so a self-hosted-runner/proxy variant is a config change, not a rewrite.
- **Weekly cron → open an issue**, not a PR gate — keeps a flaky external-API call off PR CI and never exposes the secret to fork PRs.

## Prerequisite

Requires an `ANTHROPIC_API_KEY` **repo secret**. Until it's set, the scheduled run exits non-zero (missing key) without filing anything.

## Verification

`ruff check` clean; `pytest tests/scripts/test_check_model_staleness.py` — **11 passed**. Workflow YAML parses.

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)