### PR TITLE
docs(claude-md): move cloud-setup guidance into an on-demand skill

### DIFF
--- a/.claude/skills/cloud-setup/SKILL.md
+++ b/.claude/skills/cloud-setup/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: cloud-setup
+description: "Use when working in a Claude Code web/cloud session (claude.ai/code) for this repo, or when asked how to install this plugin, run its skills, or set up tooling in a fresh cloud VM — covers the Setup script, the SessionStart fallback hook, and the file-based fallback when network policy blocks plugin install."
+---
+
+# Cloud sessions (claude.ai/code)
+
+Plugins are a **local CLI / IDE** feature. A Claude Code web session runs in a
+fresh managed VM that clones this repo; setup scripts and env vars are set in the
+cloud **UI** (not a repo file) — see
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web).
+
+**Install the plugin via the Setup script (loads this session).** Claude
+loads all skills, agents, and commands once when it starts, so the plugin must
+be on disk *before* Claude launches. The environment **Setup script** (cloud UI) runs
+pre-boot and its filesystem is snapshotted and reused — installing the plugin
+there makes it load in the **same** session. The `claude` CLI **is** available in
+cloud environments. Paste the body of [`.claude/cloud-setup.sh`](../../cloud-setup.sh)
+into the *Setup script* field; it installs the toolchain and then the plugin
+(`claude plugin marketplace add bdfinst/agentic-dev-team` +
+`claude plugin install dev-team@bfinster`), always exiting 0. See
+[`docs/cloud-setup.md`](../../../docs/cloud-setup.md) for the focused recipe, the exact
+snippet, and the verification probe.
+
+**`SessionStart` hook is a fallback only — it lands next session.**
+`.claude/settings.json` registers a `SessionStart` hook
+(`.claude/install-dev-team.sh`), gated to **`DEV_TEAM_CLOUD_INSTALL=1`** (set it
+in *Environment variables*; leave it unset locally). Because the hook runs *after*
+boot, the plugin it installs only takes effect on the **next** session — use the
+Setup script for same-session loading.
+
+**If a network policy blocks the install, use the plugin's files directly.** The
+skills and agents are plain files in this repo; run any workflow manually:
+
+- a skill → `plugins/dev-team/skills/<name>/SKILL.md` (e.g. `/plan` →
+  read `plugins/dev-team/skills/plan/SKILL.md` and follow its steps);
+- a review agent → `plugins/dev-team/agents/<name>.md`;
+- the catalog → `plugins/dev-team/knowledge/agent-registry.md`.
+
+**Test tooling in cloud.** The same `.claude/cloud-setup.sh` that installs the
+plugin also installs this repo's gates (`jq`, `shellcheck`, the Python
+dev deps, and `gh`) — one paste into the *Setup script* field covers both. There
+is no dedicated secrets store yet — treat env vars as visible to anyone who can
+edit the environment.
+
+For the full walkthrough of running a plugin's skills from a web session (the
+Setup-script install plus the file-based fallback), see
+[`docs/cloud-setup.md`](../../../docs/cloud-setup.md) and
+[`docs/using-plugin-skills-in-the-web-environment.md`](../../../docs/using-plugin-skills-in-the-web-environment.md).
+
+See `plugins/dev-team/CLAUDE.md` for the full orchestration pipeline configuration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,50 +113,7 @@ A release PR is opened automatically. Merging it creates a GitHub Release with a
 
 ## Cloud sessions (claude.ai/code)
 
-Plugins are a **local CLI / IDE** feature. A Claude Code web session runs in a
-fresh managed VM that clones this repo; setup scripts and env vars are set in the
-cloud **UI** (not a repo file) — see
-[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web).
-
-**Install the plugin via the Setup script (loads this session).** Claude
-loads all skills, agents, and commands once when it starts, so the plugin must
-be on disk *before* Claude launches. The environment **Setup script** (cloud UI) runs
-pre-boot and its filesystem is snapshotted and reused — installing the plugin
-there makes it load in the **same** session. The `claude` CLI **is** available in
-cloud environments. Paste the body of [`.claude/cloud-setup.sh`](.claude/cloud-setup.sh)
-into the *Setup script* field; it installs the toolchain and then the plugin
-(`claude plugin marketplace add bdfinst/agentic-dev-team` +
-`claude plugin install dev-team@bfinster`), always exiting 0. See
-[`docs/cloud-setup.md`](docs/cloud-setup.md) for the focused recipe, the exact
-snippet, and the verification probe.
-
-**`SessionStart` hook is a fallback only — it lands next session.**
-`.claude/settings.json` registers a `SessionStart` hook
-(`.claude/install-dev-team.sh`), gated to **`DEV_TEAM_CLOUD_INSTALL=1`** (set it
-in *Environment variables*; leave it unset locally). Because the hook runs *after*
-boot, the plugin it installs only takes effect on the **next** session — use the
-Setup script for same-session loading.
-
-**If a network policy blocks the install, use the plugin's files directly.** The
-skills and agents are plain files in this repo; run any workflow manually:
-
-- a skill → `plugins/dev-team/skills/<name>/SKILL.md` (e.g. `/plan` →
-  read `plugins/dev-team/skills/plan/SKILL.md` and follow its steps);
-- a review agent → `plugins/dev-team/agents/<name>.md`;
-- the catalog → `plugins/dev-team/knowledge/agent-registry.md`.
-
-**Test tooling in cloud.** The same `.claude/cloud-setup.sh` that installs the
-plugin also installs this repo's gates (`jq`, `shellcheck`, the Python
-dev deps, and `gh`) — one paste into the *Setup script* field covers both. There
-is no dedicated secrets store yet — treat env vars as visible to anyone who can
-edit the environment.
-
-For the full walkthrough of running a plugin's skills from a web session (the
-Setup-script install plus the file-based fallback), see
-[`docs/cloud-setup.md`](docs/cloud-setup.md) and
-[`docs/using-plugin-skills-in-the-web-environment.md`](docs/using-plugin-skills-in-the-web-environment.md).
-
-See `plugins/dev-team/CLAUDE.md` for the full orchestration pipeline configuration.
+For running this repo in a Claude Code web/cloud session — installing the plugin via the Setup script, the SessionStart fallback, and the file-based fallback — see the `cloud-setup` skill (`.claude/skills/cloud-setup/SKILL.md`) or [`docs/cloud-setup.md`](docs/cloud-setup.md).
 
 ## graphify
 

