### PR TITLE
fix(skills): pin the scheduled-wake-up calling contract for long-running jobs

### DIFF
--- a/docs/using-plugin-skills-in-the-web-environment.md
+++ b/docs/using-plugin-skills-in-the-web-environment.md
@@ -75,7 +75,10 @@ tool surface from the surrounding Remote runtime. The two tell-tale symptoms:
   one of these tools directly: it requires `prompt` (and `reason`) on every
   call unless `stop: true` is passed instead — there is no "just wait, no
   prompt" shape. This is upstream Remote-runtime tool-contract behavior, not
-  anything this plugin defines or can wrap.
+  anything this plugin defines or can wrap — but the skills that tell an agent
+  to wait on a long-running job now carry that contract, in
+  [`plugins/dev-team/knowledge/long-run-waiting.md`](../plugins/dev-team/knowledge/long-run-waiting.md),
+  so a backstop timer is not silently lost to a malformed arm call.
 
 This inheritance is an **upstream Claude Code / Remote-runtime behavior — it is
 not fixable in this plugin repo** (no plugin setting, hook, or config removes the

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -819,6 +819,20 @@
       "anchor": "how-this-connects-to-the-rest-of-the-toolkit"
     }
   },
+  "plugins/dev-team/knowledge/long-run-waiting.md": {
+    "Pick the waiting mechanism first": {
+      "summary": "| Situation | Mechanism |",
+      "anchor": "pick-the-waiting-mechanism-first"
+    },
+    "The scheduled wake-up calling contract": {
+      "summary": "Every scheduler in this family takes the **work to do on wake** as a required",
+      "anchor": "the-scheduled-wake-up-calling-contract"
+    },
+    "Re-arming loops": {
+      "summary": "A check-in that is supposed to repeat must carry its own continuation: the",
+      "anchor": "re-arming-loops"
+    }
+  },
   "plugins/dev-team/knowledge/microservice-testing.md": {
     "The Layers (per service)": {
       "summary": "| Layer | Scope | What it verifies | Doubles |",

--- a/plugins/dev-team/knowledge/long-run-waiting.md
+++ b/plugins/dev-team/knowledge/long-run-waiting.md
@@ -1,0 +1,66 @@
+# Waiting on Long-Running Work
+
+Read before arming any timer, monitor, or self-re-arming check-in for a job
+that outlives a single turn: mutation runs, long evals, CI jobs, full test
+suites, watched PRs. Skills that reference this file: `/long-eval`,
+`/mutation-testing`, `/stryker-xunit-v2-shim`, `/ci-debugging`, `/ship`.
+
+## Pick the waiting mechanism first
+
+| Situation | Mechanism |
+| --- | --- |
+| The job emits a stream (log file, command output) and you want the event the moment it appears | A monitor on that stream, with an exit condition — never an unbounded `tail -f` |
+| The job's progress is only readable by re-running a status command | A scheduled wake-up whose body re-runs that status command |
+| A wake could be missed (container recycle, dropped notification) | A scheduled wake-up as a **backstop**, in addition to the primary signal |
+| Anything | **Never** a foreground `sleep`/`while true` in Bash — it burns the turn and cannot survive a recycle |
+
+The tool that arms a scheduled wake-up is **surface-specific** — a session may
+expose a wake-up scheduler, a `send_later`-style reminder, a cron-style
+Routine, or none of them. Use whichever the session actually exposes; if none
+does, say so and fall back to reporting status when the operator next asks.
+Do not synthesize a wait out of `sleep`.
+
+## The scheduled wake-up calling contract
+
+Every scheduler in this family takes the **work to do on wake** as a required
+argument. There is no "just wait, no instructions" call shape. Concretely, on
+the Remote runtime's `ScheduleWakeup`:
+
+- `prompt` (**required**) — the instruction re-issued when the timer fires.
+  This is the whole point of the call: the wake-up replays the prompt, it does
+  not resume some remembered intent.
+- `reason` (**required**) — one short sentence on what is being waited for.
+- `delaySeconds` — clamped to `[60, 3600]`.
+- `stop: true` — ends the loop. This is the **only** shape that may omit
+  `prompt`, and it takes **no other fields**.
+
+**The failure this prevents:** calling the scheduler with only a delay (or
+only a reason) fails with
+
+```
+Error: `prompt` is required when `stop` is not true.
+```
+
+and — the part that actually costs you — **no timer is armed**. A backstop that
+errored is a backstop that never fires, so a missed wake is never recovered and
+the run looks stalled with nothing scheduled to notice. Two call shapes, both
+complete:
+
+- **Arm / re-arm:** `delaySeconds` + `prompt` + `reason`.
+- **Stand down:** `stop: true` alone.
+
+Ending a check-in loop means the second shape. Passing a `reason` that explains
+why you are stopping — with no `stop: true` — is the same malformed call as
+above, not a stop.
+
+## Re-arming loops
+
+A check-in that is supposed to repeat must carry its own continuation: the
+`prompt` you pass has to re-issue the same status-check-and-re-arm instruction,
+because the next firing starts from that prompt and nothing else.
+
+State the terminal condition inside the prompt, so the loop can end itself —
+"stop re-arming once `status` reports `DONE`, or if the operator said stop"
+— and end it with a `stop: true` call, not by silently letting the last wake
+pass. A loop with no terminal condition in its own prompt runs until the
+operator kills it.

--- a/plugins/dev-team/skills/ci-debugging/SKILL.md
+++ b/plugins/dev-team/skills/ci-debugging/SKILL.md
@@ -81,6 +81,7 @@ Before calling `Monitor` on a job whose completion time matters:
 2. If a signal exists, set `timeout_ms` to a safety margin over that estimate (e.g., double it), capped at the tool's documented max (3,600,000 ms / 1 hour).
 3. If no signal exists, don't guess — set `persistent: true` and pair it with a command that exits on the job's own terminal state (success/failure/timeout), never an unbounded `tail -f`/`while true` with no exit condition, so the monitor self-terminates instead of requiring a manual `TaskStop`.
 4. Never silently re-arm after a timeout without noting the estimate was wrong; if a re-arm is needed, widen the estimate or switch to `persistent: true` rather than repeating the same timeout.
+5. If the wait is handled by a scheduled wake-up instead of `Monitor` (no stream to watch, or a backstop against a missed notification), follow the calling contract in [`knowledge/long-run-waiting.md`](../../knowledge/long-run-waiting.md) — an arm/re-arm call needs the instruction to replay plus a reason, and standing down is a `stop`-only call. A malformed call arms no timer at all.
 
 ### 5. Fix and verify
 

--- a/plugins/dev-team/skills/long-eval/SKILL.md
+++ b/plugins/dev-team/skills/long-eval/SKILL.md
@@ -102,14 +102,23 @@ is **never persisted**, so `cells()` reconstructs it each launch.
 
 4. **Arm a backstop timer** as insurance against a missed wake. Schedule a
    self-re-arming check-in (the session's scheduling tool — e.g. `send_later` /
-   a Routine, ~20 min out) whose body runs the same `ensure-alive` + `status`
-   and re-arms itself, **unless** the run is `DONE` or the user said stop. The
-   backstop only matters if a wake is ever missed; the recycle-wake is the
-   primary trigger.
+   `ScheduleWakeup` / a Routine, ~20 min out) whose body runs the same
+   `ensure-alive` + `status` and re-arms itself, **unless** the run is `DONE`
+   or the user said stop. The backstop only matters if a wake is ever missed;
+   the recycle-wake is the primary trigger.
+
+   Follow the calling contract in
+   [`knowledge/long-run-waiting.md`](../../knowledge/long-run-waiting.md):
+   every arm/re-arm call carries the instruction to replay (`prompt`) and a
+   `reason` — a call with only a delay fails the "prompt is required when stop
+   is not true" validation and **arms nothing**, which silently costs you the
+   backstop you thought you had.
 
 5. **Report and stop when `DONE`.** When `status` shows `DONE=True`, read
    `summary.json` from the out-dir, report the final result, and **stop
-   re-arming the backstop.** A `flap`-flagged cell (mixed pass/fail across
+   re-arming the backstop** — for a wake-up scheduler that means one
+   `stop: true`-only call, not a call that merely explains why you are
+   stopping. A `flap`-flagged cell (mixed pass/fail across
    samples) is low-confidence — surface it for quarantine/rewrite rather than
    trusting its verdict.
 

--- a/plugins/dev-team/skills/mutation-testing/SKILL.md
+++ b/plugins/dev-team/skills/mutation-testing/SKILL.md
@@ -145,6 +145,8 @@ Real mutation runs take 15 min – several hours. During that window the tool em
 - **Portable Python wrapper** — a Python script that runs the tool as a subprocess, polls the log file, and emits one status + zero-or-more `[RED-FLAG]` lines per tick. Cross-platform via Python 3.8+ stdlib; works outside Claude Code (CI, direct terminal). The Stryker.NET reference in [`references/languages/csharp-stryker-net.md`](references/languages/csharp-stryker-net.md) documents the shipped wrapper (`csharp_stryker_net_wrapper.py`) + status loop (`csharp_stryker_net_status_loop.py`).
 - **In-session Monitor** — inside a Claude Code session, a `Monitor` tool call on the log file stream that emits an event on each recognized red-flag pattern. Cleaner integration but no coverage for out-of-session (CI, direct-terminal) operators.
 
+Whichever you pick, never implement the cadence as a foreground `sleep` loop. If the tick is driven by a scheduled wake-up rather than a stream monitor, see [`knowledge/long-run-waiting.md`](../../knowledge/long-run-waiting.md) for the calling contract — a wake-up armed without its replay instruction fails validation and schedules nothing, so the "inspection loop" stops inspecting after tick one.
+
 Per-language references may add tool-specific red-flag signatures — the language file lists them alongside the parse patterns.
 
 ## Step 3: Parse results

--- a/plugins/dev-team/skills/ship/SKILL.md
+++ b/plugins/dev-team/skills/ship/SKILL.md
@@ -126,8 +126,11 @@ not re-running:
   stop. Do not re-run any phase.
 - **Open PR for the issue → in-flight; MONITOR.** Report the PR and its CI
   state (`gh pr checks <pr>`). If the PR is `BEHIND` main, rebase it onto
-  `main` and hand back to its checks; otherwise wait on the open gate. Do
-  **not** re-enter spec→plan→build.
+  `main` and hand back to its checks; otherwise wait on the open gate — if you
+  arm a timer to re-check, follow
+  [`knowledge/long-run-waiting.md`](../../knowledge/long-run-waiting.md), whose
+  contract makes the re-fired prompt this guard already expects. Do **not**
+  re-enter spec→plan→build.
 - **Spec / sub-issues / plan exist but no PR yet → partially in-flight;
   RESUME.** Continue from the earliest incomplete phase against the existing
   artifacts (e.g. `--skip-spec` when the spec epic already exists; build onto

--- a/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
+++ b/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
@@ -150,7 +150,10 @@ A full run can take hours; a wrong harness wastes all of it. Two gates:
 
 Widen `mutate` back to the full scope and launch. A full Stryker run is
 long-running — start it in the background and watch it (a Monitor plus a periodic
-status check), rather than blocking on it.
+status check), rather than blocking on it. If the periodic check is a scheduled
+wake-up, follow the calling contract in
+[`knowledge/long-run-waiting.md`](../../knowledge/long-run-waiting.md) — a
+wake-up armed without its replay instruction schedules nothing.
 
 Before recording any score, **reject the observation-failure signature**: a
 near-zero score with almost everything *Survived* means it bound to the v3 project

--- a/tests/knowledge/test_long_run_waiting_doc.py
+++ b/tests/knowledge/test_long_run_waiting_doc.py
@@ -1,0 +1,89 @@
+"""Content guards for the long-run waiting/scheduling contract doc.
+
+The doc exists because a scheduled wake-up armed without its replay
+instruction fails validation and schedules *nothing* — the backstop the
+skill thought it armed never fires. These checks pin the parts of the
+contract an agent has to read to avoid that call, and pin the pointers
+from the skills that tell an agent to wait on a long-running job.
+"""
+
+from __future__ import annotations
+
+from _repo_root import REPO_ROOT
+
+PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+DOC = PLUGIN / "knowledge" / "long-run-waiting.md"
+
+# Every skill whose instructions can lead an agent to arm a timer for work
+# that outlives a turn must point at the contract.
+REFERRING_SKILLS = (
+    "long-eval",
+    "mutation-testing",
+    "stryker-xunit-v2-shim",
+    "ci-debugging",
+    "ship",
+)
+
+
+def _doc_text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_doc_exists():
+    assert DOC.is_file(), f"missing knowledge doc: {DOC}"
+
+
+def test_doc_states_prompt_is_required_to_arm():
+    """The failing call shape is the whole reason the doc exists."""
+    text = _doc_text()
+    assert "`prompt` is required when `stop` is not true." in text, (
+        "the doc must quote the exact validation error verbatim so an agent "
+        "that hit it can match the message to this contract"
+    )
+    assert "**required**" in text, "prompt/reason must be marked required"
+
+
+def test_doc_states_a_failed_arm_schedules_nothing():
+    """The expensive part isn't the error — it's the timer that never armed."""
+    text = _doc_text().lower()
+    assert "no timer is armed" in text
+    assert "never fires" in text
+
+
+def test_doc_states_the_stop_only_call_shape():
+    """Standing down is `stop: true` alone — not a reason-only call."""
+    text = _doc_text()
+    assert "`stop: true` alone" in text
+    assert "takes **no other fields**" in text
+
+
+def test_doc_forbids_sleep_loops():
+    text = _doc_text().lower()
+    assert "sleep" in text, "the doc must rule out foreground sleep loops"
+
+
+def test_doc_requires_self_re_arming_prompts_to_carry_a_terminal_condition():
+    text = _doc_text().lower()
+    assert "terminal condition" in text
+
+
+def test_referring_skills_point_at_the_doc():
+    for skill in REFERRING_SKILLS:
+        skill_md = PLUGIN / "skills" / skill / "SKILL.md"
+        assert skill_md.is_file(), f"missing skill: {skill_md}"
+        assert "knowledge/long-run-waiting.md" in skill_md.read_text(
+            encoding="utf-8"
+        ), (
+            f"{skill}/SKILL.md tells an agent to wait on long-running work but "
+            "does not point at knowledge/long-run-waiting.md"
+        )
+
+
+def test_doc_lists_the_skills_that_reference_it():
+    """Keep the doc's own 'who reads this' list honest with the pointers."""
+    text = _doc_text()
+    for skill in REFERRING_SKILLS:
+        assert f"`/{skill}`" in text, (
+            f"knowledge/long-run-waiting.md does not list /{skill} among the "
+            "skills that reference it"
+        )


### PR DESCRIPTION
## Summary

- Sessions running the plugin's long-job skills kept surfacing `` Error: `prompt` is required when `stop` is not true. `` Nothing in the plugin emits that string — it is the session's wake-up scheduler (`ScheduleWakeup` on the Remote runtime) rejecting an *arm* call that omitted the instruction to replay. The skills that tell an agent to wait on work outliving a turn described the **cadence** ("schedule a self-re-arming check-in ~20 min out", "stop re-arming the backstop", "a Monitor plus a periodic status check") but never the **call shape**, so the agent reached for a delay-only or reason-only call. The cost is not the error text: a rejected call arms no timer, so the backstop the skill believed it had never fires and a missed wake is never recovered — the run just looks stalled.
- Adds `plugins/dev-team/knowledge/long-run-waiting.md`: mechanism choice (stream monitor vs scheduled wake-up vs backstop, never a foreground `sleep`), the two complete call shapes (arm = delay + prompt + reason; stand down = `stop: true` alone, which is also the *only* shape that may omit the prompt), and the rule that a re-arming loop must carry its own continuation and terminal condition inside the prompt it schedules.
- Points the five skills that can lead an agent into that call at the contract — `long-eval`, `mutation-testing`, `stryker-xunit-v2-shim`, `ci-debugging`, `ship` — and cross-links `docs/using-plugin-skills-in-the-web-environment.md`, which had already recorded the upstream contract but only for repo developers, not for agents running the skills.

## Test Plan

- [x] New `tests/knowledge/test_long_run_waiting_doc.py` pins the contract statements (verbatim error string, "no timer is armed", the `stop: true`-alone shape, the terminal-condition rule) and asserts every listed skill actually carries the pointer — both directions, so doc and skills can't drift apart.
- [x] `python3 scripts/check_md_references.py` — clean (all new cross-links are file-relative).
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py --check` — index regenerated and current.
- [x] Full pre-push directory list: `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks` → 6140 passed, 45 skipped, 10 xfailed.
- [x] `scripts/ci-local.sh` via the `pre-push` hook — "All local CI checks passed."

Content-only change to shipped knowledge + skill markdown, plus one new test; no hook, script, or manifest behavior changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0193pMJpsaTFCqFNYHvACNzB)_