### PR TITLE
fix(gherkin-derive): require endpoint-specific scenario titles

### DIFF
--- a/plugins/dev-team/scripts/gherkin_cross_feature_duplicate_titles_gate.py
+++ b/plugins/dev-team/scripts/gherkin_cross_feature_duplicate_titles_gate.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""gherkin_cross_feature_duplicate_titles_gate.py — flag a scenario title that
+appears under two or more distinct Feature: blocks (issue #1526).
+
+Mirrors `gherkin_failure_path_gate.py`'s shape: scans `.feature` files under
+one or more directories, parses each `Feature:` block's scenario titles (with
+each scenario's own line number), and flags any title that recurs under more
+than one distinct Feature title. A title repeated multiple times under the
+*same* Feature title is out of scope here — that is
+`gherkin_feature_merge.py`'s own within-file merge-dedup concern (issue
+#1420), already handled there. This gate exists because a generic,
+surface-agnostic scenario title (e.g. "returns error for invalid input") can
+collide across two unrelated endpoints/surfaces; `gherkin_feature_merge.py`'s
+dedup only ever compares titles *within* the Feature block it is merging
+into, so a cross-file collision like this is otherwise invisible until a
+human notices two features documenting "the same" scenario.
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+
+Usage:
+    python3 gherkin_cross_feature_duplicate_titles_gate.py --dir <dir> [--dir <dir> ...] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "lib"))
+
+from _gherkin_text import FEATURE_PREFIX as _FEATURE_PREFIX
+from _gherkin_text import SCENARIO_OUTLINE_PREFIX as _SCENARIO_OUTLINE_PREFIX
+from _gherkin_text import SCENARIO_PREFIX as _SCENARIO_PREFIX
+from _gherkin_text import safe_for_terminal as _safe_for_terminal
+from _gherkin_text import stripped as _stripped
+from _gherkin_text import trim_trailing_tag_run as _trim_trailing_tag_run
+from _vendored_tree import find_files as _find_files
+
+
+def find_feature_files(directories: list) -> list:
+    """Return every `.feature` file under `directories`, pruning vendored
+    trees, sorted for deterministic output."""
+    return _find_files(directories, lambda path: path.suffix == ".feature")
+
+
+def parse_scenario_locations(text: str, path) -> list:
+    """Return one entry per `Scenario:`/`Scenario Outline:` line across every
+    `Feature:` block in `text`: {file, feature_title, scenario_title, line}.
+    `line` is the scenario's own 1-based line number (not the enclosing
+    Feature block's), since the report needs to point at the exact
+    colliding line, not just the block it lives in."""
+    lines = text.splitlines(keepends=True)
+    header_indices = [
+        i for i, line in enumerate(lines) if _stripped(line).strip().startswith(_FEATURE_PREFIX)
+    ]
+    entries = []
+    for idx, header_index in enumerate(header_indices):
+        feature_title = _stripped(lines[header_index]).strip()[len(_FEATURE_PREFIX) :].strip()
+        end_index = header_indices[idx + 1] if idx + 1 < len(header_indices) else len(lines)
+        end_index = _trim_trailing_tag_run(lines, header_index, end_index)
+        for line_index in range(header_index + 1, end_index):
+            stripped = _stripped(lines[line_index]).strip()
+            if stripped.startswith(_SCENARIO_OUTLINE_PREFIX):
+                title = stripped[len(_SCENARIO_OUTLINE_PREFIX) :].strip()
+            elif stripped.startswith(_SCENARIO_PREFIX):
+                title = stripped[len(_SCENARIO_PREFIX) :].strip()
+            else:
+                continue
+            entries.append(
+                {
+                    "file": str(path),
+                    "feature_title": feature_title,
+                    "scenario_title": title,
+                    "line": line_index + 1,
+                }
+            )
+    return entries
+
+
+def find_cross_feature_duplicates(entries: list) -> list:
+    """Group `entries` by scenario title; return one finding per title that
+    appears under 2+ *distinct* Feature titles: {scenario_title,
+    occurrences: [{feature_title, file, line}, ...]}. A title repeated only
+    under one Feature title (any number of times) is not a finding — that is
+    gherkin_feature_merge.py's own within-file dedup concern, out of scope
+    here."""
+    by_title = defaultdict(list)
+    for entry in entries:
+        by_title[entry["scenario_title"]].append(entry)
+
+    findings = []
+    for title, occurrences in by_title.items():
+        if len({o["feature_title"] for o in occurrences}) < 2:
+            continue
+        findings.append(
+            {
+                "scenario_title": title,
+                "occurrences": [
+                    {
+                        "feature_title": o["feature_title"],
+                        "file": o["file"],
+                        "line": o["line"],
+                    }
+                    for o in occurrences
+                ],
+            }
+        )
+    findings.sort(key=lambda f: f["scenario_title"])
+    return findings
+
+
+def main(argv: list | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="gherkin_cross_feature_duplicate_titles_gate.py",
+        description="Flag a scenario title duplicated across distinct Feature: blocks.",
+    )
+    parser.add_argument("--dir", dest="dirs", action="append", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    files = find_feature_files(args.dirs)
+
+    if not files:
+        # Mirrors gherkin_failure_path_gate.py's identical decision: a --dir
+        # that resolves to zero .feature files must say so distinctly, not
+        # report an affirmative all-clear for zero evidence scanned.
+        dirs_display = ", ".join(str(d) for d in args.dirs)
+        message = f"no .feature files found under {dirs_display} — gate did not run"
+        if args.json:
+            print(json.dumps({"scanned": [], "findings": [], "warning": message}, indent=2))
+        else:
+            # --dir is composed by gherkin-derive from a probe of the target
+            # repo, not always typed by a human — the same untrusted-path
+            # class as a scanned file's path, sanitized the same way.
+            print(f"WARN: no .feature files found under {_safe_for_terminal(dirs_display)} — gate did not run")
+        return 2
+
+    all_entries = []
+    for path in files:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        all_entries.extend(parse_scenario_locations(text, path))
+
+    findings = find_cross_feature_duplicates(all_entries)
+
+    if args.json:
+        print(json.dumps({"scanned": [str(f) for f in files], "findings": findings}, indent=2))
+        return 1 if findings else 0
+
+    if findings:
+        print(f"FAIL: {len(findings)} scenario title(s) duplicated across distinct Feature blocks:")
+        for finding in findings:
+            title = _safe_for_terminal(finding["scenario_title"])
+            locations = " and ".join(
+                f"{_safe_for_terminal(o['feature_title'])} "
+                f"({_safe_for_terminal(o['file'])}:{o['line']})"
+                for o in finding["occurrences"]
+            )
+            print(f"  - \"{title}\" appears in {locations}")
+        return 1
+
+    print(
+        f"OK: {len(all_entries)} scenario(s) scanned, "
+        "no title is duplicated across distinct Feature blocks."
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/scripts/gherkin_failure_path_gate.py
+++ b/plugins/dev-team/scripts/gherkin_failure_path_gate.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -33,30 +32,10 @@ sys.path.insert(0, str(_HERE / "lib"))
 from _gherkin_text import FEATURE_PREFIX as _FEATURE_PREFIX
 from _gherkin_text import SCENARIO_OUTLINE_PREFIX as _SCENARIO_OUTLINE_PREFIX
 from _gherkin_text import SCENARIO_PREFIX as _SCENARIO_PREFIX
+from _gherkin_text import safe_for_terminal as _safe_for_terminal
 from _gherkin_text import stripped as _stripped
+from _gherkin_text import trim_trailing_tag_run as _trim_trailing_tag_run
 from _vendored_tree import find_files as _find_files
-
-# C0/C1 control characters (excluding the ordinary whitespace already
-# stripped elsewhere) — stripped before printing scanned-file content to a
-# terminal. A `.feature` file's Feature: title is untrusted (it comes from
-# whatever repository is being scanned) and could otherwise inject terminal
-# escape sequences (CWE-150) or masquerade as trusted tool output fed back
-# into an agent's report.
-_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
-
-
-def _safe_for_terminal(text: str, limit: int = 200) -> str:
-    """Strip control characters and bound length before printing untrusted
-    scanned-file text to a terminal (the `--json` path is unaffected —
-    `json.dumps` already escapes control characters)."""
-    return _CONTROL_CHARS.sub("", text)[:limit]
-
-
-def _is_tag_line(line: str) -> bool:
-    stripped = _stripped(line).strip()
-    if not stripped:
-        return False
-    return all(tok.startswith("@") for tok in stripped.split())
 
 # Entries are literal substrings, not stems — "exceeds" does not match
 # "exceed" — matching gherkin_feature_merge.py's `is_stale` in spirit (a
@@ -106,19 +85,12 @@ def parse_features(text: str, path) -> list:
         title = _stripped(lines[header_index]).strip()[len(_FEATURE_PREFIX) :].strip()
         end_index = header_indices[idx + 1] if idx + 1 < len(header_indices) else len(lines)
         # A `@tag`/blank-line run immediately preceding the next Feature:
-        # header belongs to that next block, not this one (Gherkin tags
-        # attach to the declaration that follows them) — mirrors
-        # gherkin_feature_merge.py's _block_end fix for the identical bug.
-        # Without this, a tag like `@error-handling` on the *following*
-        # Feature block leaks into this block's scenario_text, and a
-        # keyword match against that leaked tag can make this block pass
-        # the gate even though it has no failure-path scenario of its own.
-        while end_index > header_index + 1:
-            prev = lines[end_index - 1]
-            if _stripped(prev).strip() == "" or _is_tag_line(prev):
-                end_index -= 1
-            else:
-                break
+        # header belongs to that next block, not this one. Without this, a
+        # tag like `@error-handling` on the *following* Feature block leaks
+        # into this block's scenario_text, and a keyword match against that
+        # leaked tag can make this block pass the gate even though it has no
+        # failure-path scenario of its own.
+        end_index = _trim_trailing_tag_run(lines, header_index, end_index)
         body = lines[header_index + 1 : end_index]
         scenario_titles = []
         for line in body:
@@ -201,7 +173,10 @@ def main(argv: list | None = None) -> int:
         if args.json:
             print(json.dumps({"scanned": [], "findings": [], "warning": message}, indent=2))
         else:
-            print(f"WARN: {message}")
+            # --dir is composed by gherkin-derive from a probe of the target
+            # repo, not always typed by a human — the same untrusted-path
+            # class as a scanned file's path, sanitized the same way.
+            print(f"WARN: no .feature files found under {_safe_for_terminal(dirs_display)} — gate did not run")
         return 2
 
     all_features = []
@@ -218,7 +193,9 @@ def main(argv: list | None = None) -> int:
     if findings:
         print(f"FAIL: {len(findings)} Feature block(s) missing a failure-path scenario:")
         for entry in findings:
-            print(f"  - {entry['file']}:{entry['line']} — {_safe_for_terminal(entry['feature_title'])}")
+            path = _safe_for_terminal(entry["file"])
+            title = _safe_for_terminal(entry["feature_title"])
+            print(f"  - {path}:{entry['line']} — {title}")
         return 1
 
     print(f"OK: {len(all_features)} Feature block(s) scanned, all have a failure-path scenario.")

--- a/plugins/dev-team/scripts/gherkin_feature_merge.py
+++ b/plugins/dev-team/scripts/gherkin_feature_merge.py
@@ -42,7 +42,10 @@ sys.path.insert(0, str(_HERE / "lib"))
 from _gherkin_text import FEATURE_PREFIX as _FEATURE_PREFIX
 from _gherkin_text import SCENARIO_OUTLINE_PREFIX as _SCENARIO_OUTLINE_PREFIX
 from _gherkin_text import SCENARIO_PREFIX as _SCENARIO_PREFIX
+from _gherkin_text import is_tag_line as _is_tag_line
+from _gherkin_text import safe_for_terminal as _safe_for_terminal
 from _gherkin_text import stripped as _stripped
+from _gherkin_text import trim_trailing_tag_run as _trim_trailing_tag_run
 
 _BACKGROUND_PREFIX = "Background:"
 _SCENARIO_PREFIXES = (_SCENARIO_OUTLINE_PREFIX, _SCENARIO_PREFIX)
@@ -101,13 +104,6 @@ def _split_lines(text: str) -> list:
     return text.splitlines(keepends=True)
 
 
-def _is_tag_line(line: str) -> bool:
-    stripped = _stripped(line).strip()
-    if not stripped:
-        return False
-    return all(tok.startswith("@") for tok in stripped.split())
-
-
 def _scenario_title(line: str) -> str | None:
     """Return the title text if `line` is a Scenario:/Scenario Outline: line."""
     stripped = _stripped(line).strip()
@@ -143,14 +139,7 @@ def _block_end(lines: list, header_index: int) -> int:
     malformed-feature-block."""
     for j in range(header_index + 1, len(lines)):
         if _stripped(lines[j]).strip().startswith(_FEATURE_PREFIX):
-            end = j
-            while end > header_index + 1:
-                prev = lines[end - 1]
-                if _stripped(prev).strip() == "" or _is_tag_line(prev):
-                    end -= 1
-                else:
-                    break
-            return end
+            return _trim_trailing_tag_run(lines, header_index, j)
     return len(lines)
 
 
@@ -542,8 +531,9 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             print(json.dumps(_merge_payload(written=False, error=ERROR_MALFORMED_CANDIDATES)))
         else:
             _write_error(
-                f"gherkin_feature_merge: candidates file {args.candidates} is malformed "
-                f"(error={candidates_error}) — no scenarios merged, existing file left untouched"
+                f"gherkin_feature_merge: candidates file {_safe_for_terminal(args.candidates)} "
+                f"is malformed (error={candidates_error}) — no scenarios merged, existing file "
+                f"left untouched"
             )
         return 2
 
@@ -555,14 +545,14 @@ def _cmd_merge(args: argparse.Namespace) -> int:
         elif result.error == ERROR_FEATURE_NOT_FOUND:
             _write_error(
                 f"gherkin_feature_merge: could not locate Feature: {args.feature_title!r} "
-                f"in {args.existing} — no scenarios merged, existing file left untouched "
-                f"(error={result.error})"
+                f"in {_safe_for_terminal(args.existing)} — no scenarios merged, existing file "
+                f"left untouched (error={result.error})"
             )
         else:
             _write_error(
-                f"gherkin_feature_merge: found Feature: {args.feature_title!r} in {args.existing} "
-                f"but its structure could not be parsed — no scenarios merged, existing file "
-                f"left untouched (error={result.error})"
+                f"gherkin_feature_merge: found Feature: {args.feature_title!r} in "
+                f"{_safe_for_terminal(args.existing)} but its structure could not be parsed — "
+                f"no scenarios merged, existing file left untouched (error={result.error})"
             )
         return 2
 
@@ -595,7 +585,10 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             )
         )
     else:
-        print(f"OK: merged {len(result.added_titles)} new scenario(s) into {args.existing}")
+        print(
+            f"OK: merged {len(result.added_titles)} new scenario(s) into "
+            f"{_safe_for_terminal(args.existing)}"
+        )
     return 0
 
 
@@ -655,8 +648,9 @@ def _cmd_check_stale(args: argparse.Namespace) -> int:
     else:
         for entry in findings:
             print(
-                f"possibly stale: {args.existing}:{entry['line']} ({entry['title']!r}) — "
-                f"asserts {entry['then_text']!r}, code now does {entry['observed']!r}"
+                f"possibly stale: {_safe_for_terminal(args.existing)}:{entry['line']} "
+                f"({entry['title']!r}) — asserts {entry['then_text']!r}, "
+                f"code now does {entry['observed']!r}"
             )
         for title in unmatched_titles:
             print(

--- a/plugins/dev-team/scripts/gherkin_stub_gate.py
+++ b/plugins/dev-team/scripts/gherkin_stub_gate.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -61,21 +60,8 @@ _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE / "lib"))
 
 from _bdd_markers import MARKERS_BY_EXT as _MARKERS_BY_EXT
+from _gherkin_text import safe_for_terminal as _safe_for_terminal
 from _vendored_tree import find_files as _find_files
-
-# See gherkin_failure_path_gate.py's identical constant/helper: strips
-# control characters from untrusted scanned-file content before it reaches
-# a terminal (CWE-150 / indirect prompt-injection via tool output). Below
-# the repo's own "third occurrence" extraction threshold (two call sites),
-# so kept local rather than hoisted to lib/.
-_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
-
-
-def _safe_for_terminal(text: str, limit: int = 200) -> str:
-    """Strip control characters and bound length before printing untrusted
-    scanned-file text to a terminal (the `--json` path is unaffected —
-    `json.dumps` already escapes control characters)."""
-    return _CONTROL_CHARS.sub("", text)[:limit]
 
 
 def find_step_definition_files(directories: list[Path]) -> list[Path]:
@@ -146,7 +132,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.json:
             print(json.dumps({"scanned": [], "pending": [], "warning": message}, indent=2))
         else:
-            print(f"WARN: {message}")
+            # --dir is composed by gherkin-derive from a probe of the target
+            # repo, not always typed by a human — the same untrusted-path
+            # class as a scanned file's path, sanitized the same way.
+            print(
+                f"WARN: no step-definition files found under "
+                f"{_safe_for_terminal(dirs_display)} — gate did not run"
+            )
         return 2
 
     pending = find_pending_stubs(files)
@@ -158,10 +150,9 @@ def main(argv: list[str] | None = None) -> int:
     if pending:
         print(f"FAIL: {len(pending)} pending step definition(s) — bdd-runner mode is not done:")
         for entry in pending:
-            print(
-                f"  - {entry['file']}:{entry['line']} ({entry['language']}) — "
-                f"{_safe_for_terminal(entry['text'])}"
-            )
+            path = _safe_for_terminal(entry["file"])
+            text = _safe_for_terminal(entry["text"])
+            print(f"  - {path}:{entry['line']} ({entry['language']}) — {text}")
         return 1
 
     print(f"OK: {len(files)} step-definition file(s) scanned, no pending stubs remain.")

--- a/plugins/dev-team/scripts/lib/_gherkin_text.py
+++ b/plugins/dev-team/scripts/lib/_gherkin_text.py
@@ -1,19 +1,45 @@
 """_gherkin_text.py — line-level Gherkin text primitives shared across the
-`.feature`-file scripts (gherkin_feature_merge.py, gherkin_failure_path_gate.py).
+`.feature`-file *parsers* (`gherkin_feature_merge.py`, `gherkin_failure_path_gate.py`,
+`gherkin_cross_feature_duplicate_titles_gate.py`), plus a general
+untrusted-text/path terminal-safety helper also used by `gherkin_stub_gate.py`
+(a step-definition scanner — it never parses `.feature` files, and imports only
+`safe_for_terminal`, none of the Gherkin block-parsing primitives below).
 
 Hoisted out after `_stripped()` and the `Feature:`/`Scenario:`/`Scenario
 Outline:` prefix constants were found duplicated byte-for-byte between the two
-scripts (issue #1420 code-review follow-up) — the same "third occurrence"
-threshold `_vendored_tree.py` was extracted at.
+`.feature`-file parsers (issue #1420 code-review follow-up) — the same "third
+occurrence" threshold `_vendored_tree.py` was extracted at. `is_tag_line`/
+`safe_for_terminal` and `trim_trailing_tag_run` joined later (issue #1526) at
+that same third-occurrence point — the latter closes the trailing `@tag`/
+blank-line look-back loop that was independently duplicated in all three
+`.feature`-file parsers (`gherkin_feature_merge.py`'s `_block_end`, and the two
+gate scripts' own block-scanning loops).
 
 Stdlib-only. Python 3.8+ (ADR 0014/0015).
 """
 
 from __future__ import annotations
 
+import re
+
 FEATURE_PREFIX = "Feature:"
 SCENARIO_OUTLINE_PREFIX = "Scenario Outline:"
 SCENARIO_PREFIX = "Scenario:"
+
+# Full C0 + C1 control-character range — stripped before printing untrusted
+# scanned-file content (or a path derived from it) to a terminal. A
+# `.feature` file's content (titles, and the path it was found at) comes
+# from whatever repository is being scanned, and could otherwise inject
+# terminal escape sequences (CWE-150), forge fake report lines via an
+# embedded CR/LF, or masquerade as trusted tool output fed back into an
+# agent's report. Titles are always single lines (parsed via `splitlines()`
+# then `.strip()`), so stripping CR/LF/tab from title text is a no-op; a
+# filesystem path has no such guarantee, so the full range — not just the
+# subset that happened to matter for line-oriented title text — is needed
+# now that this function also sanitizes paths.
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+TERMINAL_DISPLAY_LIMIT = 200
 
 
 def stripped(line: str) -> str:
@@ -21,3 +47,40 @@ def stripped(line: str) -> str:
     caller reconstructing text from `splitlines(keepends=True)` output stays
     byte-exact for everything except the ending itself."""
     return line.rstrip("\r\n")
+
+
+def safe_for_terminal(text: str, limit: int = TERMINAL_DISPLAY_LIMIT) -> str:
+    """Strip control characters and bound length before printing untrusted
+    scanned-file text (or a path derived from it) to a terminal — the
+    `--json` path is unaffected, `json.dumps` already escapes control
+    characters. Apply this to every piece of untrusted text reaching a
+    terminal print, including file paths: a filename is drawn from the same
+    untrusted repository as titles and can legally contain control bytes on
+    POSIX filesystems."""
+    return CONTROL_CHARS.sub("", text)[:limit]
+
+
+def is_tag_line(line: str) -> bool:
+    """True when `line` is a Gherkin `@tag` line (every token starts with
+    `@`) — used to walk a Feature block's trailing tag/blank-line run back
+    onto the *next* block it actually belongs to, not this one."""
+    text = stripped(line).strip()
+    if not text:
+        return False
+    return all(tok.startswith("@") for tok in text.split())
+
+
+def trim_trailing_tag_run(lines: list, header_index: int, end_index: int) -> int:
+    """Back `end_index` up past a trailing `@tag`/blank-line run so it lands
+    on the true end of the Feature block starting at `header_index` —
+    Gherkin tags attach to the declaration that *follows* them, so a
+    `@tag` (or blank line) immediately preceding the next Feature: header
+    belongs to that next block, not this one. Without this, a tag on the
+    following Feature block would leak into this block's body."""
+    while end_index > header_index + 1:
+        prev = lines[end_index - 1]
+        if stripped(prev).strip() == "" or is_tag_line(prev):
+            end_index -= 1
+        else:
+            break
+    return end_index

--- a/plugins/dev-team/skills/gherkin-derive/SKILL.md
+++ b/plugins/dev-team/skills/gherkin-derive/SKILL.md
@@ -151,6 +151,20 @@ operator, or its non-interactive default) instead of guessing a destination.
 If a file already exists at that composed path, **read it** before authoring
 anything for that surface — Step 5 merges into it rather than overwriting.
 
+**Surface identifiers must be unique per method+path (or equivalent
+distinguishing element for non-HTTP surfaces) — never collapse two different
+surfaces onto the same `<surface>` stem (issue #1526).** For an API Provider
+surface, derive `<surface>` from both the HTTP method and the normalized
+path (e.g. `GET /users/{id}` → `get_users_id`, `DELETE /users/{id}` →
+`delete_users_id`) so two endpoints that differ only by method or path never
+compose the same file/feature-title pair. For a non-HTTP surface
+(message-queue consumer, cron job, CLI command, exported function), use the
+fully-qualified name (queue/topic name, job name, module.function) for the
+same reason. A surface-identifier collision is a defect regardless of how it
+happens — it silently merges two unrelated behaviors' scenarios into one
+Feature block, where the exact-title dedup in Step 5 will treat a second
+surface's same-titled scenario as an existing duplicate and drop it.
+
 ## Step 3 — Author scenarios
 
 Use the same templates as `/gherkin-public`: **API Provider**, **UI**,
@@ -170,6 +184,21 @@ directly when the tools are unavailable. Do not invent a generic
 the surface's name or signature. When no such condition is discoverable for a
 surface, mark that scenario `# TODO: no observed failure path — hand-author`
 instead of fabricating one — an honest gap beats an invented scenario.
+
+**Titles must be specific enough to identify the surface without relying on
+the `Feature:` header for context (issue #1526).** A `Scenario:` title read
+in isolation — in a CI report, a BDD runner's scenario list, or a coverage
+dashboard — must be recognizable as belonging to its specific surface, not a
+generic category label that could describe any endpoint (e.g. `returns error
+for invalid input`, `handles success case`). Prefer wording that names the
+concrete condition or resource involved (e.g. `rejects the request when the
+id path parameter is non-numeric`, `returns the created order with a 201 and
+Location header`) over a bare category name. This applies to success-path
+titles as well as failure-path titles — the no-generic-placeholder rule
+above already covers failure-path *content*; this rule covers *all* scenario
+*titles*. A title that is merely a paraphrase of the surface name (the same
+words as the `Feature:` line, reworded) fails this rule the same way a
+placeholder failure condition does.
 
 **Label the provenance** in each `.feature` file header:
 
@@ -521,6 +550,28 @@ files found under `<dir>`, re-check the feature-files directory," never as
 an `OK`/all-clear (a scan of zero files finding zero problems is not the
 same as zero problems). Skip entirely in `none` mode (no `.feature` files
 are written).
+
+**Every mode that writes `.feature` files — report the cross-feature
+duplicate-title gate (issue #1526).** Same scope as the failure-path gate
+immediately above — not `bdd-runner`-only, since the collision this checks
+for exists whenever `.feature` files exist:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_cross_feature_duplicate_titles_gate.py --dir <feature-files-dir>
+```
+
+Print the gate's result as its own report section, never folded into the
+general summary: `OK: no scenario title is duplicated across distinct
+Feature blocks` when it exits 0, or `N scenario title(s) duplicated across
+distinct Feature blocks` when it exits 1, listing each finding as `"<title>"
+appears in <feature-title-A> (<file>:<line>) and <feature-title-B>
+(<file>:<line>) — confirm these are genuinely the same behavior, or rename
+one to be surface-specific`. **A third outcome exists — exit 2 means the
+gate did not run** (no `.feature` files were found under the scanned
+directory, most often a mistyped or mis-probed `--dir`); report this as
+"gate did not run — no `.feature` files found under `<dir>`, re-check the
+feature-files directory," never as an `OK`/all-clear. Skip entirely in
+`none` mode (no `.feature` files are written).
 
 **Every mode — report the analysis-coverage gate (issue #1450).** Unlike
 the two gates above, this one runs even in `none` mode: the surface

--- a/plugins/dev-team/skills/gherkin-public/SKILL.md
+++ b/plugins/dev-team/skills/gherkin-public/SKILL.md
@@ -48,6 +48,8 @@ For each component in the map, generate one `.feature` file per public surface u
 
 **Grounding scenarios in real behavior.** The component map names each surface but not its actual branches or error-handling depth. If the target repo has `.codegraph/` (CodeGraph MCP server, `mcp__codegraph__codegraph_explore` — fast callers/callees/impact lookups) and/or a Repowise MCP server (`get_context`/`search_codebase` — verified context and semantic search), prefer them over raw `Grep` to inspect a surface's real failure conditions before writing its failure scenario, rather than inferring one from the surface name alone. Never assume either is present — fall back to `Read`/`Grep`/`Glob` when absent; the tools are simply unavailable (no error) on repos without an index.
 
+**Titles must be specific enough to identify the surface without relying on the `Feature:` header for context (issue #1526).** A `Scenario:` title read in isolation — in a CI report, a BDD runner's scenario list, or a coverage dashboard — must be recognizable as belonging to its specific surface, not a generic category label that could describe any endpoint (e.g. `returns error for invalid input`, `handles success case`). Prefer wording that names the concrete condition or resource involved (e.g. `rejects the request when the id path parameter is non-numeric`, `returns the created order with a 201 and Location header`) over a bare category name. A title that is merely a paraphrase of the surface name (the same words as the `Feature:` line, reworded) fails this rule.
+
 **API Provider** (one `.feature` per endpoint):
 
 ```gherkin

--- a/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
@@ -1,0 +1,252 @@
+"""Unit tests for scripts/gherkin_cross_feature_duplicate_titles_gate.py
+(issue #1526).
+
+Covers cross-Feature scenario-title collision detection, the main() CLI's
+exit-code contract, and the explicit out-of-scope carve-out for a title
+repeated within the *same* Feature block (that's gherkin_feature_merge.py's
+own merge-dedup concern, not this gate's).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
+
+import gherkin_cross_feature_duplicate_titles_gate as gate
+
+ORDERS_FEATURE = """Feature: POST /orders
+
+  Scenario: returns error for invalid input
+    Given an invalid payload
+    When the order is created
+    Then the response status is 400
+"""
+
+USERS_FEATURE = """Feature: POST /users
+
+  Scenario: returns error for invalid input
+    Given an invalid payload
+    When the user is created
+    Then the response status is 400
+"""
+
+REFUNDS_FEATURE = """Feature: POST /refunds
+
+  Scenario: returns the created refund with a 201
+    Given a valid payload
+    When the refund is created
+    Then the response status is 201
+"""
+
+
+def test_same_title_across_two_distinct_features_is_flagged():
+    entries = gate.parse_scenario_locations(ORDERS_FEATURE, "orders.feature")
+    entries += gate.parse_scenario_locations(USERS_FEATURE, "users.feature")
+    findings = gate.find_cross_feature_duplicates(entries)
+    assert len(findings) == 1
+    assert findings[0]["scenario_title"] == "returns error for invalid input"
+    feature_titles = {o["feature_title"] for o in findings[0]["occurrences"]}
+    assert feature_titles == {"POST /orders", "POST /users"}
+
+
+def test_distinct_titles_across_features_produce_no_findings():
+    entries = gate.parse_scenario_locations(ORDERS_FEATURE, "orders.feature")
+    entries += gate.parse_scenario_locations(REFUNDS_FEATURE, "refunds.feature")
+    findings = gate.find_cross_feature_duplicates(entries)
+    assert findings == []
+
+
+def test_title_repeated_within_the_same_feature_is_not_flagged():
+    """Out of scope by design: a title repeated under the *same* Feature
+    title is gherkin_feature_merge.py's own within-file merge-dedup concern
+    (issue #1420), not this gate's."""
+    doubled = """Feature: POST /orders
+
+  Scenario: returns error for invalid input
+    Given an invalid payload
+    When the order is created
+    Then the response status is 400
+
+  Scenario: returns error for invalid input
+    Given a different invalid payload
+    When the order is created
+    Then the response status is 400
+"""
+    entries = gate.parse_scenario_locations(doubled, "orders.feature")
+    assert len(entries) == 2
+    findings = gate.find_cross_feature_duplicates(entries)
+    assert findings == []
+
+
+def test_parse_scenario_locations_records_each_scenarios_own_line():
+    entries = gate.parse_scenario_locations(ORDERS_FEATURE, "orders.feature")
+    assert len(entries) == 1
+    assert entries[0]["feature_title"] == "POST /orders"
+    assert entries[0]["scenario_title"] == "returns error for invalid input"
+    assert entries[0]["line"] == 3
+
+
+def test_scenario_outline_titles_are_included():
+    text = """Feature: GET /widgets
+
+  Scenario Outline: returns error for invalid input
+    Given a <bad> payload
+    Then the response status is 400
+
+    Examples:
+      | bad |
+      | x   |
+"""
+    entries = gate.parse_scenario_locations(text, "widgets.feature")
+    assert len(entries) == 1
+    assert entries[0]["scenario_title"] == "returns error for invalid input"
+
+
+def test_tag_on_a_following_feature_block_does_not_leak_into_this_blocks_scenarios():
+    text = ORDERS_FEATURE + "\n@error-handling\n" + USERS_FEATURE
+    entries = gate.parse_scenario_locations(text, "combined.feature")
+    assert len(entries) == 2
+    assert {e["feature_title"] for e in entries} == {"POST /orders", "POST /users"}
+
+
+def test_main_json_output_contract(tmp_path, capsys):
+    (tmp_path / "orders.feature").write_text(ORDERS_FEATURE)
+    (tmp_path / "users.feature").write_text(USERS_FEATURE)
+    exit_code = gate.main(["--dir", str(tmp_path), "--json"])
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"scanned", "findings"}
+    assert len(payload["findings"]) == 1
+    finding = payload["findings"][0]
+    assert finding["scenario_title"] == "returns error for invalid input"
+    assert len(finding["occurrences"]) == 2
+    for occurrence in finding["occurrences"]:
+        assert set(occurrence) == {"feature_title", "file", "line"}
+
+
+def test_main_names_titles_and_locations_for_findings(tmp_path, capsys):
+    (tmp_path / "orders.feature").write_text(ORDERS_FEATURE)
+    (tmp_path / "users.feature").write_text(USERS_FEATURE)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "returns error for invalid input" in out
+    assert "POST /orders" in out
+    assert "POST /users" in out
+    assert "orders.feature:3" in out
+    assert "users.feature:3" in out
+
+
+def test_main_exits_zero_when_no_titles_collide(tmp_path, capsys):
+    (tmp_path / "orders.feature").write_text(ORDERS_FEATURE)
+    (tmp_path / "refunds.feature").write_text(REFUNDS_FEATURE)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_does_not_silently_pass_when_dir_does_not_exist(tmp_path, capsys):
+    missing_dir = tmp_path / "does-not-exist"
+    exit_code = gate.main(["--dir", str(missing_dir)])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "OK" not in out
+    assert "no .feature files found" in out
+
+
+def test_main_json_warns_when_dir_does_not_exist(tmp_path, capsys):
+    missing_dir = tmp_path / "does-not-exist"
+    exit_code = gate.main(["--dir", str(missing_dir), "--json"])
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scanned"] == []
+    assert payload["findings"] == []
+    assert "no .feature files found" in payload["warning"]
+
+
+def test_main_strips_control_characters_from_scenario_title_in_text_output(tmp_path, capsys):
+    """CWE-150: a title is untrusted (drawn from whatever repo is being
+    scanned) and must not be able to inject terminal escape sequences into
+    the gate's own report."""
+    hostile_title = "returns error for invalid input\x1b[31m"
+    orders = f"""Feature: POST /orders
+
+  Scenario: {hostile_title}
+    Given an invalid payload
+    Then the response status is 400
+"""
+    users = f"""Feature: POST /users
+
+  Scenario: {hostile_title}
+    Given an invalid payload
+    Then the response status is 400
+"""
+    (tmp_path / "orders.feature").write_text(orders)
+    (tmp_path / "users.feature").write_text(users)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "returns error for invalid input" in out
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_main_strips_control_characters_from_file_path_in_text_output(tmp_path, capsys):
+    """The scanned file's path is drawn from the same untrusted repository as
+    scenario/feature titles — a crafted filename must not bypass the same
+    CWE-150 guard applied to title text right next to it in the report."""
+    hostile_name = "orders\x1b[31m.feature"
+    (tmp_path / hostile_name).write_text(ORDERS_FEATURE)
+    (tmp_path / "users.feature").write_text(USERS_FEATURE)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+
+
+def test_main_strips_control_characters_from_feature_title_in_text_output(tmp_path, capsys):
+    """The Feature: title guard is a separate _safe_for_terminal call site
+    from the scenario title and file path guards — each needs its own
+    hostile-input coverage, or reverting just this one call would leave the
+    whole suite green."""
+    orders = """Feature: POST /orders\x1b[31m
+
+  Scenario: returns error for invalid input
+    Given an invalid payload
+    Then the response status is 400
+"""
+    users = """Feature: POST /users\x1b[31m
+
+  Scenario: returns error for invalid input
+    Given an invalid payload
+    Then the response status is 400
+"""
+    (tmp_path / "orders.feature").write_text(orders)
+    (tmp_path / "users.feature").write_text(users)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "POST /orders" in out
+
+
+def test_main_strips_control_characters_from_dirs_display_when_dir_is_missing(tmp_path, capsys):
+    """--dir is composed by gherkin-derive from a probe of the target repo,
+    not always typed by a human — the WARN branch's dirs_display needs the
+    same guard as a scanned file's path, since it's the same untrusted-path
+    class."""
+    hostile_dir = tmp_path / "nope\x1b[31m"
+    exit_code = gate.main(["--dir", str(hostile_dir)])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "no .feature files found" in out

--- a/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
@@ -202,3 +204,52 @@ def test_main_json_warns_when_dir_does_not_exist(tmp_path, capsys):
     assert payload["scanned"] == []
     assert payload["findings"] == []
     assert "no .feature files found" in payload["warning"]
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_main_strips_control_characters_from_file_path_in_text_output(tmp_path, capsys):
+    """Security regression (issue #1526 review): the scanned file's path is
+    drawn from the same untrusted repository as the Feature title printed
+    right next to it, and must get the same CWE-150 terminal-escape guard —
+    a crafted filename must not bypass it."""
+    hostile_name = "orders\x1b[31m.feature"
+    (tmp_path / hostile_name).write_text(HAPPY_ONLY)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+
+
+def test_main_strips_control_characters_from_feature_title_in_text_output(tmp_path, capsys):
+    """The Feature: title guard is a separate _safe_for_terminal call site
+    from the file-path guard above — each needs its own hostile-input
+    coverage, or reverting just this one call would leave the suite green."""
+    hostile = """Feature: Orders API\x1b[31m
+
+  Scenario: Create order succeeds
+    Given a valid payload
+    When the order is created
+    Then the response status is 201
+"""
+    (tmp_path / "orders.feature").write_text(hostile)
+    exit_code = gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "Orders API" in out
+
+
+def test_main_strips_control_characters_from_dirs_display_when_dir_is_missing(tmp_path, capsys):
+    """--dir is composed by gherkin-derive from a probe of the target repo,
+    not always typed by a human — the WARN branch's dirs_display needs the
+    same guard as a scanned file's path, since it's the same untrusted-path
+    class."""
+    hostile_dir = tmp_path / "nope\x1b[31m"
+    exit_code = gate.main(["--dir", str(hostile_dir)])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "no .feature files found" in out

--- a/plugins/dev-team/tests/scripts/test_gherkin_feature_merge.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_feature_merge.py
@@ -481,6 +481,36 @@ def test_cli_merge_malformed_candidates_json_error_is_distinct_from_existing_blo
     assert payload["error"] != gfm.ERROR_MALFORMED_FEATURE_BLOCK
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_malformed_candidates_strips_control_characters_from_candidates_path(tmp_path):
+    """Security regression (issue #1526 review round 3): the malformed-
+    candidates error branch is a separate _safe_for_terminal call site from
+    the merge-success branch already covered — --candidates is the same
+    untrusted-path class as --existing."""
+    existing = tmp_path / "orders.feature"
+    existing.write_text(ORDERS_FEATURE, encoding="utf-8")
+    hostile_dir = tmp_path / "cand\x1b[31m"
+    hostile_dir.mkdir()
+    candidates = hostile_dir / "candidates.txt"
+    candidates.write_text("  @dangling-tag-with-no-scenario\n", encoding="utf-8")
+
+    proc = _run_cli(
+        "merge",
+        "--existing",
+        str(existing),
+        "--candidates",
+        str(candidates),
+        "--feature-title",
+        "Orders API",
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "malformed" in proc.stderr.lower()
+
+
 def test_cli_merge_title_mismatch_exits_2_and_leaves_file_unchanged(tmp_path):
     existing = tmp_path / "orders.feature"
     existing.write_text(ORDERS_FEATURE, encoding="utf-8")
@@ -524,6 +554,66 @@ def test_cli_merge_malformed_existing_block_exits_2_and_leaves_file_unchanged(tm
     assert "structure could not be parsed" in proc.stderr
     assert "error=malformed-feature-block" in proc.stderr
     assert existing.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_title_mismatch_strips_control_characters_from_existing_path(tmp_path):
+    """Security regression (issue #1526 review round 3): the feature-not-
+    found error branch is a separate _safe_for_terminal call site from the
+    merge-success branch already covered."""
+    hostile_dir = tmp_path / "exist\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "orders.feature"
+    existing.write_text(ORDERS_FEATURE, encoding="utf-8")
+    candidates = tmp_path / "candidates.txt"
+    candidates.write_text(_unit("New one").text, encoding="utf-8")
+
+    proc = _run_cli(
+        "merge",
+        "--existing",
+        str(existing),
+        "--candidates",
+        str(candidates),
+        "--feature-title",
+        "Nonexistent Surface",
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "could not locate Feature" in proc.stderr
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_malformed_existing_block_strips_control_characters_from_existing_path(
+    tmp_path,
+):
+    """Security regression (issue #1526 review round 3): the malformed-
+    feature-block error branch is a separate _safe_for_terminal call site
+    from the merge-success branch already covered."""
+    hostile_dir = tmp_path / "exist\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "orders.feature"
+    existing.write_text("Feature: Orders API\n\n  @smoke\n", encoding="utf-8")
+    candidates = tmp_path / "candidates.txt"
+    candidates.write_text(_unit("New one").text, encoding="utf-8")
+
+    proc = _run_cli(
+        "merge",
+        "--existing",
+        str(existing),
+        "--candidates",
+        str(candidates),
+        "--feature-title",
+        "Orders API",
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "structure could not be parsed" in proc.stderr
 
 
 def test_cli_merge_dry_run_never_touches_filesystem(tmp_path):
@@ -670,6 +760,64 @@ def test_cli_check_stale_non_json_report_names_file_and_line(tmp_path):
     assert proc.returncode == 0
     assert f"{existing}:4" in proc.stdout
     assert "possibly stale" in proc.stdout
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_check_stale_strips_control_characters_from_existing_path_in_text_output(tmp_path):
+    """Security regression (issue #1526 review round 3): check-stale's
+    'possibly stale' report is a separate _safe_for_terminal call site from
+    merge's success-branch guard already covered — --existing is the same
+    untrusted-path class in both subcommands."""
+    hostile_dir = tmp_path / "orders\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "orders.feature"
+    existing.write_text(ORDERS_FEATURE, encoding="utf-8")
+    proc = _run_cli(
+        "check-stale",
+        "--existing",
+        str(existing),
+        "--feature-title",
+        "Orders API",
+        "--observed",
+        "Create order succeeds with valid payload=202",
+    )
+    assert proc.returncode == 0
+    assert "\x1b" not in proc.stdout
+    assert "possibly stale" in proc.stdout
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_strips_control_characters_from_existing_path_in_text_output(tmp_path):
+    """Security regression (issue #1526 review): --existing is composed by
+    gherkin-derive from a probe of the target repository, the same
+    untrusted-path class as a scanned file's path in the sibling gate
+    scripts — a crafted path must not bypass the CWE-150 terminal-escape
+    guard applied there."""
+    hostile_dir = tmp_path / "orders\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "orders.feature"
+    existing.write_text(ORDERS_FEATURE, encoding="utf-8")
+    candidates = tmp_path / "candidates.txt"
+    candidates.write_text(_unit("New one").text, encoding="utf-8")
+
+    proc = _run_cli(
+        "merge",
+        "--existing",
+        str(existing),
+        "--candidates",
+        str(candidates),
+        "--feature-title",
+        "Orders API",
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "\x1b" not in proc.stdout
+    assert "OK: merged" in proc.stdout
 
 
 def test_cli_check_stale_observed_title_containing_equals_is_not_truncated(tmp_path):

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts"))
@@ -212,6 +214,52 @@ def test_main_accepts_multiple_dir_flags(tmp_path):
     (d2 / "b_steps.js").write_text("return this.pending();\n")
     rc = gherkin_stub_gate.main(["--dir", str(d1), "--dir", str(d2)])
     assert rc == 1
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_main_strips_control_characters_from_file_path_in_text_output(tmp_path, capsys):
+    """Security regression (issue #1526 review, extended to this gate): the
+    scanned step-definition file's path is drawn from the same untrusted
+    repository as its pending-marker text, and must get the same CWE-150
+    terminal-escape guard — a crafted filename must not bypass it."""
+    hostile_name = "orders\x1b[31m_steps.js"
+    (tmp_path / hostile_name).write_text("return this.pending();\n")
+    exit_code = gherkin_stub_gate.main(["--dir", str(tmp_path)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+
+
+def test_main_strips_control_characters_from_pending_marker_text_in_text_output(tmp_path, capsys):
+    """Security regression (issue #1526 review round 3): the pending-marker
+    line itself (`entry['text']`) is a separate `_safe_for_terminal` call
+    site from the file-path guard above — untrusted step-definition source
+    content, the same threat class. Reverting just this wrap would leave the
+    suite green even though the file-path test still passes."""
+    steps = tmp_path / "steps"
+    steps.mkdir()
+    (steps / "a_steps.js").write_text("return this.pending(); \x1b[31m\n")
+    exit_code = gherkin_stub_gate.main(["--dir", str(steps)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "this.pending()" in out
+
+
+def test_main_strips_control_characters_from_dirs_display_when_dir_is_missing(tmp_path, capsys):
+    """--dir is composed by gherkin-derive from a probe of the target repo,
+    not always typed by a human — the WARN branch's dirs_display needs the
+    same guard as a scanned file's path, since it's the same untrusted-path
+    class."""
+    hostile_dir = tmp_path / "nope\x1b[31m"
+    exit_code = gherkin_stub_gate.main(["--dir", str(hostile_dir)])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "no step-definition files found" in out
 
 
 def test_unrecognized_extension_is_never_scanned_for_markers(tmp_path):

--- a/plugins/dev-team/tests/scripts/test_gherkin_text.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_text.py
@@ -1,0 +1,99 @@
+"""Unit tests for scripts/lib/_gherkin_text.py (issue #1526).
+
+Exercises `safe_for_terminal` and `is_tag_line` directly against the shared
+helper — hoisted here from `gherkin_failure_path_gate.py` and
+`gherkin_cross_feature_duplicate_titles_gate.py`'s duplicate copies (each
+script's own test file covers its own behavior built on top of this shared
+helper, not this module's internals a second time).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))
+
+import _gherkin_text as gherkin_text
+
+
+def test_safe_for_terminal_strips_c0_control_characters():
+    assert gherkin_text.safe_for_terminal("returns error\x1b[31m") == "returns error[31m"
+
+
+def test_safe_for_terminal_strips_c1_control_characters():
+    assert gherkin_text.safe_for_terminal("returns error\x9btitle") == "returns errortitle"
+
+
+def test_safe_for_terminal_bounds_length_to_default_limit():
+    result = gherkin_text.safe_for_terminal("x" * 300)
+    assert len(result) == gherkin_text.TERMINAL_DISPLAY_LIMIT
+
+
+def test_safe_for_terminal_respects_explicit_limit():
+    assert gherkin_text.safe_for_terminal("abcdef", limit=3) == "abc"
+
+
+def test_safe_for_terminal_passes_through_ordinary_text_unchanged():
+    assert gherkin_text.safe_for_terminal("returns 201 Created") == "returns 201 Created"
+
+
+def test_safe_for_terminal_strips_embedded_newlines():
+    """This helper is also applied to filesystem paths (issue #1526), which
+    have no line-oriented `.strip()` guarantee the way a parsed title does —
+    an embedded CR/LF must not survive, or a crafted path could forge a fake
+    extra report line."""
+    assert gherkin_text.safe_for_terminal("orders\nOK: fake line") == "ordersOK: fake line"
+    assert gherkin_text.safe_for_terminal("orders\r\nOK: fake line") == "ordersOK: fake line"
+
+
+def test_safe_for_terminal_strips_tabs():
+    assert gherkin_text.safe_for_terminal("orders\ttab") == "orderstab"
+
+
+def test_is_tag_line_true_for_single_tag():
+    assert gherkin_text.is_tag_line("  @error-handling\n") is True
+
+
+def test_is_tag_line_true_for_multiple_tags():
+    assert gherkin_text.is_tag_line("@wip @error-handling\n") is True
+
+
+def test_is_tag_line_false_for_blank_line():
+    assert gherkin_text.is_tag_line("\n") is False
+
+
+def test_is_tag_line_false_for_scenario_line():
+    assert gherkin_text.is_tag_line("  Scenario: returns 400\n") is False
+
+
+def test_is_tag_line_false_when_only_some_tokens_are_tagged():
+    assert gherkin_text.is_tag_line("@wip not-a-tag\n") is False
+
+
+def _lines(text):
+    return text.splitlines(keepends=True)
+
+
+def test_trim_trailing_tag_run_backs_up_over_a_trailing_tag_and_blank_line():
+    lines = _lines(
+        "Feature: POST /orders\n"
+        "\n"
+        "  Scenario: returns 400\n"
+        "\n"
+        "@error-handling\n"
+        "Feature: POST /users\n"
+    )
+    # end_index candidate is the next Feature: header's index (line 6, 0-based 5)
+    assert gherkin_text.trim_trailing_tag_run(lines, header_index=0, end_index=5) == 3
+
+
+def test_trim_trailing_tag_run_stops_at_a_real_content_line():
+    lines = _lines("Feature: POST /orders\n\n  Scenario: returns 400\n    Given x\n")
+    assert gherkin_text.trim_trailing_tag_run(lines, header_index=0, end_index=4) == 4
+
+
+def test_trim_trailing_tag_run_never_backs_up_past_the_header_line():
+    lines = _lines("Feature: POST /orders\n\n\n")
+    assert gherkin_text.trim_trailing_tag_run(lines, header_index=0, end_index=3) == 1


### PR DESCRIPTION
## Summary

- Adds a rule to `gherkin-derive/SKILL.md` Step 2 requiring surface identifiers to be unique per method+path (or an equivalent distinguishing element for non-HTTP surfaces), so two distinct surfaces never compose the same file/feature-title pair.
- Adds a rule to Step 3 (and `gherkin-public/SKILL.md`'s equivalent section) requiring `Scenario:` titles to be specific enough to identify their surface without relying on the `Feature:` header for context — extending the existing no-generic-placeholder rule (previously failure-path-only) to all scenario titles.
- Adds `gherkin_cross_feature_duplicate_titles_gate.py`, wired into Step 6's report, which mechanically detects a scenario title duplicated across 2+ distinct `Feature:` blocks — the structural signal that a generic title has collided across two unrelated surfaces (never flagging a title repeated within the *same* block, which is `gherkin_feature_merge.py`'s own merge-dedup concern).
- During review, extracted a shared `plugins/dev-team/scripts/lib/_gherkin_text.py` helper (`safe_for_terminal`, `trim_trailing_tag_run`) now used by all four `.feature`/step-definition scripts (`gherkin_feature_merge.py`, `gherkin_failure_path_gate.py`, `gherkin_stub_gate.py`, and the new gate), closing several CWE-150 terminal-escape-injection gaps (an unsanitized scanned-file path or `--dir` value printed in text output right next to an already-sanitized title) and consolidating a tag/blank-line block-boundary trim loop that had been duplicated across three parsers past this repo's own documented "third occurrence" extraction threshold.

## Review process

This went through three rounds of independent multi-agent review (17-agent full panel, twice; targeted re-checks after each fix pass) before landing. Findings applied: the DRY extraction above, five CWE-150 sanitization fixes (including one in the pre-existing `gherkin_failure_path_gate.py`), a widened control-character regex (previously excluded CR/LF, which is safe for single-line title text but not for filesystem paths — closing a newline report-forgery risk), and test coverage for every new sanitize call site.

Two items were surfaced but deliberately deferred as out of scope for this PR (they're not part of issue #1526 and touch a script this PR never modifies): Unicode bidi-override/line-separator character stripping in `safe_for_terminal` (a broader Trojan-Source-style hardening question, not ASCII CWE-150), and `gherkin_stub_merge.py`'s own independent (never touched here) instance of the same untrusted-path-in-error-message pattern. Will file a follow-up issue for both.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q` — full pre-push surface, green (5429 passed, 3 pre-existing environment-gated skips)
- [x] `ruff check` clean on all touched files
- [x] New/extended tests exercise every new `safe_for_terminal` call site and the extracted `trim_trailing_tag_run` helper directly

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)