### PR TITLE
chore: move non-contract keys (cites, scope, enforcement) out of agent frontmatter into the body

### DIFF
--- a/plugins/dev-team/agents/a11y-review.md
+++ b/plugins/dev-team/agents/a11y-review.md
@@ -5,19 +5,20 @@ description: WCAG 2.1 AA compliance, semantic HTML, ARIA, keyboard navigation, f
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.svelte
-  - **/*.html
-  - **/*.jsx
-  - **/*.tsx
-  - **/*.vue
-  - **/*.razor
-  - **/*.cshtml
-  - **/*.jsp
 ---
 
 # Accessibility Review
+
+Scope:
+- **/*.svelte
+- **/*.html
+- **/*.jsx
+- **/*.tsx
+- **/*.vue
+- **/*.razor
+- **/*.cshtml
+- **/*.jsp
+Cites: [adversarial-review-protocol]
 
 Scope: UI component and template files only (.svelte, .html, .jsx, .tsx, .vue, .razor, .cshtml, .jsp).
 Skip non-component files (utilities, services, stores, configs, tests, routes/pages without markup).

--- a/plugins/dev-team/agents/ai-provenance-review.md
+++ b/plugins/dev-team/agents/ai-provenance-review.md
@@ -5,11 +5,12 @@ description: Checks whether AI-authored test assertions and non-obvious producti
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
-cites: [adversarial-review-protocol]
-scope: always
 ---
 
 # AI Provenance & Regeneration Safety Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
 
 Context needs: full-file
 File scope: All changed files

--- a/plugins/dev-team/agents/angular-reactivity-review.md
+++ b/plugins/dev-team/agents/angular-reactivity-review.md
@@ -5,15 +5,16 @@ description: Angular Zone.js change-detection pitfalls, OnPush + immutability vi
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.component.ts
-  - **/*.component.html
-  - **/*.service.ts
-  - **/*.ts
 ---
 
 # Angular Reactivity Review
+
+Scope:
+- **/*.component.ts
+- **/*.component.html
+- **/*.service.ts
+- **/*.ts
+Cites: [adversarial-review-protocol]
 
 Scope: Angular component, directive, and service files (`.component.ts`,
 `.component.html`, `.service.ts`, and general `.ts` files in Angular projects).

--- a/plugins/dev-team/agents/arch-review.md
+++ b/plugins/dev-team/agents/arch-review.md
@@ -5,11 +5,14 @@ description: Architectural alignment — ADR compliance, layer boundary violatio
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
-cites: [architecture-assessment, adversarial-review-protocol]
-scope: always
 ---
 
 # Architecture Review
+
+Scope: always
+Cites:
+- architecture-assessment
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/claude-setup-review.md
+++ b/plugins/dev-team/agents/claude-setup-review.md
@@ -5,12 +5,15 @@ description: CLAUDE.md completeness, rules, skills, path accuracy, and agent fro
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol, directory-enumeration]
-enforcement: script
-scope: always
 ---
 
 # Claude Setup Review
+
+Scope: always
+Cites:
+- adversarial-review-protocol
+- directory-enumeration
+Enforcement: script
 
 > **Implemented by:** scripts/claude_setup_review.py
 

--- a/plugins/dev-team/agents/codebase-recon.md
+++ b/plugins/dev-team/agents/codebase-recon.md
@@ -4,7 +4,6 @@ description: Reconnaissance agent that surveys a codebase's structure, entry poi
 tools: Read, Grep, Glob, Bash, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk, mcp__plugin_repowise_repowise__get_why
 model: opus
 effort: high
-enforcement: script
 ---
 
 > **Implemented by:** scripts/codebase_recon.py
@@ -14,6 +13,8 @@ enforcement: script
 Think carefully and step-by-step; this problem is harder than it looks.
 
 # Codebase Recon Agent
+
+Enforcement: script
 
 Context needs: project-structure
 

--- a/plugins/dev-team/agents/complexity-review.md
+++ b/plugins/dev-team/agents/complexity-review.md
@@ -5,11 +5,14 @@ description: Cyclomatic complexity, nesting depth, function size, parameter coun
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: sonnet
 effort: high
-cites: [object-calisthenics, adversarial-review-protocol]
-scope: always
 ---
 
 # Complexity Review
+
+Scope: always
+Cites:
+- object-calisthenics
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/component-architecture-review.md
+++ b/plugins/dev-team/agents/component-architecture-review.md
@@ -5,17 +5,20 @@ description: Reusable component extraction and frontend duplication — repeated
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [frontend-component-architecture, adversarial-review-protocol]
-scope:
-  - **/*.jsx
-  - **/*.tsx
-  - **/*.vue
-  - **/*.svelte
-  - **/*.component.ts
-  - **/*.component.html
 ---
 
 # Component Architecture Review
+
+Scope:
+- **/*.jsx
+- **/*.tsx
+- **/*.vue
+- **/*.svelte
+- **/*.component.ts
+- **/*.component.html
+Cites:
+- frontend-component-architecture
+- adversarial-review-protocol
 
 Scope: frontend component files (`.jsx`, `.tsx`, `.vue`, `.svelte`, Angular
 `*.component.ts` + their templates, and `.js`/`.ts` modules that render UI).

--- a/plugins/dev-team/agents/concurrency-review.md
+++ b/plugins/dev-team/agents/concurrency-review.md
@@ -5,11 +5,12 @@ description: Race conditions, async pitfalls, idempotency, shared state safety
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope: always
 ---
 
 # Concurrency Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
 
 Output JSON:
 

--- a/plugins/dev-team/agents/correctness-review.md
+++ b/plugins/dev-team/agents/correctness-review.md
@@ -5,11 +5,12 @@ description: Functional/behavioral defects where implementation diverges from ev
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
-cites: [adversarial-review-protocol]
-scope: always
 ---
 
 # Correctness Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
 
 Output JSON:
 

--- a/plugins/dev-team/agents/data-flow-tracer.md
+++ b/plugins/dev-team/agents/data-flow-tracer.md
@@ -4,10 +4,11 @@ description: Traces a use case through all architecture layers, mapping data acc
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk, Bash(graphify *)
 model: sonnet
 effort: high
-cites: [adversarial-review-protocol]
 ---
 
 # Data Flow Tracer
+
+Cites: [adversarial-review-protocol]
 
 Context needs: project-structure
 

--- a/plugins/dev-team/agents/doc-review.md
+++ b/plugins/dev-team/agents/doc-review.md
@@ -5,11 +5,12 @@ description: Documentation accuracy, README staleness, API doc alignment, inline
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope: always
 ---
 
 # Documentation Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
 
 Output JSON:
 

--- a/plugins/dev-team/agents/domain-review.md
+++ b/plugins/dev-team/agents/domain-review.md
@@ -5,11 +5,15 @@ description: Domain boundaries, abstraction leaks, business logic placement
 tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
-cites: [domain-modeling, ubiquitous-language, adversarial-review-protocol]
-scope: always
 ---
 
 # Domain Review
