### PR TITLE
fix(skills): migrate remaining skills off the legacy reports/ path

### DIFF
--- a/evals/fixtures/tmr-phase1-missing-seams/phase-1.md
+++ b/evals/fixtures/tmr-phase1-missing-seams/phase-1.md
@@ -1,7 +1,7 @@
 # Phase 1 — Analysis (test-modernize)
 
 - Repo slug: `orders-api`
-- Assessment file: `reports/cd-test-architecture-orders-api.md`
+- Assessment file: `.dev-team-reports/cd-test-architecture-orders-api.md`
 - Resolved sink: `local-files`
 - Quality targets: line ≥ 90%, branch ≥ 90%, mutants = 0, determinism = 100%, wall-clock = fastest achievable
 

--- a/evals/fixtures/tmr-phase1-pass/phase-1.md
+++ b/evals/fixtures/tmr-phase1-pass/phase-1.md
@@ -1,7 +1,7 @@
 # Phase 1 — Analysis (test-modernize)
 
 - Repo slug: `orders-api`
-- Assessment file: `reports/cd-test-architecture-orders-api.md`
+- Assessment file: `.dev-team-reports/cd-test-architecture-orders-api.md`
 - Resolved sink: `gh` (<https://github.com/acme/orders-api/issues/42>)
 - Quality targets: line ≥ 90%, branch ≥ 90%, mutants = 0, determinism = 100%, wall-clock = fastest achievable
 

--- a/plugins/dev-team/docs/test-evaluation.md
+++ b/plugins/dev-team/docs/test-evaluation.md
@@ -106,7 +106,7 @@ Ordered lowest-risk first, each step independently shippable. The spine is **bas
 
 ### Step 6: Report
 
-Output goes to `reports/cd-test-architecture-<app>.md`. Tables, not prose: components and patterns, current tests and their CD-fitness, gaps, target architecture, pre-merge gate composition, migration path, next steps.
+Output goes to `.dev-team-reports/cd-test-architecture-<app>.md`. Tables, not prose: components and patterns, current tests and their CD-fitness, gaps, target architecture, pre-merge gate composition, migration path, next steps.
 
 ---
 

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -2383,7 +2383,7 @@
       "anchor": "6-report"
     },
     "Output": {
-      "summary": "Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component).",
+      "summary": "Write to `.dev-team-reports/cd-test-architecture-<app>.md` (or chat for a single component).",
       "anchor": "output"
     },
     "Integration": {
@@ -2639,7 +2639,7 @@
       "anchor": "step-5-prioritization"
     },
     "Output Format": {
-      "summary": "Write the report to `reports/competitive-analysis-<date>.md` using this structure.",
+      "summary": "Write the report to `.dev-team-reports/competitive-analysis-<date>.md` using this structure.",
       "anchor": "output-format"
     },
     "Presenting Results": {
@@ -4409,7 +4409,7 @@
       "anchor": "threats-to-validity"
     },
     "Report": {
-      "summary": "Write the report to `reports/orchestration-benchmark-<date>.md`.",
+      "summary": "Write the report to `.dev-team-reports/orchestration-benchmark-<date>.md`.",
       "anchor": "report"
     },
     "Relationship to other tooling": {
@@ -5593,7 +5593,7 @@
       "anchor": "5-report"
     },
     "Output": {
-      "summary": "A concise advisory report (to chat for a single unit, or to `reports/test-design-<target>.md` for a module):",
+      "summary": "A concise advisory report (to chat for a single unit, or to `.dev-team-reports/test-design-<target>.md` for a module):",
       "anchor": "output"
     },
     "Integration": {
@@ -5635,7 +5635,7 @@
       "anchor": "5-aggregate-and-de-duplicate"
     },
     "6. Report": {
-      "summary": "Produce one report (chat for a small target; `reports/test-design-<date>.md`",
+      "summary": "Produce one report (chat for a small target; `.dev-team-reports/test-design-<date>.md`",
       "anchor": "6-report"
     }
   },
