### PR TITLE
feat: measure effectiveness of gherkin-derive scenarios

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1336,6 +1336,10 @@
       "summary": "Self-reported per-task completion log, one file per calendar date.",
       "anchor": "metricsdate-task-logjsonl-eg-2026-02-20-task-logjsonl"
     },
+    "`gherkin-derive-effectiveness.jsonl`": {
+      "summary": "Per-scenario roll-up correlating a `/gherkin-derive`-discovered surface with",
+      "anchor": "gherkin-derive-effectivenessjsonl"
+    },
     "Adding a new stream": {
       "summary": "1.",
       "anchor": "adding-a-new-stream"
@@ -4813,6 +4817,10 @@
     "6. Post the converge history": {
       "summary": "Append a markdown block to the parent (or `FEATURE.md`):",
       "anchor": "6-post-the-converge-history"
+    },
+    "6b. Gherkin effectiveness roll-up (conditional)": {
+      "summary": "When `memory/<workflow>/<slug>/gherkin.md` exists (Phase 2b ran — see",
+      "anchor": "6b-gherkin-effectiveness-roll-up-conditional"
     },
     "7. Waiver handling": {
       "summary": "If the operator chooses to waive a target:",

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -383,6 +383,31 @@ Self-reported per-task completion log, one file per calendar date.
 
 ---
 
+## `gherkin-derive-effectiveness.jsonl`
+
+Per-scenario roll-up correlating a `/gherkin-derive`-discovered surface with
+whatever coverage/mutation-delta data the calling workflow already measured,
+so there is a signal on whether BDD-derived scenarios track real
+coverage/mutation movement (issue #1296). One record per scenario per
+roll-up run — not deduplicated across runs, since coverage/mutation deltas
+are re-measured every convergence iteration.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `surface` | string, nullable | The discovered surface name/path from `gherkin.md`'s surface-inventory table |
+| `discovery_source` | string, nullable | `openapi` \| `route` \| `test` \| `signature` (per `/gherkin-derive` Step 2), as recorded in the inventory |
+| `provenance` | string, nullable | `specification` \| `characterization`, as recorded in the inventory |
+| `binding_mode` | string, nullable | `none` \| `xunit-with-annotations` \| `bdd-runner` |
+| `bound_story` | number or string, nullable | The Story/issue id from `gherkin-bindings.json`, when that file exists for the run (only produced by `/gherkin-public`) |
+| `coverage_delta` | object, nullable | `{line_pct, branch_pct}` — workflow-level delta between the two coverage snapshots passed to the roll-up, not an isolated per-scenario attribution (no finer-grained mapping exists today) |
+| `mutation_delta` | object, nullable | `{survivors_after_delta}` — workflow-level survivor-count delta, same caveat as `coverage_delta` |
+
+- **Emitter:** `plugins/dev-team/scripts/gherkin_effectiveness_rollup.py`, invoked from `/quality-targets-converge` Step 6b after each convergence iteration's re-measure, when `gherkin.md` exists for the workflow slug.
+- **Consent:** unconditional (derived metrics only; no prompt/file-content capture).
+- **Consumers:** none yet — this is the roll-up a future `/harness-audit`-style review reads to compare BDD-derived vs. hand-written test effectiveness.
+
+---
+
 ## Adding a new stream
 
 1. Name it `metrics/<name>.jsonl` (or `.json` for a single-current-value

--- a/plugins/dev-team/scripts/gherkin_effectiveness_rollup.py
+++ b/plugins/dev-team/scripts/gherkin_effectiveness_rollup.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""gherkin_effectiveness_rollup.py — roll up gherkin-derive scenario data
+against the coverage/mutation measurements the plugin already computes,
+so there is a signal on whether BDD-derived tests catch more real defects
+than ad hoc ones (issue #1296).
+
+Today `/gherkin-derive` writes a surface inventory (`gherkin.md`) and
+`/gherkin-public` writes a scenario→Story map (`gherkin-bindings.json`), while
+`/coverage-baseline`, `/coverage-delta`, and the mutation baseline/history
+files separately track coverage and mutation-survivor counts. Nothing
+correlates the two. This script reads whatever of those files exist for one
+workflow run and emits one JSONL record per discovered scenario to
+`metrics/gherkin-derive-effectiveness.jsonl` (append-only, per the
+`performance-metrics` skill's convention).
+
+**Attribution granularity is honest, not exact.** No file in this plugin
+today maps an individual scenario to the specific test(s) that exercise it
+at the mutation/coverage level — `gherkin-bindings.json` maps a scenario to a
+*Story* (which may bind several tests), and coverage/mutation deltas are
+measured per-file or repo-wide, not per-scenario. This script therefore
+reports the best available repo/workflow-level coverage and mutation deltas
+alongside each scenario's provenance and binding mode, and does NOT claim a
+delta is caused solely by that scenario's test. Treat the emitted
+`coverage_delta` / `mutation_delta` fields as workflow-level context for the
+scenario, not as isolated per-scenario attribution.
+
+The surface-inventory table format is not fixed by `/gherkin-derive` today,
+so parsing is deliberately lenient: any markdown table under the file is
+scanned for columns whose header contains "surface", "source", "provenance",
+or "mode" (case-insensitive); a file with no such table yields a warning on
+stderr and zero scenario records, rather than crashing.
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_OUT = Path("metrics/gherkin-derive-effectiveness.jsonl")
+
+_TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+_SEPARATOR_CELL_RE = re.compile(r"^\s*:?-{2,}:?\s*$")
+
+# Header keywords this parser recognizes, mapped to the output field name.
+_COLUMN_KEYWORDS: Dict[str, str] = {
+    "surface": "surface",
+    "source": "discovery_source",
+    "provenance": "provenance",
+    "mode": "binding_mode",
+    "file": "files",
+}
+
+
+class RollupWarning(Exception):
+    """Non-fatal condition worth surfacing on stderr; callers keep going."""
+
+
+def _split_row(line: str) -> List[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def parse_surface_table(text: str) -> List[Dict[str, str]]:
+    """Return one dict per data row of the first markdown table whose header
+    matches at least one column in `_COLUMN_KEYWORDS`. Returns [] if no such
+    table is found."""
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines) - 1:
+        header_match = _TABLE_ROW_RE.match(lines[i])
+        sep_match = _TABLE_ROW_RE.match(lines[i + 1]) if header_match else None
+        if header_match and sep_match:
+            sep_cells = _split_row(lines[i + 1])
+            if all(_SEPARATOR_CELL_RE.match(c) for c in sep_cells if c):
+                header_cells = [c.lower() for c in _split_row(lines[i])]
+                field_for_col = {}
+                for idx, cell in enumerate(header_cells):
+                    for keyword, field in _COLUMN_KEYWORDS.items():
+                        if keyword in cell:
+                            field_for_col[idx] = field
+                            break
+                if field_for_col:
+                    rows: List[Dict[str, str]] = []
+                    j = i + 2
+                    while j < len(lines) and _TABLE_ROW_RE.match(lines[j]):
+                        cells = _split_row(lines[j])
+                        row = {
+                            field: cells[idx]
+                            for idx, field in field_for_col.items()
+                            if idx < len(cells)
+                        }
+                        if row:
+                            rows.append(row)
+                        j += 1
+                    return rows
+        i += 1
+    return []
+
+
+def load_scenarios(gherkin_md: Optional[Path]) -> List[Dict[str, str]]:
+    if gherkin_md is None:
+        return []
+    if not gherkin_md.is_file():
+        raise RollupWarning(f"surface inventory not found: {gherkin_md}")
+    rows = parse_surface_table(gherkin_md.read_text(encoding="utf-8"))
+    if not rows:
+        raise RollupWarning(f"no recognizable surface table in: {gherkin_md}")
+    return rows
+
+
+def load_json(path: Optional[Path]) -> Optional[dict]:
+    if path is None:
+        return None
+    if not path.is_file():
+        return None
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_bindings(bindings_json: Optional[Path]) -> Dict[str, object]:
+    data = load_json(bindings_json)
+    return data if isinstance(data, dict) else {}
+
+
+def scenario_key(surface: str) -> str:
+    """Best-effort key to look up a surface in `gherkin-bindings.json`, which
+    is keyed `<feature-file>::<scenario-name>`. The inventory table has no
+    fixed scenario-name column, so this matches by surface/feature-file
+    prefix rather than requiring an exact key."""
+    return surface.strip()
+
+
+def coverage_delta(baseline: Optional[dict], current: Optional[dict]) -> Optional[dict]:
+    if not baseline or not current:
+        return None
+    delta = {}
+    for field in ("line_pct", "branch_pct"):
+        b, c = baseline.get(field), current.get(field)
+        if isinstance(b, (int, float)) and isinstance(c, (int, float)):
+            delta[field] = round(c - b, 2)
+    return delta or None
+
+
+def mutation_delta(baseline: Optional[dict], current: Optional[dict]) -> Optional[dict]:
+    if not baseline or not current:
+        return None
+    b, c = baseline.get("survivors_after"), current.get("survivors_after")
+    if isinstance(b, (int, float)) and isinstance(c, (int, float)):
+        return {"survivors_after_delta": c - b}
+    return None
+
+
+def build_records(
+    scenarios: List[Dict[str, str]],
+    bindings: Dict[str, object],
+    cov_delta: Optional[dict],
+    mut_delta: Optional[dict],
+) -> List[dict]:
+    records = []
+    for row in scenarios:
+        surface = row.get("surface", "")
+        record = {
+            "surface": surface or None,
+            "discovery_source": row.get("discovery_source"),
+            "provenance": row.get("provenance"),
+            "binding_mode": row.get("binding_mode"),
+            "bound_story": bindings.get(scenario_key(surface)),
+            "coverage_delta": cov_delta,
+            "mutation_delta": mut_delta,
+        }
+        records.append(record)
+    return records
+
+
+def append_jsonl(records: List[dict], out_path: Path) -> int:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("a", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, sort_keys=True))
+            fh.write("\n")
+    return len(records)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gherkin-md", type=Path, help="surface inventory markdown (gherkin.md)")
+    parser.add_argument("--bindings-json", type=Path, help="gherkin-bindings.json, if present")
+    parser.add_argument("--baseline-coverage", type=Path, help="baseline-coverage.json")
+    parser.add_argument("--current-coverage", type=Path, help="latest coverage measurement (same shape as baseline-coverage.json)")
+    parser.add_argument("--baseline-mutation", type=Path, help="baseline-mutation.json")
+    parser.add_argument("--current-mutation", type=Path, help="latest mutation measurement (same shape as baseline-mutation.json)")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help=f"output JSONL path (default: {DEFAULT_OUT})")
+    args = parser.parse_args(argv)
+
+    try:
+        scenarios = load_scenarios(args.gherkin_md)
+    except RollupWarning as exc:
+        print(f"gherkin_effectiveness_rollup: {exc}", file=sys.stderr)
+        scenarios = []
+
+    if not scenarios:
+        print("gherkin_effectiveness_rollup: no scenarios to roll up; nothing written", file=sys.stderr)
+        return 0
+
+    bindings = load_bindings(args.bindings_json)
+    cov_delta = coverage_delta(load_json(args.baseline_coverage), load_json(args.current_coverage))
+    mut_delta = mutation_delta(load_json(args.baseline_mutation), load_json(args.current_mutation))
+
+    records = build_records(scenarios, bindings, cov_delta, mut_delta)
+    count = append_jsonl(records, args.out)
+    print(f"gherkin_effectiveness_rollup: wrote {count} record(s) to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/quality-targets-converge/SKILL.md
+++ b/plugins/dev-team/skills/quality-targets-converge/SKILL.md
@@ -193,6 +193,33 @@ Append a markdown block to the parent (or `FEATURE.md`):
 
 Same CLI pattern as `/coverage-baseline` and `/coverage-delta`.
 
+### 6b. Gherkin effectiveness roll-up (conditional)
+
+When `memory/<workflow>/<slug>/gherkin.md` exists (Phase 2b ran — see
+`/gherkin-derive`), run the roll-up after every iteration's re-measure so
+there is a standing signal on whether the derived scenarios track real
+coverage/mutation movement (issue #1296):
+
+```bash
+python3 plugins/dev-team/scripts/gherkin_effectiveness_rollup.py \
+  --gherkin-md memory/<workflow>/<slug>/gherkin.md \
+  --bindings-json memory/<workflow>/<slug>/gherkin-bindings.json \
+  --baseline-coverage memory/<workflow>/<slug>/baseline-coverage.json \
+  --current-coverage <this iteration's coverage measurement> \
+  --baseline-mutation memory/<workflow>/<slug>/baseline-mutation.json \
+  --current-mutation <this iteration's mutation measurement> \
+  --out metrics/gherkin-derive-effectiveness.jsonl
+```
+
+Omit any flag whose file doesn't exist for this run (e.g. no
+`gherkin-bindings.json` when the workflow only derived scenarios via
+`/gherkin-derive` and never ran `/gherkin-public`) — the script degrades
+gracefully and still records provenance/binding-mode per scenario with the
+correlated field left `null`. When `gherkin.md` is absent (binding mode
+`none`, or Phase 2b never ran), skip this step entirely — there is nothing
+to roll up. This is a metrics side-effect only; it never changes convergence
+gaps or which action Step 4 dispatches.
+
 ### 7. Waiver handling
 
 If the operator chooses to waive a target:
@@ -211,6 +238,7 @@ Print:
 - Whether the loop converged, halted, or is mid-iteration.
 - Any waivers recorded.
 - The path to `converge-<iteration>.json` and to `waivers.json` (if any).
+- The path to `metrics/gherkin-derive-effectiveness.jsonl` when Step 6b ran.
 
 ## Examples / Integration
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_effectiveness_rollup.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_effectiveness_rollup.py
@@ -1,0 +1,147 @@
+"""Tests for gherkin_effectiveness_rollup.py (issue #1296)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import gherkin_effectiveness_rollup as rollup  # noqa: E402
+
+GHERKIN_MD = """# Surface inventory
+
+| Surface | Discovery source | Provenance | Mode | Files |
+| --- | --- | --- | --- | --- |
+| POST /orders | openapi | specification | bdd-runner | features/orders-post.feature |
+| GET /orders/{id} | route | specification | bdd-runner | features/orders-get.feature |
+| legacy CSV export | test | characterization | xunit-with-annotations | features/csv-export.feature |
+"""
+
+GHERKIN_MD_NO_TABLE = "# Surface inventory\n\nNo surfaces discovered.\n"
+
+
+def test_parse_surface_table_extracts_rows():
+    rows = rollup.parse_surface_table(GHERKIN_MD)
+    assert len(rows) == 3
+    assert rows[0] == {
+        "surface": "POST /orders",
+        "discovery_source": "openapi",
+        "provenance": "specification",
+        "binding_mode": "bdd-runner",
+        "files": "features/orders-post.feature",
+    }
+    assert rows[2]["provenance"] == "characterization"
+
+
+def test_parse_surface_table_returns_empty_when_no_table():
+    assert rollup.parse_surface_table(GHERKIN_MD_NO_TABLE) == []
+
+
+def test_load_scenarios_missing_file_raises_warning(tmp_path):
+    with pytest.raises(rollup.RollupWarning):
+        rollup.load_scenarios(tmp_path / "missing.md")
+
+
+def test_load_scenarios_none_returns_empty():
+    assert rollup.load_scenarios(None) == []
+
+
+def test_coverage_delta_computes_pct_change():
+    baseline = {"line_pct": 41.2, "branch_pct": 28.7}
+    current = {"line_pct": 55.0, "branch_pct": 40.0}
+    delta = rollup.coverage_delta(baseline, current)
+    assert delta == {"line_pct": 13.8, "branch_pct": 11.3}
+
+
+def test_coverage_delta_none_when_either_missing():
+    assert rollup.coverage_delta(None, {"line_pct": 1}) is None
+    assert rollup.coverage_delta({"line_pct": 1}, None) is None
+
+
+def test_mutation_delta_computes_survivor_change():
+    baseline = {"survivors_after": 12}
+    current = {"survivors_after": 4}
+    assert rollup.mutation_delta(baseline, current) == {"survivors_after_delta": -8}
+
+
+def test_build_records_attaches_bindings_and_deltas():
+    scenarios = [{"surface": "POST /orders", "provenance": "specification", "binding_mode": "bdd-runner"}]
+    bindings = {"POST /orders": 311}
+    records = rollup.build_records(scenarios, bindings, {"line_pct": 5.0}, {"survivors_after_delta": -2})
+    assert records == [
+        {
+            "surface": "POST /orders",
+            "discovery_source": None,
+            "provenance": "specification",
+            "binding_mode": "bdd-runner",
+            "bound_story": 311,
+            "coverage_delta": {"line_pct": 5.0},
+            "mutation_delta": {"survivors_after_delta": -2},
+        }
+    ]
+
+
+def test_append_jsonl_is_append_only(tmp_path):
+    out = tmp_path / "gherkin-derive-effectiveness.jsonl"
+    rollup.append_jsonl([{"a": 1}], out)
+    rollup.append_jsonl([{"a": 2}], out)
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in lines] == [{"a": 1}, {"a": 2}]
+
+
+def test_main_end_to_end(tmp_path, capsys):
+    gherkin_md = tmp_path / "gherkin.md"
+    gherkin_md.write_text(GHERKIN_MD, encoding="utf-8")
+
+    bindings_json = tmp_path / "gherkin-bindings.json"
+    bindings_json.write_text(json.dumps({"POST /orders": 311}), encoding="utf-8")
+
+    baseline_cov = tmp_path / "baseline-coverage.json"
+    baseline_cov.write_text(json.dumps({"line_pct": 40.0, "branch_pct": 30.0}), encoding="utf-8")
+    current_cov = tmp_path / "current-coverage.json"
+    current_cov.write_text(json.dumps({"line_pct": 50.0, "branch_pct": 35.0}), encoding="utf-8")
+
+    out = tmp_path / "out.jsonl"
+
+    exit_code = rollup.main(
+        [
+            "--gherkin-md", str(gherkin_md),
+            "--bindings-json", str(bindings_json),
+            "--baseline-coverage", str(baseline_cov),
+            "--current-coverage", str(current_cov),
+            "--out", str(out),
+        ]
+    )
+
+    assert exit_code == 0
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    records = [json.loads(line) for line in lines]
+    orders_record = next(r for r in records if r["surface"] == "POST /orders")
+    assert orders_record["bound_story"] == 311
+    assert orders_record["coverage_delta"] == {"line_pct": 10.0, "branch_pct": 5.0}
+
+    captured = capsys.readouterr()
+    assert "wrote 3 record(s)" in captured.out
+
+
+def test_main_no_gherkin_md_writes_nothing(tmp_path, capsys):
+    out = tmp_path / "out.jsonl"
+    exit_code = rollup.main(["--out", str(out)])
+    assert exit_code == 0
+    assert not out.exists()
+    captured = capsys.readouterr()
+    assert "no scenarios to roll up" in captured.err
+
+
+def test_main_missing_gherkin_md_warns_and_continues(tmp_path, capsys):
+    out = tmp_path / "out.jsonl"
+    exit_code = rollup.main(["--gherkin-md", str(tmp_path / "missing.md"), "--out", str(out)])
+    assert exit_code == 0
+    assert not out.exists()
+    captured = capsys.readouterr()
+    assert "surface inventory not found" in captured.err


### PR DESCRIPTION
## Summary
- Add `plugins/dev-team/scripts/gherkin_effectiveness_rollup.py` (stdlib-only) that reads a workflow's surface inventory (`gherkin.md`), any `gherkin-bindings.json`, and the coverage/mutation baseline+current measurements `/quality-targets-converge` already computes, and emits one JSONL record per scenario to `metrics/gherkin-derive-effectiveness.jsonl`.
- Wire it into `/quality-targets-converge` as Step 6b, running automatically after each convergence iteration's re-measure when `gherkin.md` exists.
- Document the new stream in `knowledge/telemetry-schema.md` (required by `tests/hooks/test_boundary_events.py`'s coverage check).
- Attribution is deliberately honest about granularity: no file in the plugin today maps a scenario to the exact test(s) that exercise it, so deltas are workflow-level context, not isolated per-scenario causation — documented in the script's docstring and the telemetry schema entry.

This gives a future `/harness-audit`-style review actual evidence to compare BDD-derived vs. hand-written test effectiveness, instead of relying on intuition about whether the ceremony pays for itself.

## Test plan
- [x] New unit tests: `plugins/dev-team/tests/scripts/test_gherkin_effectiveness_rollup.py` (12 tests, all passing)
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — clean
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Full pytest gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3913 passed, 1 skipped
- [x] `scripts/ci-local.sh` via pre-push hook — all checks passed

Closes #1296
Part of #1282