+
+Scope: always
+Cites:
+- domain-modeling
+- ubiquitous-language
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/js-fp-review.md
+++ b/plugins/dev-team/agents/js-fp-review.md
@@ -5,17 +5,18 @@ description: Array mutations, parameter mutations, global state, impure patterns
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.js
-  - **/*.ts
-  - **/*.jsx
-  - **/*.tsx
-  - **/*.mjs
-  - **/*.cjs
 ---
 
 # JS FP Review
+
+Scope:
+- **/*.js
+- **/*.ts
+- **/*.jsx
+- **/*.tsx
+- **/*.mjs
+- **/*.cjs
+Cites: [adversarial-review-protocol]
 
 Scope: JavaScript and TypeScript files only (`.js`, `.ts`, `.jsx`, `.tsx`).
 Skip this agent entirely if the project has no JS/TS files.

--- a/plugins/dev-team/agents/naming-review.md
+++ b/plugins/dev-team/agents/naming-review.md
@@ -5,11 +5,14 @@ description: Naming clarity, conventions, magic values, and consistency
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: sonnet
 effort: high
-cites: [design-smells, adversarial-review-protocol]
-scope: always
 ---
 
 # Naming Review
+
+Scope: always
+Cites:
+- design-smells
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -4,12 +4,13 @@ description: Central dispatcher that routes tasks to specialized agents and coor
 tools: Read, Grep, Glob, Agent, Skill
 model: sonnet
 effort: high
-enforcement: script
 ---
 
 > **Implemented by:** scripts/orchestrator.py
 
 # Orchestrator Agent
+
+Enforcement: script
 
 Context needs: project-structure
 

--- a/plugins/dev-team/agents/performance-review.md
+++ b/plugins/dev-team/agents/performance-review.md
@@ -5,11 +5,12 @@ description: Resource leaks, N+1 queries, unbounded growth, timeouts, algorithmi
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope: always
 ---
 
 # Performance Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
 
 Output JSON:
 

--- a/plugins/dev-team/agents/progress-guardian.md
+++ b/plugins/dev-team/agents/progress-guardian.md
@@ -4,11 +4,14 @@ description: Tracks plan step completion, enforces commit discipline, and gates 
 tools: Read, Grep, Glob
 model: haiku
 effort: high
-cites: [adversarial-review-protocol, directory-enumeration]
-enforcement: script
 ---
 
 # Progress Guardian
+
+Cites:
+- adversarial-review-protocol
+- directory-enumeration
+Enforcement: script
 
 > **Implemented by:** scripts/progress_guardian.py
 

--- a/plugins/dev-team/agents/react-reactivity-review.md
+++ b/plugins/dev-team/agents/react-reactivity-review.md
@@ -5,15 +5,16 @@ description: React hook rules violations, stale closures in useEffect, missing d
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.jsx
-  - **/*.tsx
-  - **/*.js
-  - **/*.ts
 ---
 
 # React Reactivity Review
+
+Scope:
+- **/*.jsx
+- **/*.tsx
+- **/*.js
+- **/*.ts
+Cites: [adversarial-review-protocol]
 
 Scope: React component and hook files (`.jsx`, `.tsx`, and `.js`/`.ts` files
 that import from `react`). Skip this agent entirely if the project has no

--- a/plugins/dev-team/agents/refactor-opportunity-review.md
+++ b/plugins/dev-team/agents/refactor-opportunity-review.md
@@ -5,11 +5,14 @@ description: Assesses refactoring opportunities after tests pass (TDD REFACTOR p
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [design-smells, adversarial-review-protocol]
-scope: always
 ---
 
 # Refactor Opportunity Review
+
+Scope: always
+Cites:
+- design-smells
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/security-review.md
+++ b/plugins/dev-team/agents/security-review.md
@@ -5,11 +5,15 @@ description: Injection, auth/authz, data exposure, security headers, crypto
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
-cites: [owasp-detection, accepted-risks-schema, adversarial-review-protocol]
-scope: always
 ---
 
 # Security Review
+
+Scope: always
+Cites:
+- owasp-detection
+- accepted-risks-schema
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/session-analysis.md
+++ b/plugins/dev-team/agents/session-analysis.md
@@ -4,7 +4,6 @@ description: Map an aggregated session digest to probable plugin causes and rank
 tools: Read
 model: sonnet
 effort: high
-cites: [adversarial-review-protocol]
 ---
 
 Output JSON:
@@ -18,6 +17,8 @@ Severity: error=high-severity recurring pattern (≥3 sessions) requiring a plug
 Context needs: full-file
 
 # Session Analysis
+
+Cites: [adversarial-review-protocol]
 
 Role: worker. You read **only** the deterministic session digest produced by
 `scripts/session_extract.py` (a metrics-only JSON object) and map its aggregated

--- a/plugins/dev-team/agents/spec-compliance-review.md
+++ b/plugins/dev-team/agents/spec-compliance-review.md
@@ -5,11 +5,14 @@ description: Verify implementation matches specification before quality review a
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol, directory-enumeration]
-scope: always
 ---
 
 # Spec Compliance Review
+
+Scope: always
+Cites:
+- adversarial-review-protocol
+- directory-enumeration
 
 Context needs: full-file
 File scope: All changed files

--- a/plugins/dev-team/agents/structure-review.md
+++ b/plugins/dev-team/agents/structure-review.md
@@ -5,11 +5,15 @@ description: SRP violations, DRY, coupling, nesting depth, file organization
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: sonnet
 effort: high
-cites: [design-smells, object-calisthenics, adversarial-review-protocol]
-scope: always
 ---
 
 # Structure Review
+
+Scope: always
+Cites:
+- design-smells
+- object-calisthenics
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/svelte-review.md
+++ b/plugins/dev-team/agents/svelte-review.md
@@ -5,14 +5,15 @@ description: Svelte reactivity pitfalls, closure state leaks, $state proxy issue
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.svelte
-  - **/*.svelte.ts
-  - **/*.svelte.js
 ---
 
 # Svelte Review
+
+Scope:
+- **/*.svelte
+- **/*.svelte.ts
+- **/*.svelte.js
+Cites: [adversarial-review-protocol]
 
 Scope: Svelte files only (`.svelte`, `.svelte.ts`, `.svelte.js`).
 Skip this agent entirely if the project has no Svelte files.

--- a/plugins/dev-team/agents/test-review.md
+++ b/plugins/dev-team/agents/test-review.md
@@ -5,11 +5,17 @@ description: Test quality, coverage gaps, assertion quality, and test hygiene
 tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: sonnet
 effort: high
-cites: [testability-patterns, result-verification, test-automation-maturity, adversarial-review-protocol, oracle-provenance]
-scope: always
 ---
 
 # Test Review
+
+Scope: always
+Cites:
+- testability-patterns
+- result-verification
+- test-automation-maturity
+- adversarial-review-protocol
+- oracle-provenance
 
 Output JSON:
 

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -5,11 +5,26 @@ description: xUnit test smells, test double selection, and test-pyramid layer pl
 tools: Read, Grep, Glob, Skill, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: sonnet
 effort: high
-cites: [test-smells, test-automation-principles, test-doubles, value-patterns, test-pyramid, fixture-construction, test-organization, test-refactoring, testability-patterns, result-verification, database-test-patterns, cd-test-architecture, microservice-testing, adversarial-review-protocol]
-scope: always
 ---
 
 # Test Smell Review
+
+Scope: always
+Cites:
+- test-smells
+- test-automation-principles
+- test-doubles
+- value-patterns
+- test-pyramid
+- fixture-construction
+- test-organization
+- test-refactoring
+- testability-patterns
+- result-verification
+- database-test-patterns
+- cd-test-architecture
+- microservice-testing
+- adversarial-review-protocol
 
 Output JSON:
 

--- a/plugins/dev-team/agents/token-efficiency-review.md
+++ b/plugins/dev-team/agents/token-efficiency-review.md
@@ -5,14 +5,15 @@ description: Token usage optimization, file length, CLAUDE.md size, LLM anti-pat
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-enforcement: script
-scope: always
 ---
 
 > **Implemented by:** scripts/token_efficiency_review.py
 
 # Token Efficiency Review
+
+Scope: always
+Cites: [adversarial-review-protocol]
+Enforcement: script
 
 Output JSON:
 

--- a/plugins/dev-team/agents/vue-reactivity-review.md
+++ b/plugins/dev-team/agents/vue-reactivity-review.md
@@ -5,14 +5,15 @@ description: Vue ref/reactive unwrapping pitfalls, watchEffect dependency tracki
 tools: Read, Grep, Glob, mcp__codegraph__codegraph_explore, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: haiku
 effort: high
-cites: [adversarial-review-protocol]
-scope:
-  - **/*.vue
-  - **/*.js
-  - **/*.ts
 ---
 
 # Vue Reactivity Review
