### PR TITLE
feat(cost-report): measure context pollution separately from one-time token spend

### DIFF
--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -215,6 +215,15 @@
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/code_intelligence_turn_mark.py\""
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/phase_marker.py\""
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -79,6 +79,20 @@ pace     --log .claude/metrics/cost-metering.jsonl [--budget B] [--period-days 3
          period. With --budget it flags when the current pace would exhaust the
          budget and suggests dropping a model tier for the rest of the window.
 
+phase-mark --transcript T --phase LABEL [--log .claude/metrics/phase-markers.jsonl]
+         Context-pollution measurement (#1520): append one phase-boundary
+         marker capturing the main-loop resident context occupancy and the
+         cumulative output spend at a `/handoff` boundary. Fired by the
+         `phase_marker.py` PostToolUse hook. Kept in its own log, never folded
+         into the incremental `record` state.
+
+phase-report --log .claude/metrics/phase-markers.jsonl [--json]
+         Report per-phase resident-vs-spent ratios from the phase markers: for
+         each phase, the context still resident at its boundary vs the output
+         tokens spent during it. A high ratio distinguishes context that
+         lingered (pollution) from one-time cost — a distinction the session
+         totals cannot make.
+
 The transcript schema is read defensively (usage may sit on the record or under
 `message`; model + agent attribution likewise), so it tolerates schema drift.
 """
@@ -751,6 +765,157 @@ def cmd_pace(args, pricing) -> int:
     return 0
 
 
+def _resident_and_spent(path: Path) -> tuple[int, int]:
+    """(resident_tokens, spent_output_cumulative) for the MAIN-LOOP context (#1520).
+
+    Context-pollution measurement is about the *live orchestrating* context —
+    the one that "charges rent" every subsequent turn per Martin Fowler's "The
+    Orchestrator's Tax" — so both figures are computed over main-loop
+    (non-sidechain) turns only; subagent contexts are separate and are
+    discarded at their own SubagentStop.
+
+      * resident_tokens = the MOST-RECENT main-loop usage record's context
+        occupancy (input + cache_read + cache_creation) — what still occupies
+        the window at this point, the same numerator context_ceiling_guard.py
+        uses. Overwritten each turn so it ends as the last turn's occupancy.
+      * spent_output_cumulative = the sum of output_tokens across all main-loop
+        turns so far — the one-time generation bill accrued to this point.
+
+    Read defensively (schema drift tolerated the same way parse_transcript does);
+    a missing/unreadable transcript returns (0, 0) rather than raising, so the
+    fail-open phase-mark hook never breaks a turn.
+    """
+    resident = 0
+    spent_output = 0
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return 0, 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("isSidechain"):
+            continue  # main-loop context only
+        usage = _first_present_field(rec, "usage")
+        if not isinstance(usage, dict):
+            continue
+        resident = (
+            (usage.get("input_tokens", 0) or 0)
+            + (usage.get("cache_read_input_tokens", 0) or 0)
+            + (usage.get("cache_creation_input_tokens", 0) or 0)
+        )
+        spent_output += usage.get("output_tokens", 0) or 0
+    return resident, spent_output
+
+
+def cmd_phase_mark(args, pricing) -> int:
+    """Append one phase-boundary marker to the phase-markers log (#1520).
+
+    Fired by the `phase_marker.py` PostToolUse hook when `/handoff` runs (a
+    phase boundary). Captures the resident/spent snapshot at the boundary so
+    `phase-report` can later derive per-phase context-pollution ratios the
+    session totals alone cannot (the harness records no phase marker itself —
+    the reason per-phase cost attribution was removed in #170). Kept in its OWN
+    log, deliberately NOT folded into the incremental `record` state, so this
+    additive dimension never touches that security-sensitive hot path.
+
+    Fail-open: a missing transcript is a no-op success (the hook must never
+    break a turn)."""
+    tpath = Path(args.transcript)
+    if not tpath.is_file():
+        return 0
+    resident, spent = _resident_and_spent(tpath)
+    from datetime import datetime, timezone
+
+    line = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "transcript": tpath.name,
+        "phase": args.phase or "unlabeled",
+        "resident_tokens": resident,
+        "spent_output_cumulative": spent,
+    }
+    log = Path(args.log)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a") as fh:
+        fh.write(json.dumps(line) + "\n")
+    return 0
+
+
+def _phase_rows(entries: list) -> list:
+    """Per-phase resident/spent rows from ordered phase markers (#1520).
+
+    `spent_output_cumulative` is monotonic across a session, so a phase's own
+    spend is the delta from the prior marker; `resident_tokens` is a snapshot,
+    used as-is. `resident_to_spent_ratio = resident / spent_phase` is the
+    context-pollution proxy — high means a large resident footprint relative to
+    the fresh generation the phase did (context that lingered rather than being
+    compacted). `None` when the phase spent nothing new (ratio undefined), never
+    a divide-by-zero.
+    """
+    rows = []
+    prev_spent = 0
+    for e in entries:
+        resident = e.get("resident_tokens", 0) or 0
+        spent_cum = e.get("spent_output_cumulative", 0) or 0
+        # A cumulative counter can only go up within a session; clamp at 0 so a
+        # transcript rotation (counter reset) never yields a negative phase spend.
+        spent_phase = max(spent_cum - prev_spent, 0)
+        prev_spent = spent_cum
+        ratio = round(resident / spent_phase, 2) if spent_phase > 0 else None
+        rows.append(
+            {
+                "phase": e.get("phase", "unlabeled"),
+                "resident_tokens": resident,
+                "spent_tokens": spent_phase,
+                "resident_to_spent_ratio": ratio,
+            }
+        )
+    return rows
+
+
+def cmd_phase_report(args, pricing) -> int:
+    """Print per-phase resident/spent ratios from the phase-markers log (#1520)."""
+    log = Path(args.log)
+    if not log.is_file():
+        print("no phase markers recorded yet; nothing to report")
+        return 0
+    entries = []
+    for line in log.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    rows = _phase_rows(entries)
+    if getattr(args, "json", False):
+        print(json.dumps({"by_phase": rows}, indent=2))
+        return 0
+    print("# Context pollution — resident vs one-time spend, per phase (#1520)")
+    print(f"{'PHASE':<24} {'RESIDENT':>10} {'SPENT':>10} {'RESIDENT/SPENT':>15}")
+    print("-" * 62)
+    for r in rows:
+        ratio = "-" if r["resident_to_spent_ratio"] is None else f"{r['resident_to_spent_ratio']:.2f}"
+        print(
+            f"{r['phase']:<24} {r['resident_tokens']:>10} {r['spent_tokens']:>10} "
+            f"{ratio:>15}"
+        )
+    print(
+        "\nresident = main-loop context occupancy at the phase's /handoff boundary; "
+        "spent = output tokens generated during the phase. A high ratio flags a "
+        "phase whose context lingered (pollution) rather than being one-time cost. "
+        "Session-scoped proxy: resident is sampled at the /handoff marker, the "
+        "closest phase boundary the harness exposes."
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pricing", default=str(_DEFAULT_PRICING))
@@ -791,6 +956,21 @@ def main(argv: list[str]) -> int:
         default=7,
         help="rolling lookback used to estimate the current daily rate",
     )
+    p = sub.add_parser("phase-mark")
+    p.add_argument("--transcript", required=True)
+    p.add_argument(
+        "--phase",
+        default=None,
+        help="phase label for this boundary marker (e.g. research/plan/implement)",
+    )
+    p.add_argument(
+        "--log", default=str(artifact_paths.metrics_dir() / "phase-markers.jsonl")
+    )
+    p = sub.add_parser("phase-report")
+    p.add_argument(
+        "--log", default=str(artifact_paths.metrics_dir() / "phase-markers.jsonl")
+    )
+    p.add_argument("--json", action="store_true")
 
     args = ap.parse_args(argv)
     pricing = _load_pricing(Path(args.pricing))
@@ -799,6 +979,8 @@ def main(argv: list[str]) -> int:
         "record": cmd_record,
         "regression": cmd_regression,
         "pace": cmd_pace,
+        "phase-mark": cmd_phase_mark,
+        "phase-report": cmd_phase_report,
     }[args.cmd](args, pricing)
 
 

--- a/plugins/dev-team/hooks/phase_marker.py
+++ b/plugins/dev-team/hooks/phase_marker.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""phase_marker — PostToolUse:Skill hook (issue #1520).
+
+A phase boundary in the three-phase workflow is where the orchestrator
+compacts context before the next phase — i.e. where `/handoff` (continue
+mode) runs. This hook fires on every Skill invocation, filters to `handoff`,
+and records a context-pollution marker via `hooks/lib/cost_meter.py
+phase-mark`: the main-loop resident context occupancy at the boundary and the
+cumulative output spend so far. `cost-report`'s `phase-report` later turns the
+sequence of markers into per-phase resident-vs-spent ratios — the distinction
+between context that lingered (pollution) and one-time cost that the session
+totals cannot make.
+
+Why a hook and not a prose instruction: the emission has to be reliable, not
+dependent on the orchestrator remembering to call a script (hooks enforce, prose
+gets ignored). PostToolUse hooks carry no token usage, but they DO carry
+`transcript_path`, and the cost-meter library derives resident/spent by parsing
+the transcript — the same mechanism the Stop-hook cost meter uses.
+
+Contract (docs/python-hook-contract.md):
+    Input : PostToolUse:Skill JSON on stdin
+    Output: appends .claude/metrics/phase-markers.jsonl; no stdout. Exit 0.
+    Posture: record-only and fail-open. Any error → exit 0 silently.
+    Opt-out: DEV_TEAM_COST_METER=off disables (shares the cost meter's switch).
+
+Stdlib-only. Python 3.8+. See ADR 0014.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_COST_METER_LIB = _HOOK_DIR / "lib" / "cost_meter.py"
+_LIB_DIR = _HOOK_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import artifact_paths
+import telemetry_consent
+
+# Skill label sanity — same shape the telemetry hook accepts for a skill name.
+_LABEL_RE = re.compile(r"^[A-Za-z0-9_-]{1,40}$")
+
+
+def _load_input() -> dict:
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _phase_label(tool_input: dict) -> str:
+    """Best-effort phase label for the marker.
+
+    `/handoff`'s args may name the phase being closed (e.g. `research`); when
+    present and sane, use it, else fall back to the neutral `handoff` label.
+    The per-phase report is still meaningful with neutral labels — the
+    resident/spent delta between consecutive markers is the signal — a label
+    only makes the row easier to read.
+    """
+    args = tool_input.get("args")
+    if isinstance(args, str):
+        first = args.strip().split()[0] if args.strip() else ""
+        if _LABEL_RE.match(first):
+            return first
+    return "handoff"
+
+
+def main() -> int:
+    if os.environ.get("DEV_TEAM_COST_METER") == "off":
+        return 0
+    if not telemetry_consent.is_enabled():
+        return 0
+    if shutil.which("python3") is None or not _COST_METER_LIB.is_file():
+        return 0
+
+    payload = _load_input()
+    if not payload:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+    skill = tool_input.get("skill") or tool_input.get("name") or ""
+    if not isinstance(skill, str) or skill != "handoff":
+        return 0
+
+    transcript = payload.get("transcript_path")
+    if not isinstance(transcript, str) or not transcript or not Path(transcript).is_file():
+        return 0
+
+    cwd_hint = payload.get("cwd")
+    if isinstance(cwd_hint, str) and cwd_hint and Path(cwd_hint).is_dir():
+        cwd = cwd_hint
+    else:
+        cwd = os.getcwd()
+
+    log_path = artifact_paths.resolve_file("metrics", "phase-markers.jsonl", cwd)
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                str(_COST_METER_LIB),
+                "phase-mark",
+                "--transcript",
+                transcript,
+                "--phase",
+                _phase_label(tool_input),
+                "--log",
+                str(log_path),
+            ],
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1322,6 +1322,10 @@
       "summary": "Per-session token/cost summary, incrementally accumulated from the",
       "anchor": "cost-meteringjsonl"
     },
+    "`phase-markers.jsonl`": {
+      "summary": "Per-phase context-pollution markers (#1520), one row appended at each `/handoff`",
+      "anchor": "phase-markersjsonl"
+    },
     "`artifact-usage.json`": {
       "summary": "Not JSONL — a single JSON object keyed by skill/agent name, upserted on",
       "anchor": "artifact-usagejson"
@@ -2845,6 +2849,10 @@
     "Review value (#348)": {
       "summary": "`/build` records, per inline review checkpoint, whether review actually changed",
       "anchor": "review-value-348"
+    },
+    "Context pollution — per-phase resident vs one-time spend (#1520)": {
+      "summary": "A one-time token bill and context that lingers and \"charges rent\" on every",
+      "anchor": "context-pollution-per-phase-resident-vs-one-time-spend-1520"
     },
     "Privacy boundary": {
       "summary": "The meter persists **only** token counts, dollar amounts, model identifiers,",

--- a/plugins/dev-team/knowledge/telemetry-schema.md
+++ b/plugins/dev-team/knowledge/telemetry-schema.md
@@ -100,6 +100,27 @@ transcript on each `Stop` hook fire.
 
 ---
 
+## `phase-markers.jsonl`
+
+Per-phase context-pollution markers (#1520), one row appended at each `/handoff`
+(a phase boundary). Distinct stream from `cost-metering.jsonl` — deliberately
+kept out of that log's incremental `record` state so this additive dimension
+never touches the security-sensitive hot path.
+
+| Field | Type | Values / source |
+|---|---|---|
+| `timestamp` | string | ISO-8601 UTC |
+| `transcript` | string | Transcript file basename (not full path) |
+| `phase` | string | Phase label — the first `/handoff` args token when sane, else `handoff` (or `unlabeled` for a direct library call) |
+| `resident_tokens` | int | Main-loop context occupancy at the boundary: the most-recent non-sidechain turn's `input + cache_read + cache_creation` |
+| `spent_output_cumulative` | int | Cumulative main-loop `output_tokens` across the session up to this boundary (monotonic; `phase-report` deltas it into per-phase spend) |
+
+- **Emitter:** `hooks/phase_marker.py` (PostToolUse:Skill, filters to `handoff`) → `hooks/lib/cost_meter.py::cmd_phase_mark()`.
+- **Consent:** gated by `telemetry_consent.is_enabled()`; shares the cost meter's `DEV_TEAM_COST_METER=off` opt-out.
+- **Consumers:** `skills/cost-report/SKILL.md` (§ Context pollution, via `phase-report`), `skills/harness-audit/SKILL.md` (§ Analyze orchestration complexity).
+
+---
+
 ## `artifact-usage.json`
 
 Not JSONL — a single JSON object keyed by skill/agent name, upserted on

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -231,6 +231,15 @@
             "command": "sh hooks/py.sh hooks/code_intelligence_turn_mark.py"
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh hooks/py.sh hooks/phase_marker.py"
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/plugins/dev-team/skills/cost-report/SKILL.md
+++ b/plugins/dev-team/skills/cost-report/SKILL.md
@@ -116,12 +116,44 @@ A run that is mostly `no_op` is evidence the review ceremony is over-provisioned
 for that class of work — feed it back into the `/plan` plan-tier and `/build`
 per-step complexity routing. Counts only; no code or file content is stored.
 
+## Context pollution — per-phase resident vs one-time spend (#1520)
+
+A one-time token bill and context that lingers and "charges rent" on every
+subsequent turn are economically different costs (Martin Fowler, "The
+Orchestrator's Tax"). The session totals above cannot tell them apart. The
+`phase_marker.py` PostToolUse hook records a marker at every `/handoff` (a
+phase boundary) capturing, for the **main-loop** context, the resident
+occupancy and the cumulative output spend at that boundary. `phase-report`
+turns the marker sequence into a per-phase ratio:
+
+```bash
+log=".claude/metrics/phase-markers.jsonl"; [ -f "$log" ] || log="metrics/phase-markers.jsonl"
+python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py phase-report --log "$log"
+```
+
+Report the per-phase `resident_tokens`, `spent_tokens` (output generated during
+the phase), and `resident_to_spent_ratio`. A **high** ratio flags a phase whose
+context stayed resident (pollution — a candidate for earlier mid-phase
+compaction or narrower subagent scoping) rather than being one-time cost; a low
+ratio means most of the phase's spend was transient. If the log is absent, tell
+the user no phase boundary has been recorded yet (the hook records on each
+`/handoff`).
+
+**Honesty caveat — this is a session-scoped proxy, not exact per-phase
+accounting.** `resident` is sampled at the `/handoff` marker because that is the
+closest phase boundary the harness exposes; the harness records no explicit
+phase marker of its own (the same reason per-command/per-phase *cost*
+attribution was removed in #170 — see Attribution dimensions above). The metric
+lives in its own `phase-markers.jsonl` log and is never folded into the
+`cost-metering.jsonl` incremental state.
+
 ## Privacy boundary
 
 The meter persists **only** token counts, dollar amounts, model identifiers,
-the main/subagent thread flag, and agent-type identifiers — never prompt text,
-code, file paths, or tool payloads. `metrics/cost-metering.jsonl` is a
-metrics-only artifact by construction.
+the main/subagent thread flag, agent-type identifiers, and — for phase markers —
+a phase label and the resident/spent token counts. It never records prompt
+text, code, file paths, or tool payloads. `metrics/cost-metering.jsonl` and
+`metrics/phase-markers.jsonl` are metrics-only artifacts by construction.
 
 1. **Account pace (optional, #142).** When the user asks "am I on track for my
    budget", "how much have I burned this week", or "which model should I use for

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -302,6 +302,14 @@ Review the current pipeline for components that may be unnecessary overhead:
 1. **Phase count**: Are all three phases (Research, Plan, Implement) needed for the types of tasks being run? If most tasks are simple, suggest a fast path.
 2. **Review checkpoint frequency**: Are inline reviews running on every step? If most steps are trivial, the complexity classification (see `skills/plan/SKILL.md` § Complexity Classification) should be catching this.
 3. **Unused skills**: Skills loaded but never applied in logged sessions.
+4. **Context pollution per phase (#1520)**: Read the per-phase resident-vs-spend ratios from the phase markers (`phase-report`) and flag phases whose context lingered rather than being one-time cost — candidates for earlier mid-phase compaction or narrower subagent scoping. Skip if the log is absent.
+
+   ```bash
+   log=".claude/metrics/phase-markers.jsonl"; [ -f "$log" ] || log="metrics/phase-markers.jsonl"
+   [ -f "$log" ] && python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py phase-report --log "$log" --json
+   ```
+
+   A phase with a high `resident_to_spent_ratio` spent proportionally little fresh generation while carrying a large resident context — cite it in § Orchestration Simplification Opportunities as a compaction/scoping candidate. This is a session-scoped proxy (resident is sampled at the `/handoff` boundary — see `skills/cost-report/SKILL.md` § Context pollution), not exact per-phase accounting.
 
 ### 8. Produce report
 
@@ -406,6 +414,7 @@ Write the report to the output path using this structure:
 ## Orchestration Simplification Opportunities
 
 - <Finding and recommendation>
+- <Context-pollution candidates (#1520): any phase with a high resident/spent ratio from `phase-report` — recommend earlier mid-phase compaction or narrower subagent scoping. Omit if no phase markers logged.>
 
 ## Summary
 

--- a/plugins/dev-team/tests/hooks/test_phase_marker.py
+++ b/plugins/dev-team/tests/hooks/test_phase_marker.py
@@ -1,0 +1,282 @@
+"""Unit tests for the context-pollution phase-marker pipeline (#1520).
+
+Covers both halves:
+  * hooks/lib/cost_meter.py — the `phase-mark` (emit) and `phase-report`
+    (per-phase resident/spent) subcommands plus their `_resident_and_spent`
+    and `_phase_rows` helpers.
+  * hooks/phase_marker.py — the PostToolUse:Skill hook that fires the emit on
+    `/handoff`, exercised as a module with a crafted stdin payload (the
+    working-tree code path — the installed cache copy is a separate snapshot).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_HOOKS = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
+_HOOKS_LIB = _HOOKS / "lib"
+
+
+def _load(module_name: str, path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Distinct sys.modules key — a sibling hooks/cost_meter.py of the same basename
+# exists, so pin the lib version by path (see test_cost_meter_lib.py #1120).
+cost_meter = _load("cost_meter_lib_phase", _HOOKS_LIB / "cost_meter.py")
+phase_marker = _load("phase_marker_hook", _HOOKS / "phase_marker.py")
+
+_PRICING = {"cache_write_multiplier": 1.25, "cache_read_multiplier": 0.1, "models": {}, "aliases": {}}
+
+
+def _usage(inp, out, cache_read=0, cache_create=0, *, sidechain=False):
+    rec = {
+        "message": {
+            "model": "claude-x",
+            "usage": {
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_create,
+            },
+        }
+    }
+    if sidechain:
+        rec["isSidechain"] = True
+    return json.dumps(rec) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# _resident_and_spent
+# ---------------------------------------------------------------------------
+
+
+def test_resident_is_last_mainloop_occupancy_spent_is_cumulative_output(tmp_path):
+    t = tmp_path / "t.jsonl"
+    t.write_text(
+        _usage(100, 40, cache_read=10, cache_create=5)
+        + _usage(200, 60, cache_read=20, cache_create=5)
+    )
+    resident, spent = cost_meter._resident_and_spent(t)
+    # resident = last main-loop turn's input+cache_read+cache_creation.
+    assert resident == 200 + 20 + 5
+    # spent = cumulative output across both turns.
+    assert spent == 40 + 60
+
+
+def test_resident_and_spent_ignores_sidechain_turns(tmp_path):
+    t = tmp_path / "t.jsonl"
+    t.write_text(
+        _usage(100, 40)
+        + _usage(9999, 9999, cache_read=9999, sidechain=True)  # subagent — excluded
+    )
+    resident, spent = cost_meter._resident_and_spent(t)
+    assert resident == 100  # the sidechain turn did not overwrite it
+    assert spent == 40  # nor add to the main-loop spend
+
+
+def test_resident_and_spent_missing_file_is_zero(tmp_path):
+    assert cost_meter._resident_and_spent(tmp_path / "nope.jsonl") == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# cmd_phase_mark
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_phase_mark_appends_marker(tmp_path):
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(300, 50, cache_read=100))
+    log = tmp_path / "metrics" / "phase-markers.jsonl"
+    cost_meter.cmd_phase_mark(
+        SimpleNamespace(transcript=str(t), phase="plan", log=str(log)), _PRICING
+    )
+    entry = json.loads(log.read_text().splitlines()[-1])
+    assert entry["phase"] == "plan"
+    assert entry["resident_tokens"] == 400
+    assert entry["spent_output_cumulative"] == 50
+
+
+def test_cmd_phase_mark_missing_transcript_is_noop(tmp_path):
+    log = tmp_path / "metrics" / "phase-markers.jsonl"
+    rc = cost_meter.cmd_phase_mark(
+        SimpleNamespace(transcript=str(tmp_path / "nope.jsonl"), phase=None, log=str(log)),
+        _PRICING,
+    )
+    assert rc == 0
+    assert not log.exists()
+
+
+def test_cmd_phase_mark_defaults_unlabeled(tmp_path):
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(10, 5))
+    log = tmp_path / "m.jsonl"
+    cost_meter.cmd_phase_mark(SimpleNamespace(transcript=str(t), phase=None, log=str(log)), _PRICING)
+    assert json.loads(log.read_text().splitlines()[-1])["phase"] == "unlabeled"
+
+
+# ---------------------------------------------------------------------------
+# _phase_rows
+# ---------------------------------------------------------------------------
+
+
+def test_phase_rows_computes_deltas_and_ratio():
+    entries = [
+        {"phase": "research", "resident_tokens": 5000, "spent_output_cumulative": 1000},
+        {"phase": "plan", "resident_tokens": 8000, "spent_output_cumulative": 1400},
+    ]
+    rows = cost_meter._phase_rows(entries)
+    assert rows[0] == {
+        "phase": "research",
+        "resident_tokens": 5000,
+        "spent_tokens": 1000,
+        "resident_to_spent_ratio": 5.0,
+    }
+    # plan's own spend is the delta 1400-1000=400; 8000/400 = 20.0.
+    assert rows[1]["spent_tokens"] == 400
+    assert rows[1]["resident_to_spent_ratio"] == 20.0
+
+
+def test_phase_rows_zero_spend_ratio_is_none_not_div_by_zero():
+    rows = cost_meter._phase_rows(
+        [{"phase": "p", "resident_tokens": 100, "spent_output_cumulative": 0}]
+    )
+    assert rows[0]["resident_to_spent_ratio"] is None
+
+
+def test_phase_rows_clamps_counter_reset_to_zero():
+    # A transcript rotation resets the cumulative counter; the delta must clamp
+    # at 0 rather than go negative.
+    rows = cost_meter._phase_rows(
+        [
+            {"phase": "a", "resident_tokens": 10, "spent_output_cumulative": 900},
+            {"phase": "b", "resident_tokens": 10, "spent_output_cumulative": 100},
+        ]
+    )
+    assert rows[1]["spent_tokens"] == 0
+    assert rows[1]["resident_to_spent_ratio"] is None
+
+
+# ---------------------------------------------------------------------------
+# cmd_phase_report
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_phase_report_json(tmp_path, capsys):
+    log = tmp_path / "m.jsonl"
+    log.write_text(
+        json.dumps({"phase": "implement", "resident_tokens": 6000, "spent_output_cumulative": 2000}) + "\n"
+    )
+    cost_meter.cmd_phase_report(SimpleNamespace(log=str(log), json=True), _PRICING)
+    out = json.loads(capsys.readouterr().out)
+    assert out["by_phase"][0]["phase"] == "implement"
+    assert out["by_phase"][0]["resident_to_spent_ratio"] == 3.0
+
+
+def test_cmd_phase_report_no_file(tmp_path, capsys):
+    rc = cost_meter.cmd_phase_report(
+        SimpleNamespace(log=str(tmp_path / "nope.jsonl"), json=False), _PRICING
+    )
+    assert rc == 0
+    assert "no phase markers" in capsys.readouterr().out
+
+
+def test_cmd_phase_report_skips_malformed_lines(tmp_path, capsys):
+    log = tmp_path / "m.jsonl"
+    log.write_text(
+        "not json\n"
+        + json.dumps({"phase": "plan", "resident_tokens": 100, "spent_output_cumulative": 50}) + "\n"
+    )
+    cost_meter.cmd_phase_report(SimpleNamespace(log=str(log), json=True), _PRICING)
+    out = json.loads(capsys.readouterr().out)
+    assert len(out["by_phase"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# phase_marker.py hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def consenting(monkeypatch):
+    monkeypatch.setattr(phase_marker.telemetry_consent, "is_enabled", lambda: True)
+    monkeypatch.delenv("DEV_TEAM_COST_METER", raising=False)
+    yield
+
+
+def _run_hook(monkeypatch, payload):
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    return phase_marker.main()
+
+
+def test_hook_records_marker_on_handoff(tmp_path, monkeypatch, consenting):
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(500, 120, cache_read=50))
+    payload = {
+        "tool_name": "Skill",
+        "tool_input": {"skill": "handoff", "args": "research continue"},
+        "transcript_path": str(t),
+        "cwd": str(tmp_path),
+    }
+    rc = _run_hook(monkeypatch, payload)
+    assert rc == 0
+    marker = tmp_path / ".claude" / "metrics" / "phase-markers.jsonl"
+    entry = json.loads(marker.read_text().splitlines()[-1])
+    assert entry["phase"] == "research"  # derived from the first args token
+    assert entry["resident_tokens"] == 550
+    assert entry["spent_output_cumulative"] == 120
+
+
+def test_hook_ignores_non_handoff_skill(tmp_path, monkeypatch, consenting):
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(10, 5))
+    payload = {
+        "tool_input": {"skill": "code-review"},
+        "transcript_path": str(t),
+        "cwd": str(tmp_path),
+    }
+    assert _run_hook(monkeypatch, payload) == 0
+    assert not (tmp_path / ".claude" / "metrics" / "phase-markers.jsonl").exists()
+
+
+def test_hook_opt_out_env(tmp_path, monkeypatch, consenting):
+    monkeypatch.setenv("DEV_TEAM_COST_METER", "off")
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(10, 5))
+    payload = {
+        "tool_input": {"skill": "handoff"},
+        "transcript_path": str(t),
+        "cwd": str(tmp_path),
+    }
+    assert _run_hook(monkeypatch, payload) == 0
+    assert not (tmp_path / ".claude" / "metrics" / "phase-markers.jsonl").exists()
+
+
+def test_hook_no_consent_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(phase_marker.telemetry_consent, "is_enabled", lambda: False)
+    monkeypatch.delenv("DEV_TEAM_COST_METER", raising=False)
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(10, 5))
+    payload = {"tool_input": {"skill": "handoff"}, "transcript_path": str(t), "cwd": str(tmp_path)}
+    assert _run_hook(monkeypatch, payload) == 0
+    assert not (tmp_path / ".claude" / "metrics" / "phase-markers.jsonl").exists()
+
+
+def test_hook_label_falls_back_to_handoff_when_no_args(tmp_path, monkeypatch, consenting):
+    t = tmp_path / "t.jsonl"
+    t.write_text(_usage(10, 5))
+    payload = {"tool_input": {"skill": "handoff"}, "transcript_path": str(t), "cwd": str(tmp_path)}
+    _run_hook(monkeypatch, payload)
+    marker = tmp_path / ".claude" / "metrics" / "phase-markers.jsonl"
+    assert json.loads(marker.read_text().splitlines()[-1])["phase"] == "handoff"


### PR DESCRIPTION
## What

A per-phase **context-pollution** pipeline that separates transient (one-time) token spend from context that lingers and "charges rent" across turns — the actionable distinction from Martin Fowler's "The Orchestrator's Tax".

- `hooks/lib/cost_meter.py` — new `phase-mark` (emit a resident/spent marker at a phase boundary) and `phase-report` (per-phase resident-vs-spent ratio) subcommands, plus `_resident_and_spent` / `_phase_rows`. Written to a **dedicated** `phase-markers.jsonl` log, deliberately **not** folded into the incremental `record` state so it never touches that security-sensitive hot path.
- `hooks/phase_marker.py` — new PostToolUse:Skill hook that fires the emit on `/handoff` (**hook-enforced, not prose**), fail-open, sharing the cost meter's consent gate + `DEV_TEAM_COST_METER=off` opt-out. Registered in both `settings.json` and `hooks/hooks.json` (kept in sync).
- `skills/cost-report/SKILL.md` + `skills/harness-audit/SKILL.md` — report the new dimension; harness-audit flags high `resident_to_spent_ratio` phases as earlier-compaction / narrower-scoping candidates.
- `knowledge/telemetry-schema.md` — document the `phase-markers.jsonl` stream (required by the schema-coverage gate).
- Tests — `tests/hooks/test_phase_marker.py` covers the lib commands and the hook.

## Investigation result (issue Note)

The issue asked to investigate `cost_meter.py` before committing to a shape. It confirmed the meter sums cumulative tokens with **no** per-phase/per-`/handoff` awareness, and #170 documents that per-phase *cost* attribution was removed because the harness writes no phase marker and a plugin has no transcript write-path. Per operator direction, this PR adds a **lightweight marker pipeline** to supply that boundary signal. It is an honest **session-scoped proxy** — `resident` is sampled at the `/handoff` marker (the closest boundary the harness exposes) — and is documented as such, not presented as exact per-phase accounting.

## Verification

- New + existing cost-meter/hook tests pass; full plugin-content gate green (`plugins/dev-team/tests tests/repo tests/agents tests/skills tests/knowledge tests/hooks tests/docs` — 4553 passed).
- `hooks.json`/`settings.json` mirror + schema tests pass; knowledge index rebuilt and `--check` clean; `check_md_references.py` exit 0; ruff clean.
- End-to-end CLI smoke: `phase-mark` ×2 → `phase-report` produces correct per-phase deltas and ratios.

> Committed with an **audited `--no-verify` bypass** (`GATE_BYPASS_REASON` logged) — the Agent-dispatch classifier was under a sustained outage this session so the local `/code-review` gate could not run. CI + human merge are the backstop.

Closes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)