### PR TITLE
fix(ci): wire ruff check into ci-local.sh's pre-push gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,18 +15,16 @@ _mkdocs_src/
 # EnterWorktree tool scratch dirs (per-agent git worktrees, not repo content)
 .claude/worktrees/
 
-# Runtime metrics logs — leading **/ so they match whether hooks write to the
+# Runtime metrics — ignored by default (deny-by-default: metrics/ is
+# generated-runtime-data territory — session digests, telemetry, review-value,
+# verify-log, boundary-events, cost-metering, learning-loop state, ... — a new
+# metrics file should need an explicit un-ignore to land in git, not the other
+# way around). Leading **/ so this matches whether hooks write to the
 # repo-root metrics/ or plugins/dev-team/metrics/ (cwd-dependent) — #1081.
-# Session-review trend digest (per-run runtime data; consumed locally — #129)
-**/metrics/session-digest.jsonl
-# Opt-in telemetry beacon event log (local-only; never checked in — #135)
-**/metrics/telemetry.jsonl
-# Per-checkpoint review-value meter (runtime data; counts-only — #348)
-**/metrics/review-value.jsonl
-# Per-slice /verify evidence log (runtime data; counts-only — #727)
-**/metrics/verify-log.jsonl
-# Boundary-level policy-gateway event log (runtime data; rule-IDs-only — #859)
-**/metrics/boundary-events.jsonl
+**/metrics/*
+# …but keep the deliberately-tracked audit trails.
+!**/metrics/config-changelog.jsonl
+!**/metrics/eval-variance.jsonl
 
 # Effort-band model routing (per-user, never checked in)
 # - ladder: optional ordered model list (.claude/model-ladder.json), hand-written by users behind restricted endpoints

--- a/evals/code-review-benchmark/adapters/defects4j_adapter.py
+++ b/evals/code-review-benchmark/adapters/defects4j_adapter.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import csv
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional
 
 from .common import BenchmarkCase, run_with_timeout, unified_diff_hunks
 

--- a/evals/comparative/score.py
+++ b/evals/comparative/score.py
@@ -311,16 +311,6 @@ def parse_reference(reports_dir: Path) -> list[EmittedFinding]:
             if not severity:
                 severity = _level_from_id(rule_id)
 
-            # CWE (informational — not required for matching but emitted for stats)
-            cwe = None
-            for bl in block_lines:
-                cm = REF_FIELD_CWE.match(bl)
-                if cm:
-                    cwe_m = re.search(r"CWE-\d+", cm.group("cwe"))
-                    if cwe_m:
-                        cwe = cwe_m.group(0)
-                    break
-
             # File(s) + line(s)
             emitted_block = False
             for fm in REF_FILE_LINE.finditer(block):
@@ -622,11 +612,8 @@ def print_scorecard(scores: list[SystemScore]) -> None:
         [str(len(s.extra_emissions)) for s in scores],
     ))
 
-    # Per-concern recall
+    # Per-concern recall: group by reference_concern attribute from the expected list
     print("\n  Recall by reference concern:")
-    concerns = sorted({m.expected_id[:m.expected_id.rfind('-')] if '-' in m.expected_id else m.expected_id
-                       for s in scores for m in s.matches})
-    # Simpler: group by reference_concern attribute from the expected list
     expected, _sup, _ranks = load_ground_truth()
     by_concern: dict[str, list[str]] = {}
     for ef in expected:

--- a/evals/custom-tools/validate.py
+++ b/evals/custom-tools/validate.py
@@ -25,8 +25,8 @@ SCHEMA_PATH = REPO / "plugins/dev-team/knowledge/schemas/unified-finding-v1.json
 
 # Import the SARIF parser from the sibling static-analysis-tools validator.
 sys.path.insert(0, str(REPO / "evals/static-analysis-tools"))
-from validate import parse_sarif, load_schema_registry  # type: ignore
-from jsonschema import Draft202012Validator
+from validate import parse_sarif, load_schema_registry  # type: ignore  # noqa: E402
+from jsonschema import Draft202012Validator  # noqa: E402
 
 
 def run_tool(script: Path, target: Path) -> dict[str, Any]:
@@ -80,7 +80,7 @@ def main() -> int:
     assert_sarif_shape(sarif, "entropy-check")
     try:
         assert_rule_ids(sarif, {"short-secret", "low-entropy-secret", "weak-placeholder", "cross-env-reuse"})
-        print(f"  [OK] all 4 expected rule_ids fired on fixture")
+        print("  [OK] all 4 expected rule_ids fired on fixture")
     except AssertionError as e:
         print(f"  [FAIL] {e}")
         fail += 1
@@ -98,7 +98,7 @@ def main() -> int:
     assert_sarif_shape(sarif, "model-hash-verify")
     try:
         assert_rule_ids(sarif, {"integrity-failure", "no-provenance"})
-        print(f"  [OK] both expected rule_ids fired on fixture")
+        print("  [OK] both expected rule_ids fired on fixture")
     except AssertionError as e:
         print(f"  [FAIL] {e}")
         fail += 1

--- a/evals/static-analysis-tools/validate.py
+++ b/evals/static-analysis-tools/validate.py
@@ -214,7 +214,7 @@ def check_install_hints() -> int:
         print(f"[FAIL] install-hint check: missing hints for {sorted(missing)}")
         return 1
 
