### PR TITLE
fix(setup): gitignore .review-passed and .mcp.json by default

### DIFF
--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -769,9 +769,14 @@ this blanket ignore would wrongly hide).
 
 `/test-improve`, `/build`, and the review workflows write per-run resume
 state, progress bookkeeping, reports, and metrics into `memory/`, `reports/`,
-`metrics/`, and `plans/`. These are regeneratable runtime artifacts, not
-deliverables — but `/build` commits the working tree per completed step, so
-without an ignore rule they land in the project's history (issue #1101).
+`metrics/`, and `plans/`; `/code-review` additionally writes a
+`.review-passed` gate file at the repo root, consumed and deleted by the
+pre-commit hook on the next matching commit — but left behind whenever that
+commit never happens (files edited after review, or `--no-verify`), cluttering
+`git status` and risking capture by a stray `git add -A` (issue #1377). These
+are regeneratable runtime artifacts, not deliverables — but `/build` commits
+the working tree per completed step, so without an ignore rule they land in
+the project's history (issue #1101).
 
 In a downstream project, `memory/` is exclusively dev-team runtime state, so
 the whole folder is safe to ignore. Idempotently append the block (create
@@ -781,11 +786,12 @@ the whole folder is safe to ignore. Idempotently append the block (create
 MARKER="# dev-team workflow runtime artifacts"
 if ! grep -qF "$MARKER" .gitignore 2>/dev/null; then
   printf '\n%s\n%s\n' \
-    "$MARKER (regeneratable; not deliverables — issue #1101)" \
+    "$MARKER (regeneratable; not deliverables — issues #1101, #1377)" \
     "memory/
 reports/
 metrics/
-plans/" >> .gitignore
+plans/
+.review-passed" >> .gitignore
   echo "gitignore-updated"
 else
   echo "gitignore-already-covered"
@@ -796,6 +802,37 @@ If the project relocated `reports/` via `DEV_TEAM_REPORTS` or `metrics/` via
 `DEV_TEAM_TASK_METRICS`, add that path instead of the default. Record whether
 the block was added for the Step 12 report. Under `--dry-run`, report what
 would be appended without writing.
+
+**`.mcp.json` machine-specific-path hygiene (issue #1376).** Separately —
+still downstream-projects-only, same Step 2 `in-repo` skip — a project's
+`.mcp.json` (written by `index-codebase`/Repowise setup or hand-registered
+MCP servers) commonly bakes in the absolute filesystem path of the machine
+that wrote it (e.g. a Repowise or CodeGraph server's `args` array). If
+committed, every other clone inherits a path that doesn't exist on their
+machine and the server fails to start. Idempotently append its own block
+(independent marker, so this check runs and self-heals even on a repo where
+the runtime-artifacts block above was already added by an older `/setup`):
+
+```bash
+MCP_MARKER="# dev-team hygiene — machine-specific MCP config"
+if ! grep -qF "$MCP_MARKER" .gitignore 2>/dev/null; then
+  printf '\n%s\n%s\n' \
+    "$MCP_MARKER (absolute-path pollution — issue #1376)" \
+    ".mcp.json" >> .gitignore
+  echo "mcp-json-gitignore-updated"
+else
+  echo "mcp-json-gitignore-already-covered"
+fi
+```
+
+This ignores `.mcp.json` going forward regardless of whether it currently
+exists — the same "detect it whenever we write or see it" contract issue
+#1376 asks for. If `.mcp.json` is already tracked by git (`git ls-files
+--error-unmatch .mcp.json` exits 0), tell the operator to `git rm --cached
+.mcp.json` themselves rather than doing it automatically — untracking is a
+history-visible action `/setup` should not take silently. Record whether the
+block was added for the Step 12 report. Under `--dry-run`, report what would
+be appended without writing.
 
 ### 12. Report
 
@@ -845,7 +882,7 @@ an install predating this guard gets self-healed the next time `/setup` runs.
 - `.claude/project-stack.json` — stack detection results
 - `.claude/CLAUDE.md` — project conventions
 - `.claude/settings.json` — PostToolUse formatting hook (prettier + eslint)
-- `.gitignore` — dev-team runtime artifacts (memory/, reports/, metrics/, plans/)   [downstream only; omit if already covered]
+- `.gitignore` — dev-team runtime artifacts (memory/, reports/, metrics/, plans/, .review-passed) plus `.mcp.json` machine-specific-path hygiene (#1376)   [downstream only; omit if already covered]
 - Activated templates: ts-enforcer, esm-enforcer, react-testing
 
 ### Recommendations

--- a/tests/skills/test_setup_gitignore_hygiene.py
+++ b/tests/skills/test_setup_gitignore_hygiene.py
@@ -1,0 +1,70 @@
+"""#1376 / #1377 — `/setup` Step 11 must gitignore `.review-passed` and
+`.mcp.json` by default for downstream projects.
+
+`.review-passed` (the /code-review gate file) is deleted by the pre-commit
+hook on its happy path, but lingers as untracked clutter whenever a commit
+never follows a passed review (files edited after review, or
+`--no-verify`) — issue #1377. `.mcp.json` commonly bakes in the absolute
+filesystem path of the machine that wrote it (Repowise/CodeGraph MCP
+registration) and breaks for every other clone if committed — issue #1376.
+
+These are structural sensors over shipped SKILL.md prose — pure text greps,
+matching the pattern in test_setup_install_guards.py — not state-mutating
+filesystem tests, since the actual `.gitignore` append is a shell block an
+agent runs, not a standalone script this suite can invoke directly.
+"""
+
+from __future__ import annotations
+
+import re
+
+from skill_doc_helpers import PLUGIN_ROOT, collapsed, section_outside_code
+
+SETUP = (PLUGIN_ROOT / "skills" / "setup" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_review_passed_is_appended_to_runtime_artifacts_gitignore_block():
+    body = collapsed(SETUP)
+    # Bound the match to the fenced bash block itself (MARKER= line up to
+    # the closing ```), not the whole document — .review-passed also
+    # appears, unrelated, in the Step 12 sample report further down.
+    block = re.search(r'MARKER="# dev-team workflow runtime artifacts".*?```', body)
+    assert block
+    assert ".review-passed" in block.group(0)
+
+
+def test_mcp_json_gets_its_own_idempotent_gitignore_block():
+    body = collapsed(SETUP)
+    # Same bounding as above — .mcp.json also recurs later in the prose
+    # (the already-tracked-file guidance, the Step 12 report).
+    block = re.search(r'MCP_MARKER="# dev-team hygiene[^"]*".*?```', body)
+    assert block
+    content = block.group(0)
+    assert ".mcp.json" in content
+    assert 'grep -qF "$MCP_MARKER" .gitignore' in content
+
+
+def test_mcp_json_block_is_downstream_only_like_the_runtime_artifacts_block():
+    body = collapsed(SETUP)
+    mcp_section = body[body.index("machine-specific-path hygiene (issue #1376)"):]
+    assert "downstream-projects-only" in mcp_section[:400]
+
+
+def test_mcp_json_already_tracked_case_defers_to_operator_not_auto_untrack():
+    body = collapsed(SETUP)
+    assert "git rm --cached" in body
+    assert "rather than doing it automatically" in body
+
+
+def test_step_12_report_mentions_both_new_gitignore_entries():
+    # Scoped to the Step 12 section itself — the unscoped version of this
+    # check is satisfied trivially by unrelated Step 11 prose, since both
+    # substrings already co-occur there regardless of what Step 12 says.
+    # section_outside_code (not section()) because the Step 12 body embeds
+    # a fenced sample report that itself contains ### -level headers
+    # (e.g. "### Prerequisites") which would otherwise trip the boundary
+    # check and truncate the section before reaching the real content.
+    step_12 = section_outside_code(SETUP, r"^### 12\. Report", boundary_pattern=r"^### ")
+    assert ".review-passed" in step_12
+    assert ".mcp.json" in step_12
+    assert "#1376" in step_12


### PR DESCRIPTION
## Summary
- `/setup` Step 11's runtime-artifacts gitignore block now also covers `.review-passed`, so `/code-review`'s gate file no longer lingers as untracked clutter when a commit doesn't immediately follow a passed review.
- Adds a second, independently-idempotent gitignore block for `.mcp.json`, which commonly bakes in the absolute filesystem path of the machine that registered a Repowise/CodeGraph MCP server and breaks for every other clone if committed. Defers to the operator (`git rm --cached`) rather than auto-untracking if it's already tracked — keeping the only history-visible step human-gated.
- New test file `tests/skills/test_setup_gitignore_hygiene.py` (5 tests) verifies both blocks, their idempotency, and the Step 12 report text — all bounded to the specific fenced blocks/sections they claim to check (not whole-document regex) after code review caught three false-negative tests during development.

Reviewed by doc-review, structure-review, correctness-review, test-review, security-review, and spec-compliance-review — all issues found were fixed before this PR.

Closes #1376
Closes #1377

## Test plan
- [x] `pytest tests/skills/test_setup_gitignore_hygiene.py -v` — 5/5 pass
- [x] Full required pytest surface (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 4275 passed, 3 skipped (pre-existing, unrelated)
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `ruff check` on the two changed files — clean
- [x] Manually confirmed each new test catches the regression it claims to guard against (reverted each fix locally, verified the test fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)