### PR TITLE
fix: extract shared single-pass runner for MCP tool-grant check scripts

### DIFF
--- a/plugins/dev-team/scripts/check_agent_tool_mapping.py
+++ b/plugins/dev-team/scripts/check_agent_tool_mapping.py
@@ -48,9 +48,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
     GET_WHY,
-    fix_tools_line,
-    missing_tools,
-    parse_tools,
+    run_grants_check,
 )
 
 # Tiers ---------------------------------------------------------------------
@@ -115,6 +113,14 @@ def swept_agents(agents_dir: Path) -> list[str]:
     return out
 
 
+def _targets(agents_dir: Path) -> dict[str, tuple[Path, list[str]]]:
+    return {name: (agents_dir / f"{name}.md", required) for name, required in TIER_CONFIG.items()}
+
+
+def _unclassified(covered: list[str]) -> list[str]:
+    return sorted(name for name in covered if name not in TIER_CONFIG and name not in EXCLUSIONS)
+
+
 def evaluate(agents_dir: Path) -> dict:
     """Return the mapping report: covered set, offenders, unclassified.
 
@@ -124,28 +130,13 @@ def evaluate(agents_dir: Path) -> dict:
     """
     swept = swept_agents(agents_dir)
     covered = sorted(set(TIER_CONFIG) | set(swept))
-
-    offenders: dict[str, list[str]] = {}
-    unclassified: list[str] = []
-    for name in covered:
-        if name in TIER_CONFIG:
-            path = agents_dir / f"{name}.md"
-            if not path.is_file():
-                offenders[name] = list(TIER_CONFIG[name])  # named target missing
-                continue
-            missing = missing_tools(path.read_text(encoding="utf-8"), TIER_CONFIG[name])
-            if missing:
-                offenders[name] = missing
-        elif name in EXCLUSIONS:
-            continue
-        else:
-            unclassified.append(name)
+    offenders, _fixed, _unfixable = run_grants_check(_targets(agents_dir))
 
     return {
         "covered": covered,
         "swept": swept,
         "offenders": offenders,
-        "unclassified": sorted(unclassified),
+        "unclassified": _unclassified(covered),
     }
 
 
@@ -155,18 +146,7 @@ def apply_fixes(agents_dir: Path) -> dict[str, list[str]]:
     Unclassified agents are not auto-fixed (they need a human classification
     decision) — the caller reports them and exits non-zero.
     """
-    fixed: dict[str, list[str]] = {}
-    for name, required in TIER_CONFIG.items():
-        path = agents_dir / f"{name}.md"
-        if not path.is_file():
-            continue
-        text = path.read_text(encoding="utf-8")
-        if parse_tools(text) is None:
-            continue
-        new_text, added = fix_tools_line(text, required)
-        if added:
-            path.write_text(new_text, encoding="utf-8")
-            fixed[name] = added
+    _offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=True)
     return fixed
 
 
@@ -182,12 +162,11 @@ def main(argv=None) -> int:
         print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
         return 1
 
-    if args.fix:
-        fixed = apply_fixes(agents_dir)
-
-    report = evaluate(agents_dir)
-    offenders = report["offenders"]
-    unclassified = report["unclassified"]
+    swept = swept_agents(agents_dir)
+    covered = sorted(set(TIER_CONFIG) | set(swept))
+    offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
+    unclassified = _unclassified(covered)
+    report = {"covered": covered, "swept": swept, "offenders": offenders, "unclassified": unclassified}
     rc = 1 if (offenders or unclassified) else 0
 
     if args.json:

--- a/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
@@ -34,7 +34,8 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
-    parse_tools,
+    parse_tools,  # noqa: F401 -- re-exported: imported directly by this script's own tests
+    run_grants_check,
 )
 from mcp_tool_grants import (
     fix_tools_line as _fix_tools_line,
@@ -100,6 +101,10 @@ def _skill_missing(skill_file: Path) -> list[str]:
     return list(SKILL_REQUIRED_PHRASES)
 
 
+def _targets(agents: list[Path]) -> dict[str, tuple[Path, list[str]]]:
+    return {agent_file.stem: (agent_file, MCP_TOOL_NAMES) for agent_file in agents}
+
+
 def apply_fixes(agents: list[Path]) -> tuple[dict[str, list[str]], list[str]]:
     """Append missing MCP tools to each review agent. Returns (fixed, unfixable).
 
