### PR TITLE
fix(ci): run chk_python_floor in CI, not only pre-push

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -11,6 +11,14 @@ concurrency:
   group: plugin-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# No job here writes anything — read-only is sufficient for every job,
+# matching link-check.yml's and pr-title-lint.yml's `contents: read` blocks
+# (other workflows in this repo declare permissions too, but for jobs that
+# actually write — docs.yml and epic-auto-close.yml are not read-only
+# exemplars).
+permissions:
+  contents: read
+
 jobs:
   shell-tests:
     name: Shell scripts & suite
@@ -108,6 +116,40 @@ jobs:
         run:
           bash scripts/ci-local.sh
           --only=chk_md_references,chk_skills_index,chk_rules_vs_prompts,chk_hook_units
+
+  # ADR 0014's Python 3.8 floor, proven by running it (#1635). Isolated in its
+  # own job, matching semgrep-fixtures' and cost-regression's precedent below:
+  # it needs a toolchain (a 3.8 interpreter) the other jobs don't provision.
+  # A first attempt co-tenanted it in content-guard-tests via
+  # actions/setup-python, which put that interpreter's bin dir on PATH ahead
+  # of the system python3 for every other step in that job — breaking
+  # chk_md_references (needs 3.9+ str.removeprefix) and silently degrading
+  # chk_hook_units's pytest guard to "skipped". `uv` avoids that entirely:
+  # `uv python install 3.8` only adds 3.8 to uv's own managed toolchain
+  # (found via `_resolve_python38`'s existing `uv python find 3.8` branch in
+  # ci-local.sh) and never touches PATH's `python3`. uv also has actual 3.8
+  # builds for ubuntu-latest's Ubuntu 24.04, unlike actions/setup-python,
+  # which stopped publishing 3.8 for that image.
+  #
+  # This job's `name:` is the status-check context branch protection would
+  # match on (see agent-eval.yml and pr-title-lint.yml for the same
+  # convention, where the ruleset entry already exists). It is NOT yet
+  # listed as a required check in the `main` ruleset — until it is, a red
+  # run here reports in the PR checks list but does not block merge, so a
+  # push that bypasses local hooks isn't fully caught yet. Once added, a
+  # rename here needs a matching ruleset update, or the check silently stops
+  # blocking while still reporting green.
+  python-floor:
+    name: Python 3.8 floor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Python 3.8 floor check (via ci-local)
+        run: bash scripts/ci-local.sh --only=chk_python_floor
 
   # Cost-regression gate (#140 mechanism, #171 real baseline). Isolated in its
   # own job so the read-only telemetry deploy key is never in scope for the