-    print(f"[OK]   install-hint check: all 5 tier-1 tools present with canonical format")
+    print("[OK]   install-hint check: all 5 tier-1 tools present with canonical format")
     for t in sorted(found):
         print(f"         {found[t]}")
     return 0

--- a/plugins/dev-team/hooks/contract_version_guard.py
+++ b/plugins/dev-team/hooks/contract_version_guard.py
@@ -33,7 +33,6 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 _LIB_DIR = Path(__file__).resolve().parent / "lib"
 if str(_LIB_DIR) not in sys.path:

--- a/plugins/dev-team/hooks/lib/classify_ship_outcome.py
+++ b/plugins/dev-team/hooks/lib/classify_ship_outcome.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import List, Optional
 

--- a/plugins/dev-team/hooks/lib/telemetry_report.py
+++ b/plugins/dev-team/hooks/lib/telemetry_report.py
@@ -24,7 +24,6 @@ from pathlib import Path
 def aggregate(log: Path) -> dict:
     commands: Counter = Counter()
     skills: Counter = Counter()
-    gates: Counter = Counter()  # outcome -> count, per gate name
     gate_by_name: dict[str, Counter] = {}
     total_events = 0
     for line in log.read_text().splitlines():

--- a/plugins/dev-team/hooks/mutation_adapters/stryker.py
+++ b/plugins/dev-team/hooks/mutation_adapters/stryker.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path

--- a/plugins/dev-team/hooks/telemetry.py
+++ b/plugins/dev-team/hooks/telemetry.py
@@ -31,13 +31,10 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 import sys
 import tempfile
-import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 _HOOK_DIR = Path(__file__).resolve().parent
 _LIB_DIR = _HOOK_DIR / "lib"

--- a/plugins/dev-team/hooks/token_efficiency_review.py
+++ b/plugins/dev-team/hooks/token_efficiency_review.py
@@ -15,7 +15,6 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 from pathlib import Path

--- a/plugins/dev-team/hooks/version_check.py
+++ b/plugins/dev-team/hooks/version_check.py
@@ -17,10 +17,8 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
-import tempfile
 from datetime import datetime
 from pathlib import Path
 

--- a/plugins/dev-team/install.py
+++ b/plugins/dev-team/install.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import os
 import platform
 import shutil
-import sys
-from typing import List, Tuple
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/scripts/plan_waves.py
+++ b/plugins/dev-team/scripts/plan_waves.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
-import os
 import re
 import sys
 from pathlib import Path

--- a/plugins/dev-team/scripts/recon_inventory.py
+++ b/plugins/dev-team/scripts/recon_inventory.py
@@ -31,7 +31,6 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 
 from __future__ import annotations
 
-import argparse
 import os
 import re
 import subprocess

--- a/plugins/dev-team/skills/ubiquitous-language/scripts/collect_domain_signals.py
+++ b/plugins/dev-team/skills/ubiquitous-language/scripts/collect_domain_signals.py
@@ -33,7 +33,6 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys

--- a/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
+++ b/plugins/dev-team/tests/hooks/test_bash_retry_guard.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import time
 from pathlib import Path
 

--- a/plugins/dev-team/tests/hooks/test_boundary_events.py
+++ b/plugins/dev-team/tests/hooks/test_boundary_events.py
@@ -26,7 +26,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _PLUGIN_DIR = _REPO_ROOT / "plugins" / "dev-team"

--- a/plugins/dev-team/tests/hooks/test_codegraph_bootstrap.py
+++ b/plugins/dev-team/tests/hooks/test_codegraph_bootstrap.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/plugins/dev-team/tests/hooks/test_codegraph_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_codegraph_nudge.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
+++ b/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
@@ -358,7 +358,6 @@ def test_cmd_record_rebuilds_from_scratch_on_pre_1094_state_schema(
 
 
 def test_purge_stale_removes_old_state_but_keeps_fresh(hermetic_cost_meter):
-    tmp_path = hermetic_cost_meter
     state_dir = cost_meter._state_dir()
     state_dir.mkdir(parents=True, exist_ok=True)
 

--- a/plugins/dev-team/tests/hooks/test_knowledge_index.py
+++ b/plugins/dev-team/tests/hooks/test_knowledge_index.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/plugins/dev-team/tests/hooks/test_minimal_yaml.py
+++ b/plugins/dev-team/tests/hooks/test_minimal_yaml.py
@@ -28,12 +28,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"))
 
 import minimal_yaml  # noqa: E402,F401
-from minimal_yaml import (
+from minimal_yaml import (  # noqa: E402
     FrontmatterError,
     YamlError,
     extract_frontmatter_block,
     parse_yaml,
-)  # noqa: E402
+)
 
 
 def test_yaml_import_is_not_used_by_this_module():

--- a/plugins/dev-team/tests/hooks/test_mutation_adapters_lib.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_adapters_lib.py
@@ -11,7 +11,6 @@ Byte-parity with the bash lib for the entry points mutation-gate.sh relies on:
 from __future__ import annotations
 
 import json
-import os
 import sys
 import time
 from pathlib import Path

--- a/plugins/dev-team/tests/hooks/test_mutation_gate.py
+++ b/plugins/dev-team/tests/hooks/test_mutation_gate.py
@@ -9,10 +9,8 @@ from __future__ import annotations
 
 import io
 import json
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/plugins/dev-team/tests/hooks/test_post_format.py
+++ b/plugins/dev-team/tests/hooks/test_post_format.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest import mock
 
 import pytest
 

--- a/plugins/dev-team/tests/hooks/test_refactor_test_bash_guard.py
+++ b/plugins/dev-team/tests/hooks/test_refactor_test_bash_guard.py
@@ -11,7 +11,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "hooks"))

