### PR TITLE
feat(cost-meter): persist per-subagent cache tokens in the durable log

### DIFF
--- a/docs/spikes/build-token-cost-spike.md
+++ b/docs/spikes/build-token-cost-spike.md
@@ -4,11 +4,16 @@ Answers the questions in #1512 (part of epic #1511). **Deliverable is analysis, 
 
 ## TL;DR
 
-- **The instrumentation to answer this empirically does not exist yet.** The cost meter's
-  `by_agent_type` breakdown only ever records `main` — across every ledger sampled, **zero
-  subagent threads were captured.** So per-agent overhead (Q1), spawn break-even (Q2), and the
-  real fan-out multiplier (Q3) cannot be measured from history. **A prerequisite slice must make
-  the cost meter attribute tokens to each dispatched worktree agent before any threshold is set.**
+- **CORRECTION (verified at #1513 build-time):** this spike's original claim that "the
+  instrumentation does not exist" was **wrong**. Per-subagent attribution already ships (#1094):
+  `cost_meter.py report --json` produces a full `by_agent_type` breakdown and reads the sibling
+  `subagents/agent-*.jsonl` files — confirmed on a live transcript with subagent turns (15 agent-type
+  buckets: `main` + every dispatched lens). The original "only `main`" reading was a sampling
+  artifact — the sampled `cost-metering.jsonl` records were written before any subagent was
+  dispatched. So per-agent overhead (Q1), spawn break-even (Q2), and the fan-out multiplier (Q3) **are
+  measurable today** via `cost_meter report --json <transcript>`. The only real gap #1513 closed was
+  persisting `cache_creation_input_tokens` (the F component) in the durable `cost-metering.jsonl`, not
+  just in the on-demand report.
 - **The review-value sample is far too thin and biased to prune any lens (Q4).** 10 records total,
   ~100% "found something" on nearly every lens — because the only slices that got logged happened
   to have findings. This is a sampling artifact, not evidence a lens is valuable. **Do not
@@ -83,13 +88,16 @@ volume).
 | Epic slice | Threshold from this spike |
 |---|---|
 | Default sequential / opt-in fan-out | **Adopt now** — analytically sound independent of F. |
