### PR TITLE
feat: auto-PR to pin the latest model version per family in model-routing.json

### DIFF
--- a/.github/workflows/model-staleness.yml
+++ b/.github/workflows/model-staleness.yml
@@ -1,12 +1,13 @@
 name: Model staleness
 
 # model-routing.json pins exact model IDs (claude-haiku-4-5, claude-sonnet-5,
-# claude-opus-4-8). Anthropic deprecates/retires models on a timeline, so a
-# pinned ID can silently go stale. This weekly job asks the Models API which
-# models are actually served and files a deduped tracking issue when a pinned
-# ID has disappeared. It is intentionally NOT a PR gate: keeping the external
-# API call off PR CI avoids flakiness and never exposes ANTHROPIC_API_KEY to
-# fork PRs. See scripts/check_model_staleness.py (#1271).
+# claude-opus-4-8). Anthropic ships new versions and retires old ones on a
+# timeline. This weekly job asks the Models API which models are served, and
+# for each pinned family opens a PR bumping the pin to the newest member (or,
+# when a family has no live successor, files a tracking issue). It is
+# intentionally NOT a PR gate: keeping the external API call off PR CI avoids
+# flakiness and never exposes ANTHROPIC_API_KEY to fork PRs. See
+# scripts/check_model_staleness.py (#1271).
 
 on:
   schedule:
@@ -18,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: model-staleness-${{ github.repository }}
@@ -35,9 +35,20 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Check pinned models against the live catalog
+      # Mint a short-lived token from the release bot GitHub App — the SAME
+      # identity release-please uses. An App token (not the default
+      # GITHUB_TOKEN) is what lets the bump PR's events trigger the required
+      # pull_request checks; commits it creates via the API are verified, so
+      # they satisfy the signed-commits branch rule. No dedicated PAT needed.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Reconcile pinned models against the live catalog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python3 scripts/check_model_staleness.py --repo "${{ github.repository }}"

--- a/scripts/check_model_staleness.py
+++ b/scripts/check_model_staleness.py
@@ -1,19 +1,32 @@
 #!/usr/bin/env python3
