### PR TITLE
feat(evals): fix 8 more evals/expected/*.json fixture pointers still saying .js for .ts fixtures

### DIFF
--- a/evals/expected/dm-clean-boundaries.json
+++ b/evals/expected/dm-clean-boundaries.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "dm-clean-boundaries.js",
+  "fixture": "dm-clean-boundaries.ts",
   "description": "Clean domain boundaries with proper separation of concerns",
   "applicableAgents": ["domain-review"],
   "agents": {

--- a/evals/expected/dm-leaky-abstraction.json
+++ b/evals/expected/dm-leaky-abstraction.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "dm-leaky-abstraction.js",
+  "fixture": "dm-leaky-abstraction.ts",
   "description": "Leaky abstractions exposing infrastructure details to domain layer",
   "applicableAgents": ["domain-review"],
   "agents": {

--- a/evals/expected/dm-logic-in-ui.json
+++ b/evals/expected/dm-logic-in-ui.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "dm-logic-in-ui.js",
+  "fixture": "dm-logic-in-ui.ts",
   "description": "Business logic incorrectly placed in UI or controller layer",
   "applicableAgents": ["domain-review"],
   "agents": {

--- a/evals/expected/dm-missing-dtos.json
+++ b/evals/expected/dm-missing-dtos.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "dm-missing-dtos.js",
+  "fixture": "dm-missing-dtos.ts",
   "description": "Missing DTOs causing domain entities to leak across boundaries",
   "applicableAgents": ["domain-review"],
   "agents": {

--- a/evals/expected/dm-proper-events.json
+++ b/evals/expected/dm-proper-events.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "dm-proper-events.js",
+  "fixture": "dm-proper-events.ts",
   "description": "Proper use of domain events for cross-boundary communication",
   "applicableAgents": ["domain-review"],
   "agents": {

--- a/evals/expected/te-clean-code.json
+++ b/evals/expected/te-clean-code.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "te-clean-code.js",
+  "fixture": "te-clean-code.ts",
   "description": "Clean concise code with short functions and no duplication",
   "applicableAgents": ["token-efficiency-review"],
   "agents": {

--- a/evals/expected/te-duplicate-code.json
+++ b/evals/expected/te-duplicate-code.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "te-duplicate-code.js",
+  "fixture": "te-duplicate-code.ts",
   "description": "Code with duplicated logic that should be extracted and reused",
   "applicableAgents": ["token-efficiency-review"],
   "agents": {

--- a/evals/expected/te-long-functions.json
+++ b/evals/expected/te-long-functions.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "te-long-functions.js",
+  "fixture": "te-long-functions.ts",
   "description": "Code with excessively long functions exceeding recommended line limits",
   "applicableAgents": ["token-efficiency-review"],
   "agents": {

--- a/plugins/dev-team/hooks/lib/review_gate_normalized_hash.py
+++ b/plugins/dev-team/hooks/lib/review_gate_normalized_hash.py
@@ -222,7 +222,7 @@ def _encode(parts) -> str:
     injection hazard, and a real one here because the digest's whole job is
     to be hard to collide with.
     """
-    return _FIELD_SEP.join("{}:{}".format(len(part), part) for part in parts)
+    return _FIELD_SEP.join(f"{len(part)}:{part}" for part in parts)
 
 #: Patch-metadata prefixes that carry a real change with no hunk body — a
 #: mode flip, a rename, a copy, an empty new or deleted file. See fix 4 in
@@ -317,7 +317,7 @@ def _structural_marker(raw: str) -> str | None:
 class _FileSection:
     """Accumulator for one `diff --git` section."""
 
-    __slots__ = ("path", "old_path", "fallback", "structural", "hunks", "binary", "index_line")
+    __slots__ = ("binary", "fallback", "hunks", "index_line", "old_path", "path", "structural")
 
     def __init__(self, fallback: str) -> None:
         self.path: str | None = None
@@ -457,7 +457,7 @@ def normalize_patch(patch_text: str) -> str | None:
                     close_hunk()
             elif raw.startswith("index "):
                 current.index_line = raw.strip()
-            elif raw.startswith("Binary files ") or raw.startswith("GIT binary patch"):
+            elif raw.startswith(("Binary files ", "GIT binary patch")):
                 current.binary = True
             else:
                 marker = _structural_marker(raw)

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -50,14 +50,14 @@ import re
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
 # typing, not collections.abc: the `Generator` alias below is a real runtime
 # expression (mutation_kill_headless imports the name), so `from __future__
 # import annotations` cannot defer it, and collections.abc generics are only
 # subscriptable from 3.9. ADR 0014 puts the shipped floor at 3.8.
-from typing import Callable, Dict, List, Sequence
-from dataclasses import dataclass
-from pathlib import Path
-from typing import NamedTuple
+from typing import Callable, Dict, List, NamedTuple, Sequence
 
 import csharp_stryker_net_wrapper as wrapper
 import mutation_report

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop_python.py
@@ -61,13 +61,14 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
+from pathlib import Path
+
 # typing, not collections.abc: the `Generator` alias below is a real runtime
 # expression, so `from __future__ import annotations` cannot defer it, and
 # collections.abc generics are only subscriptable from 3.9. ADR 0014 puts the
 # shipped floor at 3.8.
 from typing import Callable, Dict, List, Sequence
-from dataclasses import dataclass
-from pathlib import Path
 
 import mutation_report
 import mutation_safety_gate

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -33,13 +33,14 @@ import subprocess
 import sys
 import threading
 import time
+from datetime import datetime, timezone
+from pathlib import Path
+
 # typing, not collections.abc: the module-level type aliases below are real
 # runtime expressions, so `from __future__ import annotations` cannot defer
 # them, and collections.abc generics are only subscriptable from 3.9. ADR 0014
 # puts the shipped floor at 3.8.
 from typing import Callable, Optional, Sequence
-from datetime import datetime, timezone
-from pathlib import Path
 
 import csharp_stryker_net_wrapper as wrapper
 import mutation_report

--- a/scripts/import_probe_shipped.py
+++ b/scripts/import_probe_shipped.py
@@ -89,7 +89,7 @@ def main() -> int:
             spec.loader.exec_module(module)
         except VERSION_ERRORS:
             failures.append((path, traceback.format_exc()))
-        except Exception:
+        except Exception:  # noqa: BLE001, S110 — deliberately broad, see VERSION_ERRORS above
             # Anything else (ImportError for an unresolvable sibling, an
             # OSError from a module probing its environment) is not evidence
             # about the interpreter version.
@@ -103,9 +103,9 @@ def main() -> int:
         )
     )
     if failures:
-        print("\n{} module(s) failed to import:\n".format(len(failures)), file=sys.stderr)
+        print(f"\n{len(failures)} module(s) failed to import:\n", file=sys.stderr)
         for path, tb in failures:
-            print("=== {} ===".format(path.relative_to(REPO_ROOT)), file=sys.stderr)
+            print(f"=== {path.relative_to(REPO_ROOT)} ===", file=sys.stderr)
             print(tb, file=sys.stderr)
         print(
             "ADR 0014 sets the shipped floor at Python 3.8. See "

--- a/scripts/run_refactor_experiment.py
+++ b/scripts/run_refactor_experiment.py
@@ -23,6 +23,8 @@ Usage:
   python3 scripts/run_refactor_experiment.py --skip-dispatch            # free self-test
   python3 scripts/run_refactor_experiment.py --arm one-shot-single --task fare --trials 1
 """
+from __future__ import annotations
+
 import argparse
 import ast
 import json

--- a/tests/repo/test_agent_implemented_by_resolves.py
+++ b/tests/repo/test_agent_implemented_by_resolves.py
@@ -62,22 +62,16 @@ def test_implemented_by_resolves_inside_the_plugin(agent):
 
     if agent.name in KNOWN_UNSHIPPED:
         pytest.xfail(
-            "known unshipped implementation — {} names a repo-root script".format(
-                agent.name
-            )
+            f"known unshipped implementation — {agent.name} names a repo-root script"
         )
 
     assert reference.startswith("${CLAUDE_PLUGIN_ROOT}/"), (
-        "{}: `Implemented by: {}` is a bare path. It resolves against the user's "
-        "cwd, not the plugin, so it points nowhere on an install.".format(
-            agent.name, reference
-        )
+        f"{agent.name}: `Implemented by: {reference}` is a bare path. It resolves against the user's "
+        "cwd, not the plugin, so it points nowhere on an install."
     )
     relative = reference[len("${CLAUDE_PLUGIN_ROOT}/") :]
     assert (PLUGIN_ROOT / relative).is_file(), (
-        "{}: `Implemented by:` names {}, which does not ship".format(
-            agent.name, relative
-        )
+        f"{agent.name}: `Implemented by:` names {relative}, which does not ship"
     )
 
 
@@ -120,10 +114,10 @@ def test_skills_invoke_plugin_scripts_by_plugin_root(skill):
     ]
     if skill.parent.name in KNOWN_BARE_INVOCATION:
         assert offenders, (
-            "{} is listed as a known offender but is now clean — remove it from "
-            "KNOWN_BARE_INVOCATION".format(skill.parent.name)
+            f"{skill.parent.name} is listed as a known offender but is now clean — remove it from "
+            "KNOWN_BARE_INVOCATION"
         )
-        pytest.xfail("known bare invocation in {}".format(skill.parent.name))
+        pytest.xfail(f"known bare invocation in {skill.parent.name}")
 
     assert not offenders, (
         "{}: invokes a plugin script by a bare relative path; use "

--- a/tests/scripts/test_claude_setup_review.py
+++ b/tests/scripts/test_claude_setup_review.py
@@ -373,7 +373,7 @@ def test_markdown_link_to_a_missing_file_is_reported_once_and_unmangled(
     )
     result = run_review(plugin_root, "--skip-llm")
     payload = json.loads(
-        [line for line in result.stdout.splitlines() if line.startswith("{")][0]
+        next(line for line in result.stdout.splitlines() if line.startswith("{"))
     )
     unresolvable = [
         issue
@@ -395,7 +395,7 @@ def test_distinct_missing_paths_on_one_line_are_reported_separately(
     )
     result = run_review(plugin_root, "--skip-llm")
     payload = json.loads(
-        [line for line in result.stdout.splitlines() if line.startswith("{")][0]
+        next(line for line in result.stdout.splitlines() if line.startswith("{"))
     )
     paths = {
         issue["message"].split("'")[1]

--- a/tests/skills/test_claude_setup_review_is_on_demand.py
+++ b/tests/skills/test_claude_setup_review_is_on_demand.py
@@ -29,7 +29,7 @@ SELECT_LENSES = PLUGIN_ROOT / "scripts" / "select_lenses.py"
 
 sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
 
-import review_roster  # noqa: E402
+import review_roster
 
 
 def _lenses_for(*files):


### PR DESCRIPTION
## Summary
- Follow-up to #1622: 8 `evals/expected/*.json` files had a `"fixture"` field naming a `.js` file when the real on-disk fixture has always been `.ts` (found by domain-review and arch-review during #1622's review).
- Incidental: fixed pre-existing `ruff check .` findings hit while pushing this branch (the pre-push gate lints the whole tree, not just the diff) — 13 mechanical auto-fixes plus 4 hand-fixes (startswith-tuple merge, a documented noqa on an already-justified broad except, chmod +x on a shebang'd script, an added `from __future__ import annotations` for a sub-3.10 floor).

Commit type is `feat:` rather than `chore:` per repo convention (#1622) — the eval-semver classifier (`scripts/eval_semver_classify.sh`) requires at least a minor bump for any `evals/expected/*.json` modification, even a pure metadata correction that touches no `expectedStatus`/`applicableAgents` identity.

## Test plan
- [x] `python3 -m pytest tests/repo/test_eval_grader.py tests/repo/test_integration_tier.py tests/repo/test_workflow_audit_531.py` — 53 passed
- [x] `python3 scripts/eval_grade.py --check-corpus` — 135 expected fixtures valid, 0 warnings
- [x] `python3 -m ruff check .` — clean
- [x] Full local CI (`scripts/ci-local.sh`) — all checks passed
- [x] Reviewed by 2 full agent panels (16 agents each) via `/code-review`; zero actionable findings survived (2 `warn` findings from arch-review/ai-provenance-review were independently verified false via `ruff check --show-settings`)

Closes #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)