+
+Scope:
+- **/*.vue
+- **/*.js
+- **/*.ts
+Cites: [adversarial-review-protocol]
 
 Scope: Vue component and composable files (`.vue`, and `.js`/`.ts` files that
 import from `vue`). Skip this agent entirely if the project has no `vue`

--- a/plugins/dev-team/docs/agent_info.md
+++ b/plugins/dev-team/docs/agent_info.md
@@ -101,12 +101,13 @@ Every agent file follows this structure:
 
 The `## Skills` section is the bridge between agents and skills. The agent defines *when and why* to invoke a skill; the skill defines *how* to execute it.
 
-## Non-standard frontmatter keys
+## Non-standard body declarations
 
-Two frontmatter keys appear alongside the standard `name`/`description`/`tools`/`effort`/`model` fields and are easy to mistake for schema drift when auditing agent files. Both are intentional internal tooling metadata:
+Three `Key: value` lines appear in some agents' **bodies**, not their frontmatter — they are intentional internal tooling metadata, deliberately kept out of frontmatter because none of them are part of the official Claude Code sub-agent contract (`plugins/marketplace-dev/knowledge/agent-contract.json`); frontmatter is reserved for that contract (issue #1333).
 
-- **`cites:`** — a list of canonical skill/knowledge-file sources an agent's normative rules (MUST/SHOULD/SHALL thresholds) derive from, e.g. `cites: [owasp-detection, accepted-risks-schema]`. `scripts/citation_lint.py` reads this list and flags a warning when a stated numeric threshold doesn't appear in any cited source — catching silent drift when a canonical file changes but a reviewer agent's inline rule doesn't. See the script's module docstring for the full contract. Used by 22 agents today; see `tests/repo/test_citation_lint_corpus.py` for the regression guard over the real corpus.
-- **`enforcement: script`** — marks an agent whose behavior is deterministically implemented by a script rather than driven by free-form LLM reasoning from the persona prose alone. Agents carrying this key also carry a `> **Implemented by:** scripts/<name>.py` blockquote near the top of the file pointing at that implementation (e.g. `orchestrator.md` → `scripts/orchestrator.py`, `codebase-recon.md` → `scripts/codebase_recon.py`). Used by 5 agents today (`orchestrator`, `codebase-recon`, `claude-setup-review`, `progress-guardian`, `token-efficiency-review`).
+- **`Cites: [...]`** — a list of canonical skill/knowledge-file sources an agent's normative rules (MUST/SHOULD/SHALL thresholds) derive from, e.g. `Cites: [owasp-detection, accepted-risks-schema]`. `scripts/citation_lint.py` reads this list and flags a warning when a stated numeric threshold doesn't appear in any cited source — catching silent drift when a canonical file changes but a reviewer agent's inline rule doesn't. See the script's module docstring for the full contract. See `tests/repo/test_citation_lint_corpus.py` for the regression guard over the real corpus.
+- **`Scope: always` / `Scope:` (glob list)** — self-declares which files an agent is eligible to review; read by `/code-review`'s dispatch step (`skills/code-review/SKILL.md`) and validated by `scripts/check_agent_scope.py`.
+- **`Enforcement: script`** — marks an agent whose behavior is deterministically implemented by a script rather than driven by free-form LLM reasoning from the persona prose alone. Agents carrying this declaration also carry a `> **Implemented by:** scripts/<name>.py` blockquote near the top of the file pointing at that implementation (e.g. `orchestrator.md` → `scripts/orchestrator.py`, `codebase-recon.md` → `scripts/codebase_recon.py`).
 
 ## Add a Team Agent
 

--- a/plugins/dev-team/scripts/check_agent_scope.py
+++ b/plugins/dev-team/scripts/check_agent_scope.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-"""Validate that every review agent declares a scope: frontmatter field.
+"""Validate that every review agent declares a body-level Scope: field.
 
-Exit 0 if all review agents have a scope: field.
+``Scope:`` is a body-level declaration, not frontmatter (issue #1333 — it is
+not part of the official Claude Code sub-agent contract; see
+plugins/marketplace-dev/knowledge/agent-contract.json).
+
+Exit 0 if all review agents have a Scope: line in their body.
 Exit 1 with a list of offending agents if any are missing.
 
 Usage:
@@ -38,44 +42,28 @@ NON_REVIEW_AGENTS = {
     "ui-ux-designer",
 }
 
+SCOPE_RE = re.compile(r"^\s*Scope\s*:\s*(.*)$")
 
-def parse_frontmatter(text: str) -> dict:
-    """Return a dict of simple key: value pairs from YAML frontmatter.
 
-    Handles both scalar values (key: value) and list values:
-        key:
-          - item1
-          - item2
-    Returns {} if there is no frontmatter block.
-    """
+def has_frontmatter(text: str) -> bool:
+    """True if the file opens with a YAML frontmatter block."""
+    return text.startswith("---") and "---" in text[3:]
+
+
+def strip_frontmatter(text: str) -> str:
+    """Return the body (everything after the frontmatter block)."""
     if not text.startswith("---"):
-        return {}
-    end = text.index("---", 3)
-    fm_text = text[3:end]
-    result: dict = {}
-    current_key = None
-    for line in fm_text.splitlines():
-        # List item continuation
-        stripped = line.strip()
-        if stripped.startswith("- ") and current_key is not None:
-            value = stripped[2:].strip()
-            if isinstance(result.get(current_key), list):
-                result[current_key].append(value)
-            else:
-                result[current_key] = [value]
-            continue
-        # Key: value pair
-        m = re.match(r"^(\w[\w-]*):\s*(.*)", line)
-        if m:
-            current_key = m.group(1)
-            val = m.group(2).strip()
-            if val:
-                result[current_key] = val
-            else:
-                result[current_key] = []  # will be populated by list items
-        else:
-            current_key = None
-    return result
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    after = text.find("\n", end + 1)
+    return text[after + 1:] if after != -1 else ""
+
+
+def declares_scope(body: str) -> bool:
+    """True if the body contains a Scope: line (scalar or block-list)."""
+    return any(SCOPE_RE.match(line) for line in body.splitlines())
 
 
 def main() -> int:
@@ -104,25 +92,25 @@ def main() -> int:
         if name in NON_REVIEW_AGENTS:
             continue
         text = agent_file.read_text(encoding="utf-8")
-        fm = parse_frontmatter(text)
-        if not fm:
+        if not has_frontmatter(text):
             # No frontmatter — skip (not an agent file)
             continue
-        if "scope" not in fm:
+        body = strip_frontmatter(text)
+        if not declares_scope(body):
             missing.append(name)
 
     if missing:
-        print("FAIL: the following review agents are missing a 'scope:' frontmatter field:")
+        print("FAIL: the following review agents are missing a 'Scope:' body declaration:")
         for name in missing:
             print(f"  - {name}")
         print(
-            "\nAdd 'scope: always' for language-agnostic agents, or a list of glob patterns "
+            "\nAdd 'Scope: always' for language-agnostic agents, or a list of glob patterns "
             "for file-type-scoped agents.  See plugins/dev-team/docs/developer-notes.md."
         )
         return 1
 
     print(f"OK: all {len(list(agents_dir.glob('*.md'))) - len(NON_REVIEW_AGENTS)} "
-          f"review agents declare a scope: field.")
+          f"review agents declare a Scope: field.")
     return 0
 
 

--- a/plugins/dev-team/scripts/check_agent_tool_mapping.py
+++ b/plugins/dev-team/scripts/check_agent_tool_mapping.py
@@ -18,12 +18,13 @@ even when it carries no persona marker, and a *new* team agent can't silently
 escape the mapping:
 
 - (a) every agent named in ``TIER_CONFIG`` — deterministic coverage of the known
-  targets (``codebase-recon`` is ``enforcement: script``; ``mutation-kill`` carries
+  targets (``codebase-recon`` is ``Enforcement: script``; ``mutation-kill`` carries
   neither persona marker — branch (b) alone would miss both).
 - (b) the structural sweep — team agents detected by a ``## Behavioral Guidelines``
-  section *or* an ``enforcement: script`` frontmatter line, minus ``*-review.md``,
-  minus the documented ``EXCLUSIONS``. A swept agent in neither ``TIER_CONFIG`` nor
-  ``EXCLUSIONS`` is *unclassified* and fails — the self-extension net.
+  section *or* an ``Enforcement: script`` body line (not frontmatter — issue
+  #1333), minus ``*-review.md``, minus the documented ``EXCLUSIONS``. A swept
+  agent in neither ``TIER_CONFIG`` nor ``EXCLUSIONS`` is *unclassified* and
+  fails — the self-extension net.
 
 A granted MCP tool whose server is absent is inert at runtime; agents fall back to
 Read/Grep/Glob.
@@ -85,7 +86,7 @@ EXCLUSIONS = {
 }
 
 _BEHAVIORAL_RE = re.compile(r"^##\s+Behavioral Guidelines\s*$", re.MULTILINE)
-_ENFORCEMENT_RE = re.compile(r"^enforcement:\s*script\s*$", re.MULTILINE)
+_ENFORCEMENT_RE = re.compile(r"^Enforcement:\s*script\s*$", re.MULTILINE)
 
 
 def _agents_dir_default() -> Path:
@@ -96,7 +97,8 @@ def is_team_agent(text: str) -> bool:
     """True if the file is a team agent per agent-audit §2c's markers.
 
     A team agent carries a ``## Behavioral Guidelines`` section OR declares
-    ``enforcement: script`` (a script-enforced prose spec — still a team agent for
+    ``Enforcement: script`` (a body-level declaration, not frontmatter — issue
+    #1333 — marking a script-enforced prose spec: still a team agent for
     coverage purposes, just persona-exempt).
     """
     return bool(_BEHAVIORAL_RE.search(text) or _ENFORCEMENT_RE.search(text))

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -165,7 +165,7 @@ Include the result in the agent report table under a `Code-Intel` column.
 
 **Fix (when `--fix` is passed)**: run `python3 scripts/check_review_agent_mcp_tools.py --fix`, which appends the missing names (merge, never replacing `Read, Grep, Glob`/`Skill`). Report `FIXED: <agent> — added code-intelligence MCP tools`.
 
-3. **Code-intelligence mapping invariant (non-review team agents)**: Every non-review team agent in the #1108 mapping MUST grant its **tier's** tools in `tools:` — the **narrow** tier (`software-engineer`, `mutation-kill`, `qa-engineer`, `data-flow-tracer`) grants codegraph + the four Repowise tools, with `data-flow-tracer` also carrying a scoped `Bash(graphify *)`; the **rationale** tier (`adr-author`, `architect`, `security-engineer`, `platform-engineer`, `codebase-recon`) additionally grants `mcp__plugin_repowise_repowise__get_why`. Coverage is the union of the mapping's config keys and a structural sweep (team agents by `## Behavioral Guidelines` **or** `enforcement: script`, minus `*-review`, minus a documented exclusion list), so a new team agent that is neither mapped nor excluded fails rather than silently escaping the mapping.
+3. **Code-intelligence mapping invariant (non-review team agents)**: Every non-review team agent in the #1108 mapping MUST grant its **tier's** tools in `tools:` — the **narrow** tier (`software-engineer`, `mutation-kill`, `qa-engineer`, `data-flow-tracer`) grants codegraph + the four Repowise tools, with `data-flow-tracer` also carrying a scoped `Bash(graphify *)`; the **rationale** tier (`adr-author`, `architect`, `security-engineer`, `platform-engineer`, `codebase-recon`) additionally grants `mcp__plugin_repowise_repowise__get_why`. Coverage is the union of the mapping's config keys and a structural sweep (team agents by `## Behavioral Guidelines` **or** `Enforcement: script`, minus `*-review`, minus a documented exclusion list), so a new team agent that is neither mapped nor excluded fails rather than silently escaping the mapping.
    - FAIL if a mapped agent's `tools:` line is missing any of its tier's names, or a swept team agent is in neither the mapping nor the exclusion list (unclassified).
    - PASS if every mapped agent grants its tier's tools and every swept agent is mapped or excluded.
    - Delegated to `scripts/check_agent_tool_mapping.py` (with `TIER_CONFIG`/`EXCLUSIONS` as the single source of truth, sharing `scripts/lib/mcp_tool_grants.py` with the review-agent check as a peer). This is the non-review counterpart to invariant 2: review agents keep their five-tool set there; the mapping check never evaluates `*-review` agents.
@@ -176,7 +176,7 @@ Include the result in the agent report table under a `Mapping` column.
 
 ### 2c. Audit team agent personas
 
-A file is a **team agent** when its body contains a `## Behavioral Guidelines` section. **Exemption**: an agent that declares `enforcement: script` in its frontmatter is a script-enforced **prose spec**, not a persona-driven team agent — skip the persona checks below for it and instead verify it carries a `> **Implemented by:** <script>` pointer immediately after the H1. For each remaining team agent, check:
+A file is a **team agent** when its body contains a `## Behavioral Guidelines` section. **Exemption**: an agent that declares `Enforcement: script` in its body is a script-enforced **prose spec**, not a persona-driven team agent — skip the persona checks below for it and instead verify it carries a `> **Implemented by:** <script>` pointer immediately after the H1. For each remaining team agent, check:
 
 1. **Persona paragraph**: Is there a `You are…` sentence immediately after the H1 heading and before the first `##` section?
    - The line must begin with `You are` (case-sensitive).
@@ -202,14 +202,15 @@ Reviewer agents sometimes inline normative rules — numeric thresholds like
 "under 50 lines" or "80% coverage" — independently of the canonical skill or
 knowledge file. When that source changes, the agent silently keeps enforcing
 the stale value. The citation lint makes the dependency explicit: an agent
-declares its sources in a `cites:` frontmatter list, and every numeric threshold
+declares its sources in a body-level `Cites:` list (not frontmatter — `cites`
+is not part of the official sub-agent contract), and every numeric threshold
 the agent states on an RFC-2119 line (MUST/SHOULD/SHALL/REQUIRED/NEVER/ALWAYS)
 must also appear in a cited source.
 
 Perform the check by reading (the same mechanical, deterministic style as the
 other audits — no judgment):
 
-1. Read each agent's frontmatter and look for a `cites:` list. Each entry names
+1. Read each agent's body and look for a `Cites:` list. Each entry names
    a skill (`skills/<name>/SKILL.md`) or knowledge file (`knowledge/<name>.md`).
 2. In the agent body, find every line carrying an RFC-2119 keyword
    (MUST/MUST NOT/SHOULD/SHALL/REQUIRED/NEVER/ALWAYS). Ignore lines inside code
@@ -219,17 +220,17 @@ other audits — no judgment):
 
 Classify:
 
-- `cites:` present and every threshold backed → PASS in the Citation column.
-- `cites:` present but a threshold absent from every cited source → WARN
+- `Cites:` present and every threshold backed → PASS in the Citation column.
+- `Cites:` present but a threshold absent from every cited source → WARN
   (possible drift): report the token + line number.
-- no `cites:` but the agent states thresholds → WARN (advisory): recommend
-  adding a `cites:` list.
-- no `cites:` and no thresholds → PASS (nothing to verify).
-- `cites:` an unknown source (no matching skill/knowledge file) → WARN.
+- no `Cites:` but the agent states thresholds → WARN (advisory): recommend
+  adding a `Cites:` list.
+- no `Cites:` and no thresholds → PASS (nothing to verify).
+- `Cites:` an unknown source (no matching skill/knowledge file) → WARN.
 
 **Phase 1 is non-blocking** — these are warnings, never failures. Do not
 red-line the audit on a citation warning; surface it as an action item so drift
-is visible while `cites:` adoption grows. CI runs the deterministic counterpart,
+is visible while `Cites:` adoption grows. CI runs the deterministic counterpart,
 `scripts/citation_lint.py` (also advisory, exit 0), on every PR.
 
 ### 2e. Registry completeness (preventive)
@@ -408,7 +409,7 @@ Read each file in `.claude/hooks/*.sh` and check:
 | Agent | cites | Drift / Advisory | Status |
 | --- | --- | --- | --- |
 | complexity-review | yes | — | PASS |
-| naming-review | no | states 1 threshold, no cites: | WARN |
+| naming-review | no | states 1 threshold, no Cites: | WARN |
 | ... | | | |
 
 ## Summary

--- a/plugins/dev-team/skills/agent-eval/SKILL.md
+++ b/plugins/dev-team/skills/agent-eval/SKILL.md
@@ -227,18 +227,18 @@ change, so there is normally no operator decision to make.
 ## Cites: enforcement (drift prevention for the evals themselves)
 
 This skill grades reviewers; if a reviewer carries thresholds with no
-`cites:` declaration, `/agent-eval` is grading drift it cannot detect. Before
+`Cites:` declaration, `/agent-eval` is grading drift it cannot detect. Before
 dispatching a `--agent <name>` run:
 
 1. Probe `python3 scripts/citation_lint.py --plugin-root plugins/dev-team
    plugins/dev-team/agents/<name>.md`.
 2. If it emits an `advisory — states N normative token(s) ... declares no
-   cites:` warning, surface that **once** above the run report:
+   Cites:` warning, surface that **once** above the run report:
 
    ```text
    ⚠ agent <name> states N numeric threshold(s) on RFC-2119 lines but has no
-     cites: frontmatter. Eval results will not catch drift in those
-     thresholds. Add a cites: list naming the canonical sources.
+     Cites: declaration. Eval results will not catch drift in those
+     thresholds. Add a Cites: list naming the canonical sources.
    ```
 
 3. Continue with dispatch — the warning is advisory, never blocking (matches

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -186,13 +186,13 @@ If `--background`: run only `doc-review`, `arch-review`, `naming-review`, `struc
 
 Otherwise read the roster from the **Review Agents** section of `knowledge/agent-registry.md` — each row names an agent and its `agents/<name>.md` file. **Never `Read` the bare `agents/` directory** (it throws `EISDIR`); if you must confirm files on disk, list them with `Glob("agents/*.md")`, never a directory `Read` (see `${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`). All are enabled by default.
 
-**Agent eligibility is self-declared via `scope:` frontmatter.** For each agent in the roster, read its `agents/<name>.md` frontmatter and apply this rule:
+**Agent eligibility is self-declared via a `Scope:` body declaration.** `Scope:` is not part of the official sub-agent frontmatter contract (`agent-contract.json`), so it lives in the agent's body, not its frontmatter. For each agent in the roster, read its `agents/<name>.md` body and apply this rule:
 
-- `scope: always` → agent is eligible regardless of tech stack or file types in scope.
-- `scope:` (list of glob patterns) → agent is eligible only when at least one target file matches at least one of the declared globs (e.g. `**/*.svelte` matches any `.svelte` file). Skip the agent entirely if no target file matches.
-- Agent has no `scope:` field → treat as `scope: always` and emit a warning that the agent is missing its `scope:` declaration.
+- `Scope: always` → agent is eligible regardless of tech stack or file types in scope.
+- `Scope:` (list of glob patterns) → agent is eligible only when at least one target file matches at least one of the declared globs (e.g. `**/*.svelte` matches any `.svelte` file). Skip the agent entirely if no target file matches.
+- Agent has no `Scope:` declaration → treat as `Scope: always` and emit a warning that the agent is missing its `Scope:` declaration.
 
-This replaces any hardcoded per-agent dispatch rules. Adding or changing a review agent's trigger scope requires only editing that agent's own frontmatter — zero edits to this skill.
+This replaces any hardcoded per-agent dispatch rules. Adding or changing a review agent's trigger scope requires only editing that agent's own body — zero edits to this skill.
 
 **Framework-specific reactivity review** — dispatch based on the project's dependency manifest (`package.json` etc.):
 - React (`react` / `react-dom` in deps): include `react-reactivity-review` scoped to `.jsx`/`.tsx` and React-importing `.js`/`.ts` files
@@ -216,7 +216,7 @@ python3 "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/change_shape.py" --files
 
 It prints `{"hasRuntimeSurface": <bool>, "skipLenses": [...]}`. When `skipLenses`
 is non-empty, exclude those agents from this run and note the skip in the report
-(they were gated by change shape, not by `scope:`). The gate is **fail-safe**: any
+(they were gated by change shape, not by `Scope:`). The gate is **fail-safe**: any
 file it cannot prove is doc/config (source, an unknown extension, or functional
 Claude-config markdown under `agents/`, `skills/`, `knowledge/`, `.claude/`, …)
 counts as runtime surface and keeps every lens. This never fires on a pure-docs

--- a/plugins/dev-team/skills/code-review/sliced-mode.md
+++ b/plugins/dev-team/skills/code-review/sliced-mode.md
@@ -59,7 +59,7 @@ heuristic — any doubt yields non-declarative):
   panel** — `correctness-review` and `structure-review` only. The six-lens
   semantic panel is wasted on declaration files.
 - **Non-declarative slice**: run the **full panel** — the standard agent
-  eligibility rules from `SKILL.md` steps 3–4 (self-declared `scope:`,
+  eligibility rules from `SKILL.md` steps 3–4 (self-declared `Scope:`,
   framework reactivity lens, ai-provenance), scoped to the slice's files.
 
 The exact declarative rule is owned by `partition.py`; this file does not

--- a/plugins/dev-team/tests/scripts/test_check_agent_scope.py
+++ b/plugins/dev-team/tests/scripts/test_check_agent_scope.py
@@ -1,66 +1,64 @@
-"""Tests for scripts/check_agent_scope.py."""
+"""Tests for scripts/check_agent_scope.py.
+
+``Scope:`` is a body-level declaration, not frontmatter (issue #1333).
+"""
 
 import sys
 import textwrap
 from pathlib import Path
 
-import pytest
-
 # Make the scripts directory importable
 SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from check_agent_scope import main, parse_frontmatter  # noqa: E402
+from check_agent_scope import declares_scope, has_frontmatter, main, strip_frontmatter  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
-# parse_frontmatter unit tests
+# declares_scope / strip_frontmatter unit tests
 # ---------------------------------------------------------------------------
 
-def test_parse_frontmatter_scalar():
+def test_declares_scope_scalar():
     text = textwrap.dedent("""\
         ---
         name: my-agent
-        scope: always
-        effort: medium
         ---
         # Body
+        Scope: always
     """)
-    fm = parse_frontmatter(text)
-    assert fm["name"] == "my-agent"
-    assert fm["scope"] == "always"
-    assert fm["effort"] == "medium"
+    body = strip_frontmatter(text)
+    assert declares_scope(body)
 
 
-def test_parse_frontmatter_list():
+def test_declares_scope_list():
     text = textwrap.dedent("""\
         ---
         name: svelte-review
-        scope:
-          - **/*.svelte
-          - **/*.svelte.ts
         ---
         # Body
+        Scope:
+        - **/*.svelte
+        - **/*.svelte.ts
     """)
-    fm = parse_frontmatter(text)
-    assert fm["scope"] == ["**/*.svelte", "**/*.svelte.ts"]
+    body = strip_frontmatter(text)
+    assert declares_scope(body)
 
 
-def test_parse_frontmatter_no_frontmatter():
+def test_no_frontmatter_is_detected():
     text = "# Just a plain file\nno frontmatter here."
-    assert parse_frontmatter(text) == {}
+    assert not has_frontmatter(text)
 
 
-def test_parse_frontmatter_missing_scope():
+def test_declares_scope_false_when_missing():
     text = textwrap.dedent("""\
         ---
         name: my-agent
-        effort: low
         ---
         # Body
+        No scope line here.
     """)
-    fm = parse_frontmatter(text)
-    assert "scope" not in fm
+    body = strip_frontmatter(text)
+    assert not declares_scope(body)
 
 
 # ---------------------------------------------------------------------------
@@ -79,21 +77,21 @@ def test_main_all_agents_have_scope(tmp_path, capsys):
         name: doc-review
         description: Docs
         effort: medium
-        scope: always
         ---
         # Doc Review
+        Scope: always
     """))
     _write_agent(agents_dir, "svelte-review", textwrap.dedent("""\
         ---
         name: svelte-review
         description: Svelte
         effort: low
-        scope:
-          - **/*.svelte
         ---
         # Svelte Review
