### PR TITLE
fix: make doc-review defer to agent-contract.json over stale checker constants

### DIFF
--- a/plugins/dev-team/agents/doc-review.md
+++ b/plugins/dev-team/agents/doc-review.md
@@ -25,6 +25,19 @@ Confidence: high=mechanical update (update version, remove reference to deleted 
 
 Context needs: project-structure
 
+## Contract precedence
+
+Before asserting that a frontmatter or tool-grant pattern (e.g. an MCP
+wildcard grant like `mcp__<server>__*`) is invalid syntax, verify the claim
+against `plugins/marketplace-dev/knowledge/agent-contract.json`'s `tools`
+field spec — that file is the authoritative external contract for what
+Claude Code's own sub-agent frontmatter schema permits. A repo-internal
+checker script's expectation-list constant (e.g. `mcp_tool_grants.py`'s
+`BASE_MCP_TOOLS`) enforces a narrower convention layered on top of the
+contract; it never redefines what the contract allows, and it may be stale.
+When the two disagree, the contract wins — never cite a checker script's
+constant as proof that a pattern the contract documents is invalid.
+
 ## Skip
 
 Return `{"status": "skip", "issues": [], "summary": "No documentation files found"}` when:


### PR DESCRIPTION
## Summary
- `doc-review` had no instruction on which source outranks the other when a repo-internal checker script's expectation-list constant and the actual external contract (`agent-contract.json`) disagree on whether a frontmatter/tool-grant pattern is valid syntax — during #1325's build this let it assert the valid MCP wildcard grant `mcp__codegraph__*` was "not a valid tool name," citing `mcp_tool_grants.py`'s stale `BASE_MCP_TOOLS` constant as authoritative.
- Adds a narrow `## Contract precedence` rule to `plugins/dev-team/agents/doc-review.md`: before asserting a frontmatter/tool-grant pattern is invalid, check `plugins/marketplace-dev/knowledge/agent-contract.json`'s `tools` field spec first — it is authoritative over any repo-internal checker script's expectation-list, which enforces a narrower convention on top of the contract and may be stale.
- No other section of `doc-review.md` changes, and no fix to `mcp_tool_grants.py` is needed (already corrected in a prior build).

## Quality Gate
- [x] Tests: 3736 passed, 6 skipped (`plugins/dev-team/tests tests/{repo,agents,commands,docs,knowledge,bats,skills,scripts}`)
- [x] Type check: N/A (no JS/TS in scope)
- [x] Lint: N/A (markdown-only change)
- [x] Code review: PASS (see Decisions & Assumptions — performed manually, no actionable findings)

## Decisions & Assumptions
- Spec artifact — used issue #1340's own body as the complete spec (intent, root cause, concrete ask already present) instead of opening a separate `Spec:` epic issue, given the operator's explicit authorization to use judgment for this narrowly-scoped, single-file instruction fix.
- Plan/spec human-approval gates — self-approved (auto-approved, non-interactive autonomous run) per the operator's explicit authorization to act as the human-in-the-loop for this run; recorded in `plans/doc-review-defer-to-agent-contract.md`'s `## Approval` section.
- Code review — no `Agent`/`Task` subagent-dispatch tool was available in this execution environment, so the review-agent panel could not be spawned in parallel. Performed the review directly against the same lenses (structural gates + manual secret/scope check) given the change is a single narrowly-scoped prose addition; zero actionable findings. See `DEV_TEAM_REPORTS/code-review.md`.
- Placement of the new rule — added as a new `## Contract precedence` section immediately after the existing Status/Severity/Confidence/Context-needs block, since no existing section already addressed tool/frontmatter-syntax validity precedence.

## Test Plan
- [ ] Re-read `plugins/dev-team/agents/doc-review.md`'s new `## Contract precedence` section and confirm it states the precedence rule (contract wins over a stale checker-script constant) without altering any other instruction in the file.
- [ ] Confirm `plugins/dev-team/agents/doc-review.md`'s frontmatter (`tools:`, `model:`, `effort:`, `color:`) is unchanged from before this PR.
- [ ] Confirm the full pytest suite and the plugin's structural agent-compliance scripts (`check_registry_sync.py`, `check_review_agent_mcp_tools.py`, `check_agent_tool_mapping.py`) still pass.

## Evidence Bundle

**Checks run**
- `pytest plugins/dev-team/tests tests/{repo,agents,commands,docs,knowledge,bats,skills,scripts}` (minus the two C#/Stryker net wrapper tests per repo convention) — 3736 passed, 6 skipped
- `scripts/check_md_references.py` — clean
- `plugins/dev-team/hooks/lib/build_knowledge_index.py` — clean, no index drift
- `plugins/dev-team/scripts/check_review_agent_mcp_tools.py` — OK, all 24 review agents grant the five MCP tools
- `plugins/dev-team/scripts/check_agent_tool_mapping.py` — OK, all 14 covered agents match the tool mapping
- `scripts/check_registry_sync.py` — registry in sync
- `scripts/citation_lint.py` — 10 pre-existing advisory warnings, none referencing `doc-review`
- Manual code review (no Agent-dispatch tool available) — PASS, zero actionable findings; report at `DEV_TEAM_REPORTS/code-review.md`

**Scope notes**
- No type check or lint gate applies — this diff is a markdown-only prose addition to an agent instruction file, no source/JS/TS/Python code changed.
- Semgrep not run — no source-code target in scope.
- No CI runs existed yet for branch `issue-1340` at review time (new branch), so the pipeline-red pre-flight check was a no-op.

**Untested regions**
- Not measured — `doc-review` is a prompt-driven review agent with no unit-testable runtime; there is no coverage tool applicable to prose instruction text. The change's correctness is verified by human/eval re-read against the issue's acceptance criteria, not an automated assertion.

**Residual risks**
- Sibling issue #1342 ("review agents assert specific, checkable claims that don't hold up under verification") also touches `agents/doc-review.md`. If that PR lands first, this PR's branch must rebase and confirm both changes coexist (this PR's precedence-rule addition sits in a distinct new section, so a clean textual merge is expected, but verify on rebase).

Closes #1340
