### PR TITLE
fix: unify MCP grant-check JSON schema and consolidate agent-audit docs

### DIFF
--- a/plugins/dev-team/scripts/check_agent_tool_mapping.py
+++ b/plugins/dev-team/scripts/check_agent_tool_mapping.py
@@ -48,6 +48,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
     GET_WHY,
+    build_json_report,
     run_grants_check,
 )
 
@@ -164,17 +165,23 @@ def main(argv=None) -> int:
 
     swept = swept_agents(agents_dir)
     covered = sorted(set(TIER_CONFIG) | set(swept))
-    offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
+    offenders, fixed, unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
     unclassified = _unclassified(covered)
-    report = {"covered": covered, "swept": swept, "offenders": offenders, "unclassified": unclassified}
     rc = 1 if (offenders or unclassified) else 0
 
     if args.json:
         # --json owns stdout: emit ONLY the JSON object.
-        out = dict(report)
-        if args.fix:
-            out["fixed"] = fixed
-        print(json.dumps(out, indent=2))
+        report = build_json_report(
+            "agent-tool-mapping",
+            covered,
+            offenders,
+            ok=(rc == 0),
+            fixed=fixed,
+            unfixable=unfixable,
+            unclassified=unclassified,
+            notes={"swept": swept},
+        )
+        print(json.dumps(report, indent=2))
         return rc
 
     if args.fix:
@@ -195,7 +202,7 @@ def main(argv=None) -> int:
         for name in unclassified:
             print(f"  - {name}")
     if rc == 0:
-        print(f"OK: all {len(report['covered'])} covered agents match the tool mapping.")
+        print(f"OK: all {len(covered)} covered agents match the tool mapping.")
     return rc
 
 

--- a/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
+    build_json_report,
     parse_tools,  # noqa: F401 -- re-exported: imported directly by this script's own tests
     run_grants_check,
 )
@@ -139,18 +140,22 @@ def main() -> int:
 
     agents = find_review_agents(agents_dir)
     skill_missing = _skill_missing(skill_file)
+    offenders, fixed, unfixable = run_grants_check(_targets(agents), apply_fix=args.fix)
 
     if args.fix:
-        fixed, unfixable = apply_fixes(agents)
         rc = 1 if (unfixable or skill_missing) else 0
         if args.json:
             # --json owns stdout: emit ONLY the JSON object, nothing else.
-            print(json.dumps({
-                "reviewed": [a.stem for a in agents],
-                "fixed": fixed,
-                "unfixable": unfixable,
-                "skill_missing_phrases": skill_missing,
-            }, indent=2))
+            report = build_json_report(
+                "review-agent-mcp-tools",
+                [a.stem for a in agents],
+                offenders,
+                ok=(rc == 0),
+                fixed=fixed,
+                unfixable=unfixable,
+                notes={"skill_missing_phrases": skill_missing},
+            )
+            print(json.dumps(report, indent=2))
             return rc
         if fixed:
             for name, added in fixed.items():
@@ -165,15 +170,17 @@ def main() -> int:
                   + ", ".join(skill_missing), file=sys.stderr)
         return rc
 
-    offenders = find_offenders(agents)
     rc = 1 if (offenders or skill_missing) else 0
     if args.json:
         # --json owns stdout: emit ONLY the JSON object, nothing else.
-        print(json.dumps({
-            "reviewed": [a.stem for a in agents],
-            "offenders": offenders,
-            "skill_missing_phrases": skill_missing,
-        }, indent=2))
+        report = build_json_report(
+            "review-agent-mcp-tools",
+            [a.stem for a in agents],
+            offenders,
+            ok=(rc == 0),
+            notes={"skill_missing_phrases": skill_missing},
+        )
+        print(json.dumps(report, indent=2))
         return rc
     if offenders:
         print("FAIL: review agents missing code-intelligence MCP tools in tools::")

--- a/plugins/dev-team/scripts/check_security_assessment_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_security_assessment_mcp_tools.py
@@ -41,6 +41,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from mcp_tool_grants import (
     BASE_MCP_TOOLS,
+    build_json_report,
     run_grants_check,
 )
 
@@ -120,19 +121,21 @@ def main(argv=None) -> int:
         print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
         return 1
 
-    offenders, fixed, _unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
+    offenders, fixed, unfixable = run_grants_check(_targets(agents_dir), apply_fix=args.fix)
     unclassified = unclassified_agents(agents_dir)
     rc = 1 if (offenders or unclassified) else 0
 
     if args.json:
