### PR TITLE
fix(mutation-kill): protect the test file mutmut may corrupt; detect the Python 3.13+ pickle crash

### DIFF
--- a/plugins/dev-team/hooks/mutation_adapters/mutmut.py
+++ b/plugins/dev-team/hooks/mutation_adapters/mutmut.py
@@ -96,7 +96,8 @@ def mutmut_run(output_file: Path) -> int:
         timeout_seconds,
         argv,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
     )
     exit_code = completed.returncode
 
@@ -121,10 +122,21 @@ def mutmut_run(output_file: Path) -> int:
     # failed) is the only outcome that invalidates the run; survivors
     # (bit 2) are the expected, common case and must still be parsed.
     if exit_code & 1:
+        stderr = completed.stderr or ""
+        if "cannot pickle" in stderr and "itertools.count" in stderr:
+            hint = (
+                " Known cause: mutmut<3 crashes on Python 3.13+ "
+                "('TypeError: cannot pickle itertools.count object', a "
+                "parso/pony-ORM deepcopy incompatibility) — install mutmut "
+                "into a venv running Python <=3.12; the --runner test "
+                "command can stay on the project's real interpreter."
+            )
+        else:
+            hint = ""
         print(
             lib.emit_advisory(
                 f"MUTATION GATE ADVISORY: mutmut exited with code {exit_code}. "
-                "Skipping mutation gate."
+                f"Skipping mutation gate.{hint}"
             )
         )
         output_file.write_text("[]")

--- a/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/python-mutmut.md
@@ -24,6 +24,8 @@ pip install -e .[dev]
 
 Never `pip install --user mutmut` or run `pip install` outside a venv for this — that puts mutmut in a location whose `PATH` presence depends on the user's shell config, which is the silent-failure trap the skill's "prefer local install" note is trying to avoid.
 
