### PR TITLE
feat(evals): fix js-fp-review eval-corpus hygiene gaps and repair issue-1620 fallout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,9 +215,7 @@ DEV_TEAM_REPORTS/
 # shape above — the union of both legacy blocks' tracked exceptions.
 /.dev-team-reports/*
 !/.dev-team-reports/test-improve/
-!/.dev-team-reports/orchestration-benchmark-2026-07-18.md
-!/.dev-team-reports/orchestration-benchmark-2026-07-18-data/
-!/.dev-team-reports/harness-audit-2026-07-20.md
+
 
 # refactor-granularity campaign: per-arm shards are intermediate (resume targets);
 # the merged dataset (refactor-granularity-campaign.jsonl) is committed instead.
@@ -226,3 +224,4 @@ docs/experiments/data/refactor-granularity-test-after-*.jsonl
 
 # dev-team hygiene — machine-specific MCP config (absolute-path pollution — issues #1376, #1416)
 .mcp.json
+memory/

--- a/evals/expected/fp-global-state.json
+++ b/evals/expected/fp-global-state.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "fp-global-state.js",
+  "fixture": "fp-global-state.ts",
   "description": "Global state mutations via window, process.env, and module-level variables - should flag errors",
   "applicableAgents": ["js-fp-review"],
   "agents": {

--- a/evals/expected/fp-immutable-state.json
+++ b/evals/expected/fp-immutable-state.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "fp-immutable-state.js",
+  "fixture": "fp-immutable-state.ts",
   "description": "Immutable state management with spread operators and no direct mutation - should pass cleanly",
   "applicableAgents": ["js-fp-review"],
   "agents": {

--- a/evals/expected/fp-object-mutations.json
+++ b/evals/expected/fp-object-mutations.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "fp-object-mutations.js",
+  "fixture": "fp-object-mutations.ts",
   "description": "Direct object property mutation and Object.assign on targets - should flag errors",
   "applicableAgents": ["js-fp-review"],
   "agents": {

--- a/evals/expected/fp-pure-transforms.json
+++ b/evals/expected/fp-pure-transforms.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "fp-pure-transforms.js",
+  "fixture": "fp-pure-transforms.ts",
   "description": "Pure functional transforms with no mutations - should pass cleanly",
   "applicableAgents": ["js-fp-review"],
   "agents": {

--- a/evals/expected/fp-safe-sort.json
+++ b/evals/expected/fp-safe-sort.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "fp-safe-sort.js",
+  "fixture": "fp-safe-sort.ts",
   "description": "Sorting via spread-copy before sort, toSorted, or slice().sort() - should pass cleanly",
   "applicableAgents": ["js-fp-review"],
   "agents": {

--- a/evals/fixtures/spec-unmet-criterion/src/reset.ts
+++ b/evals/fixtures/spec-unmet-criterion/src/reset.ts
@@ -13,7 +13,7 @@ export async function requestReset(email: string, store: Store): Promise<string>
   if (!user) {
     return "no account found for that email";
   }
-  const token = insecureRandomToken()();
+  const token = insecureRandomToken();
   await store.saveToken(user.id, token, Date.now());
   return "reset link sent";
 }
@@ -24,6 +24,6 @@ export async function exportAllUsers(store: Store): Promise<unknown> {
   return (store as unknown as { dump(): unknown }).dump();
 }
 
-function insecureRandomToken()(): string {
+function insecureRandomToken(): string {
   return Math.random().toString(36).slice(2);
 }

--- a/evals/fixtures/spec-unmet-criterion/src/reset.ts
+++ b/evals/fixtures/spec-unmet-criterion/src/reset.ts
@@ -13,7 +13,7 @@ export async function requestReset(email: string, store: Store): Promise<string>
   if (!user) {
     return "no account found for that email";
   }
-  const token = cryptoRandom();
+  const token = insecureRandomToken()();
   await store.saveToken(user.id, token, Date.now());
   return "reset link sent";
 }
@@ -24,6 +24,6 @@ export async function exportAllUsers(store: Store): Promise<unknown> {
   return (store as unknown as { dump(): unknown }).dump();
 }
 
-function cryptoRandom(): string {
+function insecureRandomToken()(): string {
   return Math.random().toString(36).slice(2);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -455,7 +455,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -906,9 +906,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1012,9 +1012,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1428,8 +1428,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/plugins/dev-team/agents/js-fp-review.md
+++ b/plugins/dev-team/agents/js-fp-review.md
@@ -19,7 +19,7 @@ Scope:
 - **/*.cjs
 Cites: [adversarial-review-protocol]
 
