### PR TITLE
feat(setup): wire python/mutmut into Step 6 mutation-tool installer

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -49,8 +49,9 @@ re-describe or re-implement their mechanics:
 
 | Script | Deterministic responsibility it owns |
 | --- | --- |
-| `mutation_report.py` | Parse the report; compute the **honest** and **reported** scores; extract survivors per file grouped by mutator. |
-| `mutation_kill_loop.py` | The per-file loop: scoped run → score → survivor check → **your** generation → duplicate-guard → insert-before-class-close → build → test → commit-on-green / revert-on-failure → no-improvement stop. Delegates DOTNET_ROOT + `.sln` hide/restore to the wrapper. |
+| `mutation_report.py` | Parse the report; compute the **honest** and **reported** scores; extract survivors per file grouped by mutator. Stryker/Stryker.NET's JSON report is read directly; mutmut's `junitxml` output is normalized into the same internal shape first (`parse_mutmut_junitxml` / `score_mutmut_junitxml` / `survivors_from_mutmut_junitxml`). |
+| `mutation_kill_loop.py` | The C#/Stryker.NET per-file loop: scoped run → score → survivor check → **your** generation → duplicate-guard → insert-before-class-close → build → test → commit-on-green / revert-on-failure → no-improvement stop. Delegates DOTNET_ROOT + `.sln` hide/restore to the wrapper. |
+| `mutation_kill_loop_python.py` | The Python/mutmut per-file loop — same contract, adapted for pytest: scoped `mutmut run` (clears stale `.mutmut-cache` first) → score via `mutation_report` junitxml support → **your** generation → duplicate-guard → append-at-end-of-file (refuses on a class-based test file) → `py_compile` → scoped `pytest` → commit-on-green / revert-on-failure → no-improvement stop. Reuses `mutation_kill_loop.py`'s generic headless helpers rather than duplicating them. |
 | `stryker_shard_setup.py` | Generate one `stryker-config.shard-<slug>.json` per source project, `Stryker.sln`, and `stryker-pipeline.json` from a `.sln`. |
 | `stryker_shard_pipeline.py` | The unattended sharded pipeline: discover shards, one compounding git worktree per shard from `HEAD`, run Stryker through the wrapper's line-callback, timeout-abort, launch the survivor-fix loop **forced into `--headless`**, honest-score summary. |
 | `stryker_timeout_retry.py` | Emit a retry config scoped to only the timed-out files with an increased `additional-timeout`. |
@@ -153,7 +154,7 @@ assertion-only fixes once you reach Statement/Block.
 
 ## Speed: scoped + per-test coverage analysis
 
-The loop's scoped config sets per-test coverage (Stryker `coverageAnalysis: "perTest"`; pitest `withHistory`) so each mutant runs only its covering tests, not the full suite (observed 10–50× speedup). Scoped+per-test is the dev loop; the full run (coverage-analysis off) is the CI gate only.
+The loop's scoped config sets per-test coverage (Stryker `coverageAnalysis: "perTest"`; pitest `withHistory`) so each mutant runs only its covering tests, not the full suite (observed 10–50× speedup). Scoped+per-test is the dev loop; the full run (coverage-analysis off) is the CI gate only. mutmut has **no** per-test coverage equivalent — every mutant runs the entire `--runner` command — so scoping `--runner` itself to the smallest exercising test file is the only speed lever available for Python.
 
 ## Fresh build before a run
 
@@ -267,6 +268,7 @@ contract per language.
 | Java | pitest | `withHistory` | `@Test void …()` (JUnit 5) | `mvn compile -pl <mod> -q` | `mvn test -pl <mod> -Dtest=<class>` |
 | C# | Stryker.NET | `coverage-analysis: perTest` | `[Fact]` (xUnit) / `[Test]` (NUnit) | `dotnet build <proj> --nologo` | `dotnet test <proj> --filter FullyQualifiedName~<class>` |
 | Go | go-mutesting | (advisory; no per-test analysis) | `func Test…(t *testing.T)` | `go build ./…` | `go test -run Test… ./…` |
+| Python | mutmut | (none — no per-test coverage analysis; mutmut always runs the full scoped test command per mutant) | `def test_…():` (pytest, flat top-level function) | `python3 -m py_compile <file>` | `python3 -m pytest <file> -q` |
 
 ### Per-language prompt rules (for the generation call)
 
@@ -274,6 +276,7 @@ contract per language.
 - **Java** — match `@Test` + the assertion library in the file (AssertJ / JUnit / Hamcrest); match the fixture lifecycle (JUnit 5 / TestNG); no new `import` for already-imported classes.
 - **C#** — match `[Fact]`/`[Test]`; reuse the file's assertion library (FluentAssertions / AwesomeAssertions / NUnit `Assert`), mock library (Moq / NSubstitute), and fixture pattern (AutoFixture / builder).
 - **Go** — prefer table-driven tests; use `testify/assert` if already present, else stdlib `t.Errorf`; add no new package imports without checking `go.mod`.
+- **Python** — match the existing file's plain `assert` style (or `pytest.approx`/`pytest.raises`/`monkeypatch` when already used); flat top-level `def test_*():` functions only — no class wrapper (`mutation_kill_loop_python.py`'s insertion heuristic appends at end-of-file and refuses on a class-based test file); no new imports unless already present.
 
 ## Structurally unkillable files
 

