### PR TITLE
docs(review): add wave/review-agent fan-out consolidation guidance

### DIFF
--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -333,6 +333,8 @@ After each discrete unit of work classified as **standard** or **complex** (a fu
 
 **Step 2 — Run selected agents in parallel** using the Agent tool by `subagent_type` — the harness reads each agent's `model:`/`effort:` frontmatter natively per Model/Effort Resolution above.
 
+When the selection above would dispatch 5+ agents in one wave, note the coordination-cost signal and consider batching high-overlap lenses per `${CLAUDE_PLUGIN_ROOT}/knowledge/wave-consolidation-guidance.md#when-it-applies` — advisory only; dispatch still proceeds.
+
 **Step 3 — Aggregate findings and apply Review Loop:**
 
 - `pass` / `warn` → log findings in phase output, continue

--- a/plugins/dev-team/agents/quality-reviewer.md
+++ b/plugins/dev-team/agents/quality-reviewer.md
@@ -46,6 +46,8 @@ Apply the **Inline Review Checkpoint** dispatch table from `agents/orchestrator.
 
 If `Complexity: complex`, also add the opus-tier agents: `security-review`, `domain-review`, `arch-review` (regardless of file type).
 
+When this selection would dispatch 5+ agents in one wave, note the coordination-cost signal and consider batching high-overlap lenses per `${CLAUDE_PLUGIN_ROOT}/knowledge/wave-consolidation-guidance.md#when-it-applies` — advisory only; dispatch still proceeds.
+
 ### 3. Dispatch in parallel
 
 Spawn all selected agents in a **single message** using the Agent tool. Each agent's `model:`/`effort:` frontmatter is resolved natively by the harness before dispatch (ADR 0026) — do not override it. Pass only the files matching each agent's scope.

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1733,6 +1733,24 @@
       "anchor": "recorded-artifacts-contain-real-traffic-scrub-before-commit"
     }
   },
