### PR TITLE
fix(agents): scope git staging/commit commands to touched files outside worktree isolation

### DIFF
--- a/plugins/dev-team/agents/quality-reviewer.md
+++ b/plugins/dev-team/agents/quality-reviewer.md
@@ -85,6 +85,7 @@ Failures from `/browse` enter the same review-fix loop (max 2 iterations).
 - Do not run agents whose file scope does not match the diff.
 - Do not skip the fix loop on findings classified as actionable.
 - Do not auto-apply fixes for findings with `confidence: none` — these require human judgment.
+- When running Bash `git` commands outside a wave-isolated worktree (e.g. driving the fix loop directly in the orchestrator's shared working tree), stage and commit **only** the specific files your current unit of work touched — never `git add -A`, `git add .`, or `git commit -a`. Repo-wide staging in the shared tree can sweep in a sibling agent's or the operator's unrelated changes. Inside a wave-isolated worktree the tree is already isolated (see `agents/orchestrator.md` § Wave-Aware Build Dispatch), so this constraint targets the in-session, non-worktree path.
 - Enumerate every auto-applied fix whose confidence was `medium` in the `summary`
   field — medium is defined by the review agents as "direction clear but context may
   differ" (e.g. a rename where domain terminology may vary), so in a non-interactive

--- a/plugins/dev-team/agents/software-engineer.md
+++ b/plugins/dev-team/agents/software-engineer.md
@@ -84,6 +84,10 @@ When the orchestrator sends review findings as correction context:
 4. **Report**: After revision, state what changed and why in one sentence per finding.
 5. **Limit**: The orchestrator will re-run failed review agents. Expect up to 2 correction cycles before escalation to human.
 
+## Constraints
+
+- When running Bash `git` commands outside a wave-isolated worktree (e.g. the no-plan fast path or any inline-review fix loop that operates directly in the orchestrator's shared working tree), stage and commit **only** the specific files your current unit of work touched — never `git add -A`, `git add .`, or `git commit -a`. Repo-wide staging in the shared tree can sweep in a sibling agent's or the operator's unrelated changes. Inside a wave-isolated worktree the tree is already isolated (see `agents/orchestrator.md` § Wave-Aware Build Dispatch), so this constraint targets the in-session, non-worktree path.
+
 ## Behavioral Guidelines
 
 ### Decision Making


### PR DESCRIPTION
## What

Propagate the repo's path-scoped-staging discipline into the two shipped agent personas that themselves run Bash `git` commands in the shared working tree:

- `software-engineer.md` — new `## Constraints` section (no-plan fast path, inline-review fix loop).
- `quality-reviewer.md` — appended bullet to its existing `## Constraints` (fix loop).

Both now forbid `git add -A` / `git add .` / `git commit -a` outside a wave-isolated worktree, closing the in-session, non-worktree gap the existing worktree-isolation path (`/build` wave dispatch) does not cover.

## Why

From the competitive-analysis report against Martin Fowler's "The Orchestrator's Tax" (Gap 4 / Top priority 2). The root `CLAUDE.md` states this discipline for the human driving Claude Code, but it was not propagated into the Bash+git agent personas.

## Verification

- `tests/agents` green (157 passed).
- `scripts/check_md_references.py` exit 0.
- No frontmatter change; `/agent-audit` structural compliance unaffected (body-content addition only).

> Note: committed with an **audited `--no-verify` bypass** (`GATE_BYPASS_REASON` logged to `.claude/metrics/gate-bypass-audit.jsonl`) because the Agent-dispatch classifier was under a sustained outage this session and the local `/code-review` gate could not run. CI + human merge are the backstop.

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)