### PR TITLE
feat: add agent-contract validator for frontmatter compliance

### DIFF
--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -115,6 +115,15 @@ review agents. Check:
      declares a legacy `model: haiku|sonnet|opus` tier in frontmatter, WARN
      that the tier name is deprecated and name the band to use
      (`haiku` → `low`, `sonnet` → `medium`, `opus` → `high`)
+   - **Full contract check**: for the complete official-contract validation
+     (required fields, `name` pattern, enum membership on any field present —
+     `model`, `effort`, `permissionMode`, `memory`, `isolation`, `color`,
+     `background`, `maxTurns` — unknown/misspelled-key warnings, and a
+     plugin-ignored-field warning for `hooks`/`mcpServers`/`permissionMode`),
+     run `python3 scripts/validate_agent_contract.py <file>` and fold any
+     `error`/`warning` finding into the report as FAIL/WARN. This runs
+     alongside the band check above until a later slice migrates agents to
+     native `model:`/`effort: high` frontmatter and retires the band itself.
 
 9. **Context needs**: Does the agent declare a `Context needs:` field?
    - All agents MUST declare what input context they need

--- a/plugins/marketplace-dev/knowledge/agent-contract.json
+++ b/plugins/marketplace-dev/knowledge/agent-contract.json
@@ -1,0 +1,201 @@
+{
+    "source": "https://code.claude.com/docs/en/sub-agents#supported-frontmatter-fields",
+    "retrieved": "2026-07-22",
+    "scope": "Claude Code subagent definitions (.claude/agents/*.md and ~/.claude/agents/*.md)",
+    "required_fields": [
+        "name",
+        "description"
+    ],
+    "notes": [
+        "Only name and description are required; all other fields are optional.",
+        "Misspelled frontmatter keys are ignored silently (no error) \u2014 they do not take effect.",
+        "The markdown body below the frontmatter becomes the agent's system prompt.",
+        "Plugin-supplied subagents ignore the hooks, mcpServers, and permissionMode fields.",
+        "Fields with open value sets (tools, model full IDs) list examples/patterns rather than a closed enum.",
+        "effort's usable values depend on the chosen model \u2014 cross-check against model_efforts.json."
+    ],
+    "fields": {
+        "name": {
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+            "enum": null,
+            "default": null,
+            "description": "Unique identifier using lowercase letters and hyphens. Filename need not match; hooks receive this value as agent_type."
+        },
+        "description": {
+            "required": true,
+            "type": "string",
+            "enum": null,
+            "default": null,
+            "description": "When Claude should delegate to this subagent. Drives automatic delegation; be concrete about triggering conditions."
+        },
+        "tools": {
+            "required": false,
+            "type": "string_or_list",
+            "value_format": "Comma-separated string (e.g. 'Read, Grep, Glob, Bash') or YAML list.",
+            "valid_values": [
+                "Tool names, e.g. Read, Write, Edit, Grep, Glob, Bash",
+                "Agent (allow spawning any subagent) or Agent(type1, type2) (allowlist)",
+                "MCP patterns: mcp__<server> or mcp__<server>__*"
+            ],
+            "enum": null,
+            "default": "inherits all tools available in the main conversation",
+            "description": "Strict allowlist of tools the subagent may use. If no entry resolves to a real tool, the subagent fails to launch. Use the skills field to preload skills rather than listing Skill here."
+        },
+        "disallowedTools": {
+            "required": false,
+            "type": "string_or_list",
+            "value_format": "Comma-separated string or YAML list.",
+            "valid_values": [
+                "Tool names, e.g. Write, Edit",
+                "MCP patterns: mcp__<server>, mcp__<server>__*, or mcp__* (all MCP tools)"
+            ],
+            "enum": null,
+            "default": null,
+            "description": "Denylist of tools, removed from the inherited or specified set. Applied before tools is resolved."
+        },
+        "model": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "sonnet",
+                "opus",
+                "haiku",
+                "fable",
+                "inherit"
+            ],
+            "also_accepts": "A full model ID such as claude-opus-4-8 or claude-sonnet-5 (same values as the --model flag).",
+            "default": "inherit",
+            "description": "Model the subagent runs on: an alias, a full model ID, or inherit (use the main conversation's model)."
+        },
+        "effort": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+            ],
+            "default": "inherits from session",
+            "description": "Reasoning/effort level while this subagent is active; overrides the session effort level. Available levels depend on the model (see model_efforts.json). 'ultracode' is a Claude Code menu concept, not a valid frontmatter value."
+        },
+        "permissionMode": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "default",
+                "acceptEdits",
+                "auto",
+                "dontAsk",
+                "bypassPermissions",
+                "plan",
+                "manual"
+            ],
+            "enum_notes": {
+                "manual": "Alias for default; requires Claude Code v2.1.200 or later."
+            },
+            "default": "default",
+            "description": "How the subagent handles permission prompts. Ignored for plugin subagents. A parent using bypassPermissions, acceptEdits, or auto takes precedence and cannot be overridden."
+        },
+        "maxTurns": {
+            "required": false,
+            "type": "integer",
+            "enum": null,
+            "default": null,
+            "description": "Maximum number of agentic turns before the subagent stops."
+        },
+        "skills": {
+            "required": false,
+            "type": "list",
+            "item_type": "string",
+            "enum": null,
+            "default": null,
+            "description": "Skill names to preload into the subagent's context at startup (full skill content is injected). Cannot preload skills that set disable-model-invocation: true."
+        },
+        "mcpServers": {
+            "required": false,
+            "type": "list",
+            "item_type": "string_or_object",
+            "value_format": "Each entry is either a string naming an already-configured server, or an inline server definition object keyed by server name.",
+            "inline_server_types": [
+                "stdio",
+                "http",
+                "sse",
+                "ws"
+            ],
+            "enum": null,
+            "default": null,
+            "description": "MCP servers scoped to this subagent. Ignored for plugin subagents."
+        },
+        "hooks": {
+            "required": false,
+            "type": "object",
+            "value_format": "Object keyed by hook event; each event maps to a list of { matcher, hooks: [{ type, command }] } entries.",
+            "hook_events": [
+                "PreToolUse",
+                "PostToolUse",
+                "Stop"
+            ],
+            "hook_entry_type": "command",
+            "enum": null,
+            "default": null,
+            "description": "Lifecycle hooks scoped to this subagent. All hook events are supported; the listed ones are most common. Stop is converted to SubagentStop at runtime. Ignored for plugin subagents."
+        },
+        "memory": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "user",
+                "project",
+                "local"
+            ],
+            "default": null,
+            "description": "Persistent memory scope enabling cross-session learning. Enables Read/Write/Edit tools automatically so the subagent can manage its memory files."
+        },
+        "background": {
+            "required": false,
+            "type": "boolean",
+            "enum": [
+                true,
+                false
+            ],
+            "default": "unset (Claude decides; runs in background by default as of v2.1.198)",
+            "description": "Set to true to always run this subagent as a background task, even when Claude needs its result right away."
+        },
+        "isolation": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "worktree"
+            ],
+            "default": "unset (no isolation)",
+            "description": "Set to worktree to run the subagent in a temporary git worktree with an isolated copy of the repository. 'worktree' is the only valid value; omit the field entirely for no isolation."
+        },
+        "color": {
+            "required": false,
+            "type": "string",
+            "enum": [
+                "red",
+                "blue",
+                "green",
+                "yellow",
+                "purple",
+                "orange",
+                "pink",
+                "cyan"
+            ],
+            "default": null,
+            "description": "Display color for the subagent in the task list and transcript."
+        },
+        "initialPrompt": {
+            "required": false,
+            "type": "string",
+            "enum": null,
+            "default": null,
+            "description": "Auto-submitted as the first user turn when this agent runs as the main session agent (via --agent or the agent setting). Commands and skills are processed; prepended to any user-provided prompt."
+        }
+    }
+}

