### PR TITLE
test(mutation-kill): dedupe section-extractor in test_mutation_kill_agent.py

### DIFF
--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -155,19 +155,14 @@ def test_parallel_flag_documented_as_invocation_flag_with_agent_tool_fanout(
 
 
 def test_parallel_and_concurrency_interaction_rule_specified(text: str) -> None:
-    lines = text.splitlines()
-    start = None
-    end = len(lines)
-    for i, line in enumerate(lines):
-        if start is None and re.match(r"^## Parallel execution", line):
-            start = i + 1
-            continue
-        if start is not None and re.match(r"^## [^P]", line):
-            end = i
-            break
-    assert start is not None, "Parallel execution section not found"
-    section = "\n".join(lines[start:end])
-    assert re.search(r"concurrency", section, re.IGNORECASE)
+    parallel_section = section(
+        text,
+        r"^## Parallel execution",
+        boundary_pattern=r"^## ",
+        include_start_line=False,
+    )
+    assert parallel_section, "Parallel execution section not found"
+    assert re.search(r"concurrency", parallel_section, re.IGNORECASE)
 
 
 def test_infrastructure_exclusion_thresholds_patterns_and_log_format(


### PR DESCRIPTION
## Summary
- `test_parallel_and_concurrency_interaction_rule_specified` now calls the shared `section()` helper (already imported/used elsewhere in the file) instead of a hand-rolled section-extraction loop, removing the shadowed `section` local variable.

Closes #1547

## Test plan
- [x] `python3 -m pytest tests/agents/test_mutation_kill_agent.py -q` — 53 passed
- [x] Full `ci-local.sh` pre-push gate green (5570 passed, 1 skipped)
- [x] 4-agent code-review fast-path (security/correctness/spec-compliance/doc-review) — all pass