### PR TITLE
chore(knowledge): reconcile remaining ownership-tiered placement wording

### DIFF
--- a/plugins/dev-team/knowledge/component-test-patterns.md
+++ b/plugins/dev-team/knowledge/component-test-patterns.md
@@ -91,12 +91,12 @@ Publishes messages to a broker (often paired with a consumer in the same service
 
 Long-lived in-memory state: caches, aggregates, coordinators, websocket gateways, real-time engines.
 
-- **Coverage layers:** state-machine logic (solitary unit) → persistence & recovery (component with real or in-memory persistence) → single-node concurrency (component) → replication & leader election (cluster tests with real consensus library) → memory bounds (soak) → connection lifecycle (component).
+- **Coverage layers:** state-machine logic (solitary unit) → persistence & recovery (component with doubled persistence) → single-node concurrency (component) → replication & leader election (cluster tests with real consensus library) → memory bounds (soak) → connection lifecycle (component) → external persistence engine (doubled in component; real engine in adapter integration, out-of-band).
 - **Isolation:** double persistence; control time and event ordering to make concurrency deterministic.
 - **Success scenarios:** transitions follow documented state machine; state rebuilds identically after restart; replication lag within budget.
 - **Failure modes:** crash mid-write → consistent state on restart, no torn writes; concurrent mutations serialize without lost updates; network partition → minority steps down with documented reconciliation; memory pressure → evicts per policy, no OOM; idle connections close cleanly with documented reconnect.
-- **Double validation:** persistence doubles validated by adapter integration vs production engine; consensus doubles validated by cluster testcontainer tests.
-- **Pipeline:** unit + component Stage 1; cluster tests out-of-band on a schedule, regardless of ownership; soak + chaos out-of-pipeline vs deployed instances.
+- **Double validation:** persistence doubles validated by adapter integration against the real persistence engine, out-of-band; consensus doubles validated by cluster testcontainer tests, out-of-band.
+- **Pipeline:** unit + component Stage 1; adapter integration (persistence recovery) out-of-band on a schedule, regardless of ownership; cluster tests out-of-band on a schedule, regardless of ownership; soak + chaos out-of-pipeline vs deployed instances.
 
 ### CLI / Library
 
@@ -105,7 +105,7 @@ Binary or package consumed via CLI or an exported API.
 - **Coverage layers:** public-interface behavior (unit/component invoking the real surface) → process startup for a CLI (deployed-binary test invoking the real artifact) → any external deps via owned adapters.
 - **Isolation:** test through the public invocation surface (args/stdin/stdout/exit codes for a CLI; exported functions for a library); double external deps via adapters.
 - **Success/failure:** documented commands/flags produce documented output + exit code; bad args → documented error + non-zero exit; stdin/stdout/stderr contracts; backward-compatible public API (the consumer's contract).
-- **Double validation:** a small set of deployed-binary tests invoke the real built artifact to catch packaging/startup gaps unit tests miss.
+- **Double validation:** a small set of deployed-binary tests invoke the real built artifact to catch packaging/startup gaps unit tests miss. Unlike Scheduled Job's equivalent check (out-of-band, below), this smoke is deterministic enough to gate in-band when it exercises only the artifact itself — startup, arg parsing, exit codes — with no external system configured: any external dep it does call is already behind an owned adapter (per Isolation above), so the smoke carries none of the source/sink/scheduler coupling that pushes Scheduled Job's version out-of-band.
 - **Pipeline:** unit + component Stage 1; deployed-binary smoke Stage 1/2.
 
 ---

--- a/plugins/dev-team/knowledge/references/csharp-http-client-testing.md
+++ b/plugins/dev-team/knowledge/references/csharp-http-client-testing.md
@@ -140,7 +140,7 @@ Map directly to `knowledge/cd-test-architecture.md` § *The Six Test Types*:
 | Pure logic in the adapter (header building, query-string construction, response mapping) | **Unit** (solitary) | xUnit + the adapter constructed directly, no `HttpClient` needed |
 | Adapter speaks the wire correctly to a doubled transport: builds the right request, parses the canned response, maps non-2xx to typed errors | **Contract** | xUnit + `StubHttpMessageHandler` |
 | Resilience policy (retry/backoff/circuit-breaker/timeout) survives a doubled provider failure | **Component** (resilience) | xUnit + `StubHttpMessageHandler` + `FakeTimeProvider` + Polly bound to that `TimeProvider` |
-| Adapter against the real third-party API in a non-prod test environment | **Scheduled provider verification** (out-of-band) | xUnit/console job vs the provider's real endpoint, **never pre-merge** |
+| Adapter against the real provider API (in-house or third-party) in a non-prod test environment | **Scheduled provider verification** (out-of-band) | xUnit/console job vs the provider's real endpoint, **never pre-merge** |
 | Multi-service journey across real deployed components | **E2E** (post-deploy smoke) | Playwright for .NET — only when the four-condition E2E justification gate from `knowledge/cd-test-architecture.md#the-e2e-justification-gate` is satisfied |
 
 Contract and component tests with the stub handler are **deterministic and
@@ -149,7 +149,9 @@ pre-merge** per
 provider-verification job is the **detection** half of
 `knowledge/cd-test-architecture.md#double-validation-keeping-doubles-honest`;
 the resilience component test is the **survival** half — both are required
-when the provider is third-party (no provider cooperation assumed).
+regardless of ownership: assume the provider can break the contract without
+warning even when it's the same team's, per the universal rule in
+`knowledge/component-test-patterns.md#api-consumer`.
 
 ## Off-the-shelf alternatives to the hand-rolled stub
 


### PR DESCRIPTION
## Summary

Closes #1444 — cleans up three tangential wording inconsistencies surfaced (but out of scope) during #1434's ownership-tiered placement fix:

1. **CLI/Library vs Scheduled Job divergence.** `component-test-patterns.md`'s CLI/Library pattern gates deployed-binary smoke in-band (Stage 1/2) while Scheduled Job's equivalent runs out-of-band. Added a sentence explaining the distinction: a CLI/Library smoke that exercises only the artifact itself — with any external dep already behind an owned adapter — carries none of the source/sink/scheduler coupling that pushes Scheduled Job's version out-of-band.
2. **Stateful Service's Coverage-layers wording.** Reworded "component with real or in-memory persistence" to "doubled persistence" to match the section's own Isolation line, updated Double validation/Pipeline to explicitly call out the persistence-recovery adapter integration as out-of-band (matching the cluster-tests precedent already there), and added the missing terminal external-engine layer to match sibling Services patterns (API Provider, Event Consumer, Event Producer).
3. **`csharp-http-client-testing.md`'s provider-cooperation requirement.** Was scoped to "when the provider is third-party (no provider cooperation assumed)"; now applies unconditionally ("regardless of ownership"), in both the prose and the pyramid table row that a correctness-review pass caught still saying "third-party" — matching the universal rule stated in `component-test-patterns.md`'s API Consumer section and `cd-test-architecture.md`'s Double Validation defense #2.

## Review

Ran the code-review agent panel (`security-review`, `correctness-review`, `spec-compliance-review`, `doc-review` — selected by the change-size fast-path gate). `correctness-review` caught the leftover third-party wording in the pyramid table and an overclaim in the new CLI/Library sentence; both were fixed and verified against the panel's findings before commit.

## Test plan

- [x] `pytest tests/skills tests/knowledge tests/docs plugins/dev-team/tests -k "component_test_patterns or csharp or cd_test_architecture or knowledge"` — 240 passed
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — no index changes needed
- [x] Confirmed pre-existing (unrelated) test failures in this environment (`jsonschema`/`pytest-asyncio` missing, one mypy-adapter test) are unaffected by this diff — same 18 failures with and without the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLSmmoxmVqJxYtY1Bnwo6k)_