### PR TITLE
docs: document TaskCreate/ScheduleWakeup tool contracts + parallel-build git-race guidance

### DIFF
--- a/docs/using-plugin-skills-in-the-web-environment.md
+++ b/docs/using-plugin-skills-in-the-web-environment.md
@@ -71,6 +71,11 @@ tool surface from the surrounding Remote runtime. The two tell-tale symptoms:
 - **Remote-injected tool surface** — the nested run sees Remote-runtime tools
   (`CronCreate`, `PushNotification`, `ScheduleWakeup`, etc.) that a local CLI
   session would never expose, changing the tool set under test.
+  `ScheduleWakeup`'s own calling contract is worth knowing if you ever touch
+  one of these tools directly: it requires `prompt` (and `reason`) on every
+  call unless `stop: true` is passed instead — there is no "just wait, no
+  prompt" shape. This is upstream Remote-runtime tool-contract behavior, not
+  anything this plugin defines or can wrap.
 
 This inheritance is an **upstream Claude Code / Remote-runtime behavior — it is
 not fixable in this plugin repo** (no plugin setting, hook, or config removes the

--- a/plugins/dev-team/skills/test-improve/SKILL.md
+++ b/plugins/dev-team/skills/test-improve/SKILL.md
@@ -527,6 +527,18 @@ operator. **Phase 5 does not run** until the operator approves the set.
 
 Iterate the approved Phase-5 Story set. For **each Story**:
 
+**Never dispatch multiple Stories' build loops in parallel against one shared
+working tree (issue #1571).** Each Story's step 1 runs `/build`, which
+`git add`/`git commit`s as it goes — two or more concurrent dispatches
+against the same checkout race on the index and working files, and that race
+is real: it has produced observed data loss (reverted test files, deleted
+`.feature` files) even when the assigned files looked disjoint, because git
+index/commit operations aren't file-scoped the way file edits are. Process
+Stories one at a time in this session, or — if you fan out multiple Stories
+concurrently via the `Agent` tool — dispatch every one of them with
+`isolation: "worktree"` so each gets its own git working tree; disjoint file
+assignment alone is not a substitute for worktree isolation here.
+
 1. **Build** — invoke `/build <story-id>`. `/build` inherits the **no-refactor**
    mode from Phase 0: production-code changes are **rejected**. A Story that
    would require a production-code change is surfaced as a REFACTOR_REQUIRED
@@ -683,6 +695,11 @@ corresponding Phase-5 baseline Story that could not close under no-refactor.
 Before `/build` runs a Phase-7 Story, `/test-improve` **verifies the paired
 Phase-5 Story is closed and green**. A missing or failing Phase-5 baseline
 halts that Story until the operator resolves it.
+
+**Phase 5's parallel-dispatch warning (issue #1571) applies equally here** —
+Phase 7 runs the same per-Story `/build` loop against the same shared
+working tree; never dispatch multiple Phase-7 Stories' build loops
+concurrently without `isolation: "worktree"` on every dispatch.
 
 **End-of-phase review loop.** After all Phase-7 Stories close, run the
 **same review loop as Phase 5** (see the Phase 5 end-of-phase review loop

--- a/plugins/marketplace-dev/skills/agent-skill-authoring/SKILL.md
+++ b/plugins/marketplace-dev/skills/agent-skill-authoring/SKILL.md
@@ -105,3 +105,4 @@ New or updated `$PLUGIN/skills/*/SKILL.md` file(s) with all registry tables and 
 | Agent without Skills section | All knowledge is inline, nothing is reusable | Identify extractable capabilities |
 | Overly broad skill | Tries to cover too much, hard to reference precisely | Split into focused skills |
 | Hand-authoring an agent file | Drifts from the schema enforced by /plugin-audit | Use /agent-add (invokes the agent-create skill) |
+| Deferred tool called before its schema loads | Assumed shape (e.g. batched `TaskCreate`) fails with `InputValidationError` | Call `ToolSearch("select:<ToolName>")` first; state the real per-call contract |


### PR DESCRIPTION
## Summary
- New anti-pattern row in `agent-skill-authoring/SKILL.md`: skills must call `ToolSearch("select:<ToolName>")` before instructing a deferred tool call, since the real per-call contract is unknown until then (the `TaskCreate` batched-array footgun).
- Documented `ScheduleWakeup`'s prompt-required-unless-stop calling contract in `docs/using-plugin-skills-in-the-web-environment.md`.
- `test-improve/SKILL.md`: added an explicit warning against dispatching multiple Stories' `/build` loops in parallel against one shared working tree, in both Phase 5 (where the bug was first observed — real data loss: reverted test files, deleted `.feature` files) and Phase 7 (which runs the identical per-Story `/build` loop pattern and had no equivalent guardrail).

Closes #1546
Closes #1548
Closes #1571

## Test plan
- [x] Full `ci-local.sh` pre-push gate green (5579 passed, 1 skipped)
- [x] Content-guard tests for the touched skill/doc files pass
- [x] Knowledge index rebuilt (no diff — body-text-only edits)
- [x] 4-agent code-review fast-path, plus 2 corroboration rounds after tightening one finding (anti-pattern row length) and closing a gap a reviewer found (Phase 7 missing the #1571 cross-reference) — all pass