-        out = {
-            "reviewed": list(CODE_READING_AGENTS),
-            "offenders": offenders,
-            "unclassified": unclassified,
-        }
-        if args.fix:
-            out["fixed"] = fixed
-        print(json.dumps(out, indent=2))
+        report = build_json_report(
+            "security-assessment-mcp-tools",
+            CODE_READING_AGENTS,
+            offenders,
+            ok=(rc == 0),
+            fixed=fixed,
+            unfixable=unfixable,
+            unclassified=unclassified,
+        )
+        print(json.dumps(report, indent=2))
         return rc
 
     if args.fix:

--- a/plugins/dev-team/scripts/lib/mcp_tool_grants.py
+++ b/plugins/dev-team/scripts/lib/mcp_tool_grants.py
@@ -166,3 +166,40 @@ def run_grants_check(targets, apply_fix=False):
         if missing:
             offenders[name] = missing
     return offenders, fixed, unfixable
+
+
+def build_json_report(check, evaluated, offenders, ok, fixed=None, unfixable=None, unclassified=None, notes=None):
+    """Build the common ``--json`` envelope shared by all three grant-check scripts (#1393).
+
+    Each script's ``--json`` output previously diverged in shape (``reviewed`` vs
+    ``covered``, an ``unclassified`` key present on two scripts but absent on the
+    third, ``fixed``/``unfixable`` only appearing conditionally on ``--fix``) — a
+    caller wanting to aggregate "which grant checks are failing" across scripts had
+    no uniform surface to read. This helper gives every script the same top-level
+    keys, always present, so a future aggregator never needs a per-script branch:
+
+    - ``check``: a stable slug identifying which script produced the report.
+    - ``evaluated``: every target name the check looked at.
+    - ``offenders``: ``{name: [missing tool names]}`` (post-fix state if fixed).
+    - ``unclassified``: names present but classified into neither a required nor
+      an excluded bucket — ``[]`` when the check has no such concept.
+    - ``fixed`` / ``unfixable``: from ``run_grants_check`` — empty when detection
+      only (no ``--fix``).
+    - ``ok``: the caller's own exit-code decision, passed through rather than
+      re-derived here — some checks (e.g. the review-agent script's skill-prose
+      check) fail for reasons ``offenders``/``unclassified`` alone don't capture,
+      so this helper must not guess at "ok" from the other fields.
+    - ``notes``: a namespaced bag for the one or two fields that are genuinely
+      script-specific (e.g. ``skill_missing_phrases``, ``swept``) rather than
+      forcing every script into an identical key set that doesn't fit.
+    """
+    return {
+        "check": check,
+        "evaluated": list(evaluated),
+        "offenders": offenders,
+        "unclassified": list(unclassified or []),
+        "fixed": fixed or {},
+        "unfixable": list(unfixable or []),
+        "ok": ok,
+        "notes": notes or {},
+    }

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -159,29 +159,27 @@ Include the result in the agent report table under a `Skills-Tool` column.
 2. **Code-intelligence MCP invariant (review agents)**: Every read-only `*-review` agent MUST grant the five code-intelligence MCP tools in `tools:` — `mcp__codegraph__codegraph_explore` and `mcp__plugin_repowise_repowise__{get_context,get_symbol,search_codebase,get_risk}` — so a review on a repo with a CodeGraph/Repowise index uses verified skeletons and resolved call graphs instead of raw whole-file reads (the grant is inert when the server is absent; agents fall back to Read/Grep/Glob). This mirrors the Skills-Skill invariant: it self-extends to future `*-review` agents.
    - FAIL if any `*-review` agent's `tools:` line is missing one or more of the five names.
    - PASS if every `*-review` agent grants all five.
-   - Delegated to `scripts/check_review_agent_mcp_tools.py` (with `MCP_TOOL_NAMES` as the single source of truth); it also checks that [`code-review/SKILL.md`](../code-review/SKILL.md) still contains the code-intelligence phrases (the five tool names and `.codegraph/`) as a proxy for the detection/preference guidance — it asserts the phrases are present, not the instruction wording itself.
+   - Also checks that [`code-review/SKILL.md`](../code-review/SKILL.md) still contains the code-intelligence phrases (the five tool names and `.codegraph/`) as a proxy for the detection/preference guidance — it asserts the phrases are present, not the instruction wording itself.
 
