### PR TITLE
fix(lint): fix pre-existing ruff findings and rename N999 probe modules

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,8 +19,8 @@ if [ -x plugins/dev-team/hooks/lib/build-knowledge-index.sh ]; then
   git add plugins/dev-team/knowledge/index.json
 fi
 
-# 2. Run lint-staged: eslint --fix on the staged JS/TS files, with the
-#    autofixes automatically re-staged (see the lint-staged config in
-#    package.json). The pre-push CI mirror (scripts/ci-local.sh) still runs the
-#    full eslint gate.
+# 2. Run lint-staged: eslint --fix on staged JS/TS files and ruff check --fix
+#    on staged Python files, with the autofixes automatically re-staged (see
+#    the lint-staged config in package.json). The pre-push CI mirror
+#    (scripts/ci-local.sh) still runs the full eslint and ruff gates.
 npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:ci": "bash scripts/ci-local.sh"
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --fix"
+    "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --fix",
+    "*.py": "ruff check --fix"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",

--- a/plugins/dev-team/scripts/gherkin_stub_merge.py
+++ b/plugins/dev-team/scripts/gherkin_stub_merge.py
@@ -45,10 +45,12 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE / "lib"))
 
-from stub_extractors import ERROR_DANGLING_ANNOTATION as ERROR_DANGLING_ANNOTATION  # noqa: F401
-from stub_extractors import ERROR_UNBALANCED_BRACES as ERROR_UNBALANCED_BRACES  # noqa: F401
+from stub_extractors import (
+    ERROR_DANGLING_ANNOTATION,  # noqa: F401
+    ERROR_UNBALANCED_BRACES,  # noqa: F401
+    parse_existing_steps,
+)
 from stub_extractors import go as _go_extractor
-from stub_extractors import parse_existing_steps
 
 # This script's own error sentinels — distinct from the two structural
 # sentinels stub_extractors returns (re-exported above), the same split

--- a/plugins/dev-team/scripts/lib/stub_extractors/__init__.py
+++ b/plugins/dev-team/scripts/lib/stub_extractors/__init__.py
@@ -44,7 +44,12 @@ from __future__ import annotations
 from _bdd_markers import MARKERS_BY_EXT as _PENDING_MARKERS_BY_EXT
 
 from . import csharp, go, java, jsts
-from ._common import ERROR_DANGLING_ANNOTATION, ERROR_UNBALANCED_BRACES, ParseResult, StepBinding
+from ._common import (
+    ERROR_DANGLING_ANNOTATION,
+    ERROR_UNBALANCED_BRACES,
+    ParseResult,
+    StepBinding,
+)
 
 __all__ = [
     "ERROR_DANGLING_ANNOTATION",

--- a/plugins/dev-team/scripts/test_improve_resume.py
+++ b/plugins/dev-team/scripts/test_improve_resume.py
@@ -63,7 +63,7 @@ _HOOKS_LIB_DIR = Path(__file__).resolve().parent.parent / "hooks" / "lib"
 if str(_HOOKS_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_LIB_DIR))
 
-import artifact_paths  # noqa: E402
+import artifact_paths
 
 # Execution order (issue #1422), skipping `3` (Phase 3 has no numbered
 # progress file — see module docstring). Phase identities are unchanged

--- a/plugins/dev-team/tests/hooks/test_artifact_paths.py
+++ b/plugins/dev-team/tests/hooks/test_artifact_paths.py
@@ -20,9 +20,8 @@ _TESTS_LIB = _REPO_ROOT / "plugins" / "dev-team" / "tests" / "lib"
 if str(_TESTS_LIB) not in sys.path:
     sys.path.insert(0, str(_TESTS_LIB))
 
-import pytest
-
 import artifact_paths  # type: ignore[import-not-found]
+import pytest
 from hermetic import hermetic_git_env  # type: ignore[import-not-found]
 
 

--- a/plugins/security-assessment/CLAUDE.md
+++ b/plugins/security-assessment/CLAUDE.md
@@ -135,7 +135,7 @@ See `install.sh`. It performs four checks:
 **Harness** (Python, under `harness/`):
 
 - `redteam/orchestrator.py` + `config.py` + `lib/{http_client,result_store,scoring,feature_dict,scope_check}.py`
