### PR TITLE
fix(hooks): serialize hook state read-modify-write to close lost-update races

### DIFF
--- a/plugins/dev-team/hooks/bash_retry_guard.py
+++ b/plugins/dev-team/hooks/bash_retry_guard.py
@@ -36,16 +36,35 @@ _LIB_DIR = _HOOK_DIR / "lib"
 
 sys.path.insert(0, str(_LIB_DIR))
 try:
+    from atomic_state import (  # type: ignore[import-not-found]
+        atomic_write,
+        locked_state,
+        race_window_delay,
+    )
     from boundary_events import (  # type: ignore[import-not-found]
         emit_boundary_event as _emit_boundary_event,
     )
     from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
+    import contextlib as _contextlib
 
     def read_stdin_json() -> dict | None:  # type: ignore[misc]
         return None
 
     def _emit_boundary_event(*_args, **_kwargs) -> None:  # type: ignore[misc]
+        return None
+
+    def atomic_write(path: Path, text: str) -> None:  # type: ignore[misc]
+        try:
+            path.write_text(text, encoding="utf-8")
+        except OSError:
+            pass
+
+    @_contextlib.contextmanager
+    def locked_state(_path: Path):  # type: ignore[misc]
+        yield
+
+    def race_window_delay(_env_var: str) -> None:  # type: ignore[misc]
         return None
 
 
@@ -150,11 +169,10 @@ def _read_state(path: Path) -> dict[str, Any]:
 
 
 def _write_state(path: Path, state: dict[str, Any]) -> None:
-    try:
-        path.write_text(json.dumps(state, separators=(",", ":")), encoding="utf-8")
-    except OSError:
-        # Best-effort — the hook is advisory; failing to persist is not fatal.
-        pass
+    # Atomic (tempfile + rename) so a concurrent reader never sees a torn
+    # file. The read-increment-write cycle is additionally serialized under
+    # locked_state() in main() (#1501). Best-effort — advisory hook.
+    atomic_write(path, json.dumps(state, separators=(",", ":")))
 
 
 def main() -> int:
@@ -184,13 +202,18 @@ def main() -> int:
     normalized = _normalize(command)
     cur_hash = _cksum(normalized)
 
-    prev = _read_state(state_path)
-    if cur_hash == prev["hash"]:
-        count = prev["count"] + 1
-    else:
-        count = 1
-
-    _write_state(state_path, {"hash": cur_hash, "count": count})
+    # Serialize the read-increment-write so two concurrent invocations of the
+    # same command (e.g. a shared-cwd state key across two sessions) each add
+    # exactly one to the consecutive-run count instead of racing and losing an
+    # increment (#1501). Fail-open: an unlockable environment runs unlocked.
+    with locked_state(state_path):
+        prev = _read_state(state_path)
+        if cur_hash == prev["hash"]:
+            count = prev["count"] + 1
+        else:
+            count = 1
+        race_window_delay("DEV_TEAM_BASH_RETRY_TEST_DELAY_MS")
+        _write_state(state_path, {"hash": cur_hash, "count": count})
 
     if count >= threshold:
         print(f"bash-retry-guard: This command has run {count} consecutive times.")