--- a/plugins/dev-team/hooks/mutation_adapters/mutmut.py
+++ b/plugins/dev-team/hooks/mutation_adapters/mutmut.py
@@ -1,8 +1,8 @@
 """mutmut (Python) mutation-testing adapter — Python port of mutmut.sh.
 
 mutmut scopes to a single file via `--paths-to-mutate` and completes in
-seconds-to-minutes for typical Python unit test suites. Results come from
-`mutmut results --json`.
+seconds-to-minutes for typical Python unit test suites. mutmut has no
+`--json` results output; survivors are read from `mutmut junitxml`.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import List, Optional
 
@@ -23,8 +24,10 @@ def mutmut_detect() -> bool:
     if shutil.which("mutmut") is not None:
         return True
     try:
+        # `mutmut` is a `version` subcommand, not a `--version` flag — the
+        # flag form exits nonzero on the real CLI and always reads as absent.
         proc = subprocess.run(
-            ["python3", "-m", "mutmut", "--version"],
+            ["python3", "-m", "mutmut", "version"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
@@ -112,8 +115,12 @@ def mutmut_run(output_file: Path) -> int:
         output_file.write_text("[]")
         return 0
 
-    # exit 1 with survivors is expected — still parse results.
-    if exit_code >= 2:
+    # mutmut's exit code is a bitmask: 1=fatal error, 2=survived, 4=timeout,
+    # 8=slow (any combination ORs together; 0 means every mutant was
+    # killed). Bit 1 (fatal error — e.g. the baseline test run itself
+    # failed) is the only outcome that invalidates the run; survivors
+    # (bit 2) are the expected, common case and must still be parsed.
+    if exit_code & 1:
         print(
             lib.emit_advisory(
                 f"MUTATION GATE ADVISORY: mutmut exited with code {exit_code}. "
@@ -123,32 +130,37 @@ def mutmut_run(output_file: Path) -> int:
         output_file.write_text("[]")
         return 0
 
-    # Read survivors JSON.
+    # Read survivors from `mutmut junitxml` — mutmut's `results` subcommand
+    # has no `--json` output; junitxml is the only structured report it
+    # ships. A <testcase> with a <failure> child is a survived mutant under
+    # the default suspicious/untested policies (both "ignore").
     try:
-        results = subprocess.run(
-            [*mutmut_prefix, "results", "--json"],
+        junit = subprocess.run(
+            [*mutmut_prefix, "junitxml"],
             capture_output=True,
             text=True,
             check=False,
         )
-        raw = results.stdout or "[]"
+        raw = junit.stdout or ""
     except (FileNotFoundError, OSError):
-        raw = "[]"
+        raw = ""
 
     try:
-        data = json.loads(raw)
-    except ValueError:
-        data = []
+        root = ET.fromstring(raw) if raw.strip() else None
+    except ET.ParseError:
+        root = None
 
     zero_kills = []
-    for mutant in data:
-        status = mutant.get("status", "")
-        if status in ("survived", ""):
+    if root is not None:
+        for testcase in root.iter("testcase"):
+            if testcase.find("failure") is None:
+                continue
+            line = testcase.get("line")
             zero_kills.append(
                 {
-                    "name": f"mutant_{mutant.get('id', '?')}",
-                    "file": mutant.get("filename"),
-                    "line": mutant.get("line_number"),
+                    "name": f"mutant_{testcase.get('name', '?')}",
+                    "file": testcase.get("file"),
+                    "line": int(line) if line and line.isdigit() else None,
                     "covered": 0,
                 }
             )

--- a/plugins/dev-team/scripts/mutation_stack_sections.py
+++ b/plugins/dev-team/scripts/mutation_stack_sections.py
@@ -13,6 +13,7 @@ array once and maps stack tokens to sections:
     typescript / node   -> js       (Stryker)
     java / kotlin        -> java     (pitest)
     csharp / dotnet      -> csharp   (Stryker.NET)
+    python                -> python  (mutmut)
 
 Output is a single JSON object on stdout:
 
@@ -27,9 +28,9 @@ Three distinct outcomes:
 
 - Definite stack that maps to sections -> run ONLY those sections
   (`ambiguous` false, `note` null).
-- Definite stack that maps to NO section (e.g. pure Python — no Python
-  mutation tool is wired in) -> `sections` empty, `ambiguous` false, `note`
-  set to `no mutation tooling for detected stack (<stacks>)`. Install
+- Definite stack that maps to NO section (e.g. Ruby, Elixir — no mutation
+  tool wired in for that stack) -> `sections` empty, `ambiguous` false,
+  `note` set to `no mutation tooling for detected stack (<stacks>)`. Install
   nothing; probe nothing.
 - Empty / missing / stacks-less signal -> `ambiguous` true. This is the ONLY
   outcome that authorizes the interactive "which languages?" fallback.
@@ -53,7 +54,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 # Canonical section order — polyglot repos run matching sections in this order.
-SECTION_ORDER = ["js", "java", "csharp"]
+SECTION_ORDER = ["js", "java", "csharp", "python"]
 
 # Stack token (lowercased) -> section key.
 STACK_TO_SECTION: Dict[str, str] = {
@@ -64,6 +65,7 @@ STACK_TO_SECTION: Dict[str, str] = {
     "kotlin": "java",
     "csharp": "csharp",
     "dotnet": "csharp",
+    "python": "python",
 }
 
 

--- a/plugins/dev-team/skills/mutation-testing/SKILL.md
+++ b/plugins/dev-team/skills/mutation-testing/SKILL.md
@@ -66,7 +66,7 @@ For tool-specific flag names and config-file keys (e.g. Stryker's `timeoutMS`, p
 
 Before running the full scan, run the tool against **one covered file** and confirm the mutation-switch mechanism is actually observing mutations at runtime. On some tool + test-framework combinations (issue [#554](https://github.com/bdfinst/agentic-dev-team/issues/554), [#557](https://github.com/bdfinst/agentic-dev-team/issues/557) on Stryker.NET + xunit.v3 + MTP), the tool cheerfully runs to completion but reports **every mutant as `Survived`** because the injected `ActiveMutation` env var never reaches the test host — the score looks like `0.00 %` but the run wasted hours. This gate catches that failure mode in one file's worth of wall-clock time.
 
-**Deterministic parse source.** Parse the tool's **report JSON** (Stryker's `StrykerOutput/<run>/reports/mutation-report.json`, pitest's `target/pit-reports/mutations.xml`, mutmut's `.mutmut-cache` export, etc.). **Do not parse stdout, the ANSI progress reporter output, or any log tail** — those are lossy, reporter-config-dependent, and don't survive redirection (see `## Capturing run output safely`). The gate is deterministic only when it reads the same artifact downstream steps read.
+**Deterministic parse source.** Parse the tool's **report JSON** (Stryker's `StrykerOutput/<run>/reports/mutation-report.json`, pitest's `target/pit-reports/mutations.xml`, mutmut's `mutmut junitxml` output, etc.). **Do not parse stdout, the ANSI progress reporter output, or any log tail** — those are lossy, reporter-config-dependent, and don't survive redirection (see `## Capturing run output safely`). The gate is deterministic only when it reads the same artifact downstream steps read.
 
 **Three-way decision** (from the parsed counts):
 
@@ -326,7 +326,7 @@ timeout_warning = timeout_pct > 0.05
 
 The honest score matches the sibling `mutation-kill` agent's formula so both surfaces read the same number. It differs from Stryker's own "mutation score" line (Stryker counts `Timeout` toward the numerator). When `timeout_warning` is true, the claimed score is not trustworthy: raise the tool's `additional-timeout` (or equivalent per-tool wall-clock budget) before treating either score as a gate. The warning is advisory — not a hard gate that fails the run — so a caller can decide policy without the skill forcing one.
 
-**Emitting adapters.** Adapters emit the additive score fields only when their native tool distinguishes `Timeout` and `NoCoverage` from `Killed`/`Survived`. Today that is Stryker (JS), **Stryker.NET**, pitest, and mutmut. Advisory-only tools that do not distinguish them — today's example is **go-mutesting** — omit the fields entirely rather than emit misleading zeros; the top-level `"advisory": true` flag is the caller's signal to treat the envelope as warn-not-block. Readers that consume the new fields MUST tolerate them being absent on an advisory envelope.
+**Emitting adapters.** Adapters emit the additive score fields only when their native tool distinguishes `Timeout` and `NoCoverage` from `Killed`/`Survived`. Today that is Stryker (JS), **Stryker.NET**, and pitest. Advisory-only tools that do not distinguish them — today's examples are **go-mutesting** and **mutmut** (`mutation_report.py`/`mutation_kill_loop.py` have no mutmut-specific parsing yet; only the PostToolUse gate's per-file adapter, `hooks/mutation_adapters/mutmut.py`, is wired) — omit the fields entirely rather than emit misleading zeros; the top-level `"advisory": true` flag is the caller's signal to treat the envelope as warn-not-block. Readers that consume the new fields MUST tolerate them being absent on an advisory envelope.
 
 **Error envelopes (exit code non-zero, `<path>` still written for caller diagnostics):**
 
@@ -337,7 +337,7 @@ The honest score matches the sibling `mutation-kill` agent's formula so both sur
 
 When `<path>` itself is unwritable (read-only directory, permission denied), the skill writes nothing to disk, prints the offending path to stderr, and exits non-zero. No partial JSON is left behind.
 
-Per-tool native-report mappings (Stryker → JSON, pitest XML → JSON, mutmut → JSON, Stryker.NET JSON, go-mutesting stdout) live with each language file under [`references/languages/`](references/languages/).
+Per-tool native-report mappings (Stryker → JSON, pitest XML → JSON, mutmut JUnit XML → JSON, Stryker.NET JSON, go-mutesting stdout) live with each language file under [`references/languages/`](references/languages/).
 
 ## When not to apply
 

--- a/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
@@ -2,26 +2,33 @@
 
 Tool: [mutmut](https://mutmut.readthedocs.io/). Detection: `mutmut` in requirements or pyproject.
 
+**Pin `mutmut<3`.** mutmut 3.x ships an incompatible config/CLI contract
+(`source_paths` in a `[mutmut]` setup.cfg section, no `--paths-to-mutate`
+flag, no `run`/`results`/`junitxml` subcommands in the same shape) that the
+adapter and this reference below do not speak. `pip install mutmut`
+unpinned resolves to 3.x today.
+
 ## Install / detect
 
 Both install paths are **local** — scoped to the active virtual environment (`.venv/bin/mutmut`), not the system-wide `pip`. Pick one:
 
 ```bash
 # (a) install directly into the active venv
-pip install mutmut
+pip install "mutmut<3"
 
 # (b) declare it in pyproject.toml and let pip resolve it as a dev dep
 # [project.optional-dependencies]
-# dev = ["mutmut"]
+# dev = ["mutmut<3"]
 pip install -e .[dev]
 ```
 
 Never `pip install --user mutmut` or run `pip install` outside a venv for this — that puts mutmut in a location whose `PATH` presence depends on the user's shell config, which is the silent-failure trap the skill's "prefer local install" note is trying to avoid.
 
-Confirm the tool resolves in the active venv before configuring a run:
+Confirm the tool resolves in the active venv before configuring a run
+(`version` is a subcommand — there is no `--version` flag):
 
 ```bash
-mutmut --version
+mutmut version
 ```
 
 ## Run (scoped)
@@ -32,17 +39,34 @@ mutmut --version
 mutmut run --paths-to-mutate=src/calculator.py
 ```
 
-## Per-mutant timeout flag
+## Per-mutant timeout
 
-```bash
-mutmut run --paths-to-mutate=src/calculator.py --timeout <seconds>
-```
-
-Default shipped: 60 s. Set `--timeout` to `timeout_seconds` (formula in [`SKILL.md`](../../SKILL.md) Step 1b). mutmut passes the value to the per-mutant subprocess.
+mutmut has no `--timeout <seconds>` flag. Its own per-mutant timeout is
+`baseline_time * test_time_multiplier + test_time_base` (`-m`/`-b`,
+defaults `2.0`/`0.0`) — a mutant whose test run exceeds that computed
+budget is reported `TIMEOUT`. The shipped adapter
+(`hooks/mutation_adapters/mutmut.py`) does not rely on this; it wraps the
+whole `mutmut run` invocation in an external, OS-level timeout
+(`ADAPTER_TIMEOUT`, from `MUTATION_GATE_TIMEOUT`, default 120s) so a
+runaway run is killed regardless of mutmut's own per-mutant accounting.
 
 ## Native report → schema mapping
 
-Source: `mutmut results --json`. Each surviving mutant carries `filename`, `line_number`, and a mutmut-specific mutation type.
+mutmut has no `--json` results output. Source: `mutmut junitxml` — a
+`<testcase>` with a `<failure>` child is a survived mutant under the
+default suspicious/untested policies (both `ignore`); one without is
+killed. `name`, `file`, and `line` come from the `<testcase>` attributes:
+
+```xml
+<testcase name="Mutant #8" file="src/calculator.py" line="12">
+  <failure type="failure" message="bad_survived">--- diff ---</failure>
+</testcase>
+```
+
+Map each `<failure>`-bearing `<testcase>` to a `survived` entry in the
+normalized envelope below (`operator` has no mutmut equivalent — omit it
+or leave `null`, unlike Stryker/pitest which name a mutator/operator per
+survivor):
 
 ```json
 {
@@ -55,10 +79,15 @@ Source: `mutmut results --json`. Each surviving mutant carries `filename`, `line
   "survived": 5,
   "equivalent": 1,
   "survivors": [
-    { "file": "src/calculator.py", "line": 12, "operator": "RelationalOperator", "status": "survived" }
+    { "file": "src/calculator.py", "line": 12, "operator": null, "status": "survived" }
   ]
 }
 ```
+
+This normalized envelope is produced by the triaging agent reading the
+native report (per this doc's mapping) — `mutation_report.py` and
+`mutation_kill_loop.py` have no mutmut-specific parsing yet (see
+[SKILL.md → Machine-readable output](../../SKILL.md#machine-readable-output)).
 
 ## Language-specific notes
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -81,6 +81,19 @@ def run_scoped_mutmut(
     file changed) is silently reused otherwise, which was a real trap hit
     manually while dogfooding this loop by hand (#1354): every run must see
     its own fresh baseline, not a leftover one.
+
+    **Always reverts ``source_file`` in a ``finally``.** mutmut mutates the
+    real source file on disk for the duration of each mutant's test run and
+    restores it when that mutant finishes — but an internal mutmut crash
+    (a real, reproducible one: mutmut 2.5.1's own cache layer raises
+    ``AssertionError``/``ValueError`` on some files, confirmed while
+    dogfooding this exact function against
+    ``hooks/mutation_adapters/mutmut.py`` — see #1357) skips that restore
+    and leaves the mutated content on disk. Unlike Stryker.NET (which
+    instruments a separate build, never the real file), mutmut's crash
+    failure mode is "corrupt the file under test," so every scoped run must
+    unconditionally `git checkout --` it afterward — succeeding, failing, or
+    raising.
     """
     root = cwd or Path(".")
     (root / ".mutmut-cache").unlink(missing_ok=True)
@@ -96,14 +109,17 @@ def run_scoped_mutmut(
         "--simple-output",
     ]
     try:
-        subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
-    except (FileNotFoundError, OSError) as exc:
-        raise RuntimeError(f"mutmut run failed to start: {exc}") from exc
+        try:
+            subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise RuntimeError(f"mutmut run failed to start: {exc}") from exc
 
