### PR TITLE
fix: require fresh, correctly-scoped citations in the shared review-agent evidence check

### DIFF
--- a/plugins/dev-team/knowledge/adversarial-review-protocol.md
+++ b/plugins/dev-team/knowledge/adversarial-review-protocol.md
@@ -19,7 +19,7 @@ This pre-check runs before The Loop and before any agent-specific analysis.
 After the initial review pass, re-examine findings with the following questions. Address each challenge before delivering the report.
 
 1. **Completeness** — Did the reviewer examine every file in scope? List files NOT examined and state why.
-2. **Evidence** — Does every finding quote actual code? Flag any finding without a direct code citation.
+2. **Evidence** — Does every finding quote actual code? Flag any finding without a direct code citation. A citation quoting specific content, a line number, or a count must come from reading/grepping the **exact named file, during this pass** — not memory, and not a similarly-shaped file read earlier in the same batch (batch review of many like-shaped files — e.g. dozens of agent frontmatter blocks — is exactly where file identity gets conflated; re-open the file immediately before citing it, every time). For a claim comparing two named sources (e.g. "ADR says N, registry says M — inconsistent"), confirm both cover the same scope first — a difference explained by scope is not an inconsistency. Downgrade or withdraw any citation that fails either check.
 3. **Severity justification** — Is each error/high-severity rating backed by concrete impact (data loss, security breach, test suite failing silently, production breakage)? Downgrade if not.
 3a. **Falsifiability** — For every `error`-severity finding, state what evidence would disprove it (e.g. "would be disproven by a test showing the input is always sanitized before this call"). If no falsifying evidence can be articulated, downgrade the finding to `warning`. An unfalsifiable `error` is an opinion, not a finding.
 4. **Blind spots** — What categories of issues are ABSENT from the findings? Absence in async code with no concurrency findings, or complex business logic with no domain findings, is suspicious. State the absent category and why it isn't an issue (or add a finding).
@@ -65,6 +65,6 @@ Challenge: N round(s). Revisions: <count>. Blind spots examined: <list>. Confide
 
 Agents that emit a non-JSON report instead of a `summary` field — `data-flow-tracer` (trace report) and `session-analysis` (ranked suggestion list) — append the same `Challenge:` line to the report's closing summary sentence.
 
-- **High**: all files examined, every finding has a code citation, no suspicious absences
+- **High**: all files examined, every finding has a code citation freshly verified against the exact named file or source (not memory, not a different file from the same batch), no suspicious absences
 - **Medium**: 1-2 files not examined or 1 finding revised downward
 - **Low**: >2 files not examined, multiple revisions, or a finding was retracted