--- a/plugins/dev-team/hooks/lib/atomic_state.py
+++ b/plugins/dev-team/hooks/lib/atomic_state.py
@@ -1,0 +1,142 @@
+"""atomic_state — shared atomic-write + cross-OS advisory-lock helpers for hooks.
+
+Several advisory hooks persist tiny per-session/per-project state with a
+read-modify-write cycle against a shared on-disk file. Two concurrent
+invocations (two Bash tool calls firing close together, or two
+sessions/worktrees touching the same repo) can race and lose an update
+(#1501). This module centralizes the two primitives that close that race:
+
+- `atomic_write(path, text)` — write via a same-directory tempfile + rename
+  so a concurrent reader never observes a torn/partial file.
+- `locked_state(path)` — a cross-OS exclusive advisory lock held for the
+  full read-modify-write cycle so counters increment exactly once per
+  invocation instead of clobbering each other.
+
+The lock idiom (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows,
+fail-open when neither is available) is lifted from the already-proven copy
+in `hooks/code_intelligence_turn_mark.py::_sentinel_lock` so the two agree
+on behavior. Everything here is fail-open: any I/O or locking failure runs
+the critical section unlocked / skips the persist rather than raising —
+these are advisory nudges, never gates.
+
+Stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+try:
+    import fcntl  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — Windows has no fcntl
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — POSIX has no msvcrt
+    msvcrt = None  # type: ignore[assignment]
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Write `text` to `path` atomically via tempfile-in-same-dir + rename.
+
+    A concurrent reader sees either the old file or the fully-written new one,
+    never a partial write. Fail-open: any OSError short-circuits to a silent
+    no-op — persistence is best-effort for these advisory hooks.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}-", suffix=".tmp", dir=str(path.parent)
+        )
+    except OSError:
+        return
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except OSError:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+
+
+@contextlib.contextmanager
+def locked_state(path: Path) -> Iterator[None]:
+    """Hold an exclusive advisory lock for a full read-modify-write cycle.
+
+    Prevents the lost-update race where two concurrent invocations both read
+    the same stale value, both increment it, and one write clobbers the
+    other. `fcntl.flock` on POSIX, `msvcrt.locking` on Windows (this repo's
+    hooks target both — ADR 0014/0015). The lock file lives beside `path` as
+    `<path>.lock`.
+
+    Fail-open: a missing `fcntl` *and* `msvcrt`, or any OSError opening/locking
+    the lock file, falls through to running the critical section UNLOCKED
+    rather than raising. An unlocked lost-update is no worse than the
+    pre-#1501 behavior; a crash would be worse, and these hooks are advisory.
+    """
+    lock_path = path.parent / (path.name + ".lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        yield
+        return
+
+    # The open() failure case shares this try/except with the whole `with`
+    # body (ruff SIM115 requires open() directly in a `with`). Callers own
+    # their own OSError handling inside the critical section, so this outer
+    # except only ever fires for the open() call itself.
+    try:
+        with open(lock_path, "a+") as handle:
+            locked = False
+            try:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                        locked = True
+                    elif msvcrt is not None:
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                        locked = True
+                except OSError:
+                    locked = False
+                yield
+            finally:
+                if locked:
+                    try:
+                        if fcntl is not None:
+                            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                        elif msvcrt is not None:
+                            handle.seek(0)
+                            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    except OSError:
+                        pass
+            return
+    except OSError:
+        pass
+    yield
+
+
+def race_window_delay(env_var: str) -> None:
+    """Test-only injection point: sleep inside a locked critical section when
+    `env_var` names a millisecond delay, widening the race window so a
+    concurrency test can deterministically force two invocations to overlap
+    rather than relying on timing luck. Unset in production; a bad/missing
+    value is a no-op (fail-open). Mirrors
+    `code_intelligence_turn_mark._test_delay`.
+    """
+    raw = os.environ.get(env_var)
+    if not raw:
+        return
+    try:
+        time.sleep(int(raw) / 1000)
+    except (ValueError, OSError):
+        pass

--- a/plugins/dev-team/hooks/session_learning_trigger.py
+++ b/plugins/dev-team/hooks/session_learning_trigger.py
@@ -28,6 +28,18 @@ if str(_LIB_DIR) not in sys.path:
 import artifact_paths
 import telemetry_consent
 
+try:
+    from atomic_state import locked_state, race_window_delay
+except ImportError:  # pragma: no cover
+    import contextlib as _contextlib
+
+    @_contextlib.contextmanager
+    def locked_state(_path: Path):  # type: ignore[misc]
+        yield
+
+    def race_window_delay(_env_var: str) -> None:  # type: ignore[misc]
+        return None
+
 
 def _load_counter(state_file: Path) -> int:
     """Return the persisted counter, recovering to 0 on any error."""
@@ -165,13 +177,25 @@ def main() -> int:
     state_file = artifact_paths.resolve_file("metrics", "learning-loop-state.json", cwd)
     hook_dir = Path(__file__).resolve().parent
 
-    counter = _load_counter(state_file) + 1
+    # Serialize the load-increment-write so two SessionEnd hooks ending in the
+    # same cwd near-simultaneously each advance the counter exactly once
+    # instead of racing and losing an increment (#1501). The write itself is
+    # already atomic (tempfile + os.replace in _write_state); the lock closes
+    # the remaining read-modify-write gap. Fail-open: unlockable → runs
+    # unlocked. The dispatch stays outside the lock — it is fire-and-forget and
+    # must not hold the lock across a subprocess spawn.
+    dispatch = False
+    with locked_state(state_file):
+        counter = _load_counter(state_file) + 1
+        race_window_delay("DEV_TEAM_SESSION_LEARNING_TEST_DELAY_MS")
+        if counter >= threshold:
+            _write_state(state_file, 0)
+            dispatch = True
+        else:
+            _write_state(state_file, counter)
 
-    if counter >= threshold:
-        _write_state(state_file, 0)
+    if dispatch:
         _dispatch_background_analysis(cwd, session_id, hook_dir)
-    else:
-        _write_state(state_file, counter)
 
     return 0
 

--- a/plugins/dev-team/hooks/tdd_guard.py
+++ b/plugins/dev-team/hooks/tdd_guard.py
@@ -26,6 +26,16 @@ if str(_LIB_DIR) not in sys.path:
 
 from boundary_events import emit_boundary_event as _emit_boundary_event
 
+try:
+    from atomic_state import atomic_write
+except ImportError:  # pragma: no cover
+
+    def atomic_write(path: Path, text: str) -> None:  # type: ignore[misc]
+        try:
+            path.write_text(text)
+        except OSError:
+            pass
+
 
 def emit_boundary_event(*args, **kwargs) -> None:
     """Local safety net (#859): even a misbehaving helper must never affect
@@ -161,14 +171,13 @@ def _read_state(state_file: Path) -> tuple[str, int]:
 
 
 def _write_state(state_file: Path, file_path: str, now: int) -> None:
-    try:
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        return
-    try:
-        state_file.write_text(f"{file_path}\n{now}\n")
-    except OSError:
-        pass
+    # Atomic (tempfile + rename) so a concurrent _read_state never observes a
+    # torn/partial file (#1501). No lock is needed here: unlike the counter
+    # hooks (bash_retry_guard, session_learning_trigger), this write is NOT a
+    # function of the prior read — the state is simply "the most recent test
+    # edit," so two concurrent test-file edits racing to write is correct
+    # last-writer-wins, not a lost update. atomic_write handles the mkdir.
+    atomic_write(state_file, f"{file_path}\n{now}\n")
 
 
 def main() -> int:

--- a/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
+++ b/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
@@ -1,0 +1,173 @@
+"""Concurrency regression tests for the hook state read-modify-write race (#1501).
+
+`bash_retry_guard.py` and `session_learning_trigger.py` each maintain an
+on-disk counter with a read-increment-write cycle. Before #1501 two concurrent
+invocations against the same state file could both read the same value,
+increment, and clobber each other — silently losing an update. These tests
+drive each hook (and the shared `atomic_state.locked_state` primitive) with N
+genuinely concurrent OS processes and assert the counter lands at exactly N.
+
+A per-invocation race-window delay (`*_TEST_DELAY_MS`), injected INSIDE the
+locked critical section, widens the overlap so that if the lock were ever
+removed the workers would reliably lose updates — making these strong
+regression guards, not timing-luck tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_HOOKS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
+_LIB_DIR = _HOOKS_DIR / "lib"
+
+# N concurrent workers and the delay (ms) each holds the critical section.
+# The delay guarantees overlap: total serialized wall-clock ~= N * DELAY.
+_WORKERS = 8
+_DELAY_MS = 60
+
+
+def _run_concurrently(cmds):
+    """Launch every (argv, stdin, env) concurrently; wait for all to exit 0-ish."""
+    procs = []
+    for argv, stdin_text, env in cmds:
+        procs.append(
+            (
+                subprocess.Popen(
+                    argv,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    text=True,
+                ),
+                stdin_text,
+            )
+        )
+    # Feed stdin to all first (non-blocking-ish for tiny payloads), then wait.
+    outputs = []
+    for proc, stdin_text in procs:
+        out, err = proc.communicate(stdin_text)
+        outputs.append((proc.returncode, out, err))
+    return outputs
+
+
+# ---------------------------------------------------------------------------
+# Shared primitive: atomic_state.locked_state serializes a RMW across processes
+# ---------------------------------------------------------------------------
+
+
+def test_locked_state_serializes_concurrent_increments(tmp_path):
+    counter_file = tmp_path / "counter.json"
+    counter_file.write_text(json.dumps({"n": 0}))
+
+    worker = tmp_path / "worker.py"
+    worker.write_text(
+        textwrap.dedent(
+            f"""
+            import json, sys
+            from pathlib import Path
+            sys.path.insert(0, {str(_LIB_DIR)!r})
+            from atomic_state import locked_state, atomic_write, race_window_delay
+            p = Path({str(counter_file)!r})
+            with locked_state(p):
+                n = json.loads(p.read_text())["n"]
+                race_window_delay("LOCK_TEST_DELAY_MS")
+                atomic_write(p, json.dumps({{"n": n + 1}}))
+            """
+        )
+    )
+
+    env = {**os.environ, "LOCK_TEST_DELAY_MS": str(_DELAY_MS)}
+    cmds = [([sys.executable, str(worker)], "", env) for _ in range(_WORKERS)]
+    results = _run_concurrently(cmds)
+
+    for rc, _out, err in results:
+        assert rc == 0, f"worker failed (rc={rc}): {err}"
+
+    final = json.loads(counter_file.read_text())["n"]
+    assert final == _WORKERS, (
+        f"lost-update race: expected {_WORKERS} increments, got {final}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# bash_retry_guard.py: N identical concurrent commands -> count == N
+# ---------------------------------------------------------------------------
+
+
+def test_bash_retry_guard_no_lost_increments(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    tmpdir = tmp_path / "state"
+    tmpdir.mkdir()
+
+    payload = json.dumps({"tool_input": {"command": "git status"}, "cwd": str(work)})
+    env = {
+        **os.environ,
+        "TMPDIR": str(tmpdir),
+        "DEV_TEAM_BASH_RETRY_THRESHOLD": "1000",  # never trip the nudge
+        "DEV_TEAM_BASH_RETRY_TEST_DELAY_MS": str(_DELAY_MS),
+    }
+    cmds = [
+        ([sys.executable, str(_HOOKS_DIR / "bash_retry_guard.py")], payload, env)
+        for _ in range(_WORKERS)
+    ]
+    results = _run_concurrently(cmds)
+    for rc, _out, err in results:
+        assert rc == 0, f"hook failed (rc={rc}): {err}"
+
+    state_files = list((tmpdir / "dev-team-bash-retry").glob("*.json"))
+    assert len(state_files) == 1, f"expected one shared state file, got {state_files}"
+    count = json.loads(state_files[0].read_text())["count"]
+    assert count == _WORKERS, (
+        f"lost-update race: expected count {_WORKERS}, got {count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# session_learning_trigger.py: N concurrent SessionEnd hooks -> counter == N
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="hook requires jq on PATH")
+def test_session_learning_trigger_no_lost_increments(tmp_path):
+    project = tmp_path / "project"
+    (project / ".claude" / "metrics").mkdir(parents=True)
+
+    # telemetry_consent reads ~/.claude/telemetry.json — point HOME at a temp
+    # home with consent enabled so the hook proceeds past its consent gate.
+    fake_home = tmp_path / "home"
+    (fake_home / ".claude").mkdir(parents=True)
+    (fake_home / ".claude" / "telemetry.json").write_text('{"enabled": true}')
+
+    payload = json.dumps({"cwd": str(project), "session_id": "s"})
+    env = {
+        **os.environ,
+        "HOME": str(fake_home),
+        "DEV_TEAM_AUTO_REVIEW": "on",
+        "DEV_TEAM_AUTO_REVIEW_THRESHOLD": "100000",  # never dispatch/reset
+        "DEV_TEAM_SESSION_LEARNING_TEST_DELAY_MS": str(_DELAY_MS),
+    }
+    cmds = [
+        ([sys.executable, str(_HOOKS_DIR / "session_learning_trigger.py")], payload, env)
+        for _ in range(_WORKERS)
+    ]
+    results = _run_concurrently(cmds)
+    for rc, _out, err in results:
+        assert rc == 0, f"hook failed (rc={rc}): {err}"
+
+    state = project / ".claude" / "metrics" / "learning-loop-state.json"
+    assert state.is_file(), "hook never wrote state — consent/jq gate not satisfied?"
+    counter = json.loads(state.read_text())["counter"]
+    assert counter == _WORKERS, (
+        f"lost-update race: expected counter {_WORKERS}, got {counter}"
+    )


### PR DESCRIPTION
## Summary

Closes the read-modify-write races `concurrency-review` surfaced in #1501. `bash_retry_guard.py`, `tdd_guard.py`, and `session_learning_trigger.py` each did an unguarded RMW against shared on-disk state, so two concurrent invocations (two Bash calls close together, or two sessions/worktrees on one repo) could race and lose an update.

New shared helper `hooks/lib/atomic_state.py` centralizes two primitives, lifting the proven cross-OS lock idiom from `code_intelligence_turn_mark.py::_sentinel_lock`:
- `atomic_write(path, text)` — tempfile-in-same-dir + `os.replace` (no torn reads).
- `locked_state(path)` — exclusive advisory lock (`fcntl` POSIX / `msvcrt` Windows, fail-open) across a full RMW cycle.

Wiring:
- **bash_retry_guard / session_learning_trigger** — the increment counters wrap read→increment→write in `locked_state` so each invocation adds exactly one. session_learning_trigger's fire-and-forget dispatch stays **outside** the lock.
- **tdd_guard** — `atomic_write`, **no lock by design**: its write is not a function of the prior read, so concurrent test-file edits are correct last-writer-wins, not a lost update (documented in `_write_state`).

## Testing
- New `tests/hooks/test_hook_state_concurrency.py` drives each counter hook and the shared primitive with 8 concurrent OS processes and asserts the counter lands at exactly 8; a race-window delay injected inside the locked section makes it a strong guard.
- Verified the guard is not vacuous: the same 8 workers collapse to **1** without the lock (7 lost updates).
- `concurrency-review` pass: no actionable defects.
- ruff + mypy clean; full `ci-local.sh` green on push.

Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)