--- a/plugins/dev-team/tests/hooks/test_review_gate_hash.py
+++ b/plugins/dev-team/tests/hooks/test_review_gate_hash.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 
 _HOOKS_LIB = Path(__file__).resolve().parents[2] / "hooks" / "lib"

--- a/plugins/dev-team/tests/hooks/test_session_learning_trigger.py
+++ b/plugins/dev-team/tests/hooks/test_session_learning_trigger.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 import io
 import json
-import os
 import sys
 from pathlib import Path
 
-import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]

--- a/plugins/dev-team/tests/hooks/test_skills_index.py
+++ b/plugins/dev-team/tests/hooks/test_skills_index.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import io
-import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 import pytest
 

--- a/plugins/dev-team/tests/hooks/test_task_completion_metrics.py
+++ b/plugins/dev-team/tests/hooks/test_task_completion_metrics.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 _HOOK = (
     Path(__file__).resolve().parent.parent.parent / "hooks" / "task_completion_metrics.py"

--- a/plugins/dev-team/tests/scripts/test_build_rollback_point.py
+++ b/plugins/dev-team/tests/scripts/test_build_rollback_point.py
@@ -8,6 +8,7 @@ the exact revert boundary.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,10 +20,30 @@ sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
 
 import build_rollback_point  # noqa: E402
 
+_GIT_SCRUB_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_REFLOG_ACTION",
+)
+
+
+def _hermetic_env() -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_SCRUB_ENV_VARS}
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    return env
+
 
 def _git(cwd: Path, *args: str) -> str:
     result = subprocess.run(
-        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_hermetic_env(),
     )
     return result.stdout.strip()
 

--- a/plugins/dev-team/tests/scripts/test_change_size.py
+++ b/plugins/dev-team/tests/scripts/test_change_size.py
@@ -145,7 +145,7 @@ class TestEvaluate:
         assert out["keepAgents"] == change_size.FAST_PATH_AGENTS
 
     def test_disqualifying_scope_reports_empty_keep_agents(self):
-        out = change_size.evaluate([f"600\t0\tbig.py"])
+        out = change_size.evaluate(["600\t0\tbig.py"])
         assert out["qualifiesForFastPath"] is False
         assert out["keepAgents"] == []
 

--- a/plugins/dev-team/tests/scripts/test_claude_md_guard.py
+++ b/plugins/dev-team/tests/scripts/test_claude_md_guard.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))

--- a/plugins/dev-team/tests/scripts/test_coverage_readiness.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_readiness.py
@@ -4,7 +4,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))

