### PR TITLE
fix: relocate graphify's machine-specific settings.json hook path

### DIFF
--- a/docs/python-hook-contract.md
+++ b/docs/python-hook-contract.md
@@ -108,6 +108,19 @@ across macOS + Linux + Windows Git Bash.
   degenerate inputs, timing traces during `DEV_TEAM_DEBUG=1`.
 - Never write user-actionable messages to stderr alone. Duplicate them to
   stdout with the `ADVISORY:` prefix if the operator needs to see them.
+- **Exception — exit-2 (block) messages: mirror to stderr in addition to
+  stdout** (`pre_commit_review.py`, #1367). Some Claude Code hook-error
+  wrappers surface only stderr on a nonzero hook exit; a stdout-only block
+  message can go completely unseen there, leaving only a generic "hook
+  error, no stderr output" with no actionable reason. Stdout stays the
+  canonical, primary UI channel — stderr is additive duplication for block
+  paths specifically, not a general license to move messages to stderr.
+  Treat dual-write as the standard for any new exit-2 hook, or any existing
+  one you touch. Hooks not yet converged: stderr-only today
+  (`contract_version_guard.py`, `context_ceiling_guard.py`,
+  `pre_commit_knowledge_index.py`); stdout-only today
+  (`destructive_guard.py`, `eval_compliance_check.py`). Converging them is a
+  separate cleanup, not implied by this note.
 - The parity harness normalizes stderr before comparison. It strips ISO-8601
   timestamps, PIDs, and tmpdir path prefixes. Nothing else. If two
   implementations diverge on anything past those three axes, that is a

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -24,7 +24,9 @@ mechanism.
 Contract (docs/python-hook-contract.md):
     Input : JSON on stdin (Claude Code PreToolUse:Bash payload)
     Exit 0: allow the tool call
-    Exit 2: block the tool call (feedback returned to Claude on stdout)
+    Exit 2: block the tool call (feedback returned to Claude on stdout,
+            mirrored to stderr — some hook-error wrappers only surface
+            stderr, and a stdout-only block message was going unseen)
 
 Stdlib-only. Python 3.8+.
 """
@@ -105,6 +107,16 @@ _BYPASS_BLOCK_MESSAGE = (
 )
 
 
+def _emit_block(message: str) -> None:
+    """Write a block message to both stdout and stderr (#1367).
+
+    Stdout stays the canonical UI channel; stderr is mirrored because some
+    hook-error wrappers surface only stderr on a nonzero hook exit.
+    """
+    sys.stdout.write(message)
+    sys.stderr.write(message)
+
+
 def _staged_names() -> List[str]:
     try:
         completed = subprocess.run(
@@ -154,7 +166,7 @@ def _record_bypass_audit(flag: str, reason: str, staged_count: int) -> None:
     metrics/override-audit.jsonl precedent for a bypass a human/agent
     actively chose, not passive usage telemetry.
     """
-    log = Path("metrics") / "gate-bypass-audit.jsonl"
+    audit_log_path = Path("metrics") / "gate-bypass-audit.jsonl"
     entry = {
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "branch": _current_branch(),
@@ -163,8 +175,8 @@ def _record_bypass_audit(flag: str, reason: str, staged_count: int) -> None:
         "stagedFileCount": staged_count,
         "pluginVersion": _plugin_version(),
     }
-    log.parent.mkdir(parents=True, exist_ok=True)
-    with open(log, "a", encoding="utf-8") as handle:
+    audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(audit_log_path, "a", encoding="utf-8") as handle:
         handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
 
 
@@ -198,7 +210,7 @@ def main() -> int:
                 cwd, "pre_commit_review", "Bash", "bypass", flag, session_id
             )
             return 0
-        sys.stdout.write(_BYPASS_BLOCK_MESSAGE)
+        _emit_block(_BYPASS_BLOCK_MESSAGE)
         return 2
 
     current_hash = review_gate_hash()
@@ -220,7 +232,7 @@ def main() -> int:
     # Block. Message goes to stdout (matching the .sh's `printf` — the .sh
     # writes to stdout, not stderr, so Claude sees it in the tool-call
     # feedback stream).
-    sys.stdout.write(_BLOCK_MESSAGE)
+    _emit_block(_BLOCK_MESSAGE)
     emit_boundary_event(
         cwd, "pre_commit_review", "Bash", "block", "pre-commit-review", session_id
     )

--- a/plugins/dev-team/scripts/lib/settings_hook_guard.py
+++ b/plugins/dev-team/scripts/lib/settings_hook_guard.py
@@ -1,0 +1,125 @@
+"""Guard against machine-specific paths from graphify's Claude hook (#1367).
+
+`graphify install --project` (via its `claude install` step) appends
+PreToolUse hook entries to the target repo's shared, git-tracked
+`.claude/settings.json`, using the absolute path to the graphify binary on
+the installing machine (e.g. `/Users/alice/.local/bin/graphify`). If that
+file is committed, it bakes one developer's home-directory path into the
+repo and silently breaks for every other clone/teammate whose graphify
+binary lives somewhere else (different username, different install method —
+`uv tool`, `pipx`, `--user pip`, ... all resolve to different paths).
+
+This module scans `.claude/settings.json` for any `PreToolUse` hook entry
+that invokes graphify via an absolute filesystem path — instead of relying
+on PATH — and relocates it into `.claude/settings.local.json` (already
+gitignored, personal-machine scope). The scan is unconditional: it fixes a
+repo that already carries the pollution from a past install just as well as
+one guarding a fresh install, so `/project-init`/`/setup` can run it as a
+standing check rather than only wrapping a live installer call.
+
+No upstream flag exists to make `graphify` emit a bare, PATH-resolved
+command instead of an absolute path (checked against installed graphify
+0.9.8's `_resolve_graphify_exe`): it is a deliberate design choice, to keep
+the hook working in environments where the venv Scripts/ directory isn't on
+PATH (e.g. the VS Code Codex extension on Windows). Relocation, not an
+upstream flag, is therefore the fix.
+
+Stdlib-only, per ADR 0014/0015 (Python for cross-OS scripts).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Callable
+
+
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]|^\\\\")
+_PRE_TOOL_USE_KEY = "PreToolUse"
+
+
+def _pre_tool_use(settings: dict) -> list[dict]:
+    return settings.get("hooks", {}).get(_PRE_TOOL_USE_KEY, [])
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    text = path.read_text(encoding="utf-8").strip()
+    return json.loads(text) if text else {}
+
+
+def _dump_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _command_is_absolute_graphify(command: str) -> bool:
+    token = command.strip().split(" ", 1)[0] if command.strip() else ""
+    if not token:
+        return False
+    is_absolute = token.startswith("/") or bool(_WINDOWS_ABSOLUTE.match(token))
+    if not is_absolute:
+        return False
+    basename = re.split(r"[\\/]", token)[-1]
+    if basename.lower().endswith(".exe"):
+        basename = basename[: -len(".exe")]
+    return basename.lower() == "graphify"
+
+
+def find_absolute_graphify_entries(settings: dict) -> list[dict]:
+    """Return `PreToolUse` entries whose command invokes graphify via an
+    absolute filesystem path rather than a bare, PATH-resolved `graphify`.
+    """
+    polluting = []
+    for entry in _pre_tool_use(settings):
+        commands = (h.get("command", "") for h in entry.get("hooks", []))
+        if any(_command_is_absolute_graphify(c) for c in commands):
+            polluting.append(entry)
+    return polluting
+
+
+def fix_settings(settings_path: Path, local_settings_path: Path) -> bool:
+    """Scan `settings_path` for absolute-path graphify hook entries and
+    relocate them into `local_settings_path`.
+
+    Returns True if anything was relocated, False if `settings_path` was
+    already clean (including when it doesn't exist).
+    """
+    settings = _load_json(settings_path)
+    polluting = find_absolute_graphify_entries(settings)
+    if not polluting:
+        return False
+
+    remaining = [e for e in _pre_tool_use(settings) if e not in polluting]
+    if remaining:
+        settings.setdefault("hooks", {})[_PRE_TOOL_USE_KEY] = remaining
+    else:
+        settings.get("hooks", {}).pop(_PRE_TOOL_USE_KEY, None)
+    _dump_json(settings_path, settings)
+
+    local_settings = _load_json(local_settings_path)
+    local_pre_tool_use = local_settings.setdefault("hooks", {}).setdefault(
+        _PRE_TOOL_USE_KEY, []
+    )
+    for entry in polluting:
+        if entry not in local_pre_tool_use:
+            local_pre_tool_use.append(entry)
+    _dump_json(local_settings_path, local_settings)
+
+    return True
+
+
+def run_install_with_guard(
+    settings_path: Path,
+    local_settings_path: Path,
+    installer: Callable[[], None],
+) -> bool:
+    """Run `installer()` against `settings_path`, then apply `fix_settings`.
+
+    Returns True if a machine-specific hook entry was detected and relocated
+    to `local_settings_path`, False if the installer's output was left as-is.
+    """
+    installer()
+    return fix_settings(settings_path, local_settings_path)

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -482,7 +482,7 @@ command -v repowise > /dev/null 2>&1 && echo "installed" || echo "not-installed"
 [ -d "${PWD}/.repowise" ] && echo "indexed" || echo "not-indexed"
 ```
 
-#### Graphify — native integration, opt-in, with a CLAUDE.md guard
+#### Graphify — native integration, opt-in, with corruption/pollution guards
 
 Graphify (`graphifyy` on PyPI) is a multi-modal knowledge graph tool
 (code + docs + schemas + infra + images/video). Unlike CodeGraph it is a
@@ -494,6 +494,10 @@ This sub-section runs **only after the Graphify opt-in in Step 4c accepts** —
 that is, the user said yes. Its integration is repo-level, so none of the file
 writes below happen unless that opt-in was accepted; no model/API key is
 required to reach or complete this sub-section — the AST build is keyless.
+The one exception is the **Standing check** at the end of this sub-section
+(#1367), which runs on every `/project-init` pass regardless of the opt-in
+outcome — it audits `.claude/settings.json` for pollution left by a past
+install, not this run's.
 
 **Install (fallback chain):**
 
@@ -535,6 +539,57 @@ over-delete, taking unrelated pre-existing content with it. Guard every run:
    repo already carries).
 5. **On no corruption detected:** leave the installer's output as-is —
    nothing further to do.
+
+**Native integration, with the settings.json absolute-path guard (#1367).**
+The same `graphify install --project` call also writes PreToolUse hook
+entries into the target repo's shared, git-tracked `.claude/settings.json`,
+using the **absolute path to the graphify binary on this machine** (e.g.
+`/Users/alice/.local/bin/graphify`, or `uv tool`/`pipx`/`--user pip`
+equivalents that resolve differently per machine). If that file is
+committed as-is, it bakes one developer's path into the repo and silently
+breaks for every other clone/teammate whose graphify binary lives
+elsewhere. Immediately after running the installer:
+
+1. **Scan** `.claude/settings.json`'s `hooks.PreToolUse` array for any entry
+   whose command invokes graphify via an absolute filesystem path (POSIX or
+   Windows) instead of a bare, PATH-resolved `graphify` — that is the known
+   pollution, regardless of whether it was just written by this install or
+   left over from a previous one. (`scripts/lib/settings_hook_guard.py`
+   implements this scan/relocate logic in isolation and is unit-tested at
+   `tests/scripts/test_settings_hook_guard.py` — reuse its
+   `run_install_with_guard` function, which runs the installer then applies
+   the scan, rather than re-deriving the check by hand.)
+2. **On detected pollution:** relocate the polluting entry out of
+   `.claude/settings.json` into `.claude/settings.local.json` (already
+   gitignored, personal-machine scope — the same treatment already given to
+   the `.husky/post-commit`/`post-checkout` hooks below). The shared file
+   keeps everything else untouched. If the repo is git-tracked, check
+   `git log --all -- .claude/settings.json` — if any prior commit already
+   carries the polluting path, relocating it fixes the working tree but not
+   history; tell the operator the path may still be recoverable from history
+   and that scrubbing it (e.g. `git filter-repo`) is their call, not
+   something this guard does automatically.
+3. **On no pollution detected:** leave the installer's output as-is —
+   nothing further to do.
+
+**Standing check — run even when Graphify install is skipped.** The scan
+above only fires right after a fresh install; it does nothing for a repo
+that was graphify-installed *before* this guard existed (Graphify already
+present means it drops out of Step 4c's "missing set" and the installer
+never runs — see the idempotency rule above). So run this scan
+**unconditionally, once per `/project-init` (and therefore `/setup`) run
+whenever `.claude/settings.json` exists** — not gated behind the Graphify
+opt-in/install branch:
+
+```python
+from pathlib import Path
+from settings_hook_guard import fix_settings
+
+fix_settings(Path(".claude/settings.json"), Path(".claude/settings.local.json"))
+```
+
+This is what makes `/setup` self-healing for repos that already carry the
+baked-in path: no re-install, no opt-in prompt, just a scan-and-relocate.
 
 **Build the graph — keyless AST pass (issue #1224).** Graphify's AST
 structural graph builds with **no model/API key**: `graphify extract .` runs
@@ -582,6 +637,12 @@ graphify-out/
 ```
 
 (Or `.git/hooks/post-*` if the target repo does not use husky.)
+
+This covers the generated **git hooks** only. The machine-specific path
+`graphify install --project` writes into the *shared* `.claude/settings.json`
+itself is handled separately by the settings.json absolute-path guard
+above (#1367) — that file is not gitignored, so the fix there is to relocate
+the polluting entry, not to gitignore the whole file.
 
 ### Step 5: Verify — post-install probes
 

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -832,9 +832,14 @@ tool line.
 - CodeGraph: ✓ installed + `.codegraph/` built (keyless)   [or: ✗ declined | ✗ failed]
 - Repowise:  ✓ installed + `.repowise/` indexed (keyless)   [or: ✗ declined | ✗ failed]
 - Graphify:  ✓ `graphify-out/` built (keyless AST; enrichment key-gated)   [or: ✗ declined | ✗ failed]
+  - settings.json guard: ✓ clean   [or: ✓ relocated N machine-specific graphify hook(s) to settings.local.json (#1367)]
 
 The separate "run index-codebase first" step is no longer required — accepting
-the group installs and builds all three indexes in the same run.
+the group installs and builds all three indexes in the same run. The
+settings.json guard line reports project-init's standing check (#1367) — it
+runs on every pass, including one where Graphify install itself is skipped
+because it's already present, so a repo carrying a machine-specific path from
+an install predating this guard gets self-healed the next time `/setup` runs.
 
 ### Created
 - `.claude/project-stack.json` — stack detection results

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -86,6 +86,7 @@ def test_non_commit_silent(repo: Path) -> None:
     r = _run({"tool_name": "Bash", "tool_input": {"command": "ls -la"}}, cwd=repo)
     assert r.returncode == 0
     assert r.stdout == ""
+    assert r.stderr == ""
 
 
 def test_no_verify_bypass_without_reason_blocks(repo: Path) -> None:
@@ -96,6 +97,9 @@ def test_no_verify_bypass_without_reason_blocks(repo: Path) -> None:
     )
     assert r.returncode == 2
     assert "GATE_BYPASS_REASON" in r.stdout
+    assert "GATE_BYPASS_REASON" in r.stderr
+    # #1367: stderr mirrors stdout byte-for-byte, not just a similar message.
+    assert r.stdout == r.stderr
     assert not (repo / "metrics" / "gate-bypass-audit.jsonl").exists()
 
 
@@ -127,6 +131,7 @@ def test_no_verify_bypass_empty_reason_blocks(repo: Path) -> None:
     )
     assert r.returncode == 2
     assert "GATE_BYPASS_REASON" in r.stdout
+    assert "GATE_BYPASS_REASON" in r.stderr
 
 
 def test_bare_n_bypass_without_reason_blocks(repo: Path) -> None:
@@ -136,6 +141,7 @@ def test_bare_n_bypass_without_reason_blocks(repo: Path) -> None:
         cwd=repo,
     )
     assert r.returncode == 2
+    assert "GATE_BYPASS_REASON" in r.stderr
     assert "GATE_BYPASS_REASON" in r.stdout
 
 
@@ -195,6 +201,9 @@ def test_missing_gate_file_blocks(repo: Path) -> None:
     assert "BLOCKED" in r.stdout
     assert "/code-review" in r.stdout
     assert "--no-verify" in r.stdout
+    # #1367: mirrored to stderr so wrappers that only surface stderr on a
+    # nonzero hook exit (rather than the hook's own stdout) still show why.
+    assert "BLOCKED" in r.stderr
 
 
 def test_matching_gate_file_passes_and_is_consumed(repo: Path) -> None:
@@ -221,6 +230,7 @@ def test_stale_gate_file_blocks(repo: Path) -> None:
     )
     assert r.returncode == 2
     assert "BLOCKED" in r.stdout
+    assert "BLOCKED" in r.stderr
     # Gate file preserved because it did NOT match.
     assert (repo / ".review-passed").exists()
 
@@ -235,3 +245,5 @@ def test_extra_staged_file_after_review_blocks(repo: Path) -> None:
         {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
     )
     assert r.returncode == 2
+    assert "BLOCKED" in r.stdout
+    assert "BLOCKED" in r.stderr

--- a/plugins/dev-team/tests/scripts/test_settings_hook_guard.py
+++ b/plugins/dev-team/tests/scripts/test_settings_hook_guard.py
@@ -1,0 +1,430 @@
+"""Unit tests for scripts/lib/settings_hook_guard.py (#1367).
+
+Validates the scan -> relocate guard project-init's Step 4c wraps around
+`graphify install --project`, and that runs standalone as a repo audit (the
+same check `/setup` should re-run against a repo that was already
+graphify-installed before this guard existed). Does NOT exercise the real
+graphify binary (not installed in this sandbox) — it stubs installers that
+reproduce graphify's real behavior (additively append a machine-specific
+absolute-path PreToolUse hook alongside whatever was already in the file)
+and asserts the guard relocates that entry to `.claude/settings.local.json`
+without disturbing anything pre-existing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))
+
+import settings_hook_guard  # noqa: E402
+
+
+ALICE_EXE = "/Users/alice/.local/bin/graphify"
+BOB_EXE = "/home/bob/.local/share/uv/tools/graphifyy/bin/graphify"
+WINDOWS_EXE = r"C:\Users\alice\.local\bin\graphify.exe"
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _pollute_installer(settings_path: Path, exe: str = ALICE_EXE) -> None:
+    """Reproduce graphify's real behavior: additively append a machine-
+    specific PreToolUse hook to whatever is already in the file."""
+    settings = json.loads(settings_path.read_text(encoding="utf-8") or "{}")
+    pre_tool_use = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    pre_tool_use.append(
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": f"{exe} hook-guard search"}],
+        }
+    )
+    pre_tool_use.append(
+        {
+            "matcher": "Read|Glob",
+            "hooks": [{"type": "command", "command": f"{exe} hook-guard read"}],
+        }
+    )
+    _write_json(settings_path, settings)
+
+
+def _clean_installer(settings_path: Path) -> None:
+    """A well-behaved installer that relies on PATH, not an absolute path."""
+    settings = json.loads(settings_path.read_text(encoding="utf-8") or "{}")
+    pre_tool_use = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    pre_tool_use.append(
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "graphify hook-guard search"}],
+        }
+    )
+    _write_json(settings_path, settings)
+
+
+def test_find_absolute_graphify_entries_detects_polluting_entry():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": f"{ALICE_EXE} hook-guard search"}
+                    ],
+                }
+            ]
+        }
+    }
+
+    found = settings_hook_guard.find_absolute_graphify_entries(settings)
+
+    assert len(found) == 1
+    assert found[0]["matcher"] == "Bash"
+
+
+def test_find_absolute_graphify_entries_ignores_path_relative_command():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "graphify hook-guard search"}],
+                }
+            ]
+        }
+    }
+
+    assert settings_hook_guard.find_absolute_graphify_entries(settings) == []
+
+
+def test_find_absolute_graphify_entries_ignores_unrelated_absolute_command():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Write",
+                    "hooks": [{"type": "command", "command": "/usr/bin/env echo preexisting"}],
+                }
+            ]
+        }
+    }
+
+    assert settings_hook_guard.find_absolute_graphify_entries(settings) == []
+
+
+def test_find_absolute_graphify_entries_detects_windows_path():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": f"{WINDOWS_EXE} hook-guard search"}
+                    ],
+                }
+            ]
+        }
+    }
+
+    found = settings_hook_guard.find_absolute_graphify_entries(settings)
+
+    assert len(found) == 1
+
+
+def test_find_absolute_graphify_entries_detects_forward_slash_windows_path():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "c:/Users/alice/.local/bin/graphify.exe hook-guard search"}
+                    ],
+                }
+            ]
+        }
+    }
+
+    assert len(settings_hook_guard.find_absolute_graphify_entries(settings)) == 1
+
+
+def test_find_absolute_graphify_entries_detects_unc_path():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": r"\\server\share\graphify hook-guard search"}
+                    ],
+                }
+            ]
+        }
+    }
+
+    assert len(settings_hook_guard.find_absolute_graphify_entries(settings)) == 1
+
+
+def test_find_absolute_graphify_entries_detects_case_insensitive_basename():
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "/usr/local/bin/Graphify hook-guard search"}],
+                },
+                {
+                    "matcher": "Read|Glob",
+                    "hooks": [{"type": "command", "command": "/usr/local/bin/GRAPHIFY.EXE hook-guard read"}],
+                },
+            ]
+        }
+    }
+
+    assert len(settings_hook_guard.find_absolute_graphify_entries(settings)) == 2
+
+
+def test_find_absolute_graphify_entries_relocates_whole_entry_even_with_one_clean_command():
+    """Relocation is per-entry, not per-command — an entry with a mix of a
+    polluting and a clean command still moves as a unit (#1367 test-review)."""
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": f"{ALICE_EXE} hook-guard search"},
+                        {"type": "command", "command": "echo also-runs-here"},
+                    ],
+                }
+            ]
+        }
+    }
+
+    found = settings_hook_guard.find_absolute_graphify_entries(settings)
+
+    assert len(found) == 1
+    assert [h["command"] for h in found[0]["hooks"]] == [
+        f"{ALICE_EXE} hook-guard search",
+        "echo also-runs-here",
+    ]
+
+
+def test_find_absolute_graphify_entries_ignores_entry_with_no_hooks_key():
+    settings = {"hooks": {"PreToolUse": [{"matcher": "Bash"}]}}
+
+    assert settings_hook_guard.find_absolute_graphify_entries(settings) == []
+
+
+def test_fix_settings_relocates_two_different_prior_installs(tmp_path: Path):
+    """Two teammates' machines both polluted the same file over time —
+    both distinct absolute paths must be found and relocated together."""
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    _write_json(
+        settings_path,
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": f"{ALICE_EXE} hook-guard search"}],
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": f"{BOB_EXE} hook-guard search"}],
+                    },
+                ]
+            }
+        },
+    )
+
+    fixed = settings_hook_guard.fix_settings(settings_path, local_settings_path)
+
+    assert fixed is True
+    shared = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert "PreToolUse" not in shared.get("hooks", {})
+
+    local = json.loads(local_settings_path.read_text(encoding="utf-8"))
+    local_commands = [
+        h["command"] for entry in local["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert local_commands == [
+        f"{ALICE_EXE} hook-guard search",
+        f"{BOB_EXE} hook-guard search",
+    ]
+
+
+def test_fix_settings_does_not_duplicate_entry_already_relocated(tmp_path: Path):
+    """A re-poisoned shared file whose polluting entry already exists in the
+    local file (from an earlier relocation) must not create a duplicate."""
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    entry = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": f"{ALICE_EXE} hook-guard search"}],
+    }
+    _write_json(settings_path, {"hooks": {"PreToolUse": [entry]}})
+    _write_json(local_settings_path, {"hooks": {"PreToolUse": [dict(entry)]}})
+
+    fixed = settings_hook_guard.fix_settings(settings_path, local_settings_path)
+
+    assert fixed is True
+    local = json.loads(local_settings_path.read_text(encoding="utf-8"))
+    assert local["hooks"]["PreToolUse"] == [entry]
+
+
+def test_guard_relocates_polluting_hook_from_live_install(tmp_path: Path):
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    _write_json(
+        settings_path,
+        {
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "echo hi"}]}],
+                "PreToolUse": [
+                    {
+                        "matcher": "Write",
+                        "hooks": [{"type": "command", "command": "echo preexisting"}],
+                    }
+                ],
+            },
+            "enabledPlugins": {"foo": True},
+        },
+    )
+
+    relocated = settings_hook_guard.run_install_with_guard(
+        settings_path,
+        local_settings_path,
+        installer=lambda: _pollute_installer(settings_path),
+    )
+
+    assert relocated is True
+
+    shared = json.loads(settings_path.read_text(encoding="utf-8"))
+    # Pre-existing content survives untouched.
+    assert shared["enabledPlugins"] == {"foo": True}
+    assert shared["hooks"]["SessionStart"] == [
+        {"hooks": [{"type": "command", "command": "echo hi"}]}
+    ]
+    shared_commands = [
+        h["command"] for entry in shared["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert shared_commands == ["echo preexisting"]
+    assert not any(ALICE_EXE in c for c in shared_commands)
+
+    local = json.loads(local_settings_path.read_text(encoding="utf-8"))
+    local_commands = [
+        h["command"] for entry in local["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert local_commands == [
+        f"{ALICE_EXE} hook-guard search",
+        f"{ALICE_EXE} hook-guard read",
+    ]
+
+
+def test_guard_leaves_clean_install_untouched(tmp_path: Path):
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    _write_json(settings_path, {})
+
+    relocated = settings_hook_guard.run_install_with_guard(
+        settings_path,
+        local_settings_path,
+        installer=lambda: _clean_installer(settings_path),
+    )
+
+    assert relocated is False
+    assert not local_settings_path.exists()
+
+    shared = json.loads(settings_path.read_text(encoding="utf-8"))
+    shared_commands = [
+        h["command"] for entry in shared["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert shared_commands == ["graphify hook-guard search"]
+
+
+def test_guard_merges_into_existing_local_settings(tmp_path: Path):
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    _write_json(settings_path, {})
+    _write_json(
+        local_settings_path,
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Edit",
+                        "hooks": [{"type": "command", "command": "echo local-preexisting"}],
+                    }
+                ]
+            }
+        },
+    )
+
+    relocated = settings_hook_guard.run_install_with_guard(
+        settings_path,
+        local_settings_path,
+        installer=lambda: _pollute_installer(settings_path),
+    )
+
+    assert relocated is True
+
+    local = json.loads(local_settings_path.read_text(encoding="utf-8"))
+    local_commands = [
+        h["command"] for entry in local["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert local_commands == [
+        "echo local-preexisting",
+        f"{ALICE_EXE} hook-guard search",
+        f"{ALICE_EXE} hook-guard read",
+    ]
+
+
+def test_fix_settings_audits_pollution_left_by_a_teammates_prior_install(tmp_path: Path):
+    """The core regression scenario (#1367): a repo already carries a
+    hardcoded path from *someone else's* machine — a fresh /setup run (no
+    live installer call) must still detect and relocate it."""
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+    _write_json(
+        settings_path,
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": f"{BOB_EXE} hook-guard search"}],
+                    },
+                    {
+                        "matcher": "Read|Glob",
+                        "hooks": [{"type": "command", "command": f"{BOB_EXE} hook-guard read"}],
+                    },
+                ]
+            }
+        },
+    )
+
+    fixed = settings_hook_guard.fix_settings(settings_path, local_settings_path)
+
+    assert fixed is True
+    shared = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert "PreToolUse" not in shared.get("hooks", {})
+
+    local = json.loads(local_settings_path.read_text(encoding="utf-8"))
+    local_commands = [
+        h["command"] for entry in local["hooks"]["PreToolUse"] for h in entry["hooks"]
+    ]
+    assert local_commands == [f"{BOB_EXE} hook-guard search", f"{BOB_EXE} hook-guard read"]
+
+
+def test_fix_settings_noop_when_settings_file_absent(tmp_path: Path):
+    settings_path = tmp_path / "settings.json"
+    local_settings_path = tmp_path / "settings.local.json"
+
+    assert settings_hook_guard.fix_settings(settings_path, local_settings_path) is False
+    assert not local_settings_path.exists()