-    junit = subprocess.run(
-        [*prefix, "junitxml"], cwd=cwd, capture_output=True, text=True
-    )
-    return junit.stdout or ""
+        junit = subprocess.run(
+            [*prefix, "junitxml"], cwd=cwd, capture_output=True, text=True
+        )
+        return junit.stdout or ""
+    finally:
+        git_revert(Path(source_file), cwd=cwd)
 
 
 def extract_survivors(junitxml_text: str, source_file: str) -> List[dict]:

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""mutation_kill_loop_python.py — deterministic survivor-kill loop for
+Python/mutmut, the Python counterpart to ``mutation_kill_loop.py`` (#1357).
+
+mutmut has no project/solution structure to load from a config file the way
+Stryker.NET does — a scoped run only needs the source file and a test
+command, so there is no config-file abstraction here (unlike
+``mutation_kill_loop.py``'s ``LoopConfig``/``stryker-config.json``). Scoring
+and survivor extraction reuse ``mutation_report``'s mutmut-junitxml support
+(#1357); the two generic (non-.NET) headless-generation helpers —
+``strip_code_fences``, ``resolve_model``, ``claude_cli_available``,
+``CLAUDE_CLI`` — are imported from ``mutation_kill_loop`` rather than
+duplicated, since neither depends on anything C#-specific.
+
+**Generation is a seam, not a mechanism** (same contract as the C# loop):
+the loop never decides *what* tests to write — a caller supplies a
+``generate`` callable that returns the new pytest function text. The
+default (interactive) path is agent-driven: the ``mutation-kill`` agent
+calls :func:`run_for_file` directly, passing a ``generate`` hook backed by a
+live agent turn. A ``--headless`` CLI mode shells to ``claude --print`` for
+unattended (CI) runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence
+
+import mutation_kill_loop as _cs_loop
+import mutation_report
+
+Generator = Callable[[str, List[dict], str, str], str]
+
+# Mirrors mutation_kill_loop.NO_GENERATOR_MESSAGE — pinned so a contract test
+# can assert it verbatim.
+NO_GENERATOR_MESSAGE = (
+    "no test generator available — invoke via the mutation-kill agent "
+    "or pass --headless"
+)
+
+# Reused verbatim — neither helper is C#-specific.
+strip_code_fences = _cs_loop.strip_code_fences
+resolve_model = _cs_loop.resolve_model
+claude_cli_available = _cs_loop.claude_cli_available
+CLAUDE_CLI = _cs_loop.CLAUDE_CLI
+
+MISSING_CLAUDE_MESSAGE = (
+    f"--headless requires the Claude CLI but '{CLAUDE_CLI}' is not available. "
+    "Install Claude Code (`npm install -g @anthropic-ai/claude-code`) and "
+    "authenticate it (run `claude` once to log in, or set ANTHROPIC_API_KEY) — "
+    "or set CLAUDE_BIN to the CLI's path."
+)
+
+
+# =============================================================================
+# Scoped mutmut run — mutmut has no native JSON report; junitxml is it.
+# =============================================================================
+def _mutmut_argv() -> List[str]:
+    """Return the argv prefix for invoking mutmut — `mutmut` or `python3 -m mutmut`."""
+    if shutil.which("mutmut") is not None:
+        return ["mutmut"]
+    return [sys.executable, "-m", "mutmut"]
+
+
+def run_scoped_mutmut(
+    source_file: str,
+    *,
+    test_command: str,
+    cwd: Optional[Path] = None,
+) -> str:
+    """Run mutmut scoped to one file; return the ``mutmut junitxml`` output.
+
+    Clears any stale ``.mutmut-cache`` first — a cache from a *different*
+    scope (a prior run against another file, or a stale run from before this
+    file changed) is silently reused otherwise, which was a real trap hit
+    manually while dogfooding this loop by hand (#1354): every run must see
+    its own fresh baseline, not a leftover one.
+    """
+    root = cwd or Path(".")
+    (root / ".mutmut-cache").unlink(missing_ok=True)
+
+    prefix = _mutmut_argv()
+    argv = [
+        *prefix,
+        "run",
+        f"--paths-to-mutate={source_file}",
+        "--runner",
+        test_command,
+        "--no-progress",
+        "--simple-output",
+    ]
+    try:
+        subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise RuntimeError(f"mutmut run failed to start: {exc}") from exc
+
+    junit = subprocess.run(
+        [*prefix, "junitxml"], cwd=cwd, capture_output=True, text=True
+    )
+    return junit.stdout or ""
+
+
+def extract_survivors(junitxml_text: str, source_file: str) -> List[dict]:
+    """Return the surviving mutants for one source file (flattened).
+
+    Delegates parsing to :func:`mutation_report.survivors_from_mutmut_junitxml`
+    — mutmut names no per-mutation operator, so every survivor's
+    ``mutatorName`` is the fixed literal ``"mutmut"`` (a single group).
+    """
+    grouped = mutation_report.survivors_from_mutmut_junitxml(
+        junitxml_text, source_file
+    )
+    return [mutant for mutants in grouped.values() for mutant in mutants]
+
+
+# =============================================================================
+# Insert mechanics — detect-or-refuse, never a silent mis-insertion.
+# =============================================================================
+class InsertionRefused(Exception):
+    """Raised when the file isn't in the flat top-level ``def test_*():``
+    shape this heuristic supports.
+
+    Unlike the C# loop's "find the class-closing brace" problem, a flat
+    pytest module has no enclosing structure to locate — the safe insertion
+    point is simply end-of-file, PROVIDED the file already follows that flat
+    convention. A file with no top-level ``def test_`` function at all (e.g.
+    tests organized as ``class Test...:`` methods) doesn't match this
+    convention, and the loop refuses rather than guess.
+    """
+
+
+@dataclass(frozen=True)
+class InsertOutcome:
+    """Result of attempting to apply generated tests. ``inserted`` is False
+    when the file was left untouched; ``reason`` says why."""
+
+    inserted: bool
+    reason: str
+
+
+# A top-level (unindented) pytest test function declaration, capturing the name.
+_FUNC_RE = re.compile(r"^def\s+(test_\w+)\s*\(", re.MULTILINE)
+
+
+def detect_duplicate_functions(test_text: str, new_text: str) -> List[str]:
+    """Return the function names in ``new_text`` that already exist in the file."""
+    existing = set(_FUNC_RE.findall(test_text))
+    incoming = _FUNC_RE.findall(new_text)
+    return [name for name in incoming if name in existing]
+
+
+def append_at_end_of_file(test_file: Path, new_tests: str) -> None:
+    """Append ``new_tests`` to the end of the file, with one blank line of
+    separation, and a trailing newline.
+
+    Raises :class:`InsertionRefused` when the file has no existing top-level
+    ``def test_*():`` — the flat-module convention this heuristic supports.
+    The file is left untouched on refusal.
+    """
+    text = test_file.read_text(encoding="utf-8")
+    if not _FUNC_RE.search(text):
+        raise InsertionRefused(
+            f"refusing to insert into {test_file.name}: no top-level "
+            "`def test_*():` found — this heuristic supports only the flat "
+            "module convention (a class-based test file needs a different "
+            "insertion point, not appended at end-of-file)"
+        )
+
+    body = new_tests.strip()
+    separator = "" if text.endswith("\n\n") else ("\n" if text.endswith("\n") else "\n\n")
+    test_file.write_text(text + separator + body + "\n", encoding="utf-8")
+
+
+def apply_generated_tests(test_file: Path, new_tests: str) -> InsertOutcome:
+    """Insert generated tests, guarding duplicates and unsafe structure.
+
+    Returns an :class:`InsertOutcome`; the file is only ever written on the
+    ``inserted=True`` path. Empty generation, duplicate function names, and
+    a refused insert all leave the file untouched.
+    """
+    if not new_tests.strip():
+        return InsertOutcome(False, "no tests generated")
+
+    dupes = detect_duplicate_functions(test_file.read_text(encoding="utf-8"), new_tests)
+    if dupes:
+        return InsertOutcome(False, f"duplicate function names: {dupes}")
+
+    try:
+        append_at_end_of_file(test_file, new_tests)
+    except InsertionRefused as exc:
+        return InsertOutcome(False, str(exc))
+    return InsertOutcome(True, "inserted")
+
+
+# =============================================================================
+# Verify / commit / revert.
+# =============================================================================
+def python_compiles(test_file: Path, *, cwd: Optional[Path] = None) -> bool:
+    """Syntax-check the test file — Python's equivalent of a build step."""
+    rc = subprocess.run(
+        [sys.executable, "-m", "py_compile", str(test_file)],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    ).returncode
+    return rc == 0
+
+
+def run_scoped_pytest(test_file: Path, *, cwd: Optional[Path] = None) -> bool:
+    """Run the test file under pytest. False on any non-zero exit."""
+    rc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(test_file), "-q"],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    ).returncode
+    return rc == 0
+
+
+def git_revert(test_file: Path, *, cwd: Optional[Path] = None) -> None:
+    """Discard working-tree changes to one file (``git checkout -- <file>``)."""
+    subprocess.run(["git", "checkout", "--", str(test_file)], cwd=cwd)
+
+
+def git_commit(message: str, test_file: Path, *, cwd: Optional[Path] = None) -> bool:
+    """Stage and commit only ``test_file``. Returns True on a successful commit."""
+    subprocess.run(["git", "add", str(test_file)], cwd=cwd)
+    rc = subprocess.run(
+        ["git", "commit", "-m", message],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    ).returncode
+    return rc == 0
+
+
+def _commit_message(round_num: int, source_file: str, survivors: int, new_tests: str) -> str:
+    count = len(_FUNC_RE.findall(new_tests))
+    return (
+        f"test(mutation): kill round {round_num} — {source_file}\n\n"
+        f"{count} new test(s) targeting {survivors} surviving mutant(s)"
+    )
+
+
+# =============================================================================
+# Per-file loop — run → score → check → generate → insert → verify → commit.
+# =============================================================================
+def run_for_file(
+    source_file: str,
+    *,
+    test_file: Path,
+    source_path: Path,
+    test_command: str,
+    generate: Generator,
+    max_rounds: int = 5,
+    initial_junitxml: Optional[str] = None,
+    cwd: Optional[Path] = None,
+    log: Callable[[str], None] = print,
+) -> None:
+    """Drive the deterministic survivor-kill loop for one Python source file.
+
+    ``generate`` is the sole non-deterministic step: given survivors +
+    context it returns the raw new-test text. Everything else — scoped run,
+    scoring, duplicate/insert guards, compile/test verification,
+    revert-on-failure, commit-on-green, and the no-improvement stop — is
+    mechanical, mirroring :func:`mutation_kill_loop.run_for_file`'s contract.
+    """
+    prev_survivors: Optional[int] = None
+
+    for round_num in range(1, max_rounds + 1):
+        if initial_junitxml is not None and round_num == 1:
+            junitxml_text = initial_junitxml
+        else:
+            junitxml_text = run_scoped_mutmut(
+                source_file, test_command=test_command, cwd=cwd
+            )
+
+        survivors = extract_survivors(junitxml_text, source_file)
+        survivor_count = len(survivors)
+        summary = mutation_report.score_mutmut_junitxml(junitxml_text)
+        log(
+            f"  round {round_num}: honest={summary.honest_score:.1f}% "
+            f"survivors={survivor_count}"
+        )
+
+        if survivor_count == 0:
+            log("  no survivors — done")
+            return
+        if prev_survivors is not None and survivor_count >= prev_survivors:
+            log("  no improvement this round — stopping")
+            return
+        prev_survivors = survivor_count
+
+        new_tests = generate(
+            source_file,
+            survivors,
+            source_path.read_text(encoding="utf-8"),
+            test_file.read_text(encoding="utf-8"),
+        )
+
+        outcome = apply_generated_tests(test_file, new_tests)
+        if not outcome.inserted:
+            log(f"  not inserted ({outcome.reason}) — stopping")
+            return
+
+        if not python_compiles(test_file, cwd=cwd):
+            log("  compile check failed — reverting")
+            git_revert(test_file, cwd=cwd)
+            return
+        if not run_scoped_pytest(test_file, cwd=cwd):
+            log("  tests failed — reverting")
+            git_revert(test_file, cwd=cwd)
+            return
+
+        log("  green — committing")
+        git_commit(
+            _commit_message(round_num, source_file, survivor_count, new_tests),
+            test_file,
+            cwd=cwd,
+        )
+
+
+# =============================================================================
+# Headless generation — shell to `claude --print` for unattended runs.
+# =============================================================================
+def build_survivor_summary(survivors: List[dict], *, limit: int = 40) -> str:
+    """Render surviving mutants as a compact list."""
+    lines = []
+    for mutant in survivors[:limit]:
+        line = mutant.get("location", {}).get("start", {}).get("line", "?")
+        lines.append(f"- L{line}")
+    if len(survivors) > limit:
+        lines.append(f"- … and {len(survivors) - limit} more")
+    return "\n".join(lines)
+
+
+def build_generation_prompt(
+    source_file: str,
+    survivors: List[dict],
+    source_text: str,
+    test_text: str,
+    *,
+    source_limit: int = 8000,
+) -> str:
+    """Build the generation prompt.
+
+    The existing test file is the *only* pattern — assertion style and
+    fixture usage are inferred from it, never hardcoded here (mirrors
+    ``mutation_kill_loop.build_generation_prompt``, adapted for pytest's flat
+    ``def test_*():`` convention rather than a class/namespace-wrapped one).
+    """
+    return (
+        f"You are adding new pytest test functions that KILL surviving "
+        f"mutations in {source_file}.\n\n"
+        "Match the existing test file exactly: its imports, assertion style "
+        "(plain `assert`, pytest.approx, monkeypatch, etc.), fixtures, and "
+        "naming conventions are the pattern to follow. Do not introduce any "
+        "library, helper, or convention that does not already appear in it.\n\n"
+        f"## Surviving mutations ({len(survivors)})\n"
+        f"{build_survivor_summary(survivors)}\n\n"
+        f"## Source under test\n{source_text[:source_limit]}\n\n"
+        f"## Existing test file (the pattern to match)\n{test_text}\n\n"
+        "## Rules\n"
+        "1. Return ONLY the new top-level `def test_*():` function(s) — no "
+        "class wrapper, no imports, no module-level fixtures.\n"
+        "2. Each must run against the helpers/fixtures already in the "
+        "existing test file.\n"
+        "3. Reuse the existing file's assertion and fixture patterns exactly.\n"
+        "4. Match the existing naming convention.\n"
+        "5. Do not redeclare fixtures or helpers already present.\n"
+        "6. Every assertion must check a specific value — not just that a "
+        "call didn't raise.\n"
+    )
+
+
+def make_headless_generator(
+    model: Optional[str] = None, *, cwd: Optional[Path] = None
+) -> Generator:
+    """Return a :data:`Generator` that shells to ``claude --print``.
+
+    Identical contract to ``mutation_kill_loop.make_headless_generator``, but
+    with the Python-flavored prompt above.
+    """
+
+    def generate(
+        source_file: str,
+        survivors: List[dict],
+        source_text: str,
+        test_text: str,
+    ) -> str:
+        prompt = build_generation_prompt(source_file, survivors, source_text, test_text)
+        cmd = [CLAUDE_CLI, "--print"]
+        if model:
+            cmd += ["--model", model]
+        cmd.append(prompt)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude CLI failed (exit {result.returncode}): {result.stderr[:500]}"
+            )
+        return strip_code_fences(result.stdout)
+
+    return generate
+
+
+# =============================================================================
+# CLI — startup preflight + --headless generation.
+# =============================================================================
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="mutation_kill_loop_python.py",
+        description=(
+            "Deterministic survivor-kill loop for Python/mutmut. Agent-driven "
+            "by default; --headless enables unattended generation via the "
+            "Claude CLI."
+        ),
+    )
+    p.add_argument("--file", required=False, help="Source file to target")
+    p.add_argument(
+        "--test-command",
+        default=None,
+        help="Scoped pytest command mutmut runs per mutant (required)",
+    )
+    p.add_argument("--max-rounds", type=int, default=5, help="Max rounds per file")
+    p.add_argument(
+        "--headless",
+        action="store_true",
+        help="Unattended generation via `claude --print` (CI runs).",
+    )
+    p.add_argument(
+        "--model",
+        help=(
+            "Generation model for --headless. Default: DEV_TEAM_MUTATION_MODEL "
+            "env var, else omitted so `claude --print` uses its own default."
+        ),
+    )
+    p.add_argument("--test-file", help="Test file to extend (required with --headless)")
+    p.add_argument("--source-path", help="Source file under test (required with --headless)")
+    return p.parse_args(list(argv))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point — see :func:`mutation_kill_loop.main` for the contract
+    this mirrors."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = parse_args(argv)
+
+    if not args.headless:
+        sys.stderr.write(f"error: {NO_GENERATOR_MESSAGE}\n")
+        return 1
+
+    model = resolve_model(args.model)
+
+    if not claude_cli_available():
+        sys.stderr.write(f"error: {MISSING_CLAUDE_MESSAGE}\n")
+        return 3
+
+    if not (args.file and args.test_file and args.source_path and args.test_command):
+        sys.stderr.write(
+            "error: --headless requires --file, --test-file, --source-path, "
+            "and --test-command\n"
+        )
+        return 2
+
+    run_for_file(
+        args.file,
+        test_file=Path(args.test_file),
+        source_path=Path(args.source_path),
+        test_command=args.test_command,
+        generate=make_headless_generator(model),
+        max_rounds=args.max_rounds,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
-"""mutation_report.py — parse a Stryker mutation-report.json and compute scores.
+"""mutation_report.py — parse a native mutation report and compute scores.
 
 Generic, stdlib-only, cross-platform (macOS, Linux, Windows). Sole runtime
 dependency is python3 (>= 3.8) on PATH. Carries no repo-specific literal —
 project names, controller names, and test-library names live in the report
 being parsed, never in this module.
+
+Two native report shapes are supported, normalized to the same internal
+``{"files": {"<path>": {"mutants": [...]}}}`` dict before scoring:
+
+- Stryker / Stryker.NET's own ``mutation-report.json`` — read directly via
+  the path-based functions (``score_report``, ``survivors_by_mutator``, …).
+- mutmut's ``mutmut junitxml`` output — mutmut has no JSON report of its
+  own; ``parse_mutmut_junitxml`` converts it into the same internal shape so
+  every downstream function (scoring, survivor extraction, file discovery)
+  works identically regardless of which tool produced the data.
 
 Two scores are computed side by side:
 
@@ -29,6 +39,7 @@ CompileError are excluded from both numerator and denominator.
 from __future__ import annotations
 
 import json
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
@@ -78,14 +89,9 @@ def _iter_mutants(data: dict):
             yield mutant
 
 
-def score_report(report_path: Path) -> ScoreSummary:
-    """Compute the honest and reported scores for a mutation report.
-
-    Returns a fully zeroed :class:`ScoreSummary` when the report is absent
-    or empty — never raises for a missing file.
-    """
-    data = _load_report(report_path)
-
+def _score_data(data: dict) -> ScoreSummary:
+    """Compute the honest and reported scores for an already-parsed report
+    dict (the ``{"files": {...}}`` shape shared by every supported tool)."""
     killed = survived = timeout = no_coverage = 0
     for mutant in _iter_mutants(data):
         status = mutant.get("status")
@@ -116,8 +122,19 @@ def score_report(report_path: Path) -> ScoreSummary:
     )
 
 
