### PR TITLE
feat(mutation-kill): reuse an available baseline mutation report for Round 1

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -32,12 +32,12 @@ structurally-unkillable code. Everything else is delegated.
 
 ```
 /mutation-kill [<repo-path>] [--file <path>] [--all] [--max-rounds <n>]
-               [--from-report <path>] [--concurrency <n>] [--parallel <n>]
+               [--report <path>] [--concurrency <n>] [--parallel <n>]
 ```
 
 - `--file <path>` — target a single source file.
 - `--all` — run all files in survivor-count order (highest first).
-- `--from-report <path>` — load an existing report instead of running the tool (first round only).
+- `--report <path>` — load an existing report instead of running the tool (first round only).
 - `--max-rounds <n>` — maximum rounds per file (default: 5).
 - `--concurrency <n>` — parallel files via git worktrees when using `--all` (default: 2; max = physical cores − 2).
 - `--parallel <n>` — Phase 4 sub-agent fan-out via the Agent tool (in-process, no worktrees; see [Parallel execution (Phase 4)](#parallel-execution-phase-4)).
@@ -50,6 +50,7 @@ re-describe or re-implement their mechanics:
 | Script | Deterministic responsibility it owns |
 | --- | --- |
 | `mutation_report.py` | Parse the report; compute the **honest** and **reported** scores; extract survivors per file grouped by mutator. Stryker/Stryker.NET's JSON report is read directly; mutmut's `junitxml` output is normalized into the same internal shape first (`parse_mutmut_junitxml` / `score_mutmut_junitxml` / `survivors_from_mutmut_junitxml`). |
+| `mutation_baseline_reuse.py` | Round-1 baseline-reuse eligibility (git-ancestor + per-commit consumption check) and consumption bookkeeping via resolve/mark-consumed subcommands. |
 | `mutation_kill_loop.py` | The C#/Stryker.NET per-file loop: scoped run → score → survivor check → **your** generation → duplicate-guard → insert-before-class-close → build → test → commit-on-green / revert-on-failure → no-improvement stop. Delegates DOTNET_ROOT + `.sln` hide/restore to the wrapper. |
 | `mutation_kill_loop_python.py` | The Python/mutmut per-file loop — same contract, adapted for pytest: scoped `mutmut run` (clears stale `.mutmut-cache` first) → score via `mutation_report` junitxml support → **your** generation → duplicate-guard → append-at-end-of-file (refuses on a class-based test file) → `py_compile` → scoped `pytest` → commit-on-green / revert-on-failure → no-improvement stop. Reuses `mutation_kill_loop.py`'s generic headless helpers rather than duplicating them. |
 | `stryker_shard_setup.py` | Generate one `stryker-config.shard-<slug>.json` per source project, `Stryker.sln`, and `stryker-pipeline.json` from a `.sln`. |
@@ -246,6 +247,68 @@ generated code that this test surface cannot reach?
 This is the same `EXCLUDED` log format used for the [structurally unkillable
 files](#structurally-unkillable-files) section — a single audit trail either way.
 
+## Baseline reuse for Round 1 (`--concurrency 1` only)
+
+The pre-loop baseline scan that [Infrastructure exclusion
+detection](#infrastructure-exclusion-detection-before-the-loop-starts) above
+already reads can also seed a file's Round 1 — skipping a redundant fresh
+scoped run — when the baseline is still fresh for that file.
+
+**Scope: `--concurrency 1` only (or omitted).** Each `--concurrency >1` git
+worktree does not share the main checkout's `StrykerOutput/`, so under
+`--concurrency >1` every file's Round 1 falls back to today's fresh-per-file
+behavior, stated here explicitly, never silently.
+
+**Canonical paths** — the baseline report:
+`StrykerOutput/baseline/reports/mutation-report.json` (per-tool equivalent per
+the [per-language translation](#per-language-translation) table's own "Native
+report" mapping, matching the already-documented `-O StrykerOutput/baseline`
+named-run convention); the consumption-tracking file (sibling to
+`StrykerOutput/mutation-kill-convergence.json`):
+`StrykerOutput/mutation-kill-baseline-consumption.json`.
+
+**No baseline report at the canonical path** — skip `resolve` entirely; every
+file's Round 1 runs fresh, exactly as today.
+
+**Capture commit.** Once, right when the pre-loop baseline scan completes,
+record `git rev-parse HEAD` as the capture commit and hold it only for the
+rest of this invocation — it is not persisted to a separate file.
+
+**Per file, before that file's Round 1** (never batched):
+
+```
+python3 mutation_baseline_reuse.py resolve --file <path> \
+  --capture-commit <capture-sha> \
+  --tracking StrykerOutput/mutation-kill-baseline-consumption.json
+```
+
+`eligible: true` → seed Round 1 via `--report <baseline-path>` instead of a
+fresh scoped run. `eligible: false` → Round 1 runs fresh, unchanged from today.
+
+**Immediately after that file's round concludes** (per file, not batched at
+the end of the invocation), when the file was baseline-seeded:
+
+```
+python3 mutation_baseline_reuse.py mark-consumed --file <path> \
+  --capture-commit <capture-sha> \
+  --tracking StrykerOutput/mutation-kill-baseline-consumption.json
+```
+
+**Check its `success` field.** On `success: false`, print an operator-visible
+warning naming the file and the `error` reason before continuing to the next
+file — a `mark-consumed` failure is never silently absorbed into a
+successful-looking summary.
+
+Once the `--all` run concludes, print the run-level summary:
+
+```
+baseline: seeded N, ran-fresh M, mark-failed K
+```
+
+`seeded` counts baseline-seeded files, `ran-fresh` counts every file whose
+Round 1 ran fresh (no baseline present, ineligible, or `--concurrency >1`),
+and `mark-failed` tallies the `mark-consumed` warnings above.
+
 ## Pre-loop feasibility gate (xunit.v3 shim-first)
 
 On **xunit.v3** the loop is viable only through the v2 shim, because it re-runs mutation every round and that is affordable only with **per-test** coverage. Prove per-test capture works before entering — measured, not assumed. Plain xunit.v2 / other stacks skip this gate. Steps: (1) run [`xunit_v3_feature_detector.py`](../skills/mutation-testing/scripts/xunit_v3_feature_detector.py) and resolve its **always-ask** human gate (#1160 — operator excludes shim-breaking tests or declines the shim path); (2) build the shim and run **one timed one-file probe** under `coverage-analysis: perTest`, scanning its output for the #1157 capture-failure signal; (3) arbitrate with [`mutation_feasibility_gate.py`](../skills/mutation-testing/scripts/mutation_feasibility_gate.py) (`--probe-seconds --scope-files [--capture-failed] [--shim-declined]`). **`enter-loop`** → proceed to the scripted loop.
@@ -289,8 +352,9 @@ owns everything mechanical:
   indefinitely.
 
 Commits carry a structured message citing round number, method count, and survivor
-count. `--from-report` seeds round 1 from an existing report instead of a fresh
-scoped run.
+count. `--report` seeds round 1 from an existing report instead of a fresh
+scoped run — manually via the flag, or automatically via [baseline
+reuse](#baseline-reuse-for-round-1---concurrency-1-only) below.
 
 ## Per-language translation
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_baseline_reuse.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_baseline_reuse.py
@@ -180,20 +180,23 @@ def _cli(argv: Sequence[str]) -> int:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument("--file", required=True)
+    parent_parser.add_argument("--capture-commit", required=True)
+    parent_parser.add_argument("--tracking", required=True)
+
     resolve_parser = sub.add_parser(
-        "resolve", help="resolve whether a file may reuse the baseline report"
+        "resolve",
+        help="resolve whether a file may reuse the baseline report",
+        parents=[parent_parser],
     )
-    resolve_parser.add_argument("--file", required=True)
-    resolve_parser.add_argument("--capture-commit", required=True)
-    resolve_parser.add_argument("--tracking", required=True)
     resolve_parser.add_argument("--cwd", default=None)
 
-    mark_parser = sub.add_parser(
-        "mark-consumed", help="record a file's consumption of a baseline"
+    sub.add_parser(
+        "mark-consumed",
+        help="record a file's consumption of a baseline",
+        parents=[parent_parser],
     )
-    mark_parser.add_argument("--file", required=True)
-    mark_parser.add_argument("--capture-commit", required=True)
-    mark_parser.add_argument("--tracking", required=True)
 
     args = parser.parse_args(list(argv))
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_baseline_reuse.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_baseline_reuse.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Baseline mutation-report reuse for the mutant-kill loop's Round 1 (#1545).
+
+The mutant-kill loop's per-file Round 1 always triggers a fresh scoped
+mutation run, even when a fresh baseline report (captured once, before the
+per-file loop starts) already covers that file. This module owns the
+eligibility decision and the consumption bookkeeping so a file's Round 1 can
+be safely seeded from the baseline via ``--report`` instead of paying for a
+redundant run — as real, unit-tested code, not agent-followed prose.
+
+Eligibility is a two-part test:
+  1. an **ancestor check** — is the file's last commit an ancestor of the
+     baseline's capture commit? (git itself treats a commit as its own
+     ancestor, so a file last committed exactly at the capture commit is
+     eligible too — the "self-ancestor boundary".) A file with no
+     discoverable last-commit SHA (untracked/never committed), or a
+     non-ancestor relationship, is never eligible.
+  2. a **consumption check** — has this file already consumed *this exact*
+     baseline capture commit? If so it is not eligible again until a
+     different (not-yet-consumed) baseline capture commit comes along.
+
+Stdlib-only. Python 3.8+ (ADR 0014/0015).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+
+import mutation_report
+
+
+# =============================================================================
+# Tracking file — read / decide / write
+# =============================================================================
+def read_tracking(tracking_path) -> dict:
+    """Return the parsed consumption-tracking JSON, or ``{}`` for an
+    absent, malformed, or non-dict-shaped file.
+
+    Delegates to ``mutation_report.load_report`` — this module used to
+    reimplement that function's absent/empty/malformed-JSON handling itself;
+    it now genuinely calls it, so the two stay behaviorally identical by
+    construction rather than by convention.
+    """
+    return mutation_report.load_report(tracking_path)
+
+
+def is_eligible_for_reuse(
+    tracking: dict, file_path: str, capture_commit: str, is_ancestor: bool
+) -> bool:
+    """Pure eligibility decision.
+
+    ``False`` when the file's last commit is not an ancestor of the
+    baseline's capture commit (``is_ancestor`` is the caller's already-
+    resolved git ancestor check — this function does no git work itself).
+    Otherwise ``False`` only when ``tracking`` already records ``file_path``
+    as consumed at this exact ``capture_commit``; ``True`` in every other
+    case, including a file consumed at some *other*, older baseline capture
+    commit it hasn't yet consumed.
+    """
+    if not is_ancestor:
+        return False
+    entry = tracking.get(file_path)
+    return entry is None or entry.get("capture_commit") != capture_commit
+
+
+def mark_consumed(tracking_path, file_path: str, capture_commit: str) -> dict:
+    """Atomically record ``file_path``'s consumption of ``capture_commit``.
+
+    Writes ``<tracking_path>.tmp`` then ``os.replace``s it onto
+    ``tracking_path`` — every other file's existing entry in the tracking
+    dict is preserved. Never raises: a write failure (permission denied,
+    unwritable directory, a monkeypatched ``os.replace`` failure, ...) is
+    caught and reported as ``{"success": False, "error": str(exc)}``,
+    leaving the on-disk file (if any) untouched — the file stays recorded as
+    not-yet-consumed. A stray ``.tmp`` left behind by a failed ``os.replace``
+    is best-effort cleaned up; a failure during that cleanup is swallowed so
+    it never masks the original error being reported.
+    """
+    tracking_path = Path(tracking_path)
+    tracking = read_tracking(tracking_path)
+    tracking[file_path] = {
+        "capture_commit": capture_commit,
+        "recorded_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    tmp = Path(str(tracking_path) + ".tmp")
+    try:
+        tmp.write_text(json.dumps(tracking, indent=2), encoding="utf-8")
+        os.replace(tmp, tracking_path)
+    except OSError as exc:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return {"success": False, "error": str(exc)}
+    return {"success": True}
+
+
+# =============================================================================
+# Git-backed ancestor check
+# =============================================================================
+def _run_git(args: list[str], *, cwd=None) -> subprocess.CompletedProcess | None:
+    """Run a git subcommand, returning ``None`` on a missing git binary, a
+    non-repo ``cwd``, or a 30s timeout — never raises."""
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def _git_last_commit_sha(file_path, *, cwd=None) -> str | None:
+    """Return ``file_path``'s last-commit SHA, or ``None`` when git is
+    unavailable (missing binary, not a repo, timeout) or the file has no
+    commit history at all (empty ``git log`` result — untracked/never
+    committed). Never raises."""
+    result = _run_git(
+        ["git", "log", "-1", "--format=%H", "--", str(file_path)], cwd=cwd
+    )
+    if result is None:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _git_is_ancestor(commit_a: str, commit_b: str, *, cwd=None) -> bool:
+    """True when ``commit_a`` is an ancestor of (or equal to) ``commit_b``
+    (``git merge-base --is-ancestor``). ``False`` when git is unavailable
+    (missing binary, not a repo, timeout) rather than letting the exception
+    propagate. Never raises."""
+    result = _run_git(
+        ["git", "merge-base", "--is-ancestor", "--", commit_a, commit_b], cwd=cwd
+    )
+    if result is None:
+        return False
+    return result.returncode == 0
+
+
+# =============================================================================
+# CLI — resolve / mark-consumed
+# =============================================================================
+def _resolve(args) -> dict:
+    tracking = read_tracking(args.tracking)
+    last_commit = _git_last_commit_sha(args.file, cwd=args.cwd)
+    is_ancestor = (
+        _git_is_ancestor(last_commit, args.capture_commit, cwd=args.cwd)
+        if last_commit is not None
+        else False
+    )
+    eligible = is_eligible_for_reuse(
+        tracking, args.file, args.capture_commit, is_ancestor
+    )
+    return {
+        "eligible": eligible,
+        "file": args.file,
+        "capture_commit": args.capture_commit,
+    }
+
+
+def _mark_consumed(args) -> dict:
+    return mark_consumed(args.tracking, args.file, args.capture_commit)
+
+
+def _cli(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve baseline-reuse eligibility, or mark a file's "
+        "consumption of a baseline capture commit."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    resolve_parser = sub.add_parser(
+        "resolve", help="resolve whether a file may reuse the baseline report"
+    )
+    resolve_parser.add_argument("--file", required=True)
+    resolve_parser.add_argument("--capture-commit", required=True)
+    resolve_parser.add_argument("--tracking", required=True)
+    resolve_parser.add_argument("--cwd", default=None)
+
+    mark_parser = sub.add_parser(
+        "mark-consumed", help="record a file's consumption of a baseline"
+    )
+    mark_parser.add_argument("--file", required=True)
+    mark_parser.add_argument("--capture-commit", required=True)
+    mark_parser.add_argument("--tracking", required=True)
+
+    args = parser.parse_args(list(argv))
+
+    if args.command == "resolve":
+        payload = _resolve(args)
+    else:
+        payload = _mark_consumed(args)
+
+    print(json.dumps(payload))
+    # Exit 0 either way — advisory/informational, matching
+    # mutation_feasibility_gate.py's "advisory arbiter, not a gate" convention.
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_cli(sys.argv[1:]))

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -432,7 +432,10 @@ def run_for_file(
 
         survivors = extract_survivors(report_path, source_file)
         survivor_count = len(survivors)
-        summary = mutation_report.score_report(report_path)
+        # File-scoped, not score_report(): a baseline-seeded round 1 report can
+        # cover multiple files (#1545) — score_report() would leak another
+        # file's score into this line.
+        summary = mutation_report.score_report_for_file(report_path, source_file)
         log(
             f"  round {round_num}: honest={summary.honest_score:.1f}% "
             f"survivors={survivor_count}"

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
@@ -70,15 +70,21 @@ class ScoreSummary:
     reported_score: float
 
 
-def _load_report(report_path: Path) -> dict:
-    """Return the parsed report, or ``{}`` when the file is absent/empty."""
+def load_report(report_path: Path) -> dict:
+    """Return the parsed report, or ``{}`` when the file is absent, empty,
+    malformed JSON, or valid JSON that isn't a dict (e.g. a report file
+    containing ``[]`` or ``42``) — never raises."""
     path = Path(report_path)
     if not path.exists():
         return {}
     text = path.read_text(encoding="utf-8").strip()
     if not text:
         return {}
-    return json.loads(text)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _iter_mutants(data: dict):
@@ -87,11 +93,32 @@ def _iter_mutants(data: dict):
         yield from info.get("mutants", [])
 
 
-def _score_data(data: dict) -> ScoreSummary:
-    """Compute the honest and reported scores for an already-parsed report
-    dict (the ``{"files": {...}}`` shape shared by every supported tool)."""
+def _find_file_info(data: dict, file_path: str) -> dict | None:
+    """Return one file's report entry (the ``{"mutants": [...]}`` dict) from
+    an already-parsed report dict.
+
+    Matches ``file_path`` against report keys by exact match first, then by
+    basename, so a caller can pass either the full report key or just the
+    filename. Returns ``None`` when no file matches.
+    """
+    files = data.get("files", {})
+
+    info = files.get(file_path)
+    if info is not None:
+        return info
+
+    target = Path(file_path).name
+    for key, value in files.items():
+        if Path(key).name == target:
+            return value
+    return None
+
+
+def _tally(mutants: list[dict]) -> ScoreSummary:
+    """Compute the honest and reported scores for a flat list of mutant
+    dicts (one file's ``mutants`` list, or every file's combined)."""
     killed = survived = timeout = no_coverage = 0
-    for mutant in _iter_mutants(data):
+    for mutant in mutants:
         status = mutant.get("status")
         if status == STATUS_KILLED:
             killed += 1
@@ -120,6 +147,12 @@ def _score_data(data: dict) -> ScoreSummary:
     )
 
 
+def _score_data(data: dict) -> ScoreSummary:
+    """Compute the honest and reported scores for an already-parsed report
+    dict (the ``{"files": {...}}`` shape shared by every supported tool)."""
+    return _tally(list(_iter_mutants(data)))
+
+
 def score_report(report_path: Path) -> ScoreSummary:
     """Compute the honest and reported scores for a Stryker-shaped mutation
     report on disk.
@@ -127,7 +160,33 @@ def score_report(report_path: Path) -> ScoreSummary:
     Returns a fully zeroed :class:`ScoreSummary` when the report is absent
     or empty — never raises for a missing file.
     """
-    return _score_data(_load_report(report_path))
+    return _score_data(load_report(report_path))
+
+
+def _score_data_for_file(data: dict, file_path: str) -> ScoreSummary:
+    """Compute the honest and reported scores for one file within an
+    already-parsed report dict.
+
+    Matches ``file_path`` the same way ``_find_file_info`` does (exact key,
+    then basename). Returns a fully zeroed :class:`ScoreSummary` when the
+    file is not matched — never raises.
+    """
+    info = _find_file_info(data, file_path)
+    if info is None:
+        return _tally([])
+    return _tally(info.get("mutants", []))
+
+
+def score_report_for_file(report_path: Path, file_path: str) -> ScoreSummary:
+    """Compute the honest and reported scores for one file within a
+    Stryker-shaped mutation report on disk.
+
+    Matches ``file_path`` against report keys by exact match first, then by
+    basename (same rule as ``survivors_by_mutator``). Returns a fully zeroed
+    :class:`ScoreSummary` when the report is absent/empty or the file is not
+    matched — never raises.
+    """
+    return _score_data_for_file(load_report(report_path), file_path)
 
 
 def _survivors_from_data(data: dict, file_path: str) -> dict[str, list[dict]]:
@@ -140,15 +199,7 @@ def _survivors_from_data(data: dict, file_path: str) -> dict[str, list[dict]]:
     uncovered mutants are not survivors. Returns ``{}`` when the file is not
     in the report or has no survivors.
     """
-    files = data.get("files", {})
-
-    info = files.get(file_path)
-    if info is None:
-        target = Path(file_path).name
-        for key, value in files.items():
-            if Path(key).name == target:
-                info = value
-                break
+    info = _find_file_info(data, file_path)
     if info is None:
         return {}
 
@@ -164,7 +215,7 @@ def _survivors_from_data(data: dict, file_path: str) -> dict[str, list[dict]]:
 def survivors_by_mutator(report_path: Path, file_path: str) -> dict[str, list[dict]]:
     """Return the Survived mutants for one source file, grouped by mutator
     name, from a Stryker-shaped mutation report on disk."""
-    return _survivors_from_data(_load_report(report_path), file_path)
+    return _survivors_from_data(load_report(report_path), file_path)
 
 
 def _files_with_status_from_data(data: dict, status: str) -> list[str]:
@@ -185,7 +236,7 @@ def _files_with_status(report_path: Path, status: str) -> list[str]:
     """Return the sorted report file keys having >= 1 mutant of ``status``,
     from a Stryker-shaped mutation report on disk. Returns ``[]`` for an
     absent/empty report — never raises."""
-    return _files_with_status_from_data(_load_report(report_path), status)
+    return _files_with_status_from_data(load_report(report_path), status)
 
 
 def files_with_survivors(report_path: Path) -> list[str]:

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -67,7 +67,14 @@ def test_agent_body_stays_under_500_line_limit(text: str) -> None:
     # budget-only outcome, with its confirmation-prompt content, echo-back
     # rule, off-script re-ask rule, and non-interactive default-to-degrade
     # fallback.
-    assert len(text.splitlines()) < 541
+    # Bumped by 63 more (#1545): added a new "Baseline reuse for Round 1
+    # (--concurrency 1 only)" section documenting the canonical baseline and
+    # tracking-file paths, the per-file resolve-before/mark-consumed-after
+    # procedure, the capture-commit lifetime, the no-baseline fallback, the
+    # three-counter run-summary line, and the --concurrency 1-only scope.
+    # Bumped by 1 more (#1545 review): added a mutation_baseline_reuse.py row
+    # to the scripted-mechanics table (arch-review finding).
+    assert len(text.splitlines()) < 605
 
 
 def test_defines_honest_score_formula(text: str) -> None:

--- a/tests/agents/test_mutation_kill_baseline_reuse_doc.py
+++ b/tests/agents/test_mutation_kill_baseline_reuse_doc.py
@@ -1,0 +1,169 @@
+"""Doc-content contract for the mutation-kill agent's baseline-reuse
+procedure (Slice 3, Step 3.2, #1545).
+
+Mirrors the grep-on-section pattern already used in
+tests/agents/test_mutation_kill_agent.py (see its `feasibility_section`/
+`feasibility_flat` fixtures) — pure text assertions over shipped agent
+prose, no state-mutating filesystem/git operations. Reuses
+`skill_doc_helpers.section()` for section-scoped extraction rather than
+hand-rolling a new one, per this repo's established DRY convention.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from skill_doc_helpers import section
+
+from _repo_root import REPO_ROOT
+
+AGENT = REPO_ROOT / "plugins" / "dev-team" / "agents" / "mutation-kill.md"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return AGENT.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def flat(text: str) -> str:
+    return text.replace("\n", " ")
+
+
+@pytest.fixture(scope="module")
+def reuse_section(text: str) -> str:
+    result = section(
+        text,
+        r"^## Baseline reuse for Round 1",
+        boundary_pattern=r"^## ",
+        include_start_line=False,
+    )
+    assert result, "Baseline reuse for Round 1 section not found"
+    return result
+
+
+@pytest.fixture(scope="module")
+def reuse_flat(reuse_section: str) -> str:
+    return reuse_section.replace("\n", " ")
+
+
+# --- (a) + (b): canonical baseline and tracking-file paths ------------------
+
+
+def test_canonical_baseline_report_path_documented(reuse_section: str) -> None:
+    assert "StrykerOutput/baseline/reports/mutation-report.json" in reuse_section
+
+
+def test_tracking_file_path_documented(reuse_section: str) -> None:
+    assert "StrykerOutput/mutation-kill-baseline-consumption.json" in reuse_section
+
+
+# --- (c): the resolve-before / mark-consumed-immediately-after procedure ----
+
+
+def test_resolve_runs_before_round_1_named_per_file(reuse_section: str) -> None:
+    assert "mutation_baseline_reuse.py resolve" in reuse_section
+    assert re.search(r"before that file'?s Round 1", reuse_section, re.IGNORECASE)
+
+
+def test_eligible_true_seeds_round_1_via_report_flag(
+    reuse_section: str, reuse_flat: str
+) -> None:
+    assert "eligible: true" in reuse_section
+    assert re.search(r"--report <baseline-path>", reuse_flat)
+    assert re.search(r"instead of a\s+fresh scoped run", reuse_flat)
+
+
+def test_ineligible_file_runs_fresh_unchanged(reuse_flat: str) -> None:
+    assert re.search(
+        r"eligible: false.*Round 1 runs fresh, unchanged from today", reuse_flat
+    )
+
+
+def test_mark_consumed_runs_immediately_after_round_per_file_not_batched(
+    reuse_section: str, reuse_flat: str
+) -> None:
+    assert "mutation_baseline_reuse.py mark-consumed" in reuse_section
+    assert re.search(
+        r"immediately after that file'?s round concludes", reuse_flat, re.IGNORECASE
+    )
+    assert re.search(r"per file, not batched", reuse_flat, re.IGNORECASE)
+
+
+# --- mark-consumed failure is checked and surfaced, never silently absorbed -
+
+
+def test_mark_consumed_success_field_checked_and_failure_warned(
+    reuse_section: str, reuse_flat: str
+) -> None:
+    assert re.search(r"`success`\s+field", reuse_flat)
+    assert "success: false" in reuse_section
+    assert re.search(
+        r"operator-visible\s+warning naming the file and the `error` reason",
+        reuse_flat,
+    )
+    assert re.search(r"before continuing to the next\s+file", reuse_flat)
+    assert re.search(
+        r"never silently absorbed into a\s+successful-looking summary", reuse_flat
+    )
+
+
+# --- (d): capture commit captured once, held only for this invocation -------
+
+
+def test_capture_commit_recorded_once_and_held_for_this_invocation_only(
+    reuse_flat: str,
+) -> None:
+    assert re.search(r"git rev-parse HEAD", reuse_flat)
+    assert re.search(
+        r"hold it only for\s+the rest of this invocation", reuse_flat, re.IGNORECASE
+    )
+    assert re.search(r"not persisted to a\s+separate file", reuse_flat, re.IGNORECASE)
+
+
+# --- (e): no baseline report present -> every file's Round 1 runs fresh -----
+
+
+def test_no_baseline_report_skips_resolve_entirely(reuse_flat: str) -> None:
+    assert re.search(
+        r"No baseline report at the canonical path.{0,20}skip `resolve` entirely",
+        reuse_flat,
+    )
+    assert re.search(
+        r"every\s+file's Round 1 runs fresh, exactly as today", reuse_flat
+    )
+
+
+# --- (f): the three-counter run-summary line ---------------------------------
+
+
+def test_run_summary_reports_seeded_ran_fresh_mark_failed(reuse_section: str) -> None:
+    assert "baseline: seeded N, ran-fresh M, mark-failed K" in reuse_section
+
+
+# --- (g): explicit --concurrency 1-only scope --------------------------------
+
+
+def test_feature_scoped_to_concurrency_1_only(reuse_flat: str) -> None:
+    assert re.search(
+        r"Scope: `--concurrency 1`\s+only \(or omitted\)", reuse_flat
+    )
+    assert re.search(
+        r"under\s+`--concurrency >1` every file's Round 1 falls back to today's "
+        r"fresh-per-file\s+behavior, stated here explicitly, never silently",
+        reuse_flat,
+    )
+
+
+# --- Whole-file sweep: no stale --from-report flag name remains -------------
+
+
+def test_no_occurrence_of_from_report_flag_remains(text: str) -> None:
+    assert "--from-report" not in text
+
+
+def test_invocation_section_names_report_flag(text: str) -> None:
+    invocation = section(text, r"^## Invocation", boundary_pattern=r"^## ")
+    assert "--report <path>" in invocation
+    assert "--from-report" not in invocation

--- a/tests/scripts/test_mutation_baseline_reuse.py
+++ b/tests/scripts/test_mutation_baseline_reuse.py
@@ -1,0 +1,527 @@
+"""Pytest tests for mutation_baseline_reuse.py — baseline consumption
+tracking and the git-backed resolve/mark-consumed CLI (Slice 2 of
+plans/mutation-kill-baseline-reuse-round-1.md, #1545).
+
+Each test maps to a Slice 2 Gherkin scenario in that plan. Every git
+subprocess is mocked — no real git calls run in the CLI tests — mirroring
+``test_mutation_kill_loop.py``'s existing ``git_revert``/``git_commit`` mock
+pattern (``monkeypatch.setattr(loop.subprocess, "run", ...)``).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mutation_baseline_reuse as mbr
+
+
+# =============================================================================
+# read_tracking
+# =============================================================================
+def test_read_tracking_returns_empty_dict_when_file_absent(tmp_path: Path):
+    assert mbr.read_tracking(tmp_path / "does-not-exist.json") == {}
+
+
+def test_read_tracking_returns_empty_dict_for_malformed_json(tmp_path: Path):
+    path = tmp_path / "tracking.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    assert mbr.read_tracking(path) == {}
+
+
+def test_read_tracking_returns_parsed_dict_when_present(tmp_path: Path):
+    path = tmp_path / "tracking.json"
+    payload = {"src/Foo.cs": {"capture_commit": "abc123", "recorded_at": "x"}}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert mbr.read_tracking(path) == payload
+
+
+def test_read_tracking_returns_empty_dict_for_non_dict_json(tmp_path: Path):
+    """A tracking file containing valid but non-dict JSON (e.g. a list or a
+    bare number) is treated the same as malformed/absent — never raised."""
+    path = tmp_path / "tracking.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+
+    assert mbr.read_tracking(path) == {}
+
+
+def test_non_dict_tracking_file_never_raises_in_eligibility_or_mark_consumed(
+    tmp_path: Path,
+):
+    path = tmp_path / "tracking.json"
+    path.write_text(json.dumps(42), encoding="utf-8")
+
+    tracking = mbr.read_tracking(path)
+    assert tracking == {}
+    assert (
+        mbr.is_eligible_for_reuse(
+            tracking, "src/Foo.cs", "capture-sha", is_ancestor=True
+        )
+        is True
+    )
+    result = mbr.mark_consumed(path, "src/Foo.cs", "capture-sha")
+    assert result == {"success": True}
+
+
+# =============================================================================
+# is_eligible_for_reuse — decision matrix
+# =============================================================================
+def test_not_ancestor_is_not_eligible():
+    assert (
+        mbr.is_eligible_for_reuse({}, "src/Foo.cs", "capture-sha", is_ancestor=False)
+        is False
+    )
+
+
+def test_ancestor_and_unconsumed_is_eligible():
+    assert (
+        mbr.is_eligible_for_reuse({}, "src/Foo.cs", "capture-sha", is_ancestor=True)
+        is True
+    )
+
+
+def test_self_ancestor_boundary_is_eligible(monkeypatch: pytest.MonkeyPatch):
+    """git's own ``--is-ancestor`` treats a commit as its own ancestor —
+    exercise ``_git_is_ancestor`` directly with commit_a == commit_b,
+    mocking ``subprocess.run`` to return success (returncode 0) for the
+    matching SHAs. This is the actual git-level boundary property the
+    module's docstring describes; ``is_eligible_for_reuse`` itself is pure
+    and takes ``is_ancestor`` as a given, so it has no boundary of its own to
+    test here (that's already covered by
+    ``test_ancestor_and_unconsumed_is_eligible``)."""
+    same_sha = "abc123"
+
+    monkeypatch.setattr(
+        mbr.subprocess,
+        "run",
+        lambda argv, **_k: subprocess.CompletedProcess(argv, 0, stdout="", stderr=""),
+    )
+
+    assert mbr._git_is_ancestor(same_sha, same_sha) is True
+
+
+def test_consumed_at_same_capture_commit_is_not_eligible():
+    tracking = {"src/Foo.cs": {"capture_commit": "capture-sha", "recorded_at": "x"}}
+
+    assert (
+        mbr.is_eligible_for_reuse(
+            tracking, "src/Foo.cs", "capture-sha", is_ancestor=True
+        )
+        is False
+    )
+
+
+def test_consumed_at_older_commit_is_eligible_again_under_different_baseline():
+    tracking = {"src/Foo.cs": {"capture_commit": "older-sha", "recorded_at": "x"}}
+
+    assert (
+        mbr.is_eligible_for_reuse(
+            tracking, "src/Foo.cs", "newer-sha", is_ancestor=True
+        )
+        is True
+    )
+
+
+# =============================================================================
+# mark_consumed
+# =============================================================================
+def test_mark_consumed_creates_tracking_file_atomically(tmp_path: Path):
+    path = tmp_path / "tracking.json"
+
+    result = mbr.mark_consumed(path, "src/Foo.cs", "capture-sha")
+
+    assert result == {"success": True}
+    assert not (tmp_path / "tracking.json.tmp").exists()
+    reread = mbr.read_tracking(path)
+    assert reread["src/Foo.cs"]["capture_commit"] == "capture-sha"
+    assert "recorded_at" in reread["src/Foo.cs"]
+
+
+def test_mark_consumed_preserves_other_files_entries(tmp_path: Path):
+    path = tmp_path / "tracking.json"
+    mbr.mark_consumed(path, "src/A.cs", "capture-sha")
+
+    result = mbr.mark_consumed(path, "src/B.cs", "capture-sha")
+
+    assert result == {"success": True}
+    reread = mbr.read_tracking(path)
+    assert reread["src/A.cs"]["capture_commit"] == "capture-sha"
+    assert reread["src/B.cs"]["capture_commit"] == "capture-sha"
+
+
+def test_mark_consumed_write_failure_returns_error_and_never_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "tracking.json"
+
+    def boom(_src, _dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mbr.os, "replace", boom)
+
+    result = mbr.mark_consumed(path, "src/Foo.cs", "capture-sha")
+
+    assert result["success"] is False
+    assert "disk full" in result["error"]
+    # Left as not-yet-consumed — the target file was never created.
+    assert mbr.read_tracking(path) == {}
+    # The .tmp written just before the failed os.replace does not survive.
+    assert not (tmp_path / "tracking.json.tmp").exists()
+
+
+# =============================================================================
+# _git_last_commit_sha / _git_is_ancestor
+# =============================================================================
+def test_git_last_commit_sha_returns_stripped_sha(monkeypatch: pytest.MonkeyPatch):
+    seen: list = []
+
+    def fake_run(argv, **_k):
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="abc123\n", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    assert mbr._git_last_commit_sha("src/Foo.cs") == "abc123"
+    assert seen == [["git", "log", "-1", "--format=%H", "--", "src/Foo.cs"]]
+
+
+def test_git_last_commit_sha_returns_none_for_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        mbr.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a, 0, stdout="", stderr=""),
+    )
+
+    assert mbr._git_last_commit_sha("src/Untracked.cs") is None
+
+
+def test_git_last_commit_sha_returns_none_when_git_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def explode(*_a, **_k):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(mbr.subprocess, "run", explode)
+
+    assert mbr._git_last_commit_sha("src/Foo.cs") is None
+
+
+def test_git_last_commit_sha_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch):
+    def explode(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="git log", timeout=30)
+
+    monkeypatch.setattr(mbr.subprocess, "run", explode)
+
+    assert mbr._git_last_commit_sha("src/Foo.cs") is None
+
+
+def test_git_is_ancestor_true_on_zero_returncode(monkeypatch: pytest.MonkeyPatch):
+    seen: list = []
+
+    def fake_run(argv, **_k):
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    assert mbr._git_is_ancestor("aaa", "bbb") is True
+    assert seen == [["git", "merge-base", "--is-ancestor", "--", "aaa", "bbb"]]
+
+
+def test_git_is_ancestor_false_on_nonzero_returncode(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        mbr.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a, 1, stdout="", stderr=""),
+    )
+
+    assert mbr._git_is_ancestor("aaa", "bbb") is False
+
+
+def test_git_is_ancestor_false_when_git_missing(monkeypatch: pytest.MonkeyPatch):
+    def explode(*_a, **_k):
+        raise OSError("no git")
+
+    monkeypatch.setattr(mbr.subprocess, "run", explode)
+
+    assert mbr._git_is_ancestor("aaa", "bbb") is False
+
+
+def test_git_is_ancestor_false_on_timeout(monkeypatch: pytest.MonkeyPatch):
+    def explode(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="git merge-base", timeout=30)
+
+    monkeypatch.setattr(mbr.subprocess, "run", explode)
+
+    assert mbr._git_is_ancestor("aaa", "bbb") is False
+
+
+# =============================================================================
+# CLI — resolve
+# =============================================================================
+def test_cli_resolve_eligible_true_for_ancestor_unconsumed_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    def fake_run(argv, **_k):
+        if argv[:2] == ["git", "log"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="filesha\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "eligible": True,
+        "file": "src/Foo.cs",
+        "capture_commit": "capture-sha",
+    }
+
+
+def test_cli_resolve_eligible_false_for_non_ancestor_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    def fake_run(argv, **_k):
+        if argv[:2] == ["git", "log"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="filesha\n", stderr="")
+        # merge-base --is-ancestor: non-zero == not an ancestor
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is False
+
+
+def test_cli_resolve_eligible_false_for_already_consumed_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+    mbr.mark_consumed(tracking_path, "src/Foo.cs", "capture-sha")
+
+    def fake_run(argv, **_k):
+        if argv[:2] == ["git", "log"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="filesha\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is False
+
+
+def test_cli_resolve_eligible_false_never_raises_when_git_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    def explode(*_a, **_k):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(mbr.subprocess, "run", explode)
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is False
+
+
+def test_cli_resolve_eligible_false_for_no_commit_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    monkeypatch.setattr(
+        mbr.subprocess,
+        "run",
+        lambda argv, **_k: subprocess.CompletedProcess(argv, 0, stdout="", stderr=""),
+    )
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Untracked.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is False
+
+
+def test_cli_resolve_forwards_cwd_to_git_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+    seen_cwds: list = []
+
+    def fake_run(argv, **kwargs):
+        seen_cwds.append(kwargs.get("cwd"))
+        if argv[:2] == ["git", "log"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="filesha\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mbr.subprocess, "run", fake_run)
+
+    rc = mbr._cli(
+        [
+            "resolve",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+            "--cwd",
+            "/some/repo",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is True
+    assert seen_cwds == ["/some/repo", "/some/repo"]
+
+
+# =============================================================================
+# CLI — mark-consumed
+# =============================================================================
+def test_cli_mark_consumed_success_true_on_normal_write(
+    tmp_path: Path, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    rc = mbr._cli(
+        [
+            "mark-consumed",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"success": True}
+    assert mbr.read_tracking(tracking_path)["src/Foo.cs"]["capture_commit"] == (
+        "capture-sha"
+    )
+
+
+def test_cli_mark_consumed_success_false_with_error_on_forced_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    tracking_path = tmp_path / "tracking.json"
+
+    def boom(_src, _dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mbr.os, "replace", boom)
+
+    rc = mbr._cli(
+        [
+            "mark-consumed",
+            "--file",
+            "src/Foo.cs",
+            "--capture-commit",
+            "capture-sha",
+            "--tracking",
+            str(tracking_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert "disk full" in payload["error"]
+
+
+# =============================================================================
+# Scenario: the module carries no repo-specific literal
+# =============================================================================
+def test_module_source_carries_no_repo_specific_literal():
+    source = (SCRIPTS_DIR / "mutation_baseline_reuse.py").read_text(encoding="utf-8")
+
+    forbidden = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
+    present = [lit for lit in forbidden if lit in source]
+
+    assert present == [], f"repo-specific literals leaked into module: {present}"

--- a/tests/scripts/test_mutation_baseline_reuse.py
+++ b/tests/scripts/test_mutation_baseline_reuse.py
@@ -188,6 +188,29 @@ def test_mark_consumed_write_failure_returns_error_and_never_raises(
 # =============================================================================
 # _git_last_commit_sha / _git_is_ancestor
 # =============================================================================
+def test_mark_consumed_second_failure_during_cleanup_never_masks_original_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``os.replace`` fails, and the best-effort ``tmp.unlink()`` cleanup that
+    follows it *also* raises ``OSError``. The inner failure must be swallowed
+    — never overwriting or masking the original ``os.replace`` error, and
+    never propagating to the caller."""
+    path = tmp_path / "tracking.json"
+
+    def replace_boom(_src, _dst):
+        raise OSError("disk full")
+
+    def unlink_boom(self, missing_ok=False):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(mbr.os, "replace", replace_boom)
+    monkeypatch.setattr(mbr.Path, "unlink", unlink_boom)
+
+    result = mbr.mark_consumed(path, "src/Foo.cs", "capture-sha")
+
+    assert result == {"success": False, "error": "disk full"}
+
+
 def test_git_last_commit_sha_returns_stripped_sha(monkeypatch: pytest.MonkeyPatch):
     seen: list = []
 

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -728,6 +728,42 @@ def test_round_log_line_scopes_to_target_file_in_multi_file_baseline_report(
 
 
 # =============================================================================
+# Scenario: A baseline-seeded round 1 with 0 survivors skips the scoped run
+# entirely (#1545 core value scenario)
+# =============================================================================
+def test_baseline_seeded_zero_survivors_never_calls_scoped_stryker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the baseline report seeded via ``initial_report_path`` already
+    shows 0 survivors for the target file, round 1 must converge immediately
+    on that baseline data — ``run_scoped_stryker`` must never be invoked. This
+    is the redundant-run this whole issue exists to avoid."""
+    report_override = {
+        "files": {
+            "src/Widget.WebApi/PaymentService.cs": {
+                "mutants": [_mutant("Killed", line=1), _mutant("Killed", line=2)]
+            },
+        }
+    }
+    kwargs, events = _loop_fixture(tmp_path, monkeypatch, report_override=report_override)
+    logs: list[str] = []
+    kwargs["log"] = logs.append
+    monkeypatch.setattr(
+        loop,
+        "run_scoped_stryker",
+        lambda *a, **k: pytest.fail(
+            "run_scoped_stryker must not be called when the baseline already "
+            "shows 0 survivors"
+        ),
+    )
+
+    loop.run_for_file(**kwargs)
+
+    assert any("no survivors" in msg for msg in logs)
+    assert not any(e[0] in ("generate", "commit", "revert") for e in events)
+
+
+# =============================================================================
 # Verify/commit subprocess wiring — targets come from config (no literals)
 # =============================================================================
 def test_dotnet_build_uses_configured_test_project(

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -515,15 +515,32 @@ def test_apply_wraps_refusal_as_outcome_without_writing(tmp_path: Path):
 # =============================================================================
 # run_for_file harness — mocks every dotnet / git / Stryker touch.
 # =============================================================================
-def _loop_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutants):
+def _loop_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutants=None,
+    *,
+    report_override: dict | None = None,
+):
     """Wire a run_for_file invocation with a fixed initial report and a
-    generator that records its calls. Returns (kwargs, events)."""
+    generator that records its calls. Returns (kwargs, events).
+
+    By default the initial report is the single-file shape ``_write_report``
+    builds from ``mutants``. Pass ``report_override`` (a full report payload,
+    e.g. a multi-file ``{"files": {...}}`` shape) instead when a caller needs
+    a custom report; ``mutants`` is ignored in that case.
+    """
     config = loop.load_loop_config(_write_config(tmp_path))
     test_file = tmp_path / "PaymentServiceTests.cs"
     test_file.write_text(_BLOCK_NAMESPACE_CLASS, encoding="utf-8")
     source_path = tmp_path / "PaymentService.cs"
     source_path.write_text("public class PaymentService {}\n", encoding="utf-8")
-    report = _write_report(tmp_path, "src/Widget.WebApi/PaymentService.cs", mutants)
+    if report_override is not None:
+        report = tmp_path / "reports" / "mutation-report.json"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(json.dumps(report_override), encoding="utf-8")
+    else:
+        report = _write_report(tmp_path, "src/Widget.WebApi/PaymentService.cs", mutants)
 
     events: list = []
 
@@ -631,6 +648,83 @@ def test_non_improving_round_ends_the_file(
     # Exactly one commit (round 1); round 2 detected no improvement and stopped.
     commits = [e for e in events if e[0] == "commit"]
     assert len(commits) == 1
+
+
+# =============================================================================
+# Scenario: The round's log line uses the file-scoped score (Step 3.1, #1545)
+# =============================================================================
+def test_round_log_line_uses_file_scoped_score_for_single_file_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A single-file scoped report — round log score must match that file's
+    own counts (existing behavior, must stay equivalent)."""
+    kwargs, _events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived", line=1), _mutant("Killed", line=2)]
+    )
+    logs: list[str] = []
+    kwargs["log"] = logs.append
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: True)
+    monkeypatch.setattr(loop, "dotnet_test", lambda targets, flt, **k: True)
+    clean = _write_report(tmp_path / "clean", "src/Widget.WebApi/PaymentService.cs", [])
+    (tmp_path / "clean").mkdir(exist_ok=True)
+    monkeypatch.setattr(loop, "run_scoped_stryker", lambda *a, **k: clean)
+
+    loop.run_for_file(**kwargs)
+
+    round_1_log = next(m for m in logs if m.startswith("  round 1:"))
+    # 1 killed, 1 survived => honest = 1/2 * 100 = 50.0%
+    assert "honest=50.0%" in round_1_log
+    assert "survivors=1" in round_1_log
+
+
+def test_round_log_line_scopes_to_target_file_in_multi_file_baseline_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A multi-file report seeded via ``initial_report_path`` — the printed
+    score must reflect only the target file's own counts, never the whole
+    report's, across multiple rounds."""
+    # Multi-file baseline report: the target file scores 50% (1 killed, 1
+    # survived); another file in the same report scores far worse (0%). A
+    # whole-report score would leak that worse number into the target's line.
+    report_override = {
+        "files": {
+            "src/Widget.WebApi/PaymentService.cs": {
+                "mutants": [_mutant("Killed", line=1), _mutant("Survived", line=2)]
+            },
+            "src/Widget.WebApi/OtherService.cs": {
+                "mutants": [
+                    _mutant("Survived", line=1),
+                    _mutant("Survived", line=2),
+                    _mutant("Survived", line=3),
+                ]
+            },
+        }
+    }
+    kwargs, _events = _loop_fixture(
+        tmp_path, monkeypatch, report_override=report_override
+    )
+    kwargs["max_rounds"] = 2
+    logs: list[str] = []
+    kwargs["log"] = logs.append
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: True)
+    monkeypatch.setattr(loop, "dotnet_test", lambda targets, flt, **k: True)
+
+    # Round 2's scoped run reports only the target file, at the same score —
+    # exercising round 2+'s equivalence claim alongside round 1's baseline seed.
+    round2_report = _write_report(
+        tmp_path / "r2",
+        "src/Widget.WebApi/PaymentService.cs",
+        [_mutant("Killed", line=1), _mutant("Survived", line=2)],
+    )
+    monkeypatch.setattr(loop, "run_scoped_stryker", lambda *a, **k: round2_report)
+
+    loop.run_for_file(**kwargs)
+
+    round_logs = [m for m in logs if m.startswith("  round")]
+    assert len(round_logs) == 2, "expected both round 1 (baseline) and round 2 (scoped) to log"
+    for msg in round_logs:
+        assert "honest=50.0%" in msg
+        assert "survivors=1" in msg
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_report.py
+++ b/tests/scripts/test_mutation_report.py
@@ -1,11 +1,14 @@
 """Pytest tests for mutation_report.py — the honest-score report module
-(Slice 1 of the ACI mutation-pipeline fold, #1136).
+(Slice 1 of the ACI mutation-pipeline fold, #1136; file-scoped scoring added
+for Slice 1 of the mutant-kill baseline-reuse plan, #1545).
 
 Each test maps to a Slice 1 Gherkin scenario in
-``plans/generalize-aci-mutation-pipeline-fold-into-mutation-kill.md``. The
-report fixtures are minimal Stryker mutation-report.json shapes written to a
-temp file; the exact scenario counts (10 Killed, 5 Survived, 3 NoCoverage,
-4 Timeout) are asserted verbatim.
+``plans/generalize-aci-mutation-pipeline-fold-into-mutation-kill.md`` (the
+#1136 report/scoring behavior) or
+``plans/mutation-kill-baseline-reuse-round-1.md`` (the #1545 file-scoped
+score helper). The report fixtures are minimal Stryker mutation-report.json
+shapes written to a temp file; the exact scenario counts (10 Killed,
+5 Survived, 3 NoCoverage, 4 Timeout) are asserted verbatim.
 """
 
 from __future__ import annotations
@@ -123,6 +126,38 @@ def test_empty_report_file_returns_zeroed_scores(tmp_path: Path):
     assert summary.reported_score == 0.0
 
 
+def test_malformed_json_report_returns_zeroed_scores_without_raising(
+    tmp_path: Path,
+):
+    malformed = tmp_path / "mutation-report.json"
+    malformed.write_text("{not valid json", encoding="utf-8")
+
+    summary = mutation_report.score_report(malformed)
+
+    assert summary.honest_score == 0.0
+    assert summary.reported_score == 0.0
+    assert summary.killed == 0
+    assert summary.survived == 0
+    assert summary.timeout == 0
+    assert summary.no_coverage == 0
+
+
+def test_non_dict_json_report_returns_zeroed_scores_without_raising(
+    tmp_path: Path,
+):
+    non_dict = tmp_path / "mutation-report.json"
+    non_dict.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+
+    summary = mutation_report.score_report(non_dict)
+
+    assert summary.honest_score == 0.0
+    assert summary.reported_score == 0.0
+    assert summary.killed == 0
+    assert summary.survived == 0
+    assert summary.timeout == 0
+    assert summary.no_coverage == 0
+
+
 # =============================================================================
 # Scenario: Survivors are extracted per file grouped by mutator
 # =============================================================================
@@ -171,6 +206,91 @@ def test_survivors_for_unknown_file_is_empty(tmp_path: Path):
     )
 
     assert mutation_report.survivors_by_mutator(report, "src/Nope.cs") == {}
+
+
+# =============================================================================
+# Scenario: File-scoped mutation score (Slice 1, issue #1545)
+# =============================================================================
+def test_score_report_for_file_matches_one_file_only(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/Widget.cs": {
+                "mutants": [
+                    _mutant("Killed"),
+                    _mutant("Killed"),
+                    _mutant("Survived"),
+                ]
+            },
+            "src/Other.cs": {
+                "mutants": [
+                    _mutant("Survived"),
+                    _mutant("Survived"),
+                    _mutant("Timeout"),
+                    _mutant("NoCoverage"),
+                ]
+            },
+        },
+    )
+
+    summary = mutation_report.score_report_for_file(report, "src/Widget.cs")
+
+    assert summary.killed == 2
+    assert summary.survived == 1
+    assert summary.timeout == 0
+    assert summary.no_coverage == 0
+    # honest = 2 / (2 + 1 + 0); reported = (2 + 0) / (2 + 1 + 0 + 0)
+    assert summary.honest_score == pytest.approx(2 / 3 * 100)
+    assert summary.reported_score == pytest.approx(2 / 3 * 100)
+
+
+def test_score_report_for_file_absent_file_returns_zeroed_summary(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {"src/Widget.cs": {"mutants": [_mutant("Killed")]}},
+    )
+
+    summary = mutation_report.score_report_for_file(report, "src/Nope.cs")
+
+    assert summary.killed == 0
+    assert summary.survived == 0
+    assert summary.timeout == 0
+    assert summary.no_coverage == 0
+    assert summary.honest_score == 0.0
+    assert summary.reported_score == 0.0
+
+
+def test_score_report_for_file_matches_by_basename(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "/abs/src/Widget.cs": {
+                "mutants": [_mutant("Killed"), _mutant("Survived")]
+            }
+        },
+    )
+
+    summary = mutation_report.score_report_for_file(report, "Widget.cs")
+
+    assert summary.killed == 1
+    assert summary.survived == 1
+
+
+def test_score_report_for_file_prefers_exact_key_over_same_basename_collision(
+    tmp_path: Path,
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/A/Foo.cs": {"mutants": [_mutant("Killed"), _mutant("Killed")]},
+            "src/B/Foo.cs": {"mutants": [_mutant("Survived")]},
+        },
+    )
+
+    summary = mutation_report.score_report_for_file(report, "src/B/Foo.cs")
+
+    assert summary.killed == 0
+    assert summary.survived == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixes a real cross-scope-scoring bug: `mutation_kill_loop.run_for_file()`'s round log line called `mutation_report.score_report(report_path)` — not file-scoped — so a baseline-seeded round could silently print a whole-report score paired with one file's survivor count. Adds `mutation_report.score_report_for_file()` and wires it in for every round.
- Adds `mutation_baseline_reuse.py`: a git-backed, unit-tested module owning the Round-1 baseline-reuse eligibility decision (ancestor check + per-commit consumption tracking) and consumption bookkeeping via `resolve`/`mark-consumed` CLI subcommands — real code, not agent-followed prose, per the plan-review panel's explicit requirement.
- Documents the reuse procedure in `mutation-kill.md` (canonical paths, per-file resolve/mark-consumed sequencing, capture-commit lifetime, `success`-field failure handling, the `seeded/ran-fresh/mark-failed` run summary, `--concurrency 1`-only scope) and corrects every `--from-report` → `--report` flag-name typo.

Closes #1545

## Decisions & Assumptions
- **Ancestor-check vs. literal exact-SHA**: the spec said "exact commit-SHA comparison" for staleness, but a shared baseline captured once at one commit will almost never equal any individual file's own last-commit SHA — literal equality would make reuse fire almost never in practice. The plan reinterprets this as a `git merge-base --is-ancestor` check (still SHA-based, not date-based). **This was explicitly reconsidered once and then confirmed by the human operator** before implementation began.
- **Scope**: `--concurrency 1` only for this version — each `--concurrency >1` git worktree doesn't share the main checkout's `StrykerOutput/`, so those files fall back to today's fresh-per-file behavior, stated explicitly in the doc. (decision-defaults default, not contested)
- **Integration**: PR + auto-merge via `/pr`, no direct-to-trunk. (decision-defaults default, not contested)
- **Design revision during plan review**: the original idea proposed leaving the eligibility decision and consumption-marking to agent-followed prose with zero test coverage. A 5-reviewer panel (2 rounds) found this had zero implementing/testing code at all, so the plan was revised to make it a real, git-backed, unit-tested module (`mutation_baseline_reuse.py`) instead — mirroring this codebase's existing `git_revert`/`git_commit` subprocess pattern for invocation shape and `claude_cli_available`'s exception-safety pattern for missing-binary handling.
- **Non-blocking findings deferred to follow-up issues** (pre-existing/adjacent, not caused by this change): #1554 (shared test-file boilerplate), #1558 (missing subprocess timeouts elsewhere in `mutation_kill_loop.py`), #1559/#1561/#1562 (pre-existing complexity/duplication in `mutation_kill_loop.py`), #1560 (pre-existing `--headless` auto-commit-of-unvetted-LLM-output concern), #1563 (pre-existing coverage gaps in `dotnet_test`/`git_commit`/`_commit_message`), #1564 (test files that grew past the 500-line guideline).

## Quality Gate
- [x] Tests: 5563 passed, 3 skipped (pre-existing, unrelated — .NET SDK / real `claude` CLI opt-ins)
- [x] Type check: N/A (Python stdlib scripts + pytest, no type-checker configured)
- [x] Lint: clean (`ruff check`)
- [x] Code review: pass — 17-agent panel run 3 times (Slice 1+2 combined, Slice 3, then the final combined-diff PR gate), plus targeted re-dispatch confirming every fix. All actionable (warning/error, high/medium-confidence) findings were fixed and re-verified; remaining findings are suggestion-level or filed as separate follow-up issues (see above).

## Test Plan
- [x] `python3 -m pytest tests/scripts/test_mutation_report.py tests/scripts/test_mutation_baseline_reuse.py tests/scripts/test_mutation_kill_loop.py tests/agents/test_mutation_kill_baseline_reuse_doc.py tests/agents/test_mutation_kill_agent.py -v` — all pass
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q` — 5563 passed, 3 skipped
- [x] Manual CLI smoke test against the live repo: `mutation_baseline_reuse.py resolve` correctly reports `eligible: false` for an untracked file and `eligible: true` for a real tracked file at HEAD; `mark-consumed` correctly writes the atomic tracking file
- [x] Dedicated test proves the feature's core value scenario: a baseline-seeded Round 1 with 0 survivors never triggers the redundant scoped Stryker run

## Evidence Bundle
**Checks run**
- `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 5563 passed, 3 skipped
- `ruff check` on all touched files — clean
- `semgrep scan --config auto --quiet --json` on all touched scripts — 0 results
- Full 17-agent `/code-review` panel dispatched 3 times across the build (Slice 1+2, Slice 3, final combined-diff PR gate), plus ~15 targeted re-confirmation dispatches after each fix round

**Scope notes**
- No `tsconfig.json`/mypy config in this repo — type-check gate is N/A
- `progress_guardian.py --pre-pr` reports a warning-only scope-adherence mismatch (`tests/agents/test_mutation_kill_agent.py`'s line-budget bump, necessitated by adding a table row to `mutation-kill.md` but not declared in Slice 3's Files list) — not a blocking finding per its own design (issue #865 AC8)

**Untested regions**
- Not measured — no coverage tool configured for this Python test tree

**Residual risks**
- None escalated. Ten non-blocking findings filed as follow-up issues (#1554, #1558, #1559, #1560, #1561, #1562, #1563, #1564, plus #1547/#1549-1551 from the sibling #1543 PR's own review) rather than left silently unrecorded.
