### PR TITLE
refactor(mutation-kill): extract round-runner helper and split loop module

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -51,8 +51,10 @@ re-describe or re-implement their mechanics:
 | --- | --- |
 | `mutation_report.py` | Parse the report; compute the **honest** and **reported** scores; extract survivors per file grouped by mutator. Stryker/Stryker.NET's JSON report is read directly; mutmut's `junitxml` output is normalized into the same internal shape first (`parse_mutmut_junitxml` / `score_mutmut_junitxml` / `survivors_from_mutmut_junitxml`). |
 | `mutation_baseline_reuse.py` | Round-1 baseline-reuse eligibility (git-ancestor + per-commit consumption check) and consumption bookkeeping via resolve/mark-consumed subcommands. |
-| `mutation_kill_loop.py` | The C#/Stryker.NET per-file loop: scoped run → score → survivor check → **your** generation → duplicate-guard → insert-before-class-close → build → test → commit-on-green / revert-on-failure → no-improvement stop. Delegates DOTNET_ROOT + `.sln` hide/restore to the wrapper. |
-| `mutation_kill_loop_python.py` | The Python/mutmut per-file loop — same contract, adapted for pytest: scoped `mutmut run` (clears stale `.mutmut-cache` first) → score via `mutation_report` junitxml support → **your** generation → duplicate-guard → append-at-end-of-file (refuses on a class-based test file) → `py_compile` → scoped `pytest` → commit-on-green / revert-on-failure → no-improvement stop. Reuses `mutation_kill_loop.py`'s generic headless helpers rather than duplicating them. |
+| `mutation_kill_loop.py` | The C#/Stryker.NET per-file loop orchestration: `run_for_file` drives scoped run → score → survivor check → **your** generation → build → test → commit-on-green / revert-on-failure → no-improvement stop. Delegates DOTNET_ROOT + `.sln` hide/restore to the wrapper. |
+| `mutation_kill_insert.py` | Insertion mechanics for the C#/Stryker.NET loop: duplicate-guard → insert-before-class-close (detect-or-refuse on a file-scoped namespace or non-4-space indentation). |
+| `mutation_kill_headless.py` | Headless generation (prompt building, fence stripping, `claude --print` shell-out) plus the script's CLI entry point (`--headless`, argument parsing) invoked by the shard pipeline. |
+| `mutation_kill_loop_python.py` | The Python/mutmut per-file loop — same contract, adapted for pytest: scoped `mutmut run` (clears stale `.mutmut-cache` first) → score via `mutation_report` junitxml support → **your** generation → duplicate-guard → append-at-end-of-file (refuses on a class-based test file) → `py_compile` → scoped `pytest` → commit-on-green / revert-on-failure → no-improvement stop. Reuses `mutation_kill_headless.py`'s generic headless helpers rather than duplicating them. |
 | `stryker_shard_setup.py` | Generate one `stryker-config.shard-<slug>.json` per source project, `Stryker.sln`, and `stryker-pipeline.json` from a `.sln`. |
 | `stryker_shard_pipeline.py` | The unattended sharded pipeline: discover shards, one compounding git worktree per shard from `HEAD`, run Stryker through the wrapper's line-callback, timeout-abort, launch the survivor-fix loop **forced into `--headless`**, honest-score summary. |
 | `stryker_timeout_retry.py` | Emit a retry config scoped to only the timed-out files with an increased `additional-timeout`. |
@@ -74,7 +76,7 @@ Generation is a seam the loop calls into; it never decides *what* tests to write
   `mutation_kill_loop.run_for_file` directly, passing a `generate` hook backed by
   a **live agent turn** — you read the survivors, source, and existing test file,
   and return the new test methods. No `claude` subprocess is spawned.
