### PR TITLE
fix: suppress E402 import-not-at-top lint errors in scripts and tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -20,3 +20,16 @@ extend-exclude = [
     "evals/refactor-granularity/tasks/*/golden",
     "evals/refactor-granularity/tasks/*/reference",
 ]
+
+# E402 (module-level import not at top of file) is suppressed for the paths
+# below because they rely on the `sys.path.insert(0, ...); import module`
+# idiom to import sibling scripts/libs that aren't installed as packages —
+# a deliberate pattern in this repo's hooks/scripts/tests, not lint debt.
+[lint.per-file-ignores]
+"tests/**" = ["E402"]
+"plugins/dev-team/tests/**" = ["E402"]
+"plugins/dev-team/hooks/**" = ["E402"]
+"plugins/dev-team/scripts/**" = ["E402"]
+"plugins/dev-team/skills/agent-readiness/scanner.py" = ["E402"]
+"scripts/**" = ["E402"]
+"evals/custom-tools/validate.py" = ["E402"]


### PR DESCRIPTION
## Summary

Configure ruff to suppress E402 (module-level import not at top of file) errors across test suites, hook scripts, and utility scripts that deliberately use the `sys.path.insert(0, ...); import module` idiom to import sibling modules that aren't installed as packages.

## Changes

- Added `[lint.per-file-ignores]` section to `ruff.toml` with E402 suppression for:
  - `tests/**` — repo-level test suites
  - `plugins/dev-team/tests/**` — plugin test suites
  - `plugins/dev-team/hooks/**` — PreToolUse/PostToolUse hook scripts
  - `plugins/dev-team/scripts/**` — plugin utility scripts
  - `plugins/dev-team/skills/agent-readiness/scanner.py` — specific skill module
  - `scripts/**` — repo-level utility scripts
  - `evals/custom-tools/validate.py` — eval fixture validator

## Implementation Details

This is a deliberate pattern in the repo's hooks, scripts, and tests — not lint debt. The suppression is scoped to specific paths where this idiom is used, allowing E402 to remain enforced elsewhere in the codebase as a quality gate for shipped code.

https://claude.ai/code/session_01XMN1zfxSmW81CFBLVta9HD