### PR TITLE
feat: prefer CodeGraph/Repowise for gherkin-derive discovery and grounding

### DIFF
--- a/plugins/dev-team/skills/gherkin-derive/SKILL.md
+++ b/plugins/dev-team/skills/gherkin-derive/SKILL.md
@@ -75,12 +75,26 @@ order**, most authoritative first:
 Stop climbing the list once a surface is described by a higher-priority source —
 do not duplicate a route's scenarios from its tests.
 
+**Graph-assisted discovery.** If the target repo has `.codegraph/` (CodeGraph
+MCP server, `mcp__codegraph__codegraph_explore` — fast callers/callees/impact
+lookups) and/or a Repowise MCP server (`get_context`/`search_codebase` —
+verified context and semantic search), prefer them over raw `Grep` for
+locating routes, handlers, and exported signatures. Never assume either is
+present — fall back to `Read`/`Grep`/`Glob` when absent; the tools are simply
+unavailable (no error) on repos without an index.
+
 ## Step 3 — Author scenarios
 
 Use the same templates as `/gherkin-public`: **API Provider**, **UI**,
 **Batch / Scheduled Job**, **CLI / Library**, **API / Event Consumer**. Every
 scenario covers at least one success and one failure path, and every step is
 observable at the boundary — no internal calls.
+
+**Grounding failure scenarios.** When CodeGraph/Repowise are available, use
+`codegraph_explore` (or Repowise `get_context`/`search_codebase`) to inspect a
+surface's actual branches and error-handling depth before writing a failure
+scenario, rather than inferring it from the signature text alone. Falls back
+to reading the source directly when the tools are unavailable.
 
 **Label the provenance** in each `.feature` file header:
 


### PR DESCRIPTION
## Summary
- `gherkin-derive` derived surfaces and failure scenarios from raw grep/text reads only. Add graph-assisted discovery (Step 2) and failure-branch grounding (Step 3) that prefer `codegraph_explore` / Repowise `get_context`/`search_codebase` when available, falling back to Read/Grep/Glob otherwise.
- No `allowed-tools` frontmatter change: I checked precedent first (`code-review/SKILL.md`, the flagship graph-assisted skill) and found no skill anywhere in the repo declares `mcp__*` tools in `allowed-tools` — only *agents* gate MCP tools via their sandboxed `tools:` allowlist. Skills run in the main session and already have access to whatever MCP servers are connected; `code-review` documents graph usage in prose with a "prefer X, fallback Y, never assume" pattern instead. I followed that established pattern rather than the literal frontmatter grant the issue proposed.

## Test plan
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py`
- [x] `python3 scripts/check_md_references.py`
- [x] Full pytest gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3974 passed, 3 skipped
- [x] `scripts/ci-local.sh` via pre-push hook — all 18 checks passed

Closes #1295
Part of #1282