+**The mutmut venv's own Python must be <= 3.12 — distinct from the `--runner`'s interpreter.** `mutmut<3` (2.5.1) crashes under Python 3.13+ with `TypeError: cannot pickle 'itertools.count' object` (a parso/pony-ORM deepcopy incompatibility inside mutmut's own line-caching layer) and produces a junitxml report with **zero testcases at all** — indistinguishable from a fully-converged file by survivor count alone (#1359). This is a version constraint on the interpreter mutmut *itself* runs under, not on the project: build the mutmut venv with `python3.12 -m venv <path>` (or any <=3.12 interpreter) even when the project's real Python is newer, and point `--runner` at the project's normal interpreter (e.g. `--runner "python3 -m pytest ..."`, which can be 3.13+) — only the mutmut process itself needs the older Python. `mutation_kill_loop_python.py`'s `run_for_file` treats a report with zero total mutants (`killed + survived + timeout + no_coverage == 0`) as a crash signal, not convergence, and stops without declaring `survivors == 0` — but avoiding the crash in the first place is cheaper than recovering from it every round.
+
 Confirm the tool resolves in the active venv before configuring a run
 (`version` is a subcommand — there is no `--version` flag):
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -72,6 +72,7 @@ def run_scoped_mutmut(
     source_file: str,
     *,
     test_command: str,
+    test_file: Optional[Path] = None,
     cwd: Optional[Path] = None,
 ) -> str:
     """Run mutmut scoped to one file; return the ``mutmut junitxml`` output.
@@ -82,18 +83,28 @@ def run_scoped_mutmut(
     manually while dogfooding this loop by hand (#1354): every run must see
     its own fresh baseline, not a leftover one.
 
-    **Always reverts ``source_file`` in a ``finally``.** mutmut mutates the
-    real source file on disk for the duration of each mutant's test run and
-    restores it when that mutant finishes — but an internal mutmut crash
-    (a real, reproducible one: mutmut 2.5.1's own cache layer raises
-    ``AssertionError``/``ValueError`` on some files, confirmed while
-    dogfooding this exact function against
+    **Always reverts ``source_file`` (and ``test_file``, when given) in a
+    ``finally``.** mutmut mutates the real source file on disk for the
+    duration of each mutant's test run and restores it when that mutant
+    finishes — but an internal mutmut crash (a real, reproducible one: mutmut
+    2.5.1's own cache layer raises ``AssertionError``/``ValueError`` on some
+    files, confirmed while dogfooding this exact function against
     ``hooks/mutation_adapters/mutmut.py`` — see #1357) skips that restore
     and leaves the mutated content on disk. Unlike Stryker.NET (which
     instruments a separate build, never the real file), mutmut's crash
     failure mode is "corrupt the file under test," so every scoped run must
     unconditionally `git checkout --` it afterward — succeeding, failing, or
     raising.
+
+    The **test file** the ``--runner`` command exercises is exposed to the
+    same failure mode — mutmut 2.5.1 has also been observed to truncate the
+    runner's test file to empty via a crashed ``.bak``-restore (#1359),
+    which silently breaks the *next* round's baseline (mutmut then reports
+    zero mutants — a false "converged" positive, not real coverage). Passing
+    ``test_file`` reverts it alongside ``source_file`` in the same
+    ``finally``; each round's ``git checkout --`` restores exactly the
+    state committed at the end of the previous round, which is always the
+    correct baseline for the round about to run.
     """
     root = cwd or Path(".")
     (root / ".mutmut-cache").unlink(missing_ok=True)
@@ -120,6 +131,8 @@ def run_scoped_mutmut(
         return junit.stdout or ""
     finally:
         git_revert(Path(source_file), cwd=cwd)
+        if test_file is not None:
+            git_revert(test_file, cwd=cwd)
 
 
 def extract_survivors(junitxml_text: str, source_file: str) -> List[dict]:
@@ -294,7 +307,7 @@ def run_for_file(
             junitxml_text = initial_junitxml
         else:
             junitxml_text = run_scoped_mutmut(
-                source_file, test_command=test_command, cwd=cwd
+                source_file, test_command=test_command, test_file=test_file, cwd=cwd
             )
 
         survivors = extract_survivors(junitxml_text, source_file)
@@ -305,6 +318,19 @@ def run_for_file(
             f"survivors={survivor_count}"
         )
 
+        total_mutants = (
+            summary.killed + summary.survived + summary.timeout + summary.no_coverage
+        )
+        if total_mutants == 0:
+            log(
+                "  zero mutants generated — this is NOT convergence. mutmut "
+                "produced no results at all (a real internal crash — e.g. "
+                "the known Python 3.13+ pickle incompatibility, 'TypeError: "
+                "cannot pickle itertools.count object' — or a file with no "
+                "executable statements). Stopping without declaring "
+                "survivors == 0 (#1359)."
+            )
+            return
         if survivor_count == 0:
             log("  no survivors — done")
             return

--- a/plugins/dev-team/tests/hooks/test_mutmut_adapter.py
+++ b/plugins/dev-team/tests/hooks/test_mutmut_adapter.py
@@ -60,9 +60,9 @@ _JUNIT_ONE_SURVIVOR = """<?xml version="1.0" ?>
 """
 
 
-def _stub_run_with_timeout(returncode: int):
+def _stub_run_with_timeout(returncode: int, stderr: str = ""):
     def fake_run(_seconds, argv, **_kwargs):
-        return subprocess.CompletedProcess(args=argv, returncode=returncode)
+        return subprocess.CompletedProcess(args=argv, returncode=returncode, stderr=stderr)
 
     return fake_run
 
@@ -349,6 +349,33 @@ def test_run_fatal_error_advisory_names_exit_code_and_skip(tmp_path, monkeypatch
     out_file = tmp_path / "z.json"
     assert mm.mutmut_run(out_file) == 0
     assert "exited with code 1. Skipping mutation gate." in capsys.readouterr().out
+
+
+def test_run_fatal_error_names_python_314_pickle_crash_when_detected(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """mutmut<3 crashes with `TypeError: cannot pickle 'itertools.count'
+    object` on Python 3.13+ (a parso/pony-ORM deepcopy incompatibility,
+    #1359) — a real, reproducible fatal error, not a generic one. The
+    advisory should name the known cause and the fix (install mutmut into
+    a <=3.12 venv) rather than leaving the operator to rediscover it."""
+    monkeypatch.setattr(mm, "_changed_python_source", lambda: "src/calc.py")
+    monkeypatch.setattr(mm, "_mutmut_argv", lambda: ["mutmut"])
+    monkeypatch.setattr(
+        mm.lib,
+        "run_with_timeout",
+        _stub_run_with_timeout(
+            1, stderr="TypeError: cannot pickle 'itertools.count' object"
+        ),
+    )
+    monkeypatch.setattr(mm.subprocess, "run", _stub_subprocess_run(""))
+
+    out_file = tmp_path / "z.json"
+    assert mm.mutmut_run(out_file) == 0
+    out = capsys.readouterr().out
+    assert "exited with code 1. Skipping mutation gate." in out
+    assert "Python 3.13+" in out
+    assert "<=3.12" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -108,6 +108,77 @@ def test_run_scoped_mutmut_reverts_source_file_on_the_success_path_too(
     assert reverted == [Path("src/a.py")]
 
 
+def test_run_scoped_mutmut_reverts_test_file_too_when_mutmut_crashes(
+    tmp_path: Path, monkeypatch
+):
+    """mutmut 2.5.1 has also been observed to corrupt the *runner's test
+    file* (truncate it to empty via a crashed .bak-restore, #1359) — not
+    just the source file. run_scoped_mutmut must revert both when a
+    test_file is supplied, even when the mutmut subprocess itself raises."""
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated mutmut internal crash")
+
+    monkeypatch.setattr(loop.subprocess, "run", boom)
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: reverted.append(path))
+
+    with pytest.raises(RuntimeError):
+        loop.run_scoped_mutmut(
+            "src/a.py",
+            test_command="pytest",
+            test_file=Path("tests/test_a.py"),
+            cwd=tmp_path,
+        )
+
+    assert reverted == [Path("src/a.py"), Path("tests/test_a.py")]
+
+
+def test_run_scoped_mutmut_reverts_test_file_on_the_success_path_too(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    class _FakeCompleted:
+        stdout = "<testsuites></testsuites>"
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _FakeCompleted())
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: reverted.append(path))
+
+    loop.run_scoped_mutmut(
+        "src/a.py",
+        test_command="pytest",
+        test_file=Path("tests/test_a.py"),
+        cwd=tmp_path,
+    )
+
+    assert reverted == [Path("src/a.py"), Path("tests/test_a.py")]
+
+
+def test_run_scoped_mutmut_does_not_revert_test_file_when_not_supplied(
+    tmp_path: Path, monkeypatch
+):
+    """Backward compatibility: callers that don't pass test_file (none did
+    before #1359) must see identical behavior to before this change."""
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    class _FakeCompleted:
+        stdout = "<testsuites></testsuites>"
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _FakeCompleted())
+
+    reverted = []
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: reverted.append(path))
+
+    loop.run_scoped_mutmut("src/a.py", test_command="pytest", cwd=tmp_path)
+
+    assert reverted == [Path("src/a.py")]
+
+
 def test_extract_survivors_filters_to_target_file():
     xml = _junit(
         _survived("Mutant #1", "src/a.py", 5),
@@ -221,6 +292,49 @@ def test_run_for_file_stops_immediately_on_zero_survivors(tmp_path: Path, monkey
 
     assert calls["generate"] == 0
     assert "test_new" not in test_file.read_text(encoding="utf-8")
+
+
+def test_run_for_file_does_not_treat_zero_mutants_as_convergence(
+    tmp_path: Path, monkeypatch
+):
+    """mutmut<3 crashes on Python 3.13+ ('TypeError: cannot pickle
+    itertools.count object', #1359) and produces a junitxml report with
+    zero testcases at all — indistinguishable from real survivors=0 by
+    count alone. run_for_file must not log "no survivors — done" (a false
+    convergence claim) for this case, and must never call generate()."""
+    empty_junit = (
+        '<?xml version="1.0" ?>\n'
+        '<testsuites disabled="0" errors="0" failures="0" tests="0" time="0.0">'
+        '<testsuite disabled="0" errors="0" failures="0" name="mutmut" '
+        'skipped="0" tests="0" time="0"/></testsuites>\n'
+    )
+    monkeypatch.setattr(loop, "run_scoped_mutmut", lambda *a, **k: empty_junit)
+
+    calls = {"generate": 0}
+
+    def fake_generate(*_args):
+        calls["generate"] += 1
+        return "def test_new():\n    assert True\n"
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    logged = []
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=fake_generate,
+        log=logged.append,
+    )
+
+    assert calls["generate"] == 0
+    assert not any("no survivors" in line for line in logged)
+    assert any("zero mutants generated" in line for line in logged)
+    assert any("NOT convergence" in line for line in logged)
 
 
 def test_run_for_file_generates_inserts_and_commits_on_green(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- `run_scoped_mutmut` now reverts the runner's **test file** (in addition to the source file, already fixed by #1357) in its `finally` block — mutmut<3 can truncate the test file to empty via a crashed `.bak`-restore, which previously required a throwaway git-worktree workaround to run safely.
- `run_for_file` now treats a junitxml report with **zero total mutants** (`killed+survived+timeout+no_coverage == 0`) as a non-convergent crash signal instead of silently declaring `survivors == 0` — this is the real failure mode of mutmut<3 crashing under Python 3.13+ (`TypeError: cannot pickle 'itertools.count' object`), verified live against the actual crash.
- The runtime gate adapter (`mutmut.py::mutmut_run`) now captures stderr and names this exact known cause in its advisory instead of a generic "exited with code N" message.
- `python-mutmut.md` documents that the mutmut *installation* venv must be Python <=3.12, distinct from the `--runner`'s test interpreter.

Found while running the bounded mutant-kill pass for #1354.

## Test plan
- [x] New regression tests for `run_scoped_mutmut` reverting `test_file` (crash path, success path, and backward-compat when not supplied)
- [x] New regression test for `run_for_file`'s zero-mutants guard (asserts `generate()` is never called and the log does not claim "no survivors")
- [x] New regression test for the adapter's pickle-crash-specific advisory text
- [x] Live end-to-end repro against the real Python 3.14 mutmut crash — confirmed the loop no longer declares false convergence
- [x] `ruff check` clean on all changed files
- [x] Full pytest dir list: 3888 passed, 1 skipped (pre-existing) — no regressions

Closes #1359
Part of #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)