@@ -107,27 +112,13 @@ def apply_fixes(agents: list[Path]) -> tuple[dict[str, list[str]], list[str]]:
     to (a missing line, or a block-list form) — these are reported and cause a
     non-zero exit rather than a silent false "OK" (they can't be auto-fixed).
     """
-    fixed: dict[str, list[str]] = {}
-    unfixable: list[str] = []
-    for agent_file in agents:
-        text = agent_file.read_text(encoding="utf-8")
-        if parse_tools(text) is None:
-            unfixable.append(agent_file.stem)
-            continue
-        new_text, added = fix_tools_line(text)
-        if added:
-            agent_file.write_text(new_text, encoding="utf-8")
-            fixed[agent_file.stem] = added
+    _offenders, fixed, unfixable = run_grants_check(_targets(agents), apply_fix=True)
     return fixed, unfixable
 
 
 def find_offenders(agents: list[Path]) -> dict[str, list[str]]:
     """Return {agent: missing tool names} for review agents lacking any of the five."""
-    offenders: dict[str, list[str]] = {}
-    for agent_file in agents:
-        missing = missing_mcp_tools(agent_file.read_text(encoding="utf-8"))
-        if missing:
-            offenders[agent_file.stem] = missing
+    offenders, _fixed, _unfixable = run_grants_check(_targets(agents))
     return offenders
 
 

--- a/plugins/dev-team/scripts/check_security_assessment_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_security_assessment_mcp_tools.py
@@ -41,9 +41,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
-    fix_tools_line,
-    missing_tools,
-    parse_tools,
+    run_grants_check,
 )
 
 # The security-assessment code-reading agents (#1388) — the 8 agents that
@@ -84,17 +82,15 @@ def _agents_dir_default() -> Path:
     return Path(__file__).parent.parent.parent / "security-assessment" / "agents"
 
 
+def _targets(agents_dir: Path) -> dict[str, tuple[Path, list[str]]]:
+    return {
+        name: (agents_dir / f"{name}.md", BASE_MCP_TOOLS) for name in CODE_READING_AGENTS
+    }
+
+
 def find_offenders(agents_dir: Path) -> dict[str, list[str]]:
     """Return {agent: missing tool names} for code-reading agents under-granted."""
-    offenders: dict[str, list[str]] = {}
-    for name in CODE_READING_AGENTS:
-        path = agents_dir / f"{name}.md"
-        if not path.is_file():
-            offenders[name] = list(BASE_MCP_TOOLS)  # named target missing
-            continue
-        missing = missing_tools(path.read_text(encoding="utf-8"), BASE_MCP_TOOLS)
-        if missing:
-            offenders[name] = missing
+    offenders, _fixed, _unfixable = run_grants_check(_targets(agents_dir))
     return offenders
 
 
@@ -108,18 +104,7 @@ def unclassified_agents(agents_dir: Path) -> list[str]:
 
 def apply_fixes(agents_dir: Path) -> dict[str, list[str]]:
     """Append missing BASE_MCP_TOOLS to each under-granted code-reading agent."""
-    fixed: dict[str, list[str]] = {}
-    for name in CODE_READING_AGENTS:
-        path = agents_dir / f"{name}.md"
-        if not path.is_file():
-            continue
-        text = path.read_text(encoding="utf-8")
-        if parse_tools(text) is None:
-            continue
-        new_text, added = fix_tools_line(text, BASE_MCP_TOOLS)
-        if added:
-            path.write_text(new_text, encoding="utf-8")
-            fixed[name] = added
+    _offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=True)
     return fixed
 
 
@@ -135,10 +120,7 @@ def main(argv=None) -> int:
         print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
         return 1
 
-    if args.fix:
-        fixed = apply_fixes(agents_dir)
-
-    offenders = find_offenders(agents_dir)
+    offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
     unclassified = unclassified_agents(agents_dir)
     rc = 1 if (offenders or unclassified) else 0
 

--- a/plugins/dev-team/scripts/lib/mcp_tool_grants.py
+++ b/plugins/dev-team/scripts/lib/mcp_tool_grants.py
@@ -125,3 +125,44 @@ def fix_tools_line(text, required):
     new_line = m.group(1) + ", ".join(new_tokens)
     new_text = text[: m.start()] + new_line + text[m.end() - len(m.group(3)) :]
     return new_text, added
+
+
+def run_grants_check(targets, apply_fix=False):
+    """Single read+parse pass per target, shared by all three grant-check scripts.
+
+    ``targets`` is ``{name: (path, required)}``. Each target's file is read from
+    disk **at most once** regardless of ``apply_fix`` — the offender computation
+    below reuses the (possibly just-fixed) in-memory text rather than re-reading,
+    which is what let ``--fix`` runs silently do a second full read+parse pass
+    per file in the three callers before this helper existed (#1392).
+
+    Returns ``(offenders, fixed, unfixable)``:
+      - ``offenders``: ``{name: [missing tool names]}``, reflecting the
+        post-fix state when ``apply_fix`` is true.
+      - ``fixed``: ``{name: [tool names added]}`` — populated only when
+        ``apply_fix`` is true.
+      - ``unfixable``: ``[name, ...]`` — targets whose file exists but has no
+        appendable inline ``tools:`` line — populated only when ``apply_fix``
+        is true (mirrors each caller's prior ``apply_fixes()`` semantics).
+    """
+    offenders = {}
+    fixed = {}
+    unfixable = []
+    for name, (path, required) in targets.items():
+        if not path.is_file():
+            offenders[name] = list(required)
+            continue
+        text = path.read_text(encoding="utf-8")
+        if apply_fix:
+            if parse_tools(text) is None:
+                unfixable.append(name)
+            else:
+                new_text, added = fix_tools_line(text, required)
+                if added:
+                    path.write_text(new_text, encoding="utf-8")
+                    fixed[name] = added
+                    text = new_text
+        missing = missing_tools(text, required)
+        if missing:
+            offenders[name] = missing
+    return offenders, fixed, unfixable

--- a/plugins/dev-team/tests/scripts/test_mcp_tool_grants_run_grants_check.py
+++ b/plugins/dev-team/tests/scripts/test_mcp_tool_grants_run_grants_check.py
@@ -1,0 +1,106 @@
+"""Tests for `mcp_tool_grants.run_grants_check` — the shared single-pass runner
+extracted from the three near-duplicate MCP tool-grant check scripts (#1393),
+which also closes the double read+parse regression on `--fix` (#1392).
+"""
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from mcp_tool_grants import run_grants_check
+
+REQUIRED = ["mcp__a__x", "mcp__b__y"]
+
+
+def _agent(directory: Path, name: str, tools_line: str) -> Path:
+    path = directory / f"{name}.md"
+    path.write_text(f"---\nname: {name}\ntools: {tools_line}\n---\n# {name}\n", encoding="utf-8")
+    return path
+
+
+def test_detect_only_reports_missing_without_writing(tmp_path):
+    path = _agent(tmp_path, "foo", "Read, Grep, Glob")
+    before = path.read_text(encoding="utf-8")
+
+    offenders, fixed, unfixable = run_grants_check({"foo": (path, REQUIRED)})
+
+    assert offenders == {"foo": REQUIRED}
+    assert fixed == {}
+    assert unfixable == []
+    assert path.read_text(encoding="utf-8") == before  # untouched
+
+
+def test_apply_fix_writes_once_and_offenders_reflect_post_fix_state(tmp_path):
+    path = _agent(tmp_path, "foo", "Read, Grep, Glob")
+
+    offenders, fixed, unfixable = run_grants_check({"foo": (path, REQUIRED)}, apply_fix=True)
+
+    assert fixed == {"foo": REQUIRED}
+    assert offenders == {}  # computed from the already-fixed text, not stale
+    assert unfixable == []
+    assert "mcp__a__x" in path.read_text(encoding="utf-8")
+
+
+def test_apply_fix_reads_target_file_exactly_once(tmp_path, monkeypatch):
+    # Regression guard for #1392: the previous per-script pattern
+    # (`apply_fixes()` then a separate `find_offenders()` call) read every
+    # target file's text from disk twice on `--fix`. The shared runner must
+    # do a single `read_text()` per target regardless of `apply_fix`.
+    path = _agent(tmp_path, "foo", "Read, Grep, Glob")
+    read_calls = []
+    real_read_text = Path.read_text
+
+    def counting_read_text(self, *args, **kwargs):
+        if self == path:
+            read_calls.append(1)
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    run_grants_check({"foo": (path, REQUIRED)}, apply_fix=True)
+
+    assert len(read_calls) == 1
+
+
+def test_missing_file_is_an_offender_and_not_unfixable(tmp_path):
+    missing = tmp_path / "ghost.md"
+
+    offenders, fixed, unfixable = run_grants_check({"ghost": (missing, REQUIRED)}, apply_fix=True)
+
+    assert offenders == {"ghost": REQUIRED}
+    assert fixed == {}
+    assert unfixable == []  # no file to attempt fixing — distinct from unfixable
+
+
+def test_no_tools_line_is_unfixable_and_reported_as_fully_missing(tmp_path):
+    path = tmp_path / "notools.md"
+    path.write_text("---\nname: notools\n---\n# body\n", encoding="utf-8")
+
+    offenders, fixed, unfixable = run_grants_check({"notools": (path, REQUIRED)}, apply_fix=True)
+
+    assert unfixable == ["notools"]
+    assert fixed == {}
+    assert offenders == {"notools": REQUIRED}
+
+
+def test_already_compliant_target_is_not_an_offender_and_nothing_is_fixed(tmp_path):
+    path = _agent(tmp_path, "foo", "Read, Grep, Glob, " + ", ".join(REQUIRED))
+
+    offenders, fixed, unfixable = run_grants_check({"foo": (path, REQUIRED)}, apply_fix=True)
+
+    assert offenders == {}
+    assert fixed == {}
+    assert unfixable == []
+
+
+def test_second_apply_fix_pass_is_idempotent(tmp_path):
+    path = _agent(tmp_path, "foo", "Read, Grep, Glob")
+    run_grants_check({"foo": (path, REQUIRED)}, apply_fix=True)
+
+    offenders, fixed, unfixable = run_grants_check({"foo": (path, REQUIRED)}, apply_fix=True)
+
+    assert offenders == {}
+    assert fixed == {}
+    assert unfixable == []


### PR DESCRIPTION
## Summary

- Extract a shared single-pass runner (`mcp_tool_grants.run_grants_check`) used by all three MCP tool-grant check scripts, replacing their near-duplicate `apply_fixes()`/offender-detection loop bodies (#1393).
- As a direct consequence, fix the `--fix` double read+parse regression in `check_agent_tool_mapping.py` and `check_security_assessment_mcp_tools.py`, where `main()` called `apply_fixes()` and then a separate `find_offenders()`/`evaluate()` pass, re-reading and re-parsing every target file a second time (#1392).

Closes #1392
Closes #1393

## Key Changes

- `plugins/dev-team/scripts/lib/mcp_tool_grants.py` — new `run_grants_check(targets, apply_fix=False)`: reads each target file **at most once**, optionally applies+writes the fix, and computes `offenders` from the resulting in-memory text (post-fix when fixing) rather than re-reading from disk.
- `check_security_assessment_mcp_tools.py`, `check_agent_tool_mapping.py`, `check_review_agent_mcp_tools.py` — `apply_fixes()`/`find_offenders()`/`evaluate()` now delegate to the shared runner; `main()` in the two affected scripts calls it once instead of chaining two passes.
- Public function signatures, CLI flags, and JSON report shapes are unchanged for all three scripts — existing callers (`ci-local.sh`'s `chk_sa_mcp_tools`, `/agent-audit`, and each script's own tests) are unaffected.
- New test file `plugins/dev-team/tests/scripts/test_mcp_tool_grants_run_grants_check.py`, including a regression guard that monkeypatches `Path.read_text` to assert each target file is read exactly once during `--fix`.

## Decisions & Scope

- `#1393`'s issue body is truncated on GitHub before it states explicit acceptance criteria — it cuts off mid-sentence in the Problem section, before an Acceptance list. This PR sticks to the fully-specified complaint (the duplicated `apply_fixes()`/offender-detection loop bodies) rather than guessing further scope. Left out, as genuinely ambiguous without a stated acceptance bar:
  - Unifying the three scripts' already-diverged JSON report shapes (`skill_missing_phrases` vs `covered`/`swept` vs bare `unclassified`) — doing so would be a breaking change for any existing JSON consumer, and nothing in the truncated issue confirms it's in scope.
  - Consolidating `agent-audit/SKILL.md`'s three per-script prose paragraphs — each documents genuinely script-specific detail (different config names, different fix behaviors), not pure duplication.

## Test Plan

- [x] `plugins/dev-team/tests/scripts/test_mcp_tool_grants_run_grants_check.py` (new) — single-pass behavior, including the read-count regression guard for #1392.
- [x] All three scripts' existing test suites (`test_check_security_assessment_mcp_tools.py`, `test_check_agent_tool_mapping.py`, `test_check_review_agent_mcp_tools.py`) — pass unchanged (54 tests).
- [x] Full pytest dir list (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 4360 passed, 9 skipped, 0 failed.
- [x] `ruff check .` — no new findings (only the pre-existing 8 `N999` redteam-probe exemptions).
- [x] Live-ran all three scripts against the real repo in both detect and `--fix` mode — all report `OK`, `--fix` is a no-op (repo was already clean), confirmed idempotent.
- [x] `python3 scripts/check_md_references.py` and `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — both clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuGCykM5KWBpmy3xuaUx4r)_