-def survivors_by_mutator(report_path: Path, file_path: str) -> Dict[str, List[dict]]:
-    """Return the Survived mutants for one source file, grouped by mutator name.
+def score_report(report_path: Path) -> ScoreSummary:
+    """Compute the honest and reported scores for a Stryker-shaped mutation
+    report on disk.
+
+    Returns a fully zeroed :class:`ScoreSummary` when the report is absent
+    or empty — never raises for a missing file.
+    """
+    return _score_data(_load_report(report_path))
+
+
+def _survivors_from_data(data: dict, file_path: str) -> Dict[str, List[dict]]:
+    """Return the Survived mutants for one source file, grouped by mutator
+    name, from an already-parsed report dict.
 
     Matches ``file_path`` against report keys by exact match first, then by
     basename, so a caller can pass either the full report key or just the
@@ -125,7 +142,6 @@ def survivors_by_mutator(report_path: Path, file_path: str) -> Dict[str, List[di
     uncovered mutants are not survivors. Returns ``{}`` when the file is not
     in the report or has no survivors.
     """
-    data = _load_report(report_path)
     files = data.get("files", {})
 
     info = files.get(file_path)
@@ -147,19 +163,31 @@ def survivors_by_mutator(report_path: Path, file_path: str) -> Dict[str, List[di
     return grouped
 
 
-def _files_with_status(report_path: Path, status: str) -> List[str]:
-    """Return the sorted report file keys having >= 1 mutant of ``status``.
+def survivors_by_mutator(report_path: Path, file_path: str) -> Dict[str, List[dict]]:
+    """Return the Survived mutants for one source file, grouped by mutator
+    name, from a Stryker-shaped mutation report on disk."""
+    return _survivors_from_data(_load_report(report_path), file_path)
 
-    The report keys are the file identifiers exactly as Stryker emits them
-    (relative source paths); the caller decides how to interpret them. Returns
-    ``[]`` for an absent/empty report — never raises.
+
+def _files_with_status_from_data(data: dict, status: str) -> List[str]:
+    """Return the sorted report file keys having >= 1 mutant of ``status``,
+    from an already-parsed report dict.
+
+    The report keys are the file identifiers exactly as the tool emits them
+    (relative source paths); the caller decides how to interpret them.
     """
-    data = _load_report(report_path)
     return sorted(
         key
         for key, info in data.get("files", {}).items()
         if any(m.get("status") == status for m in info.get("mutants", []))
     )
+
+
+def _files_with_status(report_path: Path, status: str) -> List[str]:
+    """Return the sorted report file keys having >= 1 mutant of ``status``,
+    from a Stryker-shaped mutation report on disk. Returns ``[]`` for an
+    absent/empty report — never raises."""
+    return _files_with_status_from_data(_load_report(report_path), status)
 
 
 def files_with_survivors(report_path: Path) -> List[str]:
@@ -178,3 +206,72 @@ def files_with_timeouts(report_path: Path) -> List[str]:
     modules call it instead of re-walking the report (AC4).
     """
     return _files_with_status(report_path, STATUS_TIMEOUT)
+
+
+# =============================================================================
+# mutmut — no native JSON report; junitxml is its only structured output.
+# =============================================================================
+def parse_mutmut_junitxml(xml_text: str) -> dict:
+    """Convert ``mutmut junitxml`` output into the internal ``{"files": {...}}``
+    shape every scoring/survivor function above already consumes.
+
+    mutmut marks a survived mutant with a ``<failure>`` child
+    (``message="bad_survived"``) and a timed-out mutant with a distinct
+    ``<error>`` child (``message="bad_timeout"``, ``error_type="timeout"``) —
+    the two are never conflated, so a real Timeout is never miscounted as a
+    Survived. Every other ``<testcase>`` — including a suspicious-but-ignored
+    mutant under mutmut's default ``suspicious_policy="ignore"`` — is Killed;
+    mutmut's default reporting granularity cannot distinguish "cleanly
+    killed" from "suspicious but ignored" any further than that. mutmut has
+    no NoCoverage concept (it always runs the full scoped test command
+    against every mutant), so that count is always zero here.
+
+    Malformed or empty input returns an empty ``{"files": {}}`` rather than
+    raising — callers see it as an empty report, same as a missing file.
+    """
+    files: Dict[str, dict] = {}
+    if not xml_text.strip():
+        return {"files": files}
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return {"files": files}
+
+    for testcase in root.iter("testcase"):
+        file_key = testcase.get("file")
+        if not file_key:
+            continue
+        if testcase.find("failure") is not None:
+            status = STATUS_SURVIVED
+        elif testcase.find("error") is not None:
+            status = STATUS_TIMEOUT
+        else:
+            status = STATUS_KILLED
+        line = testcase.get("line")
+        mutant = {
+            "id": testcase.get("name", "?"),
+            "mutatorName": "mutmut",
+            "status": status,
+            "location": {
+                "start": {"line": int(line) if line and line.isdigit() else None}
+            },
+            "replacement": "",
+        }
+        files.setdefault(file_key, {"mutants": []})["mutants"].append(mutant)
+
+    return {"files": files}
+
+
+def score_mutmut_junitxml(xml_text: str) -> ScoreSummary:
+    """Compute the honest and reported scores directly from ``mutmut
+    junitxml`` output (no report file on disk needed)."""
+    return _score_data(parse_mutmut_junitxml(xml_text))
+
+
+def survivors_from_mutmut_junitxml(
+    xml_text: str, file_path: str
+) -> Dict[str, List[dict]]:
+    """Return the Survived mutants for one file from ``mutmut junitxml``
+    output, grouped by mutator name (always ``"mutmut"`` — the tool names no
+    per-mutation operator the way Stryker/pitest do)."""
+    return _survivors_from_data(parse_mutmut_junitxml(xml_text), file_path)

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -276,19 +276,21 @@ and prints one JSON object:
 ```
 
 - `sections` — the sections to run, from `js` (JS/TS — Stryker), `java`
-  (Java/Kotlin — pitest), `csharp` (C#/.NET — Stryker.NET). The mapping is
-  `typescript`/`node`/`javascript` → `js`, `java`/`kotlin` → `java`,
-  `csharp`/`dotnet` → `csharp`. **Run every section in `sections` and no
-  others.** More than one may apply in a polyglot repo.
+  (Java/Kotlin — pitest), `csharp` (C#/.NET — Stryker.NET), `python`
+  (Python — mutmut). The mapping is `typescript`/`node`/`javascript` → `js`,
+  `java`/`kotlin` → `java`, `csharp`/`dotnet` → `csharp`, `python` →
+  `python`. **Run every section in `sections` and no others.** More than one
+  may apply in a polyglot repo.
 - `ambiguous` — `true` **only** when the stack signal is genuinely empty or
   missing (no `.claude/project-stack.json`, unreadable/invalid, or an empty
   `stacks` array). This is the **only** outcome that authorizes the
   interactive fallback below.
-- `note` — set when a definite stack matched no section (e.g. a pure-Python
-  repo — there is no Python mutation tool wired into this step). When `note`
-  is non-null, `sections` is empty and `ambiguous` is `false`: install
-  **nothing**, probe **nothing** (no `dotnet`, `node`, or `mvn`), print the
-  `note` line verbatim, and skip the rest of this step.
+- `note` — set when a definite stack matched no section (e.g. a Ruby or
+  Elixir repo — there is no mutation tool wired into this step for that
+  stack). When `note` is non-null, `sections` is empty and `ambiguous` is
+  `false`: install **nothing**, probe **nothing** (no `dotnet`, `node`,
+  `mvn`, or `pip`), print the `note` line verbatim, and skip the rest of
+  this step.
 
 **Interactive fallback — only when `ambiguous` is `true`.** When a definite
 stack was detected (`ambiguous` is `false`), never prompt; honor `sections`
@@ -303,12 +305,13 @@ with no recognizable stack) fall back to asking:
 > 1. **JS/TS** — Stryker (`@stryker-mutator/core`)
 > 2. **Java / Kotlin** — pitest (`pitest-maven` or `info.solidsoft.gradle.pitest`)
 > 3. **C# / .NET** — Stryker.NET (`dotnet-stryker`)
-> 4. **All of the above**
-> 5. **None — skip mutation tooling**
+> 4. **Python** — mutmut
+> 5. **All of the above**
+> 6. **None — skip mutation tooling**
 
-Parse the response. If they choose 4, treat it as selecting 1, 2, and 3
-(i.e. `sections` = `["js", "java", "csharp"]`). If 5, skip the rest of this
-step.
+Parse the response. If they choose 5, treat it as selecting 1, 2, 3, and 4
+(i.e. `sections` = `["js", "java", "csharp", "python"]`). If 6, skip the
+rest of this step.
 
 Each language subsection below **re-asserts its own gate as its literal
 first step** — a section whose key is not in `sections` returns immediately,
@@ -658,6 +661,52 @@ dotnet stryker --version 2>/dev/null || dotnet tool run dotnet-stryker --version
 
 ---
 
+#### Python — mutmut
+
+**Stack gate (first step — hard precondition):** if `python` is not in the
+Step 6 helper's `sections`, return immediately. Do **not** run the
+prerequisites probe below (no `command -v mutmut`, no `pip show mutmut`).
+Only proceed when `python` is in `sections`.
+
+**Prerequisites check:**
+
+```bash
+command -v python3 && python3 --version
+python3 -m pip --version
+```
+
+If `python3` or `pip` is not found, tell the user: "Python 3 with pip is
+required for mutmut. Install it from <https://www.python.org> and re-run
+`/setup`."
+
+**Check if mutmut is already installed in the active environment:**
+
+```bash
+python3 -m mutmut --version 2>/dev/null || mutmut --version 2>/dev/null
+```
+
+**If not installed, install it locally — scoped to the active virtual
+environment, never `--user` or system-wide** (that puts mutmut in a location
+whose `PATH` presence depends on shell config, the silent-failure trap this
+step exists to avoid):
+
+```bash
+python3 -m pip install mutmut
+```
+
+If the project declares dev dependencies in `pyproject.toml`
+(`[project.optional-dependencies]` / `[tool.poetry.group.dev.dependencies]`),
+prefer adding `mutmut` there and installing via the project's existing dev-
+dependency flow instead of a bare `pip install`.
+
+**Verify:**
+
+```bash
+python3 -m mutmut --version 2>/dev/null || mutmut --version
+```
+
+---
+
 ### 7. Select agent templates
 
 Based on detected stack, select applicable templates from `templates/agents/`:
@@ -762,10 +811,11 @@ Display a summary of everything installed and created:
 
 Report a mutation-testing line **only for sections actually in scope** — the
 `sections` the Step 6 helper returned (Stryker for `js`, pitest for `java`,
-Stryker.NET for `csharp`). Never list a tool for a stack that was not
-detected. When the helper's `note` was set (a detected stack with no
-mutation tool wired in, e.g. pure Python), report that one line verbatim —
-`no mutation tooling for detected stack (<stacks>)` — and no tool line.
+Stryker.NET for `csharp`, mutmut for `python`). Never list a tool for a
+stack that was not detected. When the helper's `note` was set (a detected
+stack with no mutation tool wired in, e.g. Ruby or Elixir), report that one
+line verbatim — `no mutation tooling for detected stack (<stacks>)` — and no
+tool line.
 
 ### Coverage baseline readiness (JS/TS only)
 - ✓ json-summary + coverage scope present   [ready + meaningful]

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -688,16 +688,19 @@ python3 -m mutmut --version 2>/dev/null || mutmut --version 2>/dev/null
 **If not installed, install it locally — scoped to the active virtual
 environment, never `--user` or system-wide** (that puts mutmut in a location
 whose `PATH` presence depends on shell config, the silent-failure trap this
-step exists to avoid):
+step exists to avoid). **Pin `mutmut<3`** — mutmut 3.x ships an incompatible
+config/CLI contract (`source_paths` in a `[mutmut]` setup.cfg section, no
+`--paths-to-mutate` flag) that the shipped adapter
+(`hooks/mutation_adapters/mutmut.py`) does not speak:
 
 ```bash
-python3 -m pip install mutmut
+python3 -m pip install "mutmut<3"
 ```
 
 If the project declares dev dependencies in `pyproject.toml`
 (`[project.optional-dependencies]` / `[tool.poetry.group.dev.dependencies]`),
-prefer adding `mutmut` there and installing via the project's existing dev-
-dependency flow instead of a bare `pip install`.
+prefer adding `mutmut<3` there and installing via the project's existing
+dev-dependency flow instead of a bare `pip install`.
 
 **Verify:**
 

--- a/plugins/dev-team/tests/hooks/test_mutmut_adapter.py
+++ b/plugins/dev-team/tests/hooks/test_mutmut_adapter.py
@@ -1,0 +1,211 @@
+"""Tests for the mutmut (Python) adapter's real-CLI contract.
+
+The shipped adapter shipped with two latent bugs, confirmed by running the
+real `mutmut` 2.x CLI against this repo's own code while dogfooding the
+mutation-testing pipeline (issue tracking: mutmut/python-setup epic):
+
+1. `mutmut_detect()`'s fallback probe used `python3 -m mutmut --version` — a
+   flag that does not exist on the real CLI (it is a `version` subcommand)
+   and always exits nonzero, so the fallback always read as "not installed".
+2. `mutmut_run()` treated any exit code `>= 2` as a tool error to skip. The
+   real CLI's exit code is a bitmask (1=fatal error, 2=survived, 4=timeout,
+   8=slow); a run with survivors — the common, expected case — legitimately
+   returns 2 (or higher combined with other bits), so the gate silently
+   discarded every real survivor list. It also read results via
+   `mutmut results --json`, a flag the CLI does not support at all — the
+   call always failed and fell back to an empty list regardless of the real
+   exit code.
+
+These tests pin the fixed behavior against the real CLI's documented/
+observed contract (exit-code bitmask, `mutmut junitxml` output shape).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "dev-team"
+sys.path.insert(0, str(_PLUGIN_ROOT / "hooks"))
+
+from mutation_adapters import mutmut as mm  # noqa: E402
+
+_JUNIT_ALL_KILLED = """<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="2" time="0.0">
+\t<testsuite disabled="0" errors="0" failures="0" name="mutmut" tests="2" time="0">
+\t\t<testcase name="Mutant #1" file="src/calc.py" line="5">
+\t\t\t<system-out>x = 1</system-out>
+\t\t</testcase>
+\t\t<testcase name="Mutant #2" file="src/calc.py" line="6">
+\t\t\t<system-out>y = 2</system-out>
+\t\t</testcase>
+\t</testsuite>
+</testsuites>
+"""
+
+_JUNIT_ONE_SURVIVOR = """<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="1" tests="2" time="0.0">
+\t<testsuite disabled="0" errors="0" failures="1" name="mutmut" tests="2" time="0">
+\t\t<testcase name="Mutant #1" file="src/calc.py" line="5">
+\t\t\t<system-out>x = 1</system-out>
+\t\t</testcase>
+\t\t<testcase name="Mutant #2" file="src/calc.py" line="12">
+\t\t\t<failure type="failure" message="bad_survived">--- diff ---</failure>
+\t\t\t<system-out>y = 2</system-out>
+\t\t</testcase>
+\t</testsuite>
+</testsuites>
+"""
+
+
+def _stub_run_with_timeout(returncode: int):
+    def fake_run(_seconds, argv, **_kwargs):
+        return subprocess.CompletedProcess(args=argv, returncode=returncode)
+
+    return fake_run
+
+
+def _stub_subprocess_run(stdout: str):
+    def fake_run(_argv, **_kwargs):
+        return subprocess.CompletedProcess(args=_argv, returncode=0, stdout=stdout)
+
+    return fake_run
+
+
+# ---------------------------------------------------------------------------
+# mutmut_detect() — the `version` subcommand fallback (not `--version`)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_true_when_console_script_on_path(monkeypatch) -> None:
+    monkeypatch.setattr(mm.shutil, "which", lambda _name: "/usr/local/bin/mutmut")
+    assert mm.mutmut_detect() is True
+
+
+def test_detect_true_via_version_subcommand_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(mm.shutil, "which", lambda _name: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(mm.subprocess, "run", fake_run)
+    assert mm.mutmut_detect() is True
+    assert calls == [["python3", "-m", "mutmut", "version"]]
+
+
+def test_detect_false_and_advisory_when_absent(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mm.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        mm.subprocess,
+        "run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(args=argv, returncode=2),
+    )
+    assert mm.mutmut_detect() is False
+    assert "not installed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# mutmut_run() — exit-code bitmask + junitxml parsing
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_killed_writes_empty_zero_kills(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(0))
+    monkeypatch.setattr(mm.subprocess, "run", _stub_subprocess_run(_JUNIT_ALL_KILLED))
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    assert out_file.read_text() == "[]"
+
+
+def test_run_with_survivors_bit_still_parses_results(tmp_path, monkeypatch) -> None:
+    """Exit code 2 (survived bit) is the expected, common outcome — not an
+    error — and must still yield the survivor from junitxml."""
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(2))
+    monkeypatch.setattr(mm.subprocess, "run", _stub_subprocess_run(_JUNIT_ONE_SURVIVOR))
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    import json
+
+    zero_kills = json.loads(out_file.read_text())
+    assert zero_kills == [
+        {"name": "mutant_Mutant #2", "file": "src/calc.py", "line": 12, "covered": 0}
+    ]
+
+
+def test_run_survived_plus_slow_bits_still_parses_results(tmp_path, monkeypatch) -> None:
+    """Real observed exit code: 10 = survived (2) | slow (8) — no fatal bit."""
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(10))
+    monkeypatch.setattr(mm.subprocess, "run", _stub_subprocess_run(_JUNIT_ONE_SURVIVOR))
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    import json
+
+    assert len(json.loads(out_file.read_text())) == 1
+
+
+def test_run_fatal_error_bit_skips_gate(tmp_path, monkeypatch, capsys) -> None:
+    """Exit code 1 (fatal error only) must skip — the baseline run itself
+    failed, so there is nothing valid to parse."""
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(1))
+
+    called = []
+
+    def fake_run(argv, **_kwargs):
+        called.append(argv)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
+
+    monkeypatch.setattr(mm.subprocess, "run", fake_run)
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    assert out_file.read_text() == "[]"
+    assert not called, "must not attempt to read junitxml after a fatal error"
+    assert "MUTATION GATE ADVISORY" in capsys.readouterr().out
+
+
+def test_run_timeout_skips_gate(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(124))
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    assert out_file.read_text() == "[]"
+
+
+def test_run_malformed_junitxml_yields_empty_list_not_a_crash(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(mm.lib, "run_with_timeout", _stub_run_with_timeout(2))
+    monkeypatch.setattr(mm.subprocess, "run", _stub_subprocess_run("not xml at all"))
+
+    out_file = tmp_path / "zero-kills.json"
+    rc = mm.mutmut_run(out_file)
+
+    assert rc == 0
+    assert out_file.read_text() == "[]"

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -53,7 +53,11 @@ def test_agent_body_stays_under_500_line_limit(text: str) -> None:
     # frontmatter grew a `color:` line under the new fleet-wide convention.
     # Bumped by 1 more (#1335): this agent (file-mutating) gained a
     # `memory: project` line under the same fleet-wide convention.
-    assert len(text.splitlines()) < 503
+    # Bumped by 3 more (#1357): Python/mutmut support added — a
+    # mutation_kill_loop_python.py row in the scripted-mechanics table, a
+    # Python row in the per-language translation table, and a Python prompt
+    # rule.
+    assert len(text.splitlines()) < 506
 
 
 def test_defines_honest_score_formula(text: str) -> None:

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -65,6 +65,49 @@ def _killed(name: str, file: str, line: int) -> str:
     return f'<testcase name="{name}" file="{file}" line="{line}"><system-out>x</system-out></testcase>'
 
 
+def test_run_scoped_mutmut_reverts_source_file_even_when_mutmut_crashes(
+    tmp_path: Path, monkeypatch
+):
+    """mutmut mutates the real source file on disk per-mutant and restores it
+    when done — but a mutmut-internal crash (real, reproducible: mutmut
+    2.5.1's own cache layer, confirmed while dogfooding this exact function
+    against hooks/mutation_adapters/mutmut.py, #1357) skips that restore and
+    leaves mutated content on disk. run_scoped_mutmut must always revert the
+    source file, even when the mutmut subprocess itself raises."""
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated mutmut internal crash")
+
+    monkeypatch.setattr(loop.subprocess, "run", boom)
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: reverted.append(path))
+
+    with pytest.raises(RuntimeError):
+        loop.run_scoped_mutmut("src/a.py", test_command="pytest", cwd=tmp_path)
+
+    assert reverted == [Path("src/a.py")]
+
+
+def test_run_scoped_mutmut_reverts_source_file_on_the_success_path_too(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    class _FakeCompleted:
+        stdout = "<testsuites></testsuites>"
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _FakeCompleted())
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: reverted.append(path))
+
+    loop.run_scoped_mutmut("src/a.py", test_command="pytest", cwd=tmp_path)
+
+    assert reverted == [Path("src/a.py")]
+
+
 def test_extract_survivors_filters_to_target_file():
     xml = _junit(
         _survived("Mutant #1", "src/a.py", 5),

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -1,0 +1,313 @@
+"""Pytest tests for mutation_kill_loop_python.py — the Python/mutmut
+counterpart to mutation_kill_loop.py's survivor-kill loop mechanics (#1357).
+
+Every mutmut / git / pytest subprocess is mocked — no real mutmut run
+happens here (that's covered by the manual, real-tool dogfooding recorded
+in #1354/#1357's issue history). Insertion mechanics run against real
+tmp_path files since they're pure file I/O with no subprocess involved.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mutation_kill_loop_python as loop  # noqa: E402
+
+FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
+
+
+# =============================================================================
+# Reused headless helpers actually come from mutation_kill_loop
+# =============================================================================
+def test_headless_helpers_are_reused_not_duplicated():
+    import mutation_kill_loop as cs_loop
+
+    assert loop.strip_code_fences is cs_loop.strip_code_fences
+    assert loop.resolve_model is cs_loop.resolve_model
+    assert loop.claude_cli_available is cs_loop.claude_cli_available
+    assert loop.CLAUDE_CLI == cs_loop.CLAUDE_CLI
+
+
+# =============================================================================
+# extract_survivors — delegates to mutation_report's junitxml support
+# =============================================================================
+def _junit(*testcases: str, failures: int = 0) -> str:
+    body = "\n".join(testcases)
+    return (
+        '<?xml version="1.0" ?>\n'
+        f'<testsuites errors="0" failures="{failures}" tests="{len(testcases)}">\n'
+        f'<testsuite errors="0" failures="{failures}" name="mutmut" tests="{len(testcases)}">\n'
+        f"{body}\n</testsuite></testsuites>\n"
+    )
+
+
+def _survived(name: str, file: str, line: int) -> str:
+    return (
+        f'<testcase name="{name}" file="{file}" line="{line}">'
+        '<failure type="failure" message="bad_survived">diff</failure></testcase>'
+    )
+
+
+def _killed(name: str, file: str, line: int) -> str:
+    return f'<testcase name="{name}" file="{file}" line="{line}"><system-out>x</system-out></testcase>'
+
+
+def test_extract_survivors_filters_to_target_file():
+    xml = _junit(
+        _survived("Mutant #1", "src/a.py", 5),
+        _survived("Mutant #2", "src/b.py", 9),
+        _killed("Mutant #3", "src/a.py", 1),
+        failures=2,
+    )
+    survivors = loop.extract_survivors(xml, "src/a.py")
+
+    assert len(survivors) == 1
+    assert survivors[0]["location"]["start"]["line"] == 5
+    assert survivors[0]["mutatorName"] == "mutmut"
+
+
+# =============================================================================
+# Insertion mechanics — flat top-level `def test_*():` convention
+# =============================================================================
+def test_append_at_end_of_file_adds_new_tests(tmp_path: Path):
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+
+    loop.append_at_end_of_file(test_file, "def test_new():\n    assert 1 == 1\n")
+
+    text = test_file.read_text(encoding="utf-8")
+    assert "def test_existing():" in text
+    assert "def test_new():" in text
+    # existing content preserved, new content appended after it
+    assert text.index("test_existing") < text.index("test_new")
+
+
+def test_append_refuses_when_no_existing_top_level_test_function(tmp_path: Path):
+    """A class-based test file (or any file with no top-level `def test_`)
+    doesn't match the flat convention this heuristic supports — refuse
+    rather than guess an insertion point."""
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text(
+        "class TestCalc:\n    def test_existing(self):\n        assert True\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(loop.InsertionRefused):
+        loop.append_at_end_of_file(test_file, "def test_new():\n    assert True\n")
+
+    # file must be left untouched on refusal
+    assert "test_new" not in test_file.read_text(encoding="utf-8")
+
+
+def test_detect_duplicate_functions_finds_name_collisions():
+    existing = "def test_a():\n    pass\n\ndef test_b():\n    pass\n"
+    incoming = "def test_b():\n    pass\n"
+    assert loop.detect_duplicate_functions(existing, incoming) == ["test_b"]
+
+
+def test_apply_generated_tests_empty_generation_not_inserted(tmp_path: Path):
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+
+    outcome = loop.apply_generated_tests(test_file, "   \n")
+
+    assert outcome.inserted is False
+    assert "no tests generated" in outcome.reason
+
+
+def test_apply_generated_tests_duplicate_name_not_inserted(tmp_path: Path):
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+
+    outcome = loop.apply_generated_tests(
+        test_file, "def test_existing():\n    assert False\n"
+    )
+
+    assert outcome.inserted is False
+    assert "duplicate" in outcome.reason
+    # original content unchanged
+    assert "assert True" in test_file.read_text(encoding="utf-8")
+
+
+def test_apply_generated_tests_success_path_inserts(tmp_path: Path):
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+
+    outcome = loop.apply_generated_tests(test_file, "def test_new():\n    assert 2 == 2\n")
+
+    assert outcome.inserted is True
+    assert "def test_new():" in test_file.read_text(encoding="utf-8")
+
+
+# =============================================================================
+# run_for_file — full loop with every subprocess mocked
+# =============================================================================
+def test_run_for_file_stops_immediately_on_zero_survivors(tmp_path: Path, monkeypatch):
+    calls = {"generate": 0}
+    monkeypatch.setattr(loop, "run_scoped_mutmut", lambda *a, **k: _junit(_killed("Mutant #1", "src/a.py", 1)))
+
+    def fake_generate(*_args):
+        calls["generate"] += 1
+        return "def test_new():\n    assert True\n"
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=fake_generate,
+    )
+
+    assert calls["generate"] == 0
+    assert "test_new" not in test_file.read_text(encoding="utf-8")
+
+
+def test_run_for_file_generates_inserts_and_commits_on_green(tmp_path: Path, monkeypatch):
+    """One round: survivors found -> generate -> insert -> compile+test pass
+    -> commit. Then a second scoped run reports zero survivors, so the loop
+    stops cleanly without a second commit attempt."""
+    xml_with_survivor = _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    xml_clean = _junit(_killed("Mutant #1", "src/a.py", 3))
+    responses = [xml_with_survivor, xml_clean]
+    monkeypatch.setattr(loop, "run_scoped_mutmut", lambda *a, **k: responses.pop(0))
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: True)
+
+    committed = []
+    monkeypatch.setattr(
+        loop, "git_commit", lambda message, test_file, **k: committed.append(message) or True
+    )
+    monkeypatch.setattr(loop, "git_revert", lambda *a, **k: pytest.fail("must not revert on green"))
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=lambda *_a: "def test_new():\n    assert 1 == 1\n",
+    )
+
+    assert "def test_new():" in test_file.read_text(encoding="utf-8")
+    assert len(committed) == 1
+    assert "kill round 1" in committed[0]
+
+
+def test_run_for_file_reverts_on_failing_scoped_test(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        loop, "run_scoped_mutmut", lambda *a, **k: _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    )
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: False)
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda test_file, **k: reverted.append(test_file))
+    monkeypatch.setattr(
+        loop, "git_commit", lambda *a, **k: pytest.fail("must not commit on a failing test")
+    )
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=lambda *_a: "def test_new():\n    assert False\n",
+    )
+
+    assert reverted == [test_file]
+
+
+def test_run_for_file_stops_on_no_improvement(tmp_path: Path, monkeypatch):
+    """Same survivor count twice in a row must stop the loop, not loop forever."""
+    same_xml = _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    responses = [same_xml, same_xml]
+    monkeypatch.setattr(loop, "run_scoped_mutmut", lambda *a, **k: responses.pop(0))
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: True)
+
+    committed = []
+    monkeypatch.setattr(loop, "git_commit", lambda m, f, **k: committed.append(m) or True)
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def fake_generate(*_a):
+        calls["n"] += 1
+        return f"def test_new_{calls['n']}():\n    assert True\n"
+
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=fake_generate,
+        max_rounds=5,
+    )
+
+    # Round 1 commits (first round always proceeds — prev_survivors starts
+    # None); round 2 sees the same count and stops without generating again.
+    assert len(committed) == 1
+    assert calls["n"] == 1
+
+
+# =============================================================================
+# No repo-specific literal leaked into the module
+# =============================================================================
+def test_module_source_carries_no_repo_specific_literal():
+    source = (SCRIPTS_DIR / "mutation_kill_loop_python.py").read_text(encoding="utf-8")
+    present = [literal for literal in FORBIDDEN_LITERALS if literal in source]
+    assert present == [], f"repo-specific literals leaked into module: {present}"
+
+
+# =============================================================================
+# CLI preflight — mirrors mutation_kill_loop.py's fail-fast contract
+# =============================================================================
+def test_main_without_headless_fails_fast_with_no_generator_message(capsys):
+    rc = loop.main([])
+    assert rc == 1
+    assert loop.NO_GENERATOR_MESSAGE in capsys.readouterr().err
+
+
+def test_main_headless_without_required_flags_errors(monkeypatch, capsys):
+    monkeypatch.setattr(loop, "claude_cli_available", lambda: True)
+    rc = loop.main(["--headless"])
+    assert rc == 2
+    assert "requires --file" in capsys.readouterr().err
+
+
+def test_main_headless_missing_claude_cli_fails_before_touching_files(monkeypatch, capsys):
+    monkeypatch.setattr(loop, "claude_cli_available", lambda: False)
+    rc = loop.main(["--headless", "--file", "a.py"])
+    assert rc == 3
+    assert "Claude CLI" in capsys.readouterr().err

--- a/tests/scripts/test_mutation_report_mutmut.py
+++ b/tests/scripts/test_mutation_report_mutmut.py
@@ -1,0 +1,172 @@
+"""Pytest tests for mutation_report.py's mutmut junitxml support (#1357).
+
+mutmut has no native JSON report — ``mutmut junitxml`` is its only
+structured output. These fixtures mirror the real shape observed running
+mutmut 2.5.1 against this repo's own code (see #1354/#1357): a survived
+mutant carries a ``<failure message="bad_survived">`` child, a timed-out
+mutant carries a distinct ``<error message="bad_timeout" type="timeout">``
+child, and a killed (or suspicious-but-ignored) mutant carries neither.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mutation_report  # noqa: E402
+
+
+def _junit(*testcases: str, failures: int = 0, errors: int = 0) -> str:
+    body = "\n".join(testcases)
+    return (
+        '<?xml version="1.0" ?>\n'
+        f'<testsuites disabled="0" errors="{errors}" failures="{failures}" '
+        f'tests="{len(testcases)}" time="0.0">\n'
+        f'<testsuite disabled="0" errors="{errors}" failures="{failures}" '
+        f'name="mutmut" tests="{len(testcases)}" time="0">\n'
+        f"{body}\n"
+        "</testsuite>\n"
+        "</testsuites>\n"
+    )
+
+
+def _killed_tc(name: str, file: str, line: int) -> str:
+    return f'<testcase name="{name}" file="{file}" line="{line}"><system-out>x</system-out></testcase>'
+
+
+def _survived_tc(name: str, file: str, line: int) -> str:
+    return (
+        f'<testcase name="{name}" file="{file}" line="{line}">'
+        '<failure type="failure" message="bad_survived">diff</failure>'
+        "</testcase>"
+    )
+
+
+def _timeout_tc(name: str, file: str, line: int) -> str:
+    return (
+        f'<testcase name="{name}" file="{file}" line="{line}">'
+        '<error type="timeout" message="bad_timeout">diff</error>'
+        "</testcase>"
+    )
+
+
+# =============================================================================
+# parse_mutmut_junitxml — normalizes into the shared {"files": {...}} shape
+# =============================================================================
+def test_survived_testcase_maps_to_survived_status():
+    xml = _junit(_survived_tc("Mutant #1", "src/calc.py", 12), failures=1)
+    data = mutation_report.parse_mutmut_junitxml(xml)
+
+    mutants = data["files"]["src/calc.py"]["mutants"]
+    assert len(mutants) == 1
+    assert mutants[0]["status"] == mutation_report.STATUS_SURVIVED
+    assert mutants[0]["location"]["start"]["line"] == 12
+    assert mutants[0]["mutatorName"] == "mutmut"
+
+
+def test_timeout_testcase_maps_to_timeout_not_survived():
+    """A <error type="timeout"> must never be counted as Survived — that's
+    the exact inversion bug fixed in the PostToolUse gate adapter (#1356);
+    the report parser must get this right independently."""
+    xml = _junit(_timeout_tc("Mutant #2", "src/calc.py", 20), errors=1)
+    data = mutation_report.parse_mutmut_junitxml(xml)
+
+    mutants = data["files"]["src/calc.py"]["mutants"]
+    assert mutants[0]["status"] == mutation_report.STATUS_TIMEOUT
+
+
+def test_bare_testcase_maps_to_killed():
+    xml = _junit(_killed_tc("Mutant #3", "src/calc.py", 5))
+    data = mutation_report.parse_mutmut_junitxml(xml)
+
+    assert data["files"]["src/calc.py"]["mutants"][0]["status"] == (
+        mutation_report.STATUS_KILLED
+    )
+
+
+def test_mixed_report_groups_by_file():
+    xml = _junit(
+        _killed_tc("Mutant #1", "src/a.py", 1),
+        _survived_tc("Mutant #2", "src/a.py", 2),
+        _survived_tc("Mutant #3", "src/b.py", 9),
+        failures=2,
+    )
+    data = mutation_report.parse_mutmut_junitxml(xml)
+
+    assert {m["status"] for m in data["files"]["src/a.py"]["mutants"]} == {
+        mutation_report.STATUS_KILLED,
+        mutation_report.STATUS_SURVIVED,
+    }
+    assert len(data["files"]["src/b.py"]["mutants"]) == 1
+
+
+def test_empty_input_yields_empty_files_dict():
+    assert mutation_report.parse_mutmut_junitxml("") == {"files": {}}
+
+
+def test_malformed_xml_yields_empty_files_dict_not_a_crash():
+    assert mutation_report.parse_mutmut_junitxml("not xml") == {"files": {}}
+
+
+# =============================================================================
+# score_mutmut_junitxml — reuses _score_data, same formulas as Stryker
+# =============================================================================
+def test_score_counts_killed_survived_and_timeout_correctly():
+    xml = _junit(
+        _killed_tc("Mutant #1", "src/a.py", 1),
+        _killed_tc("Mutant #2", "src/a.py", 2),
+        _survived_tc("Mutant #3", "src/a.py", 3),
+        _timeout_tc("Mutant #4", "src/a.py", 4),
+        failures=1,
+        errors=1,
+    )
+    summary = mutation_report.score_mutmut_junitxml(xml)
+
+    assert summary.killed == 2
+    assert summary.survived == 1
+    assert summary.timeout == 1
+    assert summary.no_coverage == 0
+    # honest = killed / (killed + survived + no_coverage) = 2/3
+    import pytest
+
+    assert summary.honest_score == pytest.approx(2 / 3 * 100)
+
+
+def test_score_of_empty_report_is_zeroed():
+    summary = mutation_report.score_mutmut_junitxml("")
+    assert summary.honest_score == 0.0
+    assert summary.killed == 0
+
+
+# =============================================================================
+# survivors_from_mutmut_junitxml — same grouping contract as survivors_by_mutator
+# =============================================================================
+def test_survivors_from_junitxml_filters_to_one_file():
+    xml = _junit(
+        _survived_tc("Mutant #1", "src/a.py", 1),
+        _survived_tc("Mutant #2", "src/b.py", 2),
+        _killed_tc("Mutant #3", "src/a.py", 3),
+        failures=2,
+    )
+    grouped = mutation_report.survivors_from_mutmut_junitxml(xml, "src/a.py")
+
+    assert set(grouped) == {"mutmut"}
+    assert len(grouped["mutmut"]) == 1
+    assert grouped["mutmut"][0]["location"]["start"]["line"] == 1
+
+
+def test_survivors_from_junitxml_matches_by_basename():
+    xml = _junit(_survived_tc("Mutant #1", "/abs/path/src/a.py", 1), failures=1)
+    grouped = mutation_report.survivors_from_mutmut_junitxml(xml, "a.py")
+
+    assert set(grouped) == {"mutmut"}

--- a/tests/skills/test_setup_mutation_stack_gate.py
+++ b/tests/skills/test_setup_mutation_stack_gate.py
@@ -122,6 +122,32 @@ def test_tokens_are_case_and_whitespace_insensitive() -> None:
     assert result["sections"] == ["js"]
 
 
+def test_node_synonym_alone_maps_to_js() -> None:
+    """Isolates the `node` synonym entry — a JS-only signal via `typescript`
+    doesn't exercise this specific key/value pair."""
+    assert mss.select_sections(["node"])["sections"] == ["js"]
+
+
+def test_javascript_synonym_alone_maps_to_js() -> None:
+    assert mss.select_sections(["javascript"])["sections"] == ["js"]
+
+
+def test_kotlin_synonym_alone_maps_to_java() -> None:
+    assert mss.select_sections(["kotlin"])["sections"] == ["java"]
+
+
+def test_ambiguous_result_echoes_normalized_stacks() -> None:
+    """The ambiguous branch's `stacks` key must echo the (normalized) input,
+    not just be present with any value."""
+    result = mss.select_sections([])
+    assert result["stacks"] == []
+
+
+def test_definite_result_echoes_normalized_stacks() -> None:
+    result = mss.select_sections([" TypeScript ", "Node"])
+    assert result["stacks"] == ["typescript", "node"]
+
+
 # ---------------------------------------------------------------------------
 # CLI — reads .claude/project-stack.json, prints one JSON object
 # ---------------------------------------------------------------------------
@@ -135,6 +161,12 @@ def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess
         cwd=str(cwd) if cwd is not None else None,
         check=False,
     )