-| Slice-packing cost model | **Blocked on measuring F.** Ship the meter-per-subagent instrumentation first, then set the pack-below-F cutoff. |
-| Shared context pack | Justified in principle (re-exploration is per-agent); size the win from the measured re-exploration component of F. |
+| Slice-packing cost model | **Unblocked** — F is measurable now via `cost_meter report --json` (and, after #1513, from the durable log). Measure F on a representative fan-out build, then set the pack-below-F cutoff. |
+| Shared context pack | Justified in principle (re-exploration is per-agent); size the win from the measured re-exploration component of F (same meter). |
 | Diff-gated / cheap-first review | **Adopt now** — gate dispatch on diff domain regardless of Q4 data. |
 | Auto-prune lenses from review-value | **Do not adopt.** Sample too small/biased; revisit at N≥100. |
 
-## New prerequisite slice this spike surfaces
+## Prerequisite slice — RESOLVED
 
-**`chore: meter per-subagent token usage during fan-out builds`** — the cost meter's `by_agent_type`
-must record dispatched worktree agents, not just `main`. Without it, F stays unmeasured and the
-slice-packing cutoff is a guess. This blocks the slice-packing and shared-context-pack slices.
+**`chore: meter per-subagent token usage during fan-out builds`** (#1513) was filed on the mistaken
+premise that the cost meter could not attribute per-subagent tokens. It can — #1094 already did.
+#1513 was narrowed at build-time to its one real gap: persisting `cache_creation_input_tokens` (the
+F component) in the durable `cost-metering.jsonl` so F is legible from the log, not only from
+`cost_meter report --json`. The slice-packing and shared-context-pack slices are **not blocked** —
+F is measurable now.

--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -616,12 +616,14 @@ def cmd_record(args, pricing) -> int:
     from datetime import datetime, timezone
 
     def _slim(bucket: dict) -> dict:
+        # Persist cost + every token field per bucket (#1513), deriving the
+        # token names from _TOKEN_FIELDS (the single source of truth used by
+        # _new_bucket/_accumulate_lines) so a future field flows into the
+        # durable log automatically. cache_creation is the spawn-floor F
+        # component the epic measures — it must live in the log, not only in
+        # `report --json`.
         return {
-            k: {
-                "cost_usd": b["cost_usd"],
-                "input_tokens": b["input_tokens"],
-                "output_tokens": b["output_tokens"],
-            }
+            k: {"cost_usd": b["cost_usd"], **{f: b[f] for f in _TOKEN_FIELDS}}
             for k, b in bucket.items()
         }
 

--- a/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
+++ b/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
@@ -131,6 +131,93 @@ def test_cmd_record_persists_byte_offset_state(hermetic_cost_meter):
     assert state["offset"] == transcript.stat().st_size
 
 
+def _usage_line_with_cache(model, inp, out, cache_create, cache_read, *, sidechain=False, attribution=None):
+    rec = {
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cache_creation_input_tokens": cache_create,
+                "cache_read_input_tokens": cache_read,
+            },
+        },
+    }
+    if sidechain:
+        rec["isSidechain"] = True
+    if attribution:
+        rec["attributionAgent"] = attribution
+    return json.dumps(rec) + "\n"
+
+
+def test_cmd_record_persists_cache_tokens_per_bucket(hermetic_cost_meter):
+    """#1513 — the durable log's per-bucket slim output must carry
+    cache_creation_input_tokens (the spawn-floor F component), so F is readable
+    from cost-metering.jsonl, not only from `report --json`."""
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(
+        _usage_line_with_cache("claude-x", 100, 50, 108000, 5000)
+        + _usage_line_with_cache(
+            "claude-x", 20, 900, 40000, 2000, sidechain=True, attribution="security-review"
+        )
+    )
+
+    cost_meter.cmd_record(SimpleNamespace(transcript=str(transcript), log=str(log)), _PRICING)
+
+    entry = json.loads(log.read_text().splitlines()[-1])
+    # Every dimension's buckets carry both cache fields.
+    for dim in ("by_agent_type", "by_thread", "by_model"):
+        for bucket in entry[dim].values():
+            assert "cache_creation_input_tokens" in bucket
+            assert "cache_read_input_tokens" in bucket
+    # The subagent's spawn floor is now legible from the log — both cache
+    # fields, on all three dimensions, value-checked (not just present).
+    assert entry["by_agent_type"]["security-review"]["cache_creation_input_tokens"] == 40000
+    assert entry["by_agent_type"]["security-review"]["cache_read_input_tokens"] == 2000
+    assert entry["by_agent_type"]["main"]["cache_creation_input_tokens"] == 108000
+    assert entry["by_agent_type"]["main"]["cache_read_input_tokens"] == 5000
+    assert entry["by_thread"]["subagent"]["cache_creation_input_tokens"] == 40000
+    assert entry["by_thread"]["subagent"]["cache_read_input_tokens"] == 2000
+    # by_model aggregates both records (same model claude-x): 108000+40000, 5000+2000.
+    assert entry["by_model"]["claude-x"]["cache_creation_input_tokens"] == 148000
+    assert entry["by_model"]["claude-x"]["cache_read_input_tokens"] == 7000
+
+
+def test_log_round_trips_cache_keys_and_readers_consume_it(hermetic_cost_meter, capsys):
+    """AC3 — a durable log whose buckets carry the new cache keys round-trips
+    intact and is consumed by readers. Asserts observable output, not just a
+    (tautological) return code: regression must hit the real >=2-session branch
+    ('no cost regression'), and pace must print the cumulative spend."""
+    tmp_path = hermetic_cost_meter
+    transcript = tmp_path / "transcript.jsonl"
+    log = tmp_path / "metrics" / "cost-metering.jsonl"
+    transcript.write_text(_usage_line_with_cache("claude-x", 100, 50, 108000, 5000))
+    cost_meter.cmd_record(SimpleNamespace(transcript=str(transcript), log=str(log)), _PRICING)
+    # A second session so regression exercises the real comparison branch.
+    transcript.write_text(_usage_line_with_cache("claude-x", 120, 60, 90000, 4000))
+    cost_meter._state_file(transcript).unlink(missing_ok=True)
+    cost_meter.cmd_record(SimpleNamespace(transcript=str(transcript), log=str(log)), _PRICING)
+
+    lines = log.read_text().splitlines()
+    assert len(lines) == 2  # both sessions persisted (disambiguates the branch below)
+    # Round-trip: the new cache keys survive in the durable log's buckets.
+    assert json.loads(lines[-1])["by_agent_type"]["main"]["cache_creation_input_tokens"] == 90000
+
+    rc = cost_meter.cmd_regression(
+        SimpleNamespace(log=str(log), tolerance=0.5, window=0), _PRICING
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no cost regression" in out  # the real >=2-session branch, not "only N session(s)"
+
+    cost_meter.cmd_pace(
+        SimpleNamespace(log=str(log), budget=None, period_days=30, window_days=7), _PRICING
+    )
+    assert "cumulative spend" in capsys.readouterr().out
+
+
 def test_cmd_record_second_fire_only_tails_new_content(
     hermetic_cost_meter, monkeypatch
 ):


### PR DESCRIPTION
## What

Persist per-subagent **cache-creation tokens** in the durable cost log so the spawn-floor `F` the epic wants is readable from `cost-metering.jsonl`, not only via ad-hoc `cost_meter report --json`. Final slice of epic #1511.

## Key finding (corrects the spike)

Per-subagent token attribution **already ships** — #1094 built it. Verified live: on a real fan-out transcript the meter yields a 15-bucket `by_agent_type` breakdown (`main` + every dispatched lens) and reads the sibling `subagents/agent-*.jsonl` files. The spike's "only `main`" conclusion was a **sampling artifact** (its 6 records were written before any subagent dispatch). So #1513 was **narrowed** at build-time from "build the attribution machinery" (already done) to its one real gap.

## Changes

- `plugins/dev-team/hooks/lib/cost_meter.py` — `cmd_record`'s `_slim()` now emits `cache_creation_input_tokens` + `cache_read_input_tokens` per `by_agent_type`/`by_thread`/`by_model` bucket, derived from `_TOKEN_FIELDS` (single source of truth, no duplicated literals). Backward-compatible log-schema addition — `regression`/`pace`/`run_report` read `total.cost_usd`, never the bucket key set.
- `plugins/dev-team/tests/hooks/test_cost_meter_lib.py` — value-checks both cache fields across all three dimensions (incl. `by_model` aggregation 148000/7000); a round-trip + reader test asserting real observable output.
- `docs/spikes/build-token-cost-spike.md` — corrects the "instrumentation missing" claim; notes `F` is measurable now and the packing slices are **unblocked**.

## Verification

- Full pytest gate: **5463 passed, 3 skipped**; ruff clean. (One earlier full-run flake was the harness's careful-mode blocking the destructive-guard test's subprocess — passes deterministically on rerun; unrelated to this diff.)
- `/code-review` backstop: slice checkpoint (spec-compliance + correctness), backstop (test + structure), and full-panel corroboration — all pass, 0 actionable outstanding. Test-review's ERROR (a tautological assertion) and structure's DRY nit were fixed in-loop.
- Dogfooded on a real transcript: `security-review` bucket persists `cache_creation_input_tokens=306096` — a concrete `F` datapoint now legible from the log.

## Decisions & follow-ups

- Original #1513 scope (build attribution) → **Skipped**: already delivered by #1094 (see the #1513 re-scope comment).
- Surfaced pre-existing gap: `cmd_regression`/`cmd_pace` math has no value coverage → **#1531**.

Closes #1513
Part of #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
