### PR TITLE
fix(project-init): gitignore .mcp.json when Repowise is provisioned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ DEV_TEAM_REPORTS/
 # the merged dataset (refactor-granularity-campaign.jsonl) is committed instead.
 docs/experiments/data/refactor-granularity-tdd-*.jsonl
 docs/experiments/data/refactor-granularity-test-after-*.jsonl
+
+# dev-team hygiene — machine-specific MCP config (absolute-path pollution — issues #1376, #1416)
+.mcp.json

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -345,7 +345,9 @@ in the missing set (regardless of key presence — its AST graph builds keyless)
 The per-tool mechanics below are unchanged; Step 4c only decides *whether* each
 runs. Each remains user-scoped/gitignored exactly as before, except Graphify's
 documented repo-level native integration — which is written on any Graphify
-accept (it does not require a key).
+accept (it does not require a key) — and the `.mcp.json` machine-specific-path
+hygiene standing check (#1416, filed under Repowise's sub-section below),
+which touches this repo's own `.gitignore`.
 
 #### CodeGraph — strictly personal, never committed
 
@@ -458,12 +460,24 @@ Run this tool's install/index through the `repowise-setup` skill (or the
 `.repowise/` to git's **global** ignore so the index never clutters the repo,
 and runs a **keyless** index (`--index-only`, no provider key requested).
 
+The install steps below run only when Step 4c's keyless-group opt-in accepts
+and Repowise is in the missing set. **The one exception is the `.mcp.json`
+standing check at the end of this sub-section (#1416)**, which runs on every
+`/project-init` pass regardless of the group's outcome — accept, decline, or
+already-present — the same carve-out the Graphify sub-section's own Standing
+check (#1367) makes below.
+
 **Install steps (executed only when the all-or-none group is accepted):**
 
 1. Install: prefer `uv tool install repowise`, else `pipx install repowise`,
    else `python3 -m pip install --user repowise`.
 2. Index keyless: run the repowise index in `--index-only` mode so no API key
-   is requested; the index lands under `.repowise/` (gitignored).
+   is requested; the index lands under `.repowise/` (gitignored). This step
+   (or an equivalent `repowise init` invocation) is known to write a
+   project-root `.mcp.json` registering the repowise MCP server, with an
+   `args` array baking in this machine's absolute filesystem path — the
+   **standing check below** (not gated behind this install branch) covers it
+   regardless of whether `.mcp.json` existed before this run.
 3. Register the MCP server for this Claude Code installation (user scope), the
    same way any personal MCP server is added — point the user at
    `claude mcp add --help` for the exact invocation. **Server-name caveat:**
@@ -481,6 +495,55 @@ and runs a **keyless** index (`--index-only`, no provider key requested).
 command -v repowise > /dev/null 2>&1 && echo "installed" || echo "not-installed"
 [ -d "${PWD}/.repowise" ] && echo "indexed" || echo "not-indexed"
 ```
+
+**Standing check — `.mcp.json` machine-specific-path hygiene, runs every pass
+(issues #1376, #1416).** Unlike the install steps above, this check is **not**
+gated behind the all-or-none group's accept/decline branch or the
+"already present" skip — a repo can carry an ungitignored `.mcp.json` from a
+Repowise install that predates this guard, and once Repowise shows as
+already-present the accept-gated install steps above never re-run (the same
+shape issue #1367's Graphify settings.json standing check, below, already
+solves for a different pollution class). It is filed under the Repowise
+sub-section because that install is the more common source of a project's
+`.mcp.json`, but the check itself is repo-wide — it also covers a `.mcp.json`
+written by `index-codebase` or a hand-registered MCP server. So run this scan
+unconditionally, once per `/project-init` (and therefore `/setup`) run,
+idempotently appending the same `.gitignore` marker block `/setup` applies
+for its own downstream backstop check, so the two never duplicate an entry
+regardless of which one runs first. The marker prefix (everything up to and
+including `machine-specific MCP config`) must stay byte-identical between
+the two blocks — `grep -qF` matches that prefix only, so the trailing
+issue-number suffix may differ, but changing the prefix itself in only one
+place breaks idempotency (`tests/skills/test_project_init_mcp_json_hygiene.py`
+pins both copies):
+
+```bash
+MCP_MARKER="# dev-team hygiene — machine-specific MCP config"
+if ! grep -qF "$MCP_MARKER" .gitignore 2>/dev/null; then
+  printf '\n%s\n%s\n' \
+    "$MCP_MARKER (absolute-path pollution — issues #1376, #1416)" \
+    ".mcp.json" >> .gitignore
+  echo "mcp-json-gitignore-updated"
+else
+  echo "mcp-json-gitignore-already-covered"
+fi
+```
+
+This check is intentionally **not** scoped to the downstream-only, Step 2
+`in-repo`-skip case the way `/setup`'s own backstop check is — a
+machine-specific path in `.mcp.json` breaks every clone or teammate
+regardless of whether the repo is this plugin's own checkout or a downstream
+project, so this standing check applies in both. If `.mcp.json` is already
+tracked by git (`git ls-files --error-unmatch .mcp.json` exits 0), do not
+untrack it automatically — tell the operator to run `git rm --cached
+.mcp.json` themselves, same posture as #1376, and record that outcome too.
+Merge one of `{"mcp_hygiene": {"gitignore": "added"}}`,
+`{"mcp_hygiene": {"gitignore": "already-covered"}}`, or (when the
+already-tracked case above fires) `{"mcp_hygiene": {"gitignore":
+"added-but-tracked"}}` into `.claude/init-state.json` — a top-level key
+rather than nested under `repowise`, since this check runs independently of
+Repowise's own install state. Report the outcome as its own line in Step 6's
+summary below (and the caller's own report, when `/setup` is the caller).
 
 #### Graphify — native integration, opt-in, with corruption/pollution guards
 
@@ -696,6 +759,10 @@ After every configured lane probes green, give the user:
   CodeGraph is strictly user-level/personal and Graphify is the repo-level
   native integration; its AST build is keyless, with semantic enrichment as a
   key-gated add-on.
+- **`.mcp.json` machine-specific-path hygiene** (issue #1416, runs
+  independently of Repowise's own install/decline state): added the block,
+  found it already covered, or flagged that `.mcp.json` is still git-tracked
+  and needs `git rm --cached`.
 - Files created (greenfield only).
 
 ## Greenfield JS/TS scaffold

--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -765,7 +765,11 @@ Create a project-specific `skills/pr/SKILL.md` if one doesn't exist, referencing
 **Downstream projects only** — skip this step entirely when Step 2 detected
 `in-repo` (the plugin-dev repo curates its own `.gitignore`, and it tracks
 deliverables under `memory/` such as `decisions.md` and eval fixtures that
-this blanket ignore would wrongly hide).
+this blanket ignore would wrongly hide). One carve-out: the `.mcp.json`
+standing check `project-init`'s Repowise sub-section runs (#1416) is
+unconditional and reaches in-repo too, via this skill's own Step 4 — that one
+`.gitignore` entry lands regardless of Step 2's result. See the `.mcp.json`
+paragraph below.
 
 `/test-improve`, `/build`, and the review workflows write per-run resume
 state, progress bookkeeping, reports, and metrics into `memory/`, `reports/`,
@@ -803,11 +807,11 @@ If the project relocated `reports/` via `DEV_TEAM_REPORTS` or `metrics/` via
 the block was added for the Step 12 report. Under `--dry-run`, report what
 would be appended without writing.
 
-**`.mcp.json` machine-specific-path hygiene (issue #1376).** Separately —
-still downstream-projects-only, same Step 2 `in-repo` skip — a project's
-`.mcp.json` (written by `index-codebase`/Repowise setup or hand-registered
-MCP servers) commonly bakes in the absolute filesystem path of the machine
-that wrote it (e.g. a Repowise or CodeGraph server's `args` array). If
+**`.mcp.json` machine-specific-path hygiene (issues #1376, #1416).**
+Separately — still downstream-projects-only, same Step 2 `in-repo` skip — a
+project's `.mcp.json` (written by `index-codebase`, hand-registered MCP
+servers, or any other means) commonly bakes in the absolute filesystem path
+of the machine that wrote it (e.g. a CodeGraph server's `args` array). If
 committed, every other clone inherits a path that doesn't exist on their
 machine and the server fails to start. Idempotently append its own block
 (independent marker, so this check runs and self-heals even on a repo where
@@ -825,6 +829,19 @@ else
 fi
 ```
 
+This exact marker (including the em dash) is also emitted, unconditionally
+and regardless of in-repo/downstream, by the `.mcp.json` machine-specific-path
+hygiene standing check in `project-init`'s Repowise sub-section (issue #1416
+— Repowise's own install path is the more common source of a project's
+`.mcp.json`, and that check no longer waits for this downstream-only Step 11
+pass to cover it). The marker prefix (everything up to and including
+`machine-specific MCP config`) must stay byte-identical between the two
+blocks — `grep -qF` matches that prefix only, so the trailing issue-number
+suffix may differ, but changing the prefix itself in only one place breaks
+idempotency. This block remains a downstream-only, defense-in-depth backstop
+for `.mcp.json` files written by means other than Repowise (e.g.
+`index-codebase`, hand-registered MCP servers).
+
 This ignores `.mcp.json` going forward regardless of whether it currently
 exists — the same "detect it whenever we write or see it" contract issue
 #1376 asks for. If `.mcp.json` is already tracked by git (`git ls-files
@@ -832,7 +849,10 @@ exists — the same "detect it whenever we write or see it" contract issue
 .mcp.json` themselves rather than doing it automatically — untracking is a
 history-visible action `/setup` should not take silently. Record whether the
 block was added for the Step 12 report. Under `--dry-run`, report what would
-be appended without writing.
+be appended without writing. Reached via `/setup` (Step 4 runs `/project-init`
+before this step), this block normally reports already-covered, since
+`/project-init`'s own standing check already ran first — the "added" outcome
+is what a direct, standalone `/project-init` invocation reports.
 
 ### 12. Report
 
@@ -868,6 +888,7 @@ tool line.
 ### Code-intelligence indexes (project-init Step 4c — all-or-none group)
 - CodeGraph: ✓ installed + `.codegraph/` built (keyless)   [or: ✗ declined | ✗ failed]
 - Repowise:  ✓ installed + `.repowise/` indexed (keyless)   [or: ✗ declined | ✗ failed]
+  - `.mcp.json` gitignore: ✓ added   [or: ✓ already covered | ⚠ tracked by git — run `git rm --cached .mcp.json` (#1416)]
 - Graphify:  ✓ `graphify-out/` built (keyless AST; enrichment key-gated)   [or: ✗ declined | ✗ failed]
   - settings.json guard: ✓ clean   [or: ✓ relocated N machine-specific graphify hook(s) to settings.local.json (#1367)]
 
@@ -877,12 +898,15 @@ settings.json guard line reports project-init's standing check (#1367) — it
 runs on every pass, including one where Graphify install itself is skipped
 because it's already present, so a repo carrying a machine-specific path from
 an install predating this guard gets self-healed the next time `/setup` runs.
+The `.mcp.json` gitignore line reports project-init's own standing check
+(#1416) the same way — it runs on every pass, in-repo included, regardless of
+Repowise's own install/decline state for that run.
 
 ### Created
 - `.claude/project-stack.json` — stack detection results
 - `.claude/CLAUDE.md` — project conventions
 - `.claude/settings.json` — PostToolUse formatting hook (prettier + eslint)
-- `.gitignore` — dev-team runtime artifacts (memory/, reports/, metrics/, plans/, .review-passed) plus `.mcp.json` machine-specific-path hygiene (#1376)   [downstream only; omit if already covered]
+- `.gitignore` — dev-team runtime artifacts (memory/, reports/, metrics/, plans/, .review-passed)   [downstream only; omit if already covered] plus `.mcp.json` machine-specific-path hygiene (#1376, #1416)   [runs in-repo too, via project-init's Repowise standing check; omit if already covered]
 - Activated templates: ts-enforcer, esm-enforcer, react-testing
 
 ### Recommendations

--- a/tests/skills/test_project_init_mcp_json_hygiene.py
+++ b/tests/skills/test_project_init_mcp_json_hygiene.py
@@ -1,0 +1,177 @@
+"""#1416 — Repowise's install steps in `project-init/SKILL.md` must gitignore
+`.mcp.json` themselves, immediately as part of provisioning, and self-heal on
+repos where Repowise was already installed before this guard existed.
+
+`/setup` Step 11's `.mcp.json` hygiene block (#1376) is downstream-projects-
+only and skipped entirely for the `in-repo` case, but Repowise's `init`
+write happens in `/project-init` regardless of which skill invoked it — so
+the write and the ignore-hygiene were decoupled, leaving an in-repo gap.
+This must be fixed at the source: Repowise's own sub-section, as an
+unconditional **standing check** (same shape as the Graphify settings.json
+standing check, issue #1367, elsewhere in this file) rather than a step
+gated behind the accept/decline branch — otherwise it would never run for a
+repo where Repowise is already present (Step 4c's own "already present"
+skip means the accept-gated install steps never re-run).
+
+Same structural-sensor style as tests/skills/test_setup_gitignore_hygiene.py
+— pure text greps over shipped SKILL.md prose.
+"""
+
+from __future__ import annotations
+
+import re
+
+from skill_doc_helpers import PLUGIN_ROOT, REPO_ROOT, collapsed, section_outside_code
+
+PROJECT_INIT = (PLUGIN_ROOT / "skills" / "project-init" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+SETUP = (PLUGIN_ROOT / "skills" / "setup" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _mcp_json_standing_check() -> str:
+    """Bound to just the Repowise `.mcp.json` standing-check paragraph — not
+    the whole Repowise sub-section — so a false pass can't come from `.mcp.json`
+    incidentally appearing in the install steps' prose (it does, at the
+    Step 2 write-awareness sentence) or in Step 6's summary line further
+    down. `section_outside_code` (not `section`) because the paragraph
+    itself embeds a fenced bash block, and a fence-naive boundary match
+    could be tripped by a line inside that fence."""
+    return section_outside_code(
+        PROJECT_INIT,
+        r"^\*\*Standing check — `\.mcp\.json` machine-specific-path hygiene",
+        boundary_pattern=r"^#### ",
+        include_start_line=True,
+    )
+
+
+def _setup_step_11_mcp_json_block() -> str:
+    """Bound to `/setup`'s own `.mcp.json` paragraph (not the whole Step 11
+    gitignore-hygiene section, which also covers the unrelated runtime-
+    artifacts block) for the same false-pass reason as above."""
+    return section_outside_code(
+        SETUP,
+        r"^\*\*`\.mcp\.json` machine-specific-path hygiene",
+        boundary_pattern=r"^### ",
+        include_start_line=True,
+    )
+
+
+def test_repowise_standing_check_gitignores_mcp_json():
+    check = _mcp_json_standing_check()
+    # Bound to the MCP_MARKER...fi bash block itself — .mcp.json also recurs
+    # earlier in the install steps' prose and later in Step 6's summary, so
+    # an unscoped substring check would be trivially satisfied even if this
+    # block were deleted. section_outside_code already strips the ``` fence
+    # delimiter lines (but keeps their content), so the block's own closing
+    # `fi` — not a stripped-away ``` — is what bounds the match here.
+    block = re.search(r'MCP_MARKER="# dev-team hygiene[^"]*".*?\bfi\b', collapsed(check))
+    assert block, "expected the MCP_MARKER gitignore-append bash block in the standing check"
+    content = block.group(0)
+    assert ".mcp.json" in content
+    assert 'grep -qF "$MCP_MARKER" .gitignore' in content
+
+
+def test_repowise_standing_check_is_not_gated_behind_install_branch():
+    check = _mcp_json_standing_check()
+    assert "not" in check
+    assert "already present" in check
+    # The claim under test is that this is unconditional, not merely that
+    # the words "/setup" and "/project-init" co-occur somewhere nearby.
+    assert "never re-run" in check
+
+
+def test_repowise_mcp_json_hygiene_uses_same_marker_as_setup_step_11():
+    # Reusing the exact marker string from setup/SKILL.md's own .mcp.json
+    # block means whichever runs first is idempotent against the other — no
+    # duplicate .gitignore entry regardless of call order. grep -qF matches
+    # the marker prefix only, so the differing issue-number suffixes in the
+    # two appended comment lines don't break this.
+    marker = '# dev-team hygiene — machine-specific MCP config'
+    assert marker in _mcp_json_standing_check()
+    setup_block = _setup_step_11_mcp_json_block()
+    assert marker in setup_block
+    assert 'grep -qF "$MCP_MARKER" .gitignore' in setup_block
+
+
+def test_repowise_mcp_json_already_tracked_defers_to_operator():
+    check = collapsed(_mcp_json_standing_check())
+    assert "git rm --cached" in check
+    assert "do not" in check and "untrack it automatically" in check
+
+
+def test_repowise_standing_check_is_not_downstream_only():
+    # Unlike /setup's Step 11 (which keeps the Step 2 in-repo skip), this
+    # check is deliberately unconditional for in-repo too — a stale
+    # machine-specific path breaks every clone regardless of which kind of
+    # repo wrote it.
+    check = collapsed(_mcp_json_standing_check())
+    assert "in-repo" in check
+    assert "downstream-only" in check or "downstream-projects-only" in check
+
+
+def test_repowise_standing_check_records_state():
+    check = collapsed(_mcp_json_standing_check())
+    # A top-level "mcp_hygiene" key, not nested under "repowise" — the check
+    # runs independently of Repowise's own install/decline state, so filing
+    # its outcome under the Repowise key would misrepresent a run where
+    # Repowise itself was declined but the standing check still fired.
+    assert '"mcp_hygiene"' in check
+    assert '"gitignore"' in check
+    assert "init-state.json" in check
+
+
+def test_repowise_standing_check_covers_already_tracked_state():
+    # A third recorded outcome for the one branch that leaves the repo still
+    # broken (already git-tracked, needs operator follow-up) — distinct from
+    # "added" and "already-covered" so a re-run can tell them apart.
+    check = collapsed(_mcp_json_standing_check())
+    assert "added-but-tracked" in check
+
+
+def test_repowise_subsection_head_carves_out_the_standing_check():
+    # The Graphify sub-section explicitly tells the executing agent its own
+    # Standing check (#1367) runs regardless of the opt-in outcome, right at
+    # the top of that sub-section. The Repowise sub-section needs the same
+    # carve-out at its own head — otherwise an agent following Step 4c's
+    # "already present" or "declined" branches (both of which just print a
+    # message and continue) never has a reason to read this far into the
+    # Repowise sub-section at all.
+    head = section_outside_code(
+        PROJECT_INIT,
+        r"^#### Repowise — keyless local index, MCP server",
+        boundary_pattern=r"^\*\*Install steps",
+    )
+    assert "#1416" in head
+    assert "regardless of the group" in head or "regardless of" in head
+
+
+def test_repo_own_gitignore_preseeds_the_mcp_json_marker():
+    # This repo is in-repo (not downstream), and the standing check is
+    # unconditional for in-repo too — so without pre-seeding the entry here,
+    # the very next /project-init (or /setup) run against this checkout would
+    # append the block on the spot, producing exactly the unexpected dirty
+    # working tree issue #1416 is about. Pre-seeding makes that first run a
+    # no-op ("already-covered") instead.
+    gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    assert "# dev-team hygiene — machine-specific MCP config" in gitignore
+    assert ".mcp.json" in gitignore
+
+
+def test_setup_step_11_cross_references_project_init_1416():
+    # #1416 moved primary responsibility to project-init's standing check;
+    # setup's own block stays as a downstream-only defense-in-depth backstop
+    # for .mcp.json files written by other means — that split should be
+    # explicit in setup's own prose, not only in project-init's.
+    block = collapsed(_setup_step_11_mcp_json_block())
+    assert "#1416" in block
+    assert "project-init" in block
+
+
+def test_step_6_summary_mentions_mcp_json_hygiene_outcome():
+    # Mirrors test_setup_gitignore_hygiene.py's
+    # test_step_12_report_mentions_both_new_gitignore_entries — the
+    # analogous reporting claim for project-init's own summary step.
+    step_6 = section_outside_code(PROJECT_INIT, r"^### Step 6: Summary", boundary_pattern=r"^## ")
+    assert ".mcp.json" in step_6
+    assert "#1416" in step_6

--- a/tests/skills/test_setup_gitignore_hygiene.py
+++ b/tests/skills/test_setup_gitignore_hygiene.py
@@ -46,7 +46,7 @@ def test_mcp_json_gets_its_own_idempotent_gitignore_block():
 
 def test_mcp_json_block_is_downstream_only_like_the_runtime_artifacts_block():
     body = collapsed(SETUP)
-    mcp_section = body[body.index("machine-specific-path hygiene (issue #1376)"):]
+    mcp_section = body[body.index("machine-specific-path hygiene (issues #1376, #1416)"):]
     assert "downstream-projects-only" in mcp_section[:400]
 
 


### PR DESCRIPTION
## Problem

`/project-init`'s Repowise install steps write a project-root `.mcp.json` baking in a machine-specific absolute path. Gitignore hygiene for that file only lived in `/setup` Step 11, which is downstream-projects-only and skips entirely for the `in-repo` case — so a repo carrying Repowise's write (this repo included) never got it ignored.

## Fix

- Added an **unconditional standing check** to Repowise's own sub-section in `project-init/SKILL.md` (mirroring the existing Graphify settings.json standing check, #1367) instead of a step gated behind the accept/decline branch. This self-heals regardless of in-repo/downstream, caller (`/setup`, direct `/project-init`, or any future caller), or whether Repowise is already installed — the accept-gated install steps never re-run once a tool is already present, so gating the hygiene there would have missed exactly the repo state #1416 describes.
- Reuses the exact same `.gitignore` marker `/setup`'s own block uses, so neither duplicates an entry regardless of call order.
- If `.mcp.json` is already tracked by git, does **not** untrack it automatically — tells the operator to `git rm --cached .mcp.json` themselves (same posture as #1376).
- Pre-seeded this repo's own `.gitignore` with the entry, so the next in-repo run is a no-op instead of an unexpected dirty working tree.
- `/setup` Step 11's block stays in place as a downstream-only, defense-in-depth backstop for `.mcp.json` files written by means other than Repowise (hand-registered MCP servers, `index-codebase`, etc.) — both files now cross-reference each other explicitly, and the outcome is recorded under a top-level `mcp_hygiene` key in `.claude/init-state.json` (not nested under `repowise`, since the check runs independently of Repowise's own install/decline state).

Per the issue's third bullet: **`/setup` Step 11's `.mcp.json` block is not redundant** — it remains the correct defense-in-depth standing check for `.mcp.json` files written by means other than Repowise.

## Deferred (flagged here per review, not fixed — out of proportion to this isolated fix)

- **ADR 0012** (`docs/adr/0012-auto-bootstrap-codegraph-index-per-clone.md`, still `Accepted`) describes a commit-`.mcp.json`-for-CodeGraph workflow. Verified this was already dead before this change: `codegraph_bootstrap.py` keys purely on `.codegraph/` presence, and `project-init/SKILL.md`'s CodeGraph section (unchanged by this diff) already forbids writing project `.mcp.json` — the reversal is test-locked via issue #846. Worth a follow-up issue to mark the ADR Superseded.
- **`/setup --dry-run`** promises "no files written," but Step 4 invokes `/project-init` with no dry-run pass-through at all today. Pre-existing and sweeping — affects every write `/project-init` makes (npm/pip installs, scaffold files, the existing #1367 Graphify check), not specific to this change. Worth its own follow-up issue.
- The gitignore-append shell block is duplicated across `setup/SKILL.md` and `project-init/SKILL.md` rather than extracted into a shared stdlib-Python helper (this skill's own established pattern for `claude_md_guard.py`/`settings_hook_guard.py`). Only 2 occurrences exist today (repo's rule-of-three not met); tests pin both copies so drift fails CI.

## Test plan

- [x] `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` — 4372 passed, 9 skipped
- [x] `scripts/check_md_references.py` — clean
- [x] `plugins/dev-team/hooks/lib/build_knowledge_index.py` — clean, no stray changes
- [x] New structural-sensor tests in `tests/skills/test_project_init_mcp_json_hygiene.py` (16 tests total across both hygiene test files)

Closes #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPQ3MnZBW99EwZjvx7mSz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPQ3MnZBW99EwZjvx7mSz4)_