+
+
+def _collapsed(text: str) -> str:
+    """Collapse whitespace runs so argparse's line-wrapped --help output can
+    still be matched against an unwrapped expected substring."""
+    return " ".join(text.split())
 
 
 def _write_stack(project_dir: Path, stacks) -> None:
@@ -192,6 +224,43 @@ def test_cli_stacks_flag_bypasses_file() -> None:
     r = _run_cli("--stacks", "csharp")
     out = json.loads(r.stdout)
     assert out["sections"] == ["csharp"]
+
+
+def test_cli_stacks_flag_splits_multiple_comma_separated_values() -> None:
+    r = _run_cli("--stacks", "csharp,typescript,java")
+    out = json.loads(r.stdout)
+    assert out["sections"] == ["js", "java", "csharp"]
+
+
+def test_cli_default_project_dir_is_cwd(tmp_path: Path) -> None:
+    """No positional arg -> the `project_dir` default ('.') resolves against
+    the current directory, same as passing '.' explicitly."""
+    _write_stack(tmp_path, ["typescript"])
+    r = _run_cli(cwd=tmp_path)
+    out = json.loads(r.stdout)
+    assert out["sections"] == ["js"]
+
+
+def test_cli_help_documents_project_dir_default() -> None:
+    """A mutmut string mutation wraps the value in `XX...XX` rather than
+    replacing it, so a plain substring check can't distinguish mutated help
+    text from real — the original text is still contained inside the
+    wrapper. Assert exact equality of the collapsed help text's argument
+    line instead."""
+    r = _run_cli("--help")
+    collapsed = _collapsed(r.stdout)
+    assert "Project directory (default: current directory)." in collapsed
+    assert "XX" not in collapsed
+
+
+def test_cli_help_documents_stacks_flag() -> None:
+    r = _run_cli("--help")
+    collapsed = _collapsed(r.stdout)
+    assert (
+        "Comma-separated stacks to use directly, bypassing the file (testing)."
+        in collapsed
+    )
+    assert "XX" not in collapsed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_setup_mutation_stack_gate.py
+++ b/tests/skills/test_setup_mutation_stack_gate.py
@@ -4,11 +4,11 @@ Two layers of contract:
 
 1. Behavioral — the `mutation_stack_sections.py` helper maps a repo's
    `stacks` array to the sections /setup runs. A JS-only signal selects only
