### PR TITLE
feat: ground gherkin-derive failure scenarios in real code branches

### DIFF
--- a/plugins/dev-team/skills/gherkin-derive/SKILL.md
+++ b/plugins/dev-team/skills/gherkin-derive/SKILL.md
@@ -119,11 +119,18 @@ Use the same templates as `/gherkin-public`: **API Provider**, **UI**,
 scenario covers at least one success and one failure path, and every step is
 observable at the boundary — no internal calls.
 
-**Grounding failure scenarios.** When CodeGraph/Repowise are available, use
-`codegraph_explore` (or Repowise `get_context`/`search_codebase`) to inspect a
-surface's actual branches and error-handling depth before writing a failure
-scenario, rather than inferring it from the signature text alone. Falls back
-to reading the source directly when the tools are unavailable.
+**Ground every failure path in an observed condition.** Before filling a
+failure-scenario placeholder, locate a specific failure condition actually
+present in the code — a conditional, a thrown/raised exception, a documented
+or observed HTTP status code, a validation rule — and cite it in the scenario
+body. When CodeGraph/Repowise are available, use `codegraph_explore` (or
+Repowise `get_context`/`search_codebase`) to inspect a surface's actual
+branches and error-handling depth for this; fall back to reading the source
+directly when the tools are unavailable. Do not invent a generic
+`<invalid request>` / `<failure-mode-summary>` placeholder as a paraphrase of
+the surface's name or signature. When no such condition is discoverable for a
+surface, mark that scenario `# TODO: no observed failure path — hand-author`
+instead of fabricating one — an honest gap beats an invented scenario.
 
 **Label the provenance** in each `.feature` file header:
 
@@ -142,7 +149,7 @@ to reading the source directly when the tools are unavailable.
 Feature: <surface>
   Scenario: <success path>
     ...
-  Scenario: <failure path>
+  Scenario: <failure path — a real observed condition, or the hand-author TODO>
     ...
 ```
 


### PR DESCRIPTION
## Summary
- Requires `gherkin-derive` Step 3 to cite an observed conditional, thrown exception, or status code when authoring a failure scenario, instead of paraphrasing the surface signature into a generic placeholder.
- When no such condition is discoverable, the scenario is marked `# TODO: no observed failure path — hand-author` rather than inventing one.

## Test plan
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py`
- [x] `python3 scripts/check_md_references.py`
- [x] Full pytest gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3901 passed, 1 skipped
- [x] `scripts/ci-local.sh` via pre-push hook — all local CI checks passed

Closes #1294
Part of #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)