-- 8 probes: `redteam/probes/{01..08}_*.py`
+- 8 probes: `redteam/probes/probe_{01..08}_*.py`
 - `tools/{service-comm-parser,shared-cred-hash-match}.py`
 
 See `plans/security-review-companion-plugin.md` for the step-by-step history.

--- a/plugins/security-assessment/commands/export-pdf.md
+++ b/plugins/security-assessment/commands/export-pdf.md
@@ -64,7 +64,7 @@ pandoc "$INPUT" \
 **Fallback (weasyprint + python-markdown):**
 
 The input Markdown is derived from a scanned repo / probed model (see
-`08_report_generator.py`, `service-comm-parser.py`) — treat it as
+`probe_08_report_generator.py`, `service-comm-parser.py`) — treat it as
 untrusted. Rendered HTML/CSS can reference remote resources (`<img
 src="https://...">`, CSS `url(...)`), and weasyprint fetches those by
 default, which is a plausible SSRF vector at PDF-conversion time. Pass a

--- a/plugins/security-assessment/docs/workflows.md
+++ b/plugins/security-assessment/docs/workflows.md
@@ -52,14 +52,14 @@ The `security-assessment` plugin provides two **orchestrator** commands that seq
 
 Eight probes (in `harness/redteam/probes/`) run in sequence:
 
-1. `01_api_recon` — documentation paths, HTTP methods, content types, server headers.
-2. `02_schema_discovery` — the model's input feature list.
-3. `03_feature_sensitivity` — sweep each feature across a value range.
-4. `04_boundary_mapping` — binary-search per-feature decision boundaries.
-5. `05_evasion_attack` — adversarial inputs that receive low fraud scores.
-6. `06_input_validation` — malformed-input handling.
-7. `07_model_extraction` — surrogate models trained against captured scores.
-8. `08_report_generator` — compiles probe outputs into `adversarial-report.md`.
+1. `probe_01_api_recon` — documentation paths, HTTP methods, content types, server headers.
+2. `probe_02_schema_discovery` — the model's input feature list.
+3. `probe_03_feature_sensitivity` — sweep each feature across a value range.
+4. `probe_04_boundary_mapping` — binary-search per-feature decision boundaries.
+5. `probe_05_evasion_attack` — adversarial inputs that receive low fraud scores.
+6. `probe_06_input_validation` — malformed-input handling.
+7. `probe_07_model_extraction` — surrogate models trained against captured scores.
+8. `probe_08_report_generator` — compiles probe outputs into `adversarial-report.md`.
 
 ---
 