-   `js` (never a `dotnet` probe); a pure-Python/unrecognized signal selects
-   nothing and is NOT ambiguous (installs/probes nothing); a C#/.NET signal
-   selects `csharp`; polyglot selects each matching section; and only an
-   empty/missing signal is `ambiguous` (the sole path to the interactive
-   fallback).
+   `js` (never a `dotnet` probe); a Python signal selects `python` (mutmut);
+   an unrecognized signal (e.g. Ruby) selects nothing and is NOT ambiguous
+   (installs/probes nothing); a C#/.NET signal selects `csharp`; polyglot
+   selects each matching section; and only an empty/missing signal is
+   `ambiguous` (the sole path to the interactive fallback).
 
 2. Doc-shape — the SKILL.md prose calls the helper, each language subsection
    re-asserts its own gate as its literal first step, the interactive
@@ -57,18 +57,19 @@ def test_js_only_signal_runs_only_js_section() -> None:
     assert "java" not in result["sections"]
 
 
-def test_python_only_signal_installs_and_probes_nothing() -> None:
-    """A definite-but-unsupported stack (pure Python) selects nothing, is not
-    ambiguous, and carries the one-line note — so no fallback, no probes."""
+def test_python_signal_runs_mutmut_section() -> None:
+    """A Python stack selects the `python` (mutmut) section and carries no
+    unsupported-stack note."""
     result = mss.select_sections(["python"])
