### PR TITLE
perf(mutation-kill): add timeouts to long-running subprocess.run calls

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -19,7 +19,19 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from mutation_kill_loop import Generator, RunContext, load_loop_config, run_for_file
+from mutation_kill_loop import (
+    Generator,
+    RunContext,
+    _timeout_from_env,
+    load_loop_config,
+    run_for_file,
+)
+
+# Timeout for the `claude --print` generation subprocess. Overridable via env
+# var since a legitimately slow/large prompt may need a larger budget than
+# this default — unlike the 30s used by this codebase's git-shelling
+# helpers, this subprocess routinely runs for tens of seconds to minutes.
+CLAUDE_GENERATION_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_GENERATION_TIMEOUT_S", 300)
 
 # The Claude CLI binary. Overridable via CLAUDE_BIN so a non-PATH install can
 # be pointed at without editing this module.
@@ -154,13 +166,21 @@ def make_headless_generator(
         if model:
             cmd += ["--model", model]
         cmd.append(prompt)
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=cwd,
+                check=False,
+                timeout=CLAUDE_GENERATION_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"claude --print generation timed out after "
+                f"{CLAUDE_GENERATION_TIMEOUT_S}s (set "
+                "DEV_TEAM_MUTATION_GENERATION_TIMEOUT_S to raise it)"
+            ) from exc
         if result.returncode != 0:
             raise RuntimeError(
                 f"claude CLI failed (exit {result.returncode}): {result.stderr[:500]}"

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -60,6 +60,37 @@ from mutation_kill_insert import apply_generated_methods, count_methods
 Generator = Callable[[str, list[dict], str, str], str]
 
 
+def _timeout_from_env(name: str, default: int) -> int:
+    """Parse a positive-integer timeout (seconds) from an env var.
+
+    Fails fast with a message naming the offending env var, rather than the
+    bare, unattributed ``ValueError`` a naked ``int(os.environ.get(...))``
+    would raise on a malformed override.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{name} must be an integer number of seconds, got {raw!r}"
+        ) from None
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive number of seconds, got {value}")
+    return value
+
+
+# Timeouts for the long-running subprocesses this loop shells out to. Each is
+# overridable via env var since a legitimately slow project (a large solution,
+# a heavyweight test suite) may need a larger budget than these defaults —
+# unlike the 30s used by this codebase's git-shelling helpers, these
+# subprocesses (a Stryker run, a dotnet build/test) routinely run for minutes.
+STRYKER_RUN_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_STRYKER_TIMEOUT_S", 3600)
+DOTNET_BUILD_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_BUILD_TIMEOUT_S", 600)
+DOTNET_TEST_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_TEST_TIMEOUT_S", 600)
+
+
 # =============================================================================
 # Config — everything path-shaped comes from stryker-config.json.
 # =============================================================================
@@ -168,18 +199,25 @@ def run_scoped_stryker(
     try:
         if sln is not None and sln_hidden is not None:
             wrapper.hide_sln(sln, sln_hidden)
-        subprocess.run(
-            [
-                stryker_bin,
-                "--config-file",
-                str(config_path),
-                "--output",
-                str(output_dir),
-            ],
-            env=env,
-            cwd=cwd,
-            check=False,
-        )
+        try:
+            subprocess.run(
+                [
+                    stryker_bin,
+                    "--config-file",
+                    str(config_path),
+                    "--output",
+                    str(output_dir),
+                ],
+                env=env,
+                cwd=cwd,
+                check=False,
+                timeout=STRYKER_RUN_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Stryker run timed out after {STRYKER_RUN_TIMEOUT_S}s for "
+                f"{source_file} (set DEV_TEAM_MUTATION_STRYKER_TIMEOUT_S to raise it)"
+            ) from exc
     finally:
         if sln is not None and sln_hidden is not None:
             wrapper.restore_sln(sln, sln_hidden)
@@ -201,15 +239,24 @@ def extract_survivors(report_path: Path, source_file: str) -> list[dict]:
 # Verify / commit / revert — all dotnet & git go through subprocess.
 # =============================================================================
 def dotnet_build(targets: Sequence[str], *, cwd: Path | None = None) -> bool:
-    """Build every configured test-project. False if any target fails."""
+    """Build every configured test-project. False if any target fails or
+    times out."""
     for target in targets:
-        rc = subprocess.run(
-            ["dotnet", "build", target, "-c", "Debug", "--nologo"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            check=False,
-        ).returncode
+        try:
+            rc = subprocess.run(
+                ["dotnet", "build", target, "-c", "Debug", "--nologo"],
+                capture_output=True,
+                text=True,
+                cwd=cwd,
+                check=False,
+                timeout=DOTNET_BUILD_TIMEOUT_S,
+            ).returncode
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(
+                f"error: dotnet build timed out after {DOTNET_BUILD_TIMEOUT_S}s "
+                f"for {target} (set DEV_TEAM_MUTATION_BUILD_TIMEOUT_S to raise it)\n"
+            )
+            return False
         if rc != 0:
             return False
     return True
@@ -219,24 +266,32 @@ def dotnet_test(
     targets: Sequence[str], test_filter: str, *, cwd: Path | None = None
 ) -> bool:
     """Run the scoped test filter across every test-project. False on any
-    non-zero exit or reported failure."""
+    non-zero exit, reported failure, or timeout."""
     for target in targets:
-        result = subprocess.run(
-            [
-                "dotnet",
-                "test",
-                target,
-                "-c",
-                "Debug",
-                "--no-build",
-                "--filter",
-                f"FullyQualifiedName~{test_filter}",
-            ],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "dotnet",
+                    "test",
+                    target,
+                    "-c",
+                    "Debug",
+                    "--no-build",
+                    "--filter",
+                    f"FullyQualifiedName~{test_filter}",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=cwd,
+                check=False,
+                timeout=DOTNET_TEST_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(
+                f"error: dotnet test timed out after {DOTNET_TEST_TIMEOUT_S}s "
+                f"for {target} (set DEV_TEAM_MUTATION_TEST_TIMEOUT_S to raise it)\n"
+            )
+            return False
         failed = 0
         for line in (result.stdout + result.stderr).splitlines():
             match = re.search(r"Failed:\s*(\d+)", line)

--- a/tests/scripts/test_mutation_kill_headless.py
+++ b/tests/scripts/test_mutation_kill_headless.py
@@ -141,6 +141,42 @@ def test_headless_generator_invokes_claude_print_and_strips_fences(
     assert "New_Case_KillsMutant" in out
 
 
+# Scenario: A hung `claude --print` generation call is bounded by a timeout,
+# not left to hang forever (#1558)
+def test_headless_generator_passes_a_timeout(monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            returncode = 0
+            stdout = "void New_Case() {}"
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
+    generate = headless.make_headless_generator(None)
+    generate("S.cs", [_mutant("Survived", "ArithmeticOperator", 10)], "class S {}", "class T {}")
+
+    assert captured["timeout"] == headless.CLAUDE_GENERATION_TIMEOUT_S
+
+
+def test_headless_generator_timeout_raises_a_named_error(monkeypatch: pytest.MonkeyPatch):
+    def fake_run(argv, **kwargs):
+        raise headless.subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
+    generate = headless.make_headless_generator(None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        generate("S.cs", [_mutant("Survived", "ArithmeticOperator", 10)], "class S {}", "class T {}")
+
+    assert str(headless.CLAUDE_GENERATION_TIMEOUT_S) in str(exc_info.value)
+    assert "DEV_TEAM_MUTATION_GENERATION_TIMEOUT_S" in str(exc_info.value)
+
+
 # Scenario: --model resolves from the flag, then the env var, else None
 def test_model_resolves_from_env_when_set(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DEV_TEAM_MUTATION_MODEL", "env-model")

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -189,6 +189,113 @@ def test_scoped_run_delegates_dotnet_root_and_sln_to_wrapper(
 
 
 # =============================================================================
+# Scenario: A hung Stryker subprocess is bounded by a timeout, not left to
+# hang forever (#1558)
+# =============================================================================
+def test_scoped_stryker_run_passes_a_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = loop.load_loop_config(_write_config(tmp_path, solution=None))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out")
+
+    assert captured["timeout"] == loop.STRYKER_RUN_TIMEOUT_S
+
+
+def test_scoped_stryker_run_timeout_raises_a_named_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = loop.load_loop_config(_write_config(tmp_path, solution=None))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out")
+
+    assert str(loop.STRYKER_RUN_TIMEOUT_S) in str(exc_info.value)
+    assert "DEV_TEAM_MUTATION_STRYKER_TIMEOUT_S" in str(exc_info.value)
+
+
+def test_scoped_stryker_run_restores_sln_even_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A timeout is just another exception path through run_scoped_stryker's
+    # try/finally — the .sln must be restored and the scoped config cleaned
+    # up exactly as on any other failure, not just the happy path.
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    calls: list = []
+    monkeypatch.setattr(
+        loop.wrapper, "hide_sln", lambda sln, sln_hidden: calls.append("hide_sln")
+    )
+    monkeypatch.setattr(
+        loop.wrapper, "restore_sln", lambda sln, sln_hidden: calls.append("restore_sln")
+    )
+
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError):
+        loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out")
+
+    assert calls == ["hide_sln", "restore_sln"]
+
+
+# =============================================================================
+# Scenario: Timeout env vars parse cleanly, or fail with a named message
+# (#1558) — pinned against literal values, not the module constant under
+# test, so a regression to the parsing logic itself is actually caught.
+# =============================================================================
+def test_timeout_from_env_returns_the_default_when_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SOME_TIMEOUT_VAR", raising=False)
+    assert loop._timeout_from_env("SOME_TIMEOUT_VAR", 42) == 42
+
+
+def test_timeout_from_env_parses_an_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOME_TIMEOUT_VAR", "99")
+    assert loop._timeout_from_env("SOME_TIMEOUT_VAR", 42) == 99
+
+
+def test_timeout_from_env_rejects_a_non_numeric_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOME_TIMEOUT_VAR", "not-a-number")
+    with pytest.raises(ValueError, match="SOME_TIMEOUT_VAR"):
+        loop._timeout_from_env("SOME_TIMEOUT_VAR", 42)
+
+
+def test_timeout_from_env_rejects_a_non_positive_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOME_TIMEOUT_VAR", "0")
+    with pytest.raises(ValueError, match="SOME_TIMEOUT_VAR"):
+        loop._timeout_from_env("SOME_TIMEOUT_VAR", 42)
+
+
+# =============================================================================
 # run_for_file harness — mocks every dotnet / git / Stryker touch.
 # =============================================================================
 def _loop_fixture(
@@ -545,6 +652,75 @@ def test_dotnet_build_uses_configured_test_project(
         "Debug",
         "--nologo",
     ]
+
+
+# =============================================================================
+# Scenario: A hung `dotnet build`/`dotnet test` is bounded by a timeout — it
+# fails (and reverts) rather than hanging the loop forever (#1558)
+# =============================================================================
+def test_dotnet_build_passes_a_timeout(monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.dotnet_build(["test/Foo.Tests/Foo.Tests.csproj"])
+
+    assert captured["timeout"] == loop.DOTNET_BUILD_TIMEOUT_S
+
+
+def test_dotnet_build_timeout_is_treated_as_a_build_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.dotnet_build(["test/Foo.Tests/Foo.Tests.csproj"]) is False
+    err = capsys.readouterr().err
+    assert str(loop.DOTNET_BUILD_TIMEOUT_S) in err
+    assert "DEV_TEAM_MUTATION_BUILD_TIMEOUT_S" in err
+
+
+def test_dotnet_test_passes_a_timeout(monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+
+    class _R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.dotnet_test(["test/Foo.Tests/Foo.Tests.csproj"], "FooTests")
+
+    assert captured["timeout"] == loop.DOTNET_TEST_TIMEOUT_S
+
+
+def test_dotnet_test_timeout_is_treated_as_a_test_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.dotnet_test(["test/Foo.Tests/Foo.Tests.csproj"], "FooTests") is False
+    err = capsys.readouterr().err
+    assert str(loop.DOTNET_TEST_TIMEOUT_S) in err
+    assert "DEV_TEAM_MUTATION_TEST_TIMEOUT_S" in err
 
 
 def test_git_revert_checks_out_only_the_test_file(


### PR DESCRIPTION
## Summary

- Adds `timeout=` + `except subprocess.TimeoutExpired` handling to the 4 previously unbounded `subprocess.run` calls in `mutation_kill_loop.py`: the Stryker run, `dotnet build`, `dotnet test`, and the `--headless` `claude --print` generation call.
- Extracts a validating `_timeout_from_env(name, default)` helper (fails fast on a non-numeric or non-positive override) used by all 4 timeout constants, each overridable via a `DEV_TEAM_MUTATION_*_TIMEOUT_S` env var.
- On timeout: Stryker/generation raise a `RuntimeError` naming the timeout value + override env var; `dotnet build`/`dotnet test` log the same and return `False` (feeding the existing revert path).

Went through a full 17-agent `/code-review` pass (twice — once before and once after a fix-loop iteration); see `.dev-team-reports/code-review.md` for the full findings/fix log. Net result: no blocking findings. A few residual suggestion-level items (further duplication extraction, pre-existing file-size hotspots, a pre-existing unrelated comment) were deliberately left as accepted minor debt rather than expanding this PR's scope.

One review finding — `git_revert`/`git_commit`/`claude_cli_available` still lack timeouts — was out of #1558's cited scope and filed separately as #1572.

## Test plan

- [x] `pytest tests/scripts/test_mutation_kill_loop.py` — 42/42 pass (14 new/restructured tests: timeout wiring + failure-handling for all 4 call sites, `.sln`-restore-on-timeout, and 4 unit tests for the new `_timeout_from_env` helper)
- [x] `ruff check` clean
- [x] Full pre-push local CI mirror (`scripts/ci-local.sh`) green

Closes #1558
Part of #1567