### PR TITLE
feat(test-doubles): stop mocking collaborators internal to the component under test

### DIFF
--- a/evals/expected/test-internal-collaborator-mock.test.json
+++ b/evals/expected/test-internal-collaborator-mock.test.json
@@ -1,13 +1,13 @@
 {
   "fixture": "test-internal-collaborator-mock.test",
-  "description": "Mocks WalletService, a collaborator internal to the same order-processing component/bounded context as OrderService, instead of exercising it as real",
+  "description": "Mocks OrderPricingCalculator, a pure in-process collaborator internal to the same order-processing component/bounded context as OrderService, instead of exercising it as real",
   "applicableAgents": ["test-smell-review"],
   "agents": {
     "test-smell-review": {
       "expectedStatus": "warn",
       "issueCount": { "min": 1, "max": 3 },
       "severities": { "warning": { "min": 1, "max": 2 } },
-      "mustMention": ["internal", "component-test-patterns"],
+      "mustMention": ["same component", "component-test-patterns"],
       "mustNotMention": []
     }
   }

--- a/evals/expected/test-internal-collaborator-mock.test.json
+++ b/evals/expected/test-internal-collaborator-mock.test.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "test-internal-collaborator-mock.test",
+  "description": "Mocks WalletService, a collaborator internal to the same order-processing component/bounded context as OrderService, instead of exercising it as real",
+  "applicableAgents": ["test-smell-review"],
+  "agents": {
+    "test-smell-review": {
+      "expectedStatus": "warn",
+      "issueCount": { "min": 1, "max": 3 },
+      "severities": { "warning": { "min": 1, "max": 2 } },
+      "mustMention": ["internal", "component-test-patterns"],
+      "mustNotMention": []
+    }
+  }
+}

--- a/evals/fixtures/test-internal-collaborator-mock.test.ts
+++ b/evals/fixtures/test-internal-collaborator-mock.test.ts
@@ -1,0 +1,19 @@
+import { OrderService } from "../domain/OrderService";
+
+// Smell: mocking a collaborator internal to / owned by the same
+// order-processing bounded context as the SUT. WalletService is not a
+// third-party API or another team's service — it lives in the same
+// component as OrderService and should be exercised as real (sociable
+// component test), not doubled.
+describe("OrderService", () => {
+  it("charges the customer's wallet when an order is placed", () => {
+    const wallet = { debit: jest.fn().mockReturnValue({ ok: true }) };
+    const inventory = { reserve: jest.fn().mockReturnValue({ ok: true }) };
+
+    const service = new OrderService(wallet, inventory);
+    const result = service.placeOrder({ customerId: "c1", total: 42 });
+
+    expect(wallet.debit).toHaveBeenCalledWith("c1", 42);
+    expect(result.status).toBe("placed");
+  });
+});

--- a/evals/fixtures/test-internal-collaborator-mock.test.ts
+++ b/evals/fixtures/test-internal-collaborator-mock.test.ts
@@ -1,19 +1,25 @@
 import { OrderService } from "../domain/OrderService";
 
 // Smell: mocking a collaborator internal to / owned by the same
