### PR TITLE
feat(code-review): adopt the shared select_lenses resolver in Step 3

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -195,22 +195,23 @@ If `--background`: run only `doc-review`, `arch-review`, `naming-review`, `struc
 
 Otherwise read the roster from the **Review Agents** section of `knowledge/agent-registry.md` — each row names an agent and its `agents/<name>.md` file. **Never `Read` the bare `agents/` directory** (it throws `EISDIR`); if you must confirm files on disk, list them with `Glob("agents/*.md")`, never a directory `Read` (see `${CLAUDE_PLUGIN_ROOT}/knowledge/directory-enumeration.md`). All are enabled by default.
 
-**Agent eligibility is self-declared via a `Scope:` body declaration.** `Scope:` is not part of the official sub-agent frontmatter contract (`agent-contract.json`), so it lives in the agent's body, not its frontmatter. For each agent in the roster, read its `agents/<name>.md` body and apply this rule:
+**Agent eligibility is resolved by `select_lenses.py` (#1523).** Run:
 
-- `Scope: always` → agent is eligible regardless of tech stack or file types in scope.
-- `Scope:` (list of glob patterns) → agent is eligible only when at least one target file matches at least one of the declared globs (e.g. `**/*.svelte` matches any `.svelte` file). Skip the agent entirely if no target file matches.
-- Agent has no `Scope:` declaration → treat as `Scope: always` and emit a warning that the agent is missing its `Scope:` declaration.
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/select_lenses.py --files <target files>
+```
 
-This replaces any hardcoded per-agent dispatch rules. Adding or changing a review agent's trigger scope requires only editing that agent's own body — zero edits to this skill.
+Take its `lenses` array as the Scope-eligible roster, and **surface its `warnings`** in the review output (an agent missing its `Scope:` declaration is included include-biased and named — never silently dropped). The resolver reads each review agent's body-level `Scope:` declaration — `Scope: always` (eligible for any non-empty changeset) or a glob list (eligible only when at least one target file matches a declared glob). `Scope:` is a body declaration, not frontmatter (`agent-contract.json`). This is the single source of truth shared with `/build`'s inline checkpoints: adding or changing an agent's trigger scope needs only an edit to that agent's own body — zero edits to this skill. (The framework-reactivity agents react/vue/angular are **not** in the resolver's roster; they are governed by the manifest rule below. `svelte-review` and `ai-provenance-review` **are** resolver-governed via their own `Scope:` declarations.)
 
 **Framework-specific reactivity review** — dispatch based on the project's dependency manifest (`package.json` etc.):
 
 - React (`react` / `react-dom` in deps): include `react-reactivity-review` scoped to `.jsx`/`.tsx` and React-importing `.js`/`.ts` files
 - Vue (`vue` in deps): include `vue-reactivity-review` scoped to `.vue` and Vue-importing `.js`/`.ts` files
 - Angular (`@angular/core` in deps): include `angular-reactivity-review` scoped to `*.component.ts`, `*.component.html`, `*.service.ts`, and general `.ts` files
-- Svelte (`.svelte`/`.svelte.ts`/`.svelte.js` files present): include `svelte-review` scoped to those files (Svelte projects do not require a manifest entry — file presence is sufficient)
 
-**AI-provenance review**: include `ai-provenance-review` whenever test files or production code are in scope. It audits AI-authored assertions and non-obvious decisions for verification debt and regeneration risk.
+(Svelte needs no bullet here: `svelte-review` is resolver-governed via its own `**/*.svelte` `Scope:` globs — file presence triggers it through `select_lenses.py` above.)
+
+**AI-provenance review**: `ai-provenance-review` is resolver-governed via its own `Scope: always` declaration — the resolver includes it on every non-empty changeset. It audits AI-authored assertions and non-obvious decisions for verification debt and regeneration risk.
 
 If `review-config.json` exists at the repo root, honor its per-agent `"enabled": false` flags.
 

--- a/tests/scripts/test_select_lenses.py
+++ b/tests/scripts/test_select_lenses.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 _SCRIPT = _REPO_ROOT / "plugins" / "dev-team" / "scripts" / "select_lenses.py"
@@ -239,3 +241,83 @@ def test_cli_empty_files_yields_no_lenses():
         env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LANG": "C.UTF-8"},
     )
     assert json.loads(r.stdout)["lenses"] == []
+
+
+# ---------------------------------------------------------------------------
+# #1523 — frozen equivalence baseline for /code-review Step 3 adoption.
+# ALWAYS_LENSES and the expected sets are hand-derived from the agents' own
+# Scope: declarations (the pre-#1523 in-model rule's output), NOT copied from
+# select_lenses' output — so a match proves equivalence rather than restating
+# the resolver. A new Scope: always review lens must update ALWAYS_LENSES
+# deliberately (that break is the intended "review the baseline" signal).
+# ---------------------------------------------------------------------------
+ALWAYS_LENSES = {
+    "ai-provenance-review", "arch-review", "claude-setup-review", "complexity-review",
+    "concurrency-review", "correctness-review", "doc-review", "domain-review",
+    "naming-review", "performance-review", "refactor-opportunity-review",
+    "security-review", "spec-compliance-review", "structure-review", "test-review",
+    "test-smell-review", "token-efficiency-review",
+}
+FILE_TYPE_LENSES = {
+    "a11y-review", "js-fp-review", "component-architecture-review", "svelte-review",
+}
+REACTIVITY_LENSES = {
+    "react-reactivity-review", "vue-reactivity-review", "angular-reactivity-review",
+}
+
+_BASELINE = [
+    (["svc/foo.py"], set()),                                                    # backend — A only
+    (["docs/x.md"], set()),                                                     # docs — A only
+    (["svc/handler.ts"], {"js-fp-review"}),                                     # .ts→js-fp boundary
+    (["src/App.tsx"], {"js-fp-review", "a11y-review", "component-architecture-review"}),
+    (["src/W.vue"], {"a11y-review", "component-architecture-review"}),          # NOT js-fp
+    (["src/W.svelte"], {"a11y-review", "component-architecture-review", "svelte-review"}),
+    (["a/x.component.ts"], {"js-fp-review", "component-architecture-review"}),  # NOT a11y
+    (["tpl/p.html"], {"a11y-review"}),                                          # a11y only
+    # .component.html matches BOTH a11y (.html suffix) and component-architecture (.component.html).
+    (["a/x.component.html"], {"a11y-review", "component-architecture-review"}),
+    # multi-file union pulls file-type lenses from both members (.ts→js-fp; .svelte→a11y+comp-arch+svelte).
+    (["svc/handler.ts", "src/W.svelte"],
+     {"js-fp-review", "a11y-review", "component-architecture-review", "svelte-review"}),
+]
+
+
+@pytest.mark.parametrize("files,extra", _BASELINE)
+def test_frozen_baseline_selection(files, extra):
+    lenses = set(json.loads(_run(*files).stdout)["lenses"])
+    assert lenses == ALWAYS_LENSES | extra
+
+
+def test_manifest_governed_reactivity_lenses_never_in_roster():
+    # Input-independent invariant (build_review_roster excludes MANIFEST_GOVERNED),
+    # so asserted once rather than per baseline shape.
+    lenses = set(json.loads(_run("src/App.tsx").stdout)["lenses"])
+    assert lenses.isdisjoint(REACTIVITY_LENSES)
+
+
+def test_baseline_fixture_exercises_every_file_type_lens():
+    # Guards the _BASELINE fixture table (not select_lenses runtime): every
+    # file-type lens must be triggered by at least one shape.
+    covered = set()
+    for _files, extra in _BASELINE:
+        covered |= extra
+    assert FILE_TYPE_LENSES <= covered
+
+
+def test_file_type_lens_set_is_pinned_to_the_known_four():
+    # Guard: a future agent introducing a new file-type Scope pattern trips this,
+    # forcing a new baseline shape rather than going silently unverified.
+    roster, _ = SL.build_review_roster(
+        SL._HERE.parent / "agents", SL._HERE.parent / "knowledge" / "agent-registry.md"
+    )
+    file_type = {name for name, scope, _ in roster if isinstance(scope, list)}
+    assert file_type == FILE_TYPE_LENSES
+    always = {name for name, scope, _ in roster if scope == "always"}
+    assert always == ALWAYS_LENSES
+
+
+# review-config.json "enabled: false" honoring is orchestrator-executed prose
+# (no shared function implements it), so it has no executable unit oracle — a
+# set-difference test would be a self-referential tautology. Its presence is
+# guarded instead by the content-guard in test_code_review_frontend_dispatch.py
+# (review-config.json paragraph still in Step 3). See #1523 plan AC6.

--- a/tests/skills/test_code_review_frontend_dispatch.py
+++ b/tests/skills/test_code_review_frontend_dispatch.py
@@ -69,3 +69,27 @@ def test_review_agent_skill_does_not_key_on_retired_model_tier_line():
 
 def test_frontend_architecture_notes_the_code_review_integration():
     assert "/code-review" in FRONTEND_ARCH
+
+
+# ---------------------------------------------------------------------------
+# #1523 — /code-review Step 3 adopts the shared select_lenses.py resolver.
+# ---------------------------------------------------------------------------
+def test_step3_resolves_eligibility_via_select_lenses_and_surfaces_warnings():
+    assert "select_lenses.py" in CODE_REVIEW
+    assert "surface its `warnings`" in CODE_REVIEW  # AC1 — one contiguous phrase, not two loose substrings
+
+
+def test_step3_keeps_layered_gates_and_manifest_rule():
+    # The shape/size gates and review-config honoring stay, layered on top.
+    assert "change_shape.py" in CODE_REVIEW
+    assert "change_size.py" in CODE_REVIEW
+    assert "review-config.json" in CODE_REVIEW
+    # Layering direction: resolver selection precedes the change-shape/size gates.
+    assert CODE_REVIEW.index("select_lenses.py") < CODE_REVIEW.index("change_shape.py")
+
+
+def test_step3_reconciled_redundant_svelte_and_ai_provenance_prose():
+    # Old Svelte framework bullet is gone (svelte-review is resolver-governed).
+    assert "files present): include `svelte-review`" not in CODE_REVIEW
+    # Old narrower ai-provenance prose is gone (it is Scope: always → resolver-governed).
+    assert "include `ai-provenance-review` whenever test files or production code" not in CODE_REVIEW


### PR DESCRIPTION
## What

Route `/code-review` Step 3's Scope-eligibility through the shared `select_lenses.py` resolver (the one `/build` already uses), replacing the in-model per-agent `Scope:` reading — **one selection mechanism instead of two**. Final slice of epic #1511.

Equivalence-preserving by design (the resolver implements the identical glob rule the prose described); the value is unification — so the imminent **#1524** (`svelte-review` removal) and every future scope change touches one mechanism, not two that can silently diverge.

## Changes

- `plugins/dev-team/skills/code-review/SKILL.md` — Step 3 now runs `select_lenses.py --files <target files>` and surfaces its `warnings`; the redundant Svelte framework bullet is removed and the ai-provenance bullet collapsed (both are resolver-governed via their own `Scope:`). `change_shape.py`/`change_size.py`, the react/vue/angular **manifest** rule, and `review-config.json` honoring are **unchanged**, layered on top.
- `tests/scripts/test_select_lenses.py` — a frozen equivalence baseline (10 shapes) whose expected sets are **hand-derived from the agents' `Scope:` declarations, independent of the resolver's output** (so a match proves equivalence, not a restatement); covers the `.ts`→js-fp and `.vue`-excludes-js-fp boundaries; a file-type-lens-set pin that fails loudly if a new file-type agent appears.
- `tests/skills/test_code_review_frontend_dispatch.py` — content-guards (resolver referenced + warnings surfaced; gates/manifest/review-config paragraphs intact and ordered; old Svelte + narrower ai-provenance prose gone).

## One documented behavior clarification

ai-provenance-review is `Scope: always`, so the resolver includes it even on docs-only diffs — superseding bullet 213's narrower prose that was never actually `Scope:`-enforced. Resolved toward the agent's own declared scope (stated in the plan, not silent).

## Verification

- Full pytest gate: **5479 passed, 3 skipped**; ruff clean.
- `/code-review`: review checkpoint (doc + spec-compliance + test — **test caught a tautological assertion**, deleted in-loop) and a backstop (test corroboration + token-efficiency) + full-panel — all pass, 0 actionable outstanding.
- AC8 confirmed a no-op: the frontend-dispatch guards key on registry/Glob-EISDIR/frontmatter, not the replaced prose.

Closes #1523
Part of #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