--- a/ruff.toml
+++ b/ruff.toml
@@ -51,9 +51,11 @@ extend-exclude = [
 #
 # This stops ruff's autofixes from rewriting shipped code into 3.9+ syntax. It
 # is NOT what proves the floor holds: that is the "Python 3.8 floor" job in
-# .github/workflows/plugin-tests.yml, which runs the plugin's real test suite
-# on a real 3.8 interpreter. The interpreter is the oracle — neither a linter
-# setting nor a hand-maintained list of "APIs newer than 3.8" can be trusted
+# .github/workflows/plugin-tests.yml, which byte-compiles and imports every
+# shipped module on a real 3.8 interpreter (not yet the plugin's full test
+# suite — see issue #1635's "Out of scope" for that follow-up). The
+# interpreter is the oracle — neither a linter setting nor a hand-maintained
+# list of "APIs newer than 3.8" can be trusted
 # to know what 3.8 accepts, and the list version of this gate proved exactly
 # that by passing a `dict | dict` merge which 3.8 rejects.
 #

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -195,9 +195,10 @@ chk_python_only() {
 #
 # Byte-compile catches syntax; the import probe catches evaluation (a PEP 585
 # generic in a module-level type alias compiles everywhere and raises on 3.8).
-# Running the shipped suite on 3.8 is the strong form and belongs in CI, where
-# provisioning an interpreter plus test deps is free; see the note in
-# tests/repo/test_python_floor.py.
+# Running the shipped suite on 3.8 is the strong form and belongs in CI; the
+# "Python 3.8 floor" job in .github/workflows/plugin-tests.yml runs this
+# check today, not yet the full suite — see the scope note in
+# scripts/import_probe_shipped.py (issue #1635's "Out of scope").
 #
 # Fails — never skips — when no 3.8 can be obtained. A gate that quietly
 # downgrades to "skipped" on the machines least likely to have the floor

--- a/scripts/import_probe_shipped.py
+++ b/scripts/import_probe_shipped.py
@@ -2,9 +2,9 @@
 """Import every shipped plugin module under the current interpreter.
 
 Run by the "Python 3.8 floor" job in `.github/workflows/plugin-tests.yml`.
-That job's main gate is the plugin's own test suite on a real 3.8; this probe
-covers the remainder — modules the suite never imports, which would otherwise
-reach users untested on the floor interpreter.
+That job's gate is this probe plus a byte-compile pass over the shipped tree
+(not yet the plugin's full test suite on 3.8 — see issue #1635's "Out of
+scope" for that follow-up).
 
 Byte-compiling proves a file *parses*. It does not prove it *imports*, and the
 gap between those two is exactly where the shipped tree had drifted: PEP 585

--- a/tests/repo/test_python_floor.py
+++ b/tests/repo/test_python_floor.py
@@ -27,7 +27,12 @@ So the floor is declared in exactly one machine-readable place —
 `ruff.toml`'s `[per-file-target-version]` — and proven by `chk_python_floor`
 in `scripts/ci-local.sh`, which resolves a real 3.8 interpreter and makes it
 byte-compile and import every shipped module. That check runs in the default
-gate, so the pre-push hook enforces it on every push.
+gate, so the pre-push hook enforces it on every push — and, since #1635, a
+dedicated `python-floor` job in `.github/workflows/plugin-tests.yml` also
+runs it on every PR, so a push that bypasses local hooks (`--no-verify`, a
+hookless cloud session) is still caught by CI. Making a red run actually
+block a GitHub-UI merge needs the job's name added to `main`'s
+required-status-check ruleset — a follow-up, not yet configured.
 
 What follows pins those parts to each other. It deliberately contains no
 opinion about which APIs are too new; that question belongs to the
@@ -48,6 +53,7 @@ RUFF_CONFIG = REPO_ROOT / "ruff.toml"
 ADR = REPO_ROOT / "docs" / "adr" / "0014-python-for-cross-os-scripts.md"
 CI_LOCAL = REPO_ROOT / "scripts" / "ci-local.sh"
 IMPORT_PROBE = REPO_ROOT / "scripts" / "import_probe_shipped.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "plugin-tests.yml"
 
 #: The floor every part below must agree on, in each part's own notation.
 FLOOR_RUFF = "py38"
@@ -78,6 +84,24 @@ def ci_local() -> str:
     return CI_LOCAL.read_text(encoding="utf-8")
 
 
+@pytest.fixture(scope="module")
+def ci_workflow() -> str:
+    return CI_WORKFLOW.read_text(encoding="utf-8")
+
+
+def _only_lists(workflow: str) -> list[list[str]]:
+    """Every `--only=<comma-list>` argument actually invoked in the
+    workflow, split into its component check names. Comment lines are
+    stripped first — a future `#`-prefixed mention of `--only=chk_python_
+    floor` (a commented-out step, or a comment quoting the rejected
+    content-guard-tests wiring this file's own docstrings describe) must
+    not satisfy a caller looking for the real invocation."""
+    body = "\n".join(
+        line for line in workflow.splitlines() if not line.lstrip().startswith("#")
+    )
+    return [lst.split(",") for lst in re.findall(r"--only=([\w,-]+)", body)]
+
+
 class TestTheFloorIsDeclaredOnce:
     def test_ruff_declares_it_for_the_shipped_tree(self):
         """The single source of truth, and the only thing that keeps ruff's own
@@ -102,8 +126,10 @@ class TestTheFloorIsDeclaredOnce:
 
     def test_the_adr_states_the_same_floor(self):
         """ADR 0014 carries the rationale. Prose that disagrees with the
-        tooling is how a floor quietly stops meaning anything."""
-        assert FLOOR_DOTTED in ADR.read_text(encoding="utf-8")
+        tooling is how a floor quietly stops meaning anything. Anchored to
+        "Python 3.8" rather than a bare "3.8" substring, which could match an
+        unrelated version reference or section number."""
+        assert re.search(r"Python\s+" + re.escape(FLOOR_DOTTED), ADR.read_text(encoding="utf-8"))
 
 
 def _floor_check_body(ci_local: str) -> str:
@@ -116,9 +142,9 @@ class TestTheFloorIsProvenByRunningIt:
     skip itself, should fail here.
 
     Wiring note: `chk_python_floor` runs in the default (no `--only`) gate, so
-    the pre-push hook enforces it on every push. Adding it to a CI job means
-    appending `chk_python_floor` to that job's `--only=` list, which needs
-    `workflow` scope on the pushing credential.
+    the pre-push hook enforces it on every push. Since #1635 it also runs in
+    its own `python-floor` CI job, via a `--only=chk_python_floor` invocation
+    — see `TestTheFloorIsCheckedInCI` below for that leg's pin.
     """
 
     def test_ci_local_defines_the_floor_check(self, ci_local):
@@ -164,3 +190,67 @@ class TestTheFloorIsProvenByRunningIt:
         source = IMPORT_PROBE.read_text(encoding="utf-8")
         assert "exec_module" in source, "the probe must actually import modules"
         assert "VERSION_ERRORS" in source, "failures must come from the interpreter"
+
+
+class TestTheFloorIsCheckedInCI:
+    """chk_python_floor running in the default local gate (above) only
+    enforces it on pushes that go through the pre-push hook. #1635: a push
+    that bypasses hooks — --no-verify, a hookless cloud session — must still
+    be run by something, which means a CI job has to name chk_python_floor
+    in its own --only= list explicitly. (Blocking a GitHub-UI merge on a red
+    run additionally needs the job in main's required-status-check ruleset
+    — a follow-up, not something a test in this repo can pin.)"""
+
+    def test_a_ci_job_runs_the_floor_check(self, ci_workflow):
+        """A bare `in workflow` check passes on any mention of the name — a
+        comment, a doc reference, a commented-out step — without the check
+        being wired into a job's --only= list. Anchor to the real invocation,
+        matching this file's own _floor_check_body/CHECKS-array rigor
+        elsewhere."""
+        only_lists = _only_lists(ci_workflow)
+        assert any("chk_python_floor" in lst for lst in only_lists), (
+            "no job in .github/workflows/plugin-tests.yml passes chk_python_floor "
+            "in a --only= list — the floor is only enforced by the local "
+            "pre-push hook, which a --no-verify push, a hookless cloud "
+            "session, or a GitHub-UI merge all bypass"
+        )
+
+    def test_the_floor_job_runs_nothing_else(self, ci_workflow):
+        """Defence-in-depth against #1635's own review fallout: a first
+        attempt co-tenanted this check via actions/setup-python, which DID
+        put the floor interpreter on PATH ahead of a check that needs 3.9+
+        (chk_md_references' str.removeprefix) and silently degraded a
+        pytest-backed check to 'skipped' (chk_hook_units). The shipped `uv`
+        mechanism doesn't have that failure mode, but pinning the isolation
+        — not just the presence — means a future edit can't quietly revert
+        to co-tenanting without this test noticing, without also forbidding
+        a second, equally-isolated invocation (e.g. a future matrix leg)
+        that the isolation property itself has no objection to."""
+        floor_lists = [lst for lst in _only_lists(ci_workflow) if "chk_python_floor" in lst]
+        assert floor_lists and all(lst == ["chk_python_floor"] for lst in floor_lists), (
+            "chk_python_floor must be the only check in every --only= list "
+            f"that invokes it — found {floor_lists!r}. Co-tenanting it risks "
+            "the exact PATH-shadowing regression #1635's review caught once "
+            "already"
+        )
+
+    def test_the_floor_job_is_named_for_the_docs_that_reference_it(self, ci_workflow):
+        """ruff.toml and root CLAUDE.md both cite a "Python 3.8 floor" job by
+        that exact string. Nothing else pins the job's `name:` to those
+        references, so a rename would leave both silently stale. Anchored to
+        end-of-line: an unanchored match would also satisfy on the job's own
+        *step* name ("Python 3.8 floor check (via ci-local)"), which shares
+        the same literal prefix but isn't the job-level name at all — a
+        step's `name:` is preceded by a `- ` list-item marker when it's the
+        step's first key, as it is here, which `^\\s*` cannot absorb, so
+        this pattern doesn't match it. The "3.8" here is deliberately a
+        literal, not FLOOR_DOTTED: this string will be the status-check
+        context the `main` ruleset matches once the job is added there (see
+        the module docstring above — not yet configured), so it must change
+        only with a deliberate ruleset update, never silently alongside a
+        future floor bump."""
+        assert re.search(r"(?m)^\s*name:\s*Python 3\.8 floor\s*$", ci_workflow), (
+            'no job in .github/workflows/plugin-tests.yml is named exactly '
+            '"Python 3.8 floor" — ruff.toml and CLAUDE.md both reference it '
+            "by that literal string"
+        )


### PR DESCRIPTION
## Summary
- The ADR 0014 Python-3.8-floor gate (`chk_python_floor` in `scripts/ci-local.sh`) only ran via the local pre-push hook — a push that skips hooks (a hookless cloud session, a GitHub-UI merge, `git commit --no-verify`) skipped it entirely.
- Adds a dedicated `python-floor` job to `.github/workflows/plugin-tests.yml`, provisioning the floor interpreter via `astral-sh/setup-uv@v6` and running `bash scripts/ci-local.sh --only=chk_python_floor`.
- **Design changed mid-review**: a first attempt co-tenanted the check inside `content-guard-tests` via `actions/setup-python`. Two independent review rounds found this would shadow `python3` on PATH for every other step in that job — breaking `chk_md_references` (needs 3.9+ `str.removeprefix`) and silently degrading `chk_hook_units`'s pytest guard to a no-op "skipped". Fixed by isolating the check in its own job (matching the `semgrep-fixtures`/`cost-regression` precedent already in this file) using `uv`, which `_resolve_python38` already supports and which never touches PATH's `python3`.
- Fixes a pre-existing doc overclaim in `ruff.toml`, `scripts/import_probe_shipped.py`, and `scripts/ci-local.sh`: all three said the CI job "runs the plugin's real test suite" on 3.8; it only byte-compiles + imports.
- Adds a workflow-level `permissions: contents: read` block (none of this file's 6 jobs write anything) — closes a gap this diff's own security-review pass found.
- `tests/repo/test_python_floor.py` gains a `TestTheFloorIsCheckedInCI` class: presence in a `--only=` list, isolation (nothing else co-tenants that list), and the job's `name:` matching the exact string `ruff.toml`/`CLAUDE.md` already cite — went through 3 full anchoring-defect rounds (a bare substring check, then an unanchored regex, both independently caught and fixed by multiple review agents) before converging on a genuinely mutation-resistant assertion.

## Outstanding, by design (not defects)
1. **Live-fire verification** (this issue's own acceptance criterion): plant a 3.9-only construct, confirm the CI job goes red, revert, confirm green. Next step after this merges.
2. **Required-status-check ruleset**: `main`'s branch-protection ruleset currently requires 8 named checks; "Python 3.8 floor" isn't among them yet (verified via the GitHub API). You approved adding it — but only *after* the live-fire verification above, per this repo's "make it fail on purpose once before you trust it" rule.

## Out-of-scope findings surfaced, not acted on
- `googleapis/release-please-action@v5` (holds a GitHub App token with `contents: write` + `pull-requests: write`) is tag-pinned, not SHA-pinned — a higher-value SHA-pinning target than anything in this PR.
- `opt-in-tests.yml` and `wrapper-windows.yml` also lack a `permissions:` block.
- A pre-existing `if:` condition asymmetry between the two telemetry steps in `cost-regression` (a Dependabot PR would skip key-loading but still attempt the SSH clone, failing red instead of falling back).

## Test plan
- [x] `python3 -m pytest tests/repo -q` — 668+ passed, no new failures
- [x] `python3 -m ruff check .` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/plugin-tests.yml'))"` — valid
- [x] Full local CI (`scripts/ci-local.sh`) — all checks passed
- [x] Reviewed by 3 full 16-agent panels via `/code-review`; every actionable finding fixed and re-verified
- [ ] Live-fire verification on this PR's real CI run (planned next)

Closes #1635

🤖 Generated with [Claude Code](https://claude.com/claude-code)