### PR TITLE
fix(mutation-kill): stop test_mutation_gate.py from leaking ADAPTER_* env into later tests

### DIFF
--- a/plugins/dev-team/tests/hooks/test_mutation_gate.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_gate.py
@@ -27,12 +27,37 @@ def _feed(monkeypatch, text: str) -> None:
     monkeypatch.setattr("sys.stdin", io.StringIO(text))
 
 
+_ADAPTER_ENV_KEYS = (
+    "ADAPTER_TIMEOUT",
+    "ADAPTER_COMMAND",
+    "ADAPTER_RUNNER_STDOUT",
+    "ADAPTER_SOURCE_FILE",
+)
+
+
 @pytest.fixture(autouse=True)
 def _hermetic_tmpdir(monkeypatch, tmp_path):
     monkeypatch.setenv("TMPDIR", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MUTATION_GATE_SKIP", raising=False)
     monkeypatch.delenv("MUTATION_GATE_TIMEOUT", raising=False)
+    yield
+    # mutation_gate.main() sets ADAPTER_* via plain `os.environ[...] = ...`
+    # (real config for a real subprocess adapter, not monkeypatch.setenv) —
+    # monkeypatch.delenv(key, raising=False) called *before* the test is a
+    # no-op when the key is absent at that point (MonkeyPatch.delitem only
+    # records an undo entry when the key currently exists; raising=False on a
+    # missing key just returns without appending to the undo stack), so it
+    # cannot pre-register cleanup for a key main() is about to create.
+    # Without this explicit teardown, running this file leaks
+    # ADAPTER_TIMEOUT=60 into the real process environment for every test
+    # that runs afterward in the same (possibly xdist-parallel) worker —
+    # observed corrupting test_mutmut_adapter.py's default-timeout
+    # assertions under CI's worker grouping (#1359's PR CI failure; this
+    # file's own local run never surfaced it since nothing after it in the
+    # same file depends on these defaults).
+    for key in _ADAPTER_ENV_KEYS:
+        os.environ.pop(key, None)
 
 
 def test_main_returns_zero_on_empty_stdin(monkeypatch):


### PR DESCRIPTION
## Summary
Follow-up to #1360, which merged before this fix landed. PR #1360's CI failed on "Plugin content & hooks" (5 timeout-message assertions across `test_mutmut_adapter.py`/`test_stryker_adapter.py`/`test_stryker_net_adapter.py`) because `test_mutation_gate.py`'s tests leaked `ADAPTER_TIMEOUT=60` (and 3 other `ADAPTER_*` vars) into the real process environment for the rest of the pytest worker — `mutation_gate.main()` sets these via plain `os.environ[...] = ...` (real config for a subprocess adapter, not test scaffolding), and `monkeypatch.delenv(key, raising=False)` called *before* the leak happens is a no-op when the key doesn't exist yet (confirmed against this pytest version's `MonkeyPatch.delitem` source — it only registers an undo entry when the key currently exists).

#1360 was merged (by the repo owner) at the moment I discovered and was about to push this fix, so it landed as commit `cbace5d0` on `mutation` without it — this PR carries just the missing piece via a clean cherry-pick of the already-tested fix.

Fix: explicit `yield` + `os.environ.pop(...)` teardown instead of a pre-registered `delenv`.

## Test plan
- [x] Verified the leak is gone: `ADAPTER_TIMEOUT` is `None` both before and after running `test_mutation_gate.py` standalone (previously ended up `"60"` after)
- [x] The 5 previously-failing tests all pass when run together, single-process, in the same file order CI uses
- [x] `ruff check` clean
- [x] Full pytest dir list: 3888 passed, 1 skipped (pre-existing) — no regressions

Part of #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)