### PR TITLE
fix(gherkin-scripts): sanitize gherkin_stub_merge.py, widen bidi hardening

### DIFF
--- a/plugins/dev-team/scripts/gherkin_stub_merge.py
+++ b/plugins/dev-team/scripts/gherkin_stub_merge.py
@@ -45,6 +45,7 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE / "lib"))
 
+from _gherkin_text import safe_for_terminal as _safe_for_terminal
 from stub_extractors import (
     ERROR_DANGLING_ANNOTATION,  # noqa: F401
     ERROR_UNBALANCED_BRACES,  # noqa: F401
@@ -335,8 +336,8 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             print(json.dumps(_merge_payload(written=False, error=ERROR_UNREADABLE_CANDIDATES)))
         else:
             _write_error(
-                f"gherkin_stub_merge: --candidates {args.candidates} could not be read "
-                f"({exc}) — no steps merged"
+                f"gherkin_stub_merge: --candidates {_safe_for_terminal(args.candidates)} "
+                f"could not be read ({exc}) — no steps merged"
             )
         return 2
 
@@ -360,8 +361,9 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             print(json.dumps(_merge_payload(written=False, error=ERROR_MALFORMED_CANDIDATES)))
         else:
             _write_error(
-                f"gherkin_stub_merge: candidates file {args.candidates} is malformed "
-                f"(error={candidates_error}) — no steps merged, existing file left untouched"
+                f"gherkin_stub_merge: candidates file {_safe_for_terminal(args.candidates)} "
+                f"is malformed (error={candidates_error}) — no steps merged, existing file "
+                f"left untouched"
             )
         return 2
 
@@ -372,8 +374,9 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             print(json.dumps(_merge_payload(written=False, error=result.error)))
         else:
             _write_error(
-                f"gherkin_stub_merge: {args.existing} structure could not be parsed "
-                f"(error={result.error}) — no steps merged, existing file left untouched"
+                f"gherkin_stub_merge: {_safe_for_terminal(args.existing)} structure could not "
+                f"be parsed (error={result.error}) — no steps merged, existing file left "
+                f"untouched"
             )
         return 2
 
@@ -406,7 +409,10 @@ def _cmd_merge(args: argparse.Namespace) -> int:
             )
         )
     else:
-        print(f"OK: merged {len(result.added_patterns)} new step(s) into {args.existing}")
+        print(
+            f"OK: merged {len(result.added_patterns)} new step(s) into "
+            f"{_safe_for_terminal(args.existing)}"
+        )
     return 0
 
 

--- a/plugins/dev-team/scripts/lib/_gherkin_text.py
+++ b/plugins/dev-team/scripts/lib/_gherkin_text.py
@@ -26,18 +26,25 @@ FEATURE_PREFIX = "Feature:"
 SCENARIO_OUTLINE_PREFIX = "Scenario Outline:"
 SCENARIO_PREFIX = "Scenario:"
 
