### PR TITLE
feat: wire agent-contract validator into agent-audit, drop agent-eval calibration mode

### DIFF
--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -102,28 +102,23 @@ review agents. Check:
    - MUST show the skip JSON response format
    - WARN if skip section is missing
 
-8. **Effort band**: Does the agent declare `effort: low|medium|high` in
-   its YAML frontmatter?
-   - All agents MUST declare the reasoning-effort band their task needs
-   - Valid values: `low`, `medium`, `high`
-   - WARN if missing or outside the valid set
-   - **Single source**: the band MUST be declared only in frontmatter — it is
-     the only value the resolver reads. WARN if a body `Effort:` line (or other
-     prose) restates the band; that duplicate is a drift source and must be
-     removed.
-   - **Deprecation (warn, never error this release)**: if the agent still
-     declares a legacy `model: haiku|sonnet|opus` tier in frontmatter, WARN
-     that the tier name is deprecated and name the band to use
-     (`haiku` → `low`, `sonnet` → `medium`, `opus` → `high`)
-   - **Full contract check**: for the complete official-contract validation
-     (required fields, `name` pattern, enum membership on any field present —
-     `model`, `effort`, `permissionMode`, `memory`, `isolation`, `color`,
-     `background`, `maxTurns` — unknown/misspelled-key warnings, and a
-     plugin-ignored-field warning for `hooks`/`mcpServers`/`permissionMode`),
-     run `python3 scripts/validate_agent_contract.py <file>` and fold any
-     `error`/`warning` finding into the report as FAIL/WARN. This runs
-     alongside the band check above until a later slice migrates agents to
-     native `model:`/`effort: high` frontmatter and retires the band itself.
+8. **Model/effort contract**: Does the agent's frontmatter conform to the
+   native Claude Code sub-agent contract (ADR 0026)?
+   - Run `python3 scripts/validate_agent_contract.py <file>` and fold every
+     `error` into FAIL and every `warning` into WARN in the report. This is
+     the sole frontmatter-contract check — required-field presence (`name`,
+     `description`), `name` pattern, enum membership on any field present
+     (`model`, `effort`, `permissionMode`, `memory`, `isolation`, `color`,
+     `background`, `maxTurns`), unknown/misspelled-key warnings, and the
+     plugin-ignored-field warning for `hooks`/`mcpServers`/`permissionMode`.
+   - **This repo's own convention**: every `plugins/dev-team/` and
+     `plugins/security-assessment/` agent declares `model:` (an alias, full
+     model ID, or `inherit`) and `effort: high` — WARN if either is missing,
+     since that is this repo's local practice, not a contract requirement.
+   - **Single source**: `model:`/`effort:` MUST be declared only in
+     frontmatter. WARN if a body line restates either as prose (e.g. an
+     `Effort:` line, or a body-level model-tier label) — that duplicate is a
+     drift source and must be removed.
 
 9. **Context needs**: Does the agent declare a `Context needs:` field?
    - All agents MUST declare what input context they need

--- a/tests/commands/test_agent_audit_model_effort.py
+++ b/tests/commands/test_agent_audit_model_effort.py
@@ -1,9 +1,10 @@
-"""Tests for /agent-audit — it validates the effort vocabulary (effort:
-low|medium|high in frontmatter) and warns on a legacy model: tier name,
-naming the band to use.
+"""Tests for /agent-audit — it validates the native model:/effort: contract
+(ADR 0026) via the shared contract validator, plus this repo's own
+convention that every agent declares model:/effort: high.
 
 Ported from tests/commands/agent_audit_effort_tests.bats (issue #675:
-bats -> pytest).
+bats -> pytest); rewritten for epic #1284's native-contract migration
+(issue #1290).
 """
 
 from __future__ import annotations
@@ -17,16 +18,21 @@ AGENTS_DIR = REPO_ROOT / "plugins" / "dev-team" / "agents"
 TEMPLATES_DIR = REPO_ROOT / "plugins" / "dev-team" / "templates" / "agents"
 
 
-def test_agent_audit_validates_effort_low_medium_high() -> None:
+def test_agent_audit_runs_the_shared_contract_validator() -> None:
     text = AUDIT.read_text(encoding="utf-8")
-    assert re.search(r"effort:.*low\|medium\|high", text)
+    assert "scripts/validate_agent_contract.py" in text
 
 
-def test_agent_audit_warns_on_legacy_model_tier_name() -> None:
-    # The audit names the deprecated model: tier and the band to use instead.
+def test_agent_audit_states_the_repo_convention_of_model_and_effort_high() -> None:
     text = AUDIT.read_text(encoding="utf-8")
-    assert re.search(r"deprecat", text, re.IGNORECASE)
-    assert re.search(r"model:.*(haiku|sonnet|opus)", text, re.IGNORECASE)
+    assert re.search(r"effort: high", text)
+    assert re.search(r"`model:`", text)
+
+
+def test_agent_audit_no_longer_treats_model_tier_as_deprecated() -> None:
+    # model: haiku|sonnet|opus is the native contract now, not a legacy tier.
+    text = AUDIT.read_text(encoding="utf-8")
+    assert not re.search(r"deprecat.*model:.*(haiku|sonnet|opus)", text, re.IGNORECASE | re.DOTALL)
 
 
 def test_agent_audit_no_longer_keys_on_retired_model_tier_body_line() -> None:


### PR DESCRIPTION
## Summary

`agent-audit/SKILL.md`'s frontmatter check 8 was running the shared contract
validator (`scripts/validate_agent_contract.py`, #1285) alongside a
hand-rolled effort-band check and a `model:`-tier deprecation warning. Now
that every agent declares the native `model:`/`effort:` contract (#1287) and
the band resolver/ladder/calibration infrastructure is retired (#1288), the
validator is the sole frontmatter gate; the band check and the now-backwards
deprecation warning (`model: haiku/sonnet/opus` is the contract, not a
legacy tier) are gone. This repo's own convention — every agent declares
`model:` and `effort: high` — is called out as a WARN-level local practice,
not folded into the generalized contract check.

`agent-eval`'s `--calibrate` mode was already dropped in #1288 (its
supporting scripts were being deleted in that PR, so leaving the SKILL.md
text dangling would have broken that PR's own tests) — this issue's
remaining scope was the `agent-audit` wiring above.

Renamed/rewrote `tests/commands/test_agent_audit_effort.py` →
`test_agent_audit_model_effort.py` for the new contract.

## Test plan

- [x] `python3 -m pytest tests/commands/test_agent_audit_model_effort.py` — pass
- [x] Full pre-push pytest tree (split into two serial chunks due to heavy
      concurrent-session CPU load on this machine) — 2167 + 1751 passed, 1
      skipped, zero failures
- [x] `scripts/ci-local.sh` (full 18-check pre-push gate) — all pass

Closes #1290
Part of #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)