--- a/plugins/dev-team/tests/scripts/test_lesson_validate.py
+++ b/plugins/dev-team/tests/scripts/test_lesson_validate.py
@@ -15,7 +15,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(

--- a/plugins/dev-team/tests/structure/test_script_references.py
+++ b/plugins/dev-team/tests/structure/test_script_references.py
@@ -21,7 +21,6 @@ import re
 import shlex
 from pathlib import Path
 
-import pytest
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[2]
 

--- a/plugins/security-assessment/harness/redteam/probes/06_input_validation.py
+++ b/plugins/security-assessment/harness/redteam/probes/06_input_validation.py
@@ -7,7 +7,6 @@ Produces: results/06_validation.json
 """
 from __future__ import annotations
 
-import math
 from typing import Any
 
 from ..lib import http_client, result_store, scoring

--- a/plugins/security-assessment/harness/redteam/probes/08_report_generator.py
+++ b/plugins/security-assessment/harness/redteam/probes/08_report_generator.py
@@ -10,7 +10,6 @@ Produces: results/08_report.json  AND  results/adversarial-report.md
 from __future__ import annotations
 
 import html
-import json
 from datetime import datetime, timezone
 
 from .. import config
@@ -157,7 +156,7 @@ def run() -> None:
 
     # Markdown report (human-readable; refined in place by the analyst agent)
     md_lines = [
-        f"# Adversarial ML Red-Team Report",
+        "# Adversarial ML Red-Team Report",
         "",
         f"**Target**: `{config.TARGET_URL}`  ",
         f"**Generated**: {report['generated_at']}",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,7 +51,9 @@ pytest-xdist>=3.0
 # Required by the Python static-analysis lane (dev-team plugin): /build's
 # self-heal pass and /code-review's static pre-pass dispatch ruff (lint +
 # autofix, native SARIF; SARIF needs >= 0.3.1) whenever Python files are in
-# scope — including this repo's own Python sources.
+# scope — including this repo's own Python sources. Also the tool behind
+# chk_ruff in scripts/ci-local.sh, which lints the repo's own Python against
+# ruff.toml (repo root) as a blocking pre-push gate.
 ruff>=0.3.1
 
 # Required by the same Python static-analysis lane: mypy (type checking,

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,22 @@
+# Config for `ruff check` (wired into scripts/ci-local.sh's chk_ruff gate).
+#
+# extend-exclude adds to ruff's built-in default exclude list rather than
+# replacing it. Every entry here is a corpus of intentionally non-conformant
+# or frozen snapshot Python that lint debt should never accrue against:
+#   - **/rule-fixtures, **/fixtures, **/fixture, **/fixture-repo: semgrep rule
+#     positive/negative snippets and eval-harness fixture repos — demonstration
+#     code, not maintained source.
+#   - **/acc_*.py: acceptance-test files "injected at grading" by the TDD/
+#     refactor-granularity experiment harnesses (evals/fixtures/exp-tdd-*,
+#     evals/refactor-granularity/tasks/*) — frozen grading corpora.
+#   - evals/refactor-granularity/tasks/*/{golden,reference}: canonical
+#     solution snapshots for the same experiment corpus.
+extend-exclude = [
+    "**/fixtures",
+    "**/fixture",
+    "**/fixture-repo",
+    "**/rule-fixtures",
+    "**/acc_*.py",
+    "evals/refactor-granularity/tasks/*/golden",
+    "evals/refactor-granularity/tasks/*/reference",
+]

--- a/scripts/analyze_refactor_experiment.py
+++ b/scripts/analyze_refactor_experiment.py
@@ -9,7 +9,6 @@ the 4 tasks. Prints a readable summary and writes a JSON summary.
 
 Usage: python3 scripts/analyze_refactor_experiment.py
 """
-import glob
 import json
 import statistics as st
 from collections import defaultdict
@@ -22,12 +21,12 @@ ARMS = ["tdd-refactor", "no-refactor-single", "one-shot-single", "continuous-sin
 
 def load():
     cells = defaultdict(dict)  # (task,arm,trial) -> {stage: row}
-    for l in open(MERGED):
-        l = l.strip()
-        if not l:
+    for line in open(MERGED):
+        line = line.strip()
+        if not line:
             continue
         try:
-            r = json.loads(l)
+            r = json.loads(line)
         except Exception:
             continue
         cells[(r["task"], r["arm"], r["trial"])][r["stage"]] = r
@@ -101,9 +100,12 @@ def main():
         cost_taskmed = [med(by_arm_task[(arm, t)]["cost"]) for t in tasks]
         cb = med(blast_taskmed)
         co = med(cost_taskmed)
-        mut = med(d["mutation"]); cov = med(d["coverage"]); mi = med(d["mi"])
+        mut = med(d["mutation"])
+        cov = med(d["coverage"])
+        mi = med(d["mi"])
         ccn = med(d["ccn"])
-        core = round(100 * st.mean(d["core"])); edge = round(100 * st.mean(d["edge"]))
+        core = round(100 * st.mean(d["core"]))
+        edge = round(100 * st.mean(d["edge"]))
         viol = sum(d["violation"])
         bpd = round(cb / co, 1) if cb and co else None
         summary["arms"][arm] = dict(cum_blast=cb, cost=co, blast_per_dollar=bpd,

--- a/scripts/analyze_tdd_experiment.py
+++ b/scripts/analyze_tdd_experiment.py
@@ -50,7 +50,7 @@ def load(paths: list[Path]) -> dict:
         if text[0] == "[":
             items = json.loads(text)
         else:
-            items = [json.loads(l) for l in text.splitlines() if l.strip()]
+            items = [json.loads(line) for line in text.splitlines() if line.strip()]
         for r in items:
             key = (r["task"], r["arm"], r["trial"], r["stage"])
             rows[key] = r

--- a/scripts/analyze_tdd_pays.py
+++ b/scripts/analyze_tdd_pays.py
@@ -703,9 +703,6 @@ def main(argv: list[str]) -> int:
 
     out_lines.append("\n\n## Stage-0 CORE and EDGE pass rates\n")
     s0 = stage0_summary(rows)
-    tasks_list = sorted({k[0] for k in s0})
-    arms_list = sorted({k[1] for k in s0})
-    clarities_list = sorted({k[2] for k in s0})
 
     for metric, label in [("core_pass_rate", "CORE"), ("edge_pass_rate", "EDGE")]:
         out_lines.append(f"\n### {label} pass rate\n")

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -90,7 +90,7 @@ section() { printf '\n%s== %s ==%s\n' "$bold" "$1" "$reset"; }
 # tools per job, so a full-toolchain gate here would false-fail those jobs.
 if [ -z "$ONLY" ]; then
   missing=()
-  for t in shellcheck jq python3 semgrep; do
+  for t in shellcheck jq python3 semgrep ruff; do
     command -v "$t" >/dev/null 2>&1 || missing+=("$t")
   done
   if [ "${#missing[@]}" -gt 0 ]; then
@@ -211,6 +211,12 @@ chk_eslint() {
     printf '%s∼ skipped (npx not found)%s\n' "$yellow" "$reset"
   fi
 }
+# Python lint (ruff.toml at repo root excludes fixture/eval-corpus snippet
+# dirs — see that file's header comment for why). Same tool /code-review and
+# /build's self-heal dispatch on Python files (plugins/dev-team/skills/
+# static-analysis-integration/SKILL.md); this gate keeps the repo's own
+# Python at the bar those skills hold contributor changes to.
+chk_ruff() { ruff check .; }
 # plugins/dev-team/tests/hooks/parity/ (the .sh↔.py parity harness) was retired
 # in #618 (epic #572) once every shipped hook + script became Python-only. The
 # going-forward coverage lives in plugins/dev-team/tests/hooks/test_*.py and
@@ -289,6 +295,7 @@ CHECKS=(
   "nav integrity (mkdocs nav → assembled file)::chk_nav_integrity"
   "eval-corpus semver contract::chk_eval_semver"
   "eslint::chk_eslint"
+  "ruff check (Python lint)::chk_ruff"
   "plugin hook + script unit tests (pytest plugins/dev-team/tests)::chk_hook_units"
 )
 

--- a/scripts/claude_setup_review.py
+++ b/scripts/claude_setup_review.py
@@ -276,7 +276,7 @@ def check_duplicate_names(agents_dir: Path) -> List[dict]:
                         + ", ".join(files)
                     ),
                     file=files[0],
-                    suggested_fix=f"Rename one of the agents to a unique name.",
+                    suggested_fix="Rename one of the agents to a unique name.",
                 )
             )
 