-Include the result in the agent report table under a `Code-Intel` column.
-
-**Fix (when `--fix` is passed)**: run `python3 scripts/check_review_agent_mcp_tools.py --fix`, which appends the missing names (merge, never replacing `Read, Grep, Glob`/`Skill`). Report `FIXED: <agent> — added code-intelligence MCP tools`.
-
-3. **Code-intelligence mapping invariant (non-review team agents)**: Every non-review team agent in the #1108 mapping MUST grant its **tier's** tools in `tools:` — the **narrow** tier (`software-engineer`, `mutation-kill`, `qa-engineer`, `data-flow-tracer`) grants codegraph + the four Repowise tools, with `data-flow-tracer` also carrying a scoped `Bash(graphify *)`; the **rationale** tier (`adr-author`, `architect`, `security-engineer`, `platform-engineer`, `codebase-recon`) additionally grants `mcp__plugin_repowise_repowise__get_why`. Coverage is the union of the mapping's config keys and a structural sweep (team agents by `## Behavioral Guidelines` **or** `Enforcement: script`, minus `*-review`, minus a documented exclusion list), so a new team agent that is neither mapped nor excluded fails rather than silently escaping the mapping.
+3. **Code-intelligence mapping invariant (non-review team agents)**: Every non-review team agent in the #1108 mapping MUST grant its **tier's** tools in `tools:` — the **narrow** tier (`software-engineer`, `mutation-kill`, `qa-engineer`, `data-flow-tracer`) grants codegraph + the four Repowise tools, with `data-flow-tracer` also carrying a scoped `Bash(graphify *)`; the **rationale** tier (`adr-author`, `architect`, `security-engineer`, `platform-engineer`, `codebase-recon`) additionally grants `mcp__plugin_repowise_repowise__get_why`. Coverage is the union of the mapping's config keys and a structural sweep (team agents by `## Behavioral Guidelines` **or** `Enforcement: script`, minus `*-review`, minus a documented exclusion list), so a new team agent that is neither mapped nor excluded fails rather than silently escaping the mapping. This is the non-review counterpart to invariant 2: review agents keep their five-tool set there; this check never evaluates `*-review` agents.
    - FAIL if a mapped agent's `tools:` line is missing any of its tier's names, or a swept team agent is in neither the mapping nor the exclusion list (unclassified).
    - PASS if every mapped agent grants its tier's tools and every swept agent is mapped or excluded.