### PR DESCRIPTION
## Summary
- `graphify install --project` writes PreToolUse hooks into the shared, git-tracked `.claude/settings.json` using the absolute path to the graphify binary on the installing machine, breaking for every other clone.
- Add `scripts/lib/settings_hook_guard.py` (mirrors `claude_md_guard.py`): scans `settings.json` for a graphify hook invoked via an absolute path and relocates it into the gitignored `.claude/settings.local.json`.
- `project-init`'s Step 4c now wraps this guard around a fresh install and runs it as a standing check every pass, so `/setup` self-heals repos that were graphify-installed before this guard existed.
- Mirror `pre_commit_review.py`'s exit-2 block messages to stderr (in addition to stdout) so hook-error wrappers that only surface stderr still show the actionable reason; documented as an exception in `docs/python-hook-contract.md`.

Closes #1367

## Test plan
- [x] `scripts/ci-local.sh` passes locally (lint, unit tests, semgrep fixtures, red-team harness smoke, markdown/nav/skills integrity)
- [x] New unit tests in `plugins/dev-team/tests/scripts/test_settings_hook_guard.py` cover relocation, dedup, and no-op cases
- [x] New test in `plugins/dev-team/tests/hooks/test_pre_commit_review.py` covers the dual stdout/stderr block-message emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)