--- a/docs/using-plugin-skills-in-the-web-environment.md
+++ b/docs/using-plugin-skills-in-the-web-environment.md
@@ -178,4 +178,4 @@ points bear directly on the fallback path in this doc:
   `plugins/<plugin>/knowledge/agent-registry.md`.
 - Next-session fallback only: set `DEV_TEAM_CLOUD_INSTALL=1` to enable the
   `SessionStart` hook.
-- Authoritative summary: `CLAUDE.md` → *Cloud sessions (claude.ai/code)*.
+- Authoritative summary: the `cloud-setup` skill (`.claude/skills/cloud-setup/SKILL.md`) or [`docs/cloud-setup.md`](cloud-setup.md).


### PR DESCRIPTION
## Summary
- Moves the "Cloud sessions (claude.ai/code)" section out of the always-loaded root `CLAUDE.md` (47 lines, ~2,682 chars) into a new on-demand skill, `.claude/skills/cloud-setup/SKILL.md`, replacing it with a one-line pointer.
- Repoints a stale cross-reference in `docs/using-plugin-skills-in-the-web-environment.md` that still named `CLAUDE.md`'s Cloud sessions section as authoritative.
- Identified by a `/doctor` run's Check 4 (lazy-loading migration candidates); the migration itself and its own diff went through a full `/code-review` panel before this PR.

## Quality Gate
- [x] Tests: 4197 passed, 1 skipped, 0 failed (`plugins/dev-team/tests`)
- [x] Type check: N/A (no `tsconfig.json`)
- [x] Lint: `ruff check` clean, `eslint` clean
- [x] Code review: 17-agent panel (full `Scope: always` roster — no fast-path narrowing on this small diff, `.claude/` markdown counts as functional config, never doc-only) — 1 real finding (structure-review, high confidence) fixed in this branch's single commit; 2 non-actionable suggestions left as report-only

## Decisions & Assumptions
- **No GitHub issue opened for this change** — inferable: the `/doctor` skill's own propose→confirm→apply flow (two `AskUserQuestion` gates) already served as the human approval step for this specific, low-risk documentation move; treated as distinct from the repo's issue-first convention for plugin *feature* work.
- **Landed on a fresh branch off `main`, not the already-open `graphify-hook` PR (#1374)** — explicit human decision: kept unrelated to the nudge-hook feature PR currently awaiting merge.

## Test Plan
- [ ] Confirm `.claude/skills/cloud-setup/SKILL.md` loads when a session's task concerns cloud/web setup
- [ ] Confirm the root `CLAUDE.md` pointer and the `docs/using-plugin-skills-in-the-web-environment.md` cross-reference both resolve to the new skill

## Evidence Bundle
**Checks run**
- `python3 -m pytest plugins/dev-team/tests -n auto --dist loadfile -q` (via `scripts/ci-local.sh`) — 4197 passed, 1 skipped
- `ruff check` / `eslint` — clean
- `/code-review` (auto-scoped to uncommitted changes) — 17 agents dispatched (full `Scope: always` roster); 12 pass, 3 self-classified `skip` (no applicable surface), 2 warn (1 actionable — fixed; 1 non-actionable suggestion)
- Full `scripts/ci-local.sh` pre-push mirror (19 checks) — all green

**Scope notes**
- No `tsconfig.json` → type check skipped (N/A)
- This diff has no runtime code surface (pure documentation/skill-content relocation); language-specific review lenses self-skipped (no matching file types)

**Untested regions**
- Not measured — no coverage tool/baseline detected for markdown-only content

**Residual risks**
- `arch-review` flagged a pre-existing gap: `scripts/check_md_references.py`'s `SCAN_DIRS` doesn't cover `.claude/skills/` or the root `CLAUDE.md`, so links there aren't CI-guarded (not introduced by this diff, not fixed here)
- `doc-review` flagged a minor link-formatting inconsistency in the new skill file's last line (bare code span vs. markdown link) — left as-is, non-blocking