-   - Delegated to `scripts/check_agent_tool_mapping.py` (with `TIER_CONFIG`/`EXCLUSIONS` as the single source of truth, sharing `scripts/lib/mcp_tool_grants.py` with the review-agent check as a peer). This is the non-review counterpart to invariant 2: review agents keep their five-tool set there; the mapping check never evaluates `*-review` agents.
-
-Include the result in the agent report table under a `Mapping` column.
-
-**Fix (when `--fix` is passed)**: run `python3 scripts/check_agent_tool_mapping.py --fix`, which appends the missing tier names (merge, never replacing existing grants). Unclassified agents are reported, not auto-fixed — classify each into `TIER_CONFIG` or `EXCLUSIONS`. Report `FIXED: <agent> — added code-intelligence mapping tools`.
 
 4. **Code-intelligence grant invariant (security-assessment plugin, issue #1388)**: Invariants 2 and 3 above cover `plugins/dev-team/agents/` only. Every agent in `CODE_READING_AGENTS` (`authorization-logic-review`, `business-logic-domain-review`, `compliance-edge-annotator`, `cross-repo-synthesizer`, `deep-code-reasoning`, `fp-reduction`, `recon-driven-scan`, `tool-finding-narrative-annotator`) MUST grant the same five-tool `BASE_MCP_TOOLS` set in `tools:`. The remaining 5 synthesis-only `plugins/security-assessment/agents/*.md` files (`redteam-report-generator`, `exec-report-generator`, `redteam-recon-analyzer`, `redteam-evasion-analyzer`, `redteam-extraction-analyzer`) interpret a fixed set of upstream probe/report artifacts and produce narrative output rather than reasoning about arbitrary target-repo code, and are excluded — the grant would be inert for them (this is a fixed classification, not a `Glob`-presence heuristic: `exec-report-generator` carries `Glob` for its own artifact-directory walk yet is still excluded).
    - FAIL if a code-reading agent's `tools:` line is missing one or more of the five names, or an agent on disk is in neither roster (unclassified).
    - PASS if every code-reading agent grants all five and every agent on disk is classified.
-   - Delegated to `plugins/dev-team/scripts/check_security_assessment_mcp_tools.py` (sharing `scripts/lib/mcp_tool_grants.py`'s `BASE_MCP_TOOLS` as the single source of truth with invariants 2 and 3). Wired into `scripts/ci-local.sh` as `chk_sa_mcp_tools` so drift fails CI, not just this manual audit pass.
 
-Include the result in the agent report table under a `SA-MCP` column.
+**Mechanics for invariants 2–4**: all three delegate to `scripts/lib/mcp_tool_grants.py`'s shared `run_grants_check` (single read+parse pass per agent, both for detection and `--fix`) and, under `--json`, report the same envelope (`check`/`evaluated`/`offenders`/`unclassified`/`fixed`/`unfixable`/`ok`/`notes`) so results are comparable across the three checks.
 
-**Fix (when `--fix` is passed)**: run `python3 plugins/dev-team/scripts/check_security_assessment_mcp_tools.py --fix`, which appends the missing names (merge, never replacing existing grants). Unclassified agents are reported, not auto-fixed — classify each into `CODE_READING_AGENTS` or `NON_CODE_READING_AGENTS`. Report `FIXED: <agent> — added code-intelligence MCP tools`.
+| Invariant | Report column | Delegated script | Config source of truth | Unclassified handling |
+|---|---|---|---|---|
+| 2. Code-intelligence (review agents) | `Code-Intel` | `scripts/check_review_agent_mcp_tools.py` | `MCP_TOOL_NAMES` | n/a — glob-discovered, no roster |
+| 3. Code-intelligence mapping (non-review) | `Mapping` | `scripts/check_agent_tool_mapping.py` | `TIER_CONFIG` / `EXCLUSIONS` | reported, not auto-fixed |
+| 4. Code-intelligence (security-assessment) | `SA-MCP` | `plugins/dev-team/scripts/check_security_assessment_mcp_tools.py` | `CODE_READING_AGENTS` / `NON_CODE_READING_AGENTS` | reported, not auto-fixed |
+
+Include each invariant's result in the agent report table under its column above. Invariant 4 is additionally wired into `scripts/ci-local.sh` as `chk_sa_mcp_tools`, so drift fails CI, not just this manual audit pass.
+
+**Fix (when `--fix` is passed)**: run the delegated script above with `--fix` — it appends its missing tool names to `tools:` (merge, never replacing existing grants such as `Read, Grep, Glob`/`Skill`). Unclassified agents, where applicable, are reported, not auto-fixed — classify each into the config or exclusion list named above. Report `FIXED: <agent> — added <tool names>`.
 
 ### 2c. Audit team agent personas
 

--- a/plugins/dev-team/tests/scripts/test_check_agent_tool_mapping.py
+++ b/plugins/dev-team/tests/scripts/test_check_agent_tool_mapping.py
@@ -141,8 +141,17 @@ def test_json_report_smoke(tmp_path, capsys):
     rc = main(["--agents-dir", str(agents), "--json"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert set(out) == {"covered", "swept", "offenders", "unclassified"}
-    assert "software-engineer" in out["covered"]
+    # Common envelope shared by all three MCP grant-check scripts (#1393).
+    assert set(out) == {
+        "check", "evaluated", "offenders", "unclassified", "fixed", "unfixable", "ok", "notes",
+    }
+    assert out["check"] == "agent-tool-mapping"
+    assert "software-engineer" in out["evaluated"]
+    assert out["ok"] is True
+    assert out["fixed"] == {}
+    assert out["unfixable"] == []
+    assert "swept" in out["notes"]
+    assert "software-engineer" in out["notes"]["swept"]
 
 
 def test_block_form_tools_line_is_unfixable_not_mangled():

--- a/plugins/dev-team/tests/scripts/test_check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/tests/scripts/test_check_review_agent_mcp_tools.py
@@ -227,3 +227,40 @@ def test_main_json_emits_only_json_on_stdout(tmp_path, capsys):
     parsed = json.loads(out)
     assert rc == 1
     assert "bar-review" in parsed["offenders"]
+
+
+def test_json_report_smoke(tmp_path, capsys):
+    import json
+
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "foo-review", "Read, Grep, Glob, " + ", ".join(MCP_TOOL_NAMES))
+    rc = _call_main(agents_dir, skill_file, "--json")
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    # Common envelope shared by all three MCP grant-check scripts (#1393).
+    assert set(out) == {
+        "check", "evaluated", "offenders", "unclassified", "fixed", "unfixable", "ok", "notes",
+    }
+    assert out["check"] == "review-agent-mcp-tools"
+    assert out["evaluated"] == ["foo-review"]
+    assert out["offenders"] == {}
+    assert out["unclassified"] == []
+    assert out["fixed"] == {}
+    assert out["unfixable"] == []
+    assert out["ok"] is True
+    assert out["notes"] == {"skill_missing_phrases": []}
+
+
+def test_json_report_fix_mode_reflects_post_fix_offenders(tmp_path, capsys):
+    import json
+
+    agents_dir, skill_file = _tmp_env(tmp_path)
+    _agent(agents_dir, "baz-review", "Read, Grep, Glob")
+    rc = _call_main(agents_dir, skill_file, "--fix", "--json")
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["check"] == "review-agent-mcp-tools"
+    assert "baz-review" in out["fixed"]
+    assert out["offenders"] == {}  # computed from the already-fixed text
+    assert out["unfixable"] == []
+    assert out["ok"] is True

--- a/plugins/dev-team/tests/scripts/test_check_security_assessment_mcp_tools.py
+++ b/plugins/dev-team/tests/scripts/test_check_security_assessment_mcp_tools.py
@@ -144,9 +144,18 @@ def test_json_report_smoke(tmp_path, capsys):
     rc = main(["--agents-dir", str(agents), "--json"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert set(out) == {"reviewed", "offenders", "unclassified"}
+    # Common envelope shared by all three MCP grant-check scripts (#1393).
+    assert set(out) == {
+        "check", "evaluated", "offenders", "unclassified", "fixed", "unfixable", "ok", "notes",
+    }
+    assert out["check"] == "security-assessment-mcp-tools"
+    assert set(out["evaluated"]) == set(CODE_READING_AGENTS)
     assert out["offenders"] == {}
     assert out["unclassified"] == []
+    assert out["fixed"] == {}
+    assert out["unfixable"] == []
+    assert out["ok"] is True
+    assert out["notes"] == {}
 
 
 def test_main_missing_agents_dir_returns_one(tmp_path, capsys):


### PR DESCRIPTION
## Summary

Follow-up to #1400 (the shared single-pass runner for the three MCP tool-grant check scripts). That PR explicitly deferred two things pending confirmation, since #1393's issue body is truncated on GitHub before it states acceptance criteria for either. Both are implemented here.

1. **Unify the three scripts' `--json` schema.** Each had already diverged (`reviewed` vs `covered`, `unclassified` present on two but absent on the third, `fixed`/`unfixable` only conditionally present). I re-checked for live consumers before touching this — `scripts/ci-local.sh`'s `chk_sa_mcp_tools` calls plain-text mode, and `/agent-audit` reads human-readable stdout, not `--json`. Nothing in the repo parses this JSON except each script's own smoke test, so there was no breaking-change risk in reshaping it now.
2. **Consolidate `agent-audit/SKILL.md`'s three near-identical paragraphs** (invariants 2–4) — the repeated "Include the result... column" / "Fix (when `--fix` is passed)..." mechanics, not the genuinely distinct invariant definitions.

## Key Changes

- `plugins/dev-team/scripts/lib/mcp_tool_grants.py` — new `build_json_report(check, evaluated, offenders, ok, fixed=None, unfixable=None, unclassified=None, notes=None)`. `ok` is passed in by the caller rather than re-derived, because one check (the review-agent script's skill-prose requirement) can fail for a reason `offenders`/`unclassified` don't capture.
- All three scripts now emit the same envelope under `--json`:
  ```json
  {
    "check": "<script-slug>",
    "evaluated": [...],
    "offenders": {...},
    "unclassified": [...],
    "fixed": {...},
    "unfixable": [...],
    "ok": true,
    "notes": {}
  }
  ```
  Script-specific extras (`skill_missing_phrases`, `swept`) move into `notes` instead of being top-level keys only some scripts have.
- `check_review_agent_mcp_tools.py`'s `--fix --json` path now reports real post-fix `offenders` (previously hardcoded to `{}`) — a genuine, previously-untested behavior gap, now covered by a new test.
- `plugins/dev-team/skills/agent-audit/SKILL.md` — invariants 2–4 keep their own definition/FAIL/PASS bullets and script-specific caveats (e.g. invariant 2's skill-prose check, invariant 4's `exec-report-generator` exclusion note); the repeated column/fix-instruction boilerplate is now one shared table + one shared fix paragraph.

## Test Plan

- [x] Updated each script's `test_json_report_smoke` to assert the new envelope shape and exact `check` slug.
- [x] Added `test_json_report_fix_mode_reflects_post_fix_offenders` for the review-agent script — the previously-untested `--fix --json` combination.
- [x] `tests/scripts/test_agent_audit_integration.py` — still passes; both literal script-path substrings it pins survive in the new table.
- [x] `python3 scripts/check_md_references.py` and `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — both clean.
- [x] Full pytest dir list (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — 4362 passed, 9 skipped, 0 failed.
- [x] `ruff check .` — no new findings (only the pre-existing 8 `N999` redteam-probe exemptions).
- [x] Live-ran all three scripts' `--json` and `--fix --json` against the real repo — identical envelope shape across all three, `--fix` a no-op (repo already clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuGCykM5KWBpmy3xuaUx4r)_