### PR TITLE
chore(mutation-feasibility-gate): type Decision.outcome as an Enum and group probe params

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
@@ -23,15 +23,21 @@ Stdlib-only. Python 3.8+.
 from __future__ import annotations
 
 import argparse
+import enum
 import json
 import os
 import sys
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 
-ENTER_LOOP = "enter-loop"
-DEGRADE = "degrade"
-ASK_OPERATOR = "ask-operator"
+
+class Outcome(enum.Enum):
+    """The three valid ``Decision.outcome`` values the arbiter can return."""
+
+    ENTER_LOOP = "enter-loop"
+    DEGRADE = "degrade"
+    ASK_OPERATOR = "ask-operator"
+
 
 # Wall-clock ceiling for a single estimated loop round. Not a magic constant on
 # the probe side — the round estimate is *derived from the measured probe*
@@ -71,8 +77,19 @@ def estimate_round_seconds(probe_seconds: float, scope_file_count: int) -> float
 
 
 @dataclass(frozen=True)
+class ProbeResult:
+    """The shim-first one-file probe's measurements — the four values that
+    always travel together as one probe's result set."""
+
+    shim_declined: bool
+    capture_failed: bool
+    probe_seconds: float
+    scope_file_count: int
+
+
+@dataclass(frozen=True)
 class Decision:
-    outcome: str  # ENTER_LOOP | DEGRADE | ASK_OPERATOR
+    outcome: Outcome
     reason: str
     estimated_round_seconds: float | None = None
     budget_seconds: float | None = None
@@ -82,17 +99,16 @@ class Decision:
         """The precise waiver line to record when degrading; None when the
         loop is entered (no waiver needed) or when the operator still has to
         be asked (no waiver yet — pending operator input)."""