-"""Detect pinned models in model-routing.json that are no longer served (#1271).
+"""Keep model-routing.json pinned to the latest version of each model family (#1271).
 
 `plugins/dev-team/knowledge/model-routing.json` pins exact model IDs. Anthropic
-deprecates and retires models on a timeline, so a pinned ID can silently go
-stale. This script is invoked by `.github/workflows/model-staleness.yml` on a
-weekly cron: it reads the pinned IDs, fetches the live catalog from the Models
-API (`GET /v1/models`), and opens (or leaves alone, if already open) a single
-deduped tracking issue when any pinned ID has disappeared from the catalog.
+ships new versions and retires old ones on a timeline. This script (invoked
+weekly by `.github/workflows/model-staleness.yml`, or on demand) reconciles the
+pins against the live catalog from the Models API (`GET /v1/models`):
 
-Auth: `ANTHROPIC_API_KEY` in the environment. Endpoint host is `ANTHROPIC_BASE_URL`
-if set (so a self-hosted-runner/proxy variant is a config change, not a rewrite),
-else api.anthropic.com. GitHub calls go through `gh` (needs `GH_TOKEN`), mirroring
-scripts/epic_auto_close.py.
+  * For each pinned ID it derives the model *family* (the tier word, ignoring
+    version digits — e.g. `claude-opus-4-8` -> `opus`) and finds the newest
+    member of that family in the live catalog, ranked by `created_at`.
+    `created_at` — not version-digit parsing — is used deliberately: the old
+    `claude-3-haiku-20240307` naming puts the number first, so digit parsing
+    mis-sorts across naming schemes.
+  * When the newest family member differs from the pinned ID, it opens (or
+    reuses) a PR that repoints `model-routing.json` to the newer ID. The PR's
+    commit is created through the GitHub GraphQL API (`createCommitOnBranch`),
+    so it is verified/signed and satisfies the branch ruleset.
+  * When a pinned family has NO live members at all (whole tier removed — can't
+    be auto-fixed), it opens a deduped tracking issue instead.
 
-Usage: check_model_staleness.py --repo OWNER/REPO [--routing PATH] [--dry-run]
+Auth: `ANTHROPIC_API_KEY` for the catalog; `GH_TOKEN` for GitHub. The workflow
+supplies a token minted from the release-bot GitHub App (the same identity
+release-please uses) with contents + pull-requests write, so the opened PR
+triggers the required checks and its API-created commit is verified.
+`ANTHROPIC_BASE_URL` overrides the API host (self-hosted-runner/proxy variant).
+
+Usage: check_model_staleness.py --repo OWNER/REPO [--base BRANCH]
+                                [--routing PATH] [--dry-run]
 
 Stdlib-only. Python 3.8+.
 """
@@ -21,16 +34,25 @@ Stdlib-only. Python 3.8+.
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.request
 
 DEFAULT_ROUTING = "plugins/dev-team/knowledge/model-routing.json"
 DEFAULT_BASE_URL = "https://api.anthropic.com"
+DEFAULT_BASE_BRANCH = "main"
 ANTHROPIC_VERSION = "2023-06-01"
-ISSUE_TITLE = "chore: pinned model(s) in model-routing.json are no longer served"
+BRANCH_PREFIX = "chore/pin-latest-models-"
+PR_TITLE = "chore: pin latest model versions in model-routing.json"
+ISSUE_TITLE = "chore: pinned model family in model-routing.json has no live successor"
+
+_MODEL_PREFIX = "claude-"
+_DIGITS = re.compile(r"^\d+$")
 
 
 def pinned_model_ids(routing: dict) -> list:
@@ -41,32 +63,108 @@ def pinned_model_ids(routing: dict) -> list:
     are irrelevant — a model listed under several keys collapses to one entry.
     """
     ids = {
-        v for v in routing.values() if isinstance(v, str) and v.startswith("claude-")
+        v
+        for v in routing.values()
+        if isinstance(v, str) and v.startswith(_MODEL_PREFIX)
     }
     return sorted(ids)
 
 
-def stale_models(pinned: list, live_ids) -> list:
-    """Pinned IDs absent from the live catalog, order-preserved."""
-    live = set(live_ids)
-    return [model for model in pinned if model not in live]
+def family_of(model_id: str) -> str:
+    """The tier word of a model ID, with `claude-` and all version digits removed.
+
+    `claude-opus-4-8` -> `opus`; `claude-sonnet-5` -> `sonnet`;
+    `claude-3-7-sonnet-20250219` -> `sonnet`; `claude-haiku-4-5` -> `haiku`.
+    Non-numeric tokens (other than the `claude` marker) are joined with `-`, so
+    a hypothetical multi-word family still round-trips.
+    """
+    tokens = model_id.split("-")
+    words = [t for t in tokens if t != "claude" and t and not _DIGITS.match(t)]
+    return "-".join(words)
 
 
-def issue_body(stale: list, live_ids: list) -> str:
-    """Markdown body for the tracking issue."""
-    stale_lines = "\n".join(f"- `{m}`" for m in stale)
-    active = "\n".join(f"- `{m}`" for m in sorted(live_ids) if m.startswith("claude-"))
+def latest_in_family(family: str, live_models: list) -> dict:
+    """The newest live model in `family` (by `created_at`), or {} if none.
+
+    `live_models` is a list of `{"id", "created_at"}`. `created_at` is ISO-8601
+    UTC, so lexical max is chronological max.
+    """
+    members = [m for m in live_models if family_of(m["id"]) == family]
+    if not members:
+        return {}
+    return max(members, key=lambda m: m.get("created_at", ""))
+
+
+def plan_bumps(pinned: list, live_models: list):
+    """Return (bumps, gone).
+
+    `bumps` maps each pinned ID whose family has a newer member to that newer
+    ID. `gone` lists pinned IDs whose family has no live members at all (no
+    successor — cannot be auto-bumped).
+    """
+    bumps: dict = {}
+    gone: list = []
+    for old in pinned:
+        latest = latest_in_family(family_of(old), live_models)
+        if not latest:
+            gone.append(old)
+        elif latest["id"] != old:
+            bumps[old] = latest["id"]
+    return bumps, gone
+
+
+def rewrite_routing_text(raw: str, id_map: dict) -> str:
+    """Replace each old model ID with its new ID in the raw JSON text.
+
+    Operates on the quoted string form (`"<id>"`) so formatting and comments-as-
+    blank-lines are preserved and a shorter ID can't match inside a longer one.
+    """
+    for old, new in id_map.items():
+        raw = raw.replace(f'"{old}"', f'"{new}"')
+    return raw
+
+
+def branch_name(bumps: dict) -> str:
+    """Deterministic branch name for a given target set of bumps.
+
+    Same desired bumps -> same branch (dedup); a new target -> a new branch.
+    """
+    digest = hashlib.sha1(
+        json.dumps(bumps, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{BRANCH_PREFIX}{digest}"
+
+
+def pr_body(bumps: dict) -> str:
+    rows = "\n".join(f"- `{old}` → `{new}`" for old, new in sorted(bumps.items()))
     return (
-        "The weekly model-staleness check found pinned model ID(s) in "
-        "`plugins/dev-team/knowledge/model-routing.json` that the Models API "
-        "(`GET /v1/models`) no longer returns — they are deprecated or "
-        "retired.\n\n"
-        "## No longer served\n\n"
-        f"{stale_lines}\n\n"
-        "## Fix\n\n"
-        "Repoint each stale band in `model-routing.json` to a current, "
-        "bare canonical ID (no dated snapshot suffix — see ADR 0024), then "
-        "run the routing tests:\n\n"
+        "The weekly model-staleness check found newer versions available for "
+        "model families pinned in `plugins/dev-team/knowledge/model-routing.json`.\n\n"
+        "## Proposed bumps\n\n"
+        f"{rows}\n\n"
+        '"Newest" is the family member with the latest `created_at` in the '
+        "Models API (`GET /v1/models`) — not a version-digit sort, which "
+        "mis-orders the older `claude-3-*` naming.\n\n"
+        "Review that each new ID is the intended tier before merging.\n\n"
+        "---\n"
+        "_Opened automatically by `scripts/check_model_staleness.py` "
+        "(`.github/workflows/model-staleness.yml`)._"
+    )
+
+
+def issue_body(gone: list, live_ids: list) -> str:
+    gone_lines = "\n".join(f"- `{m}`" for m in gone)
+    active = "\n".join(
+        f"- `{m}`" for m in sorted(live_ids) if m.startswith(_MODEL_PREFIX)
+    )
+    return (
+        "The weekly model-staleness check found pinned model ID(s) whose whole "
+        "family has disappeared from the Models API — there is no newer version "
+        "to bump to automatically, so this needs a human decision.\n\n"
+        "## No live successor\n\n"
+        f"{gone_lines}\n\n"
+        "Repoint each affected band in `model-routing.json` to a current, bare "
+        "canonical ID (no dated snapshot suffix — see ADR 0024), then run:\n\n"
         "```\n"
         "pytest tests/knowledge/test_model_routing_defaults.py \\\n"
         "  plugins/dev-team/tests/hooks/test_model_resolve.py\n"
@@ -74,19 +172,20 @@ def issue_body(stale: list, live_ids: list) -> str:
         "## Currently served `claude-*` models\n\n"
         f"{active}\n\n"
         "---\n"
-        "_Filed automatically by `scripts/check_model_staleness.py` "
-        "(`.github/workflows/model-staleness.yml`)._"
+        "_Filed automatically by `scripts/check_model_staleness.py`._"
     )
 
 
-def fetch_live_model_ids(base_url: str, api_key: str) -> list:
-    """Every served model ID via `GET /v1/models`, following pagination.
+# --- I/O boundaries --------------------------------------------------------
 
-    Raises on transport/auth failure so an infra problem surfaces as a
-    non-zero process exit (CI red) rather than being mistaken for "nothing
-    stale".
+
+def fetch_live_models(base_url: str, api_key: str) -> list:
+    """Every served model as `{"id", "created_at"}` via `GET /v1/models`.
+
+    Raises on transport/auth failure so an infra problem surfaces as a non-zero
+    process exit (CI red) rather than being mistaken for "nothing to do".
     """
-    ids: list = []
+    models: list = []
     after: str = ""
     while True:
         url = f"{base_url.rstrip('/')}/v1/models?limit=100"
@@ -94,27 +193,167 @@ def fetch_live_model_ids(base_url: str, api_key: str) -> list:
             url += f"&after_id={after}"
         req = urllib.request.Request(
             url,
-            headers={
-                "x-api-key": api_key,
-                "anthropic-version": ANTHROPIC_VERSION,
-            },
+            headers={"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION},
         )
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
-        ids.extend(model["id"] for model in payload.get("data", []))
+        for model in payload.get("data", []):
+            models.append(
+                {"id": model["id"], "created_at": model.get("created_at", "")}
+            )
         if not payload.get("has_more"):
             break
         after = payload.get("last_id") or ""
         if not after:
             break
-    return ids
+    return models
+
+
+def _gh(args: list, check: bool = True, stdin: str = None) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        input=stdin,
+    )
+    return result.stdout
+
+
+def open_pr_for_branch(repo: str, branch: str) -> int:
+    """Number of an open PR whose head is `branch`, or 0 if none."""
+    out = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]
+    )
+    prs = json.loads(out)
+    return int(prs[0]["number"]) if prs else 0
+
+
+def _ref_sha(repo: str, ref: str) -> str:
+    out = _gh(["api", f"repos/{repo}/git/ref/heads/{ref}"])
+    return json.loads(out)["object"]["sha"]
+
+
+def create_branch(repo: str, branch: str, sha: str) -> None:
+    _gh(
+        [
+            "api",
+            f"repos/{repo}/git/refs",
+            "-f",
+            f"ref=refs/heads/{branch}",
+            "-f",
+            f"sha={sha}",
+        ]
+    )
+
+
+def commit_file(
+    repo: str, branch: str, expected_head: str, path: str, content: str, message: str
+) -> None:
+    """Create a verified commit on `branch` via the GraphQL API."""
+    payload = {
+        "query": (
+            "mutation($input: CreateCommitOnBranchInput!) {"
+            " createCommitOnBranch(input: $input) { commit { oid } } }"
+        ),
+        "variables": {
+            "input": {
+                "branch": {
+                    "repositoryNameWithOwner": repo,
+                    "branchName": branch,
+                },
+                "message": {"headline": message},
+                "expectedHeadOid": expected_head,
+                "fileChanges": {
+                    "additions": [
+                        {
+                            "path": path,
+                            "contents": base64.b64encode(
+                                content.encode("utf-8")
+                            ).decode("ascii"),
+                        }
+                    ]
+                },
+            }
+        },
+    }
+    _gh(["api", "graphql", "--input", "-"], stdin=json.dumps(payload))
+
+
+def create_pr(repo: str, base: str, branch: str, title: str, body: str) -> None:
+    _gh(
+        [
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--base",
+            base,
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+        ]
+    )
+
+
+def open_bump_pr(
+    repo: str, base: str, branch: str, path: str, content: str, title: str, body: str
+) -> None:
+    """Create `branch` at base head, commit the rewritten file, and open a PR."""
+    base_sha = _ref_sha(repo, base)
+    create_branch(repo, branch, base_sha)
+    commit_file(repo, branch, base_sha, path, content, title)
+    create_pr(repo, base, branch, title, body)
+
+
+def close_superseded_bump_prs(repo: str, keep_branch: str) -> None:
+    """Close any older open bump PRs (branch prefix) that aren't `keep_branch`."""
+    out = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName",
+        ]
+    )
+    for pr in json.loads(out):
+        head = pr.get("headRefName", "")
+        if head.startswith(BRANCH_PREFIX) and head != keep_branch:
+            _gh(
+                [
+                    "pr",
+                    "close",
+                    str(pr["number"]),
+                    "--repo",
+                    repo,
+                    "--comment",
+                    f"Superseded by a newer pin PR (#{keep_branch}).",
+                ],
+                check=False,
+            )
 
 
 def find_open_issue(repo: str, title: str) -> int:
-    """Number of an open issue whose title matches exactly, or 0 if none."""
-    result = subprocess.run(
+    out = _gh(
         [
-            "gh",
             "issue",
             "list",
             "--repo",
@@ -125,34 +364,32 @@ def find_open_issue(repo: str, title: str) -> int:
             f'"{title}" in:title',
             "--json",
             "number,title",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
+        ]
     )
-    for issue in json.loads(result.stdout):
+    for issue in json.loads(out):
         if issue.get("title") == title:
             return int(issue["number"])
     return 0
 
 
 def create_issue(repo: str, title: str, body: str) -> None:
-    subprocess.run(
-        ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
-        check=True,
-    )
+    _gh(["issue", "create", "--repo", repo, "--title", title, "--body", body])
+
+
+# --- orchestration ---------------------------------------------------------
 
 
 def main(argv: list) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True, help="OWNER/REPO")
+    parser.add_argument("--base", default=DEFAULT_BASE_BRANCH, help="Base branch")
     parser.add_argument(
         "--routing", default=DEFAULT_ROUTING, help="Path to routing.json"
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Report staleness but do not open an issue.",
+        help="Report bumps but open no PR or issue.",
     )
     args = parser.parse_args(argv)
 
@@ -163,34 +400,60 @@ def main(argv: list) -> int:
     base_url = os.environ.get("ANTHROPIC_BASE_URL") or DEFAULT_BASE_URL
 
     with open(args.routing, "r", encoding="utf-8") as fh:
-        routing = json.load(fh)
+        raw = fh.read()
+    routing = json.loads(raw)
     pinned = pinned_model_ids(routing)
     if not pinned:
         print(f"No pinned model IDs found in {args.routing}; nothing to check.")
         return 0
 
-    live_ids = fetch_live_model_ids(base_url, api_key)
-    stale = stale_models(pinned, live_ids)
+    live_models = fetch_live_models(base_url, api_key)
+    live_ids = [m["id"] for m in live_models]
+    bumps, gone = plan_bumps(pinned, live_models)
 
     print(f"Pinned: {', '.join(pinned)}")
     print(f"Live catalog: {len(live_ids)} models")
 
-    if not stale:
-        print("All pinned models are currently served. Nothing to do.")
+    if not bumps and not gone:
+        print("All pinned models are the latest in their family. Nothing to do.")
         return 0
 
-    print(f"STALE (no longer served): {', '.join(stale)}")
-    if args.dry_run:
-        print("Dry run — not opening an issue.")
-        return 0
+    if bumps:
+        summary = ", ".join(f"{o}->{n}" for o, n in sorted(bumps.items()))
+        print(f"BUMPS: {summary}")
+        branch = branch_name(bumps)
+        if args.dry_run:
+            print(f"Dry run — would open PR on branch {branch}.")
+        else:
+            existing = open_pr_for_branch(args.repo, branch)
+            if existing:
+                print(f"Bump PR already open (#{existing}); not duplicating.")
+            else:
+                new_content = rewrite_routing_text(raw, bumps)
+                open_bump_pr(
+                    args.repo,
+                    args.base,
+                    branch,
+                    args.routing,
+                    new_content,
+                    PR_TITLE,
+                    pr_body(bumps),
+                )
+                close_superseded_bump_prs(args.repo, branch)
+                print(f"Opened bump PR on branch {branch}.")
 
-    existing = find_open_issue(args.repo, ISSUE_TITLE)
-    if existing:
-        print(f"Tracking issue already open (#{existing}); not filing a duplicate.")
-        return 0
+    if gone:
+        print(f"NO SUCCESSOR (family removed): {', '.join(gone)}")
+        if args.dry_run:
+            print("Dry run — would file a tracking issue.")
+        else:
+            existing = find_open_issue(args.repo, ISSUE_TITLE)
+            if existing:
+                print(f"Tracking issue already open (#{existing}); not duplicating.")
+            else:
+                create_issue(args.repo, ISSUE_TITLE, issue_body(gone, live_ids))
+                print("Opened tracking issue.")
 
-    create_issue(args.repo, ISSUE_TITLE, issue_body(stale, live_ids))
-    print("Opened tracking issue.")
     return 0
 
 

--- a/tests/scripts/test_check_model_staleness.py
+++ b/tests/scripts/test_check_model_staleness.py
@@ -1,9 +1,10 @@
 """Tests for scripts/check_model_staleness.py (#1271).
 
-Covers the pure comparison logic (pinned-ID extraction, staleness diff, issue
-body) against fixtures, plus the main() control flow with the network
-(`fetch_live_model_ids`) and GitHub (`find_open_issue`/`create_issue`)
-boundaries monkeypatched. No network, no `gh`.
+Covers the pure logic (pinned-ID extraction, family derivation, latest-by-
+created_at selection, bump planning, formatting-preserving text rewrite, and
+deterministic branch naming), plus the main() control flow with the network
+(`fetch_live_models`) and GitHub (`open_bump_pr` / `create_issue` / the dedup
+lookups) boundaries monkeypatched. No network, no `gh`.
 """
 
 from __future__ import annotations
@@ -23,12 +24,13 @@ _spec.loader.exec_module(mod)
 # --- pinned_model_ids ------------------------------------------------------
 
 
-def test_pinned_ids_current_shape() -> None:
+def test_pinned_ids_dedupe_and_skip_non_models() -> None:
     routing = {
         "low": "claude-haiku-4-5",
         "medium": "claude-sonnet-5",
         "high": "claude-opus-4-8",
-        "rounding": "round_half_up",
+        "opus": "claude-opus-4-8",  # legacy alias — collapses
+        "rounding": "round_half_up",  # not a model
     }
     assert mod.pinned_model_ids(routing) == [
         "claude-haiku-4-5",
@@ -37,55 +39,98 @@ def test_pinned_ids_current_shape() -> None:
     ]
 
 
-def test_pinned_ids_dedupes_legacy_alias_keys() -> None:
-    # Pre-#1269 shape: the same three IDs listed under bands AND aliases.
-    routing = {
-        "low": "claude-haiku-4-5",
-        "medium": "claude-sonnet-5",
-        "high": "claude-opus-4-8",
-        "haiku": "claude-haiku-4-5",
-        "sonnet": "claude-sonnet-5",
-        "opus": "claude-opus-4-8",
-        "rounding": "round_half_up",
-    }
-    assert mod.pinned_model_ids(routing) == [
-        "claude-haiku-4-5",
-        "claude-opus-4-8",
-        "claude-sonnet-5",
+# --- family_of -------------------------------------------------------------
+
+
+def test_family_of_new_scheme() -> None:
+    assert mod.family_of("claude-opus-4-8") == "opus"
+    assert mod.family_of("claude-sonnet-5") == "sonnet"
+    assert mod.family_of("claude-haiku-4-5") == "haiku"
+
+
+def test_family_of_old_scheme_number_first() -> None:
+    # Old naming puts the version first; family word must still be extracted.
+    assert mod.family_of("claude-3-7-sonnet-20250219") == "sonnet"
+    assert mod.family_of("claude-3-haiku-20240307") == "haiku"
+
+
+# --- latest_in_family (ranks by created_at, not digits) --------------------
+
+
+def _live():
+    return [
+        {"id": "claude-opus-4-8", "created_at": "2026-05-01T00:00:00Z"},
+        {"id": "claude-opus-4-7", "created_at": "2026-02-01T00:00:00Z"},
+        {"id": "claude-sonnet-5", "created_at": "2026-01-01T00:00:00Z"},
+        # Old naming, huge digits, but OLDER by created_at — must NOT win.
+        {"id": "claude-3-haiku-20240307", "created_at": "2024-03-07T00:00:00Z"},
+        {"id": "claude-haiku-4-5", "created_at": "2025-10-01T00:00:00Z"},
     ]
 
 
-def test_pinned_ids_skips_non_model_values() -> None:
-    assert mod.pinned_model_ids({"rounding": "round_half_up"}) == []
+def test_latest_prefers_created_at_over_digits() -> None:
+    # 20240307 digits dwarf 4-5, but created_at makes claude-haiku-4-5 newest.
+    assert mod.latest_in_family("haiku", _live())["id"] == "claude-haiku-4-5"
+    assert mod.latest_in_family("opus", _live())["id"] == "claude-opus-4-8"
 
 
-# --- stale_models ----------------------------------------------------------
+def test_latest_empty_when_family_absent() -> None:
+    assert mod.latest_in_family("fable", _live()) == {}
 
 
-def test_stale_none_when_all_served() -> None:
-    pinned = ["claude-haiku-4-5", "claude-opus-4-8"]
-    live = ["claude-haiku-4-5", "claude-opus-4-8", "claude-sonnet-5"]
-    assert mod.stale_models(pinned, live) == []
+# --- plan_bumps ------------------------------------------------------------
 
 
-def test_stale_flags_missing_and_preserves_order() -> None:
-    pinned = ["claude-haiku-4-5", "claude-opus-4-8", "claude-sonnet-5"]
-    live = ["claude-sonnet-5"]
-    assert mod.stale_models(pinned, live) == [
-        "claude-haiku-4-5",
-        "claude-opus-4-8",
-    ]
+def test_plan_bumps_flags_only_superseded() -> None:
+    pinned = ["claude-haiku-4-5", "claude-opus-4-7", "claude-sonnet-5"]
+    bumps, gone = mod.plan_bumps(pinned, _live())
+    assert bumps == {"claude-opus-4-7": "claude-opus-4-8"}  # 4-7 -> 4-8
+    assert gone == []
 
 
-# --- issue_body ------------------------------------------------------------
+def test_plan_bumps_reports_family_with_no_successor() -> None:
+    pinned = ["claude-opus-4-8", "claude-fable-5"]
+    bumps, gone = mod.plan_bumps(pinned, _live())
+    assert bumps == {}
+    assert gone == ["claude-fable-5"]
 
 
-def test_issue_body_lists_stale_ids() -> None:
-    body = mod.issue_body(["claude-opus-4-8"], ["claude-sonnet-5", "gpt-ignored"])
-    assert "`claude-opus-4-8`" in body
-    assert "no longer" in body.lower()
-    # Only claude-* live models are echoed under "currently served".
-    assert "gpt-ignored" not in body
+# --- rewrite_routing_text (formatting-preserving) --------------------------
+
+
+def test_rewrite_preserves_formatting_and_only_changes_ids() -> None:
+    raw = (
+        "{\n"
+        '  "low": "claude-haiku-4-5",\n'
+        "\n"
+        '  "high": "claude-opus-4-7",\n'
+        '  "rounding": "round_half_up"\n'
+        "}\n"
+    )
+    out = mod.rewrite_routing_text(raw, {"claude-opus-4-7": "claude-opus-4-8"})
+    assert '"high": "claude-opus-4-8"' in out
+    assert '"low": "claude-haiku-4-5"' in out  # untouched
+    assert "\n\n" in out  # blank line preserved
+    assert "claude-opus-4-7" not in out
+
+
+def test_rewrite_quoted_match_avoids_substring_bleed() -> None:
+    raw = '{"a": "claude-opus-4-8", "b": "claude-opus-4-8-fast"}'
+    out = mod.rewrite_routing_text(raw, {"claude-opus-4-8": "claude-opus-5"})
+    assert '"claude-opus-5"' in out
+    assert "claude-opus-4-8-fast" in out  # longer ID untouched
+
+
+# --- branch_name -----------------------------------------------------------
+
+
+def test_branch_name_is_deterministic_and_prefixed() -> None:
+    a = mod.branch_name({"claude-opus-4-7": "claude-opus-4-8"})
+    b = mod.branch_name({"claude-opus-4-7": "claude-opus-4-8"})
+    c = mod.branch_name({"claude-sonnet-4-6": "claude-sonnet-5"})
+    assert a == b
+    assert a != c
+    assert a.startswith(mod.BRANCH_PREFIX)
 
 
 # --- main() flow (boundaries monkeypatched) --------------------------------
@@ -98,7 +143,7 @@ def _write_routing(tmp_path: Path) -> Path:
             {
                 "low": "claude-haiku-4-5",
                 "medium": "claude-sonnet-5",
-                "high": "claude-opus-4-8",
+                "high": "claude-opus-4-7",
                 "rounding": "round_half_up",
             }
         ),
@@ -107,70 +152,80 @@ def _write_routing(tmp_path: Path) -> Path:
     return p
 
 
+def _stub_gh(monkeypatch, opened, issued, open_pr=0, open_issue=0):
+    monkeypatch.setattr(mod, "fetch_live_models", lambda base, key: _live())
+    monkeypatch.setattr(mod, "open_pr_for_branch", lambda repo, branch: open_pr)
+    monkeypatch.setattr(mod, "find_open_issue", lambda repo, title: open_issue)
+    monkeypatch.setattr(mod, "close_superseded_bump_prs", lambda repo, keep: None)
+    monkeypatch.setattr(
+        mod,
+        "open_bump_pr",
+        lambda repo, base, branch, path, content, title, body: opened.update(
+            branch=branch, content=content
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "create_issue",
+        lambda repo, title, body: issued.update(title=title, body=body),
+    )
+
+
 def test_main_no_api_key_returns_2(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     routing = _write_routing(tmp_path)
     assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 2
 
 
-def test_main_all_served_does_not_file_issue(tmp_path, monkeypatch) -> None:
+def test_main_opens_pr_for_superseded_pin(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    monkeypatch.setattr(
-        mod,
-        "fetch_live_model_ids",
-        lambda base, key: ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-4-8"],
-    )
-    called = {"create": 0}
-    monkeypatch.setattr(
-        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
-    )
+    opened, issued = {}, {}
+    _stub_gh(monkeypatch, opened, issued)
     routing = _write_routing(tmp_path)
     assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
-    assert called["create"] == 0
+    assert "claude-opus-4-8" in opened["content"]  # bumped 4-7 -> 4-8
+    assert "claude-opus-4-7" not in opened["content"]
+    assert not issued  # nothing gone
 
 
-def test_main_stale_files_issue_when_none_open(tmp_path, monkeypatch) -> None:
+def test_main_skips_when_bump_pr_already_open(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    monkeypatch.setattr(
-        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
-    )
-    monkeypatch.setattr(mod, "find_open_issue", lambda repo, title: 0)
-    created = {}
-    monkeypatch.setattr(
-        mod,
-        "create_issue",
-        lambda repo, title, body: created.update(title=title, body=body),
-    )
+    opened, issued = {}, {}
+    _stub_gh(monkeypatch, opened, issued, open_pr=99)
     routing = _write_routing(tmp_path)
     assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
-    assert "claude-haiku-4-5" in created["body"]
-    assert "claude-opus-4-8" in created["body"]
+    assert not opened  # deduped
 
 
-def test_main_stale_skips_when_issue_already_open(tmp_path, monkeypatch) -> None:
+def test_main_dry_run_opens_nothing(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    monkeypatch.setattr(
-        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
-    )
-    monkeypatch.setattr(mod, "find_open_issue", lambda repo, title: 42)
-    called = {"create": 0}
-    monkeypatch.setattr(
-        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
-    )
-    routing = _write_routing(tmp_path)
-    assert mod.main(["--repo", "o/r", "--routing", str(routing)]) == 0
-    assert called["create"] == 0
-
-
-def test_main_dry_run_never_files(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    monkeypatch.setattr(
-        mod, "fetch_live_model_ids", lambda base, key: ["claude-sonnet-5"]
-    )
-    called = {"create": 0}
-    monkeypatch.setattr(
-        mod, "create_issue", lambda *a, **k: called.__setitem__("create", 1)
-    )
+    opened, issued = {}, {}
+    _stub_gh(monkeypatch, opened, issued)
     routing = _write_routing(tmp_path)
     assert mod.main(["--repo", "o/r", "--routing", str(routing), "--dry-run"]) == 0
-    assert called["create"] == 0
+    assert not opened and not issued
+
+
+def test_main_files_issue_when_family_gone(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    opened, issued = {}, {}
+    _stub_gh(monkeypatch, opened, issued)
+    # A pin whose family has no live member at all.
+    p = tmp_path / "model-routing.json"
+    p.write_text(json.dumps({"high": "claude-fable-5"}), encoding="utf-8")
+    assert mod.main(["--repo", "o/r", "--routing", str(p)]) == 0
+    assert "claude-fable-5" in issued["body"]
+    assert not opened
+
+
+def test_main_all_latest_does_nothing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    opened, issued = {}, {}
+    _stub_gh(monkeypatch, opened, issued)
+    p = tmp_path / "model-routing.json"
+    p.write_text(
+        json.dumps({"high": "claude-opus-4-8", "medium": "claude-sonnet-5"}),
+        encoding="utf-8",
+    )
+    assert mod.main(["--repo", "o/r", "--routing", str(p)]) == 0
+    assert not opened and not issued


### PR DESCRIPTION
## What

Evolves the weekly model-staleness action (#1271) from **issue-filing-only** to **proactively keeping `model-routing.json` on the latest version of each family**.

## How

For each pinned ID, `scripts/check_model_staleness.py` now:
1. Derives the **family** — tier word, version digits removed (`claude-opus-4-8` → `opus`; `claude-3-7-sonnet-20250219` → `sonnet`).
2. Finds the newest live family member, ranked by the Models API **`created_at`** (not version-digit parsing — the old `claude-3-haiku-20240307` naming puts the number first and mis-sorts).
3. When newer than the pin, opens a **deduped** PR (stable per-target branch, supersedes older bump PRs) repointing `model-routing.json` via a formatting-preserving text rewrite. The commit is created through the GitHub GraphQL API (`createCommitOnBranch`) so it's **verified/signed** for the branch ruleset.
4. Only when a family has **no live successor at all**, falls back to the existing deduped tracking issue.

## Auth (answering the earlier question)

The workflow mints a token from the **release-bot GitHub App** (`RELEASE_BOT_CLIENT_ID` / `RELEASE_BOT_PRIVATE_KEY`) — the same identity release-please uses. That's what lets the bump PR trigger the required `pull_request` checks (a `GITHUB_TOKEN`-authored PR wouldn't), with no new secret. `TELEMETRY_DEPLOY_KEY` was rejected: it's a read-only SSH deploy key, which can't call the API or open PRs.

## Behaviour notes

- **Proactive**: opens a PR whenever a newer version exists (chosen scope), not only on retirement.
- **Trigger**: Sundays 13:00 UTC + `workflow_dispatch` (Run-workflow button / `gh workflow run model-staleness.yml`).

## Verification

`ruff check`/`format` clean; `pytest tests/scripts/test_check_model_staleness.py` — **16 passed**; full `scripts/ci-local.sh` green on push (3888 passed, 1 pre-existing skip). Workflow YAML parses.

Closes #1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)