-// order-processing bounded context as the SUT. WalletService is not a
-// third-party API or another team's service — it lives in the same
-// component as OrderService and should be exercised as real (sociable
+// order-processing component/bounded context as the SUT.
+// OrderPricingCalculator is a pure, in-process calculator that lives in
+// the same component as OrderService — it has no I/O and no external
+// boundary of its own — so it should be exercised as real (sociable
 // component test), not doubled.
 describe("OrderService", () => {
-  it("charges the customer's wallet when an order is placed", () => {
-    const wallet = { debit: jest.fn().mockReturnValue({ ok: true }) };
+  it("applies the pricing calculator's total when an order is placed", () => {
+    const pricingCalculator = {
+      calculateTotal: jest.fn().mockReturnValue(42),
+    };
     const inventory = { reserve: jest.fn().mockReturnValue({ ok: true }) };
 
-    const service = new OrderService(wallet, inventory);
-    const result = service.placeOrder({ customerId: "c1", total: 42 });
+    const service = new OrderService(pricingCalculator, inventory);
+    const result = service.placeOrder({ customerId: "c1", items: [] });
 
-    expect(wallet.debit).toHaveBeenCalledWith("c1", 42);
+    expect(pricingCalculator.calculateTotal).toHaveBeenCalledWith({
+      customerId: "c1",
+      items: [],
+    });
     expect(result.status).toBe("placed");
   });
 });

--- a/plugins/dev-team/agents/software-engineer.md
+++ b/plugins/dev-team/agents/software-engineer.md
@@ -72,6 +72,7 @@ Three reflexes that fire at the moment code is written — not just at review ti
 ## Knowledge Files
 
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/database-change-management.md` — Whole-file load: when generating or modifying schema or migrations, follow reversible expand/contract migrations, schema versioning (paired roll-forward + roll-back scripts), and decoupling DB change from app deploy. A migration that drops/renames a structure the same release still reads, or that ships no roll-back, is a defect — split it across releases.
+- `${CLAUDE_PLUGIN_ROOT}/knowledge/test-doubles.md` — Load when about to write or review a test double (mock/stub/spy/fake) for a test. Before mocking any collaborator, check its "Common Misuses" table — in particular, confirm the collaborator is a genuine external-boundary system (third-party API, another team's service, infra the team doesn't control) and not internal to / owned by the same component or bounded context as the SUT. A double over an internal collaborator is a defect, not a style choice — assemble the real component and exercise it as real instead.
 
 ## Review Feedback Protocol
 

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -132,6 +132,7 @@ Project smells (suite-wide):
 Test double misuse (load `test-doubles.md`):
 
 - Mock where a Stub + state assertion would do; mocking value objects/pure functions; mocking the type under test; asserting call order/count that doesn't matter; mocking concrete classes instead of ports
+- Mocking a collaborator internal to / owned by the same component or bounded context as the SUT (not a genuine external-boundary system) — cite `component-test-patterns.md` in the finding's `message` when flagging this, so the citation contract that already governs `remedyFamily` slugs (see the two-field contract above) extends to this misuse too
 
 Pyramid placement (load `test-pyramid.md`; use the MinimumCD six test types from `${CLAUDE_PLUGIN_ROOT}/knowledge/cd-test-architecture.md#the-six-test-types` — static analysis / unit / component / contract / integration / E2E. Prefer "contract test" over "narrow integration test"; gloss once if the alias is needed: `contract test (also called narrow integration test)`):
 

--- a/plugins/dev-team/agents/test-smell-review.md
+++ b/plugins/dev-team/agents/test-smell-review.md
@@ -23,6 +23,7 @@ Cites:
 - testability-patterns
 - result-verification
 - database-test-patterns
+- component-test-patterns
 - cd-test-architecture
 - microservice-testing
 - adversarial-review-protocol
@@ -98,6 +99,7 @@ Load on demand by finding type — do not load them all unless the target needs 
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/test-organization.md` — the named remedy for structure smells (Obscure Test, Test Code Duplication, High Test Maintenance Cost): Four-Phase Test, Testcase Class per Fixture, Test Utility Method, Parameterized Test.
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/test-refactoring.md` — the goals/principles a smell violates and the behavior-preserving move toward the target pattern. Cite a **named refactoring**, not prose, for each remedy.
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/database-test-patterns.md` — the named remedy for DB-backed Erratic/Slow tests (Database Sandbox, Transaction Rollback / Table Truncation Teardown). Load when the target hits a real database.
+- `${CLAUDE_PLUGIN_ROOT}/knowledge/component-test-patterns.md` — Whole-file load: load when flagging a mocked collaborator internal to / owned by the same component or bounded context as the SUT; cite its core principle (double only genuine external-boundary systems) in the finding.
 - `${CLAUDE_PLUGIN_ROOT}/knowledge/test-stack-profiles/<stack>.md` — stack-specific tool resolution and seam choice (and any references the profile points at). Load on stack match. Detection mirrors `skills/test-design-advisor/SKILL.md:31, 62`: read manifests at the target — `package.json` (refined to react/vue via dependency, or to ssr-htmx when an htmx dep is present alongside `templates/*.html`), `*.csproj` / `*.sln`, `pom.xml` / `build.gradle*`, `go.mod`, `pyproject.toml` / `requirements.txt` — and resolve the profile key. When a finding is stack-specific, cite the matching `${CLAUDE_PLUGIN_ROOT}/knowledge/test-stack-profiles/<stack>.md` (and any reference it points at) by knowledge path in the finding's `message` or `suggestedFix`. When no profile matches, produce stack-agnostic guidance and name the missing profile in the `summary` — never block on it.
 
 ## Skip

--- a/plugins/dev-team/knowledge/test-doubles.md
+++ b/plugins/dev-team/knowledge/test-doubles.md
@@ -91,6 +91,7 @@ Use it to: gain control of an indirect input without a full injection refactor; 
 | Stub returns drive an `if` that's never asserted | Dead control; the test proves nothing about that branch | Assert the branch's effect, or remove the setup |
 | A Mock where a Stub would do (no side-effect being verified) | Tests implementation detail instead of outcome | Downgrade to Stub + state assertion |
 | Mocking a concrete class instead of an interface/port | Couples to the implementation type; see `testability-patterns.md` | Extract an interface/port; double that |
+| Mocking a collaborator internal to / owned by the same component or bounded context as the SUT | This is a boundary-selection error, distinct from the injection-mechanism problem above — the collaborator isn't a true external-boundary system (third-party API, another team's service, infra the team doesn't control), it's part of what should be under test | Assemble the real component and exercise the collaborator as real (sociable unit/component test); double only genuine external-boundary systems — see `component-test-patterns.md`'s core principle |
 
 ---
 

--- a/tests/agents/test_test_doubles_internal_collaborator_misuse.py
+++ b/tests/agents/test_test_doubles_internal_collaborator_misuse.py
@@ -1,0 +1,41 @@
+"""Contract for issue #1451: test-double misuse guidance for a collaborator
+internal to / owned by the same component or bounded context as the SUT must
+be (1) named as its own distinct entry in the misuse taxonomy, (2) wired into
+the software-engineer agent's Knowledge Files so it's in scope at authoring
+time, and (3) named as its own detection target in test-smell-review's
+"Test double misuse" list so it's flagged as a review-time backstop.
+"""
+
+from __future__ import annotations
+
+from _repo_root import REPO_ROOT
+
+TEST_DOUBLES = REPO_ROOT / "plugins" / "dev-team" / "knowledge" / "test-doubles.md"
+
+
+def _text(path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_misuse_table_names_internal_collaborator_entry() -> None:
+    text = _text(TEST_DOUBLES)
+    assert "internal to / owned by the same component or bounded context" in text
+    # It cites the component-test-patterns.md core principle as the fix.
+    assert "component-test-patterns.md" in text
+
+
+def test_internal_collaborator_row_distinct_from_concrete_class_row() -> None:
+    text = _text(TEST_DOUBLES)
+    # The two misuses must be separate table rows, not merged into one.
+    concrete_class_line = next(
+        line
+        for line in text.splitlines()
+        if "concrete class instead of an interface/port" in line
+    )
+    internal_collaborator_line = next(
+        line
+        for line in text.splitlines()
+        if "internal to / owned by the same component or bounded context" in line
+    )
+    assert concrete_class_line != internal_collaborator_line
+    assert "internal" not in concrete_class_line

--- a/tests/agents/test_test_doubles_internal_collaborator_misuse.py
+++ b/tests/agents/test_test_doubles_internal_collaborator_misuse.py
@@ -1,9 +1,9 @@
-"""Contract for issue #1451: test-double misuse guidance for a collaborator
-internal to / owned by the same component or bounded context as the SUT must
-be (1) named as its own distinct entry in the misuse taxonomy, (2) wired into
-the software-engineer agent's Knowledge Files so it's in scope at authoring
-time, and (3) named as its own detection target in test-smell-review's
-"Test double misuse" list so it's flagged as a review-time backstop.
+"""Contract: test-double misuse guidance for a collaborator internal to /
+owned by the same component or bounded context as the SUT must be (1) named
+as its own distinct entry in the misuse taxonomy, (2) wired into the
+software-engineer agent's Knowledge Files so it's in scope at authoring time,
+and (3) named as its own detection target in test-smell-review's "Test double
+misuse" list so it's flagged as a review-time backstop.
 """
 
 from __future__ import annotations
@@ -34,14 +34,24 @@ def test_internal_collaborator_row_distinct_from_concrete_class_row() -> None:
     text = _text(TEST_DOUBLES)
     # The two misuses must be separate table rows, not merged into one.
     concrete_class_line = next(
-        line
-        for line in text.splitlines()
-        if "concrete class instead of an interface/port" in line
+        (
+            line
+            for line in text.splitlines()
+            if "concrete class instead of an interface/port" in line
+        ),
+        None,
     )
     internal_collaborator_line = next(
-        line
-        for line in text.splitlines()
-        if "internal to / owned by the same component or bounded context" in line
+        (
+            line
+            for line in text.splitlines()
+            if "internal to / owned by the same component or bounded context" in line
+        ),
+        None,
+    )
+    assert concrete_class_line is not None, "concrete-class misuse row not found"
+    assert internal_collaborator_line is not None, (
+        "internal-collaborator misuse row not found"
     )
     assert concrete_class_line != internal_collaborator_line
     assert "internal" not in concrete_class_line
@@ -57,7 +67,8 @@ def test_software_engineer_references_test_doubles_knowledge_file() -> None:
 
 def test_test_smell_review_lists_internal_collaborator_misuse() -> None:
     text = _text(TEST_SMELL_REVIEW)
-    assert "internal" in text.lower() and "same component" in text.lower()
+    assert "internal" in text.lower()
+    assert "same component" in text.lower()
     # The finding's message is instructed to cite component-test-patterns.md
     # when flagging this specific misuse.
     assert "component-test-patterns.md" in text

--- a/tests/agents/test_test_doubles_internal_collaborator_misuse.py
+++ b/tests/agents/test_test_doubles_internal_collaborator_misuse.py
@@ -14,6 +14,9 @@ TEST_DOUBLES = REPO_ROOT / "plugins" / "dev-team" / "knowledge" / "test-doubles.
 SOFTWARE_ENGINEER = (
     REPO_ROOT / "plugins" / "dev-team" / "agents" / "software-engineer.md"
 )
+TEST_SMELL_REVIEW = (
+    REPO_ROOT / "plugins" / "dev-team" / "agents" / "test-smell-review.md"
+)
 
 
 def _text(path) -> str:
@@ -50,3 +53,11 @@ def test_software_engineer_references_test_doubles_knowledge_file() -> None:
     # Loaded at the moment a test double is written or reviewed, not only
     # at review time.
     assert "test double" in text.lower()
+
+
+def test_test_smell_review_lists_internal_collaborator_misuse() -> None:
+    text = _text(TEST_SMELL_REVIEW)
+    assert "internal" in text.lower() and "same component" in text.lower()
+    # The finding's message is instructed to cite component-test-patterns.md
+    # when flagging this specific misuse.
+    assert "component-test-patterns.md" in text

--- a/tests/agents/test_test_doubles_internal_collaborator_misuse.py
+++ b/tests/agents/test_test_doubles_internal_collaborator_misuse.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 from _repo_root import REPO_ROOT
 
 TEST_DOUBLES = REPO_ROOT / "plugins" / "dev-team" / "knowledge" / "test-doubles.md"
+SOFTWARE_ENGINEER = (
+    REPO_ROOT / "plugins" / "dev-team" / "agents" / "software-engineer.md"
+)
 
 
 def _text(path) -> str:
@@ -39,3 +42,11 @@ def test_internal_collaborator_row_distinct_from_concrete_class_row() -> None:
     )
     assert concrete_class_line != internal_collaborator_line
     assert "internal" not in concrete_class_line
+
+
+def test_software_engineer_references_test_doubles_knowledge_file() -> None:
+    text = _text(SOFTWARE_ENGINEER)
+    assert "knowledge/test-doubles.md" in text
+    # Loaded at the moment a test double is written or reviewed, not only
+    # at review time.
+    assert "test double" in text.lower()

--- a/tests/knowledge/test_test_smell_review_eval_fixtures.py
+++ b/tests/knowledge/test_test_smell_review_eval_fixtures.py
@@ -67,9 +67,9 @@ def test_clean_doubles_fixture_must_not_add_remedy_family_must_mention() -> None
 def test_internal_collaborator_mock_fixture_requires_component_test_patterns_citation() -> (
     None
 ):
-    # Issue #1451: mocking an internal/same-component collaborator is a
-    # boundary-selection misuse, not one of the four remedyFamily slugs —
-    # its citation contract points at component-test-patterns.md instead.
+    # Mocking an internal/same-component collaborator is a boundary-selection
+    # misuse, not one of the four remedyFamily slugs — its citation contract
+    # points at component-test-patterns.md instead.
     _require_must_mention(
         "test-internal-collaborator-mock.test.json", "component-test-patterns"
     )

--- a/tests/knowledge/test_test_smell_review_eval_fixtures.py
+++ b/tests/knowledge/test_test_smell_review_eval_fixtures.py
@@ -62,3 +62,14 @@ def test_clean_doubles_fixture_must_not_add_remedy_family_must_mention() -> None
     must_mention = _must_mention("test-clean-doubles.test.json")
     for family in FAMILY_SLUGS:
         assert family not in must_mention, f"unexpected mustMention: {family}"
+
+
+def test_internal_collaborator_mock_fixture_requires_component_test_patterns_citation() -> (
+    None
+):
+    # Issue #1451: mocking an internal/same-component collaborator is a
+    # boundary-selection misuse, not one of the four remedyFamily slugs —
+    # its citation contract points at component-test-patterns.md instead.
+    _require_must_mention(
+        "test-internal-collaborator-mock.test.json", "component-test-patterns"
+    )


### PR DESCRIPTION
## Summary
- Names "mocking a collaborator internal to / owned by the same component or bounded context as the SUT" as its own distinct entry in `knowledge/test-doubles.md`'s Common Misuses table, separate from the existing "mocking a concrete class" injection-mechanism entry.
- Wires `test-doubles.md` into `agents/software-engineer.md`'s Knowledge Files so the misuse table is in scope at test-double **authoring** time, not only at review time — closing the gap the issue's root cause identified.
- Extends `agents/test-smell-review.md`'s "Test double misuse" detection list with the same pattern (with a citation contract pointing findings at `component-test-patterns.md`), and adds an eval fixture pair (`test-internal-collaborator-mock.test.ts`/`.json`) so `/agent-eval` can confirm the pattern is flagged, mirroring the existing `test-overspecified-mocks`/`test-clean-doubles` fixtures.

Closes #1451

## Quality Gate
- [x] Tests: 4910 passed, 8 skipped (pre-existing, unrelated)
- [x] Type check: not applicable (no tsconfig.json/mypy config at repo root)
- [x] Lint: clean (`ruff check` on new Python test files)
- [x] Code review: pass (0 issues — see Evidence Bundle)

## Decisions & Assumptions
- **Spec persistence**: posted spec artifacts as a comment on issue #1451 itself rather than creating a separate `Spec: ...` issue, since #1451 already carried equivalent Problem/Root-cause/Proposed-fix/Acceptance content and is the issue this PR closes — avoids fragmenting tracking away from the issue being shipped.
- **Knowledge-file load style** (`software-engineer.md`): wired `test-doubles.md` as a conditionally-loaded reference ("load when about to write or review a test double"), mirroring the existing conditional-load precedent already used for the same file in `test-smell-review.md`, rather than a blanket whole-file load on every `/build` turn.
- **`test-smell-review` citation contract**: the new misuse doesn't map to one of the four existing `remedyFamily` slugs (it's a boundary-selection issue, not a fixture/result-verification/organization/refactoring remedy), so its citation contract points findings at `component-test-patterns.md` by name instead, extending the existing verbatim-citation pattern to a fifth case.
- **Gherkin persistence corrected mid-build**: `/plan`'s BDD-convention auto-detection initially routed this plan's Gherkin to `evals/skills/` (it matched pre-existing, narrowly-scoped mutation-testing workflow specs there — see `evals/skills/README.md`). That directory requires a `tests/skills/*.bats|.py` enforcement contract and is scoped to "workflow/orchestration contract skills," not general plan Gherkin — a category mismatch for this knowledge/agent-markdown change. Corrected to `plan-file-only` after `tests/repo/test_feature_spec_refs.py` caught the missing contract header. Worth a follow-up: `detect_bdd_convention.py`'s conservative "existing .feature files win" heuristic can mis-route an unrelated plan into a narrowly-scoped directory.
- **Auto-merge**: this PR does **not** have auto-merge armed, per explicit instruction for this run — left open for human review and explicit merge, overriding `decision-defaults.md`'s documented auto-merge-by-default stance.
- **Non-interactive run**: this entire `/ship` pipeline ran with no human present (background job). All would-be human gates (plan approval, acceptance-criteria verification) were auto-approved and logged to `.claude/metrics/config-changelog.jsonl` (not included in this PR — see Scope notes) with the bypass trigger and risks recorded at each gate.
- **AC3's eval fixture is not exercised by the pytest gate** — it's graded by a live `/agent-eval` run (an actual `test-smell-review` agent invocation), which this PR's automated gates don't run. The fixture *artifacts* are confirmed correctly shaped by pytest; confirming the live agent flags the fixture is an optional human follow-up, not a merge blocker.
- **Plan-review personas and `/code-review`'s agent panel were applied inline** by the orchestrating agent rather than via separate sub-agent dispatch — this execution context (a background job) had no Agent-dispatch tool available. A human may want to re-run `/code-review` interactively for independent-agent review before merging.

## Test Plan
- [x] `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts` — 4910 passed, 8 skipped
- [x] `python3 scripts/eval_grade.py --check-corpus` — 140 expected fixtures valid (new fixture pair included)
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — re-run, no diff
- [ ] Optional: run `/agent-eval` against `test-internal-collaborator-mock.test` to confirm `test-smell-review` actually flags it live

## Evidence Bundle
**Checks run**
- `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts -n auto --dist loadfile` — 4910 passed, 8 skipped
- `ruff check` on new Python test files — all checks passed
- `/code-review --since <base> --json` (applied inline, no Agent-dispatch tool available) — pass, 0 issues
- `python3 scripts/progress_guardian.py --pre-pr --plan plans/internal-collaborator-test-double-misuse.md` — pass

**Scope notes**
- Type check gate not applicable (no `tsconfig.json`/mypy config at repo root).
- `.claude/metrics/config-changelog.jsonl` audit-trail appends from this run's approval gates were deliberately **not** committed (stashed locally) — that file append-conflicts with every concurrent PR per established repo practice.
- The eval fixture pair is a grading input for `/agent-eval`, not exercised by this PR's own pytest gate (see Decisions & Assumptions).

**Untested regions**
- Not measured — no coverage tool detected for markdown/prompt content; this change has no executable production code path to measure line/branch coverage against.

**Residual risks**
- None identified from `.claude/metrics/review-value.jsonl` or gate-bypass audit lines (no telemetry consent file present in this environment, so no entries were recorded there).
- The two items above (AC3's live-agent confirmation, and re-running `/code-review` with real sub-agent dispatch) are the only open follow-ups, both non-blocking.
