### PR TITLE
fix(mutation-kill): add missing subprocess timeouts, fix xdist races, clamp budget_seconds

### DIFF
--- a/docs/python-hook-contract.md
+++ b/docs/python-hook-contract.md
@@ -99,6 +99,10 @@ Claude Code or by the plugin's own settings.json:
   `1` routes to the `.py` port.
 - `MUTATION_SMOKE_GATE_SKIP` — hook-specific escape hatch (see the
   smoke-gate hook).
+- `DEV_TEAM_VERSION_CHECK_CACHE_DIR` — overrides `version_check.py`'s daily
+  cache directory (default `/tmp`). Test-only escape hatch (#1574) so pytest
+  can give each worker/run its own cache path instead of racing on the one
+  real, shared `/tmp` file; production callers never set it.
 
 A hook MUST NOT depend on any variable not listed here without adding it
 to this doc. That is the mechanism that keeps parity fixtures reproducible

--- a/plugins/dev-team/hooks/version_check.py
+++ b/plugins/dev-team/hooks/version_check.py
@@ -17,6 +17,7 @@ Stdlib-only. Python 3.8+. See docs/python-hook-contract.md.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from datetime import datetime
@@ -31,8 +32,14 @@ def _cache_dir() -> Path:
     MSYS-mounted temp directory, so the same literal is portable across the
     three platforms this port targets. Byte-parity with the .sh requires
     the same literal here.
+
+    ``DEV_TEAM_VERSION_CHECK_CACHE_DIR``, when set, overrides this — a
+    test-only escape hatch (#1574) so pytest can give each worker/run its
+    own cache path instead of racing on the one real, shared `/tmp` file.
+    Production callers never set it, so real behavior is unchanged.
     """
-    return Path("/tmp")
+    override = os.environ.get("DEV_TEAM_VERSION_CHECK_CACHE_DIR")
+    return Path(override) if override else Path("/tmp")
 
 
 def _today_cache_file() -> Path:

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_feasibility_gate.py
@@ -52,6 +52,18 @@ WAIVER_MESSAGE = (
 )
 
 
+def _clamp_budget_seconds(budget_seconds: float) -> float:
+    """Clamp a non-positive budget back to ``DEFAULT_ROUND_BUDGET_SECONDS``.
+
+    Shared by :func:`resolve_budget_seconds` (env-sourced) and
+    :func:`decide` (an explicit ``budget_seconds``/``--budget-seconds``
+    override) so a non-positive value is treated identically regardless of
+    which path it arrived by (#1549) — an explicit ``0``/negative override
+    no longer silently bypasses the clamp and forces ``ASK_OPERATOR`` on
+    every invocation."""
+    return budget_seconds if budget_seconds > 0 else DEFAULT_ROUND_BUDGET_SECONDS
+
+
 def resolve_budget_seconds(env: dict | None = None) -> float:
     """The per-round wall-clock ceiling — ``DEFAULT_ROUND_BUDGET_SECONDS``
     unless ``DEV_TEAM_MUTATION_ROUND_BUDGET_SECONDS`` overrides it. A
@@ -64,7 +76,7 @@ def resolve_budget_seconds(env: dict | None = None) -> float:
         val = float(raw)
     except (TypeError, ValueError):
         return DEFAULT_ROUND_BUDGET_SECONDS
-    return val if val > 0 else DEFAULT_ROUND_BUDGET_SECONDS
+    return _clamp_budget_seconds(val)
 
 
 def estimate_round_seconds(probe_seconds: float, scope_file_count: int) -> float:
@@ -119,6 +131,8 @@ def decide(probe: ProbeResult, *, budget_seconds: float | None = None) -> Decisi
     """
     if budget_seconds is None:
         budget_seconds = resolve_budget_seconds()
+    else:
+        budget_seconds = _clamp_budget_seconds(budget_seconds)
 
     if probe.shim_declined:
         return Decision(

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -33,6 +33,10 @@ from mutation_kill_loop import (
 # helpers, this subprocess routinely runs for tens of seconds to minutes.
 CLAUDE_GENERATION_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_GENERATION_TIMEOUT_S", 300)
 
+# Timeout for the `claude --version` availability probe — small, since it's
+# a startup check, not a generation call.
+CLAUDE_VERSION_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_VERSION_TIMEOUT_S", 30)
+
 # The Claude CLI binary. Overridable via CLAUDE_BIN so a non-PATH install can
 # be pointed at without editing this module.
 CLAUDE_CLI = os.environ.get("CLAUDE_BIN", "claude")
@@ -135,9 +139,13 @@ def claude_cli_available() -> bool:
     """True if the Claude CLI responds to ``--version``."""
     try:
         result = subprocess.run(
-            [CLAUDE_CLI, "--version"], capture_output=True, text=True, check=False
+            [CLAUDE_CLI, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=CLAUDE_VERSION_TIMEOUT_S,
         )
-    except (FileNotFoundError, OSError):
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -89,6 +89,10 @@ def _timeout_from_env(name: str, default: int) -> int:
 STRYKER_RUN_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_STRYKER_TIMEOUT_S", 3600)
 DOTNET_BUILD_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_BUILD_TIMEOUT_S", 600)
 DOTNET_TEST_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_TEST_TIMEOUT_S", 600)
+# 30s matches this codebase's other git-shelling helper
+# (mutation_baseline_reuse.py's ``_run_git``) — near-instant local git
+# operations against a repo that's presumably already responsive.
+GIT_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_GIT_TIMEOUT_S", 30)
 
 
 # =============================================================================
@@ -299,19 +303,46 @@ def dotnet_test(
 
 def git_revert(test_file: Path, *, cwd: Path | None = None) -> None:
     """Discard working-tree changes to one file (``git checkout -- <file>``)."""
-    subprocess.run(["git", "checkout", "--", str(test_file)], cwd=cwd, check=False)
+    try:
+        subprocess.run(
+            ["git", "checkout", "--", str(test_file)],
+            cwd=cwd,
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git checkout timed out after {GIT_TIMEOUT_S}s reverting "
+            f"{test_file} (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to raise it)\n"
+        )
 
 
 def git_commit(message: str, test_file: Path, *, cwd: Path | None = None) -> bool:
     """Stage and commit only ``test_file``. Returns True on a successful commit."""
-    subprocess.run(["git", "add", str(test_file)], cwd=cwd, check=False)
-    rc = subprocess.run(
-        ["git", "commit", "-m", message],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-        check=False,
-    ).returncode
+    try:
+        # `--` guards against a test_file path that happens to start with
+        # `-` being parsed as a git flag instead of a path (#1584) —
+        # matching git_revert's existing `git checkout --` convention.
+        subprocess.run(
+            ["git", "add", "--", str(test_file)],
+            cwd=cwd,
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+        rc = subprocess.run(
+            ["git", "commit", "-m", message],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        ).returncode
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git add/commit timed out after {GIT_TIMEOUT_S}s for "
+            f"{test_file} (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to raise it)\n"
+        )
+        return False
     return rc == 0
 
 

--- a/plugins/dev-team/tests/hooks/test_destructive_guard.py
+++ b/plugins/dev-team/tests/hooks/test_destructive_guard.py
@@ -38,6 +38,12 @@ def _feed(monkeypatch, payload: dict) -> None:
 
 
 def test_main_warns_on_process_destruction(monkeypatch, capsys):
+    # #1574/#1578: isolate from the real, repo-shared careful-state.json —
+    # every other main()-calling test in this file that exercises the warn
+    # path already does this; these two didn't, so a concurrent session
+    # flipping real careful-mode state mid-run could flip this test from
+    # warn (exit 0) to block (exit 2).
+    monkeypatch.setattr(destructive_guard, "_careful_active", lambda: False)
     _feed(monkeypatch, {"tool_input": {"command": "kill -9 1234"}})
     assert destructive_guard.main() == 0
     out = capsys.readouterr().out
@@ -47,6 +53,7 @@ def test_main_warns_on_process_destruction(monkeypatch, capsys):
 
 
 def test_main_warns_on_permission_escalation(monkeypatch, capsys):
+    monkeypatch.setattr(destructive_guard, "_careful_active", lambda: False)
     _feed(monkeypatch, {"tool_input": {"command": "chmod 777 /etc/passwd"}})
     assert destructive_guard.main() == 0
     out = capsys.readouterr().out

--- a/tests/hooks/test_version_check.py
+++ b/tests/hooks/test_version_check.py
@@ -9,9 +9,13 @@ Covers the observable contract of the daily version-check hook:
      depends on real HEAD vs origin/main).
 
 The .sh (and this .py port) reads the cache from the hard-coded
-`/tmp/adt-version-check-<today>` path — no `${TMPDIR:-/tmp}` fallback. To
-avoid clobbering the developer's real cache, we save-and-restore any
-pre-existing file around each test.
+`/tmp/adt-version-check-<today>` path — no `${TMPDIR:-/tmp}` fallback in
+production. These tests never touch that real, shared path: each test
+points the hook at its own `tmp_path`-scoped cache directory via
+`DEV_TEAM_VERSION_CHECK_CACHE_DIR` (#1574) — worker/run-unique by
+construction, since `tmp_path` is unique per test — so concurrent
+pytest-xdist workers, or an entirely separate concurrent pytest process,
+can never share or race on the file under test.
 """
 
 from __future__ import annotations
@@ -28,45 +32,29 @@ from _repo_root import REPO_ROOT as _REPO_ROOT
 
 _HOOK_PY = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "version_check.py"
 
-# Every test in this file shares one fixed, non-worker-scoped path
-# (/tmp/adt-version-check-<today>, see _cache_path() below) with no per-worker
-# isolation. Under `-n auto`, two of these tests can land on different
-# workers and race each other's read/write of that same file. Force them
-# onto a single worker so they're serialized relative to each other instead
-# (issue #1495) — this trades this file's own internal parallelism for
-# correctness; it does not affect any other file's distribution.
-pytestmark = pytest.mark.xdist_group(name="version-check-shared-cache")
+_HOOKS_DIR = _HOOK_PY.parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import version_check  # type: ignore[import-not-found]
 
 
-def _cache_path() -> Path:
+@pytest.fixture
+def cache_file(tmp_path: Path) -> Path:
+    """This test's own cache file, inside its own `tmp_path` cache dir."""
     # Must match version_check.py's own local-time `today` exactly (it
     # mirrors the ported .sh's `date +%Y-%m-%d`) or the cache path this
     # test reads/writes diverges from the one the hook under test uses.
     today = datetime.now().strftime("%Y-%m-%d")  # noqa: DTZ005
-    return Path("/tmp") / f"adt-version-check-{today}"
+    return tmp_path / f"adt-version-check-{today}"
 
 
-@pytest.fixture
-def restore_cache_file():
-    """Save whatever /tmp/adt-version-check-<today> currently is, restore it
-    after the test — so real user cache is never clobbered."""
-    cache = _cache_path()
-    original = cache.read_bytes() if cache.is_file() else None
-    try:
-        yield cache
-    finally:
-        if original is None:
-            if cache.is_file():
-                cache.unlink()
-        else:
-            cache.write_bytes(original)
-
-
-def _run(stdin: bytes = b"{}") -> subprocess.CompletedProcess:
+def _run(stdin: bytes = b"{}", *, cache_dir: Path) -> subprocess.CompletedProcess:
     env = {
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "LANG": "C.UTF-8",
         "HOME": os.environ.get("HOME", "/tmp"),
+        "DEV_TEAM_VERSION_CHECK_CACHE_DIR": str(cache_dir),
     }
     return subprocess.run(
         [sys.executable, str(_HOOK_PY)],
@@ -78,50 +66,59 @@ def _run(stdin: bytes = b"{}") -> subprocess.CompletedProcess:
     )
 
 
-def test_cache_hit_with_message_echoes_and_exits(
-    restore_cache_file: Path,
-) -> None:
-    restore_cache_file.write_text("cached notice line\n")
-    r = _run()
+def test_cache_hit_with_message_echoes_and_exits(cache_file: Path) -> None:
+    cache_file.write_text("cached notice line\n")
+    r = _run(cache_dir=cache_file.parent)
     assert r.returncode == 0
     assert r.stdout.decode() == "cached notice line\n"
 
 
-def test_cache_hit_empty_is_silent_pass(restore_cache_file: Path) -> None:
-    restore_cache_file.write_text("")
-    r = _run()
+def test_cache_hit_empty_is_silent_pass(cache_file: Path) -> None:
+    cache_file.write_text("")
+    r = _run(cache_dir=cache_file.parent)
     assert r.returncode == 0
     assert r.stdout == b""
 
 
-def test_malformed_stdin_still_consumed(restore_cache_file: Path) -> None:
-    restore_cache_file.write_text("")  # cache-short-circuit past network
-    r = _run(stdin=b"{broken json ")
+def test_malformed_stdin_still_consumed(cache_file: Path) -> None:
+    cache_file.write_text("")  # cache-short-circuit past network
+    r = _run(stdin=b"{broken json ", cache_dir=cache_file.parent)
     assert r.returncode == 0
     assert r.stdout == b""
 
 
-def test_stdin_variants_all_exit_0(restore_cache_file: Path) -> None:
-    restore_cache_file.write_text("")
+def test_stdin_variants_all_exit_0(cache_file: Path) -> None:
+    cache_file.write_text("")
     for payload in (b"", b'{"malformed":', b'{"tool_name":"Read"}'):
-        r = _run(stdin=payload)
+        r = _run(stdin=payload, cache_dir=cache_file.parent)
         assert r.returncode == 0
         assert r.stdout == b""
 
 
-def test_cache_replayed_line_normalization(restore_cache_file: Path) -> None:
+def test_cache_replayed_line_normalization(cache_file: Path) -> None:
     """Bash's `CACHED=$(cat)` strips trailing newlines; `echo` adds exactly one
     back when non-empty. Verify the port matches byte-for-byte."""
-    restore_cache_file.write_text("notice\n\n\n")  # trailing whitespace
-    r = _run()
+    cache_file.write_text("notice\n\n\n")  # trailing whitespace
+    r = _run(cache_dir=cache_file.parent)
     assert r.returncode == 0
     assert r.stdout == b"notice\n"
 
 
-def test_cache_with_multi_line_message(restore_cache_file: Path) -> None:
+def test_cache_with_multi_line_message(cache_file: Path) -> None:
     """A multi-line cache is echoed with each line preserved (bash `echo` on
     a multi-line variable emits the whole thing plus one trailing LF)."""
-    restore_cache_file.write_text("line1\nline2")
-    r = _run()
+    cache_file.write_text("line1\nline2")
+    r = _run(cache_dir=cache_file.parent)
     assert r.returncode == 0
     assert r.stdout == b"line1\nline2\n"
+
+
+def test_cache_dir_falls_back_to_real_tmp_when_override_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every other test in this file always sets DEV_TEAM_VERSION_CHECK_CACHE_DIR
+    (#1574) to avoid the real, shared /tmp path — which means the actual
+    production default (what every real user hits) went untested as a side
+    effect. Pin it directly, without touching the real cache file."""
+    monkeypatch.delenv("DEV_TEAM_VERSION_CHECK_CACHE_DIR", raising=False)
+    assert version_check._cache_dir() == Path("/tmp")

--- a/tests/scripts/test_mutation_feasibility_gate.py
+++ b/tests/scripts/test_mutation_feasibility_gate.py
@@ -239,3 +239,27 @@ def test_cli_budget_flag_wiring(capsys):
     assert payload["outcome"] == gate.Outcome.ASK_OPERATOR.value
     assert "budget" in payload["reason"]
     assert payload["waiver"] is None
+
+
+def test_cli_explicit_nonpositive_budget_is_clamped_not_passed_through(capsys):
+    # #1549: `--budget-seconds 0` used to reach decide() unclamped (argparse
+    # sets 0.0, not None, so the `budget_seconds is None` branch never fired),
+    # forcing ASK_OPERATOR regardless of how fast the probe was. A fast probe
+    # with an explicit non-positive override must now enter the loop, exactly
+    # as it would with no --budget-seconds flag at all.
+    rc = gate._cli(
+        ["--probe-seconds", "1", "--scope-files", "1", "--budget-seconds", "0"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["outcome"] == gate.Outcome.ENTER_LOOP.value
+    assert payload["budget_seconds"] == gate.DEFAULT_ROUND_BUDGET_SECONDS
+
+
+def test_decide_clamps_an_explicit_negative_budget_seconds():
+    probe = gate.ProbeResult(
+        shim_declined=False, capture_failed=False, probe_seconds=1.0, scope_file_count=1
+    )
+    decision = gate.decide(probe, budget_seconds=-5.0)
+    assert decision.outcome is gate.Outcome.ENTER_LOOP
+    assert decision.budget_seconds == gate.DEFAULT_ROUND_BUDGET_SECONDS

--- a/tests/scripts/test_mutation_kill_headless.py
+++ b/tests/scripts/test_mutation_kill_headless.py
@@ -321,3 +321,31 @@ def test_claude_cli_available_reflects_subprocess_outcome(
 
     monkeypatch.setattr(headless.subprocess, "run", _missing)
     assert headless.claude_cli_available() is False
+
+
+def test_claude_cli_available_passes_a_timeout(monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+
+    class _OK:
+        returncode = 0
+
+    def fake_run(*a, **k):
+        captured.update(k)
+        return _OK()
+
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
+
+    headless.claude_cli_available()
+
+    assert captured["timeout"] == headless.CLAUDE_VERSION_TIMEOUT_S
+
+
+def test_claude_cli_available_treats_a_timeout_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fake_run(*a, **k):
+        raise headless.subprocess.TimeoutExpired(a[0] if a else [], k.get("timeout"))
+
+    monkeypatch.setattr(headless.subprocess, "run", fake_run)
+
+    assert headless.claude_cli_available() is False

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -739,6 +739,71 @@ def test_git_revert_checks_out_only_the_test_file(
 
 
 # =============================================================================
+# Scenario: A hung `git checkout`/`git add`/`git commit` is bounded by a
+# timeout, not left to hang the loop forever (#1572 — same class of fix as
+# #1558's dotnet_build/dotnet_test/Stryker timeouts).
+# =============================================================================
+def test_git_revert_passes_a_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: captured.update(k))
+
+    loop.git_revert(tmp_path / "PaymentServiceTests.cs")
+
+    assert captured["timeout"] == loop.GIT_TIMEOUT_S
+
+
+def test_git_revert_timeout_is_logged_not_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.git_revert(tmp_path / "PaymentServiceTests.cs")  # must not raise
+
+    err = capsys.readouterr().err
+    assert str(loop.GIT_TIMEOUT_S) in err
+    assert "DEV_TEAM_MUTATION_GIT_TIMEOUT_S" in err
+
+
+def test_git_commit_passes_a_timeout_to_add_and_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.git_commit("msg", tmp_path / "PaymentServiceTests.cs")
+
+    assert calls[0][0] == ["git", "add", "--", str(tmp_path / "PaymentServiceTests.cs")]
+    assert calls[0][1]["timeout"] == loop.GIT_TIMEOUT_S
+    assert calls[1][0][:2] == ["git", "commit"]
+    assert calls[1][1]["timeout"] == loop.GIT_TIMEOUT_S
+
+
+def test_git_commit_timeout_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_commit("msg", tmp_path / "PaymentServiceTests.cs") is False
+    err = capsys.readouterr().err
+    assert str(loop.GIT_TIMEOUT_S) in err
+    assert "DEV_TEAM_MUTATION_GIT_TIMEOUT_S" in err
+
+
+# =============================================================================
 # Scenario: `python mutation_kill_loop.py --headless ...` — the real
 # subprocess entry point stryker_shard_pipeline.py invokes by filename —
 # dispatches to mutation_kill_headless.main() without double-loading this


### PR DESCRIPTION
## Summary
- `git_revert`/`git_commit`/`claude_cli_available` now bound their `subprocess.run` calls with a timeout, mirroring #1558's `dotnet_build`/`dotnet_test`/Stryker pattern. `git_commit`'s `git add` also gained the `--` path separator `git_revert`'s `git checkout --` already used — this closes the `mutation_kill_loop.py` half of #1584's security finding; the `mutation_kill_loop_python.py` sibling still needs the same guard (tracked separately, see #1580/#1583/#1584).
- `test_version_check.py` now isolates each test with its own `tmp_path`-scoped cache dir via a new `DEV_TEAM_VERSION_CHECK_CACHE_DIR` test-only override (documented in `docs/python-hook-contract.md`), replacing the `xdist_group` mitigation that didn't protect against a separate concurrent pytest process touching the same real `/tmp` file.
- `test_destructive_guard.py`'s two warn-path tests now monkeypatch `_careful_active`, matching every other `main()`-calling test in the file.
- `mutation_feasibility_gate.decide()` now clamps an explicit non-positive `budget_seconds` the same way `resolve_budget_seconds()` already clamps an env-sourced one, via a shared `_clamp_budget_seconds()` helper.

Closes #1572
Closes #1574
Closes #1578
Closes #1549

## Test plan
- [x] Full `ci-local.sh` pre-push gate green (5579 passed, 1 skipped)
- [x] Targeted files re-run standalone and under `-n auto --dist loadgroup` to confirm the xdist races are actually closed
- [x] 17-agent code-review panel run twice (first pass + corroboration pass on the final diff after fixing every finding) — all pass, no outstanding actionable issues