--- a/plugins/security-assessment/harness/redteam/lib/feature_dict.py
+++ b/plugins/security-assessment/harness/redteam/lib/feature_dict.py
@@ -1,6 +1,6 @@
 """feature_dict — curated fraud-detection feature dictionary.
 
-Used by `02_schema_discovery.py` as the brute-force fallback when no OpenAPI
+Used by `probe_02_schema_discovery.py` as the brute-force fallback when no OpenAPI
 spec is available. Ten categories × ~20 features each, covering common
 fraud-scoring feature surfaces.
 

--- a/plugins/security-assessment/harness/redteam/lib/result_store.py
+++ b/plugins/security-assessment/harness/redteam/lib/result_store.py
@@ -47,7 +47,7 @@ def exists(name: str) -> bool:
 # ── Typed helpers for common artefacts ────────────────────────────────────────
 
 def get_discovered_features() -> list[str]:
-    """Return the feature list produced by probe 02_schema_discovery."""
+    """Return the feature list produced by probe_02_schema_discovery."""
     data = load("02_schema")
     return list(data.get("features", []))
 

--- a/plugins/security-assessment/harness/redteam/orchestrator.py
+++ b/plugins/security-assessment/harness/redteam/orchestrator.py
@@ -74,14 +74,14 @@ class Agent:
 
 
 AGENTS: list[Agent] = [
-    Agent("01", "01_api_recon.py"),
-    Agent("02", "02_schema_discovery.py", ("01",)),
-    Agent("03", "03_feature_sensitivity.py", ("02",)),
-    Agent("04", "04_boundary_mapping.py", ("02", "03")),
-    Agent("05", "05_evasion_attack.py", ("02", "03", "04")),
-    Agent("06", "06_input_validation.py", ("02",)),
-    Agent("07", "07_model_extraction.py", ("02", "03")),
-    Agent("08", "08_report_generator.py", ("01", "02", "03", "04", "05", "06", "07")),
+    Agent("01", "probe_01_api_recon.py"),
+    Agent("02", "probe_02_schema_discovery.py", ("01",)),
+    Agent("03", "probe_03_feature_sensitivity.py", ("02",)),
+    Agent("04", "probe_04_boundary_mapping.py", ("02", "03")),
+    Agent("05", "probe_05_evasion_attack.py", ("02", "03", "04")),
+    Agent("06", "probe_06_input_validation.py", ("02",)),
+    Agent("07", "probe_07_model_extraction.py", ("02", "03")),
+    Agent("08", "probe_08_report_generator.py", ("01", "02", "03", "04", "05", "06", "07")),
 ]
 
 

--- a/plugins/security-assessment/harness/redteam/probes/probe_01_api_recon.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_01_api_recon.py
@@ -1,4 +1,4 @@
-"""01_api_recon — probe documentation paths, HTTP methods, content types, server headers.
+"""probe_01_api_recon — probe documentation paths, HTTP methods, content types, server headers.
 
 Captures what the API leaks before any knowledge of the schema. Output is
 consumed by probe 02 (schema discovery) to pick the right feature-discovery

--- a/plugins/security-assessment/harness/redteam/probes/probe_02_schema_discovery.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_02_schema_discovery.py
@@ -1,4 +1,4 @@
-"""02_schema_discovery — discover the model's input feature list.
+"""probe_02_schema_discovery — discover the model's input feature list.
 
 Four-strategy cascade per the opus_repo_scan_test reference:
   1. OpenAPI directly (fetch /openapi.json, parse schema)

--- a/plugins/security-assessment/harness/redteam/probes/probe_03_feature_sensitivity.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_03_feature_sensitivity.py
@@ -1,4 +1,4 @@
-"""03_feature_sensitivity — sweep each discovered feature across a value range,
+"""probe_03_feature_sensitivity — sweep each discovered feature across a value range,
 measure how the fraud score responds, rank features by influence.
 
 Produces: results/03_sensitivity.json

--- a/plugins/security-assessment/harness/redteam/probes/probe_04_boundary_mapping.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_04_boundary_mapping.py
@@ -1,4 +1,4 @@
-"""04_boundary_mapping — binary-search per-feature decision boundaries.
+"""probe_04_boundary_mapping — binary-search per-feature decision boundaries.
 
 For each sensitive feature (from probe 03's rankings), find the exact value at
 which the fraud score flips between fraud and not-fraud. Assumes the score is

--- a/plugins/security-assessment/harness/redteam/probes/probe_05_evasion_attack.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_05_evasion_attack.py
@@ -1,4 +1,4 @@
-"""05_evasion_attack — search for adversarial inputs that receive low fraud
+"""probe_05_evasion_attack — search for adversarial inputs that receive low fraud
 scores despite looking like fraud.
 
 Three methods in order of cost:

--- a/plugins/security-assessment/harness/redteam/probes/probe_06_input_validation.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_06_input_validation.py
@@ -1,4 +1,4 @@
-"""06_input_validation — exercise malformed inputs.
+"""probe_06_input_validation — exercise malformed inputs.
 
 Type confusion, nulls, oversized strings, Unicode edge cases, NaN/Infinity.
 Detects fail-open paths and information leakage via error messages.

--- a/plugins/security-assessment/harness/redteam/probes/probe_07_model_extraction.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_07_model_extraction.py
@@ -1,4 +1,4 @@
-"""07_model_extraction — train surrogate models against captured scores.
+"""probe_07_model_extraction — train surrogate models against captured scores.
 
 Latin-Hypercube sampling + three surrogate models (decision tree, random
 forest, linear regression). R² on a held-out 20% sample is the extraction

--- a/plugins/security-assessment/harness/redteam/probes/probe_08_report_generator.py
+++ b/plugins/security-assessment/harness/redteam/probes/probe_08_report_generator.py
@@ -1,4 +1,4 @@
-"""08_report_generator — compile probe outputs into adversarial-report.md.
+"""probe_08_report_generator — compile probe outputs into adversarial-report.md.
 
 The report is consumed by prompt adversarial-05-report (the red-team-report-
 generator Claude agent) for refinement into executive form. This script

--- a/tests/commands/test_export_pdf_doc.py
+++ b/tests/commands/test_export_pdf_doc.py
@@ -1,7 +1,7 @@
 """Regression test for the security-assessment plugin's /export-pdf command.
 
 The weasyprint fallback path renders Markdown that is ultimately derived