-    assert result["sections"] == []
+    assert result["sections"] == ["python"]
     assert result["ambiguous"] is False
-    assert result["note"] == "no mutation tooling for detected stack (python)"
+    assert result["note"] is None
 
 
 def test_unrecognized_signal_installs_nothing_not_ambiguous() -> None:
-    """An unrecognized-but-present stack behaves like Python: nothing, no
-    fallback (it is a definite signal, just unsupported here)."""
+    """An unrecognized-but-present stack (e.g. Ruby, Elixir) selects nothing,
+    is not ambiguous, and carries the one-line note — no fallback, no probes
+    (it is a definite signal, just unsupported here)."""
     result = mss.select_sections(["ruby", "elixir"])
     assert result["sections"] == []
     assert result["ambiguous"] is False
@@ -86,6 +87,15 @@ def test_polyglot_signal_runs_each_matching_section() -> None:
     """Polyglot repo runs every matching section, in canonical order."""
     result = mss.select_sections(["csharp", "typescript", "java"])
     assert result["sections"] == ["js", "java", "csharp"]
+    assert result["ambiguous"] is False
+    assert result["note"] is None
+
+
+def test_polyglot_signal_including_python_runs_all_sections() -> None:
+    """A polyglot repo with Python alongside another supported stack runs
+    both sections, in canonical order (`python` last)."""
+    result = mss.select_sections(["python", "typescript"])
+    assert result["sections"] == ["js", "python"]
     assert result["ambiguous"] is False
     assert result["note"] is None
 
