### PR TITLE
fix(review-gate): move .review-passed to .claude/memory/

### DIFF
--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -212,10 +212,10 @@ The full lifecycle of these files — discovery to applied fix, including who ow
 
 ### 9. Pre-commit gate file
 
-When the review was auto-scoped to uncommitted changes and the final status is `pass` or `warn`, the orchestrator writes `.review-passed` — a SHA-256 hash of the reviewed file list:
+When the review was auto-scoped to uncommitted changes and the final status is `pass` or `warn`, the orchestrator writes `.review-passed` to `.claude/memory/` — a SHA-256 hash of the reviewed file list:
 
 ```bash
-git diff --cached --name-only | sort | shasum -a 256 | cut -d' ' -f1 > .review-passed
+mkdir -p .claude/memory && git diff --cached --no-color | shasum -a 256 | cut -d' ' -f1 > .claude/memory/.review-passed
 ```
 
 The pre-commit hook reads this file to verify the staged files match what was actually reviewed. If the review failed, `.review-passed` is **not** written, and commits are blocked until the review is re-run and passes.

--- a/plugins/dev-team/docs/concurrent-use.md
+++ b/plugins/dev-team/docs/concurrent-use.md
@@ -13,7 +13,7 @@ The plugin's local coordination state is per-checkout, not shared:
 
 | State | Where | Shared across checkouts? |
 | --- | --- | --- |
-| Review gate `.review-passed` | repo root, **gitignored** | No — local to each working tree |
+| Review gate `.review-passed` | `.claude/memory/`, **gitignored** | No — local to each working tree |
 | Plan / build progress | `plans/<name>.md` (**tracked**) | Merges through normal git |
 
 So two developers, each with their **own clone**, never collide on these — and

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -237,7 +237,8 @@ def main() -> int:
 
     current_hash = review_gate_hash()
 