-Scope: JavaScript and TypeScript files only (`.js`, `.ts`, `.jsx`, `.tsx`).
+Scope: JavaScript and TypeScript files only (`.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, `.cjs`).
 Skip this agent entirely if the project has no JS/TS files.
 
 Output JSON: per `${CLAUDE_PLUGIN_ROOT}/knowledge/review-agent-output-contract.md` (Whole-file load: short, canonical schema).
@@ -34,7 +34,7 @@ Context needs: diff-only
 
 Return `{"status": "skip", "issues": [], "summary": "No JS/TS files in target"}` when:
 
-- No `.js`, `.ts`, `.jsx`, or `.tsx` files exist in the target
+- No `.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, or `.cjs` files exist in the target
 - All target files are non-JavaScript/TypeScript
 
 ## Detect

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -69,10 +69,8 @@ import mutation_report
 import mutation_safety_gate
 from mutation_kill_insert_python import apply_generated_tests, count_tests
 from mutation_kill_shared import (
-    GIT_TIMEOUT_S,  # noqa: F401 — re-exported for tests (loop.GIT_TIMEOUT_S), matching the C# sibling's export name
-)
-from mutation_kill_shared import (
     CLAUDE_CLI,
+    GIT_TIMEOUT_S,  # noqa: F401 — re-exported for tests (loop.GIT_TIMEOUT_S), matching the C# sibling's export name
     _timeout_from_env,
     claude_cli_available,
     git_commit,

--- a/tests/repo/test_dev_team_reports_gitignore_consolidation.py
+++ b/tests/repo/test_dev_team_reports_gitignore_consolidation.py
@@ -1,9 +1,12 @@
 """Slice 9, Step 9.7 (= Slice 6, Step 6.2): `.gitignore`'s reports-domain block
 consolidates `DEV_TEAM_REPORTS/` and `reports/` into one new top-level
-`.dev-team-reports/` catch-all, carrying the union of both legacy blocks'
-tracked exceptions. Both legacy blocks (bare `/reports/*` and the standalone
-`DEV_TEAM_REPORTS/` line) stay completely unchanged as a safety net for
-un-migrated content (AC19, plan Slice 9 Step 9.7).
+`.dev-team-reports/` catch-all. Both legacy blocks (bare `/reports/*` and the
+standalone `DEV_TEAM_REPORTS/` line) stay completely unchanged as a safety
+net for un-migrated content (AC19, plan Slice 9 Step 9.7). The
+`orchestration-benchmark`/`harness-audit` tracked exceptions this block once
+also carried were dropped from `.dev-team-reports/*`; the legacy bare
+`reports/*` exceptions for those same two artifacts remain, see
+`test_legacy_reports_root_stays_unchanged` below.
 
 These assertions run `git check-ignore` against the repo's real `.gitignore`
 so they verify the shipped rule, not a copy. `git check-ignore` matches on the
@@ -45,13 +48,8 @@ def test_adhoc_dev_team_reports_output_is_ignored():
     assert _is_ignored(".dev-team-reports/review-agent-output.md")
 
 
-def test_dev_team_reports_tracked_exceptions_are_unignored():
+def test_dev_team_reports_test_improve_exception_is_unignored():
     assert not _is_ignored(".dev-team-reports/test-improve/some-repo/baseline.json")
-    assert not _is_ignored(".dev-team-reports/orchestration-benchmark-2026-07-18.md")
-    assert not _is_ignored(
-        ".dev-team-reports/orchestration-benchmark-2026-07-18-data/raw.json"
-    )
-    assert not _is_ignored(".dev-team-reports/harness-audit-2026-07-20.md")
 
 
 def test_legacy_dev_team_reports_root_stays_ignored_unchanged():

--- a/tests/repo/test_gitignore_claude_scoped_relocation.py
+++ b/tests/repo/test_gitignore_claude_scoped_relocation.py
@@ -6,8 +6,7 @@ Slice 9's Step 9.7 — see `test_dev_team_reports_gitignore_consolidation.py` fo
 that coverage; this file covers only the memory/metrics/plans domains Step
 6.2 was left to close, plus the two review-flagged gaps: `.claude/memory/
 build-phase.json` and `.claude/memory/test-improve/` were previously
-uncovered by any rule (AC11), and the bare `memory/test-improve/` rule has
-been removed now that its runtime state relocated.
+uncovered by any rule (AC11).
 
 These assertions run `git check-ignore` against the repo's real `.gitignore`
 so they verify the shipped rule, not a copy. `git check-ignore` matches on
@@ -69,10 +68,6 @@ def test_claude_memory_test_improve_nested_gap_closed():
     # children, not nested dirs — previously uncovered.
     assert _is_ignored(".claude/memory/test-improve/some-slug/phase-0.md")
     assert _is_ignored(".claude/memory/test-improve/some-slug/refactor-backlog.md")
-
-
-def test_bare_memory_test_improve_rule_no_longer_exists():
-    assert not _is_ignored("memory/test-improve/some-slug/phase-0.md")
 
 
 def test_security_assessment_memory_patterns_unaffected():

--- a/tests/scripts/_mutation_kill_loop_python_test_helpers.py
+++ b/tests/scripts/_mutation_kill_loop_python_test_helpers.py
@@ -26,10 +26,10 @@ from _mutation_test_helpers import SCRIPTS_DIR
 
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-import mutation_kill_loop_python as loop  # noqa: E402
+import mutation_kill_loop_python as loop
 
 
-def _ctx(test_file: Path, source_file: Path, *, log=print, **overrides) -> "loop.RunContext":
+def _ctx(test_file: Path, source_file: Path, *, log=print, **overrides) -> loop.RunContext:
     """Build a RunContext for these tests — a thin local convenience since
     the vast majority of tests here only vary test_file/source_file/log."""
     fields = {

--- a/tests/scripts/test_mutation_kill_loop_python.py
+++ b/tests/scripts/test_mutation_kill_loop_python.py
@@ -23,11 +23,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import mutation_kill_loop_python as loop
 import pytest
 from _mutation_kill_loop_python_test_helpers import _junit, _killed, _survived
 from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
-
-import mutation_kill_loop_python as loop  # noqa: E402 (sys.path set up by the helper import above)
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_kill_loop_python_cli.py
+++ b/tests/scripts/test_mutation_kill_loop_python_cli.py
@@ -17,12 +17,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import _mutation_kill_loop_python_test_helpers  # noqa: F401 (sys.path side effect)
+import mutation_kill_loop_python as loop
+import mutation_kill_shared as shared
 import pytest
 from _mutation_test_helpers import FORBIDDEN_LITERALS, SCRIPTS_DIR
-
-import _mutation_kill_loop_python_test_helpers  # noqa: F401 (sys.path side effect)
-import mutation_kill_loop_python as loop  # noqa: E402
-import mutation_kill_shared as shared  # noqa: E402
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_kill_loop_python_orchestration.py
+++ b/tests/scripts/test_mutation_kill_loop_python_orchestration.py
@@ -14,11 +14,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import mutation_kill_loop_python as loop
 import pytest
 from _mutation_kill_loop_python_test_helpers import _ctx, _junit, _killed, _survived
 from _mutation_test_helpers import git_hermetic, hermetic_git_env
-
-import mutation_kill_loop_python as loop  # noqa: E402 (sys.path set up by the helper import above)
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_kill_loop_python_verify.py
+++ b/tests/scripts/test_mutation_kill_loop_python_verify.py
@@ -23,9 +23,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import _mutation_kill_loop_python_test_helpers  # noqa: F401 (sys.path side effect)
-
-import mutation_kill_loop_python as loop  # noqa: E402
-import mutation_kill_shared as shared  # noqa: E402
+import mutation_kill_loop_python as loop
+import mutation_kill_shared as shared
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Corrects five `evals/expected/fp-*.json` `fixture` pointers (`.js`→`.ts`) — the four named in #1622 plus a fifth (`fp-global-state.json`) found during review — and extends `js-fp-review.md`'s prose Scope/Skip to include `.mjs`/`.cjs`, matching its own dispatch glob.
- Deliberately does **not** implement #1622's item 1 (a `mustNotMention`-vs-fixture-content `--check-corpus` rule): prototyped it and ran it through a full independent review panel; `mustNotMention` is graded against the agent's *output* text, never fixture source, so the proposed check produced 100% false positives on the real corpus. Left a comment on #1622 explaining why.
- Repairs invalid TypeScript syntax (`insecureRandomToken()()`) left by #1620's rename commit.
- Narrows two `.gitignore` repo-hygiene tests broken by that same commit's stray `.gitignore` edit (one trimmed to keep its still-valid assertion, one removed) rather than reverting the `.gitignore` change, at explicit request.
- Fixes pre-existing, unrelated ruff violations caught by the push gate.

## Known, disclosed tradeoff (not fixed here)

`.gitignore`'s unanchored `memory/` rule (from #1620's commit) matches at any depth, so it silently suppresses any *new* file under `.claude/memory/` (the decision-log directory) from ever entering git history, with no test left to catch that class of regression. `test_security_assessment_memory_patterns_unaffected` is now vacuous for the same reason.

## Follow-ups filed

- #1630 — 8 more `evals/expected/*.json` files with the same stale `.js`→`.ts` `fixture`-pointer defect, outside #1622's named scope.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks` — green
- [x] `python3 scripts/eval_grade.py --check-corpus` — 135 fixtures valid
- [x] `ruff check .` — clean
- [x] `bash scripts/ci-local.sh` — all local CI checks passed
- [x] Independently reviewed by the full review-agent panel across three iterations, converging clean

Closes #1622
Closes #1620