-- **`--headless`.** For unattended CI, `mutation_kill_loop.py --headless` shells to
+- **`--headless`.** For unattended CI, `mutation_kill_headless.py --headless` shells to
   `claude --print --model <m>` for generation. `--model` resolves from
   `DEV_TEAM_MUTATION_MODEL` then a pinned default — never an unstated literal.
   Invoking the bare CLI with neither an agent generator nor `--headless` fails

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""mutation_kill_headless.py — unattended generation via `claude --print` + CLI.
+
+Extracted from ``mutation_kill_loop.py`` (#1562): headless generation (prompt
+building, fence stripping, shelling to the Claude CLI) and the script's CLI
+argument parsing / entry point are one responsibility cluster — a change to
+the Claude prompt wording and a change to a ``--headless`` CLI flag are two
+unrelated reasons to touch this file, but neither has anything to do with the
+scoped-Stryker-run or insertion mechanics that live in the sibling modules.
+
+This module is the executable entry point (``python3 mutation_kill_headless.py
+--headless ...``) invoked by ``stryker_shard_pipeline.py``'s forced-headless
+per-shard survivor-fix loop; the agent-driven default path still calls
+:func:`mutation_kill_loop.run_for_file` directly with its own ``generate`` hook
+and never touches this file.
+
+Generic, stdlib-only, cross-platform (macOS, Linux, Windows).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import mutation_kill_loop as loop
+
+# The exact message the bare-CLI startup preflight prints. Pinned so the
+# contract test can assert it verbatim.
+NO_GENERATOR_MESSAGE = (
+    "no test generator available — invoke via the mutation-kill agent "
+    "or pass --headless"
+)
+
+# The Claude CLI binary. Overridable via CLAUDE_BIN so a non-PATH install can
+# be pointed at without editing this module.
+CLAUDE_CLI = os.environ.get("CLAUDE_BIN", "claude")
+
+# Printed when --headless is requested but the Claude CLI can't be reached.
+# Names exactly how to install and authenticate it, and mutates no files.
+MISSING_CLAUDE_MESSAGE = (
+    f"--headless requires the Claude CLI but '{CLAUDE_CLI}' is not available. "
+    "Install Claude Code (`npm install -g @anthropic-ai/claude-code`) and "
+    "authenticate it (run `claude` once to log in, or set ANTHROPIC_API_KEY) — "
+    "or set CLAUDE_BIN to the CLI's path."
+)
+
+
+# =============================================================================
+# Headless generation — shell to `claude --print` for unattended runs.
+# =============================================================================
+def resolve_model(explicit: str | None = None) -> str | None:
+    """Resolve the generation model: ``--model`` > ``DEV_TEAM_MUTATION_MODEL``
+    > ``None``. When ``None``, ``--model`` is omitted from the ``claude --print``
+    invocation and the Claude CLI uses its own default — the plugin never pins a
+    model snapshot id in source (models are resolved dynamically, not literalized;
+    cf. ADR 0008 and the no-pinned-snapshots guard)."""
+    if explicit:
+        return explicit
+    return os.environ.get("DEV_TEAM_MUTATION_MODEL") or None
+
+
+_FENCE_OPEN_RE = re.compile(r"^```[\w-]*\n?")
+_FENCE_CLOSE_RE = re.compile(r"\n?```$")
+
+
+def strip_code_fences(text: str) -> str:
+    """Strip one leading and one trailing markdown code fence, if present.
+
+    Claude may wrap generated methods in a ```` ```csharp ```` block; the loop
+    inserts raw method text, so the fence is removed on both ends.
+    """
+    text = _FENCE_OPEN_RE.sub("", text.strip())
+    text = _FENCE_CLOSE_RE.sub("", text.strip())
+    return text.strip()
+
+
+def build_survivor_summary(survivors: list[dict], *, limit: int = 40) -> str:
+    """Render surviving mutants as a compact, framework-agnostic list."""
+    lines = []
+    for mutant in survivors[:limit]:
+        line = mutant.get("location", {}).get("start", {}).get("line", "?")
+        mutator = mutant.get("mutatorName", "?")
+        replacement = mutant.get("replacement", "")
+        lines.append(f"- L{line} {mutator}: {replacement}".rstrip())
+    if len(survivors) > limit:
+        lines.append(f"- … and {len(survivors) - limit} more")
+    return "\n".join(lines)
+
+
+def build_generation_prompt(
+    source_file: str,
+    survivors: list[dict],
+    source_text: str,
+    test_text: str,
+    *,
+    source_limit: int = 8000,
+) -> str:
+    """Build the generation prompt.
+
+    The existing test file is the *only* pattern — assertion library, mocking
+    approach, fixtures, and naming conventions are all inferred from it. No
+    library name is hardcoded here, so the prompt is repo-agnostic (AC1).
+    """
+    return (
+        f"You are adding new test methods that KILL surviving mutations in "
+        f"{source_file}.\n\n"
+        "Match the existing test file exactly: its imports, assertion style, "
+        "mocking approach, fixtures, and naming conventions are the pattern to "
+        "follow. Do not introduce any library, helper, or convention that does "
+        "not already appear in it.\n\n"
+        f"## Surviving mutations ({len(survivors)})\n"
+        f"{build_survivor_summary(survivors)}\n\n"
+        f"## Source under test\n{source_text[:source_limit]}\n\n"
+        f"## Existing test file (the pattern to match)\n{test_text}\n\n"
+        "## Rules\n"
+        "1. Return ONLY the new test methods — no class wrapper, namespace, or "
+        "imports.\n"
+        "2. Each must compile against the helpers already in the existing test "
+        "file.\n"
+        "3. Reuse the existing file's assertion, mocking, and fixture patterns "
+        "exactly.\n"
+        "4. Match the existing naming convention.\n"
+        "5. Do not redeclare fields or helpers already present.\n"
+        "6. Do not emit closing braces for the class or namespace.\n"
+    )
+
+
+def claude_cli_available() -> bool:
+    """True if the Claude CLI responds to ``--version``."""
+    try:
+        result = subprocess.run(
+            [CLAUDE_CLI, "--version"], capture_output=True, text=True, check=False
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def make_headless_generator(
+    model: str | None = None, *, cwd: Path | None = None
+) -> loop.Generator:
+    """Return a :data:`loop.Generator` that shells to ``claude --print``.
+
+    The returned callable builds the prompt from the existing test file (the
+    pattern) plus the survivor summary, invokes the Claude CLI, and strips
+    markdown code fences from the result before it is inserted. ``--model`` is
+    passed only when ``model`` is set; when ``None`` the Claude CLI uses its own
+    default (the plugin pins no model snapshot id).
+    """
+
+    def generate(
+        source_file: str,
+        survivors: list[dict],
+        source_text: str,
+        test_text: str,
+    ) -> str:
+        prompt = build_generation_prompt(source_file, survivors, source_text, test_text)
+        cmd = [CLAUDE_CLI, "--print"]
+        if model:
+            cmd += ["--model", model]
+        cmd.append(prompt)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude CLI failed (exit {result.returncode}): {result.stderr[:500]}"
+            )
+        return strip_code_fences(result.stdout)
+
+    return generate
+
+
+# =============================================================================
+# CLI — startup preflight (Slice 2) + --headless generation (Slice 3).
+# =============================================================================
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="mutation_kill_headless.py",
+        description=(
+            "Config-driven survivor-kill loop. Agent-driven by default; "
+            "--headless enables unattended generation via the Claude CLI."
+        ),
+    )
+    p.add_argument("--config", default="stryker-config.json", help="stryker-config.json path")
+    p.add_argument("--file", help="Source file to target (basename or path)")
+    p.add_argument("--output", default="StrykerOutput/agent", help="Scoped-run output dir")
+    p.add_argument("--max-rounds", type=int, default=5, help="Max rounds per file")
+    p.add_argument("--stryker-bin", default="dotnet-stryker", help="Stryker executable")
+    p.add_argument(
+        "--headless",
+        action="store_true",
+        help="Unattended generation via `claude --print` (CI / shard pipeline).",
+    )
+    p.add_argument(
+        "--model",
+        help=(
+            "Generation model for --headless. Default: DEV_TEAM_MUTATION_MODEL "
+            "env var, else omitted so `claude --print` uses its own default."
+        ),
+    )
+    p.add_argument("--test-file", help="Test file to extend (required with --headless)")
+    p.add_argument("--source-path", help="Source file under test (required with --headless)")
+    p.add_argument("--report", help="Initial mutation report to seed round 1 (--headless)")
+    return p.parse_args(list(argv))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point.
+
+    The CLI has no way to inject an agent generator (that path calls
+    ``mutation_kill_loop.run_for_file`` directly). So without ``--headless``
+    there is no generator, and we fail fast **at startup** — before resolving
+    config, probing DOTNET_ROOT, running Stryker, or touching any file.
+
+    With ``--headless`` the generator shells to ``claude --print``. The Claude
+    CLI is preflight-checked *before* any file argument validation, so a
+    missing CLI fails cleanly at startup and mutates nothing.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = parse_args(argv)
+
+    if not args.headless:
+        sys.stderr.write(f"error: {NO_GENERATOR_MESSAGE}\n")
+        return 1
+
+    model = resolve_model(args.model)
+
+    # Preflight the CLI first — a missing CLI must fail before we touch any
+    # file or validate run arguments.
+    if not claude_cli_available():
+        sys.stderr.write(f"error: {MISSING_CLAUDE_MESSAGE}\n")
+        return 3
+
+    if not (args.file and args.test_file and args.source_path):
+        sys.stderr.write(
+            "error: --headless requires --file, --test-file, and --source-path\n"
+        )
+        return 2
+
+    loop.run_for_file(
+        args.file,
+        config=loop.load_loop_config(Path(args.config)),
+        test_file=Path(args.test_file),
+        source_path=Path(args.source_path),
+        output_dir=Path(args.output),
+        generate=make_headless_generator(model),
+        max_rounds=args.max_rounds,
+        initial_report_path=Path(args.report) if args.report else None,
+        stryker_bin=args.stryker_bin,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_insert.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_insert.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""mutation_kill_insert.py — detect-or-refuse test-method insertion mechanics.
+
+Extracted from ``mutation_kill_loop.py`` (#1562): inserting generated methods
+into a C# test file is a self-contained regex/text concern with no dependency
+on Stryker, dotnet, or git. Splitting it out means a change to the insertion
+heuristic never touches the scoped-run or verify/commit code in the sibling
+``mutation_kill_loop.py``, and vice versa.
+
+Generic, stdlib-only, cross-platform (macOS, Linux, Windows).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class InsertionRefused(Exception):
+    """Raised when the class-closing brace can't be located safely.
+
+    The insert heuristic only supports conventional block-namespace,
+    4-space-indented C# test classes. For a file-scoped namespace (no wrapping
+    braces) or non-4-space indentation, the loop refuses rather than append
+    into a structurally wrong location.
+    """
+
+
+@dataclass(frozen=True)
+class InsertOutcome:
+    """Result of attempting to apply generated methods. ``inserted`` is False
+    when the file was left untouched; ``reason`` says why. ``method_count`` is
+    the number of test methods found in the generated text — owned here (where
+    ``TEST_METHOD_RE`` lives) rather than recomputed by a caller, so a change
+    to the method-matching heuristic never has to touch a sibling module."""
+
+    inserted: bool
+    reason: str
+    method_count: int = 0
+
+
+# Matches a public test-method declaration (async Task or void), capturing the
+# method name. Framework-agnostic — no attribute or library name is assumed.
+TEST_METHOD_RE = re.compile(
+    r"public\s+(?:async\s+)?(?:void|Task(?:<[^>]*>)?)\s+(\w+)\s*\("
+)
+
+# A file-scoped namespace declaration ends with a semicolon and has no
+# wrapping braces: ``namespace Foo.Bar;``
+_FILE_SCOPED_NS_RE = re.compile(r"^\s*namespace\s+[\w.]+\s*;", re.MULTILINE)
+
+
+def detect_duplicate_methods(test_text: str, new_text: str) -> list[str]:
+    """Return the method names in ``new_text`` that already exist in the file."""
+    existing = set(TEST_METHOD_RE.findall(test_text))
+    incoming = TEST_METHOD_RE.findall(new_text)
+    return [name for name in incoming if name in existing]
+
+
+def _find_block_namespace_class_close(lines: Sequence[str]) -> int | None:
+    """Return the index of the class-closing brace, or None to refuse.
+
+    Walks from the end: finds the namespace-closing brace (a line whose
+    stripped form is ``}``), then the last line that is exactly four spaces
+    followed by ``}`` before it — the conventional block-namespace class
+    close. Any other indentation yields None (refuse).
+    """
+    ns_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() == "}":
+            ns_idx = i
+            break
+    if ns_idx is None:
+        return None
+    for i in range(ns_idx - 1, -1, -1):
+        if lines[i].rstrip("\r\n") == "    }":
+            return i
+    return None
+
+
+def insert_before_class_close(test_file: Path, new_methods: str) -> None:
+    """Insert ``new_methods`` before the test class's closing brace.
+
+    Raises :class:`InsertionRefused` for a file-scoped namespace or any
+    non-4-space-indented class the heuristic can't safely locate. The file is
+    left untouched on refusal.
+    """
+    text = test_file.read_text(encoding="utf-8")
+    if _FILE_SCOPED_NS_RE.search(text):
+        raise InsertionRefused(
+            f"refusing to insert into {test_file.name}: file-scoped namespace "
+            "detected — the class-close heuristic supports only block-namespace, "
+            "4-space-indented classes"
+        )
+
+    lines = text.splitlines(keepends=True)
+    cc_idx = _find_block_namespace_class_close(lines)
+    if cc_idx is None:
+        raise InsertionRefused(
+            f"refusing to insert into {test_file.name}: could not locate a "
+            "conventional 4-space class-closing brace (non-standard indentation?)"
+        )
+
+    block = (
+        ["\n"]
+        + [ln if ln.endswith("\n") else ln + "\n" for ln in new_methods.strip().splitlines()]
+        + ["\n"]
+    )
+    lines = lines[:cc_idx] + block + lines[cc_idx:]
+    test_file.write_text("".join(lines), encoding="utf-8")
+
+
+def apply_generated_methods(test_file: Path, new_methods: str) -> InsertOutcome:
+    """Insert generated methods, guarding duplicates and unsafe structure.
+
+    Returns an :class:`InsertOutcome`; the file is only ever written on the
+    ``inserted=True`` path. Empty generation, duplicate method names, and a
+    refused insert all leave the file untouched.
+    """
+    if not new_methods.strip():
+        return InsertOutcome(False, "no methods generated")
+
+    dupes = detect_duplicate_methods(test_file.read_text(encoding="utf-8"), new_methods)
+    if dupes:
+        return InsertOutcome(False, f"duplicate method names: {dupes}")
+
+    try:
+        insert_before_class_close(test_file, new_methods)
+    except InsertionRefused as exc:
+        return InsertOutcome(False, str(exc))
+    return InsertOutcome(True, "inserted", method_count=len(TEST_METHOD_RE.findall(new_methods)))

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -5,64 +5,45 @@ Migrated from the ACI ``nextgen-test-upgrade-process`` mutation agent and
 de-hardcoded: nothing repo-specific lives here. Project / test-project /
 mutate targets come from ``stryker-config.json``; ``DOTNET_ROOT`` resolution
 and ``.sln`` hide/restore reuse the shipped ``csharp_stryker_net_wrapper``;
-scoring and survivor extraction reuse ``mutation_report``.
+scoring and survivor extraction reuse ``mutation_report``. Insertion mechanics
+live in the sibling ``mutation_kill_insert``; headless generation and the CLI
+entry point live in the sibling ``mutation_kill_headless`` (#1562) — this
+module owns only config, the scoped Stryker run, verify/commit, and the
+per-file round orchestration.
 
 Generic, stdlib-only, cross-platform (macOS, Linux, Windows). The only
-non-stdlib imports are the two sibling plugin modules in this same
-``scripts/`` directory.
+non-stdlib imports are the sibling plugin modules in this same ``scripts/``
+directory.
 
 **Generation is a seam, not a mechanism.** The loop never decides *what*
 tests to write — a caller supplies a ``generate`` callable that returns the
 new test-method text. The default (interactive) path is agent-driven: the
 ``mutation-kill`` agent calls :func:`run_for_file` directly, passing a
-``generate`` hook backed by a live agent turn. A ``--headless`` CLI mode
+``generate`` hook backed by a live agent turn. ``mutation_kill_headless.py``
 shells to ``claude --print`` for unattended (CI / shard-pipeline) runs.
-Invoking the CLI with neither an injected generator nor ``--headless`` fails
-fast at startup — before any Stryker run or file mutation.
 """
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 import csharp_stryker_net_wrapper as wrapper
+import mutation_kill_insert as insert
 import mutation_report
 
-# A generator is any callable the agent (or, in Slice 3, the headless CLI)
-# supplies: given the source filename, the surviving mutants, the source
-# text, and the current test text, it returns the raw text of new test
-# methods to insert. The loop owns everything *around* this call; the
-# callable owns the single genuinely-LLM step.
+# A generator is any callable the agent (or the headless CLI) supplies: given
+# the source filename, the surviving mutants, the source text, and the
+# current test text, it returns the raw text of new test methods to insert.
+# The loop owns everything *around* this call; the callable owns the single
+# genuinely-LLM step.
 Generator = Callable[[str, list[dict], str, str], str]
-
-# The exact message the bare-CLI startup preflight prints. Pinned so the
-# contract test can assert it verbatim.
-NO_GENERATOR_MESSAGE = (
-    "no test generator available — invoke via the mutation-kill agent "
-    "or pass --headless"
-)
-
-# The Claude CLI binary. Overridable via CLAUDE_BIN so a non-PATH install can
-# be pointed at without editing this module.
-CLAUDE_CLI = os.environ.get("CLAUDE_BIN", "claude")
-
-# Printed when --headless is requested but the Claude CLI can't be reached.
-# Names exactly how to install and authenticate it, and mutates no files.
-MISSING_CLAUDE_MESSAGE = (
-    f"--headless requires the Claude CLI but '{CLAUDE_CLI}' is not available. "
-    "Install Claude Code (`npm install -g @anthropic-ai/claude-code`) and "
-    "authenticate it (run `claude` once to log in, or set ANTHROPIC_API_KEY) — "
-    "or set CLAUDE_BIN to the CLI's path."
-)
 
 
 # =============================================================================
@@ -203,120 +184,6 @@ def extract_survivors(report_path: Path, source_file: str) -> list[dict]:
 
 
 # =============================================================================
-# Insert mechanics — detect-or-refuse, never a silent mis-insertion.
-# =============================================================================
-class InsertionRefused(Exception):
-    """Raised when the class-closing brace can't be located safely.
-
-    The insert heuristic only supports conventional block-namespace,
-    4-space-indented C# test classes. For a file-scoped namespace (no wrapping
-    braces) or non-4-space indentation, the loop refuses rather than append
-    into a structurally wrong location.
-    """
-
-
-@dataclass(frozen=True)
-class InsertOutcome:
-    """Result of attempting to apply generated methods. ``inserted`` is False
-    when the file was left untouched; ``reason`` says why."""
-
-    inserted: bool
-    reason: str
-
-
-# Matches a public test-method declaration (async Task or void), capturing the
-# method name. Framework-agnostic — no attribute or library name is assumed.
-_METHOD_RE = re.compile(
-    r"public\s+(?:async\s+)?(?:void|Task(?:<[^>]*>)?)\s+(\w+)\s*\("
-)
-
-# A file-scoped namespace declaration ends with a semicolon and has no
-# wrapping braces: ``namespace Foo.Bar;``
-_FILE_SCOPED_NS_RE = re.compile(r"^\s*namespace\s+[\w.]+\s*;", re.MULTILINE)
-
-
-def detect_duplicate_methods(test_text: str, new_text: str) -> list[str]:
-    """Return the method names in ``new_text`` that already exist in the file."""
-    existing = set(_METHOD_RE.findall(test_text))
-    incoming = _METHOD_RE.findall(new_text)
-    return [name for name in incoming if name in existing]
-
-
-def _find_block_namespace_class_close(lines: Sequence[str]) -> int | None:
-    """Return the index of the class-closing brace, or None to refuse.
-
-    Walks from the end: finds the namespace-closing brace (a line whose
-    stripped form is ``}``), then the last line that is exactly four spaces
-    followed by ``}`` before it — the conventional block-namespace class
-    close. Any other indentation yields None (refuse).
-    """
-    ns_idx = None
-    for i in range(len(lines) - 1, -1, -1):
-        if lines[i].strip() == "}":
-            ns_idx = i
-            break
-    if ns_idx is None:
-        return None
-    for i in range(ns_idx - 1, -1, -1):
-        if lines[i].rstrip("\r\n") == "    }":
-            return i
-    return None
-
-
-def insert_before_class_close(test_file: Path, new_methods: str) -> None:
-    """Insert ``new_methods`` before the test class's closing brace.
-
-    Raises :class:`InsertionRefused` for a file-scoped namespace or any
-    non-4-space-indented class the heuristic can't safely locate. The file is
-    left untouched on refusal.
-    """
-    text = test_file.read_text(encoding="utf-8")
-    if _FILE_SCOPED_NS_RE.search(text):
-        raise InsertionRefused(
-            f"refusing to insert into {test_file.name}: file-scoped namespace "
-            "detected — the class-close heuristic supports only block-namespace, "
-            "4-space-indented classes"
-        )
-
-    lines = text.splitlines(keepends=True)
-    cc_idx = _find_block_namespace_class_close(lines)
-    if cc_idx is None:
-        raise InsertionRefused(
-            f"refusing to insert into {test_file.name}: could not locate a "
-            "conventional 4-space class-closing brace (non-standard indentation?)"
-        )
-
-    block = (
-        ["\n"]
-        + [ln if ln.endswith("\n") else ln + "\n" for ln in new_methods.strip().splitlines()]
-        + ["\n"]
-    )
-    lines = lines[:cc_idx] + block + lines[cc_idx:]
-    test_file.write_text("".join(lines), encoding="utf-8")
-
-
-def apply_generated_methods(test_file: Path, new_methods: str) -> InsertOutcome:
-    """Insert generated methods, guarding duplicates and unsafe structure.
-
-    Returns an :class:`InsertOutcome`; the file is only ever written on the
-    ``inserted=True`` path. Empty generation, duplicate method names, and a
-    refused insert all leave the file untouched.
-    """
-    if not new_methods.strip():
-        return InsertOutcome(False, "no methods generated")
-
-    dupes = detect_duplicate_methods(test_file.read_text(encoding="utf-8"), new_methods)
-    if dupes:
-        return InsertOutcome(False, f"duplicate method names: {dupes}")
-
-    try:
-        insert_before_class_close(test_file, new_methods)
-    except InsertionRefused as exc:
-        return InsertOutcome(False, str(exc))
-    return InsertOutcome(True, "inserted")
-
-
-# =============================================================================
 # Verify / commit / revert — all dotnet & git go through subprocess.
 # =============================================================================
 def dotnet_build(targets: Sequence[str], *, cwd: Path | None = None) -> bool:
@@ -384,17 +251,112 @@ def git_commit(message: str, test_file: Path, *, cwd: Path | None = None) -> boo
     return rc == 0
 
 
-def _commit_message(round_num: int, source_file: str, survivors: int, new_methods: str) -> str:
-    count = len(_METHOD_RE.findall(new_methods))
+def _commit_message(
+    round_num: int, source_file: str, survivor_count: int, method_count: int
+) -> str:
     return (
         f"test(mutation): kill round {round_num} — {source_file}\n\n"
-        f"{count} new test method(s) targeting {survivors} surviving mutant(s)"
+        f"{method_count} new test method(s) targeting {survivor_count} surviving mutant(s)"
     )
 
 
 # =============================================================================
 # Per-file loop — run → score → check → generate → insert → verify → commit.
 # =============================================================================
+@dataclass(frozen=True)
+class RunContext:
+    """Everything a round of :func:`run_for_file` needs that stays constant
+    across every round for one source file — extracted (#1561) so
+    ``_run_round`` takes one bundle instead of a long, mixed parameter list."""
+
+    source_file: str
+    config: LoopConfig
+    test_file: Path
+    source_path: Path
+    output_dir: Path
+    generate: Generator
+    initial_report_path: Path | None = None
+    stryker_bin: str = "dotnet-stryker"
+    cwd: Path | None = None
+    log: Callable[[str], None] = print
+
+
+@dataclass(frozen=True)
+class _RoundResult:
+    """Outcome of one round: whether the loop should stop, and the survivor
+    count to compare against next round's no-improvement check."""
+
+    stop: bool
+    survivor_count: int
+
+
+def _run_round(round_num: int, prev_survivor_count: int | None, ctx: RunContext) -> _RoundResult:
+    """Run one round of the survivor-kill loop for one source file.
+
+    Mechanical scoped run → score → stop-condition checks → generate → insert
+    → verify → commit-on-green/revert-on-failure. The sole non-deterministic
+    step is ``ctx.generate``; everything else here is deterministic and
+    mirrors :func:`run_for_file`'s pre-#1561 inline body exactly.
+    """
+    if ctx.initial_report_path is not None and round_num == 1:
+        report_path = Path(ctx.initial_report_path)
+    else:
+        report_path = run_scoped_stryker(
+            ctx.config,
+            ctx.source_file,
+            output_dir=ctx.output_dir,
+            stryker_bin=ctx.stryker_bin,
+            cwd=ctx.cwd,
+        )
+
+    survivors = extract_survivors(report_path, ctx.source_file)
+    survivor_count = len(survivors)
+    # File-scoped, not score_report(): a baseline-seeded round 1 report can
+    # cover multiple files (#1545) — score_report() would leak another
+    # file's score into this line.
+    summary = mutation_report.score_report_for_file(report_path, ctx.source_file)
+    ctx.log(
+        f"  round {round_num}: honest={summary.honest_score:.1f}% "
+        f"survivors={survivor_count}"
+    )
+
+    if survivor_count == 0:
+        ctx.log("  no survivors — done")
+        return _RoundResult(stop=True, survivor_count=survivor_count)
+    if prev_survivor_count is not None and survivor_count >= prev_survivor_count:
+        ctx.log("  no improvement this round — stopping")
+        return _RoundResult(stop=True, survivor_count=survivor_count)
+
+    new_methods = ctx.generate(
+        ctx.source_file,
+        survivors,
+        ctx.source_path.read_text(encoding="utf-8"),
+        ctx.test_file.read_text(encoding="utf-8"),
+    )
+
+    outcome = insert.apply_generated_methods(ctx.test_file, new_methods)
+    if not outcome.inserted:
+        ctx.log(f"  not inserted ({outcome.reason}) — stopping")
+        return _RoundResult(stop=True, survivor_count=survivor_count)
+
+    if not dotnet_build(dotnet_build_targets(ctx.config), cwd=ctx.cwd):
+        ctx.log("  build failed — reverting")
+        git_revert(ctx.test_file, cwd=ctx.cwd)
+        return _RoundResult(stop=True, survivor_count=survivor_count)
+    if not dotnet_test(dotnet_test_targets(ctx.config), ctx.test_file.stem, cwd=ctx.cwd):
+        ctx.log("  tests failed — reverting")
+        git_revert(ctx.test_file, cwd=ctx.cwd)
+        return _RoundResult(stop=True, survivor_count=survivor_count)
+
+    ctx.log("  green — committing")
+    git_commit(
+        _commit_message(round_num, ctx.source_file, survivor_count, outcome.method_count),
+        ctx.test_file,
+        cwd=ctx.cwd,
+    )
+    return _RoundResult(stop=False, survivor_count=survivor_count)
+
+
 def run_for_file(
     source_file: str,
     *,
@@ -411,283 +373,28 @@ def run_for_file(
 ) -> None:
     """Drive the deterministic survivor-kill loop for one source file.
 
-    ``generate`` is the sole non-deterministic step: given survivors + context
-    it returns the raw new-method text. Everything else — scoped run, scoring,
-    duplicate/insert guards, build/test verification, revert-on-failure,
-    commit-on-green, and the no-improvement stop — is mechanical.
+    ``generate`` is the sole non-deterministic step; each round's mechanics
+    (scoped run, scoring, duplicate/insert guards, build/test verification,
+    revert-on-failure, commit-on-green, and the no-improvement stop) live in
+    :func:`_run_round` (#1561). This function only threads the round number
+    and the previous survivor count across the ``for`` loop.
     """
-    prev_survivors: int | None = None
+    ctx = RunContext(
+        source_file=source_file,
+        config=config,
+        test_file=test_file,
+        source_path=source_path,
+        output_dir=output_dir,
+        generate=generate,
+        initial_report_path=initial_report_path,
+        stryker_bin=stryker_bin,
+        cwd=cwd,
+        log=log,
+    )
+    prev_survivor_count: int | None = None
 
     for round_num in range(1, max_rounds + 1):
-        if initial_report_path is not None and round_num == 1:
-            report_path = Path(initial_report_path)
-        else:
-            report_path = run_scoped_stryker(
-                config,
-                source_file,
-                output_dir=output_dir,
-                stryker_bin=stryker_bin,
-                cwd=cwd,
-            )
-
-        survivors = extract_survivors(report_path, source_file)
-        survivor_count = len(survivors)
-        # File-scoped, not score_report(): a baseline-seeded round 1 report can
-        # cover multiple files (#1545) — score_report() would leak another
-        # file's score into this line.
-        summary = mutation_report.score_report_for_file(report_path, source_file)
-        log(
-            f"  round {round_num}: honest={summary.honest_score:.1f}% "
-            f"survivors={survivor_count}"
-        )
-
-        if survivor_count == 0:
-            log("  no survivors — done")
+        result = _run_round(round_num, prev_survivor_count, ctx)
+        if result.stop:
             return
-        if prev_survivors is not None and survivor_count >= prev_survivors:
-            log("  no improvement this round — stopping")
-            return
-        prev_survivors = survivor_count
-
-        new_methods = generate(
-            source_file,
-            survivors,
-            source_path.read_text(encoding="utf-8"),
-            test_file.read_text(encoding="utf-8"),
-        )
-
-        outcome = apply_generated_methods(test_file, new_methods)
-        if not outcome.inserted:
-            log(f"  not inserted ({outcome.reason}) — stopping")
-            return
-
-        if not dotnet_build(dotnet_build_targets(config), cwd=cwd):
-            log("  build failed — reverting")
-            git_revert(test_file, cwd=cwd)
-            return
-        if not dotnet_test(dotnet_test_targets(config), test_file.stem, cwd=cwd):
-            log("  tests failed — reverting")
-            git_revert(test_file, cwd=cwd)
-            return
-
-        log("  green — committing")
-        git_commit(
-            _commit_message(round_num, source_file, survivor_count, new_methods),
-            test_file,
-            cwd=cwd,
-        )
-
-
-# =============================================================================
-# Headless generation — shell to `claude --print` for unattended runs.
-# =============================================================================
-def resolve_model(explicit: str | None = None) -> str | None:
-    """Resolve the generation model: ``--model`` > ``DEV_TEAM_MUTATION_MODEL``
-    > ``None``. When ``None``, ``--model`` is omitted from the ``claude --print``
-    invocation and the Claude CLI uses its own default — the plugin never pins a
-    model snapshot id in source (models are resolved dynamically, not literalized;
-    cf. ADR 0008 and the no-pinned-snapshots guard)."""
-    if explicit:
-        return explicit
-    return os.environ.get("DEV_TEAM_MUTATION_MODEL") or None
-
-
-_FENCE_OPEN_RE = re.compile(r"^```[\w-]*\n?")
-_FENCE_CLOSE_RE = re.compile(r"\n?```$")
-
-
-def strip_code_fences(text: str) -> str:
-    """Strip one leading and one trailing markdown code fence, if present.
-
-    Claude may wrap generated methods in a ```` ```csharp ```` block; the loop
-    inserts raw method text, so the fence is removed on both ends.
-    """
-    text = _FENCE_OPEN_RE.sub("", text.strip())
-    text = _FENCE_CLOSE_RE.sub("", text.strip())
-    return text.strip()
-
-
-def build_survivor_summary(survivors: list[dict], *, limit: int = 40) -> str:
-    """Render surviving mutants as a compact, framework-agnostic list."""
-    lines = []
-    for mutant in survivors[:limit]:
-        line = mutant.get("location", {}).get("start", {}).get("line", "?")
-        mutator = mutant.get("mutatorName", "?")
-        replacement = mutant.get("replacement", "")
-        lines.append(f"- L{line} {mutator}: {replacement}".rstrip())
-    if len(survivors) > limit:
-        lines.append(f"- … and {len(survivors) - limit} more")
-    return "\n".join(lines)
-
-
-def build_generation_prompt(
-    source_file: str,
-    survivors: list[dict],
-    source_text: str,
-    test_text: str,
-    *,
-    source_limit: int = 8000,
-) -> str:
-    """Build the generation prompt.
-
-    The existing test file is the *only* pattern — assertion library, mocking
-    approach, fixtures, and naming conventions are all inferred from it. No
-    library name is hardcoded here, so the prompt is repo-agnostic (AC1).
-    """
-    return (
-        f"You are adding new test methods that KILL surviving mutations in "
-        f"{source_file}.\n\n"
-        "Match the existing test file exactly: its imports, assertion style, "
-        "mocking approach, fixtures, and naming conventions are the pattern to "
-        "follow. Do not introduce any library, helper, or convention that does "
-        "not already appear in it.\n\n"
-        f"## Surviving mutations ({len(survivors)})\n"
-        f"{build_survivor_summary(survivors)}\n\n"
-        f"## Source under test\n{source_text[:source_limit]}\n\n"
-        f"## Existing test file (the pattern to match)\n{test_text}\n\n"
-        "## Rules\n"
-        "1. Return ONLY the new test methods — no class wrapper, namespace, or "
-        "imports.\n"
-        "2. Each must compile against the helpers already in the existing test "
-        "file.\n"
-        "3. Reuse the existing file's assertion, mocking, and fixture patterns "
-        "exactly.\n"
-        "4. Match the existing naming convention.\n"
-        "5. Do not redeclare fields or helpers already present.\n"
-        "6. Do not emit closing braces for the class or namespace.\n"
-    )
-
-
-def claude_cli_available() -> bool:
-    """True if the Claude CLI responds to ``--version``."""
-    try:
-        result = subprocess.run(
-            [CLAUDE_CLI, "--version"], capture_output=True, text=True, check=False
-        )
-    except (FileNotFoundError, OSError):
-        return False
-    return result.returncode == 0
-
-
-def make_headless_generator(
-    model: str | None = None, *, cwd: Path | None = None
-) -> Generator:
-    """Return a :data:`Generator` that shells to ``claude --print``.
-
-    The returned callable builds the prompt from the existing test file (the
-    pattern) plus the survivor summary, invokes the Claude CLI, and strips
-    markdown code fences from the result before it is inserted. ``--model`` is
-    passed only when ``model`` is set; when ``None`` the Claude CLI uses its own
-    default (the plugin pins no model snapshot id).
-    """
-
-    def generate(
-        source_file: str,
-        survivors: list[dict],
-        source_text: str,
-        test_text: str,
-    ) -> str:
-        prompt = build_generation_prompt(source_file, survivors, source_text, test_text)
-        cmd = [CLAUDE_CLI, "--print"]
-        if model:
-            cmd += ["--model", model]
-        cmd.append(prompt)
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            check=False,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"claude CLI failed (exit {result.returncode}): {result.stderr[:500]}"
-            )
-        return strip_code_fences(result.stdout)
-
-    return generate
-
-
-# =============================================================================
-# CLI — startup preflight (Slice 2) + --headless generation (Slice 3).
-# =============================================================================
-def parse_args(argv: Sequence[str]) -> argparse.Namespace:
-    p = argparse.ArgumentParser(
-        prog="mutation_kill_loop.py",
-        description=(
-            "Config-driven survivor-kill loop. Agent-driven by default; "
-            "--headless enables unattended generation via the Claude CLI."
-        ),
-    )
-    p.add_argument("--config", default="stryker-config.json", help="stryker-config.json path")
-    p.add_argument("--file", help="Source file to target (basename or path)")
-    p.add_argument("--output", default="StrykerOutput/agent", help="Scoped-run output dir")
-    p.add_argument("--max-rounds", type=int, default=5, help="Max rounds per file")
-    p.add_argument("--stryker-bin", default="dotnet-stryker", help="Stryker executable")
-    p.add_argument(
-        "--headless",
-        action="store_true",
-        help="Unattended generation via `claude --print` (CI / shard pipeline).",
-    )
-    p.add_argument(
-        "--model",
-        help=(
-            "Generation model for --headless. Default: DEV_TEAM_MUTATION_MODEL "
-            "env var, else omitted so `claude --print` uses its own default."
-        ),
-    )
-    p.add_argument("--test-file", help="Test file to extend (required with --headless)")
-    p.add_argument("--source-path", help="Source file under test (required with --headless)")
-    p.add_argument("--report", help="Initial mutation report to seed round 1 (--headless)")
-    return p.parse_args(list(argv))
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    """CLI entry point.
-
-    The CLI has no way to inject an agent generator (that path calls
-    :func:`run_for_file` directly). So without ``--headless`` there is no
-    generator, and we fail fast **at startup** — before resolving config,
-    probing DOTNET_ROOT, running Stryker, or touching any file.
-
-    With ``--headless`` the generator shells to ``claude --print``. The Claude
-    CLI is preflight-checked *before* any file argument validation, so a
-    missing CLI fails cleanly at startup and mutates nothing.
-    """
-    argv = list(sys.argv[1:] if argv is None else argv)
-    args = parse_args(argv)
-
-    if not args.headless:
-        sys.stderr.write(f"error: {NO_GENERATOR_MESSAGE}\n")
-        return 1
-
-    model = resolve_model(args.model)
-
-    # Preflight the CLI first — a missing CLI must fail before we touch any
-    # file or validate run arguments.
-    if not claude_cli_available():
-        sys.stderr.write(f"error: {MISSING_CLAUDE_MESSAGE}\n")
-        return 3
-
-    if not (args.file and args.test_file and args.source_path):
-        sys.stderr.write(
-            "error: --headless requires --file, --test-file, and --source-path\n"
-        )
-        return 2
-
-    run_for_file(
-        args.file,
-        config=load_loop_config(Path(args.config)),
-        test_file=Path(args.test_file),
-        source_path=Path(args.source_path),
-        output_dir=Path(args.output),
-        generate=make_headless_generator(model),
-        max_rounds=args.max_rounds,
-        initial_report_path=Path(args.report) if args.report else None,
-        stryker_bin=args.stryker_bin,
-    )
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+        prev_survivor_count = result.survivor_count

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -9,8 +9,8 @@ command, so there is no config-file abstraction here (unlike
 and survivor extraction reuse ``mutation_report``'s mutmut-junitxml support
 (#1357); the two generic (non-.NET) headless-generation helpers —
 ``strip_code_fences``, ``resolve_model``, ``claude_cli_available``,
-``CLAUDE_CLI`` — are imported from ``mutation_kill_loop`` rather than
-duplicated, since neither depends on anything C#-specific.
+``CLAUDE_CLI`` — are imported from ``mutation_kill_headless`` (#1562) rather
+than duplicated, since neither depends on anything C#-specific.
 
 **Generation is a seam, not a mechanism** (same contract as the C# loop):
 the loop never decides *what* tests to write — a caller supplies a
@@ -32,23 +32,23 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-import mutation_kill_loop as _cs_loop
+import mutation_kill_headless as _cs_headless
 import mutation_report
 
 Generator = Callable[[str, list[dict], str, str], str]
 
-# Mirrors mutation_kill_loop.NO_GENERATOR_MESSAGE — pinned so a contract test
-# can assert it verbatim.
+# Mirrors mutation_kill_headless.NO_GENERATOR_MESSAGE — pinned so a contract
+# test can assert it verbatim.
 NO_GENERATOR_MESSAGE = (
     "no test generator available — invoke via the mutation-kill agent "
     "or pass --headless"
 )
 
 # Reused verbatim — neither helper is C#-specific.
-strip_code_fences = _cs_loop.strip_code_fences
-resolve_model = _cs_loop.resolve_model
-claude_cli_available = _cs_loop.claude_cli_available
-CLAUDE_CLI = _cs_loop.CLAUDE_CLI
+strip_code_fences = _cs_headless.strip_code_fences
+resolve_model = _cs_headless.resolve_model
+claude_cli_available = _cs_headless.claude_cli_available
+CLAUDE_CLI = _cs_headless.CLAUDE_CLI
 
 MISSING_CLAUDE_MESSAGE = (
     f"--headless requires the Claude CLI but '{CLAUDE_CLI}' is not available. "
@@ -397,8 +397,9 @@ def build_generation_prompt(
 
     The existing test file is the *only* pattern — assertion style and
     fixture usage are inferred from it, never hardcoded here (mirrors
-    ``mutation_kill_loop.build_generation_prompt``, adapted for pytest's flat
-    ``def test_*():`` convention rather than a class/namespace-wrapped one).
+    ``mutation_kill_headless.build_generation_prompt``, adapted for pytest's
+    flat ``def test_*():`` convention rather than a class/namespace-wrapped
+    one).
     """
     return (
         f"You are adding new pytest test functions that KILL surviving "
@@ -429,8 +430,8 @@ def make_headless_generator(
 ) -> Generator:
     """Return a :data:`Generator` that shells to ``claude --print``.
 
-    Identical contract to ``mutation_kill_loop.make_headless_generator``, but
-    with the Python-flavored prompt above.
+    Identical contract to ``mutation_kill_headless.make_headless_generator``,
+    but with the Python-flavored prompt above.
     """
 
     def generate(
@@ -491,8 +492,8 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """CLI entry point — see :func:`mutation_kill_loop.main` for the contract
-    this mirrors."""
+    """CLI entry point — see :func:`mutation_kill_headless.main` for the
+    contract this mirrors."""
     argv = list(sys.argv[1:] if argv is None else argv)
     args = parse_args(argv)
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -5,8 +5,9 @@ Migrated from the ACI ``nextgen-test-upgrade-process`` ``stryker-pipeline.py``
 and de-hardcoded: nothing repo-specific lives here. Shards are discovered from
 ``stryker-config.shard-*.json`` files (emitted by ``stryker_shard_setup.py``);
 each shard runs Stryker through the shipped ``csharp_stryker_net_wrapper`` and
-the per-shard survivor-fix loop is ``mutation_kill_loop`` forced into
-``--headless`` mode (the pipeline is unattended — there is no live agent turn).
+the per-shard survivor-fix loop is ``mutation_kill_headless`` (the CLI entry
+point over ``mutation_kill_loop``, #1562) forced into ``--headless`` mode (the
+pipeline is unattended — there is no live agent turn).
 
 Compounding worktrees: shards are processed **sequentially**, each in its own
 git worktree created from the current ``HEAD``. Because the survivor-fix loop
@@ -43,7 +44,7 @@ import mutation_report
 # ── Constants ────────────────────────────────────────────────────────────────
 
 PYTHON = sys.executable
-LOOP_SCRIPT = str(Path(__file__).resolve().parent / "mutation_kill_loop.py")
+LOOP_SCRIPT = str(Path(__file__).resolve().parent / "mutation_kill_headless.py")
 
 SHARD_GLOB = "stryker-config.shard-*.json"
 SHARD_PREFIX = "stryker-config.shard-"
@@ -260,8 +261,9 @@ def build_loop_command(
     model: str | None,
     max_rounds: int,
 ) -> list[str]:
-    """Build the ``mutation_kill_loop`` invocation. ``--headless`` is forced —
-    the pipeline is unattended and can never depend on a live agent turn."""
+    """Build the ``mutation_kill_headless`` invocation. ``--headless`` is
+    forced — the pipeline is unattended and can never depend on a live agent
+    turn."""
     cmd = [
         PYTHON,
         LOOP_SCRIPT,
@@ -298,8 +300,9 @@ def launch_survivor_fix(
 ) -> None:
     """Launch the forced-headless survivor-fix loop for a shard's survivors.
 
-    Invokes ``mutation_kill_loop`` (always with ``--headless``) once per source
-    file that still has survivors, seeding round 1 from the shard's report.
+    Invokes ``mutation_kill_headless`` (always with ``--headless``) once per
+    source file that still has survivors, seeding round 1 from the shard's
+    report.
     Runs from ``repo_root`` so fixes commit onto ``HEAD`` — that is what makes
     the *next* shard's worktree compounding.
     """

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -74,7 +74,10 @@ def test_agent_body_stays_under_500_line_limit(text: str) -> None:
     # three-counter run-summary line, and the --concurrency 1-only scope.
     # Bumped by 1 more (#1545 review): added a mutation_baseline_reuse.py row
     # to the scripted-mechanics table (arch-review finding).
-    assert len(text.splitlines()) < 605
+    # Bumped by 2 more (#1568): mutation_kill_loop.py's per-file-loop row split
+    # into three rows (mutation_kill_loop.py / mutation_kill_insert.py /
+    # mutation_kill_headless.py) reflecting the #1561/#1562 module split.
+    assert len(text.splitlines()) < 607
 
 
 def test_defines_honest_score_formula(text: str) -> None:

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -28,6 +28,8 @@ SCRIPTS_DIR = (
 )
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import mutation_kill_headless as headless
+import mutation_kill_insert as insert
 import mutation_kill_loop as loop
 
 FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
@@ -199,9 +201,9 @@ def test_bare_cli_no_generator_fails_fast_at_startup(
         raise AssertionError("startup preflight must run before any subprocess")
 
     monkeypatch.setattr(loop, "run_scoped_stryker", explode)
-    monkeypatch.setattr(loop.subprocess, "run", explode)
+    monkeypatch.setattr(headless.subprocess, "run", explode)
 
-    rc = loop.main(["--config", "stryker-config.json", "--file", "PaymentService.cs"])
+    rc = headless.main(["--config", "stryker-config.json", "--file", "PaymentService.cs"])
 
     assert rc != 0
     err = capsys.readouterr().err
@@ -220,12 +222,12 @@ def test_headless_flag_does_not_trip_the_no_generator_preflight(
     # positively proves the no-generator preflight was passed (not merely that
     # the no-generator text is absent). Pin claude_cli_available so the emitted
     # message is deterministic regardless of the host's PATH.
-    monkeypatch.setattr(loop, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(headless, "claude_cli_available", lambda: True)
 
-    rc = loop.main(["--headless"])
+    rc = headless.main(["--headless"])
 
     err = capsys.readouterr().err
-    assert loop.NO_GENERATOR_MESSAGE not in err
+    assert headless.NO_GENERATOR_MESSAGE not in err
     assert "--headless requires --file, --test-file, and --source-path" in err
     assert rc != 0
 
@@ -248,9 +250,9 @@ def test_headless_generator_invokes_claude_print_and_strips_fences(
         captured["argv"] = argv
         return _R()
 
-    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
 
-    generate = loop.make_headless_generator("some-test-model")
+    generate = headless.make_headless_generator("some-test-model")
     survivors = [_mutant("Survived", "ArithmeticOperator", 10)]
     out = generate(
         "PaymentService.cs",
@@ -260,7 +262,7 @@ def test_headless_generator_invokes_claude_print_and_strips_fences(
     )
 
     argv = captured["argv"]
-    assert argv[0] == loop.CLAUDE_CLI
+    assert argv[0] == headless.CLAUDE_CLI
     assert "--print" in argv
     # --model carries the resolved model.
     assert argv[argv.index("--model") + 1] == "some-test-model"
@@ -278,9 +280,9 @@ def test_headless_generator_invokes_claude_print_and_strips_fences(
 # Scenario: --model resolves from the flag, then the env var, else None
 def test_model_resolves_from_env_when_set(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DEV_TEAM_MUTATION_MODEL", "env-model")
-    assert loop.resolve_model() == "env-model"
+    assert headless.resolve_model() == "env-model"
     # An explicit --model wins over the env var.
-    assert loop.resolve_model("flag-model") == "flag-model"
+    assert headless.resolve_model("flag-model") == "flag-model"
 
 
 def test_model_resolves_to_none_when_env_unset(
@@ -289,7 +291,7 @@ def test_model_resolves_to_none_when_env_unset(
     # No model snapshot id is pinned in source (cf. ADR 0008 / no-pinned-snapshots
     # guard); unresolved means None so `claude --print` uses its own default.
     monkeypatch.delenv("DEV_TEAM_MUTATION_MODEL", raising=False)
-    assert loop.resolve_model() is None
+    assert headless.resolve_model() is None
 
 
 def test_headless_omits_model_flag_when_unresolved(monkeypatch: pytest.MonkeyPatch):
@@ -304,8 +306,8 @@ def test_headless_omits_model_flag_when_unresolved(monkeypatch: pytest.MonkeyPat
         captured["argv"] = argv
         return _R()
 
-    monkeypatch.setattr(loop.subprocess, "run", fake_run)
-    generate = loop.make_headless_generator(None)
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
+    generate = headless.make_headless_generator(None)
     generate("S.cs", [_mutant("Survived", "ArithmeticOperator", 10)], "class S {}", "class T {}")
     # --model is absent entirely; claude --print falls back to its own default.
     assert "--model" not in captured["argv"]
@@ -319,28 +321,28 @@ def test_default_non_headless_spawns_no_claude_subprocess(
     def explode(*a, **k):
         raise AssertionError("no subprocess may be spawned in the default mode")
 
-    monkeypatch.setattr(loop.subprocess, "run", explode)
+    monkeypatch.setattr(headless.subprocess, "run", explode)
     monkeypatch.setattr(
-        loop, "claude_cli_available", lambda: pytest.fail("must not probe the CLI")
+        headless, "claude_cli_available", lambda: pytest.fail("must not probe the CLI")
     )
 
-    rc = loop.main(["--config", "stryker-config.json", "--file", "Foo.cs"])
+    rc = headless.main(["--config", "stryker-config.json", "--file", "Foo.cs"])
 
     assert rc != 0
-    assert loop.NO_GENERATOR_MESSAGE in capsys.readouterr().err
+    assert headless.NO_GENERATOR_MESSAGE in capsys.readouterr().err
 
 
 # Scenario: Missing Claude CLI under headless fails cleanly and names the fix
 def test_missing_claude_cli_under_headless_names_remediation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    monkeypatch.setattr(loop, "claude_cli_available", lambda: False)
+    monkeypatch.setattr(headless, "claude_cli_available", lambda: False)
     # No file may be mutated: run_for_file must never be reached.
     monkeypatch.setattr(
         loop, "run_for_file", lambda *a, **k: pytest.fail("must not run — CLI missing")
     )
 
-    rc = loop.main(
+    rc = headless.main(
         [
             "--headless",
             "--file", "Foo.cs",
@@ -363,14 +365,14 @@ def test_claude_cli_available_reflects_subprocess_outcome(
     class _OK:
         returncode = 0
 
-    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _OK())
-    assert loop.claude_cli_available() is True
+    monkeypatch.setattr(headless.subprocess, "run", lambda *a, **k: _OK())
+    assert headless.claude_cli_available() is True
 
     def _missing(*a, **k):
         raise FileNotFoundError("claude")
 
-    monkeypatch.setattr(loop.subprocess, "run", _missing)
-    assert loop.claude_cli_available() is False
+    monkeypatch.setattr(headless.subprocess, "run", _missing)
+    assert headless.claude_cli_available() is False
 
 
 # =============================================================================
@@ -424,7 +426,7 @@ def test_duplicate_method_names_abort_insertion(tmp_path: Path):
         "        }\n"
     )
 
-    outcome = loop.apply_generated_methods(test_file, dup_block)
+    outcome = insert.apply_generated_methods(test_file, dup_block)
 
     assert outcome.inserted is False
     assert "duplicate" in outcome.reason.lower()
@@ -433,7 +435,7 @@ def test_duplicate_method_names_abort_insertion(tmp_path: Path):
 
 
 def test_detect_duplicate_methods_reports_only_collisions():
-    dupes = loop.detect_duplicate_methods(
+    dupes = insert.detect_duplicate_methods(
         _BLOCK_NAMESPACE_CLASS,
         "public async Task Existing_Case_Works() {}\n"
         "public async Task Brand_New_Case() {}\n",
@@ -448,9 +450,10 @@ def test_methods_inserted_before_class_closing_brace(tmp_path: Path):
     test_file = tmp_path / "PaymentServiceTests.cs"
     test_file.write_text(_BLOCK_NAMESPACE_CLASS, encoding="utf-8")
 
-    outcome = loop.apply_generated_methods(test_file, _NEW_METHOD)
+    outcome = insert.apply_generated_methods(test_file, _NEW_METHOD)
 
     assert outcome.inserted is True
+    assert outcome.method_count == 1
     lines = test_file.read_text(encoding="utf-8").splitlines()
     new_idx = next(i for i, ln in enumerate(lines) if "New_Case_KillsMutant" in ln)
     # The class-close ("    }") and namespace-close ("}") follow the new method.
@@ -471,8 +474,8 @@ def test_file_scoped_namespace_is_refused_not_corrupted(tmp_path: Path):
     test_file.write_text(_FILE_SCOPED_CLASS, encoding="utf-8")
     before = test_file.read_text(encoding="utf-8")
 
-    with pytest.raises(loop.InsertionRefused) as exc:
-        loop.insert_before_class_close(test_file, _NEW_METHOD)
+    with pytest.raises(insert.InsertionRefused) as exc:
+        insert.insert_before_class_close(test_file, _NEW_METHOD)
 
     assert "file-scoped" in str(exc.value).lower()
     # Never silently appended — file is byte-for-byte unchanged.
@@ -494,8 +497,8 @@ def test_non_four_space_indent_is_refused(tmp_path: Path):
     test_file.write_text(tabbed, encoding="utf-8")
     before = test_file.read_text(encoding="utf-8")
 
-    with pytest.raises(loop.InsertionRefused):
-        loop.insert_before_class_close(test_file, _NEW_METHOD)
+    with pytest.raises(insert.InsertionRefused):
+        insert.insert_before_class_close(test_file, _NEW_METHOD)
 
     assert test_file.read_text(encoding="utf-8") == before
 
@@ -505,7 +508,7 @@ def test_apply_wraps_refusal_as_outcome_without_writing(tmp_path: Path):
     test_file.write_text(_FILE_SCOPED_CLASS, encoding="utf-8")
     before = test_file.read_text(encoding="utf-8")
 
-    outcome = loop.apply_generated_methods(test_file, _NEW_METHOD)
+    outcome = insert.apply_generated_methods(test_file, _NEW_METHOD)
 
     assert outcome.inserted is False
     assert "file-scoped" in outcome.reason.lower()
@@ -813,8 +816,12 @@ def test_git_revert_checks_out_only_the_test_file(
 # =============================================================================
 # Scenario: The module carries no repo-specific literal
 # =============================================================================
-def test_module_source_carries_no_repo_specific_literal():
-    source = (SCRIPTS_DIR / "mutation_kill_loop.py").read_text(encoding="utf-8")
+@pytest.mark.parametrize(
+    "module_name",
+    ["mutation_kill_loop.py", "mutation_kill_insert.py", "mutation_kill_headless.py"],
+)
+def test_module_source_carries_no_repo_specific_literal(module_name: str):
+    source = (SCRIPTS_DIR / module_name).read_text(encoding="utf-8")
 
     present = [lit for lit in FORBIDDEN_LITERALS if lit in source]
-    assert present == [], f"repo-specific literals leaked into module: {present}"
+    assert present == [], f"repo-specific literals leaked into {module_name}: {present}"

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -30,15 +30,15 @@ FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq",
 
 
 # =============================================================================
-# Reused headless helpers actually come from mutation_kill_loop
+# Reused headless helpers actually come from mutation_kill_headless
 # =============================================================================
 def test_headless_helpers_are_reused_not_duplicated():
-    import mutation_kill_loop as cs_loop
+    import mutation_kill_headless as cs_headless
 
-    assert loop.strip_code_fences is cs_loop.strip_code_fences
-    assert loop.resolve_model is cs_loop.resolve_model
-    assert loop.claude_cli_available is cs_loop.claude_cli_available
-    assert loop.CLAUDE_CLI == cs_loop.CLAUDE_CLI
+    assert loop.strip_code_fences is cs_headless.strip_code_fences
+    assert loop.resolve_model is cs_headless.resolve_model
+    assert loop.claude_cli_available is cs_headless.claude_cli_available
+    assert loop.CLAUDE_CLI == cs_headless.CLAUDE_CLI
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Wave 3 slice of the mutation-kill follow-up parallelization plan, bundling #1561 and #1562 since both touch `run_for_file`'s signature/shape.

- **#1561** — `run_for_file`'s 11-parameter, ~57-line inline body is extracted into a `_run_round` helper. A `RunContext` dataclass bundles everything constant across rounds for one file (source_file, config, test_file, source_path, output_dir, generate, initial_report_path, stryker_bin, cwd, log), so `_run_round` itself takes only `(round_num, prev_survivor_count, ctx)` — 3 params, down from what would otherwise have been 9+. `run_for_file`'s own public signature is unchanged (it's the external contract the mutation-kill agent and the headless CLI call with named kwargs).
- **#1562** — `mutation_kill_loop.py` (693 lines, 5 responsibility clusters) is split along its stated axes:
  - `mutation_kill_insert.py` — insertion mechanics (duplicate-guard, insert-before-class-close, detect-or-refuse)
  - `mutation_kill_headless.py` — headless generation (prompt building, fence stripping, `claude --print` shell-out) + the CLI entry point (`parse_args`/`main`). This is now the script `stryker_shard_pipeline.py` invokes instead of `mutation_kill_loop.py`.
  - `mutation_kill_loop.py` — trimmed to `LoopConfig`, the scoped Stryker run, verify/commit, and the `RunContext`/`_run_round`/`run_for_file` orchestration.

Behavior is unchanged — this is a mechanical, no-op-in-effect refactor. Full pytest suite (5493 tests) passes throughout.

## Review

Ran the full code-review agent panel (17 agents, resolver-selected) twice — once against the initial split, once against the final content after applying fixes. Fixes applied in response to review findings:

- Removed a real mutual-import cycle: `mutation_kill_loop.py` had a leftover `if __name__ == "__main__":` shim importing back from `mutation_kill_headless.py`, which itself imports from `mutation_kill_loop.py` at module load time. Nothing invokes `mutation_kill_loop.py` as a script anymore (confirmed by repo-wide grep) — `mutation_kill_headless.py` is the sole entry point now.
- Closed a boundary leak: `_commit_message` used to import `METHOD_RE` directly from the insert module to count generated methods, contradicting the insert module's own stated one-way-decoupling rationale. `InsertOutcome` now carries a `method_count` field computed where the regex is owned.
- Qualified two sibling-module imports (`import mutation_kill_insert as insert`, `import mutation_kill_loop as loop`) to match the existing `wrapper`/`mutation_report` convention and avoid monkeypatch-fragility on a `from...import` binding.
- Two naming fixes: `prev_survivors` → `prev_survivor_count` and `METHOD_RE` → `TEST_METHOD_RE` (both were scalar/regex names that read like the list-typed `survivors` elsewhere in the file); `_commit_message`'s `survivors: int` param → `survivor_count: int` for the same reason.
- Added a missing assertion (`outcome.method_count == 1`) covering the new field.

Findings intentionally left unaddressed as pre-existing or out of scope for this mechanical refactor (noted for a possible follow-up issue):

- `mutation_kill_loop_python.py`'s own per-file loop carries the same "long inline round body" shape (CC~11) that #1561 fixed for the C# sibling — untouched here since it has no corresponding issue and this file was only touched to repoint an import.
- Several pre-existing test-coverage gaps (headless `main()`'s happy path, `dotnet_test`/`git_commit`'s real-implementation coverage, a few branch conditions) predate this split.
- Two architecture-level security observations (unattended headless generation committing to `HEAD` with no human gate; verbatim source-file embedding into the LLM prompt) are properties of the whole mutation-kill design, not of this split.

## Test plan

- [x] Full pytest suite (`plugins/dev-team/tests`, `tests/{repo,agents,commands,docs,knowledge,bats,skills,scripts,hooks}`) — 5492 passed, 1 skipped
- [x] `ruff check` on all touched files — clean
- [x] `scripts/ci-local.sh` (full local CI mirror) — all checks passed
- [x] Knowledge index rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)