-from a scanned repo or a probed model (`08_report_generator.py`,
+from a scanned repo or a probed model (`probe_08_report_generator.py`,
 `service-comm-parser.py`) — untrusted input. weasyprint fetches remote
 resources referenced in rendered HTML/CSS (`<img src="https://...">`, CSS
 `url(...)`) by default, which is a plausible SSRF vector at PDF-conversion

--- a/tests/security-assessment/harness/smoke_test.py
+++ b/tests/security-assessment/harness/smoke_test.py
@@ -99,7 +99,7 @@ def check_probes_load() -> None:
         fail(f"could not import redteam.orchestrator: {type(e).__name__}: {e}")
         return
 
-    probe_files = sorted(p.name for p in PROBES.glob("[0-9]*.py"))
+    probe_files = sorted(p.name for p in PROBES.glob("probe_[0-9]*.py"))
     if not probe_files:
         fail(f"no probe modules found under {PROBES}")
         return

--- a/tests/security-assessment/harness/test_report_generator_escaping.py
+++ b/tests/security-assessment/harness/test_report_generator_escaping.py
@@ -1,5 +1,5 @@
 """Regression test for HTML/Markdown injection in
-probes/08_report_generator.py.
+probes/probe_08_report_generator.py.
 
 `_format_*()` interpolate fields from probe result dicts — which ultimately
 originate from the probed model's own HTTP responses (an attacker-controlled
@@ -31,7 +31,7 @@ sys.path.insert(0, str(HARNESS))
 
 from redteam import orchestrator
 
-report_generator = orchestrator._import_agent("08_report_generator.py")
+report_generator = orchestrator._import_agent("probe_08_report_generator.py")
 
 PAYLOAD = '"><script>alert(document.cookie)</script>'
 


### PR DESCRIPTION
## Summary

- Fixes the 9 pre-existing ruff findings in the dev-team plugin identified in #1438: `I001` (unsorted imports), `RUF100` (unused `noqa`), `PLC0414` (useless import alias), and `EXE001` (shebang present but file not executable) across `gherkin_stub_merge.py`, `stub_extractors/__init__.py`, `test_improve_resume.py`, and `test_artifact_paths.py`. Import organization / noqa hygiene / shebang permission bits only — no logic changes.
- Resolves the security-assessment plugin's `N999` (invalid module name) findings by renaming the 8 numbered probe modules (`01_api_recon.py` → `probe_01_api_recon.py`, … `08_report_generator.py` → `probe_08_report_generator.py`) to a ruff-legal form, per the issue's operator decision (rename vs. per-file-ignore — rename chosen). Every reference is updated: `orchestrator.py`'s `AGENTS` list, `lib/feature_dict.py`, `lib/result_store.py`, `docs/workflows.md`, `commands/export-pdf.md`, `CLAUDE.md`, and the harness test suite (`tests/security-assessment/harness/{smoke_test.py,test_report_generator_escaping.py}`, `tests/commands/test_export_pdf_doc.py`).
- Also wires `ruff check --fix` into `lint-staged` (`package.json`) alongside the existing `eslint --fix` entry, so staged Python files get the same pre-commit autofix treatment as staged JS/TS. Updated the `.husky/pre-commit` comment to match.

## Test plan

- [x] `ruff check .` exits 0 repo-wide
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` — 4766 passed, 9 skipped, 0 failed
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — no diff
- [x] `python3 tests/security-assessment/harness/smoke_test.py` — all 4 checks pass (probe-loader glob updated for the new `probe_*.py` filenames)
- [x] `python3 -m pytest tests/security-assessment/` — 33 passed

Closes #1438

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVTC1zqeGu1PdB4LtCosnv)_