@@ -151,13 +161,22 @@ def test_cli_missing_stack_file_is_ambiguous(tmp_path: Path) -> None:
     assert out["ambiguous"] is True
 
 
-def test_cli_python_only_note(tmp_path: Path) -> None:
+def test_cli_python_only_runs_mutmut_section(tmp_path: Path) -> None:
     _write_stack(tmp_path, ["python"])
+    r = _run_cli(".", cwd=tmp_path)
+    out = json.loads(r.stdout)
+    assert out["sections"] == ["python"]
+    assert out["ambiguous"] is False
+    assert out["note"] is None
+
+
+def test_cli_unrecognized_stack_note(tmp_path: Path) -> None:
+    _write_stack(tmp_path, ["ruby"])
     r = _run_cli(".", cwd=tmp_path)
     out = json.loads(r.stdout)
     assert out["sections"] == []
     assert out["ambiguous"] is False
-    assert out["note"] == "no mutation tooling for detected stack (python)"
+    assert out["note"] == "no mutation tooling for detected stack (ruby)"
 
 
 def test_cli_invalid_json_is_ambiguous(tmp_path: Path) -> None:
@@ -202,11 +221,19 @@ def test_each_section_reasserts_its_gate_first() -> None:
     js = section(_text(), r"^#### JS/TS", boundary_pattern=r"^#### ")
     java = section(_text(), r"^#### Java / Kotlin", boundary_pattern=r"^#### ")
     csharp = section(_text(), r"^#### C# / .NET", boundary_pattern=r"^#### ")
+    python = section(_text(), r"^#### Python", boundary_pattern=r"^#### ")
 
-    for body, key in ((js, "js"), (java, "java"), (csharp, "csharp")):
+    for body, key in ((js, "js"), (java, "java"), (csharp, "csharp"), (python, "python")):
         assert grep(r"Stack gate \(first step", body), f"{key} missing gate header"
         assert grep(rf"`{key}` is not in", body), f"{key} gate missing membership check"
         assert grep(r"return immediately", body), f"{key} gate missing early-return"
+
+
+def test_python_section_installs_mutmut() -> None:
+    """The Python subsection installs mutmut via pip, not a global-only tool."""
+    python = section(_text(), r"^#### Python", boundary_pattern=r"^#### ")
+    assert grep(r"mutmut", python)
+    assert grep(r"pip install", python, ignore_case=True)
 
 
 def test_csharp_gate_precedes_dotnet_probe() -> None:


### PR DESCRIPTION
## Summary
- **#1353** — `/setup` Step 6 had no Python section; wired `python`/mutmut in as an installable option (`mutation_stack_sections.py` mapping + a `setup/SKILL.md` subsection mirroring the existing Stryker/pitest/Stryker.NET ones).
- **#1356** — dogfooding that revealed the shipped `mutmut` adapter had never actually detected a survivor (wrong version-check flag, inverted exit-code bitmask logic, a nonexistent `results --json` flag). Fixed and verified end-to-end against a real mutmut run.
- **#1354** (partial) — first real mutant-kill pass: `plugins/dev-team/scripts/mutation_stack_sections.py` driven from 13 real survivors to 1 (documented mutmut-classifier exclusion) via 9 new targeted tests.
- **#1357** — extended the scripted `mutation-kill` loop itself to Python/mutmut (`mutation_kill_loop_python.py` + `mutation_report.py` junitxml support + agent doc updates), since the agent previously only knew Stryker/pitest/Stryker.NET/go-mutesting.
- **Safety fix** — dogfooding the new Python loop for real against `hooks/mutation_adapters/mutmut.py` (#1356's own file) surfaced a real mutmut-internal crash that leaves the mutated source file on disk unrevereted. Fixed with an unconditional `finally`-protected `git checkout --`.

## Test plan
- [x] Full pytest dir list (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3898 passed
- [x] `scripts/ci-local.sh` — all local CI checks passed, every commit
- [x] Multiple real (non-mocked) `mutmut` runs against this repo's own code at every stage — adapter fix, mutation_stack_sections.py kill loop, and the new Python scripted loop against hooks/mutation_adapters/mutmut.py itself

## Follow-up (not in this PR)
- Driving `hooks/mutation_adapters/mutmut.py`'s own mutation score up (48 killed / 68 survived, ~41% honest, found via real dogfood run) and continuing across the rest of the repo's Python — tracked on #1354.

Closes #1353, Closes #1356, Closes #1357
Part of #1352, Part of #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)