### PR TITLE
docs: supersede ADR 0024 to allow versioned model IDs; relax routing test

### DIFF
--- a/docs/adr/0024-keep-single-model-routing-map-keyed-by-canonical-model-ids.md
+++ b/docs/adr/0024-keep-single-model-routing-map-keyed-by-canonical-model-ids.md
@@ -4,7 +4,7 @@ Date: 2026-07-20
 
 ## Status
 
-Accepted
+Accepted. The "uniform bare-canonical ID / no dated snapshot suffix" clause is superseded by [ADR 0025](0025-allow-versioned-model-ids-in-routing-map.md) (versioned/dated IDs are now allowed); the single-map, keyed-by-concrete-ID, and no-second-table decisions below still stand.
 
 Relates to [8. Use effort bands instead of model names in agent frontmatter](0008-use-effort-bands-instead-of-model-names-in-agent-frontmatter.md)
 

--- a/docs/adr/0025-allow-versioned-model-ids-in-routing-map.md
+++ b/docs/adr/0025-allow-versioned-model-ids-in-routing-map.md
@@ -1,0 +1,32 @@
+# 25. Allow versioned (dated-snapshot) model IDs in the routing map
+
+Date: 2026-07-21
+
+## Status
+
+Accepted. Supersedes the "uniform bare-canonical ID / no dated snapshot suffix" clause of [ADR 0024](0024-keep-single-model-routing-map-keyed-by-canonical-model-ids.md); ADR 0024's other decisions (one map, keyed by concrete IDs rather than generic aliases, no separate snapshot-bookkeeping table) still stand.
+
+## Context
+
+[ADR 0024](0024-keep-single-model-routing-map-keyed-by-canonical-model-ids.md) required every value in `knowledge/model-routing.json` to be a **bare canonical model ID with no dated snapshot suffix**, and dropped `claude-haiku-4-5-20251001` to `claude-haiku-4-5` to make the map uniform.
+
+The model-staleness action (#1275, shipped in #1276) now reconciles the map against the live catalog and pins the newest member of each family. It reads `GET /v1/models`, whose `id` values are **not uniform**: some models are returned as dated snapshots (`claude-haiku-4-5-20251001`), while the 5-family models (`claude-sonnet-5`, `claude-opus-4-8`) have no dated public form and come back bare. Honoring ADR 0024's uniformity clause would force the bot to strip a trailing `-YYYYMMDD` from every ID before writing — a normalization step that re-litigates which spelling is "canonical" for no functional gain.
+
+Nothing downstream needs the uniformity:
+
+- **Dispatch** — `hooks/agent_model_resolve.py` reduces the map's ID to a bare dispatch alias (`haiku|sonnet|opus`) before the Agent/Task tool sees it (#1178), so a dated ID and a bare ID dispatch identically.
+- **Calibration** — `claude -p --model <id>` accepts a concrete dated ID as readily as a bare one.
+- **Pricing / bump log** — already key by full snapshot IDs (see the note in ADR 0024's context).
+
+## Decision
+
+**Allow each band's value to be either a bare canonical ID or a dated snapshot ID** — whatever `GET /v1/models` returns as the current newest member of that family. The map is no longer required to be uniform in shape.
+
+The staleness bot therefore writes the Models API `id` verbatim; there is no suffix-stripping step. In practice this means the 5-family models stay bare (no dated form exists) while dated-snapshot models are pinned with their date — a mixed map is now expected, not a defect.
+
+## Consequences
+
+- **`test_model_routing_defaults.py` asserts family, not exact ID.** Each band must resolve to the right family name (the tier word with all version digits removed: `low`→`haiku`, `medium`→`sonnet`, `high`→`opus`) and be a `claude-*` string. It no longer pins an exact version or spelling, so a routine version bump does not break the suite.
+- **`test_no_pinned_snapshots.py` is unaffected** — it already exempts `model-routing.json` (the single source of truth is where a pinned snapshot is *supposed* to live).
+- **The 5-family / dated-family split is permanent and expected.** The map will look mixed; that is the Models API's shape, not drift to correct.
+- **ADR 0024 otherwise stands.** One map, keyed by concrete model IDs (not generic aliases), with no second snapshot table — all unchanged. Only the uniform-shape requirement is lifted.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@
 * [22. Reject the delegation-only sweep — delegation must earn its measured overhead](0022-reject-delegation-only-sweep-dispatch.md)
 * [23. Calibrate agent effort bands from the #1184 eval baseline](0023-calibrate-effort-bands-from-the-1184-eval-baseline.md)
 * [24. Keep the single model-routing map keyed by canonical model IDs](0024-keep-single-model-routing-map-keyed-by-canonical-model-ids.md)
+* [25. Allow versioned (dated-snapshot) model IDs in the routing map](0025-allow-versioned-model-ids-in-routing-map.md)

--- a/plugins/dev-team/docs/model-routing.md
+++ b/plugins/dev-team/docs/model-routing.md
@@ -131,14 +131,15 @@ routing map and bump log keep full IDs for ladder/pricing purposes.
 
 Resolution inputs:
 
-- `knowledge/model-routing.json` (shipped): the band → **canonical model ID
-  default map** (`low/medium/high`) plus legacy `haiku/sonnet/opus` keys
-  retained for the deprecation window, and the pinned ladder `rounding`
-  convention. Every value is a bare canonical model ID (`claude-haiku-4-5`,
-  `claude-sonnet-5`, `claude-opus-4-8`) — no dated snapshot suffix; the
-  5-family IDs have no dated public form, and the older IDs use their bare
-  canonical spelling to match. The default map preserves the pre-migration
-  tier mapping, so zero-config behavior is unchanged.
+- `knowledge/model-routing.json` (shipped): the band → **model ID default
+  map** (`low/medium/high`) plus the pinned ladder `rounding` convention. Each
+  value is a concrete model ID for that family — either a bare canonical ID
+  (`claude-sonnet-5`, `claude-opus-4-8`) or a dated snapshot
+  (`claude-haiku-4-5-20251001`), whichever the Models API returns as the
+  family's current newest. The map is deliberately mixed-shape: the 5-family
+  IDs have no dated public form, while other models are pinned with their
+  snapshot date. The default map preserves the pre-migration tier mapping, so
+  zero-config behavior is unchanged.
 - `.claude/model-ladder.json` (per-environment, gitignored): an optional,
   capability-ascending JSON array of the models that environment has. When
   present and valid it **overrides** the default map.

--- a/tests/knowledge/test_model_routing_defaults.py
+++ b/tests/knowledge/test_model_routing_defaults.py
@@ -2,10 +2,13 @@
 source of truth for effort band → model resolution defaults.
 
 (precondition): the routing.json file is the ONLY in-tree place that ships
-a concrete model ID, and it pins the ladder rounding convention. Every value
-is a bare canonical model ID (no dated snapshot suffix) — see ADR 0024. Every
-dispatch flows through it. The legacy tier keys (haiku/sonnet/opus) were
-dropped: the resolver normalizes those tokens to bands (low/medium/high) in
+a concrete model ID, and it pins the ladder rounding convention. Each band
+value is a concrete model ID for the right family; per ADR 0025 it may be a
+bare canonical ID OR a dated snapshot (the map is deliberately mixed-shape,
+since the staleness bot pins whatever the Models API returns), so these tests
+assert the family NAME (tier word, version digits stripped) — not an exact
+version. The legacy tier keys (haiku/sonnet/opus) were dropped: the resolver
+normalizes those tokens to bands (low/medium/high) in
 model_resolve.normalize_band() *before* the JSON lookup, so the alias keys
 were dead — never dereferenced.
 
@@ -46,19 +49,30 @@ def test_model_routing_json_contains_only_bands_and_rounding(data: dict) -> None
     ]
 
 
-# --- Effort band defaults (the post-migration vocabulary) ------------------
+# --- Effort band families (version-agnostic — see ADR 0025) ----------------
 
 
-def test_low_band_maps_to_unpinned_canonical_haiku_id(data: dict) -> None:
-    assert data["low"] == "claude-haiku-4-5"
+def _family(model_id: str) -> str:
+    """The tier word of a model ID with `claude-` and all version digits removed.
+
+    `claude-opus-4-8` -> `opus`; `claude-haiku-4-5-20251001` -> `haiku`. This
+    is what lets the assertions below tolerate any version (bare or dated).
+    """
+    return "-".join(
+        tok
+        for tok in model_id.split("-")
+        if tok != "claude" and tok and not tok.isdigit()
+    )
 
 
-def test_medium_band_maps_to_unpinned_canonical_sonnet_id(data: dict) -> None:
-    assert data["medium"] == "claude-sonnet-5"
-
-
-def test_high_band_maps_to_unpinned_canonical_opus_id(data: dict) -> None:
-    assert data["high"] == "claude-opus-4-8"
+@pytest.mark.parametrize(
+    "band,family",
+    [("low", "haiku"), ("medium", "sonnet"), ("high", "opus")],
+)
+def test_band_resolves_to_expected_family(data: dict, band: str, family: str) -> None:
+    value = data[band]
+    assert value.startswith("claude-")
+    assert _family(value) == family
 
 
 # --- legacy tier keys are gone --------------------------------------------


### PR DESCRIPTION
## Why

The pin-latest staleness bot (#1275, shipped in #1276) pins whatever `GET /v1/models` returns as each family's newest — which is a **dated snapshot** for some models (`claude-haiku-4-5-20251001`) and bare for others. That's the mixed shape ADR 0024 had banned, and it tripped the exact-equality routing test:

```
AssertionError: assert 'claude-haiku-4-5-20251001' == 'claude-haiku-4-5'
```

Per your call, we relax the rule rather than make the bot strip suffixes.

## Changes

- **ADR 0025** (new) supersedes *only* ADR 0024's "uniform bare-canonical / no dated suffix" clause — dated/versioned IDs are now allowed. ADR 0024's other decisions (one map, keyed by concrete IDs, no second table) still stand; its status is annotated and it's added to the ADR index.
- **`test_model_routing_defaults.py`** asserts each band resolves to the right **family name** — tier word with version digits stripped (`low`→`haiku`, `medium`→`sonnet`, `high`→`opus`) — and a `claude-*` string, not an exact ID. Tolerates bare, dated, and old-scheme (`claude-3-7-sonnet-…`) IDs.
- **`model-routing.md`** prose corrected: dated IDs allowed / map is intentionally mixed-shape; also drops the now-false "legacy `haiku/sonnet/opus` keys retained" line (removed in #1269).

## Why relax, not normalize

Dispatch tolerates either shape: the resolver hook reduces the map ID to an alias before the Agent/Task param (#1178), calibration uses the concrete ID, and pricing/ladder already keep full IDs. Forcing the bot to strip `-YYYYMMDD` was pure normalization with no downstream benefit.

## Verification

`ruff` clean; `pytest tests/knowledge/test_model_routing_defaults.py` — 9 passed; `tests/docs tests/repo tests/knowledge` — 689 passed; `check_md_references.py` clean.

Closes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)