@@ -5747,7 +5747,7 @@
       "anchor": "8-ordered-improvement-plan"
     },
     "9. Report": {
-      "summary": "Write `reports/test-health-<date>.md`.",
+      "summary": "Write `.dev-team-reports/test-health-<date>.md`.",
       "anchor": "9-report"
     },
     "Output": {

--- a/plugins/dev-team/knowledge/report-pdf-integration.md
+++ b/plugins/dev-team/knowledge/report-pdf-integration.md
@@ -8,8 +8,7 @@ this file rather than restating the behavior, so the wording never drifts.
 This file defines *how `--pdf` behaves*. `hooks/lib/report_pdf.py` is the render
 engine it calls; [`report-to-pdf.md`](report-to-pdf.md) is the underlying
 recipe; [`report-output-location.md`](report-output-location.md) details the
-`.dev-team-reports/` write rules — the per-skill paths (including the `reports/`
-ones) are in the table below.
+`.dev-team-reports/` write rules — the per-skill paths are in the table below.
 
 ## Contract
 
@@ -53,9 +52,9 @@ self-diagnose which they hit:
 |-------|----------------------------|--------------------|
 | `/code-review` | `.dev-team-reports/code-review.md` | `--json` or `--internal` (no file written) |
 | `/triage` | `.dev-team-reports/triage/<slug>.md` (the path just written) | never — it always writes a file |
-| `/test-health` | `reports/test-health-<date>.md` | never — it always writes a file |
-| `/cd-test-architecture` | `reports/cd-test-architecture-<app>.md` | single-component **chat-only** run (no file) |
-| `/harness-audit` | `reports/harness-audit-<date>.md`, or the `--output <path>` override | never — it always writes a file |
+| `/test-health` | `.dev-team-reports/test-health-<date>.md` | never — it always writes a file |
+| `/cd-test-architecture` | `.dev-team-reports/cd-test-architecture-<app>.md` | single-component **chat-only** run (no file) |
+| `/harness-audit` | `.dev-team-reports/harness-audit-<date>.md`, or the `--output <path>` override | never — it always writes a file |
 
 A new report-producing skill inherits `--pdf` by adding a row here, documenting
 `--pdf` in its `argument-hint`, and calling `report_pdf.py` on the path it wrote

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -113,13 +113,13 @@ Write the assessment (see Output). Keep every recommendation tied to a concrete 
 
 ## Output
 
-Write to `reports/cd-test-architecture-<app>.md` (or chat for a single component).
+Write to `.dev-team-reports/cd-test-architecture-<app>.md` (or chat for a single component).
 
 When `--pdf` was passed and a report **file** was written, render it to a
 sibling PDF per `knowledge/report-pdf-integration.md`:
 
 ```bash
-sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" reports/cd-test-architecture-<app>.md
+sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" .dev-team-reports/cd-test-architecture-<app>.md
 ```
 
 In the single-component **chat-only** case no file was written, so `--pdf` is a

--- a/plugins/dev-team/skills/competitive-analysis/SKILL.md
+++ b/plugins/dev-team/skills/competitive-analysis/SKILL.md
@@ -116,7 +116,7 @@ After listing all gaps, rank the top 5 by impact. Impact considers:
 
 ## Output Format
 
-Write the report to `reports/competitive-analysis-<date>.md` using this structure.
+Write the report to `.dev-team-reports/competitive-analysis-<date>.md` using this structure.
 
 For the header block and closing Provenance section, follow
 `knowledge/report-template.md`; the sections below are this skill's own

--- a/plugins/dev-team/skills/frontend-architecture/SKILL.md
+++ b/plugins/dev-team/skills/frontend-architecture/SKILL.md
@@ -85,7 +85,7 @@ per constraint 3.
 ### 4. Report
 
 If `--json`, emit the aggregated JSON object and stop. Otherwise produce one
-report (chat for a small target; `reports/frontend-architecture-<date>.md` for a
+report (chat for a small target; `.dev-team-reports/frontend-architecture-<date>.md` for a
 module):
 
 ```markdown

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -36,7 +36,7 @@ You have been invoked with the `/harness-audit` command.
 
 Arguments: $ARGUMENTS
 
-- `--output <path>`: Write report to a specific path. Default: `reports/harness-audit-<date>.md`
+- `--output <path>`: Write report to a specific path. Default: `.dev-team-reports/harness-audit-<date>.md`
 - `--pdf`: After writing the report, render it to a sibling PDF via `hooks/lib/report_pdf.py`, resolving against the **actual** report path written this run (the `--output` override when given, else the default). See `knowledge/report-pdf-integration.md`. Additive; non-fatal if no engine is available.
 
 ## Steps
@@ -306,7 +306,7 @@ Review the current pipeline for components that may be unnecessary overhead:
 ### 8. Produce report
 
 When `--pdf` was passed, after writing the report render **the actual output
-path** (the `--output` override when given, else `reports/harness-audit-<date>.md`)
+path** (the `--output` override when given, else `.dev-team-reports/harness-audit-<date>.md`)
 to a sibling PDF per `knowledge/report-pdf-integration.md` (additive; non-fatal
 if no engine):
 

--- a/plugins/dev-team/skills/harness-e2e-check/SKILL.md
+++ b/plugins/dev-team/skills/harness-e2e-check/SKILL.md
@@ -51,7 +51,7 @@ Arguments: $ARGUMENTS
 - No argument: run all 8 items below.
 - `--item N`: run only item N (1-6).
 - `--output <path>`: write the full report to a specific path. Default:
-  `reports/harness-e2e-check-<date>.md`.
+  `.dev-team-reports/harness-e2e-check-<date>.md`.
 
 ## The 8 items
 

--- a/plugins/dev-team/skills/issues-from-assessment/SKILL.md
+++ b/plugins/dev-team/skills/issues-from-assessment/SKILL.md
@@ -24,7 +24,7 @@ You have been invoked with the `/issues-from-assessment` command.
 
 Arguments: $ARGUMENTS
 
-- Positional: `<assessment-path>` — the file `/cd-test-architecture` wrote (`reports/cd-test-architecture-<app>.md`).
+- Positional: `<assessment-path>` — the file `/cd-test-architecture` wrote (`.dev-team-reports/cd-test-architecture-<app>.md`).
 - `--parent <issue-url>` — parent issue / Feature / Epic URL. Empty or omitted → local-files mode.
 - `--repo-slug <slug>` — slug used for the `.claude/memory/<workflow>/<slug>/` namespace. Defaults to the assessment file's `<app>` token.
 - `--workflow <name>` — the workflow namespace under `.claude/memory/` and `.claude/plans/`, and the leading tracker-label token. Defaults to `test-improve`. Callers pass their own namespace so parallel runs stay quarantined.

--- a/plugins/dev-team/skills/orchestration-benchmark/SKILL.md
+++ b/plugins/dev-team/skills/orchestration-benchmark/SKILL.md
@@ -153,7 +153,7 @@ skipped:
 
 ## Report
 
-Write the report to `reports/orchestration-benchmark-<date>.md`.
+Write the report to `.dev-team-reports/orchestration-benchmark-<date>.md`.
 
 For the header block and closing Provenance section, follow
 `knowledge/report-template.md`; the sections below are this skill's own

--- a/plugins/dev-team/skills/report-pdf/SKILL.md
+++ b/plugins/dev-team/skills/report-pdf/SKILL.md
@@ -22,7 +22,7 @@ You have been invoked with the `/report-pdf` command.
 ## Arguments
 
 - `<path.md>` (required) — path to the Markdown report to render (for example
-  `.dev-team-reports/code-review.md` or `reports/test-health-2026-07-16.md`).
+  `.dev-team-reports/code-review.md` or `.dev-team-reports/test-health-2026-07-16.md`).
 - `--out <path>` (optional) — output PDF path. Defaults to the source path with
   a `.pdf` extension, next to the source. A missing parent directory is created.
 

--- a/plugins/dev-team/skills/test-design-advisor/SKILL.md
+++ b/plugins/dev-team/skills/test-design-advisor/SKILL.md
@@ -118,7 +118,7 @@ Write the recommendation (see Output). Keep it actionable — every recommendati
 
 ## Output
 
-A concise advisory report (to chat for a single unit, or to `reports/test-design-<target>.md` for a module):
+A concise advisory report (to chat for a single unit, or to `.dev-team-reports/test-design-<target>.md` for a module):
 
 ```markdown
 ## Test Design — <target>

--- a/plugins/dev-team/skills/test-design/SKILL.md
+++ b/plugins/dev-team/skills/test-design/SKILL.md
@@ -131,7 +131,7 @@ whole suite), then fragile/obscure smells, then suggestions.
 
 ### 6. Report
 
-Produce one report (chat for a small target; `reports/test-design-<date>.md`
+Produce one report (chat for a small target; `.dev-team-reports/test-design-<date>.md`
 for a module):
 
 ```markdown

--- a/plugins/dev-team/skills/test-health/SKILL.md
+++ b/plugins/dev-team/skills/test-health/SKILL.md
@@ -164,13 +164,13 @@ Produce a risk-ordered, incremental plan — each item a concrete next move (whi
 
 ### 9. Report
 
-Write `reports/test-health-<date>.md`.
+Write `.dev-team-reports/test-health-<date>.md`.
 
 When `--pdf` was passed, render that report to a sibling PDF per
 `knowledge/report-pdf-integration.md` (additive; non-fatal if no engine):
 
 ```bash
-sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" reports/test-health-<date>.md
+sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" .dev-team-reports/test-health-<date>.md
 ```
 
 ## Output

--- a/tests/skills/test_1432_legacy_reports_path_migration.py
+++ b/tests/skills/test_1432_legacy_reports_path_migration.py
@@ -1,0 +1,126 @@
+"""#1432 — nine report-producing skills migrate off the legacy bare
+`reports/` path onto the consolidated `.dev-team-reports/` location (the
+same location #1415/Slice 9 already moved `/review-agent`, `/code-review`,
+and `/triage` to — see `test_dev_team_reports_consolidation.py`). Content-
+guard tests, one function per migrated skill, asserting the new location is
+documented and the legacy bare fragment is gone.
+
+`issues-from-assessment/SKILL.md` carries one dependent reference to
+`cd-test-architecture`'s output path (also migrated here) plus one
+pre-existing, unrelated dangling reference to a `reports/legacy-test-
+modernization-prompt.md` file that predates #1432 and does not exist in the
+repo — deliberately excluded from the bare-fragment assertion below so this
+module doesn't fail on a defect outside its own scope.
+"""
+
+from __future__ import annotations
+
+import re
+
+from skill_doc_helpers import PLUGIN_ROOT
+
+_BARE_REPORTS_RE = re.compile(r"(?<!\.dev-team-)reports/")
+
+CD_TEST_ARCHITECTURE = (
+    PLUGIN_ROOT / "skills" / "cd-test-architecture" / "SKILL.md"
+).read_text(encoding="utf-8")
+TEST_HEALTH = (PLUGIN_ROOT / "skills" / "test-health" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+HARNESS_AUDIT = (PLUGIN_ROOT / "skills" / "harness-audit" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+ORCHESTRATION_BENCHMARK = (
+    PLUGIN_ROOT / "skills" / "orchestration-benchmark" / "SKILL.md"
+).read_text(encoding="utf-8")
+FRONTEND_ARCHITECTURE = (
+    PLUGIN_ROOT / "skills" / "frontend-architecture" / "SKILL.md"
+).read_text(encoding="utf-8")
+COMPETITIVE_ANALYSIS = (
+    PLUGIN_ROOT / "skills" / "competitive-analysis" / "SKILL.md"
+).read_text(encoding="utf-8")
+HARNESS_E2E_CHECK = (
+    PLUGIN_ROOT / "skills" / "harness-e2e-check" / "SKILL.md"
+).read_text(encoding="utf-8")
+TEST_DESIGN = (PLUGIN_ROOT / "skills" / "test-design" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+TEST_DESIGN_ADVISOR = (
+    PLUGIN_ROOT / "skills" / "test-design-advisor" / "SKILL.md"
+).read_text(encoding="utf-8")
+ISSUES_FROM_ASSESSMENT = (
+    PLUGIN_ROOT / "skills" / "issues-from-assessment" / "SKILL.md"
+).read_text(encoding="utf-8")
+REPORT_PDF_INTEGRATION = (
+    PLUGIN_ROOT / "knowledge" / "report-pdf-integration.md"
+).read_text(encoding="utf-8")
+REPORT_PDF_SKILL = (PLUGIN_ROOT / "skills" / "report-pdf" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+
+
+def test_cd_test_architecture_report_path_relocated() -> None:
+    assert ".dev-team-reports/cd-test-architecture-<app>.md" in CD_TEST_ARCHITECTURE
+    assert not _BARE_REPORTS_RE.search(CD_TEST_ARCHITECTURE)
+
+
+def test_test_health_report_path_relocated() -> None:
+    assert ".dev-team-reports/test-health-<date>.md" in TEST_HEALTH
+    assert not _BARE_REPORTS_RE.search(TEST_HEALTH)
+
+
+def test_harness_audit_report_path_relocated() -> None:
+    assert ".dev-team-reports/harness-audit-<date>.md" in HARNESS_AUDIT
+    assert not _BARE_REPORTS_RE.search(HARNESS_AUDIT)
+
+
+def test_orchestration_benchmark_report_path_relocated() -> None:
+    assert ".dev-team-reports/orchestration-benchmark-<date>.md" in ORCHESTRATION_BENCHMARK
+    assert not _BARE_REPORTS_RE.search(ORCHESTRATION_BENCHMARK)
+
+
+def test_frontend_architecture_report_path_relocated() -> None:
+    assert ".dev-team-reports/frontend-architecture-<date>.md" in FRONTEND_ARCHITECTURE
+    assert not _BARE_REPORTS_RE.search(FRONTEND_ARCHITECTURE)
+
+
+def test_competitive_analysis_report_path_relocated() -> None:
+    assert ".dev-team-reports/competitive-analysis-<date>.md" in COMPETITIVE_ANALYSIS
+    assert not _BARE_REPORTS_RE.search(COMPETITIVE_ANALYSIS)
+
+
+def test_harness_e2e_check_report_path_relocated() -> None:
+    assert ".dev-team-reports/harness-e2e-check-<date>.md" in HARNESS_E2E_CHECK
+    assert not _BARE_REPORTS_RE.search(HARNESS_E2E_CHECK)
+
+
+def test_test_design_report_path_relocated() -> None:
+    assert ".dev-team-reports/test-design-<date>.md" in TEST_DESIGN
+    assert not _BARE_REPORTS_RE.search(TEST_DESIGN)
+
+
+def test_test_design_advisor_report_path_relocated() -> None:
+    assert ".dev-team-reports/test-design-<target>.md" in TEST_DESIGN_ADVISOR
+    assert not _BARE_REPORTS_RE.search(TEST_DESIGN_ADVISOR)
+
+
+def test_issues_from_assessment_dependent_reference_relocated() -> None:
+    # Scoped literal check, not the blanket _BARE_REPORTS_RE sweep: this file
+    # also carries a pre-existing, unrelated dangling reference to
+    # `reports/legacy-test-modernization-prompt.md` (a file that does not
+    # exist in the repo, predates #1432, and is out of this issue's scope).
+    assert ".dev-team-reports/cd-test-architecture-<app>.md" in ISSUES_FROM_ASSESSMENT
+
+
+def test_report_pdf_integration_table_relocated() -> None:
+    for path_frag in (
+        ".dev-team-reports/test-health-<date>.md",
+        ".dev-team-reports/cd-test-architecture-<app>.md",
+        ".dev-team-reports/harness-audit-<date>.md",
+    ):
+        assert path_frag in REPORT_PDF_INTEGRATION
+    assert "(including the `reports/`" not in REPORT_PDF_INTEGRATION
+
+
+def test_report_pdf_skill_example_relocated() -> None:
+    assert ".dev-team-reports/test-health-2026-07-16.md" in REPORT_PDF_SKILL

--- a/tests/skills/test_pdf_flag_integration.py
+++ b/tests/skills/test_pdf_flag_integration.py
@@ -67,9 +67,9 @@ def test_shared_contract_doc_exists_and_pins_wording():
     for path_frag in (
         ".dev-team-reports/code-review.md",
         ".dev-team-reports/triage/<slug>.md",
-        "reports/test-health-<date>.md",
-        "reports/cd-test-architecture-<app>.md",
-        "reports/harness-audit-<date>.md",
+        ".dev-team-reports/test-health-<date>.md",
+        ".dev-team-reports/cd-test-architecture-<app>.md",
+        ".dev-team-reports/harness-audit-<date>.md",
     ):
         assert path_frag in INTEGRATION_DOC
 

--- a/tests/skills/test_slice7_remaining_skill_artifact_paths.py
+++ b/tests/skills/test_slice7_remaining_skill_artifact_paths.py
@@ -12,11 +12,14 @@ its own memory/metrics scratch-state writes stay bare per the plan's Step
 test-audit-disable/SKILL.md.
 
 `.plans/domain/` (ubiquitous-language/SKILL.md), `~/.claude/agent-memory/`
-(templates/agents/agent-template.md), security-assessment's own memory/
-patterns (static-analysis-integration/references/security-review-adapter.md),
-and every "other" (non-AC19) reports/ domain (test-design, test-design-
-advisor, test-health, orchestration-benchmark's own report path) are
-deliberately excluded — established false-positive categories.
+(templates/agents/agent-template.md), and security-assessment's own memory/
+patterns (static-analysis-integration/references/security-review-adapter.md)
+are deliberately excluded — established false-positive categories.
+
+Note: orchestration-benchmark's own report path (along with 8 other skills)
+was migrated off the bare `reports/` path by #1432 — see
+`tests/skills/test_1432_legacy_reports_path_migration.py`, not the `.claude/`
+metrics/memory migration this module otherwise covers.
 """
 
 from __future__ import annotations
@@ -49,8 +52,6 @@ _BARE_MEMORY_RE = re.compile(r"(?<!\.claude/)memory/")
 
 def test_orchestration_benchmark_review_value_relocated() -> None:
     assert ".claude/metrics/review-value.jsonl" in ORCHESTRATION_BENCHMARK
-    # its own report path is the non-AC19 reports domain, deliberately bare
-    assert "reports/orchestration-benchmark-<date>.md" in ORCHESTRATION_BENCHMARK
 
 
 def test_plan_skill_both_config_changelog_occurrences_relocated() -> None:


### PR DESCRIPTION
## Summary
- Nine skills (cd-test-architecture, test-health, harness-audit, orchestration-benchmark, frontend-architecture, competitive-analysis, harness-e2e-check, test-design, test-design-advisor) still wrote their generated report to the legacy top-level `reports/` path — left out of #1415's explicit scope during the earlier `DEV_TEAM_REPORTS/`+`reports/` consolidation. Migrated all nine to the consolidated `.dev-team-reports/` path.
- Fixed the one dependent reference (`issues-from-assessment/SKILL.md`), `report-pdf/SKILL.md`'s own stale argument example, and `report-pdf-integration.md`'s stale table rows + lead-in text.
- Added dedicated regression coverage (`tests/skills/test_1432_legacy_reports_path_migration.py`) — one content-guard test per migrated skill, matching this repo's established convention (`test_dev_team_reports_consolidation.py`).
- Reviewed via a 12-agent `/code-review` panel; every actionable finding (naming convention, stale cross-references, test-duplication smell, coverage gap) was fixed. Two out-of-scope items were surfaced instead of silently touched: a pre-existing dangling reference in `issues-from-assessment/SKILL.md:75` to a `reports/legacy-test-modernization-prompt.md` file that doesn't exist in the repo, and a stale hardcoded report filename in `scripts/harness-fixes.sh:681` that never matched either path convention.

Closes #1432

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts -n auto --dist loadfile` — 4772 passed, 3 pre-existing environment-gated skips.
- [x] `python3 scripts/check_md_references.py` — clean.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — index rebuilt.
- [x] Pushed with `--no-verify`: `scripts/ci-local.sh`'s whole-repo `ruff check .` fails on pre-existing, unrelated debt already on `main` (confirmed via `git show main:<path> | ruff check -`) — tracked separately as #1438, operator-approved bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)