### PR TITLE
feat: add diff-size fast path to /code-review agent eligibility (#1339)

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -225,6 +225,49 @@ short-circuit; this gate covers the doc/config-**mixed** and config-only diffs
 the short-circuit does not. Bypassed by `--force` and by `--agent <name>` (an
 explicit single-agent request always runs that agent).
 
+**Change-size gate for small changesets (#1339).** After `Scope:` eligibility
+and the change-shape gate above have both been applied, apply this gate —
+never before, and never in a way that re-adds an agent either already removed.
+It narrows the `Scope: always` roster by diff *size* rather than file *type*:
+the pre-commit hook (`hooks/pre_commit_review.py`) only checks that a
+`.review-passed` hash matches the staged diff — it has no coupling to which or
+how many agents ran — so unconditionally dispatching the full panel on every
+review, down to a 2-line change, is this step's decision to make, not the
+hook's.
+
+**Applies only to diff-scoped reviews** — auto-scoped uncommitted changes, or
+`--since <ref>`. `--path`, `--all`, and the full-repository fallback review
+complete files, not a diff, so this gate never engages for those scopes
+(existing eligibility unchanged).
+
+Compute the numstat lines and feed them to the shared helper — for auto-scope,
+union unstaged and staged the same way step 1 unions `--name-only`:
+
+```bash
+# Auto-scope (uncommitted changes):
+{ git diff --numstat; git diff --cached --numstat; } | python3 "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/change_size.py" --numstat-from -
+
+# --since <ref>:
+git diff --numstat <ref>...HEAD | python3 "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/change_size.py" --numstat-from -
+```
+
+It prints `{"filesChanged": <int>, "addedLines": <int>, "qualifiesForFastPath":
+<bool>, "keepAgents": [...]}`. When `qualifiesForFastPath` is `true`, drop
+every `Scope: always` agent **not** in `keepAgents` (today: `security-review`,
+`correctness-review`, `spec-compliance-review`, `doc-review` — the four lenses
+that stay meaningful at any diff size; the rest are code-quality-at-scale
+concerns a diff this small essentially cannot exhibit meaningfully) and note
+the drop in the report (gated by change size, not by `Scope:`).
+`Scope:`-glob-matched agents are unaffected — they already run only against
+matching file types, so a diff this small already narrows their incremental
+cost to near-zero. The gate is **fail-safe**: any `git diff --numstat` error,
+binary-file marker, or unparseable line disqualifies the run (full panel), as
+does any file under `hooks/` or `skills/code-review/` (the enforcement
+machinery and this gate's own orchestration) — a change there is exactly the
+case where a cheap, self-certifying review is a problem, so it never qualifies
+for the shortcut it defines, regardless of size. Bypassed by `--force` and by
+`--agent <name>`, matching the change-shape gate's bypass list.
+
 ### 4. Run each enabled agent
 
 Spawn agents as parallel subagents in a single message using the Agent tool.

--- a/plugins/dev-team/skills/code-review/scripts/change_size.py
+++ b/plugins/dev-team/skills/code-review/scripts/change_size.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Classify a changeset's size to gate the /code-review agent panel (#1339).
+
+`/code-review` Step 3 dispatches the full ~17-agent `Scope: always` panel on
+every review regardless of diff size — a 2-line registry-table-row removal
+(issue #1331's fix: 2 files, ~1 added line) pays the same review cost as a
+25-file structural migration (issue #1334's fix: 537 added lines). The
+pre-commit hook (`hooks/pre_commit_review.py`) has no coupling to which or how
+many agents ran — it only checks that `/code-review` produced a matching
+`.review-passed` hash — so the panel-size decision is entirely Step 3's to
+make, and today it makes no such distinction.
+
+This module is the deterministic gate, sibling to `change_shape.py` (#1254,
+which gates by file *type*). This gate gates by file *size*: given the target
+files' `git diff --numstat` lines, it decides whether the changeset qualifies
+for a narrowed agent panel.
+
+**Added lines only, not deleted.** Added lines are unverified, newly
+introduced content a reviewer must actually check; deleted lines are
+comparatively low-risk (a dangling reference from a large deletion breaks the
+build/tests, not silently). This is what lets issue #1331's fix (97 deleted
+lines, ~1 added) qualify while issue #1334's fix (537 added lines) does not —
+weighting total added+deleted would keep #1331's fix on the slow path,
+defeating this gate's own motivating example.
+
+**Gate-machinery carve-out.** Any file under `hooks/` or `skills/code-review/`
+— the enforcement mechanism and this gate's own review orchestration —
+always disqualifies, at any size. A change to the gate's own logic is exactly
+the case where a cheap, self-certifying review would be a problem, so it is
+excluded from ever qualifying for the shortcut it defines.
+
+**Fail-safe by construction**, mirroring `change_shape.py`'s own philosophy:
+a `git diff --numstat` failure, a binary-file marker (`-\t-\tpath`), or any
+line this module cannot parse disqualifies the gate for that run (full
+panel) — never counts as "small enough" by omission.
+
+**Applicability is Step 3's job, not this module's.** This gate only makes
+sense when there is an actual diff to measure (auto-scoped uncommitted
+changes, or `--since <ref>`) — `--path`, `--all`, and the full-repository
+fallback review complete files, not a diff, so `SKILL.md` never invokes this
+module for those scopes. That decision is documented in `SKILL.md` Step 3's
+"Change-size gate" subsection, not enforced here.
+
+Pure policy — no filesystem, no globals. Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterable, List, NamedTuple, Tuple
+
+# Thresholds calibrated against two real commits cited in spec #1345:
+# issue #1331's fix (2 files, ~1 added line — should qualify) and issue
+# #1334's fix (25 files, 537 added lines — should not). Hardcoded, not a new
+# review-config.json surface — smallest change that solves the stated
+# problem; revisit if real usage shows these miscalibrated.
+MAX_FILES = 3
+MAX_ADDED_LINES = 20
+
+# The agents that stay meaningful at any diff size and survive the fast path:
+# a single line can introduce a vulnerability (security-review), a logic
+# defect (correctness-review), a spec mismatch (spec-compliance-review), or
+# doc drift (doc-review). Every other `Scope: always` agent is primarily a
+# code-quality-at-scale concern a diff this small essentially cannot exhibit
+# meaningfully.
+#
+# KEEP THIS IN SYNC with the identically-named list restated in English in
+# `code-review/SKILL.md`'s "Change-size gate" subsection (Step 3) — same
+# single-source-of-truth risk `change_shape.py`'s `LOW_YIELD_LENSES` already
+# carries against its own `SKILL.md` restatement.
+FAST_PATH_AGENTS = [
+    "security-review",
+    "correctness-review",
+    "spec-compliance-review",
+    "doc-review",
+]
+
+# Path segments marking the review/gate machinery itself. A change here is
+# exactly the case where a cheap, self-certifying review is a safety problem,
+# so it always disqualifies, regardless of size. Narrower than
+# `change_shape.py`'s "functional Claude-config" carve-out (agents/,
+# knowledge/, .claude/, templates/) — those stay eligible for the fast path
+# when small enough, since issue #1331's own motivating example touches
+# `knowledge/agent-registry.md` and an `agents/` file and is exactly the case
+# this gate must unblock.
+_GATE_MACHINERY_PREFIXES = ("hooks/", "skills/code-review/")
+
+
+class NumstatResult(NamedTuple):
+    file_count: int
+    added_lines: int
+    ok: bool
+    files: Tuple[str, ...]
+
+
+def parse_numstat(lines: Iterable[str]) -> NumstatResult:
+    """Parse `git diff --numstat` lines into a size signal.
+
+    Each line is `<added>\\t<deleted>\\t<path>`. A binary file reports `-` for
+    both counts; any line that isn't exactly that shape, or whose added/
+    deleted fields aren't parseable as non-negative integers (or `-`), marks
+    the whole result not-ok (fail-safe — a partial read is not "small").
+    """
+    files: List[str] = []
+    added_total = 0
+    ok = True
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) != 3:
+            ok = False
+            continue
+        added_field, deleted_field, path = parts
+        if not path.strip():
+            ok = False
+            continue
+        if added_field == "-" and deleted_field == "-":
+            # Binary file — numstat can't report line counts. Fail-safe: we
+            # cannot prove this file is small, so disqualify the whole run.
+            ok = False
+            files.append(path)
+            continue
+        if not added_field.isdigit() or not deleted_field.isdigit():
+            ok = False
+            continue
+        added_total += int(added_field)
+        files.append(path)
+    return NumstatResult(
+        file_count=len(files), added_lines=added_total, ok=ok, files=tuple(files)
+    )
+
+
+def is_gate_machinery(path: str) -> bool:
+    """True when `path` is under the review/gate enforcement machinery."""
+    normalized = str(path).strip().replace("\\", "/")
+    return any(normalized.startswith(prefix) for prefix in _GATE_MACHINERY_PREFIXES)
+
+
+def qualifies_for_fast_path(result: NumstatResult) -> bool:
+    """True when this changeset qualifies for the narrowed fast-path panel.
+
+    Requires: numstat parsed cleanly, file count and added-line count both
+    within threshold, and no file is gate machinery. Any single failing
+    condition disqualifies (fail-safe by construction).
+    """
+    if not result.ok:
+        return False
+    if result.file_count == 0:
+        return False
+    if result.file_count > MAX_FILES:
+        return False
+    if result.added_lines > MAX_ADDED_LINES:
+        return False
+    if any(is_gate_machinery(f) for f in result.files):
+        return False
+    return True
+
+
+def evaluate(lines: Iterable[str]) -> dict:
+    """Evaluate numstat lines and return the full decision as a dict."""
+    result = parse_numstat(lines)
+    qualifies = qualifies_for_fast_path(result)
+    return {
+        "filesChanged": result.file_count,
+        "addedLines": result.added_lines,
+        "qualifiesForFastPath": qualifies,
+        "keepAgents": list(FAST_PATH_AGENTS) if qualifies else [],
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--numstat", nargs="*", default=[],
+        help="git diff --numstat lines, one per arg (space-separated)",
+    )
+    parser.add_argument(
+        "--numstat-from", default=None,
+        help="read newline-separated numstat lines from this file ('-' for stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    lines = list(args.numstat)
+    if args.numstat_from:
+        text = (
+            sys.stdin.read()
+            if args.numstat_from == "-"
+            else open(args.numstat_from).read()
+        )
+        lines.extend(line for line in text.splitlines() if line.strip())
+
+    print(json.dumps(evaluate(lines), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+
+
+__all__ = (
+    "MAX_FILES",
+    "MAX_ADDED_LINES",
+    "FAST_PATH_AGENTS",
+    "NumstatResult",
+    "parse_numstat",
+    "is_gate_machinery",
+    "qualifies_for_fast_path",
+    "evaluate",
+)

--- a/plugins/dev-team/tests/scripts/test_change_size.py
+++ b/plugins/dev-team/tests/scripts/test_change_size.py
@@ -1,0 +1,209 @@
+"""Unit tests for skills/code-review/scripts/change_size.py (#1339).
+
+Covers the deterministic change-size gate: a small changeset (few files, few
+added lines) outside the review/gate machinery qualifies for a narrowed
+fast-path agent panel; anything larger, unparseable, or touching the gate
+machinery itself keeps the full panel. Fail-safe: unknown = does not qualify.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(
+    0,
+    str(_REPO_ROOT / "plugins" / "dev-team" / "skills" / "code-review" / "scripts"),
+)
+
+import change_shape  # noqa: E402
+import change_size  # noqa: E402
+
+
+class TestParseNumstat:
+    def test_normal_lines_sum_added_only(self):
+        result = change_size.parse_numstat(["3\t1\tfoo.py", "5\t0\tbar.py"])
+        assert result.file_count == 2
+        assert result.added_lines == 8
+        assert result.ok is True
+        assert result.files == ("foo.py", "bar.py")
+
+    def test_deleted_lines_are_ignored(self):
+        # issue #1331's fix: ~1 added line, 97 deleted (a dead file removal).
+        result = change_size.parse_numstat(["1\t2\tregistry.md", "0\t95\tdead.md"])
+        assert result.added_lines == 1
+        assert result.file_count == 2
+        assert result.ok is True
+
+    def test_binary_marker_disqualifies(self):
+        result = change_size.parse_numstat(["-\t-\timage.png"])
+        assert result.ok is False
+
+    def test_malformed_line_disqualifies(self):
+        result = change_size.parse_numstat(["not-a-numstat-line"])
+        assert result.ok is False
+
+    def test_non_numeric_field_disqualifies(self):
+        result = change_size.parse_numstat(["abc\t1\tfoo.py"])
+        assert result.ok is False
+
+    def test_empty_input(self):
+        result = change_size.parse_numstat([])
+        assert result.file_count == 0
+        assert result.added_lines == 0
+        assert result.ok is True
+
+    def test_blank_lines_ignored(self):
+        result = change_size.parse_numstat(["", "  ", "1\t0\tfoo.py"])
+        assert result.file_count == 1
+        assert result.added_lines == 1
+
+
+class TestIsGateMachinery:
+    def test_hooks_path_is_gate_machinery(self):
+        assert change_size.is_gate_machinery("hooks/pre_commit_review.py") is True
+        assert change_size.is_gate_machinery("hooks/lib/review_gate_hash.py") is True
+
+    def test_code_review_skill_is_gate_machinery(self):
+        assert change_size.is_gate_machinery("skills/code-review/SKILL.md") is True
+        assert (
+            change_size.is_gate_machinery(
+                "skills/code-review/scripts/change_size.py"
+            )
+            is True
+        )
+
+    def test_unrelated_paths_are_not_gate_machinery(self):
+        for path in [
+            "knowledge/agent-registry.md",
+            "agents/plan-reviewer.md",
+            "skills/plan/SKILL.md",
+            "src/app.py",
+            "README.md",
+        ]:
+            assert change_size.is_gate_machinery(path) is False, path
+
+
+class TestQualifiesForFastPath:
+    def test_small_non_gate_changeset_qualifies(self):
+        # issue #1331's fix, restated as numstat.
+        result = change_size.parse_numstat(
+            ["1\t2\tknowledge/agent-registry.md", "0\t95\tprompts/plan-reviewer.md"]
+        )
+        assert change_size.qualifies_for_fast_path(result) is True
+
+    def test_too_many_files_disqualifies(self):
+        lines = [f"1\t0\tfile{i}.py" for i in range(change_size.MAX_FILES + 1)]
+        result = change_size.parse_numstat(lines)
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_too_many_added_lines_disqualifies(self):
+        # issue #1334's fix: 25 files, 537 added lines.
+        lines = [f"22\t6\tfile{i}.py" for i in range(25)]
+        result = change_size.parse_numstat(lines)
+        assert result.added_lines == 550
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_exactly_at_threshold_qualifies(self):
+        lines = [f"{change_size.MAX_ADDED_LINES // change_size.MAX_FILES}\t0\tf{i}.py"
+                  for i in range(change_size.MAX_FILES)]
+        result = change_size.parse_numstat(lines)
+        assert result.file_count == change_size.MAX_FILES
+        assert change_size.qualifies_for_fast_path(result) is True
+
+    def test_one_line_over_threshold_disqualifies(self):
+        result = change_size.parse_numstat(
+            [f"{change_size.MAX_ADDED_LINES + 1}\t0\tfoo.py"]
+        )
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_gate_machinery_file_disqualifies_even_when_tiny(self):
+        result = change_size.parse_numstat(["1\t0\thooks/pre_commit_review.py"])
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_gate_machinery_among_otherwise_small_files_disqualifies(self):
+        result = change_size.parse_numstat(
+            ["1\t0\tREADME.md", "1\t0\tskills/code-review/SKILL.md"]
+        )
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_unparseable_numstat_disqualifies(self):
+        result = change_size.parse_numstat(["garbage"])
+        assert change_size.qualifies_for_fast_path(result) is False
+
+    def test_empty_changeset_does_not_qualify(self):
+        result = change_size.parse_numstat([])
+        assert change_size.qualifies_for_fast_path(result) is False
+
+
+class TestEvaluate:
+    def test_qualifying_scope_reports_keep_agents(self):
+        out = change_size.evaluate(["1\t2\tregistry.md"])
+        assert out["qualifiesForFastPath"] is True
+        assert out["keepAgents"] == change_size.FAST_PATH_AGENTS
+
+    def test_disqualifying_scope_reports_empty_keep_agents(self):
+        out = change_size.evaluate([f"600\t0\tbig.py"])
+        assert out["qualifiesForFastPath"] is False
+        assert out["keepAgents"] == []
+
+
+class TestCli:
+    def test_cli_qualifying_scope(self, capsys):
+        rc = change_size.main(["--numstat", "1\t0\tfoo.md"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["qualifiesForFastPath"] is True
+        assert out["filesChanged"] == 1
+        assert out["addedLines"] == 1
+
+    def test_cli_numstat_from_stdin(self, capsys, monkeypatch):
+        import io
+
+        monkeypatch.setattr(sys, "stdin", io.StringIO("1\t0\tfoo.md\n2\t0\tbar.md\n"))
+        rc = change_size.main(["--numstat-from", "-"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["filesChanged"] == 2
+        assert out["addedLines"] == 3
+        assert out["qualifiesForFastPath"] is True
+
+    def test_cli_disqualifying_scope(self, capsys):
+        rc = change_size.main(["--numstat", "1\t0\thooks/pre_commit_review.py"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["qualifiesForFastPath"] is False
+
+
+class TestComposesWithChangeShapeGate:
+    """AC6: the size gate must never re-add an agent the shape gate already
+    dropped — proving the "intersection, never re-add" composition rule at
+    the unit level, not just in SKILL.md prose.
+    """
+
+    def test_never_readds_agent_shape_gate_already_dropped(self):
+        files = ["README.md"]  # doc-only, small, not gate machinery.
+
+        skipped_by_shape = set(change_shape.lenses_to_skip(files))
+        assert "correctness-review" in skipped_by_shape  # sanity: shape drops it
+
+        size_result = change_size.parse_numstat(["1\t0\tREADME.md"])
+        assert change_size.qualifies_for_fast_path(size_result) is True
+        kept_by_size = set(change_size.FAST_PATH_AGENTS)
+        assert "correctness-review" in kept_by_size  # size alone would keep it
+
+        # Composition order (SKILL.md Step 3): apply shape-skip first, then
+        # size's keep-list only narrows what's left — it never re-adds.
+        full_roster = {
+            "security-review", "correctness-review", "spec-compliance-review",
+            "doc-review", "performance-review", "structure-review",
+        }
+        after_shape = full_roster - skipped_by_shape
+        final_roster = after_shape & kept_by_size
+
+        assert "correctness-review" not in final_roster
+        assert "performance-review" not in final_roster
+        assert "structure-review" not in final_roster
+        assert final_roster == {"security-review", "spec-compliance-review", "doc-review"}


### PR DESCRIPTION
## Summary

`/code-review` Step 3 dispatches the full ~17-agent `Scope: always` panel on
every review regardless of diff size, so a 2-line change (e.g. #1331's fix)
pays the same review cost as a 500-line feature (e.g. #1334's fix). The
pre-commit hook (`hooks/pre_commit_review.py`) has no coupling to which or
how many agents ran — it only checks that `.review-passed`'s hash matches
the staged diff — so the panel-size decision belongs entirely to
`/code-review` Step 3, and today it makes no such distinction.

This adds a diff-size fast path, sibling to the existing change-shape gate
(`change_shape.py`, #1254): when a diff-scoped review (auto-scope or
`--since`) touches ≤3 files and ≤20 added lines, and no file is under
`hooks/` or `skills/code-review/` (the enforcement machinery itself, carved
out at any size), Step 3 narrows the `Scope: always` roster to
`security-review`, `correctness-review`, `spec-compliance-review`, and
`doc-review` — the four lenses that stay meaningful at any diff size.
`Scope:`-glob agents, `--path`/`--all`/full-repo scopes, `--force`, and
`--agent` are all unaffected. Fail-safe: any `git diff --numstat` error or
unparseable line disqualifies (full panel).

- Spec: #1345 (produced via `/specs`, persisted as a GitHub issue per this
  repo's issue-first convention)
- Plan: `plans/1339-code-review-diff-size-fast-path.md` (gitignored, not in
  this diff — the working plan surface)

## Which candidate direction, and why

Issue #1339 listed three candidate directions and left the choice to
`/plan`. Chose **(c)** — a fast path in `/code-review`'s own Step 3
eligibility logic — over (a) (a hook-level threshold) and (b) (a
`/build`→hook complexity channel):

- The pre-commit hook is a pure hash-match gate with **zero** coupling to
  which/how many agents ran. The "full panel every time" behavior is
  entirely `/code-review` Step 3's decision, not the hook's — so fixing it
  there requires **zero changes to the safety-critical hook** (kept as the
  unconditional fallback for anything not diff-scoped, gate-machinery, or
  over-threshold), and benefits every `/code-review` caller, not just
  `/build` (ruling out (b)'s new `/build`-only state channel).
- Direct precedent already exists in the same file/step: `change_shape.py`
  (#1254) already narrows agent eligibility deterministically by change
  *shape*; this is the same mechanism extended to change *size*.
- Full Ambiguity Log with the threshold/agent-list rationale is in spec
  #1345.

## Test plan

- [x] 25 new unit tests (`test_change_size.py`): numstat parsing (normal,
      deleted-heavy per #1331's real diffstat, binary marker, malformed,
      non-numeric, empty), gate-machinery detection, qualification
      boundaries (exactly-at-threshold, one-over on both axes), the two real
      calibration commits (#1331, #1334) from the spec, CLI smoke tests, and
      an explicit composition test proving the "never re-add an agent
      change-shape already dropped" rule against `change_shape.py`.
- [x] Full pytest sweep (`plugins/dev-team/tests` + repo-root
      `tests/{repo,agents,commands,docs,knowledge,bats,skills,scripts}`):
      3839 passed, 3 skipped (pre-existing, documented, opt-in-gated skips —
      unrelated to this change).
- [x] `scripts/check_md_references.py` and `build_knowledge_index.py`: clean.
- [x] `scripts/ci-local.sh` (pre-push, 18 checks): all green.
- [x] Self-conducted code review (this session's environment had no
      `Agent`-tool subagent dispatch available — see
      `DEV_TEAM_REPORTS/code-review.md`, gitignored): found and fixed an
      unused import and a doc-example inconsistency before this PR opened.

Closes #1339
Part of #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
