### PR TITLE
fix: reword /build's dangling /verify references to describe the pattern

### DIFF
--- a/plugins/dev-team/knowledge/evidence-bundle.md
+++ b/plugins/dev-team/knowledge/evidence-bundle.md
@@ -3,7 +3,7 @@
 A structured "what was checked, and what wasn't" statement carried by `/build`'s
 final output and `/pr`'s PR body. Verification here is a stack of scoped
 verifiers — unit suite, type check, lint, review agents, coverage delta,
-runtime `/verify`, Farley score — not one boolean. A green checkmark alone
+runtime verification (sub-step 4.9), Farley score — not one boolean. A green checkmark alone
 over-claims: it says checks passed but not what each one actually verified,
 what it structurally cannot verify for this diff, which regions remain
 untested, or what risk was consciously accepted. The bundle closes that gap.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1309,7 +1309,7 @@
       "anchor": "review-valuejsonl"
     },
     "`verify-log.jsonl`": {
-      "summary": "Evidence that `/verify` actually ran (or was legitimately skipped) before a",
+      "summary": "Evidence that the project's own test/verification tooling actually exercised",
       "anchor": "verify-logjsonl"
     },
     "`override-audit.jsonl`": {

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -212,8 +212,9 @@ counts and outcomes only, never code or file content.
 
 ## `verify-log.jsonl`
 
-Evidence that `/verify` actually ran (or was legitimately skipped) before a
-`/build` slice with a runtime surface was marked complete. Schema modeled on
+Evidence that the project's own test/verification tooling actually exercised
+the change end-to-end (or was legitimately skipped) before a `/build` slice
+with a runtime surface was marked complete. Schema modeled on
 `review-value.jsonl`.
 
 | Field | Type | Values / source |

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   after /plan has been approved.
 argument-hint: "[--plan <path>] [--yes]"
 user-invocable: true
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, Skill(verify *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion
 ---
 
 # Build
@@ -191,7 +191,7 @@ Work each step **one behavior at a time** — never all the code then all the te
    - **UI changes (any complexity)**: After the relevant review passes (per-step for complex, at the slice checkpoint for standard), run browser verification via `/browse` in automated smoke test mode. Skip with warning if the dev server is not running. See `agents/orchestrator.md` Stage 3.
 5. **Mark step done** — Use the Edit tool to update the plan file's `## Build Progress` section on disk:
    - Change `- [ ] Step N.M: <title>` to `- [x] Step N.M: <title>` for the completed step.
-   - When every step under a slice is `[x]`, that is not the same as the slice being done — check off the parent `- [ ] Slice N: <title>` only after sub-steps 4.9 (verify) and 4.10 (invariants) both pass, if applicable; a slice with no runtime surface and no declared invariants has nothing further to wait on and may be checked off once its steps and review checkpoint(s) are done.
+   - When every step under a slice is `[x]`, that is not the same as the slice being done — check off the parent `- [ ] Slice N: <title>` only after sub-steps 4.9 (runtime verification) and 4.10 (invariants) both pass, if applicable; a slice with no runtime surface and no declared invariants has nothing further to wait on and may be checked off once its steps and review checkpoint(s) are done.
    - After all slices are `[x]`, change `**Status**: approved` to `**Status**: in-progress`.
    - This disk write is the durable commit. If a `/clear` occurs, `/continue` reads `## Build Progress` to determine the resume point without needing conversation history.
    - **Clear freeze scope (issue #865).** When every step under the slice is `[x]` and freeze was engaged for it (dispatch bookkeeping above), run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_slice_scope.py clear --hooks-dir <worktree>/hooks` before starting the next slice. A slice that never engaged freeze has nothing to clear.
@@ -208,17 +208,17 @@ Work each step **one behavior at a time** — never all the code then all the te
 
 A "done" step that only passed its own tests is not the same as a feature that works — a red suite catches structural regressions, not "it fails the first time someone actually runs it." Once a slice's steps are all `[x]` (sub-step 5) and its review checkpoint(s) have run (sub-steps 4/6), decide whether the slice has a runtime surface to exercise **before the slice may be marked `[x]` complete**:
 
-1. **Classify the slice's changed files**, per `knowledge/test-file-indicators.md`. If every changed file is a test file, or the rest are docs/config only (no source or runtime file changed), there is nothing for `/verify` to drive — record `outcome: "skipped"` with a `reason` (below) and continue.
-2. **Otherwise, invoke `/verify`** scoped to the slice's changed runtime files before the slice's checkbox is flipped to `[x]`. This generalizes the UI-only `/browse` smoke test (sub-step 4's UI bullet) into a universal completion criterion: APIs, CLIs, bots, and background jobs get the same "did this actually run" check UI changes already get.
-3. **Not bypassable by `--yes`, `DEV_TEAM_AUTO_APPROVE=1`, or no-TTY.** Contrast with the approval gates in Steps 2–3: those bypass a human judgment call when no human is present. This gate needs no human judgment — the agent runs `/verify` itself — so non-interactive mode never skips it. There is no override flag for this step.
-4. **A `/verify` failure is a failing test.** Per Step 5's "Quality ownership" language: do not mark the slice `[x]` or the plan `implemented`. Enter [Systematic Debugging](../systematic-debugging/SKILL.md), find the root cause, fix it, and re-run `/verify` before proceeding — never silently override.
+1. **Classify the slice's changed files**, per `knowledge/test-file-indicators.md`. If every changed file is a test file, or the rest are docs/config only (no source or runtime file changed), there is nothing to exercise at runtime — record `outcome: "skipped"` with a `reason` (below) and continue.
+2. **Otherwise, exercise the change end-to-end** using the project's own test/verification tooling — its test runner, checker scripts, or a direct invocation of the changed entry point (CLI command, API call, script run) — scoped to the slice's changed runtime files, before the slice's checkbox is flipped to `[x]`. This is a pattern, not a named command: there is no `/verify` skill shipped by this plugin, so pick whatever the project already uses to run/exercise the affected surface for real (e.g. its integration test suite, a smoke-test script, or manually invoking the changed function/endpoint/command). This generalizes the UI-only `/browse` smoke test (sub-step 4's UI bullet) into a universal completion criterion: APIs, CLIs, bots, and background jobs get the same "did this actually run" check UI changes already get.
+3. **Not bypassable by `--yes`, `DEV_TEAM_AUTO_APPROVE=1`, or no-TTY.** Contrast with the approval gates in Steps 2–3: those bypass a human judgment call when no human is present. This gate needs no human judgment — the agent runs the verification itself — so non-interactive mode never skips it. There is no override flag for this step.
+4. **A failed verification run is a failing test.** Per Step 5's "Quality ownership" language: do not mark the slice `[x]` or the plan `implemented`. Enter [Systematic Debugging](../systematic-debugging/SKILL.md), find the root cause, fix it, and re-run the verification before proceeding — never silently override.
 5. **Record the outcome.** Append exactly one JSON line per slice with a runtime surface to `metrics/verify-log.jsonl`, schema modeled on `metrics/review-value.jsonl` (sub-step 7):
 
    ```json
    {"timestamp":"<ISO8601>","plan":"<plan-file>","slice":"<N>","branch":"<branch>","files":["<changed runtime file>","..."],"outcome":"ran|skipped|failed-then-fixed","reason":"<set when outcome is skipped>"}
    ```
 
-   `outcome` is `ran` (`/verify` executed and passed), `skipped` (no runtime surface in the diff — `reason` states why, e.g. `"tests-only"` or `"docs-only"`), or `failed-then-fixed` (`/verify` failed at least once before the fix landed). `python3 scripts/progress_guardian.py --pre-pr` reads this log: a branch with runtime-surface changes and no matching entry fails the pre-PR gate the same way an incomplete step or a missing commit does.
+   `outcome` is `ran` (the verification ran and passed), `skipped` (no runtime surface in the diff — `reason` states why, e.g. `"tests-only"` or `"docs-only"`), or `failed-then-fixed` (the verification failed at least once before the fix landed). `python3 scripts/progress_guardian.py --pre-pr` reads this log: a branch with runtime-surface changes and no matching entry fails the pre-PR gate the same way an incomplete step or a missing commit does.
 
 ### 4.10. Run slice invariants (issue #865)
 
@@ -270,8 +270,9 @@ re-execution**; it renders data this run already produced:
   "not measured — no coverage tool detected."
 - **Residual risks**: derived-first from this run's `metrics/review-value.jsonl`
   entries with `outcome: "escalated"`, any non-interactive gate-bypass audit
-  lines printed in Steps 2–3, and any `/verify` `failed-then-fixed` entries in
-  `metrics/verify-log.jsonl`. "None identified" only when all of those are empty.
+  lines printed in Steps 2–3, and any `failed-then-fixed` runtime-verification
+  entries in `metrics/verify-log.jsonl`. "None identified" only when all of
+  those are empty.
 
 Follow the degradation rule: every one of the four section headers appears in
 the completion report even when a section has nothing to show — it states why.
@@ -312,7 +313,7 @@ unresolved escalation.
 
 - `/specs` produces the intent, architecture, and acceptance-criteria artifacts that inform the plan
 - `/plan` decomposes the feature into slices, authors each slice's Gherkin, and produces the plan this command executes
-- `/verify` exercises each runtime-surface slice end-to-end before it may be marked done (sub-step 4.9, issue #727)
+- Sub-step 4.9 exercises each runtime-surface slice end-to-end, using the project's own test/verification tooling scoped to the diff, before it may be marked done (issue #727) — this is a pattern to follow, not a named `/verify` command
 - `/code-review` runs the full review suite after implementation
 - `farley-score` scores the branch's tests (Farley Score) as the final pre-PR quality signal
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/evidence-bundle.md` defines the structured evidence bundle assembled in Step 7.5 and surfaced in the Step 8 completion report

--- a/plugins/dev-team/skills/performance-metrics/SKILL.md
+++ b/plugins/dev-team/skills/performance-metrics/SKILL.md
@@ -198,12 +198,13 @@ section).
 ### Verify Log Entry (#727)
 
 `/build` appends one entry per **slice with a runtime surface** to
-`metrics/verify-log.jsonl` (sub-step 4.9) — evidence that `/verify` actually
-exercised the change end-to-end before the slice was marked done, or was
-explicitly skipped because the diff had no runtime surface to drive. This is
-the sensor that closes the gap the #727 investigation found: a "done" feature
-that fails the first time it's really run means `/verify` was either skipped
-or never mandated in the first place.
+`metrics/verify-log.jsonl` (sub-step 4.9) — evidence that the project's own
+test/verification tooling actually exercised the change end-to-end before the
+slice was marked done, or was explicitly skipped because the diff had no
+runtime surface to drive. This is the sensor that closes the gap the #727
+investigation found: a "done" feature that fails the first time it's really
+run means runtime verification was either skipped or never mandated in the
+first place.
 
 ```json
 {
@@ -220,8 +221,8 @@ or never mandated in the first place.
 | Field | Type | Description |
 | --- | --- | --- |
 | `branch` | string | Current branch name — `scripts/progress_guardian.py --pre-pr` matches on this |
-| `files` | string[] | The slice's changed runtime files that `/verify` was scoped to |
-| `outcome` | string | `ran` (`/verify` executed and passed), `skipped` (no runtime surface — see `reason`), or `failed-then-fixed` (`/verify` failed at least once before the fix landed) |
+| `files` | string[] | The slice's changed runtime files the verification was scoped to |
+| `outcome` | string | `ran` (the verification ran and passed), `skipped` (no runtime surface — see `reason`), or `failed-then-fixed` (the verification failed at least once before the fix landed) |
 | `reason` | string \| null | Required when `outcome` is `skipped` (e.g. `"tests-only"`, `"docs-only"`); `null` otherwise |
 
 **Not disableable.** Unlike Review Value logging (`DEV_TEAM_REVIEW_VALUE=off`),

--- a/tests/commands/test_build_slice_checkbox_order.py
+++ b/tests/commands/test_build_slice_checkbox_order.py
@@ -27,7 +27,10 @@ def build_text() -> str:
 
 
 def test_slice_checkbox_flip_defers_to_verify_and_invariants(build_text: str) -> None:
-    assert "sub-steps 4.9 (verify) and 4.10 (invariants) both pass" in build_text
+    assert (
+        "sub-steps 4.9 (runtime verification) and 4.10 (invariants) both pass"
+        in build_text
+    )
 
 
 def test_slice_checkbox_flip_no_longer_unqualified(build_text: str) -> None:


### PR DESCRIPTION
## Summary

`plugins/dev-team/skills/build/SKILL.md` Step 4.9 ("Verify runtime behavior before the slice is done") and its Integration section unconditionally instructed invoking a `/verify` skill/command that does not exist anywhere in the installed plugin (`find plugins/dev-team/skills -maxdepth 1 -iname '*verify*'` returns nothing, and no half-built `/verify` skill directory exists anywhere in the repo).

**Chosen direction: reword (issue's option 2), not author a new `/verify` skill.**

Investigation confirms option 2 is correct. Issue #727 (the issue that introduced this language; landed via PR #757) explicitly describes `/verify` as *"Claude Code's built-in 'exercise the change end-to-end' skill"* — a mistaken premise about a built-in that never existed, not evidence of a planned first-class command in this repo. No open issue/PR anywhere plans to build a `/verify` skill, and no half-built directory exists. Per this repo's CLAUDE.md (no speculative design / no premature abstraction), this PR rewords Step 4.9 and the Integration section to describe the *pattern* — run the project's own test/verification tooling scoped to the slice's changed runtime files (its test runner, checker scripts, or a direct exercise of the changed entry point) — instead of naming a nonexistent slash command. This also matches the concrete friction the issue describes: falling back to running the affected checker scripts/pytest wrappers directly is exactly the pattern now documented as the intended behavior, not a workaround.

## Changes

- `plugins/dev-team/skills/build/SKILL.md`: reworded every `/verify`-as-command reference in Step 4.9 (sub-steps 1-5), the slice-checkbox-gating bullet, the evidence-bundle residual-risks bullet, and the Integration section. Removed the now-dangling `Skill(verify *)` grant from the frontmatter `allowed-tools` line.
- Cross-checked the whole plugin (`grep -rn '/verify' plugins/dev-team/`) for the same dangling-reference problem and fixed the other hits that described `/verify` as an invokable command: `plugins/dev-team/knowledge/evidence-bundle.md`, `plugins/dev-team/knowledge/telemetry-schema.md`, `plugins/dev-team/skills/performance-metrics/SKILL.md`.
- `plugins/dev-team/knowledge/index.json`: regenerated via `build_knowledge_index.py` to match the updated summary line.
- `tests/commands/test_build_slice_checkbox_order.py`: updated the one test asserting the old exact wording to match the reworded phrase (the invariant it guards — sub-steps 4.9/4.10 must gate the slice checkbox flip in the same bullet — is unchanged).

**Left unchanged (out of scope, confirmed unrelated):** `metrics/verify-log.jsonl` (a log filename/schema, not a command — kept as-is), `hooks/verify_guard.py` (an unrelated advisory hook that nudges on a repeated bash command, not a `/verify` skill), and `skills/harness-e2e-check/references/watchlist.md`'s #915 row (a historical description of a still-open, unrelated checkbox-timing bug).

No behavior/logic changes — documentation/prose-only correction plus removing one dead permission grant.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py -n auto --dist loadfile` → 3736 passed, 6 skipped
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` → clean
- [x] `python3 scripts/check_md_references.py` → clean
- [x] `grep -rn '/verify' plugins/dev-team/` re-verified post-fix: only historical CHANGELOG entries, the `metrics/verify-log.jsonl` filename, the unrelated `verify_guard.py` hook, the out-of-scope watchlist row, and new text explicitly stating no `/verify` command exists

Closes #1341