### PR TITLE
chore(mutation-kill): consolidate identical dotnet_build_targets/dotnet_test_targets

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -96,13 +96,8 @@ def load_loop_config(config_path: Path) -> LoopConfig:
     )
 
 
-def dotnet_build_targets(config: LoopConfig) -> list[str]:
-    """Build targets are exactly the configured test-projects."""
-    return list(config.test_projects)
-
-
-def dotnet_test_targets(config: LoopConfig) -> list[str]:
-    """Test targets are exactly the configured test-projects."""
+def dotnet_test_project_targets(config: LoopConfig) -> list[str]:
+    """Both the build and test targets are exactly the configured test-projects."""
     return list(config.test_projects)
 
 
@@ -384,11 +379,11 @@ def _run_round(
         ctx.log(f"  not inserted ({outcome.reason}) — stopping")
         return None
 
-    if not dotnet_build(dotnet_build_targets(ctx.config), cwd=ctx.cwd):
+    if not dotnet_build(dotnet_test_project_targets(ctx.config), cwd=ctx.cwd):
         ctx.log("  build failed — reverting")
         git_revert(ctx.test_file, cwd=ctx.cwd)
         return None
-    if not dotnet_test(dotnet_test_targets(ctx.config), ctx.test_file.stem, cwd=ctx.cwd):
+    if not dotnet_test(dotnet_test_project_targets(ctx.config), ctx.test_file.stem, cwd=ctx.cwd):
         ctx.log("  tests failed — reverting")
         git_revert(ctx.test_file, cwd=ctx.cwd)
         return None

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -84,8 +84,7 @@ def test_build_and_test_targets_derive_from_config(tmp_path: Path):
         _write_config(tmp_path, test_projects=("test/Foo.Tests/Foo.Tests.csproj",))
     )
 
-    assert loop.dotnet_build_targets(config) == ["test/Foo.Tests/Foo.Tests.csproj"]
-    assert loop.dotnet_test_targets(config) == ["test/Foo.Tests/Foo.Tests.csproj"]
+    assert loop.dotnet_test_project_targets(config) == ["test/Foo.Tests/Foo.Tests.csproj"]
 
 
 def test_config_supports_both_wrapper_and_flat_shapes(tmp_path: Path):
@@ -116,7 +115,7 @@ def test_end_to_end_fixture_derives_paths_and_extracts_survivors(tmp_path: Path)
     )
 
     # Paths derive from config — the configured test-project, no ACI literal.
-    assert loop.dotnet_build_targets(config) == [
+    assert loop.dotnet_test_project_targets(config) == [
         "test/Widget.WebApi.Tests/Widget.WebApi.Tests.csproj"
     ]
 
@@ -536,7 +535,7 @@ def test_dotnet_build_uses_configured_test_project(
         loop.subprocess, "run", lambda argv, **k: seen.append(argv) or _R()
     )
 
-    assert loop.dotnet_build(loop.dotnet_build_targets(config)) is True
+    assert loop.dotnet_build(loop.dotnet_test_project_targets(config)) is True
     assert seen[0] == [
         "dotnet",
         "build",


### PR DESCRIPTION
## Summary

- `dotnet_build_targets` and `dotnet_test_targets` in `mutation_kill_loop.py` were byte-identical (`return list(config.test_projects)`), differing only in docstring — a future divergence in build vs. test targets had no compiler/test signal forcing both to update together.
- Consolidated to a single `dotnet_test_project_targets(config)`, used at both call sites in `run_for_file`, per the issue's own suggested fix (option 1).
- Updated the 3 test assertions referencing the old names.

Went through `/code-review`'s change-size fast path (small mechanical diff — 7 added lines): `security-review`, `correctness-review`, `spec-compliance-review`, `doc-review` all passed clean, no findings.

## Test plan

- [x] `pytest tests/scripts/test_mutation_kill_loop.py` — 29/29 pass
- [x] `ruff check` clean
- [x] Full pre-push local CI mirror (`scripts/ci-local.sh`) green

Closes #1559
Part of #1567