### PR TITLE
feat(pr): add a PR template and make the shipped /pr skill template-aware

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+PR title must be a conventional-commit line — this repo squash-merges, so the
+title becomes the commit message: <type>(<scope>): <description>.
+
+Docs-only PRs (touching only *.md, .gitignore, LICENSE — no code, agent,
+skill, hook, eval fixture, or marketplace manifest) may arm `gh pr merge
+--auto --squash` at open time. Anything else needs explicit human merge.
+-->
+
+## Summary
+
+- <what changed and why, 1-3 bullets>
+
+## Test Plan
+
+- [ ] <verification step 1>
+- [ ] <verification step 2>
+
+<!--
+One line per issue this PR resolves, using a real closing keyword (Closes,
+Fixes, Resolves). For an epic issue this PR only contributes a slice of, use
+"Part of #<epic>" instead — a non-closing reference, since epics don't
+auto-close when a sub-issue's PR merges (see epic-auto-close.yml, #987).
+
+Never phrase a non-closing reference with a closing keyword, even negated —
+GitHub's parser fires on "fixes #123" regardless of surrounding words like
+"does not" or "won't" (issue #977).
+-->
+
+Closes #

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -148,7 +148,29 @@ proceed with a body the linter flagged without fixing the phrasing.
 gh pr create --title "<title>" --body "<body>" [--draft] --base <base>
 ```
 
-Use the structured template:
+**Check for a repo-provided template first**: `.github/PULL_REQUEST_TEMPLATE.md`
+(the canonical GitHub location). If it exists, use it as the body's base
+structure instead of this skill's own hardcoded template below:
+
+- Fill each of the template's existing sections with the corresponding
+  generated content where an obvious semantic match exists — a
+  "Summary"/"What"/"Description"-shaped heading gets the summary bullets; a
+  "Test(ing) Plan"/"How to test"/"Verification"-shaped heading gets the test
+  plan steps; a "Checklist" heading that already lists gate-shaped items gets
+  the Quality Gate results.
+- Preserve every section the template defines, in its own order, even when
+  nothing here auto-fills it — leave the template's own placeholder/comment
+  text for the operator rather than deleting the section.
+- Append this skill's own **Decisions & Assumptions** and **Evidence
+  Bundle** sections at the end, under their own headings, whenever the
+  template has no equivalent section for them. Never drop that content
+  silently just because the repo's template didn't ask for it.
+- Preserve the template's own HTML comments (`<!-- ... -->`) — they are
+  operator-facing instructions (e.g. "PR title must be conventional"), not
+  placeholders to strip.
+
+If no such file exists, fall back to this skill's own structured template
+exactly as before:
 
 ```markdown
 ## Summary


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with this repo's own conventions: a conventional-commit title reminder (squash-merge uses the title as the commit message), a Test Plan checklist, and a closing-keyword line per the `Closes #N` / `Part of #N` working rule.
- Teaches the shipped `/pr` skill (Step 4) to use a repo-provided `.github/PULL_REQUEST_TEMPLATE.md` as the PR body's base structure instead of always inventing its own hardcoded template — filling recognizable sections by semantic match, preserving every section the template defines, and appending the skill's own Decisions & Assumptions / Evidence Bundle sections when the template has no equivalent for them. Falls back to the existing hardcoded template unchanged when no repo template exists — this benefits every downstream project with its own template, not just this repo.

## Test Plan

- [x] Full pre-push pytest gate: 4971 passed, 3 pre-existing unrelated skips
- [x] Targeted tests confirming Step 4's edit didn't disturb what other tests pin (`test_pr_skill_references_progress_guardian_py_pre_pr`, `test_pr_skill_enables_auto_merge_by_default`): 12/12 passed
- [x] `ruff check .` and `check-python-only.py`: clean
- [x] This PR's own body was hand-written following the new template's structure, as a first dogfood check of the shape

Closes #1472