### PR TITLE
test(cost-meter): cover cmd_regression missing-log and malformed-JSON-line branches

### DIFF
--- a/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
+++ b/plugins/dev-team/tests/hooks/test_cost_meter_lib.py
@@ -553,3 +553,34 @@ def test_cmd_regression_zero_baseline_never_flags(hermetic_cost_meter, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "no cost regression" in out
+
+
+# ---------------------------------------------------------------------------
+# #1535 — cmd_regression's remaining untested branches: an absent log file and
+# the malformed-JSON-line skip.
+# ---------------------------------------------------------------------------
+def test_cmd_regression_missing_log_is_noop(hermetic_cost_meter, capsys):
+    missing = hermetic_cost_meter / "does-not-exist.jsonl"
+    rc = cost_meter.cmd_regression(SimpleNamespace(log=str(missing), tolerance=0.5, window=0), _PRICING)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no metrics log yet" in out
+
+
+def test_cmd_regression_skips_malformed_lines_and_counts_valid(hermetic_cost_meter, capsys):
+    # A garbage line between valid entries must be skipped, and the 3 valid costs
+    # ([1.0, 1.0] prior -> limit 1.5; latest 5.0) must still drive the verdict.
+    log = hermetic_cost_meter / "c.jsonl"
+    log.write_text(
+        '{"total": {"cost_usd": 1.0}}\n'
+        "NOT JSON {{\n"
+        '{"total": {"cost_usd": 1.0}}\n'
+        '{"total": {"cost_usd": 5.0}}\n'
+    )
+    rc = cost_meter.cmd_regression(SimpleNamespace(log=str(log), tolerance=0.5, window=0), _PRICING)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "COST REGRESSION" in out
+    # "prior 2" proves all 3 valid entries were counted (2 priors + latest); if the
+    # skip had also dropped a valid entry it would read "prior 1".
+    assert "rolling-mean(prior 2)=$1.0000" in out


### PR DESCRIPTION
## What

Adds unit coverage for the two remaining untested decision branches of `cost_meter.py`'s `cmd_regression`:

1. **Absent log file** → returns 0 and prints `no metrics log yet; nothing to compare` (the `log.is_file()` false branch).
2. **Malformed JSON line** → the garbage line is skipped (`except json.JSONDecodeError: continue`) and the remaining valid entries are still counted. Pinned via the `rolling-mean(prior 2)=$1.0000` output line so a dropped-valid-entry regression fails — `win_label` embeds `len(prior)`, which flips from 2 to 1 if any valid line were dropped.

Test-only; `cost_meter.py` is unchanged.

## Why

Follow-up filed during #1531's review — those two branches were the last uncovered paths in `cmd_regression`. The malformed-line oracle is spec-derived (computed from the `mean*(1+tolerance)` rule), not copied from captured output.

## Verification

Full suite green; the two new tests pass; ruff clean.

Closes #1535
Part of #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)