--- a/plugins/marketplace-dev/scripts/validate_agent_contract.py
+++ b/plugins/marketplace-dev/scripts/validate_agent_contract.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""validate_agent_contract.py — validate agent frontmatter against the
+official Claude Code sub-agent contract (knowledge/agent-contract.json).
+
+Self-contained and stdlib-only so marketplace-dev stays installable on its
+own, with no dependency on dev-team's tooling or PyYAML. Frontmatter in this
+repo's agent files is flat scalars/comma-lists (never nested YAML mappings),
+so a small line-based parser is enough — no real YAML parser needed.
+
+Checks (schema-driven from agent-contract.json, not hardcoded, so a contract
+update can't silently drift out of sync with this script):
+  - required fields (name, description) present and non-empty
+  - name matches the contract's name pattern
+  - every top-level frontmatter key is a known contract field (unknown/
+    misspelled keys are warned on — the contract notes they are silently
+    ignored, never erroring, so this script never fails on them)
+  - enum-valued fields (model, effort, permissionMode, memory, isolation,
+    color) validated against the contract's enum when present; `model` also
+    accepts a full `claude-*` ID or the literal alias set
+  - boolean/integer-typed fields (background, maxTurns) type-checked
+  - hooks/mcpServers/permissionMode on a plugins/*/agents/*.md file warn —
+    the contract states plugin-supplied subagents ignore all three
+
+Exit codes (matches this repo's other structural-check scripts):
+  0 = pass, 1 = fail (errors present), 2 = warn (warnings only)
+
+CLI usage:
+  python3 validate_agent_contract.py <agent.md> [<agent.md> ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_DEFAULT_CONTRACT = _SCRIPT_DIR / ".." / "knowledge" / "agent-contract.json"
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*):(.*)$")
+_FULL_MODEL_ID_RE = re.compile(r"^claude-[a-z0-9-]+$")
+_PLUGIN_AGENT_PATH_RE = re.compile(r"plugins/[^/]+/agents/[^/]+\.md$")
+
+
+def _contract_path() -> Path:
+    return Path(os.environ.get("AGENT_CONTRACT_JSON", str(_DEFAULT_CONTRACT)))
+
+
+def load_contract(path: Optional[Path] = None) -> Optional[dict]:
+    path = path or _contract_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _strip_value(raw: str) -> str:
+    return raw.strip().strip("'\"")
+
+
+def parse_frontmatter(text: str) -> Dict[str, str]:
+    """Return {top-level key: raw scalar value} from a markdown file's
+    frontmatter. Indented continuation/list lines are ignored — this script
+    only validates scalar fields, and every field it checks is a scalar in
+    this repo's convention."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: Dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if line.startswith((" ", "\t")):
+            continue
+        m = _TOP_LEVEL_KEY_RE.match(line)
+        if m:
+            fields[m.group(1)] = _strip_value(m.group(2))
+    return fields
+
+
+def make_issue(severity: str, file: str, message: str, field: str = "") -> dict:
+    issue = {"severity": severity, "file": file, "message": message}
+    if field:
+        issue["field"] = field
+    return issue
+
+
+def _check_required_and_pattern(
+    fields: Dict[str, str], contract: dict, file: str
+) -> List[dict]:
+    issues: List[dict] = []
+    for name, spec in contract.get("fields", {}).items():
+        if not spec.get("required"):
+            continue
+        value = fields.get(name)
+        if not value:
+            issues.append(
+                make_issue(
+                    "error",
+                    file,
+                    f"Missing required frontmatter field '{name}'",
+                    field=name,
+                )
+            )
+    name_spec = contract.get("fields", {}).get("name", {})
+    pattern = name_spec.get("pattern")
+    if pattern and fields.get("name") and not re.match(pattern, fields["name"]):
+        issues.append(
+            make_issue(
+                "error",
+                file,
+                f"name '{fields['name']}' does not match required pattern '{pattern}'",
+                field="name",
+            )
+        )
+    return issues
+
+
+def _check_unknown_keys(fields: Dict[str, str], contract: dict, file: str) -> List[dict]:
+    known = set(contract.get("fields", {}).keys())
+    issues = []
+    for key in fields:
+        if key not in known:
+            issues.append(
+                make_issue(
+                    "warning",
+                    file,
+                    f"Unknown frontmatter key '{key}' — per the contract, unrecognized "
+                    "keys are silently ignored (no error) and take no effect.",
+                    field=key,
+                )
+            )
+    return issues
+
+
+def _model_is_valid(value: str, enum: List[str]) -> bool:
+    return value in enum or bool(_FULL_MODEL_ID_RE.match(value))
+
+
+def _check_enum_and_type_fields(
+    fields: Dict[str, str], contract: dict, file: str
+) -> List[dict]:
+    issues: List[dict] = []
+    for name, spec in contract.get("fields", {}).items():
+        if name not in fields:
+            continue
+        value = fields[name]
+        enum = spec.get("enum")
+        field_type = spec.get("type")
+        if name == "model" and enum:
+            if not _model_is_valid(value, enum):
+                issues.append(
+                    make_issue(
+                        "error",
+                        file,
+                        f"model '{value}' is not one of {enum} and does not look like "
+                        "a full claude-* model ID",
+                        field=name,
+                    )
+                )
+        elif enum:
+            if value not in [str(v) for v in enum]:
+                issues.append(
+                    make_issue(
+                        "error",
+                        file,
+                        f"{name} '{value}' must be one of {enum}",
+                        field=name,
+                    )
+                )
+        elif field_type == "boolean" and value not in ("true", "false"):
+            issues.append(
+                make_issue(
+                    "error",
+                    file,
+                    f"{name} '{value}' must be a boolean (true/false)",
+                    field=name,
+                )
+            )
+        elif field_type == "integer" and not value.lstrip("-").isdigit():
+            issues.append(
+                make_issue(
+                    "error",
+                    file,
+                    f"{name} '{value}' must be an integer",
+                    field=name,
+                )
+            )
+    return issues
+
+
+def _check_plugin_ignored_fields(fields: Dict[str, str], file: str) -> List[dict]:
+    if not _PLUGIN_AGENT_PATH_RE.search(file.replace(os.sep, "/")):
+        return []
+    issues = []
+    for name in ("hooks", "mcpServers", "permissionMode"):
+        if name in fields:
+            issues.append(
+                make_issue(
+                    "warning",
+                    file,
+                    f"'{name}' is ignored for plugin-supplied sub-agents per the "
+                    "contract — this field has no effect here.",
+                    field=name,
+                )
+            )
+    return issues
+
+
+def validate_file(path: Path, contract: dict) -> List[dict]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [make_issue("error", str(path), f"Could not read file: {exc}")]
+
+    fields = parse_frontmatter(text)
+    file = str(path)
+    if not fields:
+        return [make_issue("error", file, "Could not find or parse YAML frontmatter")]
+
+    issues: List[dict] = []
+    issues += _check_required_and_pattern(fields, contract, file)
+    issues += _check_unknown_keys(fields, contract, file)
+    issues += _check_enum_and_type_fields(fields, contract, file)
+    issues += _check_plugin_ignored_fields(fields, file)
+    return issues
+
+
+def build_result(issues: List[dict]) -> dict:
+    errors = [i for i in issues if i["severity"] == "error"]
+    warnings = [i for i in issues if i["severity"] == "warning"]
+    if errors:
+        status = "fail"
+    elif warnings:
+        status = "warn"
+    else:
+        status = "pass"
+    return {"status": status, "issues": issues, "summary": ""}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate agent frontmatter against the official contract."
+    )
+    parser.add_argument("files", nargs="+", help="Agent markdown file(s) to validate")
+    args = parser.parse_args(argv)
+
+    contract = load_contract()
+    if contract is None:
+        sys.stderr.write(f"Contract file not found or invalid: {_contract_path()}\n")
+        return 1
+
+    all_issues: List[dict] = []
+    for file_arg in args.files:
+        all_issues += validate_file(Path(file_arg), contract)
+
+    result = build_result(all_issues)
+    print(json.dumps(result))
+    if result["status"] == "fail":
+        return 1
+    if result["status"] == "warn":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/marketplace-dev/skills/plugin-audit/SKILL.md
+++ b/plugins/marketplace-dev/skills/plugin-audit/SKILL.md
@@ -62,7 +62,14 @@ For every agent file:
 
 1. **Frontmatter compliance** — `name`, `description`, and `effort` (one of
    `low|medium|high`) are present; `tools` present. FAIL if `name`/`description`
-   missing or `effort` absent/invalid.
+   missing or `effort` absent/invalid. For the full official-contract check
+   (required fields, name pattern, enum membership on any field present —
+   `model`, `permissionMode`, `memory`, `isolation`, `color`, `background`,
+   `maxTurns` — unknown-key and plugin-ignored-field warnings), run
+   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_agent_contract.py <file>`
+   and fold any `error`/`warning` finding into this table as FAIL/WARN. This
+   is advisory alongside the checks above until a future slice retires the
+   effort-band requirement in favor of the contract's own defaults.
 2. **No colon in `description`** — the value must not contain `:` (breaks
    argument-hints). FAIL on a colon.
 3. **Skills–Skill invariant** — if the body has a `## Skills` heading, `tools:`

--- a/scripts/claude_setup_review.py
+++ b/scripts/claude_setup_review.py
@@ -4,7 +4,7 @@ Checks:
   - CLAUDE.md present in plugin root
   - Agent frontmatter: required fields (name, description, effort)
   - Effort value membership in VALID_EFFORT
-  - Unsupported top-level fields (model → warning)
+  - Unsupported top-level fields (hooks/mcpServers/permissionMode → warning)
   - Filename kebab-case convention
   - name field matches filename stem
   - Path references in CLAUDE.md exist on disk (with file+line)
@@ -40,8 +40,11 @@ REQUIRED_FIELDS: List[str] = ["name", "description", "effort"]
 VALID_EFFORT: List[str] = ["low", "medium", "high"]
 
 # Fields that are valid in native Claude Code agents but silently ignored
-# when an agent is shipped as part of a plugin — warn, do not error.
-UNSUPPORTED_FIELDS: List[str] = ["model", "hooks", "mcpServers", "permissionMode"]
+# when an agent is shipped as part of a plugin — warn, do not error. `model`
+# is NOT in this list: per the verified contract (agent-contract.json), a
+# plugin agent's `model:` alias/full-ID/inherit value is honored normally —
+# only hooks/mcpServers/permissionMode are ignored for plugin-supplied agents.
+UNSUPPORTED_FIELDS: List[str] = ["hooks", "mcpServers", "permissionMode"]
 
 # Regex for valid kebab-case agent filenames (e.g. my-agent.md)
 KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*\.md$")

--- a/scripts/validate_agent_contract.py
+++ b/scripts/validate_agent_contract.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""validate_agent_contract.py — repo-root wrapper for dev-team's own
+self-audit (used by /agent-audit). The one real implementation ships with
+marketplace-dev (plugins/marketplace-dev/scripts/validate_agent_contract.py)
+so it stays installable standalone in other repos; this wrapper just imports
+it, mirroring the sys.path pattern hooks/agent_model_resolve.py already uses
+for its sibling lib — one implementation, no drift between two copies.
+
+CLI usage:
+  python3 scripts/validate_agent_contract.py <agent.md> [<agent.md> ...]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_MARKETPLACE_DEV_SCRIPTS = (
+    Path(__file__).resolve().parent
+    / ".."
+    / "plugins"
+    / "marketplace-dev"
+    / "scripts"
+)
+
+if str(_MARKETPLACE_DEV_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_MARKETPLACE_DEV_SCRIPTS))
+
+from validate_agent_contract import main  # type: ignore[import-not-found]  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repo/test_no_pinned_snapshots.py
+++ b/tests/repo/test_no_pinned_snapshots.py
@@ -29,12 +29,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 #   knowledge/model-pricing.json - cost meter's pricing table (#102); must key
 #     by model snapshot because the transcript usage records emit snapshot
 #     IDs.
+#   marketplace-dev/knowledge/agent-contract.json - a verbatim capture of
+#     Anthropic's own sub-agent frontmatter docs (#1285); its `model` field's
+#     `also_accepts` value quotes their doc's own illustrative snapshot
+#     examples. Same "illustrative examples" exemption reason as
+#     docs/model-routing.md — editing the quote would break its fidelity as
+#     a verbatim contract capture.
 ALLOWED_PATHS = [
     "plugins/dev-team/knowledge/model-routing.json",
     "plugins/dev-team/docs/model-routing.md",
     "plugins/dev-team/docs/model-routing-overrides.md",
     "plugins/dev-team/templates/agents/agent-template.md",
     "plugins/dev-team/knowledge/model-pricing.json",
+    "plugins/marketplace-dev/knowledge/agent-contract.json",
 ]
 
 _SNAPSHOT_RE = re.compile(r"claude-(haiku|sonnet|opus)-[0-9]")

--- a/tests/repo/test_validate_agent_contract.py
+++ b/tests/repo/test_validate_agent_contract.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/validate_agent_contract.py — the official Claude Code
+sub-agent frontmatter contract validator (agent-contract.json), issue #1285.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validate_agent_contract.py"
+
+
+def run_validator(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "LANG": "C.UTF-8"},
+    )
+
+
+def write_agent(path: Path, frontmatter: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}\n---\n\nBody.\n")
+    return path
+
+
+def test_valid_agent_passes_clean(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\ntools: Read, Grep\neffort: high",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 0, result.stdout
+    data = json.loads(result.stdout)
+    assert data["status"] == "pass", data
+
+
+def test_missing_name_is_error(tmp_path: Path) -> None:
+    agent = write_agent(tmp_path / "my-agent.md", "description: does stuff")
+    result = run_validator(str(agent))
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["status"] == "fail", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("name" in m for m in msgs), msgs
+
+
+def test_missing_description_is_error(tmp_path: Path) -> None:
+    agent = write_agent(tmp_path / "my-agent.md", "name: my-agent")
+    result = run_validator(str(agent))
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["status"] == "fail", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("description" in m for m in msgs), msgs
+
+
+def test_bad_name_pattern_is_error(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: My_Agent\ndescription: does stuff",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["status"] == "fail", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("pattern" in m for m in msgs), msgs
+
+
+def test_unknown_frontmatter_key_is_warning(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\neffrot: high",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 2
+    data = json.loads(result.stdout)
+    assert data["status"] == "warn", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("effrot" in m for m in msgs), msgs
+
+
+def test_invalid_effort_value_is_error(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\neffort: ultra",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["status"] == "fail", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("effort" in m for m in msgs), msgs
+
+
+def test_model_alias_is_valid(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\nmodel: opus",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 0, result.stdout
+
+
+def test_model_full_id_is_valid(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\nmodel: claude-opus-4-8",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 0, result.stdout
+
+
+def test_model_unrecognized_value_is_error(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\nmodel: gpt-4",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["status"] == "fail", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("model" in m for m in msgs), msgs
+
+
+def test_hooks_on_plugin_agent_is_warning(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "plugins" / "test-plugin" / "agents" / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\nhooks: {}",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 2
+    data = json.loads(result.stdout)
+    assert data["status"] == "warn", data
+    msgs = [i["message"] for i in data["issues"]]
+    assert any("hooks" in m and "ignored" in m for m in msgs), msgs
+
+
+def test_hooks_outside_plugin_agents_path_is_not_flagged(tmp_path: Path) -> None:
+    agent = write_agent(
+        tmp_path / "my-agent.md",
+        "name: my-agent\ndescription: does stuff\nhooks: {}",
+    )
+    result = run_validator(str(agent))
+    assert result.returncode == 0, result.stdout
+
+
+def test_no_findings_against_a_real_shipped_agent() -> None:
+    """A real agent already in the repo should not raise a false positive —
+    guards against the validator drifting out of sync with actual usage."""
+    agent = REPO_ROOT / "plugins" / "dev-team" / "agents" / "architect.md"
+    assert agent.exists()
+    result = run_validator(str(agent))
+    data = json.loads(result.stdout)
+    assert result.returncode == 0, data
+    assert data["status"] == "pass", data

--- a/tests/scripts/test_claude_setup_review.py
+++ b/tests/scripts/test_claude_setup_review.py
@@ -108,13 +108,32 @@ def test_1_1_invalid_effort_value_ultra_is_exit_1(plugin_root: Path) -> None:
     assert any("ultra" in m or "effort" in m for m in msgs), msgs
 
 
-def test_1_1_top_level_model_field_is_exit_2_with_warning_severity(
+def test_1_1_top_level_model_field_is_accepted_no_warning(
+    plugin_root: Path,
+) -> None:
+    """A plugin agent's `model:` is honored per the verified contract
+    (agent-contract.json) — only hooks/mcpServers/permissionMode are ignored
+    for plugin-supplied agents, so `model:` alone must not warn."""
+    make_valid_claude_md(plugin_root)
+    (plugin_root / "agents" / "my-agent.md").write_text(
+        "---\nname: my-agent\ndescription: does stuff\neffort: low\n"
+        "model: claude-opus-4-5\n---\n\nBody.\n"
+    )
+    result = run_review(plugin_root, "--skip-llm")
+    data = json.loads(result.stdout)
+    non_llm_issues = [
+        i for i in data["issues"] if "llm-skipped" not in i.get("rule_id", "")
+    ]
+    assert non_llm_issues == [], non_llm_issues
+
+
+def test_1_1_top_level_permission_mode_field_is_exit_2_with_warning_severity(
     plugin_root: Path,
 ) -> None:
     make_valid_claude_md(plugin_root)
     (plugin_root / "agents" / "my-agent.md").write_text(
         "---\nname: my-agent\ndescription: does stuff\neffort: low\n"
-        "model: claude-opus-4-5\n---\n\nBody.\n"
+        "permissionMode: acceptEdits\n---\n\nBody.\n"
     )
     result = run_review(plugin_root, "--skip-llm")
     assert result.returncode == 2


### PR DESCRIPTION
## Summary

Anthropic's own docs (captured verbatim in `plugins/marketplace-dev/knowledge/agent-contract.json`) confirm Claude Code sub-agents natively support `model:`/`effort:` frontmatter, resolved by the harness itself. This repo built a parallel band+hook resolver (`hooks/agent_model_resolve.py` + `knowledge/model-routing.json` + ladder + calibration) before that was verified — this is **slice 1 of 6** in retiring it (epic #1284): a schema-driven contract validator, additive and non-destructive. It does not touch the existing hook/ladder/calibration system or migrate any agent's frontmatter yet — those are sequenced sub-issues (#1286-#1290).

- `plugins/marketplace-dev/scripts/validate_agent_contract.py` — stdlib-only, validates any agent `.md` frontmatter against `agent-contract.json`'s schema (required fields, `name` pattern, enum membership on `model`/`effort`/`permissionMode`/`memory`/`isolation`/`color`/`background`, unknown-key warnings, and a warning that `hooks`/`mcpServers`/`permissionMode` are inert for plugin-supplied agents). Ships with `marketplace-dev` so it stays installable standalone.
- `scripts/validate_agent_contract.py` — thin repo-root wrapper for dev-team's own `/agent-audit`.
- Wired a pointer to the validator into `agent-audit` (check #8) and `plugin-audit` (Step 2.1) SKILL.md — additive alongside the existing band checks.
- Fixed `scripts/claude_setup_review.py`'s `UNSUPPORTED_FIELDS`, which incorrectly warned that `model:` is ignored for plugin agents — per the verified contract, only `hooks`/`mcpServers`/`permissionMode` are.
- Exempted `agent-contract.json`'s verbatim illustrative snapshot-ID example from the pinned-snapshot gate (same reasoning as `docs/model-routing.md`).

## Test plan
- [x] `pytest tests/repo/test_validate_agent_contract.py` — 12 new tests (valid pass, missing required fields, bad name pattern, unknown-key warning, invalid effort, model alias/full-ID/invalid, plugin-agent hooks warning, real-agent zero-findings regression)
- [x] `pytest tests/scripts/test_claude_setup_review.py` — updated for the `model:`/`permissionMode:` behavior swap
- [x] Full pre-push suite (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3901 passed, 1 skipped (pre-existing opt-in skip)
- [x] `scripts/check_registry_sync.py` and `scripts/check_md_references.py` — clean
- [x] `ruff check` on both new scripts — clean

Closes #1285
Part of #1284