--- a/scripts/codebase_recon.py
+++ b/scripts/codebase_recon.py
@@ -23,13 +23,12 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any
 
 # Allow importing sibling lib modules regardless of cwd
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.review_result import build_result, main_exit, skipped_llm_warning
+from lib.review_result import build_result, main_exit
 from lib import deterministic_recon
 
 # ---------------------------------------------------------------------------
@@ -88,7 +87,7 @@ def step3_entry_points(
         return []
 
     # LLM path: call `claude -p`
-    lang_summary = ", ".join(l.get("name", "?") for l in lang_stats[:5]) or "unknown"
+    lang_summary = ", ".join(lg.get("name", "?") for lg in lang_stats[:5]) or "unknown"
     prompt = (
         f"Analyze the repository at {root}. "
         f"Primary languages: {lang_summary}. "

--- a/scripts/eval_persona.py
+++ b/scripts/eval_persona.py
@@ -49,9 +49,11 @@ def persona_delta(expected_dir: Path, on_trials: list[dict],
             verdict = "within noise band" if flapped else "no effect"
             noeffect += 1
         elif delta > 0:
-            verdict = "persona ADDS detection value"; helps += 1
+            verdict = "persona ADDS detection value"
+            helps += 1
         else:
-            verdict = "persona REDUCES detection value"; hurts += 1
+            verdict = "persona REDUCES detection value"
+            hurts += 1
         rows[a] = {
             "mean_pass_persona_on": o["mean_pass_at_k"],
             "mean_pass_persona_off": f["mean_pass_at_k"],

--- a/scripts/lib/apply_accepted_risks.py
+++ b/scripts/lib/apply_accepted_risks.py
@@ -29,7 +29,7 @@ import fnmatch
 import json
 import re
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
@@ -348,7 +348,7 @@ def main() -> int:
     write_jsonl(args.suppressed_out, suppressed)
     write_jsonl(args.audit_log_out, audit)
 
-    print(f"\nWrote:")
+    print("\nWrote:")
     print(f"  {args.findings} (rewritten, {len(surviving)} findings)")
     print(f"  {args.suppressed_out} ({len(suppressed)} suppressed)")
     print(f"  {args.audit_log_out} ({len(audit)} audit entries)")

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -26,6 +26,7 @@ ci_watched_paths() {
     chk_citation_lint)      printf '%s' "plugins/dev-team/ evals/ scripts/citation_lint.py" ;;
     chk_eval_semver)        printf '%s' "evals/" ;;
     chk_eslint)             printf '%s' "plugins/dev-team/ *.js *.ts *.json" ;;
+    chk_ruff)               printf '%s' "*.py ruff.toml" ;;
     chk_oe_staleness)       printf '%s' "" ;;  # advisory; intentionally always-run (no stable watched path)
     chk_parity)             printf '%s' "plugins/dev-team/tests/hooks/parity/ plugins/dev-team/hooks/" ;;
     *)                      printf '%s' "" ;;

--- a/scripts/lib/deterministic_recon.py
+++ b/scripts/lib/deterministic_recon.py
@@ -185,7 +185,7 @@ def identify_entry_points(files: list[Path], root: Path) -> list[dict]:
                     out.append({
                         "path": rel,
                         "kind": "module-index",
-                        "rationale": f"Listed as 'main' in package.json",
+                        "rationale": "Listed as 'main' in package.json",
                         "language": "JavaScript/TypeScript",
                     })
         except (json.JSONDecodeError, OSError):
@@ -340,7 +340,7 @@ def build_architecture(files: list[Path], root: Path) -> dict:
     # Summary is deterministic but thin
     summary_parts = []
     if layers:
-        layer_names = [l["name"] for l in layers]
+        layer_names = [layer["name"] for layer in layers]
         summary_parts.append(f"Code organized into {len(layers)} identifiable layer(s): {', '.join(layer_names)}.")
     else:
         summary_parts.append("No conventional layer structure detected.")

--- a/scripts/lib/normalize_findings.py
+++ b/scripts/lib/normalize_findings.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
 
 REPO = Path(__file__).resolve().parents[2]

--- a/scripts/lib/review_result.py
+++ b/scripts/lib/review_result.py
@@ -10,8 +10,6 @@ JSON and consistent exit codes:
 from __future__ import annotations
 
 import json
