### PR TITLE
docs(orchestrator): state explicit rule against full-transcript subagent status checks

### DIFF
--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -81,6 +81,8 @@ During `/build`, the orchestrator executes the plan **wave by wave** (the plan's
 
 Effective concurrency 1 (fully-dependent plan, `--jobs 1`, or `DEV_TEAM_MAX_PARALLEL_BUILDS=1`) degrades to sequential single-worktree build with no fan-out or reconcile.
 
+> Read a slice's status during a wave only from its structured result, never from a live transcript read into this orchestrating context — see `docs/agent-architecture.md` → Subagent status checks.
+
 **`worktree.baseRef` prerequisite (issue #553).** Worktree fan-out only works when Claude Code's `worktree.baseRef` setting is `"head"` — otherwise each subagent worktree branches from `origin/<default>` and cannot see the caller's uncommitted-to-remote spec, plan, or prior-wave commits. Users must set this in **`.claude/settings.json`** (project scope) or **`~/.claude/settings.json`** (user scope); plugin-scope `plugins/<name>/settings.json` and project-local `.claude/settings.local.json` are **not** honored by 2.1.198's worktree isolation. `/build`'s Step 4 detect-and-warn surfaces the requirement loudly on every invocation until the user sets it (or opts out with `DEV_TEAM_WORKTREE_BASE_FRESH=1`). Full audit trail: `docs/spikes/worktree-baseref-head-spike.md`.
 
 ## Task Size Gate

--- a/plugins/dev-team/docs/agent-architecture.md
+++ b/plugins/dev-team/docs/agent-architecture.md
@@ -80,6 +80,12 @@ Utilization is estimated via proxy signals (tool call volume, message count, acc
 
 A typical task loads 1 agent + 1-2 skills: roughly 1,000-2,000 tokens of configuration overhead. Review agents and plan review personas run as isolated sub-agents — their context burden does not accumulate in the parent.
 
+### Subagent status checks
+
+A subagent's progress or status reaches a *live* orchestrating agent's context only as its structured summary output — the verdict/findings contract the `Agent` tool already returns — never as a raw transcript read. Pulling a running subagent's full transcript into the orchestrator's working context is the failure mode Martin Fowler's ["The Orchestrator's Tax"](https://martinfowler.com/articles/orchestrator-tax.html) warns about: unlike a one-time token bill, that transcript then persists and degrades every subsequent turn. The `Agent` tool's contract already enforces this — it returns only final text/schema output, not a transcript — so the failure cannot occur through the standard dispatch path; this subsection states the rule explicitly for future tool and skill authors.
+
+**Offline-resume exception.** The `Workflow` tool's resume mechanism legitimately reads `journal.jsonl` / `agent-<id>.jsonl` transcript files to reconstruct cached results for continuation. That is an *offline* diagnostic read, not a feed into a live orchestrator's context, and is fine. The constraint targets specifically a raw-transcript read flowing back into an *active* orchestrating agent's working context.
+
 ## Plan Review Personas
 
 Before the human reviews a plan (Phase 2), a tier-scaled set of critical review personas runs **in parallel** as sub-agents. The reviewer set scales to a **plan tier** (`trivial`/`standard`/`complex`, derived from slice count, file count, per-step complexity, and whether the plan takes a stance on any high-reversal-cost decision axis) so a one-function plan does not pay a complex feature's review ceremony: `trivial` runs the Acceptance Test Critic alone, `standard` adds the Design & Architecture Critic (plus the UX Critic for user-facing plans and the Parallelization Critic when the slice count > 1), and `complex` runs all five. The Acceptance Test Critic always runs; the Parallelization Critic runs only when slice count > 1. Each persona challenges the plan from a distinct perspective:


### PR DESCRIPTION
## What

- `docs/agent-architecture.md` — new `### Subagent status checks` subsection under Context Management: a subagent's status reaches a *live* orchestrating agent only as its structured summary output (the `Agent` tool's verdict/findings contract), never as a raw transcript read, with the `Workflow` offline-resume path (`journal.jsonl` / `agent-<id>.jsonl`) called out as the explicit exception.
- `agents/orchestrator.md` § Wave-Aware Build Dispatch — one-line cross-reference to the new subsection.

## Why

From the competitive-analysis report against Martin Fowler's "The Orchestrator's Tax" (Gap 2 / Top priority 1). The safety is implicit today (a property of the harness's `Agent` tool contract) but was not a stated rule in dev-team's own docs. This makes the rule explicit for future tool/skill authors, scoped so it doesn't forbid the legitimate offline `Workflow` resume read.

## Verification

- `scripts/check_md_references.py` exit 0.
- `tests/agents tests/repo tests/docs` — 831 passed.
- No behavior change — guardrail documentation only.

> Committed with an **audited `--no-verify` bypass** (`GATE_BYPASS_REASON` logged) — the Agent-dispatch classifier was under a sustained outage this session so the local `/code-review` gate could not run. CI + human merge are the backstop.

Closes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)