-        return None if self.outcome in (ENTER_LOOP, ASK_OPERATOR) else WAIVER_MESSAGE
+        if self.outcome is Outcome.ENTER_LOOP:
+            return None
+        if self.outcome is Outcome.ASK_OPERATOR:
+            return None
+        if self.outcome is Outcome.DEGRADE:
+            return WAIVER_MESSAGE
+        raise ValueError(f"unknown outcome: {self.outcome!r}")
 
 
-def decide(
-    *,
-    shim_declined: bool,
-    capture_failed: bool,
-    probe_seconds: float,
-    scope_file_count: int,
-    budget_seconds: float | None = None,
-) -> Decision:
+def decide(probe: ProbeResult, *, budget_seconds: float | None = None) -> Decision:
     """Arbitrate between entering the loop, asking the operator, or degrading
     from the shim-first probe.
 
@@ -104,30 +120,30 @@ def decide(
     if budget_seconds is None:
         budget_seconds = resolve_budget_seconds()
 
-    if shim_declined:
+    if probe.shim_declined:
         return Decision(
-            DEGRADE,
+            Outcome.DEGRADE,
             "operator declined the shim path at the v3-feature gate (#1160)",
         )
-    if capture_failed:
+    if probe.capture_failed:
         return Decision(
-            DEGRADE,
+            Outcome.DEGRADE,
             "per-test coverage capture failed on the probe (#1157) — Stryker "
             "fell back to whole-suite-per-mutant, so each loop round pays the "
             "full-suite cost",
         )
 
-    estimated = estimate_round_seconds(probe_seconds, scope_file_count)
+    estimated = estimate_round_seconds(probe.probe_seconds, probe.scope_file_count)
     if estimated > budget_seconds:
         return Decision(
-            ASK_OPERATOR,
+            Outcome.ASK_OPERATOR,
             f"estimated round {estimated:.0f}s exceeds the {budget_seconds:.0f}s "
             "budget (per-test works but the suite is too slow to iterate)",
             estimated_round_seconds=estimated,
             budget_seconds=budget_seconds,
         )
     return Decision(
-        ENTER_LOOP,
+        Outcome.ENTER_LOOP,
         f"per-test capture works and the estimated round {estimated:.0f}s is "
         f"within the {budget_seconds:.0f}s budget",
         estimated_round_seconds=estimated,
@@ -163,14 +179,15 @@ def _cli(argv: Sequence[str]) -> int:
     )
     args = parser.parse_args(list(argv))
 
-    decision = decide(
+    probe = ProbeResult(
         shim_declined=args.shim_declined,
         capture_failed=args.capture_failed,
         probe_seconds=args.probe_seconds,
         scope_file_count=args.scope_files,
-        budget_seconds=args.budget_seconds,
     )
+    decision = decide(probe, budget_seconds=args.budget_seconds)
     payload = asdict(decision)
+    payload["outcome"] = decision.outcome.value
     payload["waiver"] = decision.waiver
     print(json.dumps(payload, indent=2))
     # Exit 0 either way — this is an advisory arbiter, not a gate that fails a run.

--- a/tests/scripts/test_mutation_feasibility_gate.py
+++ b/tests/scripts/test_mutation_feasibility_gate.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPTS_DIR = (
     Path(__file__).resolve().parents[2]
     / "plugins"
@@ -23,14 +25,14 @@ import mutation_feasibility_gate as gate
 
 
 def test_fast_pertest_probe_enters_loop():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=False,
         probe_seconds=10.0,
         scope_file_count=5,
-        budget_seconds=1800.0,
     )
-    assert d.outcome == gate.ENTER_LOOP
+    d = gate.decide(probe, budget_seconds=1800.0)
+    assert d.outcome is gate.Outcome.ENTER_LOOP
     assert d.waiver is None
     assert d.estimated_round_seconds == 50.0
 
@@ -40,66 +42,68 @@ def test_healthy_v2_repo_enters_loop_no_regression(monkeypatch):
     # path must be unchanged. Strip the budget env so the default applies
     # regardless of the host shell (hermetic).
     monkeypatch.delenv("DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS", raising=False)
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=False,
         probe_seconds=1.0,
         scope_file_count=1,
     )
-    assert d.outcome == gate.ENTER_LOOP
+    d = gate.decide(probe)
+    assert d.outcome is gate.Outcome.ENTER_LOOP
 
 
 # --- decide: degrade paths --------------------------------------------------
 
 
 def test_capture_failure_degrades_regardless_of_timing():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=True,
         probe_seconds=0.1,  # would be "fast" but capture failed
         scope_file_count=1,
-        budget_seconds=1800.0,
     )
-    assert d.outcome == gate.DEGRADE
+    d = gate.decide(probe, budget_seconds=1800.0)
+    assert d.outcome is gate.Outcome.DEGRADE
     assert "#1157" in d.reason
     assert d.waiver == gate.WAIVER_MESSAGE
 
 
 def test_shim_declined_degrades():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=True,
         capture_failed=False,
         probe_seconds=1.0,
         scope_file_count=1,
     )
-    assert d.outcome == gate.DEGRADE
+    d = gate.decide(probe)
+    assert d.outcome is gate.Outcome.DEGRADE
     assert "#1160" in d.reason
     assert d.waiver == gate.WAIVER_MESSAGE
 
 
 def test_over_budget_asks_operator():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=False,
         probe_seconds=100.0,
         scope_file_count=40,  # 4000s estimated
-        budget_seconds=1800.0,
     )
-    assert d.outcome == gate.ASK_OPERATOR
+    d = gate.decide(probe, budget_seconds=1800.0)
+    assert d.outcome is gate.Outcome.ASK_OPERATOR
     assert "budget" in d.reason
     assert d.estimated_round_seconds == 4000.0
     assert d.waiver is None
 
 
 def test_estimate_exactly_at_budget_enters_loop():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=False,
         probe_seconds=10.0,
         scope_file_count=180,  # 1800s estimated == budget
-        budget_seconds=1800.0,
     )
-    assert d.outcome == gate.ENTER_LOOP
+    d = gate.decide(probe, budget_seconds=1800.0)
+    assert d.outcome is gate.Outcome.ENTER_LOOP
     assert d.waiver is None
 
 
@@ -108,38 +112,52 @@ def test_shim_decline_wins_precedence_over_budget_alone():
     # precedence test below) so this exercises a genuinely distinct case:
     # a decline still short-circuits even when capture succeeded and only
     # the budget signal would otherwise fire.
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=True,
         capture_failed=False,
         probe_seconds=100.0,
         scope_file_count=40,  # also over budget
-        budget_seconds=1800.0,
     )
-    assert d.outcome == gate.DEGRADE
+    d = gate.decide(probe, budget_seconds=1800.0)
+    assert d.outcome is gate.Outcome.DEGRADE
     assert "#1160" in d.reason
     assert "budget" not in d.reason
 
 
 def test_shim_decline_takes_precedence_over_capture_and_budget():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=True,
         capture_failed=True,
         probe_seconds=100.0,
         scope_file_count=40,
     )
-    assert d.outcome == gate.DEGRADE
+    d = gate.decide(probe)
+    assert d.outcome is gate.Outcome.DEGRADE
     assert "#1160" in d.reason  # decline reason wins the short-circuit
 
 
 def test_capture_failure_takes_precedence_over_budget():
-    d = gate.decide(
+    probe = gate.ProbeResult(
         shim_declined=False,
         capture_failed=True,
         probe_seconds=100.0,
         scope_file_count=40,
     )
-    assert d.outcome == gate.DEGRADE
+    d = gate.decide(probe)
+    assert d.outcome is gate.Outcome.DEGRADE
     assert "#1157" in d.reason
+
+
+# --- Decision.waiver: explicit branch over all three Outcome members -------
+
+
+def test_waiver_raises_on_unrecognized_outcome():
+    # Decision.outcome is typed as Outcome, so this can only happen via a
+    # value bypassing the type system — the explicit branch must still guard
+    # against it rather than silently falling through to a wrong answer.
+    d = gate.Decision(outcome="bogus", reason="not a real Outcome member")
+    with pytest.raises(ValueError, match="unknown outcome"):
+        _ = d.waiver
 
 
 # --- estimate_round_seconds -------------------------------------------------
@@ -197,7 +215,7 @@ def test_cli_enter_loop_json(capsys):
     out = capsys.readouterr().out
     assert rc == 0
     payload = json.loads(out)
-    assert payload["outcome"] == gate.ENTER_LOOP
+    assert payload["outcome"] == gate.Outcome.ENTER_LOOP.value
     assert payload["waiver"] is None
 
 
@@ -206,7 +224,7 @@ def test_cli_capture_failed_json(capsys):
     out = capsys.readouterr().out
     assert rc == 0
     payload = json.loads(out)
-    assert payload["outcome"] == gate.DEGRADE
+    assert payload["outcome"] == gate.Outcome.DEGRADE.value
     assert payload["waiver"] == gate.WAIVER_MESSAGE
 
 
@@ -215,7 +233,7 @@ def test_cli_shim_declined_flag_wiring(capsys):
     out = capsys.readouterr().out
     assert rc == 0
     payload = json.loads(out)
-    assert payload["outcome"] == gate.DEGRADE
+    assert payload["outcome"] == gate.Outcome.DEGRADE.value
     assert "#1160" in payload["reason"]
 
 
@@ -226,6 +244,6 @@ def test_cli_budget_flag_wiring(capsys):
     )
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
-    assert payload["outcome"] == gate.ASK_OPERATOR
+    assert payload["outcome"] == gate.Outcome.ASK_OPERATOR.value
     assert "budget" in payload["reason"]
     assert payload["waiver"] is None


### PR DESCRIPTION
## Summary
- Replaces `Decision.outcome`'s bare-`str` type (constrained only by a comment listing `ENTER_LOOP | DEGRADE | ASK_OPERATOR`) with a proper `Outcome` enum, and updates `Decision.waiver` to branch explicitly on all three members (raising on anything else) instead of an inclusion check that silently treated an unrecognized value as `DEGRADE`.
- Groups `decide()`'s four probe-derived keyword args (`shim_declined`, `capture_failed`, `probe_seconds`, `scope_file_count`) into a `ProbeResult` dataclass; `decide()`'s signature is now `decide(probe: ProbeResult, *, budget_seconds: float | None = None) -> Decision`. `_cli` constructs the `ProbeResult` from parsed args before calling `decide()`.
- No other callers of `decide()` or the old string constants exist outside this file — `agents/mutation-kill.md` only references the CLI flag names (unchanged) and `mutation_baseline_reuse.py` only has a comment mentioning the module, so neither needed updates.
- Updated `tests/scripts/test_mutation_feasibility_gate.py` for the new `ProbeResult`/`Outcome` shape, plus one new test covering `Decision.waiver`'s explicit-branch guard against an unrecognized outcome value.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_mutation_feasibility_gate.py -v` → 21 passed
- [x] `python3 -m pytest plugins/dev-team/tests -q` → 2263 passed
- [x] `python3 -m pytest tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q` → 3301 passed, 3 skipped (pre-existing, environment-conditional skips unrelated to this change)
- [x] Full local CI gate (`ci-local.sh` via pre-push hook) passed on push, after two transient, unrelated cross-worker test races surfaced and were filed separately as #1574

Closes #1550
Part of #1566