-    gate_file = Path(".review-passed")
+    gate_file = Path(".claude/memory/.review-passed")
+    gate_file.parent.mkdir(parents=True, exist_ok=True)
     if gate_file.is_file():
         try:
             stored = gate_file.read_text().strip()

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -195,6 +195,7 @@ Otherwise read the roster from the **Review Agents** section of `knowledge/agent
 This replaces any hardcoded per-agent dispatch rules. Adding or changing a review agent's trigger scope requires only editing that agent's own body — zero edits to this skill.
 
 **Framework-specific reactivity review** — dispatch based on the project's dependency manifest (`package.json` etc.):
+
 - React (`react` / `react-dom` in deps): include `react-reactivity-review` scoped to `.jsx`/`.tsx` and React-importing `.js`/`.ts` files
 - Vue (`vue` in deps): include `vue-reactivity-review` scoped to `.vue` and Vue-importing `.js`/`.ts` files
 - Angular (`@angular/core` in deps): include `angular-reactivity-review` scoped to `*.component.ts`, `*.component.html`, `*.service.ts`, and general `.ts` files
@@ -420,10 +421,10 @@ For issues NOT auto-fixed (confidence: none, auto-fix failed, or suggestions), g
 
 **Skip this entire step if `--json` was set** (same reason as step 8).
 
-If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` so the pre-commit hook allows the next commit. Use the **shared gate-hash helper** so the writer and the pre-commit hook compute the hash identically — it hashes the staged **content** (the cached patch), not just the file paths (#193), so any edit after review invalidates the gate:
+If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn`, write `.review-passed` to `.claude/memory/` so the pre-commit hook allows the next commit. Use the **shared gate-hash helper** so the writer and the pre-commit hook compute the hash identically — it hashes the staged **content** (the cached patch), not just the file paths (#193), so any edit after review invalidates the gate:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py > .review-passed
+mkdir -p .claude/memory && python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py > .claude/memory/.review-passed
 ```
 
 Stage the exact changes you reviewed (`git add` them) before writing the gate, so the staged content the hook hashes matches what was reviewed. If `git diff --cached` is empty (you reviewed unstaged changes), stage them first — the gate binds to the staged patch by design.

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -234,19 +234,23 @@ def test_missing_gate_file_blocks(repo: Path) -> None:
 
 def test_matching_gate_file_passes_and_is_consumed(repo: Path) -> None:
     h = _current_hash(repo)
-    (repo / ".review-passed").write_text(h)
+    gate_path = repo / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(h)
     r = _run(
         {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
     )
     assert r.returncode == 0
     # Gate file consumed on success.
-    assert not (repo / ".review-passed").exists()
+    assert not (repo / ".claude" / "memory" / ".review-passed").exists()
 
 
 def test_stale_gate_file_blocks(repo: Path) -> None:
     """Reviewed content changed → hash mismatch → block. Gate file NOT removed."""
     h = _current_hash(repo)
-    (repo / ".review-passed").write_text(h)
+    gate_path = repo / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(h)
     # Edit the staged file's content.
     (repo / "a.ts").write_text("v2-unreviewed\n")
     env = hermetic_git_env(home=repo)
@@ -258,12 +262,14 @@ def test_stale_gate_file_blocks(repo: Path) -> None:
     assert "BLOCKED" in r.stdout
     assert "BLOCKED" in r.stderr
     # Gate file preserved because it did NOT match.
-    assert (repo / ".review-passed").exists()
+    assert (repo / ".claude" / "memory" / ".review-passed").exists()
 
 
 def test_extra_staged_file_after_review_blocks(repo: Path) -> None:
     h = _current_hash(repo)
-    (repo / ".review-passed").write_text(h)
+    gate_path = repo / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(h)
     (repo / "b.ts").write_text("new\n")
     env = hermetic_git_env(home=repo)
     subprocess.run(["git", "add", "b.ts"], cwd=repo, env=env, check=True)

--- a/tests/repo/test_multiplayer_collision.py
+++ b/tests/repo/test_multiplayer_collision.py
@@ -65,7 +65,9 @@ def _commit_hook(cwd: Path) -> subprocess.CompletedProcess:
 
 
 def _write_gate(cwd: Path) -> None:
-    (cwd / ".review-passed").write_text(_rgh.review_gate_hash(cwd=cwd))
+    gate_path = cwd / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(_rgh.review_gate_hash(cwd=cwd))
 
 
 def test_baseline_gate_written_for_current_staged_content_allows_commit(
@@ -84,7 +86,8 @@ def test_collision_a_second_agent_overwriting_review_passed_falsely_blocks_the_f
     (work / "a.ts").write_text("v1\n")
     subprocess.run(["git", "add", "a.ts"], cwd=work, env=_git_env(), check=True)
     _write_gate(work)  # agent A passed review for its staged content
-    (work / ".review-passed").write_text(
+    gate_path = work / ".claude" / "memory" / ".review-passed"
+    gate_path.write_text(
         "a-different-agents-hash\n"
     )  # agent B (same tree) overwrote it
     res = _commit_hook(work)  # A commits its still-staged change

--- a/tests/repo/test_pre_commit_review_gate.py
+++ b/tests/repo/test_pre_commit_review_gate.py
@@ -78,7 +78,9 @@ def _write_gate(work: Path, hermetic_env: dict[str, str]) -> None:
         text=True,
         check=True,
     )
-    (work / ".review-passed").write_text(result.stdout)
+    gate_path = work / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(result.stdout)
 
 
 def test_gate_exact_staged_content_that_was_reviewed_commits_cleanly(
@@ -89,7 +91,9 @@ def test_gate_exact_staged_content_that_was_reviewed_commits_cleanly(
     _write_gate(work, hermetic_env)
     result = _commit_hook(work, hermetic_env)
     assert result.returncode == 0
-    assert not (work / ".review-passed").is_file()  # consumed on success
+    assert not (
+        work / ".claude" / "memory" / ".review-passed"
+    ).is_file()  # consumed on success
 
 
 def test_gate_editing_a_reviewed_files_content_reblocks_the_commit(


### PR DESCRIPTION
## Summary

Relocates the `.review-passed` gate file from the repo root to `.claude/memory/` to keep dev-team runtime artifacts centralized and organized.

- Pre-commit hook now reads/writes from `.claude/memory/.review-passed`
- Code-review skill Step 9 writes to the same location
- File remains gitignored (under `.claude/`)
- All 20 gate-related tests pass

## Test plan

- [x] `pytest plugins/dev-team/tests/hooks/test_pre_commit_review.py` — 14 tests pass
- [x] `pytest tests/repo/test_pre_commit_review_gate.py` — 4 tests pass
- [x] `pytest tests/repo/test_multiplayer_collision.py` — 2 tests pass