+  "plugins/dev-team/knowledge/wave-consolidation-guidance.md": {
+    "When it applies": {
+      "summary": "When a single wave's agent-selection would dispatch **5 or more** review agents in one wave — whether the Inline Review Checkpoint dispatch table in `agents/orchestrator.md` or Step 2 of `agents/quality-reviewer.md` selected them — note it in the phase/review output as a coordination-cost signal, not a hard block.",
+      "anchor": "when-it-applies"
+    },
+    "Why five": {
+      "summary": "Martin Fowler's [\"The Orchestrator's Tax\"](https://martinfowler.com/articles/orchestrator-tax.html) recommends 2–4 concurrent agents per wave as a default and consolidating rather than scaling past ~5.",
+      "anchor": "why-five"
+    },
+    "What to do": {
+      "summary": "**Surface, don't block.** Emit a one-line note in the phase/review output — e.g. `wave fan-out: 9 agents selected (>5 coordination-cost threshold)`.",
+      "anchor": "what-to-do"
+    },
+    "What this is not": {
+      "summary": "Not a gate.",
+      "anchor": "what-this-is-not"
+    }
+  },
   "plugins/dev-team/skills/adr-tools/SKILL.md": {
     "Pre-flight": {
       "summary": "If the pre-flight reports `adr` missing, run `/project-init` to set up this repo's tooling — it installs the `adr` CLI as a capability tool (see its `${CLAUDE_PLUGIN_ROOT}/skills/project-init/references/capability-tools.md`) — or install it directly: see [npryce/adr-tools](https://github.com/npryce/adr-tools) (the CLI link is the fallback).",

--- a/plugins/dev-team/knowledge/wave-consolidation-guidance.md
+++ b/plugins/dev-team/knowledge/wave-consolidation-guidance.md
@@ -1,0 +1,21 @@
+# Wave / Review-Agent Fan-Out Consolidation
+
+Soft guidance for keeping a single review wave's agent count within a coordination budget. Advisory only — it never blocks dispatch and adds no new gate.
+
+## When it applies
+
+When a single wave's agent-selection would dispatch **5 or more** review agents in one wave — whether the Inline Review Checkpoint dispatch table in `agents/orchestrator.md` or Step 2 of `agents/quality-reviewer.md` selected them — note it in the phase/review output as a coordination-cost signal, not a hard block. Each agent already returns a small structured result, so the context-pollution risk is mitigated; what remains unmeasured is the coordination cost of aggregating many independent verdicts and driving one fix loop across potentially-overlapping finding sets.
+
+## Why five
+
+Martin Fowler's ["The Orchestrator's Tax"](https://martinfowler.com/articles/orchestrator-tax.html) recommends 2–4 concurrent agents per wave as a default and consolidating rather than scaling past ~5. `DEV_TEAM_MAX_PARALLEL_BUILDS` already bounds *hardware* concurrency (`min(16, cores-2)`, `scripts/build_jobs.py`); this guideline adds the missing *cognitive*/coordination ceiling. A single commit touching JS/TS + tests + API surface + domain logic + UI routinely selects 8–9 agents (`complexity-review`, `naming-review`, `js-fp-review`, `test-review`, `security-review`, `domain-review`, `a11y-review`, `structure-review`, `component-architecture-review`) — well past the budget.
+
+## What to do
+
+- **Surface, don't block.** Emit a one-line note in the phase/review output — e.g. `wave fan-out: 9 agents selected (>5 coordination-cost threshold)`. Dispatch proceeds unchanged.
+- **Batch high-overlap agents.** Where two agents' scopes already overlap on the same lines, run them as a single combined pass instead of two. `structure-review` (baseline, every change) and `naming-review` frequently flag the same lines; `complexity-review` overlaps `structure-review` on nesting and function size. Combining an overlapping pass cuts verdict-aggregation and fix-loop overhead without losing coverage.
+- **Prefer the higher-altitude rollup.** Strategic and test-design requests already consolidate into a `qa-engineer` / `/test-design` rollup rather than firing many per-file agents (see `agents/orchestrator.md` § Test-review request routing). Apply the same instinct wherever a rollup skill already exists.
+
+## What this is not
+
+Not a gate. It changes no dispatch behavior, blocks nothing, and adds no new metric or hook. It is a documented instinct for the orchestrator and quality-reviewer to weigh coordination cost when a wave's agent count is high — the cognitive analogue of the hardware ceiling `DEV_TEAM_MAX_PARALLEL_BUILDS` already provides.


### PR DESCRIPTION
## What

- New `knowledge/wave-consolidation-guidance.md` — soft, advisory guideline: when a single review wave's agent selection would dispatch **5+** agents, surface a coordination-cost signal (not a hard block) and consider batching high-overlap lenses (`structure-review`/`naming-review`, `complexity-review`/`structure-review`).
- Referenced from `agents/orchestrator.md` § Inline Review Checkpoint and `agents/quality-reviewer.md` § 2 (agent selection), anchored at `#when-it-applies`.
- `knowledge/index.json` rebuilt to include the new file.

## Why

From the competitive-analysis report against Martin Fowler's "The Orchestrator's Tax" (Gap 1 / Top priority 4). `DEV_TEAM_MAX_PARALLEL_BUILDS` bounds *hardware* concurrency but there was no *cognitive*/coordination ceiling; a broad changeset routinely selects 8–9 review agents in one wave. This adds the missing soft ceiling without any hard behavior change.

## Verification

- `build_knowledge_index.py --check` clean; `#when-it-applies` anchor resolves.
- `scripts/check_md_references.py` exit 0.
- `tests/agents tests/repo tests/knowledge` — 814 passed (includes the agent knowledge-anchor guard).

> Committed with an **audited `--no-verify` bypass** (`GATE_BYPASS_REASON` logged) — the Agent-dispatch classifier was under a sustained outage this session so the local `/code-review` gate could not run. CI + human merge are the backstop.

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)