+        Scope:
+        - **/*.svelte
     """))
-    rc = main.__wrapped__(agents_dir) if hasattr(main, "__wrapped__") else _call_main(agents_dir)
+    rc = _call_main(agents_dir)
     assert rc == 0
 
 
@@ -118,7 +116,7 @@ def test_main_non_review_agent_skipped(tmp_path, capsys):
     """Non-review agents listed in NON_REVIEW_AGENTS should not cause failure."""
     agents_dir = tmp_path / "agents"
     agents_dir.mkdir()
-    # orchestrator has no scope: field — should be skipped
+    # orchestrator has no Scope: declaration — should be skipped
     _write_agent(agents_dir, "orchestrator", textwrap.dedent("""\
         ---
         name: orchestrator

--- a/plugins/marketplace-dev/agents/plugin-best-practices-review.md
+++ b/plugins/marketplace-dev/agents/plugin-best-practices-review.md
@@ -3,9 +3,10 @@ name: plugin-best-practices-review
 description: Plugin structural best practices — agent type appropriateness, frontmatter compliance, eval coverage, and body line-count budgets
 tools: Read, Grep, Glob
 effort: medium
-cites: [agent-type-decision-rules]
 ---
 # Plugin Best Practices Review
+
+Cites: [agent-type-decision-rules]
 
 Output JSON:
 

--- a/plugins/marketplace-dev/skills/agent-create/SKILL.md
+++ b/plugins/marketplace-dev/skills/agent-create/SKILL.md
@@ -240,20 +240,23 @@ corresponding flag in Step 1 — there is no forced default for any of them.
 Do not include `hooks`, `mcpServers`, or `permissionMode` unless the user
 confirmed their inclusion in Step 8.
 
-#### `cites:` (citation drift defense)
+#### `Cites:` (citation drift defense)
 
 When a review agent inlines normative **numeric thresholds** (e.g. "functions
 MUST be under 50 lines", "coverage SHOULD reach 80%") that are owned by a
-canonical skill or knowledge file, declare those sources with a `cites:` list so
-`/plugin-audit`'s citation lint can detect drift between the agent and its source:
+canonical skill or knowledge file, declare those sources with a body-level
+`Cites:` list — **not frontmatter**: `cites` is not part of the official
+Claude Code sub-agent contract (`agent-contract.json`), so it lives in the
+generated body, near the top, alongside `Context needs:`:
 
-```yaml
-cites: [complexity, object-calisthenics]   # skill names or knowledge file stems
+```markdown
+Cites: [complexity, object-calisthenics]   # skill names or knowledge file stems
 ```
 
 Each entry resolves to `$PLUGIN/skills/<name>/SKILL.md` or `$PLUGIN/knowledge/<name>.md`.
-The lint flags any threshold the agent states on an RFC-2119 line that is absent
-from every cited source. The lint is advisory (Phase 1, non-blocking) either way.
+The citation lint flags any threshold the agent states on an RFC-2119 line
+that is absent from every cited source. The lint is advisory (Phase 1,
+non-blocking) either way.
 
 **Pre-write check.** After Step 10 generates the body, before Step 11 writes
 the file:
@@ -261,19 +264,19 @@ the file:
 1. Scan the generated body for **threshold-bearing RFC-2119 lines** — any
    line carrying `MUST|SHOULD|SHALL|REQUIRED|NEVER|ALWAYS` AND a numeric
    token (`\d+(\.\d+)?%?`), outside code fences and blockquotes.
-2. If any are found AND no `cites:` field was set, emit exactly:
+2. If any are found AND no `Cites:` line was set, emit exactly:
 
    ```text
    ⚠ Agent body states N numeric threshold(s) on RFC-2119 lines but no
-     cites: was declared. Eval drift defense will be blind on this agent.
+     Cites: was declared. Eval drift defense will be blind on this agent.
 
-     (a) add cites:  (b) proceed without
+     (a) add Cites:  (b) proceed without
    ```
 
 3. On `(a)`: prompt for a comma-separated list, validate each entry resolves
    to a real `$PLUGIN/skills/<name>/SKILL.md` or `$PLUGIN/knowledge/<name>.md`,
-   insert `cites: [<list>]` into the frontmatter, and continue to Step 11.
-4. On `(b)`: continue to Step 11 with no `cites:` — the lint will flag the
+   insert a `Cites: [<list>]` line into the body, and continue to Step 11.
+4. On `(b)`: continue to Step 11 with no `Cites:` — the lint will flag the
    agent as `advisory` going forward, which is the correct deferred state.
 
 Omit the check entirely when the body states no thresholds; nothing for the

--- a/plugins/security-assessment/agents/authorization-logic-review.md
+++ b/plugins/security-assessment/agents/authorization-logic-review.md
@@ -4,10 +4,11 @@ effort: high
 name: authorization-logic-review
 description: Top-down authorization review. Maps the access-control model (RBAC/ABAC/ACL/tenancy), then verifies enforcement at every layer. Phase 1b peer agent.
 tools: Read, Grep, Glob
-cites: [severity-floors]
 ---
 
 # Authorization Logic Review
+
+Cites: [severity-floors]
 
 Map the authorization model first, then check consistent enforcement.
 Report the gap between stated policy and observed implementation — not

--- a/plugins/security-assessment/agents/fp-reduction.md
+++ b/plugins/security-assessment/agents/fp-reduction.md
@@ -4,10 +4,11 @@ effort: high
 name: fp-reduction
 description: Applies the six-stage FP-reduction rubric to a unified-finding stream, producing a disposition register. Consumes findings + RECON (+ CPG when joern is available).
 tools: Read, Grep, Glob, Bash
-cites: [severity-floors]
 ---
 
 # FP-Reduction Agent
+
+Cites: [severity-floors]
 
 Execute the rubric defined in `skills/false-positive-reduction/SKILL.md` against
 the unified finding stream. Never silently discard a finding — every input

--- a/plugins/security-assessment/agents/recon-driven-scan.md
+++ b/plugins/security-assessment/agents/recon-driven-scan.md
@@ -4,10 +4,11 @@ effort: high
 name: recon-driven-scan
 description: Bridges RECON narrative risk claims to file/line evidence. Emits findings only when the source actually exhibits the described pattern. Phase 1b peer agent.
 tools: Read, Grep, Glob, Bash
-cites: [severity-floors]
 ---
 
 # RECON-Driven Scan Agent
+
+Cites: [severity-floors]
 
 Phase 1b peer agent. Reads the human-language risk descriptions in the
 Phase 0 RECON narrative and finds concrete file:line evidence in source for

--- a/plugins/security-assessment/agents/redteam-recon-analyzer.md
+++ b/plugins/security-assessment/agents/redteam-recon-analyzer.md
@@ -4,10 +4,11 @@ effort: high
 name: redteam-recon-analyzer
 description: Interprets probe 01 (API recon). Severity-rates info leaks, identifies the framework, recommends a feature-discovery strategy for probe 02.
 tools: Read, Grep
-cites: [severity-floors]
 ---
 
 # Red-Team Recon Analyzer
+
+Cites: [severity-floors]
 
 Interpret probe 01's API reconnaissance. The probe enumerates doc paths,
 endpoints, HTTP method matrices, and server headers — judging which leaks

--- a/scripts/citation_lint.py
+++ b/scripts/citation_lint.py
@@ -7,12 +7,13 @@ canonical file changes, the agent silently keeps enforcing the stale rule. That
 drift is invisible until a reviewer and a builder disagree.
 
 This lint makes the dependency explicit and checkable. An agent declares the
-canonical sources it derives its rules from in a ``cites:`` frontmatter list::
+canonical sources it derives its rules from in a body-level ``Cites:``
+declaration (not frontmatter — ``cites:`` is not part of the official
+Claude Code sub-agent contract, see agent-contract.json)::
 
-    ---
-    name: complexity-review
-    cites: [complexity, object-calisthenics]   # skill names or knowledge files
-    ---
+    # Complexity Review
+
+    Cites: [complexity, object-calisthenics]   # skill names or knowledge files
 
 For every **normative token** the agent states — a numeric threshold (e.g.
 ``50``, ``80%``) appearing on a line that carries an RFC-2119 keyword
@@ -24,10 +25,10 @@ on them rather than free-text rule prose.
 
 Phase 1 is **non-blocking** (warnings only, exit 0):
 
-- ``cites:`` present and every normative token backed  -> no warning.
-- ``cites:`` present, a token uncited                  -> warning (token + line).
-- no ``cites:`` and no normative tokens                -> no warning.
-- no ``cites:`` but normative tokens present           -> one advisory warning.
+- ``Cites:`` present and every normative token backed  -> no warning.
+- ``Cites:`` present, a token uncited                  -> warning (token + line).
+- no ``Cites:`` and no normative tokens                -> no warning.
+- no ``Cites:`` but normative tokens present           -> one advisory warning.
 
 Code fences (``` / ~~~ blocks) and blockquote lines (``>``) are excluded so
 illustrative examples are never mistaken for normative rules.
@@ -50,22 +51,18 @@ NORMATIVE_RE = re.compile(
 THRESHOLD_RE = re.compile(r"(?<![\w.#-])\d+(?:\.\d+)?%?")
 
 
-def parse_frontmatter_cites(text: str) -> list[str] | None:
-    """Return the ``cites:`` list, or None when the field is absent.
+def parse_cites(body: str) -> list[str] | None:
+    """Return the ``Cites:`` list from the agent body, or None when absent.
 
-    Accepts an inline flow list (``cites: [a, b]``) or a block list (``cites:``
-    followed by ``  - a`` lines). Avoids a YAML dependency (the repo's bats
-    suites already shell to Python without PyYAML guaranteed here).
+    ``Cites:`` is a body-level declaration (not frontmatter — it is not part
+    of the official Claude Code sub-agent contract). Accepts an inline flow
+    list (``Cites: [a, b]``) or a block list (``Cites:`` followed by
+    ``- a`` lines). Avoids a YAML dependency (the repo's bats suites already
+    shell to Python without PyYAML guaranteed here).
     """
-    if not text.startswith("---"):
-        return None
-    end = text.find("\n---", 3)
-    if end == -1:
-        return None
-    fm = text[3:end]
-    lines = fm.splitlines()
+    lines = body.splitlines()
     for i, line in enumerate(lines):
-        m = re.match(r"\s*cites\s*:\s*(.*)$", line)
+        m = re.match(r"\s*Cites\s*:\s*(.*)$", line)
         if not m:
             continue
         rest = m.group(1).strip()
@@ -157,8 +154,8 @@ def resolve_cite(name: str, plugin_root: Path) -> Path | None:
 def lint_agent(path: Path, plugin_root: Path) -> list[str]:
     """Return a list of warning strings for one agent file (empty == clean)."""
     text = path.read_text()
-    cites = parse_frontmatter_cites(text)
     body, base = strip_frontmatter(text)
+    cites = parse_cites(body)
     tokens = normative_tokens(body)
     warnings: list[str] = []
     name = path.stem
@@ -168,7 +165,7 @@ def lint_agent(path: Path, plugin_root: Path) -> list[str]:
             warnings.append(
                 f"{name}: advisory — states {len(tokens)} normative token(s) "
                 f"(e.g. {tokens[0][1]!r} at line {tokens[0][0] + base - 1}) but "
-                f"declares no `cites:`; add a cites: list so the rules are "
+                f"declares no `Cites:`; add a Cites: list so the rules are "
                 f"checked against their canonical source."
             )
         return warnings

--- a/tests/agents/test_agent_audit_integration_validation.py
+++ b/tests/agents/test_agent_audit_integration_validation.py
@@ -47,8 +47,10 @@ def test_claude_setup_review_has_context_needs_project_structure() -> None:
 
 
 def test_orchestrator_declares_enforcement_script_and_implemented_by() -> None:
+    # `Enforcement: script` is a body-level declaration, not frontmatter
+    # (issue #1333).
     text = (AGENTS / "orchestrator.md").read_text(encoding="utf-8")
-    assert re.search(r"^enforcement:\s*script", text, re.MULTILINE)
+    assert re.search(r"^Enforcement:\s*script", text, re.MULTILINE)
     assert re.search(r"^> \*\*Implemented by:\*\*", text, re.MULTILINE)
 
 

--- a/tests/agents/test_agent_audit_metadata.py
+++ b/tests/agents/test_agent_audit_metadata.py
@@ -17,8 +17,8 @@ def test_claude_setup_review_has_context_needs_project_structure() -> None:
 def test_orchestrator_declares_enforcement_script_and_implemented_by() -> None:
     # The orchestrator was converted to a script-enforced prose spec (PR #462):
     # it is no longer a persona-driven team agent, so instead of a "You are"
-    # persona it declares `enforcement: script` and points at its
-    # implementation.
+    # persona it declares a body-level `Enforcement: script` (not
+    # frontmatter — issue #1333) and points at its implementation.
     text = (AGENTS / "orchestrator.md").read_text(encoding="utf-8")
-    assert re.search(r"^enforcement:\s*script", text, re.MULTILINE)
+    assert re.search(r"^Enforcement:\s*script", text, re.MULTILINE)
     assert re.search(r"^> \*\*Implemented by:\*\*", text, re.MULTILINE)

--- a/tests/repo/test_agent_frontmatter_docs.py
+++ b/tests/repo/test_agent_frontmatter_docs.py
@@ -1,10 +1,12 @@
-"""Non-standard agent frontmatter keys must be documented (issue #732).
+"""Non-standard agent body declarations must be documented (issue #732).
 
-`cites:` (used by 22 agents) and `enforcement: script` (used by 5 agents) are
-intentional internal tooling metadata read by `scripts/citation_lint.py` and
-the "Implemented by:" agent convention respectively — not schema errors. This
-guard checks that a real doc explains both, so a future contributor auditing
-agent frontmatter doesn't mistake them for drift.
+`Cites:` (used by ~32 agents) and `Enforcement: script` (used by 5 agents)
+are intentional internal tooling metadata read by `scripts/citation_lint.py`
+and the "Implemented by:" agent convention respectively — not schema errors.
+Both are body-level declarations, not frontmatter (issue #1333 — neither is
+part of the official Claude Code sub-agent contract). This guard checks that
+a real doc explains both, so a future contributor auditing agent frontmatter
+doesn't mistake them for drift.
 """
 
 from __future__ import annotations
@@ -15,21 +17,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "plugins" / "dev-team" / "docs" / "agent_info.md"
 
 
-def test_agent_info_doc_explains_cites_frontmatter_key() -> None:
+def test_agent_info_doc_explains_cites_declaration() -> None:
     text = DOC.read_text(encoding="utf-8")
-    assert "`cites:`" in text, (
-        f"{DOC} should document the `cites:` frontmatter key used by "
+    assert "`Cites:" in text, (
+        f"{DOC} should document the `Cites:` body declaration used by "
         "review agents to declare their canonical knowledge sources."
     )
     assert "citation_lint.py" in text, (
         f"{DOC} should reference scripts/citation_lint.py, the tool that "
-        "consumes the `cites:` frontmatter key."
+        "consumes the `Cites:` declaration."
     )
 
 
-def test_agent_info_doc_explains_enforcement_script_frontmatter_key() -> None:
+def test_agent_info_doc_explains_enforcement_script_declaration() -> None:
     text = DOC.read_text(encoding="utf-8")
-    assert "`enforcement: script`" in text, (
-        f"{DOC} should document the `enforcement: script` frontmatter key "
+    assert "`Enforcement: script`" in text, (
+        f"{DOC} should document the `Enforcement: script` body declaration "
         "used by deterministic-script-backed agents."
     )

--- a/tests/repo/test_citation_lint.py
+++ b/tests/repo/test_citation_lint.py
@@ -2,6 +2,9 @@
 (issue #312). Phase 1 is advisory (always exit 0); these pin the warning
 behaviour on a tiny self-contained plugin tree.
 
+``Cites:`` is a body-level declaration, not frontmatter (issue #1333 — it is
+not part of the official Claude Code sub-agent contract).
+
 Ported from tests/repo/citation_lint_tests.bats (issue #572: bash -> Python).
 """
 
@@ -45,9 +48,9 @@ def test_cites_present_and_thresholds_backed_no_warning(plugin: Path) -> None:
     target.write_text(
         """---
 name: clean
-cites: [complexity, object-calisthenics]
 ---
 # Clean
+Cites: [complexity, object-calisthenics]
 Functions MUST be under 50 lines. Coverage SHOULD reach 80%.
 Classes MUST hold no more than 2 instance variables.
 """
@@ -63,9 +66,9 @@ def test_cites_present_but_threshold_uncited_warns(plugin: Path) -> None:
     target.write_text(
         """---
 name: drift
-cites: [complexity]
 ---
 # Drift
+Cites: [complexity]
 Functions MUST be under 40 lines.
 """
     )
@@ -107,7 +110,7 @@ Functions MUST be under 50 lines.
     out = res.stdout + res.stderr
     assert res.returncode == 0, out
     assert "advisory" in out
-    assert "declares no `cites:`" in out
+    assert "declares no `Cites:`" in out
 
 
 def test_thresholds_inside_code_fences_not_flagged(plugin: Path) -> None:
@@ -115,9 +118,9 @@ def test_thresholds_inside_code_fences_not_flagged(plugin: Path) -> None:
     target.write_text(
         """---
 name: fenced
-cites: [complexity]
 ---
 # Fenced
+Cites: [complexity]
 
 ```
 Functions MUST be under 40 lines.
@@ -135,9 +138,9 @@ def test_thresholds_inside_blockquotes_not_flagged(plugin: Path) -> None:
     target.write_text(
         """---
 name: quoted
-cites: [complexity]
 ---
 # Quoted
+Cites: [complexity]
 > Functions MUST be under 40 lines.
 """
     )
@@ -152,9 +155,9 @@ def test_cites_unknown_source_yields_warning(plugin: Path) -> None:
     target.write_text(
         """---
 name: badcite
-cites: [does-not-exist]
 ---
 # BadCite
+Cites: [does-not-exist]
 Functions MUST be under 50 lines.
 """
     )
@@ -170,11 +173,12 @@ def test_block_list_cites_syntax_parsed(plugin: Path) -> None:
     target.write_text(
         """---
 name: block
-cites:
-  - complexity
-  - object-calisthenics
 ---
 # Block
+Cites:
+- complexity
+- object-calisthenics
+
 Functions MUST be under 50 lines and hold no more than 2 variables.
 """
     )
@@ -189,9 +193,9 @@ def test_issue_refs_not_treated_as_thresholds(plugin: Path) -> None:
     target.write_text(
         """---
 name: issueref
-cites: [complexity]
 ---
 # IssueRef
+Cites: [complexity]
 This rule MUST follow the contract from #99 and #312.
 """
     )

--- a/tests/repo/test_validate_agent_contract.py
+++ b/tests/repo/test_validate_agent_contract.py
@@ -184,10 +184,11 @@ def test_every_shipped_agent_across_every_plugin_has_no_contract_errors() -> Non
     `/agent-audit` or `/plugin-audit` — it catches contract violations even
     when nobody remembers to run either skill.
 
-    `warning`-severity findings (unknown frontmatter keys, plugin-ignored
-    fields) are informational only and not asserted away here — plugins may
-    carry non-contract keys (e.g. dev-team's `cites:`/`scope:`) by design;
-    `/agent-audit`/`/plugin-audit` surface those for a human to judge.
+    `warning`-severity findings for a **recognized** contract field that is
+    merely inert in context (e.g. `hooks:`/`mcpServers:`/`permissionMode:`
+    ignored for plugin-supplied agents) are informational only and not
+    asserted away here — that is a deployment-context note, not a contract
+    violation.
     """
     agents = _every_shipped_agent()
     assert agents, "no plugins/*/agents/*.md files found — did the layout change?"
@@ -206,4 +207,39 @@ def test_every_shipped_agent_across_every_plugin_has_no_contract_errors() -> Non
         "Agent frontmatter contract violation(s) — fix per "
         "plugins/marketplace-dev/knowledge/agent-contract.json:\n  "
         + "\n  ".join(failures)
+    )
+
+
+def test_every_shipped_agent_frontmatter_has_no_unrecognized_keys() -> None:
+    """Nothing should be in an agent's frontmatter that isn't defined by the
+    contract (issue #1333) — this is the gate that makes that a standing
+    guarantee rather than a one-time cleanup. Fails on any 'Unknown
+    frontmatter key' warning; a plugin-ignored-field warning for a
+    *recognized* field (hooks/mcpServers/permissionMode) is a different,
+    non-violating category and is not asserted away here.
+    """
+    agents = _every_shipped_agent()
+    assert agents, "no plugins/*/agents/*.md files found — did the layout change?"
+
+    failures: list[str] = []
+    for agent in agents:
+        result = run_validator(str(agent))
+        data = json.loads(result.stdout)
+        unknown_key_warnings = [
+            i
+            for i in data["issues"]
+            if i["severity"] == "warning"
+            and i["message"].startswith("Unknown frontmatter key")
+        ]
+        if unknown_key_warnings:
+            rel = agent.relative_to(REPO_ROOT)
+            for issue in unknown_key_warnings:
+                failures.append(f"{rel}: {issue['field']}: {issue['message']}")
+
+    assert not failures, (
+        "Agent frontmatter carries a key not defined by "
+        "plugins/marketplace-dev/knowledge/agent-contract.json — move it to "
+        "the agent's body instead (see docs/agent_info.md's 'Non-standard "
+        "body declarations' section for the existing Cites:/Scope:/"
+        "Enforcement: convention):\n  " + "\n  ".join(failures)
     )


### PR DESCRIPTION
## Summary

Nothing should be in an agent's frontmatter that isn't defined by the official Claude Code sub-agent contract (`agent-contract.json`, #1285). Three keys were living in frontmatter anyway (61 occurrences across 34 agents in all three plugins): `cites` (citation drift defense), `scope` (review-agent file-type eligibility), and `enforcement` (script-backed prose spec marker). None are part of the contract, so `validate_agent_contract.py` has been WARNing on all of them.

Moves each to a body-level Title-Case declaration (`Cites:`/`Scope:`/`Enforcement:`), matching this repo's existing `Context needs:` convention — right after the H1, same value syntax (inline flow list, block list, or scalar), same semantics, just relocated:

- `scripts/citation_lint.py`'s `parse_frontmatter_cites` → `parse_cites` now reads the body instead of the frontmatter block.
- `plugins/dev-team/scripts/check_agent_scope.py`'s generic frontmatter parser is replaced with a body-scan for a `Scope:` line.
- `plugins/dev-team/scripts/check_agent_tool_mapping.py`'s `_ENFORCEMENT_RE` was already body-position-agnostic (`MULTILINE`, not frontmatter-scoped) but case-sensitive on lowercase `enforcement:` — fixed to match the new `Enforcement:` casing (the one real regression the migration surfaced, caught by `test_check_agent_tool_mapping.py`).
- `skills/code-review/SKILL.md`'s and `sliced-mode.md`'s agent-eligibility dispatch prose now points at the body declaration.
- `docs/agent_info.md`, `agent-eval/SKILL.md`, `agent-audit/SKILL.md`, and marketplace-dev's `agent-create/SKILL.md` updated so future agent authoring follows the body convention, not frontmatter.

Migrates all 34 affected agents across all three plugins (dev-team, security-assessment, and marketplace-dev's own `plugin-best-practices-review.md`, found while auditing). Post-migration, `python3 scripts/validate_agent_contract.py` against every `agents/*.md` file in every plugin reports **zero errors and zero warnings**.

Tightens `tests/repo/test_validate_agent_contract.py`'s repo-wide gate (added in #1329) with a new test that fails on any `Unknown frontmatter key` warning across every plugin's agents — the standing guarantee that this can't silently regress. A plugin-ignored-field warning for a *recognized* contract field (`hooks:`/`mcpServers:`/`permissionMode:` inert for plugin agents) is a different, non-violating category and stays informational.

## Test plan

- [x] Full pre-push pytest tree — 3719 passed, 1 skipped
- [x] `python3 scripts/validate_agent_contract.py` against every agent in every plugin — 0 errors, 0 warnings
- [x] `lychee --offline` against the exact file set CI scans — 0 errors
- [x] `check_md_references.py` / `check_registry_sync.py` — clean

Closes #1333
Part of #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)