### PR TITLE
fix(test-improve): handle a malformed test-counts-before.json as absent in Phase 1

### DIFF
--- a/plugins/dev-team/skills/test-improve/SKILL.md
+++ b/plugins/dev-team/skills/test-improve/SKILL.md
@@ -453,9 +453,19 @@ configured static-analysis tooling at all, the key is `0`, not omitted.
 
 **Existing-snapshot guard.** Before persisting, check whether
 `test-counts-before.json` already exists under
-`.dev-team-reports/test-improve/<slug>/data/` for the resolved slug. **No
-existing file** → write the fresh snapshot directly; no prompt is needed. **An
-existing file**, interactive session → prompt: *"An existing
+`.dev-team-reports/test-improve/<slug>/data/` for the resolved slug. This
+guard is Phase 1's application of the shared existing-tracked-artifact
+re-capture guard — the canonical definition and rationale live once in
+`knowledge/decision-defaults.md`'s "Re-capture: keep vs. overwrite an existing
+tracked artifact" axis; this step cites that axis for the *why* and spells out
+the operational branches below so an executing agent doesn't need to open a
+second file mid-task. **No existing file** → write the fresh snapshot
+directly; no prompt is needed. **An existing file that is malformed or
+corrupt** (fails to parse as JSON — e.g. left over from a prior interrupted
+write) → treat it as absent, never as a snapshot to keep; emit a warning
+naming why a fresh capture is happening, then write the fresh snapshot
+directly (no prompt — there is nothing valid to keep). **An existing, readable
+file**, interactive session → prompt: *"An existing
 test-counts-before.json was found for `<slug>` — overwrite it (starts a fresh
 before/after comparison) or keep it (reuse for this run)? `[keep/overwrite,
 default: keep]`"* Answering `overwrite` replaces the existing file with a
@@ -466,7 +476,10 @@ text — it never silently falls back to the default. When the run is
 **non-interactive** (no usable TTY / `DEV_TEAM_AUTO_APPROVE=1`), the prompt is
 never shown; Phase 1 defaults to **keep existing** and logs the
 auto-decision, mirroring `decision-defaults.md`'s non-interactive rule — never
-a non-default stance (overwrite) with nobody present to confirm it.
+a non-default stance (overwrite) with nobody present to confirm it. The
+malformed-file branch above is the one exception to that keep-by-default
+posture — an unreadable file is treated as absent in every mode, since there
+is nothing valid to keep.
 
 This pass does **not** invoke `/test-health` or `/cd-test-architecture`'s
 full skill.

--- a/tests/skills/test_improve_phase_1.py
+++ b/tests/skills/test_improve_phase_1.py
@@ -173,3 +173,33 @@ def test_phase_1_non_interactive_defaults_to_keep_and_logs_the_decision():
         s,
     )
     assert grep(r"decision-defaults\.md", s)
+
+
+# --- malformed-file-treated-as-absent branch (issue #1502) -------------------
+
+
+def test_phase_1_malformed_snapshot_treated_as_absent_with_warning():
+    """A corrupt/unparseable test-counts-before.json is treated as absent —
+    a fresh capture with a warning, never silently kept — matching the shared
+    re-capture axis the two newer guards already implement (#1502)."""
+    s = _phase_1_section()
+    assert grep(r"malformed|corrupt", s, ignore_case=True)
+    assert grep_multiline(
+        r"(malformed or\s+corrupt|fails to parse).{0,120}treat it as absent",
+        s,
+        ignore_case=True,
+    )
+    assert grep(r"never as a snapshot to keep", s, ignore_case=True)
+    assert grep(r"emit a warning", s, ignore_case=True)
+
+
+def test_phase_1_snapshot_guard_cites_the_shared_recapture_axis():
+    """Phase 1's guard cites decision-defaults.md's re-capture axis for the
+    *why* rather than continuing to duplicate an incomplete copy (#1502)."""
+    s = _phase_1_section()
+    assert grep(r"decision-defaults\.md", s)
+    assert grep(
+        r"Re-capture: keep vs\. overwrite an existing\s+tracked artifact",
+        s,
+        ignore_case=True,
+    )


### PR DESCRIPTION
## Summary

Surfaced by `structure-review` on PR #1499. Phase 1's existing-snapshot guard for `test-counts-before.json` predates the shared "existing-tracked-artifact re-capture" axis (`knowledge/decision-defaults.md`). It handled only *file exists* / *file absent* — not *file exists but fails to parse*. The two newer guards built on that axis (coverage-baseline's existing-baseline guard, test-improve Phase 2's mutation-baseline guard) both treat a malformed existing file as absent with a warning; Phase 1's origin guard silently lacked that branch, so a corrupt snapshot could be offered as a "keep" candidate (#1502).

- Adds the malformed-file-treated-as-absent branch to Phase 1's guard — an existing file that fails to parse as JSON is treated as absent (fresh capture + warning) in every mode, the one documented exception to keep-by-default.
- Cites `decision-defaults.md`'s re-capture axis for the *why* (like the two newer guards) instead of duplicating an incomplete copy.

## Testing
- Two new content-guard tests in `tests/skills/test_improve_phase_1.py` pin the new branch and the axis citation (18 pass).
- `check_md_references.py` clean; knowledge index unchanged; full `ci-local.sh` green on push.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)