-# Full C0 + C1 control-character range — stripped before printing untrusted
-# scanned-file content (or a path derived from it) to a terminal. A
-# `.feature` file's content (titles, and the path it was found at) comes
-# from whatever repository is being scanned, and could otherwise inject
-# terminal escape sequences (CWE-150), forge fake report lines via an
-# embedded CR/LF, or masquerade as trusted tool output fed back into an
-# agent's report. Titles are always single lines (parsed via `splitlines()`
-# then `.strip()`), so stripping CR/LF/tab from title text is a no-op; a
-# filesystem path has no such guarantee, so the full range — not just the
-# subset that happened to matter for line-oriented title text — is needed
-# now that this function also sanitizes paths.
-CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+# Full C0 + C1 control-character range, plus Unicode line/paragraph
+# separators and bidirectional-control characters — stripped before printing
+# untrusted scanned-file content (or a path derived from it) to a terminal.
+# A `.feature` file's content (titles, and the path it was found at) comes
+# from whatever repository is being scanned, and could otherwise:
+#   - inject terminal escape sequences (CWE-150) via the C0/C1 range;
+#   - forge a fake extra report line via an embedded CR/LF (C0), or via
+#     U+2028/U+2029, which several terminals still render as a hard line
+#     break even though they're outside the ASCII control range;
+#   - visually spoof a printed path/title (Trojan-Source-style) via a
+#     bidirectional-override character (U+202A-U+202E) or isolate
+#     (U+2066-U+2069), reordering how the surrounding text renders.
+# Titles are always single lines (parsed via `splitlines()` then `.strip()`),
+# so stripping any of these from title text is a no-op; a filesystem path
+# has no such guarantee, so the full range is needed now that this function
+# also sanitizes paths. `repr()`-based print sites (e.g.
+# `gherkin_feature_merge.py`'s check-stale branch) don't need this guard —
+# Python's `repr()` already escapes every character struck here.
+CONTROL_CHARS = re.compile("[\x00-\x1f\x7f-\x9f\u2028\u2029\u202a-\u202e\u2066-\u2069]")
 
 TERMINAL_DISPLAY_LIMIT = 200
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
@@ -324,6 +324,60 @@ def test_cli_merge_malformed_candidates_exits_2_and_leaves_file_unchanged(tmp_pa
     assert "malformed" in proc.stderr.lower()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_malformed_candidates_strips_control_characters_from_candidates_path(tmp_path):
+    """Security regression (issue #1529): --candidates is composed by
+    gherkin-derive from a probe of the target repository, the same
+    untrusted-path class as --existing in the sibling gherkin_feature_merge.py
+    — a crafted path must not bypass the CWE-150 terminal-escape guard
+    applied there."""
+    existing = tmp_path / "a_steps.js"
+    existing.write_text(_IMPLEMENTED_JS, encoding="utf-8")
+    hostile_dir = tmp_path / "cand\x1b[31m"
+    hostile_dir.mkdir()
+    candidates = hostile_dir / "candidates.txt"
+    candidates.write_text("Given('unterminated', function () {\n  return this.pending();\n", encoding="utf-8")
+
+    proc = _run_cli(
+        "merge", "--existing", str(existing), "--candidates", str(candidates), "--ext", ".js"
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "malformed" in proc.stderr.lower()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_missing_candidates_file_strips_control_characters_from_candidates_path(
+    tmp_path,
+):
+    """Security regression (issue #1529): the unreadable-candidates error
+    branch (a distinct _safe_for_terminal call site from the malformed-
+    candidates branch above) must sanitize --candidates the same way."""
+    existing = tmp_path / "a_steps.js"
+    existing.write_text(_IMPLEMENTED_JS, encoding="utf-8")
+    hostile_dir = tmp_path / "cand\x1b[31m"
+    hostile_dir.mkdir()
+
+    proc = _run_cli(
+        "merge",
+        "--existing",
+        str(existing),
+        "--candidates",
+        str(hostile_dir / "does_not_exist.txt"),
+        "--ext",
+        ".js",
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "could not be read" in proc.stderr
+
+
 def test_cli_merge_malformed_candidates_json_error_is_distinct_from_existing_structural_error(
     tmp_path,
 ):
@@ -448,6 +502,58 @@ def test_cli_merge_malformed_existing_file_exits_2_and_leaves_file_unchanged(tmp
     assert existing.read_text(encoding="utf-8") == malformed
     assert "structure could not be parsed" in proc.stderr
     assert f"error={gsm.ERROR_UNBALANCED_BRACES}" in proc.stderr
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_malformed_existing_file_strips_control_characters_from_existing_path(
+    tmp_path,
+):
+    """Security regression (issue #1529): --existing is composed by
+    gherkin-derive from a probe of the target repository — the structural-
+    error branch's _safe_for_terminal call must sanitize it the same way
+    the sibling gherkin_feature_merge.py does."""
+    hostile_dir = tmp_path / "exist\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "a_steps.js"
+    malformed = "Given('a thing', function () {\n  return this.pending();\n"  # never closes
+    existing.write_text(malformed, encoding="utf-8")
+    candidates = tmp_path / "candidates.txt"
+    candidates.write_text(_js_candidate("a new thing").text, encoding="utf-8")
+
+    proc = _run_cli(
+        "merge", "--existing", str(existing), "--candidates", str(candidates), "--ext", ".js"
+    )
+    assert proc.returncode == 2
+    assert "\x1b" not in proc.stderr
+    assert "structure could not be parsed" in proc.stderr
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="NTFS rejects raw control-byte filenames; POSIX-only fixture",
+)
+def test_cli_merge_writes_file_strips_control_characters_from_existing_path_in_text_output(
+    tmp_path,
+):
+    """Security regression (issue #1529): the merge-success branch's
+    _safe_for_terminal call is a separate call site from the structural-
+    error branch above — each needs its own hostile-input coverage."""
+    hostile_dir = tmp_path / "exist\x1b[31m"
+    hostile_dir.mkdir()
+    existing = hostile_dir / "a_steps.js"
+    existing.write_text(_IMPLEMENTED_JS, encoding="utf-8")
+    candidates = tmp_path / "candidates.txt"
+    candidates.write_text(_js_candidate("a new thing").text, encoding="utf-8")
+
+    proc = _run_cli(
+        "merge", "--existing", str(existing), "--candidates", str(candidates), "--ext", ".js"
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "\x1b" not in proc.stdout
+    assert "OK: merged" in proc.stdout
 
 
 def test_cli_merge_dangling_annotation_java_exits_2_and_leaves_file_unchanged(tmp_path):

--- a/plugins/dev-team/tests/scripts/test_gherkin_text.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_text.py
@@ -52,6 +52,28 @@ def test_safe_for_terminal_strips_tabs():
     assert gherkin_text.safe_for_terminal("orders\ttab") == "orderstab"
 
 
+def test_safe_for_terminal_strips_unicode_line_and_paragraph_separators():
+    """Issue #1529: some terminals render U+2028/U+2029 as a hard line
+    break even though they're outside the ASCII C0/C1 range the CR/LF fix
+    (issue #1526) covered — the same fake-report-line-forgery risk, in a
+    non-ASCII variant."""
+    assert gherkin_text.safe_for_terminal("orders\u2028OK: fake line") == "ordersOK: fake line"
+    assert gherkin_text.safe_for_terminal("orders\u2029OK: fake line") == "ordersOK: fake line"
+
+
+def test_safe_for_terminal_strips_unicode_bidi_override_characters():
+    """Issue #1529: a bidirectional-override character (e.g. U+202E
+    RIGHT-TO-LEFT OVERRIDE) can visually spoof a printed path/title
+    (Trojan-Source-style) by reordering how the surrounding text renders."""
+    assert gherkin_text.safe_for_terminal("orders\u202etitle") == "orderstitle"
+    assert gherkin_text.safe_for_terminal("orders\u202atitle") == "orderstitle"
+
+
+def test_safe_for_terminal_strips_unicode_bidi_isolate_characters():
+    assert gherkin_text.safe_for_terminal("orders\u2066iso\u2069") == "ordersiso"
+
+
+
 def test_is_tag_line_true_for_single_tag():
     assert gherkin_text.is_tag_line("  @error-handling\n") is True
 


### PR DESCRIPTION
## Summary

- `gherkin_stub_merge.py` shared the identical untrusted-path provenance as its sibling `gherkin_feature_merge.py` (both composed by gherkin-derive from a probe of the target repo) but never adopted the shared `safe_for_terminal` CWE-150 sanitizer added in #1526 — it echoed `--existing`/`--candidates` raw at four print/error sites. Now wired in at all four; the two `repr()`-based sites (already safe, since `repr()` escapes control characters) are correctly left untouched.
- Widens `_gherkin_text.py`'s `CONTROL_CHARS` regex to also strip Unicode line/paragraph separators (`U+2028`/`U+2029`, which some terminals render as a hard line break — the same fake-report-line-forgery risk the CR/LF fix in #1526 covered, just non-ASCII) and bidirectional-override/isolate characters (`U+202A`-`U+202E`, `U+2066`-`U+2069` — Trojan-Source-style visual spoofing of a printed path/title).
- Deliberately does **not** extract `gherkin_stub_merge.py`'s near-identical `_reject_path_traversal`/`_merge_payload`/`_write_atomic` duplication with `gherkin_feature_merge.py` — confirmed by review this is genuinely the *second* occurrence, and this repo's own documented convention (`_gherkin_text.py`'s module docstring) is to extract only at the third.

## Implementation note

The widened regex and its tests use Python `\uXXXX` escape-sequence text inside non-raw string literals — never literal embedded Unicode bidi/separator characters in source, which would itself trigger ruff's `PLE2502` rule (the exact obfuscation risk this fix exists to catch elsewhere). Verified by direct byte-level grep for the literal codepoints (zero matches) during review.

## Review process

Went through a 4-agent review pass (security, correctness, test-review, structure) — all passed clean. Two low-confidence, explicitly out-of-scope suggestions were surfaced and intentionally not actioned: sanitizing the dry-run full-file stdout preview (mirrors identical pre-existing behavior in `gherkin_feature_merge.py`, not a regression), and extending the bidi range to LRM/RLM/ALM marks (a further hardening step, not part of this issue).

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q` — full pre-push surface, green (5436 passed, 3 pre-existing environment-gated skips)
- [x] `ruff check` clean on all touched files
- [x] New tests cover all 4 newly-wrapped call sites in `gherkin_stub_merge.py` and each of the 3 widened regex sub-ranges distinctly

Closes #1529

🤖 Generated with [Claude Code](https://claude.com/claude-code)