### PR TITLE
fix(mutation-kill): scope git commit/revert integrity, sanitize sln path, harden survivor-kill loop

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -347,7 +347,14 @@ owns everything mechanical:
 - **Verify + revert.** The loop builds, then runs the scoped test class. If the
   build or the scoped test run fails after insertion it reverts
   (`git checkout -- <test-file>`), logs the failure, and stops the file — never
-  leaving a broken or non-compiling test file behind.
+  leaving a broken or non-compiling test file behind. A commit failure gets the
+  matching **unstage + restore** revert (`git reset -q HEAD -- <test-file>` then
+  `git checkout -- <test-file>`), because `git add` already staged the file before
+  the commit attempt failed — a plain checkout alone would restore from that
+  still-staged, still-mutated index, not HEAD. **A revert that itself fails (after
+  any of these three failure kinds) is fatal**, not silently absorbed: the loop
+  raises and aborts the file rather than continuing with the working tree in an
+  unknown state (#1598).
 - **No-improvement exit.** A round whose `survivors >= prev_survivors` does not
   reduce survivors, so the loop stops that file. This mandatory exit is what keeps
   the loop from looping forever chasing the same survivors — never loop

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -263,20 +263,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
 
-    run_for_file(
-        args.file,
-        RunContext(
-            config=load_loop_config(Path(args.config)),
-            test_file=Path(args.test_file),
-            source_path=Path(args.source_path),
-            output_dir=Path(args.output),
-            stryker_bin=args.stryker_bin,
-            initial_report_path=Path(args.report) if args.report else None,
-            generator_label=f"headless ({model or 'default'})",
-        ),
-        generate=make_headless_generator(model),
-        max_rounds=args.max_rounds,
-    )
+    try:
+        run_for_file(
+            args.file,
+            RunContext(
+                config=load_loop_config(Path(args.config)),
+                test_file=Path(args.test_file),
+                source_path=Path(args.source_path),
+                output_dir=Path(args.output),
+                stryker_bin=args.stryker_bin,
+                initial_report_path=Path(args.report) if args.report else None,
+                generator_label=f"headless ({model or 'default'})",
+            ),
+            generate=make_headless_generator(model),
+            max_rounds=args.max_rounds,
+        )
+    except RuntimeError as exc:
+        # A failed revert or a failed-commit round-abandonment raises
+        # RuntimeError (#1598) — without this, that either propagated as a
+        # raw traceback or (before the fix) was silently absorbed and this
+        # CLI still exited 0. Fits the existing 1/2/3 exit-code taxonomy
+        # above with the next unused code.
+        sys.stderr.write(f"error: {exc}\n")
+        return 4
     return 0
 
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_insert.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_insert.py
@@ -131,14 +131,24 @@ def _find_block_namespace_class_close(lines: Sequence[str]) -> int | None:
     return None
 
 
-def insert_before_class_close(test_file: Path, new_methods: str) -> None:
+def insert_before_class_close(test_file: Path, new_methods: str, text: str) -> None:
     """Insert ``new_methods`` before the test class's closing brace.
 
     Raises :class:`InsertionRefused` for a file-scoped namespace or any
     non-4-space-indented class the heuristic can't safely locate. The file is
     left untouched on refusal.
+
+    ``text`` is the current test-file content, already read by the caller
+    (:func:`apply_generated_methods`) — this function performs no read of its
+    own. A previous, optional ``test_text=`` shape let a caller pass in
+    content that bypassed reading the file's CURRENT state (including this
+    function's own refusal-guard check running against stale content rather
+    than what's actually on disk) — a real hazard even though no caller
+    exploited it. Removing the optional/None-triggered-fallback shape closes
+    that off: freshness is now entirely ``apply_generated_methods``'s
+    responsibility, which reads immediately before calling this (#1598/#1584
+    review, item 7).
     """
-    text = test_file.read_text(encoding="utf-8")
     if _FILE_SCOPED_NS_RE.search(text):
         raise InsertionRefused(
             f"refusing to insert into {test_file.name}: file-scoped namespace "
@@ -169,6 +179,18 @@ def apply_generated_methods(test_file: Path, new_methods: str) -> InsertOutcome:
     Returns an :class:`InsertOutcome`; the file is only ever written on the
     ``inserted=True`` path. Empty generation, an unsafe pattern, duplicate
     method names, and a refused insert all leave the file untouched.
+
+    Reads ``test_file`` exactly once here — immediately before the
+    duplicate-name check — and reuses that single fresh read for both the
+    check and the write (passed through to :func:`insert_before_class_close`,
+    which performs no read of its own). A prior shape let the caller (e.g.
+    ``_run_round``) thread in its OWN already-read ``test_text`` for the
+    duplicate check — but that text was read *before* the possibly
+    multi-minute ``generate()`` call, so the check ran against a stale
+    snapshot: a method name added to the file during generation (by another
+    process, or a second concurrent round) would go undetected as a
+    duplicate. Reading fresh here, after ``generate()`` has already
+    returned, closes that gap (#1598/#1584 review, item 7).
     """
     if not new_methods.strip():
         return InsertOutcome(False, "no methods generated")
@@ -177,12 +199,14 @@ def apply_generated_methods(test_file: Path, new_methods: str) -> InsertOutcome:
     if unsafe_categories:
         return InsertOutcome(False, f"refused — unsafe pattern(s): {unsafe_categories}")
 
-    dupes = detect_duplicate_methods(test_file.read_text(encoding="utf-8"), new_methods)
+    text = test_file.read_text(encoding="utf-8")
+
+    dupes = detect_duplicate_methods(text, new_methods)
     if dupes:
         return InsertOutcome(False, f"duplicate method names: {dupes}")
 
     try:
-        insert_before_class_close(test_file, new_methods)
+        insert_before_class_close(test_file, new_methods, text)
     except InsertionRefused as exc:
         return InsertOutcome(False, str(exc))
     return InsertOutcome(True, "inserted")

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -124,12 +124,16 @@ def _run_with_timeout(
     cwd: Path | None = None,
     capture_output: bool = False,
     text: bool = False,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess | None:
     """Run ``argv`` with a bounded timeout. On ``TimeoutExpired``, logs to
     stderr and returns ``None`` instead of raising, so ``dotnet_build``,
     ``dotnet_test``, ``git_revert``, and ``git_commit`` share one timeout/log
     shape instead of four copies (#1593). No ``shell``/``**kwargs``
-    passthrough: every ``argv`` runs as a list, never through a shell."""
+    passthrough: every ``argv`` runs as a list, never through a shell.
+    ``env`` defaults to ``None`` (inherit the ambient process environment,
+    today's behavior) — tests pass a scrubbed env to keep real-git regression
+    tests hermetic (#1598/#1584 review, item 4 follow-up)."""
     try:
         return subprocess.run(
             argv,
@@ -138,6 +142,7 @@ def _run_with_timeout(
             capture_output=capture_output,
             text=text,
             check=False,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         sys.stderr.write(
@@ -220,6 +225,54 @@ def _write_scoped_config(config: LoopConfig, source_file: str) -> Path:
     return path
 
 
+def _validate_solution_path(solution: str, *, cwd: Path | None = None) -> Path:
+    """Reject a ``stryker-config.json`` ``solution`` value that would escape
+    the working tree once used to derive ``sln_hidden``, and return the
+    resolved, validated absolute path.
+
+    ``solution`` is read verbatim from ``stryker-config.json`` and, before
+    this check existed, was concatenated straight into a filename
+    (``f"{config.solution}.stryker-hidden"``) with no validation — a
+    traversal-shaped value (e.g. ``"../../etc/cron.d/evil"``) would let a
+    hostile config target a file outside the repo if the config is ever read
+    from an untrusted checkout (#1598). Resolves ``solution`` against
+    ``cwd`` (or the current working directory) and rejects it unless the
+    resolved path stays under that root.
+
+    Callers must build ``sln``/``sln_hidden`` from THIS function's return
+    value, not by independently re-deriving ``Path(config.solution)`` — the
+    latter resolves against the *process* working directory when
+    ``wrapper.hide_sln``/``restore_sln``'s bare ``Path.rename()`` runs, not
+    against ``cwd`` (which only ever reaches ``subprocess.run``), so the
+    validated path and the actually-renamed path could silently diverge
+    whenever a caller passes a ``cwd`` different from the real process cwd
+    (caught in #1598/#1584 review).
+
+    **Requires a relative ``solution``; an absolute value is rejected in
+    every practical case (#1598/#1584 review, item 11).** ``pathlib``'s ``/``
+    operator silently discards ``base`` outright when the right-hand operand
+    is itself absolute (``base / "/etc/passwd" == Path("/etc/passwd")``), so
+    ``candidate`` becomes that absolute value verbatim — not "``base`` plus
+    the absolute path" as the name might suggest. The ``relative_to(base)``
+    check below then rejects it as escaping, UNLESS the absolute value
+    happens to already lie under ``base`` (a degenerate case with no
+    practical use, since a relative value achieves the same result without
+    depending on ``base``'s exact prefix). This narrows what a bare
+    ``Path(config.solution)`` used to accept before this validation existed
+    — an absolute ``solution`` is not a supported input; pass a
+    repo-relative path.
+    """
+    base = (cwd or Path.cwd()).resolve()
+    candidate = (base / solution).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        raise ValueError(
+            f"stryker-config.json 'solution' escapes the working tree: {solution!r}"
+        ) from None
+    return candidate
+
+
 def run_scoped_stryker(
     config: LoopConfig,
     source_file: str,
@@ -244,9 +297,39 @@ def run_scoped_stryker(
     assert dotnet_root is not None
     env = {**os.environ, "DOTNET_ROOT": dotnet_root}
 
+    sln: Path | None = None
+    if config.solution:
+        # Use the validated, resolved path for BOTH the check and the actual
+        # rename below — never re-derive a second, independently-resolved
+        # Path(config.solution) (#1598/#1584 review: the two could diverge).
+        sln = _validate_solution_path(config.solution, cwd=cwd)
+
     config_path = _write_scoped_config(config, source_file)
-    sln = Path(config.solution) if config.solution else None
-    sln_hidden = Path(f"{config.solution}.stryker-hidden") if config.solution else None
+    # Fixed name, no PID suffix. A PID-suffixed name was tried (#1584) to
+    # guard two processes scoped-running Stryker against the same solution
+    # concurrently, but reverted after review: stryker_shard_pipeline.py
+    # runs shards sequentially, not concurrently (see its own module
+    # docstring), so that race doesn't exist today — and a PID-suffixed name
+    # is invisible to csharp_stryker_net_wrapper.py's check_stale_hidden_sln()
+    # crash-recovery, which looks for the exact literal ".stryker-hidden"
+    # suffix, so a crashed run would leave an orphaned hidden .sln that
+    # existing recovery can no longer find or restore. If true concurrent
+    # execution is ever introduced, add uniqueness at the
+    # csharp_stryker_net_wrapper level (shared with
+    # csharp_stryker_net_slice_runner.py) with a matching update to
+    # check_stale_hidden_sln's stale-file scan.
+    sln_hidden = Path(f"{sln}.stryker-hidden") if sln is not None else None
+    if sln is not None and sln_hidden is not None:
+        # Crash-recovery refusal (#1598/#1584 review, item 6): the wrapper's
+        # own main() and csharp_stryker_net_slice_runner.py both call this
+        # before hide_sln — a stale hidden .sln left over from a prior crash
+        # is exactly what the fixed (no-PID) hidden-filename choice above is
+        # meant to make findable by this check. This caller never wired it
+        # in, silently skipping the recovery it depends on.
+        stale_err = wrapper.check_stale_hidden_sln(sln, sln_hidden)
+        if stale_err is not None:
+            config_path.unlink(missing_ok=True)
+            raise RuntimeError(stale_err)
     try:
         if sln is not None and sln_hidden is not None:
             wrapper.hide_sln(sln, sln_hidden)
@@ -254,8 +337,7 @@ def run_scoped_stryker(
             # Deliberately not routed through _run_with_timeout: a Stryker
             # timeout aborts the whole file (raise), it doesn't return a
             # None-means-failure signal for a caller to revert-and-continue
-            # like dotnet_build/dotnet_test/git_revert/git_commit do. This
-            # call also needs `env=`, which _run_with_timeout doesn't accept.
+            # like dotnet_build/dotnet_test/git_revert/git_commit do.
             subprocess.run(
                 [
                     stryker_bin,
@@ -311,6 +393,28 @@ def dotnet_build(targets: Sequence[str], *, cwd: Path | None = None) -> bool:
     return True
 
 
+# Capital-F "Failed:" only — a per-assembly `dotnet test` summary line, NOT
+# the newer SDK's trailing lowercase rollup ("Test summary: ... failed: 0 ...").
+# Kept case-sensitive (no re.IGNORECASE) deliberately: matching the rollup
+# line too would double-count every assembly's failures on top of the
+# rollup's own total (#1598/#1584 review, item 12 — see
+# test_sum_failed_counts_is_case_sensitive_not_double_counting_the_rollup_line
+# for a fixture that actually distinguishes the two, unlike a fixture where
+# both a correct and a buggy (case-insensitive) scan sum to 0).
+_FAILED_COUNT_RE = re.compile(r"Failed:\s*(\d+)")
+
+
+def _sum_failed_counts(text: str) -> int:
+    """Sum every capital-F "Failed: N" occurrence in ``text``.
+
+    Accumulates, not overwrites: a multi-assembly `dotnet test` run prints
+    one "Failed: N" line per assembly, and a last-match-wins scan would let
+    an early assembly's failures be silently masked by a later, clean
+    assembly's "Failed: 0" line (#1598).
+    """
+    return sum(int(m.group(1)) for m in _FAILED_COUNT_RE.finditer(text))
+
+
 def dotnet_test(
     targets: Sequence[str], test_filter: str, *, cwd: Path | None = None
 ) -> bool:
@@ -336,27 +440,81 @@ def dotnet_test(
         )
         if result is None:
             return False
-        failed = 0
-        for line in (result.stdout + result.stderr).splitlines():
-            match = re.search(r"Failed:\s*(\d+)", line)
-            if match:
-                failed = int(match.group(1))
-        if result.returncode != 0 or failed > 0:
+        if result.returncode != 0 or _sum_failed_counts(result.stdout + result.stderr) > 0:
             return False
     return True
 
 
-def git_revert(test_file: Path, *, cwd: Path | None = None) -> None:
-    """Discard working-tree changes to one file (``git checkout -- <file>``)."""
-    _run_with_timeout(
-        ["git", "checkout", "--", str(test_file)],
+def git_revert(
+    test_file: Path, *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> bool:
+    """Discard working-tree changes to one file (``git checkout -- <file>``).
+
+    Returns True on a successful revert, False on a non-zero exit or a
+    timeout — callers can no longer mistake a failed/timed-out revert for a
+    successful one (#1598); a leftover, uncommitted mutation left on disk
+    after a revert *claims* success is exactly the integrity gap this fixes.
+
+    ``env`` defaults to ``None`` (inherit the ambient environment); tests
+    pass a scrubbed env so this real git subprocess can't be redirected by
+    an inherited ``GIT_DIR``/``GIT_WORK_TREE`` (#1598/#1584 review, item 4
+    follow-up).
+    """
+    result = _run_with_timeout(
+        ["git", "--literal-pathspecs", "checkout", "--", str(test_file)],
         _GIT_TIMEOUT,
         operation_label=f"git checkout reverting {test_file}",
         cwd=cwd,
+        env=env,
     )
+    if result is None:
+        return False
+    return result.returncode == 0
 
 
-def git_commit(message: str, test_file: Path, *, cwd: Path | None = None) -> bool:
+def git_reset_and_revert(
+    test_file: Path, *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> bool:
+    """Unstage AND restore ``test_file`` — the correct revert after a FAILED
+    commit specifically, distinct from :func:`git_revert`.
+
+    ``git_commit`` runs ``git add -- <test_file>`` *before* attempting the
+    commit. If the commit itself then fails, ``test_file`` is left staged
+    with the mutated content. A plain ``git checkout -- <file>`` (what
+    :func:`git_revert` does) restores the working tree **from the index**,
+    which still holds the mutation — so that revert *reports* success while
+    the mutated content survives on disk, staged. This is exactly the
+    integrity gap #1598 was meant to close, still open on this specific path
+    (caught in #1598/#1584 review). Unstaging first
+    (``git reset -q HEAD -- <file>``) before the checkout makes HEAD, the
+    index, and the working tree all agree afterward.
+
+    The build-failure and test-failure revert paths never ran ``git add``,
+    so their index already equals HEAD — they intentionally keep calling
+    plain :func:`git_revert` rather than this function (a reset there would
+    be a harmless no-op, but there's no reason to pay the extra subprocess).
+
+    Returns True only if both the unstage step and the restore step succeed.
+    """
+    reset_result = _run_with_timeout(
+        ["git", "--literal-pathspecs", "reset", "-q", "HEAD", "--", str(test_file)],
+        _GIT_TIMEOUT,
+        operation_label=f"git reset unstaging {test_file}",
+        cwd=cwd,
+        env=env,
+    )
+    if reset_result is None or reset_result.returncode != 0:
+        return False
+    return git_revert(test_file, cwd=cwd, env=env)
+
+
+def git_commit(
+    message: str,
+    test_file: Path,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> bool:
     """Stage and commit only ``test_file``. Returns True on a successful commit.
 
     Mirrors the pre-#1593 behavior of not inspecting ``git add``'s own
@@ -365,21 +523,33 @@ def git_commit(message: str, test_file: Path, *, cwd: Path | None = None) -> boo
     before this extraction."""
     # `--` guards against a test_file path that happens to start with `-`
     # being parsed as a git flag instead of a path (#1584).
+    # `--literal-pathspecs` (right after `git`, #1598/#1584 review, item 5)
+    # forces every pathspec argument below — including this one — to be
+    # treated as a literal path, not a pathspec: `--` alone does NOT disable
+    # pathspec magic (`:/`, `:(exclude)`, `:!`, etc.) for the argument that
+    # follows it, so a test_file value containing those characters could
+    # otherwise silently broaden what a git command actually touches.
     add_result = _run_with_timeout(
-        ["git", "add", "--", str(test_file)],
+        ["git", "--literal-pathspecs", "add", "--", str(test_file)],
         _GIT_TIMEOUT,
         operation_label=f"git add for {test_file}",
         cwd=cwd,
+        env=env,
     )
     if add_result is None:
         return False
+    # Scoped with the same `-- <path>` pathspec as `git add` above: without
+    # it, `git commit -m message` commits the *entire* index, not just
+    # test_file — silently sweeping in whatever else happens to be staged
+    # (#1598).
     commit_result = _run_with_timeout(
-        ["git", "commit", "-m", message],
+        ["git", "--literal-pathspecs", "commit", "-m", message, "--", str(test_file)],
         _GIT_TIMEOUT,
         operation_label=f"git commit for {test_file}",
         capture_output=True,
         text=True,
         cwd=cwd,
+        env=env,
     )
     if commit_result is None:
         return False
@@ -474,48 +644,55 @@ def _score_round(
     return survivors, survivor_count
 
 
-def _run_round(
+def _revert_or_raise(ctx: RunContext, reason: str, *, after_commit: bool = False) -> None:
+    """Revert ``ctx.test_file``, raising if the revert itself fails.
+
+    ``after_commit=True`` routes through :func:`git_reset_and_revert`
+    (unstage + checkout), not plain :func:`git_revert` — ``git_commit``
+    already staged ``ctx.test_file`` before the commit attempt failed, so a
+    plain checkout alone would restore from that still-mutated index, not
+    HEAD (#1598/#1584 review). A revert that itself fails is fatal: it
+    leaves the working tree in an unknown, possibly-mutated state, so this
+    raises rather than letting the loop continue silently.
+    """
+    revert_ok = (
+        git_reset_and_revert(ctx.test_file, cwd=ctx.cwd)
+        if after_commit
+        else git_revert(ctx.test_file, cwd=ctx.cwd)
+    )
+    if not revert_ok:
+        raise RuntimeError(
+            f"revert failed for {ctx.test_file} after {reason} — the "
+            "working tree is left in an unknown state (mutated test "
+            "content may still be on disk, uncommitted)"
+        )
+
+
+def _verify_and_commit(
     round_num: int,
     source_file: str,
+    survivor_count: int,
+    new_methods: str,
     ctx: RunContext,
-    generate: Generator,
-    *,
-    prev_survivors: int | None,
 ) -> int | None:
-    """Run one round: score (via :func:`_score_round`) → generate → insert →
-    verify → commit.
+    """Build → scoped test → commit-on-green / revert-on-failure.
 
-    Returns this round's survivor count (to seed the next round's
-    no-improvement check), or ``None`` when the file is done.
+    Returns ``survivor_count`` on a successful commit, or ``None`` when the
+    round is abandoned (build failure, test failure, or commit failure —
+    each reverted via :func:`_revert_or_raise`, which raises if the revert
+    itself fails).
     """
-    scored = _score_round(round_num, source_file, ctx, prev_survivors=prev_survivors)
-    if scored is None:
-        return None
-    survivors, survivor_count = scored
-
-    new_methods = generate(
-        source_file,
-        survivors,
-        ctx.source_path.read_text(encoding="utf-8"),
-        ctx.test_file.read_text(encoding="utf-8"),
-    )
-
-    outcome = apply_generated_methods(ctx.test_file, new_methods)
-    if not outcome.inserted:
-        ctx.log(f"  not inserted ({outcome.reason}) — stopping")
-        return None
-
     if not dotnet_build(dotnet_test_project_targets(ctx.config), cwd=ctx.cwd):
         ctx.log("  build failed — reverting")
-        git_revert(ctx.test_file, cwd=ctx.cwd)
+        _revert_or_raise(ctx, "a failed build")
         return None
     if not dotnet_test(dotnet_test_project_targets(ctx.config), ctx.test_file.stem, cwd=ctx.cwd):
         ctx.log("  tests failed — reverting")
-        git_revert(ctx.test_file, cwd=ctx.cwd)
+        _revert_or_raise(ctx, "a failed test run")
         return None
 
     ctx.log("  green — committing")
-    git_commit(
+    committed = git_commit(
         _commit_message(
             round_num,
             source_file,
@@ -526,7 +703,59 @@ def _run_round(
         ctx.test_file,
         cwd=ctx.cwd,
     )
+    if not committed:
+        # A failed/timed-out commit is a round failure, not a silent
+        # success — without this check the loop would advance to the next
+        # round believing this one landed, while the test methods sit
+        # uncommitted (and possibly still staged) on disk (#1598).
+        ctx.log("  commit failed — reverting")
+        _revert_or_raise(ctx, "a failed commit", after_commit=True)
+        return None
     return survivor_count
+
+
+def _run_round(
+    round_num: int,
+    source_file: str,
+    ctx: RunContext,
+    generate: Generator,
+    *,
+    prev_survivors: int | None,
+) -> int | None:
+    """Run one round: score (via :func:`_score_round`) → generate → insert →
+    verify → commit (via :func:`_verify_and_commit`).
+
+    Returns this round's survivor count (to seed the next round's
+    no-improvement check), or ``None`` when the file is done.
+    """
+    scored = _score_round(round_num, source_file, ctx, prev_survivors=prev_survivors)
+    if scored is None:
+        return None
+    survivors, survivor_count = scored
+
+    # Read once and thread the text through both the generation prompt and
+    # the insertion helper below — apply_generated_methods (and, inside it,
+    # insert_before_class_close) accept the already-read text instead of
+    # re-reading test_file from disk a second and third time (#1584).
+    test_text = ctx.test_file.read_text(encoding="utf-8")
+    new_methods = generate(
+        source_file,
+        survivors,
+        ctx.source_path.read_text(encoding="utf-8"),
+        test_text,
+    )
+
+    # No test_text= here on purpose (#1598/#1584 review, item 7):
+    # apply_generated_methods always does its own fresh read now, shared
+    # between its duplicate-name check and the write — this pre-generation
+    # `test_text` snapshot (read above, before the possibly multi-minute
+    # `generate()` call) is only for the generation prompt.
+    outcome = apply_generated_methods(ctx.test_file, new_methods)
+    if not outcome.inserted:
+        ctx.log(f"  not inserted ({outcome.reason}) — stopping")
+        return None
+
+    return _verify_and_commit(round_num, source_file, survivor_count, new_methods, ctx)
 
 
 def run_for_file(
@@ -543,6 +772,16 @@ def run_for_file(
     duplicate/insert guards, build/test verification, revert-on-failure,
     commit-on-green, and the no-improvement stop — is mechanical, driven one
     round at a time by :func:`_run_round`.
+
+    A failed revert (after a build failure, a test failure, or a failed
+    commit) is fatal: it raises :class:`RuntimeError` rather than returning
+    silently, because a revert that can't be verified as having succeeded
+    means the working tree is left in an unknown, possibly-mutated state —
+    silently continuing to the next round or file would risk committing
+    mutated content later under a false assumption of a clean tree (#1598).
+    A failed commit itself is also a round failure, not a silent success: it
+    is reverted (unstage + restore, via :func:`git_reset_and_revert`) and the
+    round stops without advancing.
     """
     prev_survivors: int | None = None
     for round_num in range(1, max_rounds + 1):

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -19,15 +19,25 @@ default (interactive) path is agent-driven: the ``mutation-kill`` agent
 calls :func:`run_for_file` directly, passing a ``generate`` hook backed by a
 live agent turn. A ``--headless`` CLI mode shells to ``claude --print`` for
 unattended (CI) runs.
+
+**Import boundary.** Everything this module reaches for in
+``mutation_kill_headless`` is imported explicitly by name in one block below
+(``strip_code_fences``, ``resolve_model``, ``claude_cli_available``,
+``CLAUDE_CLI``, ``_timeout_from_env``) — never via a module-qualified reach
+into a private, underscore-prefixed name at an arbitrary call site. This
+keeps every cross-module dependency visible in one place instead of scattered
+through the file.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import re
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,11 +55,17 @@ NO_GENERATOR_MESSAGE = (
     "or pass --headless"
 )
 
-# Reused verbatim — neither helper is C#-specific.
+# Reused verbatim — neither helper is C#-specific. `_timeout_from_env` is
+# actually defined in mutation_kill_loop.py and only incidentally re-exported
+# by mutation_kill_headless (`from mutation_kill_loop import ... _timeout_from_env
+# ...`) — imported here the same explicit, named way as the other three
+# rather than reached via `_cs_headless._timeout_from_env` at its call site
+# below (#1598/#1584 review, item 9).
 strip_code_fences = _cs_headless.strip_code_fences
 resolve_model = _cs_headless.resolve_model
 claude_cli_available = _cs_headless.claude_cli_available
 CLAUDE_CLI = _cs_headless.CLAUDE_CLI
+_timeout_from_env = _cs_headless._timeout_from_env
 
 MISSING_CLAUDE_MESSAGE = (
     f"--headless requires the Claude CLI but '{CLAUDE_CLI}' is not available. "
@@ -67,6 +83,72 @@ def _mutmut_argv() -> list[str]:
     if shutil.which("mutmut") is not None:
         return ["mutmut"]
     return [sys.executable, "-m", "mutmut"]
+
+
+# Bounds how long a caller waits to acquire the `.mutmut-cache` lock before
+# giving up loudly rather than hanging forever behind a stuck/crashed holder.
+# Routed through mutation_kill_loop.py's _timeout_from_env pattern (imported
+# above, in the named-import block) rather than a bare magic number, matching
+# every other timeout in this codebase — an override is legitimate for a
+# large repo whose mutmut-cache lock is held longer than 300s by a slow,
+# in-flight concurrent run.
+_MUTMUT_CACHE_LOCK_TIMEOUT_S = _timeout_from_env(
+    "DEV_TEAM_MUTATION_MUTMUT_LOCK_TIMEOUT_S", 300
+)
+
+# 30s matches mutation_kill_loop.py's own _GIT_TIMEOUT (and
+# mutation_baseline_reuse.py's _run_git) — near-instant local git operations
+# against a repo that's presumably already responsive. Applied to every
+# subprocess.run git call in this module (#1598/#1584 review, item 2): none
+# of git_revert/git_reset_and_revert/git_commit previously bounded their
+# subprocess, so an unbounded git call here could hang forever instead of
+# ever reaching the RuntimeError/exit-4 fatal-revert path.
+_GIT_TIMEOUT_S = _timeout_from_env("DEV_TEAM_MUTATION_GIT_TIMEOUT_S", 30)
+
+# How often _acquire_mutmut_cache_lock re-checks the lock directory while
+# waiting. Small enough to notice a release promptly; large enough not to
+# busy-loop.
+_MUTMUT_CACHE_LOCK_POLL_INTERVAL_S = 0.1
+
+
+def _acquire_mutmut_cache_lock(root: Path, *, timeout: float = _MUTMUT_CACHE_LOCK_TIMEOUT_S) -> Path:
+    """Acquire a simple, cross-platform mutex directory guarding
+    ``.mutmut-cache`` for the duration of one scoped mutmut run (#1584).
+
+    Two concurrent ``run_scoped_mutmut`` invocations sharing the same repo
+    race on the single, fixed ``.mutmut-cache`` path — one run's cache
+    delete/mutmut-run/revert sequence can corrupt or invalidate another's
+    in-flight run. ``Path.mkdir()`` is atomic on both POSIX and Windows,
+    unlike ``fcntl``/``msvcrt`` file locks (only one of which is available on
+    any given platform), so a lock *directory* — created, then removed on
+    release — is the portable, stdlib-only mutex.
+    """
+    lock_dir = root / ".mutmut-cache.lock"
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            lock_dir.mkdir()
+            return lock_dir
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"timed out after {timeout}s waiting for the .mutmut-cache "
+                    f"lock at {lock_dir} — a concurrent run may be stuck "
+                    "holding it (remove the directory manually to recover if "
+                    "no run is actually in flight)"
+                ) from None
+            time.sleep(_MUTMUT_CACHE_LOCK_POLL_INTERVAL_S)
+
+
+def _release_mutmut_cache_lock(lock_dir: Path) -> None:
+    """Release the lock directory acquired by :func:`_acquire_mutmut_cache_lock`.
+
+    Called from a ``finally`` block — swallows ``OSError``/``FileNotFoundError``
+    (e.g. the directory was already removed) so a release-time failure never
+    masks whatever exception the run itself was raising (#1598/#1584 review).
+    """
+    with contextlib.suppress(OSError, FileNotFoundError):
+        lock_dir.rmdir()
 
 
 def run_scoped_mutmut(
@@ -106,34 +188,44 @@ def run_scoped_mutmut(
     ``finally``; each round's ``git checkout --`` restores exactly the
     state committed at the end of the previous round, which is always the
     correct baseline for the round about to run.
+
+    **Lock-guarded end to end** (#1584): the cache delete, the mutmut run
+    itself, and the revert are all held under ``.mutmut-cache.lock`` — not
+    just the delete — because mutmut's cache is shared, fixed-path state for
+    the whole repo; a second concurrent invocation reading/writing it
+    mid-run is exactly as corrupting as racing the delete alone.
     """
     root = cwd or Path(".")
-    (root / ".mutmut-cache").unlink(missing_ok=True)
-
-    prefix = _mutmut_argv()
-    argv = [
-        *prefix,
-        "run",
-        f"--paths-to-mutate={source_file}",
-        "--runner",
-        test_command,
-        "--no-progress",
-        "--simple-output",
-    ]
+    lock_dir = _acquire_mutmut_cache_lock(root)
     try:
-        try:
-            subprocess.run(argv, cwd=cwd, capture_output=True, text=True, check=False)
-        except (FileNotFoundError, OSError) as exc:
-            raise RuntimeError(f"mutmut run failed to start: {exc}") from exc
+        (root / ".mutmut-cache").unlink(missing_ok=True)
 
-        junit = subprocess.run(
-            [*prefix, "junitxml"], cwd=cwd, capture_output=True, text=True, check=False
-        )
-        return junit.stdout or ""
+        prefix = _mutmut_argv()
+        argv = [
+            *prefix,
+            "run",
+            f"--paths-to-mutate={source_file}",
+            "--runner",
+            test_command,
+            "--no-progress",
+            "--simple-output",
+        ]
+        try:
+            try:
+                subprocess.run(argv, cwd=cwd, capture_output=True, text=True, check=False)
+            except (FileNotFoundError, OSError) as exc:
+                raise RuntimeError(f"mutmut run failed to start: {exc}") from exc
+
+            junit = subprocess.run(
+                [*prefix, "junitxml"], cwd=cwd, capture_output=True, text=True, check=False
+            )
+            return junit.stdout or ""
+        finally:
+            git_revert(Path(source_file), cwd=cwd)
+            if test_file is not None:
+                git_revert(test_file, cwd=cwd)
     finally:
-        git_revert(Path(source_file), cwd=cwd)
-        if test_file is not None:
-            git_revert(test_file, cwd=cwd)
+        _release_mutmut_cache_lock(lock_dir)
 
 
 def extract_survivors(junitxml_text: str, source_file: str) -> list[dict]:
@@ -185,15 +277,25 @@ def detect_duplicate_functions(test_text: str, new_text: str) -> list[str]:
     return [name for name in incoming if name in existing]
 
 
-def append_at_end_of_file(test_file: Path, new_tests: str) -> None:
+def append_at_end_of_file(test_file: Path, new_tests: str, text: str) -> None:
     """Append ``new_tests`` to the end of the file, with one blank line of
     separation, and a trailing newline.
 
     Raises :class:`InsertionRefused` when the file has no existing top-level
     ``def test_*():`` — the flat-module convention this heuristic supports.
     The file is left untouched on refusal.
+
+    ``text`` is the current test-file content, already read by the caller
+    (:func:`apply_generated_tests`) — this function performs no read of its
+    own. A previous, optional ``test_text=`` shape let a caller pass in
+    content that bypassed reading the file's CURRENT state (including this
+    function's own refusal-guard check running against stale content rather
+    than what's actually on disk) — a real hazard even though no caller
+    exploited it. Removing the optional/None-triggered-fallback shape closes
+    that off: freshness is now entirely ``apply_generated_tests``'s
+    responsibility, which reads immediately before calling this (#1598/#1584
+    review, item 7).
     """
-    text = test_file.read_text(encoding="utf-8")
     if not _FUNC_RE.search(text):
         raise InsertionRefused(
             f"refusing to insert into {test_file.name}: no top-level "
@@ -255,6 +357,18 @@ def apply_generated_tests(test_file: Path, new_tests: str) -> InsertOutcome:
     Returns an :class:`InsertOutcome`; the file is only ever written on the
     ``inserted=True`` path. Empty generation, an unsafe pattern, duplicate
     function names, and a refused insert all leave the file untouched.
+
+    Reads ``test_file`` exactly once here — immediately before the
+    duplicate-name check — and reuses that single fresh read for both the
+    check and the write (passed through to :func:`append_at_end_of_file`,
+    which performs no read of its own). A prior shape let the caller (e.g.
+    ``run_for_file``) thread in its OWN already-read ``test_text`` for the
+    duplicate check — but that text was read *before* the possibly
+    multi-minute ``generate()`` call, so the check ran against a stale
+    snapshot: a function name added to the file during generation (by
+    another process, or a second concurrent round) would go undetected as a
+    duplicate. Reading fresh here, after ``generate()`` has already
+    returned, closes that gap (#1598/#1584 review, item 7).
     """
     if not new_tests.strip():
         return InsertOutcome(False, "no tests generated")
@@ -263,12 +377,14 @@ def apply_generated_tests(test_file: Path, new_tests: str) -> InsertOutcome:
     if unsafe_categories:
         return InsertOutcome(False, f"refused — unsafe pattern(s): {unsafe_categories}")
 
-    dupes = detect_duplicate_functions(test_file.read_text(encoding="utf-8"), new_tests)
+    text = test_file.read_text(encoding="utf-8")
+
+    dupes = detect_duplicate_functions(text, new_tests)
     if dupes:
         return InsertOutcome(False, f"duplicate function names: {dupes}")
 
     try:
-        append_at_end_of_file(test_file, new_tests)
+        append_at_end_of_file(test_file, new_tests, text)
     except InsertionRefused as exc:
         return InsertOutcome(False, str(exc))
     return InsertOutcome(True, "inserted")
@@ -301,22 +417,127 @@ def run_scoped_pytest(test_file: Path, *, cwd: Path | None = None) -> bool:
     return rc == 0
 
 
-def git_revert(test_file: Path, *, cwd: Path | None = None) -> None:
-    """Discard working-tree changes to one file (``git checkout -- <file>``)."""
-    subprocess.run(["git", "checkout", "--", str(test_file)], cwd=cwd, check=False)
+def git_revert(
+    test_file: Path, *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> bool:
+    """Discard working-tree changes to one file (``git checkout -- <file>``).
+
+    Returns True on a successful revert, False on a non-zero exit or a
+    timeout — mirrors ``mutation_kill_loop.py``'s ``git_revert`` (#1598):
+    callers can no longer mistake a failed/timed-out revert for a successful
+    one. ``run_scoped_mutmut``'s always-revert ``finally`` cleanup calls this
+    too but, matching its pre-existing best-effort contract, does not inspect
+    the return value — only ``run_for_file``'s build/test/commit-failure
+    paths (below) do.
+
+    ``env`` defaults to ``None`` (inherit the ambient environment); tests
+    pass a scrubbed env so this real git subprocess can't be redirected by
+    an inherited ``GIT_DIR``/``GIT_WORK_TREE`` (#1598/#1584 review, item 4
+    follow-up).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "--literal-pathspecs", "checkout", "--", str(test_file)],
+            cwd=cwd,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git checkout reverting {test_file} timed out after "
+            f"{_GIT_TIMEOUT_S}s (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to "
+            "raise it)\n"
+        )
+        return False
+    return result.returncode == 0
 
 
-def git_commit(message: str, test_file: Path, *, cwd: Path | None = None) -> bool:
-    """Stage and commit only ``test_file``. Returns True on a successful commit."""
-    subprocess.run(["git", "add", str(test_file)], cwd=cwd, check=False)
-    rc = subprocess.run(
-        ["git", "commit", "-m", message],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-        check=False,
-    ).returncode
-    return rc == 0
+def git_reset_and_revert(
+    test_file: Path, *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> bool:
+    """Unstage AND restore ``test_file`` — the correct revert after a FAILED
+    commit specifically. Mirrors ``mutation_kill_loop.py``'s
+    ``git_reset_and_revert`` (#1598/#1584 review).
+
+    ``git_commit`` runs ``git add -- <test_file>`` before attempting the
+    commit. If the commit itself then fails, ``test_file`` is left staged
+    with the mutated content — a plain ``git checkout -- <file>`` (what
+    :func:`git_revert` does) restores the working tree **from the index**,
+    which still holds the mutation. This unstages first
+    (``git reset -q HEAD -- <file>``) so HEAD, the index, and the working
+    tree all agree afterward. Returns True only if both steps succeed —
+    including on a timeout of either step.
+    """
+    try:
+        reset_result = subprocess.run(
+            ["git", "--literal-pathspecs", "reset", "-q", "HEAD", "--", str(test_file)],
+            cwd=cwd,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git reset unstaging {test_file} timed out after "
+            f"{_GIT_TIMEOUT_S}s (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to "
+            "raise it)\n"
+        )
+        return False
+    if reset_result.returncode != 0:
+        return False
+    return git_revert(test_file, cwd=cwd, env=env)
+
+
+def git_commit(
+    message: str,
+    test_file: Path,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Stage and commit only ``test_file``. Returns True on a successful
+    commit; False on a non-zero exit or a timeout of either step."""
+    # `--` guards against a test_file path that happens to start with `-`
+    # being parsed as a git flag instead of a path — mirrors the C# loop's
+    # git_commit and the adjacent `git checkout --` above (#1584).
+    # `--literal-pathspecs` (right after `git`, #1598/#1584 review, item 5)
+    # forces every pathspec argument below to be treated as a literal path,
+    # not a pathspec: `--` alone does NOT disable pathspec magic (`:/`,
+    # `:(exclude)`, `:!`, etc.) for the argument that follows it.
+    try:
+        subprocess.run(
+            ["git", "--literal-pathspecs", "add", "--", str(test_file)],
+            cwd=cwd,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git add for {test_file} timed out after "
+            f"{_GIT_TIMEOUT_S}s (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to "
+            "raise it)\n"
+        )
+        return False
+    try:
+        commit_result = subprocess.run(
+            ["git", "--literal-pathspecs", "commit", "-m", message, "--", str(test_file)],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"error: git commit for {test_file} timed out after "
+            f"{_GIT_TIMEOUT_S}s (set DEV_TEAM_MUTATION_GIT_TIMEOUT_S to "
+            "raise it)\n"
+        )
+        return False
+    return commit_result.returncode == 0
 
 
 def _commit_message(
@@ -333,6 +554,92 @@ def _commit_message(
         f"{count} new test(s) targeting {survivors} surviving mutant(s)"
     )
     return mutation_safety_gate.append_generator_trailer(message, generator_label)
+
+
+def _revert_or_raise(
+    test_file: Path, cwd: Path | None, reason: str, *, after_commit: bool = False
+) -> None:
+    """Revert ``test_file``, raising if the revert itself fails.
+
+    ``after_commit=True`` routes through :func:`git_reset_and_revert`
+    (unstage + checkout), not plain :func:`git_revert` — ``git_commit``
+    already staged ``test_file`` before the commit attempt failed, so a
+    plain checkout alone would restore from that still-mutated index, not
+    HEAD (#1598/#1584 review). A revert that itself fails is fatal: it
+    leaves the working tree in an unknown, possibly-mutated state, so this
+    raises rather than letting the loop continue silently.
+
+    Hoisted to module level — explicit params, not a closure capturing
+    ``test_file``/``cwd`` from an enclosing scope — to mirror
+    ``mutation_kill_loop.py``'s ``_revert_or_raise`` shape and make this
+    independently testable/monkeypatchable (#1598/#1584 review, item 3).
+    """
+    revert_ok = (
+        git_reset_and_revert(test_file, cwd=cwd)
+        if after_commit
+        else git_revert(test_file, cwd=cwd)
+    )
+    if not revert_ok:
+        raise RuntimeError(
+            f"revert failed for {test_file} after {reason} — the "
+            "working tree is left in an unknown state (mutated test "
+            "content may still be on disk, uncommitted)"
+        )
+
+
+def _verify_and_commit(
+    round_num: int,
+    source_file: str,
+    survivor_count: int,
+    new_tests: str,
+    *,
+    test_file: Path,
+    cwd: Path | None,
+    log: Callable[[str], None],
+    generator_label: str | None,
+) -> bool:
+    """Compile-check → scoped pytest → commit-on-green / revert-on-failure.
+
+    Returns True on a successful commit, False when the round is abandoned
+    (compile failure, test failure, or commit failure — each reverted via
+    :func:`_revert_or_raise`, which raises if the revert itself fails).
+
+    Mirrors ``mutation_kill_loop.py``'s ``_verify_and_commit`` extraction —
+    pulled out of ``run_for_file`` so the build/verify/commit/revert
+    sequence is independently testable/monkeypatchable with explicit params
+    instead of living inline in a ~140-line function (#1598/#1584 review,
+    item 3).
+    """
+    if not python_compiles(test_file, cwd=cwd):
+        log("  compile check failed — reverting")
+        _revert_or_raise(test_file, cwd, "a failed compile check")
+        return False
+    if not run_scoped_pytest(test_file, cwd=cwd):
+        log("  tests failed — reverting")
+        _revert_or_raise(test_file, cwd, "a failed test run")
+        return False
+
+    log("  green — committing")
+    committed = git_commit(
+        _commit_message(
+            round_num,
+            source_file,
+            survivor_count,
+            new_tests,
+            generator_label=generator_label,
+        ),
+        test_file,
+        cwd=cwd,
+    )
+    if not committed:
+        # A failed commit is a round failure, not a silent success —
+        # without this check the loop would advance believing this
+        # round landed, while the new tests sit uncommitted (and
+        # possibly still staged) on disk (#1598).
+        log("  commit failed — reverting")
+        _revert_or_raise(test_file, cwd, "a failed commit", after_commit=True)
+        return False
+    return True
 
 
 # =============================================================================
@@ -361,6 +668,14 @@ def run_for_file(
     ``generator_label``, when set, is recorded in the commit message as an
     audit trail (e.g. distinguishing an unattended ``--headless`` commit from
     an agent-driven one).
+
+    A failed revert (after a compile failure, a test failure, or a failed
+    commit) is fatal: it raises :class:`RuntimeError` rather than returning
+    silently, because a revert that can't be verified as having succeeded
+    means the working tree is left in an unknown, possibly-mutated state
+    (#1598). A failed commit itself is also a round failure, not a silent
+    success: it is reverted (unstage + restore, via
+    :func:`git_reset_and_revert`) and the round stops without advancing.
     """
     prev_survivors: int | None = None
 
@@ -401,39 +716,45 @@ def run_for_file(
             return
         prev_survivors = survivor_count
 
+        # Read once and thread the text through the generation prompt and
+        # the duplicate check below — apply_generated_tests reads the file
+        # at most once here instead of re-reading it a second time for that
+        # same purpose (#1584). This snapshot is NOT threaded into the
+        # actual insert-and-write step: generate() is an LLM call that can
+        # run for minutes, so using this pre-generation snapshot as the
+        # write base afterward would widen a microseconds-wide
+        # read-before-write race into a multi-minute one. append_at_end_of_file
+        # (inside apply_generated_tests) does its own fresh read immediately
+        # before writing instead (#1598/#1584 review).
+        test_text = test_file.read_text(encoding="utf-8")
         new_tests = generate(
             source_file,
             survivors,
             source_path.read_text(encoding="utf-8"),
-            test_file.read_text(encoding="utf-8"),
+            test_text,
         )
 
+        # No test_text= here on purpose (#1598/#1584 review, item 7):
+        # apply_generated_tests always does its own fresh read now, shared
+        # between its duplicate-name check and the write — this pre-generation
+        # `test_text` snapshot (read above, before the possibly multi-minute
+        # `generate()` call) is only for the generation prompt.
         outcome = apply_generated_tests(test_file, new_tests)
         if not outcome.inserted:
             log(f"  not inserted ({outcome.reason}) — stopping")
             return
 
-        if not python_compiles(test_file, cwd=cwd):
-            log("  compile check failed — reverting")
-            git_revert(test_file, cwd=cwd)
-            return
-        if not run_scoped_pytest(test_file, cwd=cwd):
-            log("  tests failed — reverting")
-            git_revert(test_file, cwd=cwd)
-            return
-
-        log("  green — committing")
-        git_commit(
-            _commit_message(
-                round_num,
-                source_file,
-                survivor_count,
-                new_tests,
-                generator_label=generator_label,
-            ),
-            test_file,
+        if not _verify_and_commit(
+            round_num,
+            source_file,
+            survivor_count,
+            new_tests,
+            test_file=test_file,
             cwd=cwd,
-        )
+            log=log,
+            generator_label=generator_label,
+        ):
+            return
 
 
 # =============================================================================
@@ -578,15 +899,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
 
-    run_for_file(
-        args.file,
-        test_file=Path(args.test_file),
-        source_path=Path(args.source_path),
-        test_command=args.test_command,
-        generate=make_headless_generator(model),
-        max_rounds=args.max_rounds,
-        generator_label=f"headless ({model or 'default'})",
-    )
+    try:
+        run_for_file(
+            args.file,
+            test_file=Path(args.test_file),
+            source_path=Path(args.source_path),
+            test_command=args.test_command,
+            generate=make_headless_generator(model),
+            max_rounds=args.max_rounds,
+            generator_label=f"headless ({model or 'default'})",
+        )
+    except RuntimeError as exc:
+        # A failed revert or a failed-commit round-abandonment raises
+        # RuntimeError (#1598) — mirrors mutation_kill_headless.py's main(),
+        # fitting the same 1/2/3 exit-code taxonomy with the next unused
+        # code rather than letting this either succeed silently (exit 0)
+        # or crash with a raw traceback.
+        sys.stderr.write(f"error: {exc}\n")
+        return 4
     return 0
 
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -292,26 +292,34 @@ def launch_survivor_fix(
     config_path: Path,
     model: str | None,
     max_rounds: int,
-    run: Callable[..., object] = subprocess.run,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
     resolve_test_file: TestFileResolver | None = None,
     log: Callable[[str], None] = print,
-) -> None:
+) -> bool:
     """Launch the forced-headless survivor-fix loop for a shard's survivors.
 
     Invokes ``mutation_kill_loop`` (always with ``--headless``) once per source
     file that still has survivors, seeding round 1 from the shard's report.
     Runs from ``repo_root`` so fixes commit onto ``HEAD`` — that is what makes
     the *next* shard's worktree compounding.
+
+    Returns True when every launched fix exited zero (or none were launched);
+    False the moment one exits non-zero. A non-zero exit from the headless
+    loop — including the fatal-revert exit code 4 (``mutation_kill_headless``/
+    ``mutation_kill_loop_python`` #1598) — means the working tree was just
+    declared to be in an unknown/possibly-mutated state, so processing stops
+    for the remaining files in this shard rather than silently continuing
+    onto a tree that may already be broken.
     """
     resolve_test_file = resolve_test_file or default_resolve_test_file
     report = report_path(out_dir)
     if not report.exists():
         log(f"[{ts()}] Agent SKIP: no report for {shard}")
-        return
+        return True
     files = survivor_source_files(report)
     if not files:
         log(f"[{ts()}] Agent SKIP: no survivors in {shard}")
-        return
+        return True
 
     test_projects = shard_test_projects(config_path)
     for source in files:
@@ -329,7 +337,17 @@ def launch_survivor_fix(
             max_rounds=max_rounds,
         )
         log(f"[{ts()}] Agent START (headless): {shard} — {source}")
-        run(cmd, cwd=str(repo_root))
+        result = run(cmd, cwd=str(repo_root))
+        rc = result.returncode
+        if rc != 0:
+            log(
+                f"[{ts()}] Agent FAILED (headless): {shard} — {source} "
+                f"(exit {rc}) — stopping further files in this shard; the "
+                "working tree may be left in an unknown/possibly-mutated "
+                "state"
+            )
+            return False
+    return True
 
 
 # ── Resume (skip-existing wins over max-age) ────────────────────────────────────
@@ -449,7 +467,7 @@ def process_shard(
     log(f"[{ts()}] Shard DONE: {shard}")
 
     if not skip_agent:
-        launch_survivor_fix(
+        fix_ok = launch_survivor_fix(
             shard,
             repo_root=repo_root,
             out_dir=out_dir,
@@ -462,6 +480,8 @@ def process_shard(
         )
         if events is not None:
             events.append(("fix", shard))
+        if not fix_ok:
+            return "failed"
     return "ok"
 
 

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -77,7 +77,10 @@ def test_agent_body_stays_under_500_line_limit(text: str) -> None:
     # Bumped by 2 more (#1561/#1562): mutation_kill_loop.py split into three
     # files — added mutation_kill_insert.py and mutation_kill_headless.py
     # rows to the scripted-mechanics table.
-    assert len(text.splitlines()) < 607
+    # Bumped by 7 more (#1598/#1584 review): documented the corrected
+    # commit-failure revert (unstage + restore, not a plain checkout) and
+    # the fatal-on-failed-revert contract in the "Verify + revert" bullet.
+    assert len(text.splitlines()) < 614
 
 
 def test_defines_honest_score_formula(text: str) -> None:

--- a/tests/scripts/_mutation_test_helpers.py
+++ b/tests/scripts/_mutation_test_helpers.py
@@ -12,10 +12,32 @@ under test. ``FORBIDDEN_LITERALS`` is the shared list of repo-specific
 literals (ACI project/tooling names) those modules must never leak into
 their source — mirrors the list originally defined in
 ``test_mutation_kill_loop.py`` (issue #1554).
+
+``hermetic_git_env``/``git_hermetic`` scrub the git-hook-exported env vars
+(issue #546) for the handful of tests here that shell out to a REAL git repo
+(no mocks) — see ``test_check_python_only.py``'s ``_hermetic_env``/``_git``
+for the original pattern this mirrors. Without this, a test's own ``git
+init``/``git commit`` can inherit GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE/
+GIT_PREFIX/GIT_REFLOG_ACTION from the parent process (e.g. this repo's own
+pre-push git hook) and silently target/corrupt the real parent repo's refs
+instead of the test's own tmp_path (#1598/#1584 review, item 4).
+
+Scrubbing the test's OWN setup calls (``git_hermetic``) is necessary but not
+sufficient: the production function under test shells out to git too, and
+if that call doesn't also receive a scrubbed env, only half the test is
+hermetic (#1598/#1584 review, round 3 — caught by test-smell-review/
+ai-provenance-review after round 2's fix wired the scrub into setup calls
+only). Pass ``hermetic_git_env(home=tmp_path)`` as the SUT's own ``env=``
+argument too, not just to ``git_hermetic``'s scaffolding calls.
+``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` point at ``/dev/null`` so no
+global/system gitconfig leaks in, and an optional ``home=`` overrides
+``HOME`` for the same reason.
 """
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 SCRIPTS_DIR = (
@@ -28,3 +50,42 @@ SCRIPTS_DIR = (
 )
 
 FORBIDDEN_LITERALS = ["Aci.Speedpay", "Controllers", "AwesomeAssertions", "Moq", "AutoFixture"]
+
+_GIT_SCRUB_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_REFLOG_ACTION",
+)
+
+
+def hermetic_git_env(home: Path | str | None = None) -> dict:
+    """A minimal, scrubbed environment for real ``git`` subprocess calls.
+
+    Pass this same dict as the production code's own ``env=`` argument (not
+    just to the test's setup calls) — the code under test shells out to git
+    too, and only scrubbing the test's own scaffolding leaves the assertion
+    itself running against the ambient environment (#1598/#1584 review,
+    round 3: test-smell-review/ai-provenance-review). ``home`` overrides
+    ``HOME`` so a stray ``~/.gitconfig`` can't leak in either, matching
+    ``tests/repo/conftest.py``'s ``hermetic_env`` fixture.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_SCRUB_ENV_VARS}
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    if home is not None:
+        env["HOME"] = str(home)
+    return env
+
+
+def git_hermetic(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run a real ``git`` subprocess with a hermetic, scrubbed environment."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=hermetic_git_env(home=cwd),
+        check=True,
+    )

--- a/tests/scripts/test_mutation_kill_headless.py
+++ b/tests/scripts/test_mutation_kill_headless.py
@@ -349,3 +349,35 @@ def test_claude_cli_available_treats_a_timeout_as_unavailable(
     monkeypatch.setattr(headless.subprocess, "run", fake_run)
 
     assert headless.claude_cli_available() is False
+
+
+# =============================================================================
+# Scenario: A round-abandoning RuntimeError (failed revert, failed commit —
+# #1598) propagates to a non-zero exit code instead of a silent 0 return or
+# a raw traceback (#1598/#1584 review, item 6).
+# =============================================================================
+def test_main_exits_non_zero_when_run_for_file_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    monkeypatch.setattr(headless, "claude_cli_available", lambda: True)
+
+    def boom(*a, **k):
+        raise RuntimeError("revert failed for FooTests.cs after a failed commit")
+
+    monkeypatch.setattr(headless, "run_for_file", boom)
+    config_path = _write_config(tmp_path)
+
+    rc = headless.main(
+        [
+            "--config", str(config_path),
+            "--headless",
+            "--file", "Foo.cs",
+            "--test-file", str(tmp_path / "FooTests.cs"),
+            "--source-path", str(tmp_path / "Foo.cs"),
+        ]
+    )
+
+    assert rc != 0
+    assert rc not in (1, 2, 3)  # distinct from the existing preflight exit codes
+    err = capsys.readouterr().err
+    assert "revert failed" in err

--- a/tests/scripts/test_mutation_kill_insert.py
+++ b/tests/scripts/test_mutation_kill_insert.py
@@ -113,6 +113,53 @@ def test_methods_inserted_before_class_closing_brace(tmp_path: Path):
     assert new_idx < class_close_idx < ns_close_idx
 
 
+def test_insert_before_class_close_operates_on_the_given_text_not_disk_content(
+    tmp_path: Path,
+):
+    """insert_before_class_close takes the current text as a required,
+    positional argument and performs no read of its own (#1598/#1584
+    review, item 7) — freshness is entirely apply_generated_methods's
+    responsibility. The on-disk content here has NO valid class-closing
+    brace at all (a file-scoped namespace, which the heuristic refuses)
+    while the explicitly-passed text DOES have a well-formed
+    block-namespace class. If the function silently re-read from disk
+    instead of using the given text, this would raise InsertionRefused;
+    using the given text, it must succeed."""
+    test_file = tmp_path / "PaymentServiceTests.cs"
+    test_file.write_text(_FILE_SCOPED_CLASS, encoding="utf-8")
+
+    insert.insert_before_class_close(test_file, _NEW_METHOD, _BLOCK_NAMESPACE_CLASS)
+
+    written = test_file.read_text(encoding="utf-8")
+    assert "New_Case_KillsMutant" in written
+
+
+def test_apply_generated_methods_duplicate_check_uses_fresh_disk_content(
+    tmp_path: Path,
+):
+    """The duplicate-name check must run against the CURRENT file content —
+    not a pre-generation snapshot a caller might otherwise thread through —
+    so a method added to the file externally between an earlier read (e.g.
+    before generate()) and this call (e.g. by another process, or a second
+    concurrent round) is still caught as a duplicate rather than silently
+    double-inserted (#1598/#1584 review, item 7)."""
+    test_file = tmp_path / "PaymentServiceTests.cs"
+    # Stands in for: the file already has New_Case_KillsMutant by the time
+    # apply_generated_methods actually runs, even though an earlier read
+    # (simulated by generate() in the real loop) would not have seen it yet.
+    already_has_it = _BLOCK_NAMESPACE_CLASS.replace(
+        "    }\n}\n", _NEW_METHOD + "    }\n}\n"
+    )
+    test_file.write_text(already_has_it, encoding="utf-8")
+    before = test_file.read_text(encoding="utf-8")
+
+    outcome = insert.apply_generated_methods(test_file, _NEW_METHOD)
+
+    assert outcome.inserted is False
+    assert "duplicate" in outcome.reason.lower()
+    assert test_file.read_text(encoding="utf-8") == before
+
+
 # =============================================================================
 # Scenario: Insertion into a file-scoped-namespace class is handled or refused
 # =============================================================================
@@ -122,7 +169,7 @@ def test_file_scoped_namespace_is_refused_not_corrupted(tmp_path: Path):
     before = test_file.read_text(encoding="utf-8")
 
     with pytest.raises(insert.InsertionRefused) as exc:
-        insert.insert_before_class_close(test_file, _NEW_METHOD)
+        insert.insert_before_class_close(test_file, _NEW_METHOD, _FILE_SCOPED_CLASS)
 
     assert "file-scoped" in str(exc.value).lower()
     # Never silently appended — file is byte-for-byte unchanged.
@@ -145,7 +192,7 @@ def test_non_four_space_indent_is_refused(tmp_path: Path):
     before = test_file.read_text(encoding="utf-8")
 
     with pytest.raises(insert.InsertionRefused):
-        insert.insert_before_class_close(test_file, _NEW_METHOD)
+        insert.insert_before_class_close(test_file, _NEW_METHOD, tabbed)
 
     assert test_file.read_text(encoding="utf-8") == before
 

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -23,7 +23,12 @@ import sys
 from pathlib import Path
 
 import pytest
-from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
+from _mutation_test_helpers import (
+    FORBIDDEN_LITERALS,
+    SCRIPTS_DIR,
+    git_hermetic,
+    hermetic_git_env,
+)
 
 # Ensure the module's dir is on the path so we can import it directly.
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -354,7 +359,18 @@ def _loop_fixture(
         events.append(("generate", len(survivors)))
         return new_method
 
-    monkeypatch.setattr(loop, "git_revert", lambda tf, **k: events.append(("revert", str(tf))))
+    monkeypatch.setattr(
+        loop, "git_revert", lambda tf, **k: events.append(("revert", str(tf))) or True
+    )
+    # git_reset_and_revert is what the commit-failure path actually calls
+    # (#1598/#1584 review) — tagged "revert" too so the existing
+    # kinds.count("revert") assertions keep meaning "a revert happened",
+    # regardless of which of the two functions performed it.
+    monkeypatch.setattr(
+        loop,
+        "git_reset_and_revert",
+        lambda tf, **k: events.append(("revert", str(tf))) or True,
+    )
     monkeypatch.setattr(
         loop, "git_commit", lambda msg, tf, **k: events.append(("commit", msg)) or True
     )
@@ -623,6 +639,373 @@ def test_baseline_seeded_zero_survivors_never_calls_scoped_stryker(
 
 
 # =============================================================================
+# Scenario: A failed commit is a round failure, not a silent success (#1598)
+# =============================================================================
+def test_failed_commit_reverts_and_stops_the_round(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source_file, ctx, kwargs, events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived")]
+    )
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: True)
+    monkeypatch.setattr(loop, "dotnet_test", lambda targets, flt, **k: True)
+    monkeypatch.setattr(
+        loop, "git_commit", lambda msg, tf, **k: events.append(("commit", msg)) or False
+    )
+
+    loop.run_for_file(source_file, ctx, **kwargs)
+
+    kinds = [e[0] for e in events]
+    # The commit was attempted, failed, and was NOT mistaken for success:
+    # exactly one revert follows it, and the loop stops (a second "generate"
+    # would mean it wrongly believed round 1 had landed).
+    assert kinds.count("commit") == 1
+    assert kinds.count("revert") == 1
+    assert kinds.count("generate") == 1
+
+
+def test_revert_failure_after_failed_commit_is_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source_file, ctx, kwargs, _events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived")]
+    )
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: True)
+    monkeypatch.setattr(loop, "dotnet_test", lambda targets, flt, **k: True)
+    monkeypatch.setattr(loop, "git_commit", lambda msg, tf, **k: False)
+    # The commit-failure revert path calls git_reset_and_revert, not plain
+    # git_revert (#1598/#1584 review) — that's the function that must fail
+    # here for this scenario.
+    monkeypatch.setattr(loop, "git_reset_and_revert", lambda tf, **k: False)
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(source_file, ctx, **kwargs)
+
+
+def test_revert_failure_after_build_failure_is_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source_file, ctx, kwargs, _events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived")]
+    )
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: False)
+    monkeypatch.setattr(loop, "git_revert", lambda tf, **k: False)
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(source_file, ctx, **kwargs)
+
+
+def test_revert_failure_after_test_failure_is_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source_file, ctx, kwargs, _events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived")]
+    )
+    monkeypatch.setattr(loop, "dotnet_build", lambda targets, **k: True)
+    monkeypatch.setattr(loop, "dotnet_test", lambda targets, flt, **k: False)
+    monkeypatch.setattr(loop, "git_revert", lambda tf, **k: False)
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(source_file, ctx, **kwargs)
+
+
+# =============================================================================
+# Scenario (real git, no mocks): git_reset_and_revert actually leaves both
+# the index AND the working tree matching HEAD after a commit-failure-style
+# staged mutation — the exact #1598 regression a fully-mocked test (like
+# test_failed_commit_reverts_and_stops_the_round above) cannot catch, since
+# mocking git_revert/git_commit never exercises real git index state.
+# =============================================================================
+def test_git_reset_and_revert_restores_index_and_worktree_after_a_staged_mutation(
+    tmp_path: Path,
+):
+    git_hermetic(tmp_path, "init", "-q")
+    git_hermetic(tmp_path, "config", "user.email", "test@example.com")
+    git_hermetic(tmp_path, "config", "user.name", "Test")
+    git_hermetic(tmp_path, "config", "commit.gpgsign", "false")
+
+    test_file = tmp_path / "PaymentServiceTests.cs"
+    original = "namespace Widget.Tests\n{\n    // original\n}\n"
+    test_file.write_text(original, encoding="utf-8")
+    git_hermetic(tmp_path, "add", "-A")
+    git_hermetic(tmp_path, "commit", "-q", "-m", "initial")
+
+    # Simulate what git_commit does before a commit attempt fails: the loop
+    # mutates the test file, then `git add`s it.
+    mutated = original.replace("// original", "// mutated (never actually committed)")
+    test_file.write_text(mutated, encoding="utf-8")
+    git_hermetic(tmp_path, "add", "--", str(test_file))
+
+    # Sanity: the mutation IS staged before the fix runs — this is what makes
+    # a plain `git checkout --` (git_revert alone) insufficient, and what
+    # this test would fail to prove without this check.
+    staged = git_hermetic(tmp_path, "diff", "--cached", "--name-only")
+    assert "PaymentServiceTests.cs" in staged.stdout
+
+    # env= is the point of this test: the SUT's own git subprocess must run
+    # hermetically too, not just this test's setup calls above (#1598/#1584
+    # review, round 3 — test-smell-review/ai-provenance-review found the
+    # round-2 fix scrubbed only the setup calls).
+    assert (
+        loop.git_reset_and_revert(
+            test_file, cwd=tmp_path, env=hermetic_git_env(home=tmp_path)
+        )
+        is True
+    )
+
+    # Working tree matches HEAD (not the staged mutation).
+    assert test_file.read_text(encoding="utf-8") == original
+    # Index matches HEAD too — nothing left staged.
+    status = git_hermetic(tmp_path, "status", "--porcelain")
+    assert status.stdout.strip() == ""
+
+
+# =============================================================================
+# Scenario: A refused/duplicate insertion stops the round before build/test/
+# commit ever run — orchestration-level coverage (previously only exercised
+# via mutation_kill_insert's own functions directly, #1584)
+# =============================================================================
+def test_refused_insertion_stops_the_round_without_verify_or_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source_file, ctx, kwargs, events = _loop_fixture(
+        tmp_path, monkeypatch, [_mutant("Survived")]
+    )
+    monkeypatch.setattr(
+        loop, "dotnet_build", lambda *a, **k: pytest.fail("must not build after a refused insert")
+    )
+    monkeypatch.setattr(
+        loop,
+        "apply_generated_methods",
+        lambda *a, **k: mutation_kill_insert.InsertOutcome(
+            False, "duplicate method names: ['Existing_Case_Works']"
+        ),
+    )
+
+    loop.run_for_file(source_file, ctx, **kwargs)
+
+    kinds = [e[0] for e in events]
+    assert kinds == ["generate"]
+
+
+# =============================================================================
+# Scenario: _validate_solution_path requires a RELATIVE solution — an
+# absolute value is rejected in every practical case, since pathlib's `/`
+# silently discards `base` when the right operand is already absolute
+# (#1598/#1584 review, item 11).
+# =============================================================================
+def test_validate_solution_path_rejects_an_absolute_solution_outside_cwd(
+    tmp_path: Path,
+):
+    with pytest.raises(ValueError, match="escapes the working tree"):
+        loop._validate_solution_path("/etc/passwd", cwd=tmp_path)
+
+
+def test_validate_solution_path_accepts_an_absolute_solution_already_under_cwd(
+    tmp_path: Path,
+):
+    """Pins the degenerate case the docstring names: `base / solution`
+    discards `base` outright for an absolute `solution`, so an absolute
+    value is accepted only when it already happens to lie under `base` —
+    the resulting candidate is identical to the absolute value itself, not
+    `base` joined with it."""
+    absolute_solution = str((tmp_path / "App.sln").resolve())
+
+    result = loop._validate_solution_path(absolute_solution, cwd=tmp_path)
+
+    assert result == (tmp_path / "App.sln").resolve()
+
+
+# =============================================================================
+# Scenario: config.solution is sanitized before it's used to derive the
+# hidden-.sln filename (#1598). The filename itself is FIXED, not
+# process-unique — a PID-suffixed name was tried (#1584) to guard two
+# concurrent scoped runs against the same solution, but reverted after
+# review: it would be invisible to csharp_stryker_net_wrapper.py's
+# check_stale_hidden_sln() crash-recovery, which looks for the exact literal
+# ".stryker-hidden" suffix (see test_scoped_stryker_hidden_sln_name_has_no_pid_suffix
+# below).
+# =============================================================================
+def test_run_scoped_stryker_rejects_a_traversal_solution_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = loop.load_loop_config(
+        _write_config(tmp_path, solution="../../etc/cron.d/evil.sln")
+    )
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    monkeypatch.setattr(
+        loop.wrapper,
+        "hide_sln",
+        lambda *a, **k: pytest.fail("must not hide before the solution path is validated"),
+    )
+
+    with pytest.raises(ValueError, match="escapes the working tree"):
+        loop.run_scoped_stryker(
+            config, "Foo.cs", output_dir=tmp_path / "out", cwd=tmp_path
+        )
+
+
+def test_run_scoped_stryker_accepts_a_normal_relative_solution_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Not just "must not raise" — the resolved, validated path is what
+    actually gets hidden/restored, at the FIXED (no-PID) name (#1598/#1584
+    review, item 10 test-review finding)."""
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    hide_calls: list = []
+    restore_calls: list = []
+    monkeypatch.setattr(
+        loop.wrapper,
+        "hide_sln",
+        lambda sln, sln_hidden: hide_calls.append((sln, sln_hidden)),
+    )
+    monkeypatch.setattr(
+        loop.wrapper,
+        "restore_sln",
+        lambda sln, sln_hidden: restore_calls.append((sln, sln_hidden)),
+    )
+
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _R())
+
+    loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out", cwd=tmp_path)
+
+    expected_sln = (tmp_path / "App.sln").resolve()
+    expected_hidden = Path(f"{expected_sln}.stryker-hidden")
+    assert hide_calls == [(expected_sln, expected_hidden)]
+    assert restore_calls == [(expected_sln, expected_hidden)]
+
+
+def test_run_scoped_stryker_calls_check_stale_hidden_sln_before_hiding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Mirrors the wrapper's own main() and
+    csharp_stryker_net_slice_runner.py's fleet-level caller (#1598/#1584
+    review, item 6): the stale-hidden-.sln crash-recovery check must run
+    BEFORE hide_sln, or a stale file left by a prior crash is never caught
+    here."""
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    calls: list = []
+    monkeypatch.setattr(
+        loop.wrapper,
+        "check_stale_hidden_sln",
+        lambda sln, sln_hidden: calls.append("check_stale_hidden_sln") or None,
+    )
+    monkeypatch.setattr(loop.wrapper, "hide_sln", lambda *a, **k: calls.append("hide_sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "restore_sln", lambda *a, **k: calls.append("restore_sln")
+    )
+
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _R())
+
+    loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out", cwd=tmp_path)
+
+    assert calls[:2] == ["check_stale_hidden_sln", "hide_sln"]
+
+
+def test_run_scoped_stryker_raises_when_stale_hidden_sln_check_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    monkeypatch.setattr(
+        loop.wrapper,
+        "check_stale_hidden_sln",
+        lambda sln, sln_hidden: "error: stale .stryker-hidden present\n",
+    )
+    monkeypatch.setattr(
+        loop.wrapper,
+        "hide_sln",
+        lambda *a, **k: pytest.fail("must not hide when the stale-hidden check refuses"),
+    )
+
+    with pytest.raises(RuntimeError, match="stale"):
+        loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out", cwd=tmp_path)
+
+
+def test_scoped_stryker_hidden_sln_name_has_no_pid_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """PID-suffixing the hidden .sln name was tried (#1584) and reverted
+    after review: stryker_shard_pipeline.py runs shards sequentially (no
+    concurrent race to guard against today), and a PID-suffixed name is
+    invisible to csharp_stryker_net_wrapper.py's check_stale_hidden_sln()
+    crash-recovery, which looks for the exact literal ".stryker-hidden"
+    suffix."""
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+    monkeypatch.setattr(
+        loop.wrapper, "resolve_dotnet_root", lambda preset, candidates: ("/fake", None)
+    )
+    monkeypatch.setattr(loop.wrapper, "default_probe_candidates", list)
+    hidden_names: list = []
+    monkeypatch.setattr(
+        loop.wrapper, "hide_sln", lambda sln, sln_hidden: hidden_names.append(str(sln_hidden))
+    )
+    monkeypatch.setattr(loop.wrapper, "restore_sln", lambda *a, **k: None)
+
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _R())
+
+    loop.run_scoped_stryker(config, "Foo.cs", output_dir=tmp_path / "out", cwd=tmp_path)
+
+    assert hidden_names == [str((tmp_path / "App.sln").resolve()) + ".stryker-hidden"]
+    assert str(loop.os.getpid()) not in hidden_names[0]
+
+
+# =============================================================================
+# Scenario: make_scoped_config's output shape — mutate glob, coverage
+# analysis, reporters, and dropping of unset (None) keys (#1584)
+# =============================================================================
+def test_make_scoped_config_shape(tmp_path: Path):
+    config = loop.load_loop_config(_write_config(tmp_path, solution=None))
+
+    scoped = loop.make_scoped_config(config, "PaymentService.cs")
+
+    inner = scoped["stryker-config"]
+    assert inner["mutate"] == ["**/PaymentService.cs"]
+    assert inner["coverage-analysis"] == "perTest"
+    assert inner["reporters"] == ["json"]
+    assert inner["project"] == config.project
+    assert inner["test-projects"] == config.test_projects
+    # solution was unset (None) in the loaded config — dropped entirely,
+    # never carried forward as a null value for Stryker to choke on.
+    assert "solution" not in inner
+
+
+def test_make_scoped_config_carries_a_set_solution_through(tmp_path: Path):
+    """The solution=None branch above only proves dropping — this proves the
+    opposite branch: a real configured solution is carried into the scoped
+    config, not silently dropped too (#1598/#1584 review, item 10)."""
+    config = loop.load_loop_config(_write_config(tmp_path, solution="App.sln"))
+
+    scoped = loop.make_scoped_config(config, "PaymentService.cs")
+
+    inner = scoped["stryker-config"]
+    assert inner["solution"] == "App.sln"
+
+
+# =============================================================================
 # Verify/commit subprocess wiring — targets come from config (no literals)
 # =============================================================================
 def test_dotnet_build_uses_configured_test_project(
@@ -689,6 +1072,113 @@ def test_dotnet_build_timeout_is_treated_as_a_build_failure(
     assert "DEV_TEAM_MUTATION_BUILD_TIMEOUT_S" in err
 
 
+def test_dotnet_build_returns_false_on_nonzero_returncode(
+    monkeypatch: pytest.MonkeyPatch
+):
+    """dotnet_build's own failure-path logic (a non-zero exit, no timeout
+    involved) — direct coverage, not mocked away at the orchestration level
+    (#1584)."""
+
+    class _R:
+        returncode = 1
+        stdout = ""
+        stderr = "error CS0000: something broke\n"
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.dotnet_build(["Foo.Tests.csproj"]) is False
+
+
+def test_dotnet_test_returns_false_on_nonzero_returncode_even_with_zero_failed(
+    monkeypatch: pytest.MonkeyPatch
+):
+    """A non-zero `dotnet test` exit fails the round even when the "Failed:"
+    line itself parses to 0 (e.g. the process crashed before reporting) —
+    direct coverage of dotnet_test's own failure-path logic (#1584)."""
+
+    class _R:
+        returncode = 1
+        stdout = "Failed: 0, Passed: 5\n"
+        stderr = ""
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.dotnet_test(["Foo.Tests.csproj"], "FooTests") is False
+
+
+def test_dotnet_test_accumulates_failed_count_across_multiple_assemblies(
+    monkeypatch: pytest.MonkeyPatch
+):
+    """A single `dotnet test` invocation spanning multiple test assemblies
+    prints one "Failed: N" line per assembly. The scan must SUM them, not
+    let a later, clean assembly's "Failed: 0" line overwrite an earlier
+    assembly's real failures — a last-match-wins scan would falsely report
+    success here (#1598). Fixture shape matches real `dotnet test` per-
+    assembly summary lines (item 11, #1598/#1584 review), not a synthetic
+    shorthand — see also the rollup-line non-double-count test below."""
+
+    class _R:
+        returncode = 0
+        stdout = (
+            "Failed!  - Failed:     3, Passed:     7, Skipped:     0, "
+            "Total:    10, Duration: 120 ms - Bar.Tests.dll\n"
+            "Passed!  - Failed:     0, Passed:    12, Skipped:     0, "
+            "Total:    12, Duration: 40 ms - Foo.Tests.dll\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.dotnet_test(["Foo.Tests.csproj"], "FooTests") is False
+
+
+def test_dotnet_test_trailing_lowercase_rollup_line_does_not_flip_a_clean_run(
+    monkeypatch: pytest.MonkeyPatch
+):
+    """Newer `dotnet test` SDKs (7/8) also print a final, lowercase rollup
+    line ("Test summary: total: ... failed: 0 ...") after the per-assembly
+    summaries. The scan is capital-F "Failed:" only, so this rollup line
+    must not be mistaken for a second, independent "Failed:" occurrence —
+    a fully clean multi-assembly run (returncode 0, every real "Failed:"
+    count is 0) must still report success (item 11, #1598/#1584 review)."""
+
+    class _R:
+        returncode = 0
+        stdout = (
+            "Passed!  - Failed:     0, Passed:    10, Skipped:     0, "
+            "Total:    10, Duration: 40 ms - Foo.Tests.dll\n"
+            "\n"
+            "Test summary: total: 10, failed: 0, succeeded: 10, skipped: 0, "
+            "duration: 0.1s\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.dotnet_test(["Foo.Tests.csproj"], "FooTests") is True
+
+
+def test_sum_failed_counts_is_case_sensitive_not_double_counting_the_rollup_line():
+    """A fixture where both a correct (case-sensitive) scan and a buggy
+    (case-insensitive) scan sum to 0 can't actually catch a regression to
+    ``re.IGNORECASE`` (#1598/#1584 review, item 12) — the boolean
+    ``dotnet_test`` result would be identical either way. Asserting the
+    NUMERIC total directly against a nonzero per-assembly count (3) plus a
+    nonzero lowercase rollup count (3) proves the scan is case-sensitive:
+    a case-insensitive regex would sum both `Failed:`-shaped occurrences
+    (3 + 3 = 6); the correct, case-sensitive scan counts only the real
+    capital-F per-assembly line (3)."""
+    text = (
+        "Failed!  - Failed:     3, Passed:     7, Skipped:     0, "
+        "Total:    10, Duration: 120 ms - Bar.Tests.dll\n"
+        "\n"
+        "Test summary: total: 10, failed: 3, succeeded: 7, skipped: 0, "
+        "duration: 0.1s\n"
+    )
+
+    assert loop._sum_failed_counts(text) == 3
+
+
 def test_dotnet_test_passes_a_timeout(monkeypatch: pytest.MonkeyPatch):
     captured: dict = {}
 
@@ -731,6 +1221,7 @@ def test_git_revert_checks_out_only_the_test_file(
 
     assert seen[0] == [
         "git",
+        "--literal-pathspecs",
         "checkout",
         "--",
         str(tmp_path / "PaymentServiceTests.cs"),
@@ -787,9 +1278,15 @@ def test_git_commit_passes_a_timeout_to_add_and_commit(
     result = loop.git_commit("msg", tmp_path / "PaymentServiceTests.cs")
 
     assert result is True
-    assert calls[0][0] == ["git", "add", "--", str(tmp_path / "PaymentServiceTests.cs")]
+    assert calls[0][0] == [
+        "git",
+        "--literal-pathspecs",
+        "add",
+        "--",
+        str(tmp_path / "PaymentServiceTests.cs"),
+    ]
     assert calls[0][1]["timeout"] == loop.GIT_TIMEOUT_S
-    assert calls[1][0][:2] == ["git", "commit"]
+    assert calls[1][0][:3] == ["git", "--literal-pathspecs", "commit"]
     assert calls[1][1]["timeout"] == loop.GIT_TIMEOUT_S
 
 
@@ -833,11 +1330,75 @@ def test_git_commit_commit_leg_timeout_returns_false(
     # Pin the branch this test targets by call order, not just count — a
     # future reordering of the add/commit calls should fail loudly here
     # rather than silently exercising the wrong leg.
-    assert calls[0][:2] == ["git", "add"]
+    assert calls[0][:3] == ["git", "--literal-pathspecs", "add"]
     err = capsys.readouterr().err
     assert str(loop.GIT_TIMEOUT_S) in err
     assert "DEV_TEAM_MUTATION_GIT_TIMEOUT_S" in err
     assert "git commit" in err
+
+
+def test_git_commit_scopes_the_commit_call_to_the_test_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """git commit -m message with no pathspec commits the WHOLE index, not
+    just test_file — the commit call must carry the same `-- <path>`
+    pathspec `git add` already uses (#1598)."""
+    calls: list = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    result = loop.git_commit("msg", tmp_path / "PaymentServiceTests.cs")
+
+    assert result is True
+    assert calls[1] == [
+        "git",
+        "--literal-pathspecs",
+        "commit",
+        "-m",
+        "msg",
+        "--",
+        str(tmp_path / "PaymentServiceTests.cs"),
+    ]
+
+
+def test_git_revert_returns_true_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_revert(tmp_path / "PaymentServiceTests.cs") is True
+
+
+def test_git_revert_returns_false_on_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class _R:
+        returncode = 1
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_revert(tmp_path / "PaymentServiceTests.cs") is False
+
+
+def test_git_revert_returns_false_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_revert(tmp_path / "PaymentServiceTests.cs") is False
 
 
 def test_git_commit_proceeds_to_commit_after_a_non_timeout_add_failure(
@@ -864,7 +1425,65 @@ def test_git_commit_proceeds_to_commit_after_a_non_timeout_add_failure(
 
     assert result is True
     assert len(calls) == 2
-    assert calls[1][:2] == ["git", "commit"]
+    assert calls[1][:3] == ["git", "--literal-pathspecs", "commit"]
+
+
+# =============================================================================
+# Scenario: git_reset_and_revert's own internal failure branches — every
+# other test either exercises the full real-git success path or mocks
+# git_reset_and_revert away wholesale (#1598/#1584 review, item 10).
+# =============================================================================
+def test_git_reset_and_revert_returns_false_when_reset_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list = []
+
+    class _R:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _R(1)  # reset fails
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_reset_and_revert(tmp_path / "PaymentServiceTests.cs") is False
+    # Only the reset call happens — checkout (git_revert) is never reached.
+    assert len(calls) == 1
+    assert calls[0][:3] == ["git", "--literal-pathspecs", "reset"]
+
+
+def test_git_reset_and_revert_returns_false_when_checkout_fails_after_reset_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list = []
+
+    class _R:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv[2] == "reset":
+            return _R(0)  # reset succeeds
+        return _R(1)  # checkout (git_revert) fails
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_reset_and_revert(tmp_path / "PaymentServiceTests.cs") is False
+    assert [c[2] for c in calls] == ["reset", "checkout"]
+
+
+def test_git_reset_and_revert_returns_true_when_both_steps_succeed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_reset_and_revert(tmp_path / "PaymentServiceTests.cs") is True
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -4,7 +4,9 @@ counterpart to mutation_kill_loop.py's survivor-kill loop mechanics (#1357).
 Every mutmut / git / pytest subprocess is mocked — no real mutmut run
 happens here (that's covered by the manual, real-tool dogfooding recorded
 in #1354/#1357's issue history). Insertion mechanics run against real
-tmp_path files since they're pure file I/O with no subprocess involved.
+tmp_path files since they're pure file I/O with no subprocess involved. A
+handful of git_reset_and_revert regression tests use a REAL tmp_path git
+repo (no mocks) — see their docstrings (#1598/#1584 review).
 """
 
 from __future__ import annotations
@@ -13,7 +15,12 @@ import sys
 from pathlib import Path
 
 import pytest
-from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
+from _mutation_test_helpers import (
+    FORBIDDEN_LITERALS,
+    SCRIPTS_DIR,
+    git_hermetic,
+    hermetic_git_env,
+)
 
 sys.path.insert(0, str(SCRIPTS_DIR))
 
@@ -170,6 +177,64 @@ def test_run_scoped_mutmut_does_not_revert_test_file_when_not_supplied(
     assert reverted == [Path("src/a.py")]
 
 
+# =============================================================================
+# Scenario: the .mutmut-cache delete/run/revert sequence is lock-guarded so
+# two concurrent scoped runs against the same repo can't corrupt each
+# other's cache state (#1584)
+# =============================================================================
+def test_run_scoped_mutmut_releases_the_lock_after_a_successful_run(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    class _FakeCompleted:
+        stdout = "<testsuites></testsuites>"
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda *a, **k: _FakeCompleted())
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: None)
+
+    loop.run_scoped_mutmut("src/a.py", test_command="pytest", cwd=tmp_path)
+
+    assert not (tmp_path / ".mutmut-cache.lock").exists()
+
+
+def test_run_scoped_mutmut_releases_the_lock_even_when_mutmut_crashes(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(loop, "_mutmut_argv", lambda: ["mutmut"])
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated mutmut internal crash")
+
+    monkeypatch.setattr(loop.subprocess, "run", boom)
+    monkeypatch.setattr(loop, "git_revert", lambda path, **k: None)
+
+    with pytest.raises(RuntimeError):
+        loop.run_scoped_mutmut("src/a.py", test_command="pytest", cwd=tmp_path)
+
+    assert not (tmp_path / ".mutmut-cache.lock").exists()
+
+
+def test_acquire_mutmut_cache_lock_times_out_when_already_held(tmp_path: Path):
+    held = loop._acquire_mutmut_cache_lock(tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="timed out"):
+            loop._acquire_mutmut_cache_lock(tmp_path, timeout=0.3)
+    finally:
+        loop._release_mutmut_cache_lock(held)
+
+
+def test_acquire_mutmut_cache_lock_succeeds_once_released(tmp_path: Path):
+    lock_dir = loop._acquire_mutmut_cache_lock(tmp_path)
+    assert lock_dir.exists()
+    loop._release_mutmut_cache_lock(lock_dir)
+    assert not lock_dir.exists()
+
+    # A second acquire after release must succeed immediately, not raise.
+    second = loop._acquire_mutmut_cache_lock(tmp_path, timeout=1)
+    loop._release_mutmut_cache_lock(second)
+
+
 def test_extract_survivors_filters_to_target_file():
     xml = _junit(
         _survived("Mutant #1", "src/a.py", 5),
@@ -189,9 +254,10 @@ def test_extract_survivors_filters_to_target_file():
 # =============================================================================
 def test_append_at_end_of_file_adds_new_tests(tmp_path: Path):
     test_file = tmp_path / "test_calc.py"
-    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    existing = "def test_existing():\n    assert True\n"
+    test_file.write_text(existing, encoding="utf-8")
 
-    loop.append_at_end_of_file(test_file, "def test_new():\n    assert 1 == 1\n")
+    loop.append_at_end_of_file(test_file, "def test_new():\n    assert 1 == 1\n", existing)
 
     text = test_file.read_text(encoding="utf-8")
     assert "def test_existing():" in text
@@ -205,13 +271,11 @@ def test_append_refuses_when_no_existing_top_level_test_function(tmp_path: Path)
     doesn't match the flat convention this heuristic supports — refuse
     rather than guess an insertion point."""
     test_file = tmp_path / "test_calc.py"
-    test_file.write_text(
-        "class TestCalc:\n    def test_existing(self):\n        assert True\n",
-        encoding="utf-8",
-    )
+    class_based = "class TestCalc:\n    def test_existing(self):\n        assert True\n"
+    test_file.write_text(class_based, encoding="utf-8")
 
     with pytest.raises(loop.InsertionRefused):
-        loop.append_at_end_of_file(test_file, "def test_new():\n    assert True\n")
+        loop.append_at_end_of_file(test_file, "def test_new():\n    assert True\n", class_based)
 
     # file must be left untouched on refusal
     assert "test_new" not in test_file.read_text(encoding="utf-8")
@@ -245,6 +309,57 @@ def test_apply_generated_tests_duplicate_name_not_inserted(tmp_path: Path):
     assert "duplicate" in outcome.reason
     # original content unchanged
     assert "assert True" in test_file.read_text(encoding="utf-8")
+
+
+def test_apply_generated_tests_duplicate_check_uses_fresh_disk_content(tmp_path: Path):
+    """The duplicate-name check must run against the CURRENT file content —
+    not a pre-generation snapshot a caller might otherwise thread through —
+    so a test function added to the file externally between an earlier read
+    (e.g. before generate()) and this call is still caught as a duplicate
+    rather than silently double-inserted (#1598/#1584 review, item 7)."""
+    test_file = tmp_path / "test_calc.py"
+    # Stands in for: the file already has test_new by the time
+    # apply_generated_tests actually runs, even though an earlier read
+    # (simulated by generate() in the real loop) would not have seen it yet.
+    test_file.write_text(
+        "def test_existing():\n"
+        "    assert True\n"
+        "\n"
+        "def test_new():\n"
+        "    assert 2 == 2\n",
+        encoding="utf-8",
+    )
+    before = test_file.read_text(encoding="utf-8")
+
+    outcome = loop.apply_generated_tests(test_file, "def test_new():\n    assert 2 == 2\n")
+
+    assert outcome.inserted is False
+    assert "duplicate" in outcome.reason
+    assert test_file.read_text(encoding="utf-8") == before
+
+
+def test_append_at_end_of_file_operates_on_the_given_text_not_disk_content(
+    tmp_path: Path,
+):
+    """append_at_end_of_file takes the current text as a required, positional
+    argument and performs no read of its own (#1598/#1584 review, item 7) —
+    freshness is entirely apply_generated_tests's responsibility. On-disk
+    content here has no top-level `def test_*():` at all (which the
+    heuristic refuses) while the explicitly-passed text does. If the
+    function silently re-read from disk instead of using the given text,
+    this would raise InsertionRefused; using the given text, it must
+    succeed."""
+    test_file = tmp_path / "test_calc.py"
+    test_file.write_text(
+        "class TestCalc:\n    def test_existing(self):\n        assert True\n",
+        encoding="utf-8",
+    )
+
+    loop.append_at_end_of_file(
+        test_file, "def test_new():\n    assert True\n", "def test_existing():\n    assert True\n"
+    )
+
+    assert "test_new" in test_file.read_text(encoding="utf-8")
 
 
 def test_apply_generated_tests_success_path_inserts(tmp_path: Path):
@@ -329,6 +444,222 @@ def test_unsafe_generated_test_is_refused_not_inserted(tmp_path: Path):
     assert "unsafe" in outcome.reason.lower()
     assert "network" in outcome.reason
     assert test_file.read_text(encoding="utf-8") == before
+
+
+# =============================================================================
+# Scenario: git add/commit are scoped to the pathspec, not parsed as flags
+# (#1584 — mirrors the C# loop's git_commit)
+# =============================================================================
+def test_git_commit_scopes_add_and_commit_to_the_test_file(tmp_path: Path, monkeypatch):
+    calls: list = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    result = loop.git_commit("msg", tmp_path / "test_calc.py")
+
+    assert result is True
+    assert calls[0] == [
+        "git",
+        "--literal-pathspecs",
+        "add",
+        "--",
+        str(tmp_path / "test_calc.py"),
+    ]
+    assert calls[1] == [
+        "git",
+        "--literal-pathspecs",
+        "commit",
+        "-m",
+        "msg",
+        "--",
+        str(tmp_path / "test_calc.py"),
+    ]
+
+
+# =============================================================================
+# Scenario: A hung `git checkout`/`git add`/`git commit`/`git reset` is
+# bounded by a timeout, not left to hang the loop forever — mirrors
+# mutation_kill_loop.py's _GIT_TIMEOUT coverage (#1598/#1584 review, item 2).
+# Previously none of git_revert/git_reset_and_revert/git_commit passed
+# timeout= at all, so an unbounded git call here could hang forever instead
+# of ever reaching the RuntimeError/exit-4 fatal-revert path.
+# =============================================================================
+def test_git_revert_passes_a_timeout(tmp_path: Path, monkeypatch):
+    captured: dict = {}
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **k):
+        captured.update(k)
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    loop.git_revert(tmp_path / "test_calc.py")
+
+    assert captured["timeout"] == loop._GIT_TIMEOUT_S
+
+
+def test_git_revert_timeout_is_logged_not_raised(tmp_path: Path, monkeypatch, capsys):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_revert(tmp_path / "test_calc.py") is False  # must not raise
+    err = capsys.readouterr().err
+    assert str(loop._GIT_TIMEOUT_S) in err
+    assert "DEV_TEAM_MUTATION_GIT_TIMEOUT_S" in err
+    assert "git checkout" in err
+
+
+def test_git_revert_returns_true_on_success(tmp_path: Path, monkeypatch):
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_revert(tmp_path / "test_calc.py") is True
+
+
+def test_git_revert_returns_false_on_nonzero_exit(tmp_path: Path, monkeypatch):
+    class _R:
+        returncode = 1
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_revert(tmp_path / "test_calc.py") is False
+
+
+def test_git_commit_passes_a_timeout_to_add_and_commit(tmp_path: Path, monkeypatch):
+    calls: list = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _R()
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    result = loop.git_commit("msg", tmp_path / "test_calc.py")
+
+    assert result is True
+    assert calls[0][1]["timeout"] == loop._GIT_TIMEOUT_S
+    assert calls[1][1]["timeout"] == loop._GIT_TIMEOUT_S
+
+
+def test_git_commit_add_leg_timeout_returns_false(tmp_path: Path, monkeypatch, capsys):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_commit("msg", tmp_path / "test_calc.py") is False
+    err = capsys.readouterr().err
+    assert str(loop._GIT_TIMEOUT_S) in err
+    assert "git add" in err
+
+
+def test_git_commit_commit_leg_timeout_returns_false(tmp_path: Path, monkeypatch, capsys):
+    """The `git add` leg succeeds; only the `git commit` leg's own call
+    times out — a distinct branch from the add-leg timeout above."""
+    calls: list = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return _R()
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_commit("msg", tmp_path / "test_calc.py") is False
+    assert calls[0][:3] == ["git", "--literal-pathspecs", "add"]
+    err = capsys.readouterr().err
+    assert str(loop._GIT_TIMEOUT_S) in err
+    assert "git commit" in err
+
+
+# =============================================================================
+# Scenario: git_reset_and_revert's own internal failure branches — every
+# other test either exercises the full real-git success path or mocks
+# git_reset_and_revert away wholesale (#1598/#1584 review, item 10).
+# =============================================================================
+def test_git_reset_and_revert_returns_false_when_reset_fails(
+    tmp_path: Path, monkeypatch
+):
+    calls: list = []
+
+    class _R:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _R(1)  # reset fails
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_reset_and_revert(tmp_path / "test_calc.py") is False
+    # Only the reset call happens — checkout (git_revert) is never reached.
+    assert len(calls) == 1
+    assert calls[0][:3] == ["git", "--literal-pathspecs", "reset"]
+
+
+def test_git_reset_and_revert_returns_false_when_reset_times_out(
+    tmp_path: Path, monkeypatch
+):
+    def fake_run(argv, **kwargs):
+        raise loop.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_reset_and_revert(tmp_path / "test_calc.py") is False
+
+
+def test_git_reset_and_revert_returns_false_when_checkout_fails_after_reset_succeeds(
+    tmp_path: Path, monkeypatch
+):
+    calls: list = []
+
+    class _R:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv[2] == "reset":
+            return _R(0)  # reset succeeds
+        return _R(1)  # checkout (git_revert) fails
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    assert loop.git_reset_and_revert(tmp_path / "test_calc.py") is False
+    assert [c[2] for c in calls] == ["reset", "checkout"]
+
+
+def test_git_reset_and_revert_returns_true_when_both_steps_succeed(
+    tmp_path: Path, monkeypatch
+):
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(loop.subprocess, "run", lambda argv, **k: _R())
+
+    assert loop.git_reset_and_revert(tmp_path / "test_calc.py") is True
 
 
 # =============================================================================
@@ -478,7 +809,9 @@ def test_run_for_file_reverts_on_failing_scoped_test(tmp_path: Path, monkeypatch
     monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: False)
 
     reverted = []
-    monkeypatch.setattr(loop, "git_revert", lambda test_file, **k: reverted.append(test_file))
+    monkeypatch.setattr(
+        loop, "git_revert", lambda test_file, **k: reverted.append(test_file) or True
+    )
     monkeypatch.setattr(
         loop, "git_commit", lambda *a, **k: pytest.fail("must not commit on a failing test")
     )
@@ -537,6 +870,238 @@ def test_run_for_file_stops_on_no_improvement(tmp_path: Path, monkeypatch):
 
 
 # =============================================================================
+# Scenario: A failed commit is a round failure, not a silent success (#1598),
+# mirroring mutation_kill_loop.py's C# equivalent scenario.
+# =============================================================================
+def test_failed_commit_reverts_and_stops_the_round(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        loop, "run_scoped_mutmut", lambda *a, **k: _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    )
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: True)
+
+    events: list = []
+    monkeypatch.setattr(
+        loop, "git_commit", lambda msg, tf, **k: events.append(("commit", msg)) or False
+    )
+    monkeypatch.setattr(
+        loop,
+        "git_reset_and_revert",
+        lambda tf, **k: events.append(("revert", str(tf))) or True,
+    )
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def fake_generate(*_a):
+        calls["n"] += 1
+        return "def test_new():\n    assert True\n"
+
+    loop.run_for_file(
+        "src/a.py",
+        test_file=test_file,
+        source_path=source_file,
+        test_command="pytest",
+        generate=fake_generate,
+    )
+
+    kinds = [e[0] for e in events]
+    assert kinds.count("commit") == 1
+    assert kinds.count("revert") == 1
+    assert calls["n"] == 1
+
+
+def test_revert_failure_after_failed_commit_is_fatal(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        loop, "run_scoped_mutmut", lambda *a, **k: _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    )
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "git_commit", lambda msg, tf, **k: False)
+    # The commit-failure revert path calls git_reset_and_revert, not plain
+    # git_revert (#1598/#1584 review) — that's the function that must fail.
+    monkeypatch.setattr(loop, "git_reset_and_revert", lambda tf, **k: False)
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(
+            "src/a.py",
+            test_file=test_file,
+            source_path=source_file,
+            test_command="pytest",
+            generate=lambda *_a: "def test_new():\n    assert True\n",
+        )
+
+
+def test_revert_failure_after_build_failure_is_fatal(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        loop, "run_scoped_mutmut", lambda *a, **k: _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    )
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: False)
+    monkeypatch.setattr(loop, "git_revert", lambda tf, **k: False)
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(
+            "src/a.py",
+            test_file=test_file,
+            source_path=source_file,
+            test_command="pytest",
+            generate=lambda *_a: "def test_new():\n    assert True\n",
+        )
+
+
+def test_revert_failure_after_test_failure_is_fatal(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        loop, "run_scoped_mutmut", lambda *a, **k: _junit(_survived("Mutant #1", "src/a.py", 3), failures=1)
+    )
+    monkeypatch.setattr(loop, "python_compiles", lambda *a, **k: True)
+    monkeypatch.setattr(loop, "run_scoped_pytest", lambda *a, **k: False)
+    monkeypatch.setattr(loop, "git_revert", lambda tf, **k: False)
+
+    test_file = tmp_path / "test_a.py"
+    test_file.write_text("def test_existing():\n    assert True\n", encoding="utf-8")
+    source_file = tmp_path / "a.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="revert failed"):
+        loop.run_for_file(
+            "src/a.py",
+            test_file=test_file,
+            source_path=source_file,
+            test_command="pytest",
+            generate=lambda *_a: "def test_new():\n    assert True\n",
+        )
+
+
+# =============================================================================
+# Scenario (real git, no mocks): git_reset_and_revert leaves both the index
+# AND the working tree matching HEAD after a commit-failure-style staged
+# mutation — mirrors mutation_kill_loop.py's real-git regression test for
+# the same #1598 bug class.
+# =============================================================================
+def test_git_reset_and_revert_restores_index_and_worktree_after_a_staged_mutation(
+    tmp_path: Path,
+):
+    git_hermetic(tmp_path, "init", "-q")
+    git_hermetic(tmp_path, "config", "user.email", "test@example.com")
+    git_hermetic(tmp_path, "config", "user.name", "Test")
+    git_hermetic(tmp_path, "config", "commit.gpgsign", "false")
+
+    test_file = tmp_path / "test_a.py"
+    original = "def test_existing():\n    assert True\n"
+    test_file.write_text(original, encoding="utf-8")
+    git_hermetic(tmp_path, "add", "-A")
+    git_hermetic(tmp_path, "commit", "-q", "-m", "initial")
+
+    mutated = original + "\ndef test_mutated_never_committed():\n    assert False\n"
+    test_file.write_text(mutated, encoding="utf-8")
+    git_hermetic(tmp_path, "add", "--", str(test_file))
+
+    staged = git_hermetic(tmp_path, "diff", "--cached", "--name-only")
+    assert "test_a.py" in staged.stdout
+
+    # env= is the point of this test: the SUT's own git subprocess must run
+    # hermetically too, not just this test's setup calls above (#1598/#1584
+    # review, round 3 — test-smell-review/ai-provenance-review found the
+    # round-2 fix scrubbed only the setup calls).
+    assert (
+        loop.git_reset_and_revert(
+            test_file, cwd=tmp_path, env=hermetic_git_env(home=tmp_path)
+        )
+        is True
+    )
+
+    assert test_file.read_text(encoding="utf-8") == original
+    status = git_hermetic(tmp_path, "status", "--porcelain")
+    assert status.stdout.strip() == ""
+
+
+# =============================================================================
+# Scenario: --literal-pathspecs neutralizes pathspec magic characters in a
+# test_file value — every git call in both loops treats `--` as introducing a
+# pathspec, not a literal path, so magic characters (`:/`, `:(glob)`, etc.)
+# remain active even after `--` unless --literal-pathspecs is set
+# (#1598/#1584 review, item 5). Real git (hermetic), not mocked: a mocked
+# argv-shape assertion can't prove the flag actually changes git's matching
+# behavior the way this test does.
+# =============================================================================
+def test_git_revert_with_a_literal_pathspecs_flag_does_not_broaden_scope_to_a_glob_match(
+    tmp_path: Path,
+):
+    git_hermetic(tmp_path, "init", "-q")
+    git_hermetic(tmp_path, "config", "user.email", "test@example.com")
+    git_hermetic(tmp_path, "config", "user.name", "Test")
+    git_hermetic(tmp_path, "config", "commit.gpgsign", "false")
+
+    important = tmp_path / "important.py"
+    original = "def test_important():\n    assert True\n"
+    important.write_text(original, encoding="utf-8")
+    git_hermetic(tmp_path, "add", "-A")
+    git_hermetic(tmp_path, "commit", "-q", "-m", "initial")
+
+    # Mutate the file we DON'T want touched.
+    mutated = original + "\ndef test_mutated():\n    assert False\n"
+    important.write_text(mutated, encoding="utf-8")
+
+    # A test_file value shaped like a pathspec-magic glob — without
+    # --literal-pathspecs, `git checkout -- ':(glob)*.py'` would match every
+    # .py file in the repo (including important.py) and silently revert it
+    # too. With --literal-pathspecs, this string is a literal (nonexistent)
+    # filename, so the revert affects nothing else.
+    magic_path = Path(":(glob)*.py")
+
+    result = loop.git_revert(magic_path, cwd=tmp_path, env=hermetic_git_env(home=tmp_path))
+
+    # The literal path doesn't exist, so the revert itself fails...
+    assert result is False
+    # ...and, crucially, important.py's uncommitted mutation survives —
+    # proving the operation did NOT broaden to match every .py file via glob.
+    assert important.read_text(encoding="utf-8") == mutated
+
+
+# =============================================================================
+# Scenario: _release_mutmut_cache_lock swallows a release-time OSError rather
+# than masking whatever exception the run itself was raising (#1584 review).
+# =============================================================================
+def test_release_mutmut_cache_lock_swallows_a_missing_directory(tmp_path: Path):
+    lock_dir = tmp_path / ".mutmut-cache.lock"
+    lock_dir.mkdir()
+    lock_dir.rmdir()  # already gone — simulates a race/double-release
+
+    loop._release_mutmut_cache_lock(lock_dir)  # must not raise
+
+
+# =============================================================================
+# Scenario: the mutmut-cache lock timeout is overridable via env var, not a
+# bare magic number (#1584 review, item 9) — mirrors mutation_kill_loop.py's
+# _timeout_from_env pattern.
+# =============================================================================
+def test_mutmut_cache_lock_timeout_is_overridable_via_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DEV_TEAM_MUTATION_MUTMUT_LOCK_TIMEOUT_S", "77")
+    import importlib
+
+    reloaded = importlib.reload(loop)
+    try:
+        assert reloaded._MUTMUT_CACHE_LOCK_TIMEOUT_S == 77
+    finally:
+        monkeypatch.delenv("DEV_TEAM_MUTATION_MUTMUT_LOCK_TIMEOUT_S", raising=False)
+        importlib.reload(loop)
+
+
+# =============================================================================
 # No repo-specific literal leaked into the module
 # =============================================================================
 def test_module_source_carries_no_repo_specific_literal():
@@ -566,3 +1131,31 @@ def test_main_headless_missing_claude_cli_fails_before_touching_files(monkeypatc
     rc = loop.main(["--headless", "--file", "a.py"])
     assert rc == 3
     assert "Claude CLI" in capsys.readouterr().err
+
+
+# =============================================================================
+# Scenario: A round-abandoning RuntimeError (failed revert, failed commit —
+# #1598) propagates to a non-zero exit code instead of a silent 0 return or
+# a raw traceback (#1598/#1584 review, item 6).
+# =============================================================================
+def test_main_exits_non_zero_when_run_for_file_raises(monkeypatch, capsys, tmp_path: Path):
+    monkeypatch.setattr(loop, "claude_cli_available", lambda: True)
+
+    def boom(*a, **k):
+        raise RuntimeError("revert failed for test_a.py after a failed commit")
+
+    monkeypatch.setattr(loop, "run_for_file", boom)
+
+    rc = loop.main(
+        [
+            "--headless",
+            "--file", "a.py",
+            "--test-file", str(tmp_path / "test_a.py"),
+            "--source-path", str(tmp_path / "a.py"),
+            "--test-command", "pytest",
+        ]
+    )
+
+    assert rc != 0
+    assert rc not in (1, 2, 3)
+    assert "revert failed" in capsys.readouterr().err

--- a/tests/scripts/test_stryker_shard_pipeline.py
+++ b/tests/scripts/test_stryker_shard_pipeline.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 import threading
 import time
@@ -82,12 +83,21 @@ def _write_report(out_dir: Path, files: dict) -> Path:
 
 
 class _Recorder:
-    """Collects log lines + git commands + loop-launch commands."""
+    """Collects log lines + git commands + loop-launch commands.
+
+    ``run`` returns a ``subprocess.CompletedProcess``-shaped stand-in (with a
+    ``.returncode``) — mirrors the real ``subprocess.run`` contract that
+    ``launch_survivor_fix`` inspects. Set ``run_returncode`` (or
+    ``run_returncodes`` for a per-call sequence) before invoking to simulate
+    a launched fix exiting non-zero (e.g. the #1598 fatal-revert exit code).
+    """
 
     def __init__(self):
         self.logs = []
         self.git = []
         self.launches = []
+        self.run_returncode = 0
+        self.run_returncodes: list[int] | None = None
 
     def log(self, line):
         self.logs.append(line)
@@ -97,6 +107,12 @@ class _Recorder:
 
     def run(self, cmd, cwd=None):
         self.launches.append(list(cmd))
+        rc = (
+            self.run_returncodes.pop(0)
+            if self.run_returncodes
+            else self.run_returncode
+        )
+        return subprocess.CompletedProcess(cmd, rc)
 
 
 # =============================================================================
@@ -202,6 +218,98 @@ def test_survivor_fix_launch_forces_headless(tmp_path):
     assert pipeline.LOOP_SCRIPT in cmd
     assert "--file" in cmd and "Foo.cs" in cmd
     assert "--report" in cmd
+
+
+# =============================================================================
+# Scenario: A non-zero exit from the headless loop (e.g. the #1598
+# fatal-revert exit code) stops the per-file loop instead of silently
+# continuing onto a working tree that may already be in an unknown state.
+# =============================================================================
+def test_survivor_fix_stops_launching_further_files_after_a_nonzero_exit(tmp_path):
+    rec = _Recorder()
+    rec.run_returncode = 4  # mutation_kill_headless's fatal-revert exit code
+    out_dir = tmp_path / "out" / "a"
+    config = _write_shard_config(tmp_path, "a")
+    _write_report(
+        out_dir,
+        {
+            "src/W.a/Foo.cs": {"mutants": [_mutant("Survived")]},
+            "src/W.a/Bar.cs": {"mutants": [_mutant("Survived")]},
+        },
+    )
+
+    ok = pipeline.launch_survivor_fix(
+        "a",
+        repo_root=tmp_path,
+        out_dir=out_dir,
+        config_path=config,
+        model=None,
+        max_rounds=2,
+        run=rec.run,
+        resolve_test_file=lambda source, *a: Path(f"test/W.Tests/{Path(source).stem}Tests.cs"),
+        log=rec.log,
+    )
+
+    assert ok is False
+    # Only the first file's fix is launched — the second file is never
+    # reached once the first exits non-zero.
+    assert len(rec.launches) == 1
+    assert any("FAILED (headless)" in line and "exit 4" in line for line in rec.logs)
+
+
+def test_survivor_fix_all_files_launched_when_every_exit_is_zero(tmp_path):
+    rec = _Recorder()
+    out_dir = tmp_path / "out" / "a"
+    config = _write_shard_config(tmp_path, "a")
+    _write_report(
+        out_dir,
+        {
+            "src/W.a/Foo.cs": {"mutants": [_mutant("Survived")]},
+            "src/W.a/Bar.cs": {"mutants": [_mutant("Survived")]},
+        },
+    )
+
+    ok = pipeline.launch_survivor_fix(
+        "a",
+        repo_root=tmp_path,
+        out_dir=out_dir,
+        config_path=config,
+        model=None,
+        max_rounds=2,
+        run=rec.run,
+        resolve_test_file=lambda source, *a: Path(f"test/W.Tests/{Path(source).stem}Tests.cs"),
+        log=rec.log,
+    )
+
+    assert ok is True
+    assert len(rec.launches) == 2
+
+
+def test_process_shard_marks_failed_when_a_survivor_fix_exits_nonzero(tmp_path):
+    rec = _Recorder()
+    rec.run_returncode = 4
+    _write_shard_config(tmp_path, "a")
+    _write_report(tmp_path / "out" / "a", {"src/W.a/Foo.cs": {"mutants": [_mutant("Survived")]}})
+
+    result = pipeline.process_shard(
+        "a",
+        repo_root=tmp_path,
+        worktree_base=tmp_path / ".wt",
+        shard_out_base=tmp_path / "out",
+        stryker_bin="fake-stryker",
+        model=None,
+        max_rounds=3,
+        skip_agent=False,
+        skip_existing=False,
+        max_age_hours=0,
+        log=rec.log,
+        run_stryker=lambda **kw: 0,
+        run=rec.run,
+        resolve_test_file=lambda *a: Path("test/W.Tests/FooTests.cs"),
+        git_run=rec.git_run,
+    )
+
+    assert result == "failed"
 
 
 def test_build_loop_command_always_includes_headless():


### PR DESCRIPTION
## Summary

- Closes the two "silent success" integrity gaps in `mutation_kill_loop.py`'s survivor-kill loop (#1598): `git_commit`/`git_revert` now report failure reliably instead of returning `None`, a failed commit is correctly unstaged *and* restored (the original single-checkout fix was a no-op on the dominant failure path — the mutated content was already staged by `git_commit`'s own `git add`), `dotnet_test`'s multi-assembly failure count now accumulates instead of last-match-wins, and `stryker-config.json`'s `solution` path is validated against traversal before it's used to derive the hidden `.sln` filename.
- Closes the hardening/coverage gaps from #1584: eliminates the redundant per-round test-file reads (3 → 2, with a fresh read at insertion time so a multi-minute LLM generation call can't create a stale-write race), adds a `.mutmut-cache` mutex with a configurable timeout, and scopes every `git add`/`commit`/`reset`/`checkout` with `--literal-pathspecs` plus `--` so a test-file path can never be treated as a flag or pathspec-magic value.
- Mirrors both fixes into `mutation_kill_loop_python.py` (the Python/mutmut sibling) for parity with the C#/Stryker loop, and propagates the new fatal-revert signal through `mutation_kill_headless.py`'s and `stryker_shard_pipeline.py`'s exit codes so an unattended `--headless`/shard-pipeline run can no longer silently continue past a possibly-dirty working tree.
- **Deliberately reverted**: PID-suffixing the hidden `.sln` filename. `stryker_shard_pipeline.py` runs shards sequentially today (no concurrent-run scenario exists), and the PID suffix broke `csharp_stryker_net_wrapper.py`'s existing crash-recovery detection (`check_stale_hidden_sln` looks for the literal `.stryker-hidden` name). Kept the fixed name and wired `run_scoped_stryker` into that existing crash-recovery check instead, which it was never calling.

## Review process

This PR went through 4 rounds of independent multi-agent review (17-agent panel × 3 full rounds, plus a focused 4-agent final pass) before merge-readiness. The panel caught — and this PR fixes — several defects a solo implementation pass missed, most notably:
- A commit-failure revert that reported success while leaving the mutation staged on disk (round 1).
- The Python loop's git integrity fix, timeout handling, and complexity-reduction refactor not being mirrored from the C# loop (rounds 1–3).
- A hermetic-test-environment fix that scrubbed the test's own setup calls but not the production code under test, re-opening a real repo-corruption risk with documented precedent (issue #546) (rounds 3–4).
- The shard pipeline silently discarding the new fatal-revert exit code, defeating the "not a silent success" guarantee at its only unattended production caller (round 3).

## Test Plan

- [x] `pytest tests/scripts/test_mutation_kill_loop.py tests/scripts/test_mutation_kill_loop_python.py tests/scripts/test_mutation_kill_insert.py tests/scripts/test_stryker_shard_pipeline.py tests/scripts/test_mutation_kill_headless.py tests/agents/test_mutation_kill_agent.py` — 253 passed
- [x] Full plugin-content gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks`) — 5733 passed, 4 skipped
- [x] `ruff check` on all changed files — clean
- [x] `scripts/ci-local.sh` (full local CI mirror, pre-push hook) — all 20 checks green
- [x] New real-git regression tests (hermetic, not mocked) prove the corrected commit-failure revert actually restores index + worktree to HEAD, and that `--literal-pathspecs` actually neutralizes pathspec-magic filenames

Closes #1598
Closes #1584

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTHWUCvktPGGjRjW17sDwY)_