### PR TITLE
test(mutation-testing): dedupe SCRIPTS_DIR/FORBIDDEN_LITERALS in tests/scripts/test_mutation_*.py

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,14 +12,16 @@ addopts = --import-mode=importlib
 # couple of test dirs whose modules import a sibling helper by bare name need
 # that directory made importable explicitly. Modules-under-test are unaffected:
 # those tests insert their own sys.path entries. tests/bats -> _stack_aware_helpers,
-# tests/skills -> skill_doc_helpers, tests/agents -> _plugin_dirs, repo root ->
-# _repo_root (shared REPO_ROOT constant, replacing per-file
+# tests/skills -> skill_doc_helpers, tests/agents -> _plugin_dirs, tests/scripts ->
+# _mutation_test_helpers (shared SCRIPTS_DIR/FORBIDDEN_LITERALS constants,
+# issue #1554), repo root -> _repo_root (shared REPO_ROOT constant, replacing per-file
 # Path(__file__).resolve().parents[N] computation across the test corpus).
 pythonpath =
     .
     tests/bats
     tests/skills
     tests/agents
+    tests/scripts
 # pytest-xdist's own marker, used to force a set of tests that share mutable
 # filesystem state (a fixed /tmp path, no per-worker isolation) onto a single
 # worker so `-n auto` can't interleave them into a race. Registering it here

--- a/tests/scripts/_mutation_test_helpers.py
+++ b/tests/scripts/_mutation_test_helpers.py
@@ -1,0 +1,30 @@
+"""Shared constants for tests/scripts/test_mutation_*.py.
+
+Named with a leading underscore (not ``conftest``) to avoid ambiguity with
+pytest's own conftest.py fixture-collection mechanism — this is a plain
+importable module, not a pytest plugin. Follows this repo's existing
+convention for cross-directory test helpers (``tests/agents/_plugin_dirs.py``,
+``tests/bats/_stack_aware_helpers.py``, ``tests/repo/_repo_root.py``).
+
+``SCRIPTS_DIR`` resolves the mutation-testing skill's scripts directory so
+each test module can put it on ``sys.path`` before importing the module
+under test. ``FORBIDDEN_LITERALS`` is the shared list of repo-specific
+literals (ACI project/tooling names) those modules must never leak into
+their source — mirrors the list originally defined in
+``test_mutation_kill_loop.py`` (issue #1554).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "dev-team"
+    / "skills"
+    / "mutation-testing"
+    / "scripts"
+)
+
+FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]

--- a/tests/scripts/test_mutation_baseline_reuse.py
+++ b/tests/scripts/test_mutation_baseline_reuse.py
@@ -16,15 +16,8 @@ import sys
 from pathlib import Path
 
 import pytest
+from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
 
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_baseline_reuse as mbr
@@ -544,7 +537,6 @@ def test_cli_mark_consumed_success_false_with_error_on_forced_write_failure(
 def test_module_source_carries_no_repo_specific_literal():
     source = (SCRIPTS_DIR / "mutation_baseline_reuse.py").read_text(encoding="utf-8")
 
-    forbidden = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
-    present = [lit for lit in forbidden if lit in source]
+    present = [lit for lit in FORBIDDEN_LITERALS if lit in source]
 
     assert present == [], f"repo-specific literals leaked into module: {present}"

--- a/tests/scripts/test_mutation_feasibility_gate.py
+++ b/tests/scripts/test_mutation_feasibility_gate.py
@@ -5,18 +5,10 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 
 import pytest
+from _mutation_test_helpers import SCRIPTS_DIR
 
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_feasibility_gate as gate

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -22,23 +22,14 @@ import sys
 from pathlib import Path
 
 import pytest
+from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
 
 # Ensure the module's dir is on the path so we can import it directly.
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_kill_headless  # module-split literal check below
 import mutation_kill_insert  # module-split literal check below
 import mutation_kill_loop as loop
-
-FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -13,20 +13,11 @@ import sys
 from pathlib import Path
 
 import pytest
+from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
 
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_kill_loop_python as loop
-
-FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_report.py
+++ b/tests/scripts/test_mutation_report.py
@@ -18,16 +18,9 @@ import sys
 from pathlib import Path
 
 import pytest
+from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
 
 # Ensure the module's dir is on the path so we can import it directly.
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_report
@@ -341,12 +334,5 @@ def test_file_discovery_helpers_are_empty_for_absent_report(tmp_path: Path):
 def test_module_source_carries_no_repo_specific_literal():
     source = (SCRIPTS_DIR / "mutation_report.py").read_text(encoding="utf-8")
 
-    forbidden = [
-        "Aci.Speedpay",
-        "Controllers",
-        "AwesomeAssertions",
-        "Moq",
-        "AutoFixture",
-    ]
-    present = [literal for literal in forbidden if literal in source]
+    present = [literal for literal in FORBIDDEN_LITERALS if literal in source]
     assert present == [], f"repo-specific literals leaked into module: {present}"

--- a/tests/scripts/test_mutation_report_mutmut.py
+++ b/tests/scripts/test_mutation_report_mutmut.py
@@ -11,16 +11,9 @@ child, and a killed (or suspicious-but-ignored) mutant carries neither.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugins"
-    / "dev-team"
-    / "skills"
-    / "mutation-testing"
-    / "scripts"
-)
+from _mutation_test_helpers import SCRIPTS_DIR
+
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import mutation_report


### PR DESCRIPTION
## Summary
- Adds `tests/scripts/_mutation_test_helpers.py` exporting `SCRIPTS_DIR`/`FORBIDDEN_LITERALS`, removing the duplicated path-resolution and forbidden-literal boilerplate previously re-declared in six `test_mutation_*.py` modules.
- Named with a leading underscore (not `conftest.py`) to match this repo's existing convention for cross-directory test helper modules (`tests/agents/_plugin_dirs.py`, `tests/bats/_stack_aware_helpers.py`, `tests/repo/_repo_root.py`) and to avoid ambiguity with pytest's own conftest.py fixture-discovery mechanism — this file is a plain importable module, not a pytest plugin.
- `pytest.ini` gains `tests/scripts` on `pythonpath` so the bare `from _mutation_test_helpers import ...` resolves under `--import-mode=importlib`.

Reviewed inline by `test-review` and `structure-review` before commit; both independently flagged the initial `conftest.py` naming as a high-confidence issue, which was fixed prior to this PR (renamed to `_mutation_test_helpers.py`).

Follow-up noted but out of scope here: `tests/scripts/test_stryker_shard_pipeline.py`, `test_stryker_shard_setup.py`, and `test_xunit_v3_feature_detector.py` still hand-roll the same `SCRIPTS_DIR`/`FORBIDDEN_LITERALS` boilerplate — worth a fast-follow issue.

## Test plan
- [x] `python3 -m pytest tests/scripts -q` — 906 passed, 3 skipped
- [x] Full pre-push gate (`scripts/ci-local.sh`, includes full pytest across `plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts`) — all checks passed, 5490 passed / 1 skipped

Closes #1554
Part of #1566