--- a/tests/knowledge/test_adversarial_review_protocol_evidence.py
+++ b/tests/knowledge/test_adversarial_review_protocol_evidence.py
@@ -1,0 +1,119 @@
+"""Content contract for knowledge/adversarial-review-protocol.md's Evidence
+challenge (item 2 of The Loop), strengthened for #1342.
+
+Three review agents (doc-review x2, token-efficiency-review x1), across one
+build session, each made a confident, specific, checkable claim that was
+false under direct verification:
+
+  1. doc-review flagged a scope-mismatched agent count (an ADR's fleet-wide,
+     3-plugin count vs. agent-registry.md tables that have only ever covered
+     plugins/dev-team/agents/) as an inconsistency — no inconsistency existed
+     once scope was accounted for.
+  2. token-efficiency-review fabricated a file-content claim (quoted exact
+     line numbers/content from orchestrator.md that didn't match) — the
+     claim conflated orchestrator.md with a different file in the same
+     review batch (qa-engineer.md).
+
+(A third instance — an MCP wildcard tool-grant claim — is tracked and fixed
+separately as #1340, which touches doc-review.md, not this file.)
+
+Both surviving instances share one root cause: the shared Evidence challenge
+only required a finding to quote content, not that the quote was freshly
+re-verified against the *exact* named file/source immediately before citing,
+and comparative claims were not required to confirm scope parity. This test
+guards the strengthened wording that closes both gaps.
+
+Semantic correctness (whether an agent actually follows the strengthened
+wording) is verified by eval fixtures and real usage, not by grep — these
+assertions verify the wording is present and durable, per the existing
+`tests/knowledge/test_test_review_division_of_labor.py` pattern.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = (
+    REPO_ROOT
+    / "plugins"
+    / "dev-team"
+    / "knowledge"
+    / "adversarial-review-protocol.md"
+)
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_adversarial_review_protocol_md_exists() -> None:
+    assert DOC.is_file()
+
+
+# --- Pre-existing structure (regression guards) ---
+
+
+def test_the_loop_heading_survives(text: str) -> None:
+    assert "## The Loop" in text
+
+
+def test_evidence_item_survives(text: str) -> None:
+    assert re.search(r"\*\*Evidence\*\*", text)
+
+
+def test_falsifiability_item_survives(text: str) -> None:
+    assert re.search(r"\*\*Falsifiability\*\*", text)
+
+
+def test_output_section_survives(text: str) -> None:
+    assert "## Output" in text
+
+
+# --- Strengthened Evidence requirements (#1342) ---
+
+
+def test_evidence_requires_the_exact_named_file(text: str) -> None:
+    assert re.search(r"exact named file", text, re.IGNORECASE)
+
+
+def test_evidence_requires_verification_during_this_pass_not_memory(
+    text: str,
+) -> None:
+    assert re.search(r"during this pass", text, re.IGNORECASE)
+    assert re.search(r"\bmemory\b", text, re.IGNORECASE)
+
+
+def test_evidence_calls_out_batch_review_file_identity_conflation(
+    text: str,
+) -> None:
+    # Closes instance 3 (token-efficiency-review conflating orchestrator.md
+    # with qa-engineer.md mid-batch): the wording must explicitly name
+    # batch review of similarly-shaped files as the risk case, and require
+    # re-opening the specific file immediately before citing it.
+    assert re.search(r"batch review", text, re.IGNORECASE)
+    assert re.search(r"similarly-shaped", text, re.IGNORECASE)
+    assert re.search(r"immediately before citing", text, re.IGNORECASE)
+
+
+def test_evidence_requires_scope_parity_for_comparative_claims(text: str) -> None:
+    # Closes instance 2 (doc-review's scope-mismatched agent count): a claim
+    # comparing counts/content across two sources must confirm both sources
+    # cover the same scope before it is reported as an inconsistency.
+    assert re.search(r"same scope", text, re.IGNORECASE)
+    assert re.search(r"not an inconsistency", text, re.IGNORECASE)
+
+
+def test_confidence_rubric_high_bar_matches_strengthened_evidence_item(
+    text: str,
+) -> None:
+    # The Output section's confidence rubric must name the same
+    # freshly-verified-citation standard as the Evidence item, so the two
+    # don't drift out of sync.
+    high_bullet = re.search(r"\*\*High\*\*:.*", text)
+    assert high_bullet is not None
+    assert re.search(r"freshly verified", high_bullet.group(0), re.IGNORECASE)


### PR DESCRIPTION
## Summary

Three review agents (`doc-review` x2, `token-efficiency-review` x1), across
one build session, each asserted a confident, specific, checkable claim that
proved false under direct verification — different claim shapes, same root
cause: the shared **Evidence** challenge item in
`knowledge/adversarial-review-protocol.md` (run by all 26 review agents'
Self-Challenge sections) only required a finding to quote content, not that
the quote was freshly re-verified against the exact named file/source
immediately before citing it, and comparative claims weren't required to
confirm scope parity before being reported as a mismatch.

This strengthens that one shared checkpoint so both surviving failure shapes
are caught by the challenger loop every review agent already runs:

- Citations quoting specific content, a line number, or a count must come
  from reading/grepping the exact named file **during the current pass** —
  not memory, not a similarly-shaped file read earlier in the same batch.
  Closes the `token-efficiency-review` instance (conflated `orchestrator.md`
  with `qa-engineer.md` mid-batch).
- Comparative claims across two named sources must confirm both cover the
  same scope before being reported as a mismatch. Closes the `doc-review`
  instance (an ADR's fleet-wide, 3-plugin agent count vs. a registry table
  that has only ever covered `plugins/dev-team/agents/`).
- The Output section's confidence rubric now names the same
  freshly-verified-citation standard, so the two stay in sync.

## Why this direction (of the 3 candidates #1342 raised for `/plan` to scope)

Ran this through `/plan` for real scoping (plan retained locally under
`plans/`, gitignored per repo convention). Chose candidate **(a)** — a
cite-and-verify discipline — as a single edit to the one shared knowledge
file every review agent's `Self-Challenge` section already loads, folding
candidate **(c)**'s intent (a per-file "re-read before you cite" reminder
for batch review) into the *same* edit rather than duplicating it across
~26 agent files.

**Deliberately not implementing candidate (b)** (an adversarial recheck in
`/code-review` Step 6a before auto-applying error/fail-severity fixes): in
all three recorded instances, the false claim was caught by the build
session's own verification *before* any auto-apply happened — none is an
observed case of a bad fix actually landing through that loop. Adding a
second agent pass there is process overhead in search of a problem not yet
evidenced, against this repo's North Star of the smallest change that names
the actual friction. Deferred pending a real incident.

## Cross-reference, not duplicate

Instance 1 in #1342 (an MCP wildcard tool-grant claim citing a stale checker
constant over `agent-contract.json`) is being fixed separately by **#1340**,
which adds contract-precedence guidance to `doc-review.md` itself. This PR
does not touch `doc-review.md` and has no expected mechanical overlap with
#1340's change.

## Test plan

- [x] New content-guard test (`tests/knowledge/test_adversarial_review_protocol_evidence.py`)
      asserts the strengthened wording is present and durable, plus regression
      guards for the pre-existing structure.
- [x] Full pytest sweep (`plugins/dev-team/tests tests/repo tests/agents
      tests/commands tests/docs tests/knowledge tests/bats tests/skills
      tests/scripts`, `-n auto --dist loadfile`) — 3824 passed, 3 skipped
      (pre-existing, documented opt-in skips: `dotnet`/`claude` CLI not on
      PATH — unrelated to this change).
- [x] `python3 scripts/check_md_references.py` — clean.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — no diff
      (edit didn't add/remove headings the index tracks).
- [x] `scripts/ci-local.sh` — full local CI mirror green.

Closes #1342

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>