-import sys
-from typing import Optional
 
 
 def build_result(

--- a/scripts/lib/skeleton_report.py
+++ b/scripts/lib/skeleton_report.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from severity_rank import SEVERITY_ORDER, sort_index as _severity_sort_index  # noqa: E402
+from severity_rank import sort_index as _severity_sort_index  # noqa: E402
 
 PRESENTATIONAL_MAP = {
     "error": "HIGH",  # skeleton default — real pipeline maps with exploitability
@@ -101,8 +101,8 @@ def render_report(
         f"- **Findings summary**: CRITICAL: 0  HIGH: {by_pres['HIGH']}  MEDIUM: {by_pres['MEDIUM']}  LOW: {by_pres['LOW']}"
     )
     lines.append(
-        f"- **Languages detected**: "
-        + ", ".join(l.get("name", "?") for l in recon.get("languages", [])[:5])
+        "- **Languages detected**: "
+        + ", ".join(lg.get("name", "?") for lg in recon.get("languages", [])[:5])
         or "none"
     )
     ep_count = len(recon.get("entry_points", []))
@@ -169,8 +169,8 @@ def render_report(
             if f.get("owasp"):
                 lines.append(f"- **OWASP**: {', '.join(f['owasp'])}")
             lines.append(f"- **Message**: {f.get('message', '(none)')}")
-            lines.append(f"- **Attack scenario**: [LLM-SKIPPED]")
-            lines.append(f"- **Remediation**: [LLM-SKIPPED]")
+            lines.append("- **Attack scenario**: [LLM-SKIPPED]")
+            lines.append("- **Remediation**: [LLM-SKIPPED]")
             lines.append("")
 
     # ── Section 3 — Medium & Low Findings (condensed) ─────────────────────

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -293,7 +293,9 @@ def main(argv=None) -> int:
     classify_fn = None
     if args.classify:
         size = args.classify
-        classify_fn = lambda req, _size=size: {"size": _size}
+
+        def classify_fn(req, _size=size):
+            return {"size": _size}
 
     exit_code = asyncio.run(
         run_pipeline(

--- a/scripts/run_refactor_experiment.py
+++ b/scripts/run_refactor_experiment.py
@@ -379,7 +379,7 @@ def measure_lizard(workdir, prod):
     m = re.search(r"^\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+\d+\s+file", r.stdout, re.M)
     if not m:
         # fallback: the averages row before "file analyzed"
-        rows = [l for l in r.stdout.splitlines() if re.match(r"\s*[\d.]+\s+[\d.]+\s+[\d.]+", l)]
+        rows = [line for line in r.stdout.splitlines() if re.match(r"\s*[\d.]+\s+[\d.]+\s+[\d.]+", line)]
         if rows:
             nums = re.findall(r"[\d.]+", rows[-1])
             if len(nums) >= 4:
@@ -395,7 +395,7 @@ def measure_smells(workdir, tests):
     for p in tests:
         try:
             src = p.read_text()
-            test_loc += len([l for l in src.splitlines() if l.strip()])
+            test_loc += len([line for line in src.splitlines() if line.strip()])
             tree = ast.parse(src)
         except Exception:
             continue
@@ -556,7 +556,8 @@ def _do_stage(workdir, arm, doc, model, env, run_root, cell, change):
     a = ARMS[arm]
     parts = []
     attempted = None
-    raw = lambda suffix="": run_root / "raw" / f"{cell}{suffix}.json"
+    def raw(suffix=""):
+        return run_root / "raw" / f"{cell}{suffix}.json"
     if a["authorship"] == "single":
         wp = change_write_prompt(arm, doc) if change else write_prompt_single(arm, doc)
         parts.append(dispatch(workdir, wp, model, env, raw()))

--- a/scripts/run_tdd_pays_experiment.py
+++ b/scripts/run_tdd_pays_experiment.py
@@ -42,11 +42,11 @@ from statistics import mean, stdev
 SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
 
-from run_integration_eval import extract_golden_repo, init_worktree, run_commands
-from run_tdd_experiment import (
+from run_integration_eval import extract_golden_repo, init_worktree, run_commands  # noqa: E402
+from run_tdd_experiment import (  # noqa: E402
     contamination_flags, make_cell_home, cell_env, dispatch,
     count_agent_tests, split_py_files, measure_coverage, measure_mutation,
-    inject_grade_files, TEST_NAME,
+    inject_grade_files,
 )
 
 MODEL_DEFAULT = "claude-sonnet-4-6"
@@ -230,8 +230,8 @@ def measure_blast_radius(workdir: Path, from_sha: str | None) -> dict:
         name_re = subprocess.run(
             ["git", "diff", from_sha, "HEAD", "--", "*.py"],
             cwd=str(workdir), capture_output=True, text=True, check=False)
-        api_lines = [l for l in name_re.stdout.split("\n")
-                     if l.startswith(("+def ", "-def ", "+class ", "-class "))]
+        api_lines = [line for line in name_re.stdout.split("\n")
+                     if line.startswith(("+def ", "-def ", "+class ", "-class "))]
         out["api_churn"] = len(api_lines)
     except (subprocess.CalledProcessError, OSError, ValueError):
         pass
@@ -366,7 +366,7 @@ def run_stage0(stem: str, arm: str, clarity: str, trial: int,
     workdir = Path(tempfile.mkdtemp(prefix=f"exp-{cell_id}-"))
     extract_golden_repo(fixture_dir / espec["goldenRepo"], workdir)
     init_worktree(workdir)
-    base_sha = _git_commit_all(workdir, "baseline")
+    _git_commit_all(workdir, "baseline")
 
     spec_file = espec["specClear"] if clarity == "clear" else espec["specVague"]
     if (fixture_dir / spec_file).exists():
@@ -389,7 +389,7 @@ def run_stage0(stem: str, arm: str, clarity: str, trial: int,
 
     core_files = espec.get("coreGradeFiles", [])
     edge_files = espec.get("edgeGradeFiles", [])
-    injected = inject_grade_files(fixture_dir, workdir, core_files + edge_files)
+    inject_grade_files(fixture_dir, workdir, core_files + edge_files)
     core_results = run_commands(workdir, espec.get("coreTestCommands", []))
     edge_results = run_commands(workdir, espec.get("edgeTestCommands", []))
 
@@ -669,8 +669,8 @@ def main(argv: list[str]) -> int:
                         args.model, args.skip_dispatch, not args.no_capture,
                         plugin_template=plugin_tpl)
                     prior_sha = stage0_row.pop("_post_build_sha", None)
-                    prod_paths = stage0_row.pop("_prod_paths", [])
-                    test_paths = stage0_row.pop("_test_paths", [])
+                    stage0_row.pop("_prod_paths", [])
+                    stage0_row.pop("_test_paths", [])
                     stage0_row.pop("_worktree", None)
                     if cell_key + ("stage0",) not in done_stages:
                         fh.write(json.dumps(stage0_row) + "\n")

--- a/tests/hooks/test_autoship_log.py
+++ b/tests/hooks/test_autoship_log.py
@@ -4,13 +4,12 @@ import pathlib
 import subprocess
 import sys
 
-import pytest
 
 # Ensure the lib module is importable from any working directory.
 _LIB_DIR = pathlib.Path(__file__).parent.parent.parent / "plugins" / "dev-team" / "hooks" / "lib"
 sys.path.insert(0, str(_LIB_DIR))
 
-from autoship_log import append_round, main  # noqa: E402
+from autoship_log import append_round  # noqa: E402
 
 
 class TestAppendRound:

--- a/tests/repo/test_eval_cache.py
+++ b/tests/repo/test_eval_cache.py
@@ -207,8 +207,8 @@ def test_model_dimension_changes_fingerprint(corpus: Path) -> None:
     """The fingerprint itself differs across models for the same inputs."""
     a = _run(corpus, "--fingerprint", "demo::demo-review", "--model", MODEL_A)
     b = _run(corpus, "--fingerprint", "demo::demo-review", "--model", MODEL_B)
-    sha_a = next(l for l in a.stdout.splitlines() if l.startswith("fingerprint: "))
-    sha_b = next(l for l in b.stdout.splitlines() if l.startswith("fingerprint: "))
+    sha_a = next(line for line in a.stdout.splitlines() if line.startswith("fingerprint: "))
+    sha_b = next(line for line in b.stdout.splitlines() if line.startswith("fingerprint: "))
     assert sha_a != sha_b
 
 

--- a/tests/repo/test_hermetic_adoption.py
+++ b/tests/repo/test_hermetic_adoption.py
@@ -75,7 +75,7 @@ def test_every_fixture_bats_file_that_runs_git_ops_loads_hermetic() -> None:
         "The following bats files do fixture git operations but do not "
         "source tests/lib/hermetic.bash + wire "
         "hermetic_setup/hermetic_teardown. See issue #546 for why this "
-        f"matters.\n" + "\n".join(f"  {o}" for o in offenders)
+        "matters.\n" + "\n".join(f"  {o}" for o in offenders)
     )
 
 
@@ -197,5 +197,5 @@ def test_every_python_fixture_that_runs_git_ops_uses_hermetic_env() -> None:
         "calls but do not route every call through "
         "plugins/dev-team/tests/lib/hermetic.hermetic_git_env() (env= on "
         "every git-mutating call site). See issue #715 / #546 for why this "
-        f"matters.\n" + "\n".join(f"  {o}" for o in offenders)
+        "matters.\n" + "\n".join(f"  {o}" for o in offenders)
     )

--- a/tests/repo/test_validate_agent_contract.py
+++ b/tests/repo/test_validate_agent_contract.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "validate_agent_contract.py"

--- a/tests/scripts/test_build_wave.py
+++ b/tests/scripts/test_build_wave.py
@@ -15,7 +15,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT_PY = _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "build_wave.py"

--- a/tests/scripts/test_build_wave_reconcile.py
+++ b/tests/scripts/test_build_wave_reconcile.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT_PY = _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "build_wave_reconcile.py"

--- a/tests/scripts/test_ci_local_timing.py
+++ b/tests/scripts/test_ci_local_timing.py
@@ -168,7 +168,9 @@ def test_check_set_and_order_identical_with_and_without_flag() -> None:
     assert off.returncode == on.returncode == 0
     # The section headers (one per check, printed by the aggregation loop) are the
     # check set + order; they must be identical whether or not timing is enabled.
-    headers = lambda text: [ln for ln in text.splitlines() if ln.startswith("\x1b[1m== ")]
+    def headers(text):
+        return [ln for ln in text.splitlines() if ln.startswith("\x1b[1m== ")]
+
     assert headers(off.stdout) == headers(on.stdout)
 
 
@@ -309,7 +311,9 @@ def test_changed_only_skip_renders_sentinel_and_keeps_selection() -> None:
     assert re.search(r"\d+\.\d{2}s$", oe_line)  # oe actually ran
 
     # Selection (the per-check section headers) is identical with/without timing.
-    headers = lambda t: [ln for ln in t.splitlines() if ln.startswith("\x1b[1m== ")]
+    def headers(t):
+        return [ln for ln in t.splitlines() if ln.startswith("\x1b[1m== ")]
+
     assert headers(on.stdout) == headers(off.stdout)
 
 

--- a/tests/scripts/test_code_review_benchmark_runner.py
+++ b/tests/scripts/test_code_review_benchmark_runner.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 

--- a/tests/scripts/test_csharp_stryker_net_status_loop.py
+++ b/tests/scripts/test_csharp_stryker_net_status_loop.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/scripts/test_orchestrator.py
+++ b/tests/scripts/test_orchestrator.py
@@ -6,13 +6,11 @@ Tests classification, fast-path routing, phase state persistence,
 
 from __future__ import annotations
 
-import asyncio
-import json
 import os
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -20,7 +18,7 @@ import pytest
 SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-import orchestrator as orch
+import orchestrator as orch  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +241,7 @@ async def test_gather_called_with_two_tasks_for_two_personas():
         return await original_dispatch_persona(persona, plan, skip_llm=True)
 
     with patch.object(orch, "dispatch_persona", side_effect=counting_dispatch):
-        results = await orch.dispatch_personas(personas, plan={}, skip_llm=True)
+        await orch.dispatch_personas(personas, plan={}, skip_llm=True)
 
     assert len(dispatched) == 2
     assert set(dispatched) == set(personas)

--- a/tests/scripts/test_progress_guardian.py
+++ b/tests/scripts/test_progress_guardian.py
@@ -6,12 +6,19 @@ Ported from tests/scripts/progress_guardian_tests.bats (issue #676).
 pytest's tmp_path fixture replaces the bash hermetic helper's mktemp -d +
 rm -rf isolation (see tests/lib/hermetic.bash / issue #546) — every git
 fixture below runs against its own tmp_path, never the parent worktree's
-gitdir.
+gitdir. Every `git` subprocess also scrubs the git-exported env vars and
+redirects global/system config to /dev/null (issue #546/#715): a host
+~/.gitconfig with `commit.gpgsign = true` otherwise leaks into these `git
+commit` calls and races the gpg-agent when this file's tests run in parallel
+across pytest-xdist workers, producing flaky exit-128 failures — this is why
+ci-local.sh previously had to pin this file to a single worker via `--dist
+loadfile` (see scripts/ci-local.sh's chk_hook_units comment).
 """
 
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,9 +26,26 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PG = REPO_ROOT / "scripts" / "progress_guardian.py"
 
+_GIT_SCRUB_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_REFLOG_ACTION",
+)
+
+
+def _hermetic_env() -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_SCRUB_ENV_VARS}
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    return env
+
 
 def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, env=_hermetic_env()
+    )
 
 
 def _init_repo(cwd: Path) -> None:

--- a/tests/security-assessment/harness/test_report_generator_escaping.py
+++ b/tests/security-assessment/harness/test_report_generator_escaping.py
@@ -19,7 +19,6 @@ out of the Markdown/HTML context unescaped.
 
 from __future__ import annotations
 
-import importlib
 import os
 import sys
 from pathlib import Path

--- a/tests/test_classify_ship_outcome.py
+++ b/tests/test_classify_ship_outcome.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 # Resolve module path without installing the package.
 LIB_DIR = Path(__file__).parent.parent / "plugins" / "dev-team" / "hooks" / "lib"


### PR DESCRIPTION
## Summary

- Add `chk_ruff` to `scripts/ci-local.sh` so `ruff check` blocks the local pre-push gate, the same way shellcheck/eslint already do.
- New `ruff.toml` at repo root excludes fixture/eval-corpus snippet dirs (`rule-fixtures`, `fixtures`, `acc_*.py` grading files, refactor-granularity golden/reference snapshots) — frozen or intentionally non-conformant corpora, not maintained source.
- Fixed all 105 pre-existing real lint violations in scope (73 auto-fixed, 32 by hand) so the gate lands green.
- `requirements-dev.txt` comment updated for ruff's new role.

## Related fixes found along the way

- `tests/scripts/test_progress_guardian.py` and `plugins/dev-team/tests/scripts/test_build_rollback_point.py` were leaking the host's `commit.gpgsign` into subprocess `git commit` calls, unlike sibling test files that already scrub `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` (#546/#715 pattern). This made `test_progress_guardian.py` the pytest wall-clock long pole (~57s) and flaky under `pytest-xdist` (real GPG-signing races). Fixed with the same hermetic-env scrub used elsewhere in the suite.
- `.gitignore`'s `metrics/` handling switched from an enumerated per-file ignore list to deny-by-default (`**/metrics/*` plus explicit `!` allows for the two deliberately-tracked audit trails), so new runtime-metrics files don't need a `.gitignore` edit to stay out of `git status` noise.

Closes #1362

## Test plan

- [x] `bash scripts/ci-local.sh` — full local gate green (19 checks, incl. new `ruff check (Python lint)`)
- [x] `ruff check .` — clean
- [x] Full pytest suite (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 3825 passed, 1 skipped
- [x] `tests/scripts/test_progress_guardian.py` — 5 repeated runs under full parallel distribution, no flakes (previously flaky/slow due to gpgsign leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)