### PR TITLE
fix(skills): six shipped skills invoke scripts by bare relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ evals/code-review-benchmark/.cache/
 feature-file-validation-workspace/
 
 # Repo-local pinned PMD distribution (installed by
-# scripts/install-java-static-analysis.py; large JVM binaries, never committed)
+# plugins/dev-team/scripts/install-java-static-analysis.py; large JVM binaries, never committed)
 .pmd/
 
 # Python caches

--- a/plugins/dev-team/docs/developer-notes.md
+++ b/plugins/dev-team/docs/developer-notes.md
@@ -214,7 +214,7 @@ The four landed lanes established conventions that new lanes inherit:
   (dotnet), or a repo-local gitignored tool directory (`.pmd/`). Never
   `npm install -g`, `pip install --user`, or a global toolchain assumption.
 - **A standalone installer is the exception, not the rule.** Of the four
-  lanes, only Java needed one (`scripts/install-java-static-analysis.py`),
+  lanes, only Java needed one (`plugins/dev-team/scripts/install-java-static-analysis.py`),
   because PMD has no project-level dependency mechanism to ride. Prefer the
   project's own mechanism; write an installer only when none exists.
 - **Idempotent re-runs.** Running the install twice must be safe and cheap —

--- a/plugins/dev-team/knowledge/gherkin-quality-review-dispatch.md
+++ b/plugins/dev-team/knowledge/gherkin-quality-review-dispatch.md
@@ -111,7 +111,7 @@ The mutual-blindness property above — "one message, two calls, read neither
 result until both are issued" — is asserted only in this doc's prose and in
 content-guards that check the markdown *says* the right thing; nothing runs
 two real dispatches and checks isolation held at runtime.
-`scripts/verify_gherkin_quality_critic_isolation.py` closes that gap: it
+`${CLAUDE_PLUGIN_ROOT}/scripts/verify_gherkin_quality_critic_isolation.py` closes that gap: it
 dispatches the real `gherkin-quality-critic` agent twice via two fully
 independent `claude -p` subprocess calls, each against a fixture carrying its
 own randomly-generated canary marker, and fails if either transcript contains
@@ -121,7 +121,7 @@ the *other* dispatch's canary. Like `evals/README.md`'s live eval gate, it is
 failure. It is not wired into any CI workflow by default. Run it locally:
 
 ```bash
-ANTHROPIC_API_KEY=sk-... python3 plugins/dev-team/scripts/verify_gherkin_quality_critic_isolation.py
+ANTHROPIC_API_KEY=sk-... python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify_gherkin_quality_critic_isolation.py
 ```
 
 ## Scope of this doc

--- a/plugins/dev-team/scripts/install-java-static-analysis.py
+++ b/plugins/dev-team/scripts/install-java-static-analysis.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""scripts/install-java-static-analysis.py — install a pinned PMD distribution.
+"""install-java-static-analysis.py — install a pinned PMD distribution.
 
 Stdlib-only (urllib.request, zipfile) so it runs unchanged on macOS, Linux,
 and Windows — no curl, unzip, or Git Bash required (ADR 0014).
 """
+import hashlib
+import hmac
 import os
 import shutil
 import subprocess
@@ -15,6 +17,17 @@ from pathlib import Path
 
 PMD_VERSION = "7.7.0"  # single source of truth for the pin; bump deliberately
                        # (check https://github.com/pmd/pmd/releases)
+# SHA-256 of pmd-dist-7.7.0-bin.zip, pinned alongside the version above so the
+# two can never drift apart — verified against the published GitHub release
+# asset (curl the release URL below, then `shasum -a 256`). Bump together
+# with PMD_VERSION.
+PMD_SHA256 = "be8bf68f6c1d66984bd9645a93e631b78a1c2f42f5f0f8719082fead67553940"
+if len(PMD_SHA256) != 64 or any(c not in "0123456789abcdef" for c in PMD_SHA256):
+    # Fail loudly at import time, not at the end of a real download — a
+    # malformed pin (wrong length, uppercase, stray whitespace) must never
+    # silently degrade into "every install fails checksum" discovered only
+    # in the field.
+    raise ValueError(f"PMD_SHA256 is not a 64-char lowercase hex digest: {PMD_SHA256!r}")
 
 
 def main() -> int:
@@ -51,13 +64,29 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         zip_path = Path(tmp) / archive
         urllib.request.urlretrieve(url, zip_path)
+
+        digest = hashlib.sha256()
+        with zip_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                digest.update(chunk)
+        if not hmac.compare_digest(digest.hexdigest(), PMD_SHA256.strip().lower()):
+            print(
+                f"Downloaded archive checksum mismatch: expected {PMD_SHA256}, "
+                f"got {digest.hexdigest()}. Refusing to extract.",
+                file=sys.stderr,
+            )
+            return 1
+
         with zipfile.ZipFile(zip_path) as zf:
             zf.extractall(install_dir)
 
     bin_dir = install_dir / f"pmd-bin-{PMD_VERSION}" / "bin"
-    # zipfile does not preserve the executable bit; restore it (no-op on Windows).
-    for entry in bin_dir.iterdir():
-        entry.chmod(entry.stat().st_mode | 0o755)
+    # zipfile does not preserve the executable bit; restore it on the two
+    # launchers only (no-op on Windows) rather than every extracted entry.
+    for name in ("pmd", "pmd.bat"):
+        launcher = bin_dir / name
+        if launcher.exists():
+            launcher.chmod(launcher.stat().st_mode | 0o755)
 
     print(f"PMD installed to {bin_dir}")
     print("No PATH change needed: detection probes the repo-local .pmd/ bin "

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -20,6 +20,8 @@ You have been invoked with the `/agent-audit` skill. Audit agents and
 skills for compliance with the eval system patterns documented in
 `.claude/docs/eval-system.md`.
 
+**Monorepo-relative by design (#1637).** Steps 8 and 2e's `scripts/validate_agent_contract.py` and `scripts/check_registry_sync.py` calls are intentionally bare, not a dangling-path defect. `check_registry_sync.py` hardcodes `plugins/dev-team` and checks *this marketplace repo's own* registry — it exists only at this repo's root, so no `${CLAUDE_PLUGIN_ROOT}` path could ever resolve it. `validate_agent_contract.py`'s repo-root copy is a thin wrapper delegating to `plugins/marketplace-dev/scripts/validate_agent_contract.py` (which does ship and is portable) — but there is no single variable spanning two independently-installed plugins, so the wrapper is reachable only from this monorepo checkout, where both plugin directories are siblings on disk. Both calls only make sense run from a dev-team-monorepo-shaped checkout (this repo, or a structural fork), never an installed plugin cache. See `tests/repo/test_agent_implemented_by_resolves.py`'s `INTENTIONAL_BARE_INVOCATION` set, which checks the "does not ship" premise mechanically. (This skill's `allowed-tools` frontmatter grants no `Bash` at all, so none of these three script steps — including `verify_tier.py` below — can actually execute today regardless of path form; tracked separately in #1652.)
+
 ## Orchestrator constraints
 
 1. **Check structure, not semantics.** Verify required sections,
@@ -129,8 +131,15 @@ review agents. Check:
      of it). Validate them with:
 
      ```bash
-     python3 scripts/verify_tier.py --all
+     python3 plugins/dev-team/scripts/verify_tier.py --all
      ```
+
+     This one is repo-relative, not `${CLAUDE_PLUGIN_ROOT}`-qualified, even
+     though the script ships: `/agent-audit`'s whole job is auditing the
+     agents in the *current working tree* the operator just edited.
+     `${CLAUDE_PLUGIN_ROOT}` would resolve to the installed plugin cache
+     instead — silently auditing a stale, already-released copy rather than
+     the edit under review.
 
      Fold a non-empty `errors` array into WARN, naming the agent and the
      invalid value. An agent with no declaration is correct, not incomplete —
@@ -186,12 +195,12 @@ Include the result in the agent report table under a `Skills-Tool` column.
    - FAIL if a code-reading agent's `tools:` line is missing one or more of the five names, or an agent on disk is in neither roster (unclassified).
    - PASS if every code-reading agent grants all five and every agent on disk is classified.
 
-**Mechanics for invariants 2–4**: all three delegate to `scripts/lib/mcp_tool_grants.py`'s shared `run_grants_check` (single read+parse pass per agent, both for detection and `--fix`) and, under `--json`, report the same envelope (`check`/`evaluated`/`offenders`/`unclassified`/`fixed`/`unfixable`/`ok`/`notes`) so results are comparable across the three checks.
+**Mechanics for invariants 2–4**: all three delegate to `${CLAUDE_PLUGIN_ROOT}/scripts/lib/mcp_tool_grants.py`'s shared `run_grants_check` (single read+parse pass per agent, both for detection and `--fix`) and, under `--json`, report the same envelope (`check`/`evaluated`/`offenders`/`unclassified`/`fixed`/`unfixable`/`ok`/`notes`) so results are comparable across the three checks.
 
 | Invariant | Report column | Delegated script | Config source of truth | Unclassified handling |
 |---|---|---|---|---|
-| 2. Code-intelligence (review agents) | `Code-Intel` | `scripts/check_review_agent_mcp_tools.py` | `MCP_TOOL_NAMES` | n/a — glob-discovered, no roster |
-| 3. Code-intelligence mapping (non-review) | `Mapping` | `scripts/check_agent_tool_mapping.py` | `TIER_CONFIG` / `EXCLUSIONS` | reported, not auto-fixed |
+| 2. Code-intelligence (review agents) | `Code-Intel` | `${CLAUDE_PLUGIN_ROOT}/scripts/check_review_agent_mcp_tools.py` | `MCP_TOOL_NAMES` | n/a — glob-discovered, no roster |
+| 3. Code-intelligence mapping (non-review) | `Mapping` | `${CLAUDE_PLUGIN_ROOT}/scripts/check_agent_tool_mapping.py` | `TIER_CONFIG` / `EXCLUSIONS` | reported, not auto-fixed |
 | 4. Code-intelligence (security-assessment) | `SA-MCP` | `plugins/dev-team/scripts/check_security_assessment_mcp_tools.py` | `CODE_READING_AGENTS` / `NON_CODE_READING_AGENTS` | reported, not auto-fixed |
 
 Include each invariant's result in the agent report table under its column above. Invariant 4 is additionally wired into `scripts/ci-local.sh` as `chk_sa_mcp_tools`, so drift fails CI, not just this manual audit pass.

--- a/plugins/dev-team/skills/agent-eval/SKILL.md
+++ b/plugins/dev-team/skills/agent-eval/SKILL.md
@@ -24,6 +24,8 @@ grades results — it does not review code itself.
 You have been invoked with the `/agent-eval` skill. Run review agents
 against eval fixtures and grade the results.
 
+**Monorepo-relative by design (#1637).** Every `scripts/eval_*.py`/`citation_lint.py` call in this skill is intentionally bare, not a dangling-path defect: none of these scripts ship under `plugins/dev-team/scripts/` (verified mechanically — see `tests/repo/test_agent_implemented_by_resolves.py`'s `INTENTIONAL_BARE_INVOCATION` set), so no `${CLAUDE_PLUGIN_ROOT}` path could ever resolve one. They operate on *this repo's own* `evals/` corpus, explicitly not shipped — see repo CLAUDE.md's Repository Structure — and the repo-root eval runners (`scripts/run-full-eval.sh`, `scripts/eval-changed.sh`, `scripts/run-ablation.sh`) plus `.github/workflows/agent-eval.yml` all materialize `evals/fixtures`/`evals/expected` into `.claude/evals/` via a `$PWD`-relative symlink before invoking this skill — meaningful only from this checkout's own root. The `allowed-tools` frontmatter above additionally hardcodes these bare strings as Bash permission patterns, which would stop matching if qualified.
+
 ## Orchestrator constraints
 
 1. **Do not review or design yourself.** Delegate reviews to
@@ -433,7 +435,7 @@ then aggregate deterministically and append to the trend so stability is tracked
 over time, not recomputed and lost:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_variance.py \
+python3 scripts/eval_variance.py \
   --trials-dir <dir-of-trial-actuals> \
   --append .claude/metrics/eval-variance.jsonl -o .claude/memory/eval-variance.json
 ```

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -26,6 +26,8 @@ You have been invoked with the `/harness-audit` command.
 > companion here is `/session-review`, whose `session-digest.jsonl` this command
 > consumes (Step 1).
 
+**Monorepo-relative by design (#1637).** The `scripts/eval_ablation.py --find-latest` call below is intentionally bare, not a dangling-path defect: `eval_ablation.py` does not ship under `plugins/dev-team/scripts/` (verified mechanically — see `tests/repo/test_agent_implemented_by_resolves.py`'s `INTENTIONAL_BARE_INVOCATION` set), so no `${CLAUDE_PLUGIN_ROOT}` path could ever resolve it. It reads *this repo's own* `metrics/eval-ablation.jsonl`, consistent with the note above that this command audits the dev-team plugin's own harness — it only makes sense run from a dev-team-monorepo-shaped checkout, never an installed plugin cache.
+
 ## Orchestrator constraints
 
 1. **Do not modify agents or configuration.** Produce a report only. All remediation requires human action.

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -79,7 +79,7 @@ The v2 shim is the only path that gives the mutant-kill **loop** per-test covera
 - **coverage impact** — `neutral` (excluding the test from the shim changes no coverage — e.g. `Explicit=true` tests are skipped by default, **provided the run does not enable explicit tests** via `-explicit` / `xunit.runner.json` `explicit=on`) vs `bearing` (the test runs and covers code, so excluding it inflates the loop's survivor set and makes it generate redundant tests).
 
 ```bash
-python3 scripts/xunit_v3_feature_detector.py <test-project>/**/*.cs --json
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/xunit_v3_feature_detector.py <test-project>/**/*.cs --json
 ```
 
 **Human gate — always ask, never auto-drop.** Present the full classified list every run, even when every hit is coverage-neutral. For each test the operator chooses whether to exclude it from the shim for the duration of the loop; nothing is deactivated silently. Coverage-bearing tests are flagged with the lines that go dark if excluded. The detector's `summary.recommendation` is **advisory** sizing only (few + neutral → shim path is reasonable; many or coverage-bearing → prefer skipping the loop for a single-pass `coverage-analysis: off` advisory) — the human always decides.
@@ -384,7 +384,7 @@ around them.
 ### Invocation
 
 ```bash
-python3 scripts/csharp_stryker_net_slice_runner.py \
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py \
   --slices-config mutation-slices.json \
   --slice <name>       # a single configured slice by name
   --slice all          # every configured slice, resuming past terminal ones

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -173,7 +173,7 @@ pipx install, never `npm install -g`.
   hand:
 
   ```bash
-  python3 scripts/install-java-static-analysis.py
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py
   ```
 
   It installs a pinned PMD distribution into the repo-local, gitignored

--- a/plugins/dev-team/skills/quality-targets-converge/SKILL.md
+++ b/plugins/dev-team/skills/quality-targets-converge/SKILL.md
@@ -201,7 +201,7 @@ there is a standing signal on whether the derived scenarios track real
 coverage/mutation movement (issue #1296):
 
 ```bash
-python3 plugins/dev-team/scripts/gherkin_effectiveness_rollup.py \
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_effectiveness_rollup.py \
   --gherkin-md .claude/memory/<workflow>/<slug>/gherkin.md \
   --bindings-json .claude/memory/<workflow>/<slug>/gherkin-bindings.json \
   --baseline-coverage .dev-team-reports/<workflow>/<slug>/data/baseline-coverage.json \

--- a/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
@@ -182,7 +182,7 @@ Registered by #810.
 From your project root (requires a JDK/JRE — `java` on PATH):
 
 ```bash
-python3 scripts/install-java-static-analysis.py
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py
 ```
 
 Installs a pinned PMD distribution into the repo-local **`.pmd/`**

--- a/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
@@ -167,10 +167,10 @@ pmd check -d . -R <resolved-ruleset> -f sarif --no-progress
 - **Language-conditional**: dispatch pmd, and surface its missing-tool
   install hint, only when `.java` files are in the target set — a non-Java
   repo never sees a "pmd missing" warning (graceful-degradation constraint).
-- **Install**: repo-level, `python3 scripts/install-java-static-analysis.py`
+- **Install**: repo-level, `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py`
   — installs the pinned PMD distribution into the target repo's gitignored
   `.pmd/` directory (`PMD_INSTALL_DIR` overrides). Never user-level/global.
-- **Install hint**: `pmd — Java code quality. install: python3 scripts/install-java-static-analysis.py` (surfaced only for Java target sets)
+- **Install hint**: `pmd — Java code quality. install: python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py` (surfaced only for Java target sets)
 - **Detection**: repo-local first — the `.pmd/pmd-bin-*/bin/pmd` launcher
   (`pmd.bat` on Windows) — then `command -v pmd`; verify with `pmd --version`.
 - **Capability tier**: Java code quality
@@ -473,7 +473,7 @@ Registered by #810.
 - **Ruleset**: identical to the `/code-review` invocation — see
   [Ruleset resolution](#ruleset-resolution-shared-by-both-pmd-invocations)
   under the Tier 1 pmd entry.
-- **Install**: repo-level, `python3 scripts/install-java-static-analysis.py`
+- **Install**: repo-level, `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py`
   (pinned PMD into the gitignored `.pmd/` dir; `PMD_INSTALL_DIR` overrides).
 
 **checkstyle (recognized equivalent provider)**

--- a/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
+++ b/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
@@ -74,7 +74,7 @@ xunit.v2 stack, setting `RootNamespace`/`AssemblyName`, adding the linked-`Compi
 glob and the product `ProjectReference`) plus a `stryker-config.json`:
 
 ```bash
-python3 scripts/generate_shim.py tests/<TestProject>/<TestProject>.csproj \
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/stryker-xunit-v2-shim/scripts/generate_shim.py tests/<TestProject>/<TestProject>.csproj \
   --mutate-exclude '**/gRPC/**/*.cs' --mutate-exclude '**/Caching/**/*.cs'
 ```
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -349,7 +349,7 @@ fi
 if command -v pmd >/dev/null 2>&1; then
   ok "pmd"
 else
-  warn "pmd not found — only needed for Java projects; install repo-locally with: python3 scripts/install-java-static-analysis.py"
+  warn "pmd not found — only needed for Java projects; install repo-locally with: python3 plugins/dev-team/scripts/install-java-static-analysis.py"
 fi
 
 # ruff + mypy arrive via requirements-dev.txt (pip), like semgrep — verify the

--- a/tests/repo/test_agent_implemented_by_resolves.py
+++ b/tests/repo/test_agent_implemented_by_resolves.py
@@ -81,50 +81,246 @@ def test_the_known_unshipped_list_does_not_grow_silently():
     )
 
 
-#: Shipped skills that still invoke a script by a bare `scripts/…` path. Same
-#: defect as the agent references above — the path resolves against the user's
-#: working directory, not the plugin. Most name this repository's own dev
-#: tooling (`verify_tier.py`, `check_registry_sync.py`, the `eval_*` family),
-#: which is why it went unnoticed: those skills are only ever run from this
-#: checkout, where the relative path happens to work.
+#: Shipped skills that invoke a script by a bare `scripts/…` path, tracked as a
+#: DEFECT — same shape as the agent references above, resolving against the
+#: user's cwd rather than the plugin. Delete an entry when its skill is fixed
+#: (script moved into the plugin and/or invocation qualified with
+#: ${CLAUDE_PLUGIN_ROOT}/); the list only shrinks. Empty as of #1637: the two
+#: real defects (`project-init`'s install-java-static-analysis.py,
+#: `stryker-xunit-v2-shim`'s generate_shim.py) are fixed, and the remaining
+#: bare invocations in `agent-audit`, `agent-eval`, `harness-audit` are
+#: reclassified per-script into INTENTIONAL_BARE_INVOCATION below — not a
+#: defect (see that set's docstring).
+KNOWN_BARE_INVOCATION: set[str] = set()
+
+#: (skill, script) pairs whose bare `scripts/<script>` invocation is correct,
+#: not a #1637 defect. Exemption is per SCRIPT, not per skill — a skill in
+#: this set that later grows an unrelated bare invocation of a script that
+#: DOES ship is still caught by the main test below.
 #:
-#: Tracked rather than fixed in one sweep — each needs its script either moved
-#: into the plugin or its invocation qualified, and that is a per-skill call.
-#: Delete an entry when its skill is fixed; the list only shrinks.
-KNOWN_BARE_INVOCATION = {
-    "agent-audit",
-    "agent-eval",
-    "harness-audit",
-    "project-init",
-    "stryker-xunit-v2-shim",
+#: Every entry's premise — the script does not exist under
+#: plugins/dev-team/scripts/, so no ${CLAUDE_PLUGIN_ROOT} qualification could
+#: ever resolve it — is checked mechanically, not trusted, by
+#: test_intentional_bare_invocation_pairs_do_not_ship_in_the_plugin below.
+#: Each script lives only at this repo's root and operates on this
+#: marketplace repo's own infrastructure: `check_registry_sync.py` and
+#: `validate_agent_contract.py` (a repo-root wrapper delegating to
+#: `plugins/marketplace-dev/scripts/validate_agent_contract.py` — that one
+#: ships and IS portable, but only reachable from this monorepo checkout,
+#: since there is no single ${CLAUDE_PLUGIN_ROOT}-style variable spanning two
+#: independently-installed plugins) check `plugins/dev-team/`'s own registry;
+#: the `eval_*`/`citation_lint.py` family operates on `evals/` (explicitly not
+#: shipped — see repo CLAUDE.md's Repository Structure). `agent-eval`'s
+#: strongest evidence is external to this file: the repo-root eval runners
+#: and `.github/workflows/agent-eval.yml` materialize `evals/fixtures` from
+#: `$PWD` via a symlink before invoking it, only meaningful in this checkout.
+#:
+#: Each entry's SKILL.md carries a "Monorepo-relative by design (#1637)" note
+#: near its invocations (checked below) so a reader doesn't mistake this for
+#: an oversight. Add an entry back to KNOWN_BARE_INVOCATION (as a real
+#: defect) only if its script starts shipping under plugins/dev-team/scripts/.
+#: Keyed on the path *after* `scripts/`, not the bare basename — so a future
+#: nested entry (e.g. `scripts/lib/foo.py`) is a distinct pair from
+#: `scripts/foo.py` rather than silently colliding with it.
+INTENTIONAL_BARE_INVOCATION = {
+    ("agent-audit", "validate_agent_contract.py"),
+    ("agent-audit", "check_registry_sync.py"),
+    ("agent-eval", "eval_cache.py"),
+    ("agent-eval", "run_integration_eval.py"),
+    ("agent-eval", "eval_variance.py"),
+    ("agent-eval", "eval_ablation.py"),
+    ("agent-eval", "citation_lint.py"),
+    ("harness-audit", "eval_ablation.py"),
 }
+
+#: (skill, script) pairs whose invocation is `plugins/dev-team/scripts/<script>`
+#: — repo-relative, but NOT the bare `scripts/<script>` form `_BARE_INVOCATION`
+#: matches, and NOT `${CLAUDE_PLUGIN_ROOT}`-qualified either, even though the
+#: script ships. This is the mirror-image case to INTENTIONAL_BARE_INVOCATION:
+#: there, the script doesn't ship, so only a repo-relative path can ever work.
+#: Here, the script DOES ship, but the invoking skill needs cwd-relative
+#: semantics anyway — `verify_tier.py` audits the agents in the operator's
+#: *current working tree*; `${CLAUDE_PLUGIN_ROOT}/scripts/verify_tier.py`
+#: would silently audit the installed plugin cache's (possibly stale) copy
+#: instead, since verify_tier.py resolves its target via
+#: `Path(__file__).resolve().parents[1] / "agents"`.
+#:
+#: Every entry here is invisible to `_BARE_INVOCATION` and to
+#: `test_shipped_script_refs.py`'s `${CLAUDE_PLUGIN_ROOT}/...` resolver, so
+#: `test_worktree_relative_invocations_are_declared` below scans for the raw
+#: pattern across every shipped skill and fails on any undeclared instance —
+#: this is what would have caught quality-targets-converge/SKILL.md naming
+#: `plugins/dev-team/scripts/gherkin_effectiveness_rollup.py` this way before
+#: #1637 qualified it properly instead (that script had no reason to be
+#: cwd-relative — it takes all its inputs as explicit flags).
+#: Keyed on the path after `scripts/`, same reasoning as INTENTIONAL_BARE_INVOCATION.
+INTENTIONAL_WORKTREE_RELATIVE = {
+    ("agent-audit", "verify_tier.py"),
+}
+
+# Group 1 is the path after `scripts/`, kept wide (including `/`) so a nested
+# invocation like `scripts/lib/foo.py` still matches and is kept as its own
+# distinct key (not collapsed to a basename that could collide with an
+# unrelated top-level `foo.py`).
+_BARE_INVOCATION = re.compile(r"python3?\s+(scripts/[\w./-]+\.py)")
+_WORKTREE_RELATIVE_INVOCATION = re.compile(
+    r"python3?\s+(plugins/dev-team/scripts/[\w./-]+\.py)"
+)
+
+
+def _invocation_matches(path, pattern, strip_prefix):
+    """Return [(lineno, line, subpath), ...] for every match of pattern in
+    path, one entry per match — a line with two invocations yields two
+    entries, so neither is silently skipped. subpath is the captured path
+    with strip_prefix removed (e.g. "scripts/" or "plugins/dev-team/scripts/"),
+    kept as the (skill, script) pair key so a nested path stays distinct from
+    a top-level file of the same basename."""
+    out = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for match in pattern.finditer(line):
+            subpath = match.group(1)[len(strip_prefix) :]
+            out.append((lineno, line.strip(), subpath))
+    return out
+
+
+def _bare_invocation_matches(path):
+    return _invocation_matches(path, _BARE_INVOCATION, "scripts/")
+
+
+def _worktree_relative_matches(path):
+    return _invocation_matches(
+        path, _WORKTREE_RELATIVE_INVOCATION, "plugins/dev-team/scripts/"
+    )
 
 
 @pytest.mark.parametrize("skill", SKILLS, ids=lambda p: p.parent.name)
 def test_skills_invoke_plugin_scripts_by_plugin_root(skill):
     """`python3 scripts/foo.py` inside a shipped skill runs against whatever
     happens to be in the user's working directory — usually nothing."""
+    skill_name = skill.parent.name
     offenders = [
-        line.strip()
-        for line in skill.read_text(encoding="utf-8").splitlines()
-        if re.search(r"python3?\s+scripts/[\w./-]+\.py", line)
+        f"{lineno}: {line}"
+        for lineno, line, subpath in _bare_invocation_matches(skill)
+        if (skill_name, subpath) not in INTENTIONAL_BARE_INVOCATION
     ]
-    if skill.parent.name in KNOWN_BARE_INVOCATION:
+
+    if skill_name in KNOWN_BARE_INVOCATION:
         assert offenders, (
-            f"{skill.parent.name} is listed as a known offender but is now clean — remove it from "
+            f"{skill_name} is listed as a known offender but is now clean — remove it from "
             "KNOWN_BARE_INVOCATION"
         )
-        pytest.xfail(f"known bare invocation in {skill.parent.name}")
+        pytest.xfail(f"known bare invocation in {skill_name}")
 
     assert not offenders, (
         "{}: invokes a plugin script by a bare relative path; use "
-        "${{CLAUDE_PLUGIN_ROOT}}/scripts/…\n  {}".format(
-            skill.parent.name, "\n  ".join(offenders)
-        )
+        "${{CLAUDE_PLUGIN_ROOT}}/scripts/…\n  {}".format(skill_name, "\n  ".join(offenders))
     )
 
 
 def test_the_known_bare_invocation_list_does_not_grow():
-    assert len(KNOWN_BARE_INVOCATION) <= 5, (
+    assert len(KNOWN_BARE_INVOCATION) == 0, (
         "a new shipped skill invokes a script by a bare relative path"
+    )
+
+
+def test_intentional_bare_invocation_pairs_do_not_ship_in_the_plugin():
+    """The exemption's premise, checked mechanically rather than trusted:
+    each exempted script must genuinely not exist under
+    plugins/dev-team/scripts/, so no ${CLAUDE_PLUGIN_ROOT} qualification
+    could ever resolve it — the bare form is the only one that can work, and
+    only from a monorepo checkout."""
+    now_shipped = sorted(
+        f"{skill}: {script}"
+        for skill, script in INTENTIONAL_BARE_INVOCATION
+        if (PLUGIN_ROOT / "scripts" / script).is_file()
+    )
+    assert not now_shipped, (
+        "these scripts now ship in the plugin, so their bare invocation is a real "
+        "#1637 defect, not an intentional exemption — qualify with ${CLAUDE_PLUGIN_ROOT}/ "
+        "and remove from INTENTIONAL_BARE_INVOCATION:\n  " + "\n  ".join(now_shipped)
+    )
+
+
+@pytest.mark.parametrize("skill, script", sorted(INTENTIONAL_BARE_INVOCATION))
+def test_intentional_bare_invocation_pairs_are_still_present(skill, script):
+    """Sanity check keyed to the specific PAIR, not just the skill: if
+    `agent-eval` drops its `citation_lint.py` call but keeps four others, this
+    entry must fail rather than pass on the strength of its unrelated
+    siblings — otherwise it silently becomes dead documentation."""
+    path = PLUGIN_ROOT / "skills" / skill / "SKILL.md"
+    subpaths = {subpath for _lineno, _line, subpath in _bare_invocation_matches(path)}
+    assert script in subpaths, (
+        f"({skill}, {script}) is in INTENTIONAL_BARE_INVOCATION but that invocation "
+        "is gone — remove this entry"
+    )
+
+
+@pytest.mark.parametrize(
+    "skill", sorted({skill for skill, _script in INTENTIONAL_BARE_INVOCATION})
+)
+def test_intentional_bare_invocation_skills_are_documented(skill):
+    """The skill must carry the marker explaining why its bare invocation is
+    correct, so a reader hitting it doesn't mistake it for an unfixed #1637
+    defect."""
+    path = PLUGIN_ROOT / "skills" / skill / "SKILL.md"
+    text = path.read_text(encoding="utf-8")
+    assert "Monorepo-relative by design" in text, (
+        f"{skill} is in INTENTIONAL_BARE_INVOCATION but its SKILL.md carries no "
+        "explanatory marker"
+    )
+
+
+def test_worktree_relative_invocations_are_declared():
+    """`plugins/dev-team/scripts/<name>.py` (repo-relative, matching neither
+    the bare-`scripts/` defect shape nor a `${CLAUDE_PLUGIN_ROOT}` reference)
+    is invisible to every other sensor in this file and in
+    test_shipped_script_refs.py. Scan every shipped skill directly for the
+    raw pattern so a new undeclared instance — the shape that let
+    quality-targets-converge/SKILL.md ship an unqualified reference to a
+    portable script — fails loudly instead of silently."""
+    undeclared = []
+    for skill in SKILLS:
+        skill_name = skill.parent.name
+        for lineno, line, subpath in _worktree_relative_matches(skill):
+            if (skill_name, subpath) not in INTENTIONAL_WORKTREE_RELATIVE:
+                undeclared.append(f"{skill_name}:{lineno}: {line}")
+
+    assert not undeclared, (
+        "plugins/dev-team/scripts/… invocation(s) not declared in "
+        "INTENTIONAL_WORKTREE_RELATIVE — either qualify with ${CLAUDE_PLUGIN_ROOT}/ "
+        "(the common case, if the script has no reason to need the operator's "
+        "current working tree) or add the pair with a documented reason:\n  "
+        + "\n  ".join(undeclared)
+    )
+
+
+def test_intentional_worktree_relative_pairs_do_ship_in_the_plugin():
+    """The mirror-image premise, checked mechanically: unlike
+    INTENTIONAL_BARE_INVOCATION, every entry here must genuinely ship under
+    plugins/dev-team/scripts/ — the whole justification for going
+    cwd-relative instead of ${CLAUDE_PLUGIN_ROOT}-qualified is that the
+    working tree, not the installed copy, is what must be resolved."""
+    not_shipped = sorted(
+        f"{skill}: {script}"
+        for skill, script in INTENTIONAL_WORKTREE_RELATIVE
+        if not (PLUGIN_ROOT / "scripts" / script).is_file()
+    )
+    assert not not_shipped, (
+        "these scripts do not ship under plugins/dev-team/scripts/, so a "
+        "cwd-relative reference to them is a real #1637 defect, not a "
+        "deliberate working-tree-vs-cache exemption:\n  " + "\n  ".join(not_shipped)
+    )
+
+
+@pytest.mark.parametrize("skill, script", sorted(INTENTIONAL_WORKTREE_RELATIVE))
+def test_intentional_worktree_relative_pairs_are_still_present(skill, script):
+    """Sanity check keyed to the specific PAIR, mirroring
+    test_intentional_bare_invocation_pairs_are_still_present: if the
+    invocation this entry justifies is qualified or removed, the entry must
+    fail rather than silently become dead documentation."""
+    path = PLUGIN_ROOT / "skills" / skill / "SKILL.md"
+    subpaths = {subpath for _lineno, _line, subpath in _worktree_relative_matches(path)}
+    assert script in subpaths, (
+        f"({skill}, {script}) is in INTENTIONAL_WORKTREE_RELATIVE but that invocation "
+        "is gone — remove this entry"
     )

--- a/tests/repo/test_shipped_script_refs.py
+++ b/tests/repo/test_shipped_script_refs.py
@@ -17,14 +17,21 @@ Three invariants, each model-free and deterministic:
   3. every hook command registered in settings.json resolves to a shipped
      file.
 
-Allowlist (invariant 2): /agent-eval and /session-review are maintainer
-tools that operate on THIS repo's own infrastructure (eval fixtures, session
-transcripts). They only ever run from the dev checkout, where ../../scripts/
-resolves, and their helpers (session_extract.py et al.) are coupled
-repo-root tooling that is intentionally not shipped. A NEW ../../ reference
-in ANY OTHER skill is a shipping bug - add the helper under
-plugins/dev-team/scripts/ and reference it as
-${CLAUDE_PLUGIN_ROOT}/scripts/<name> instead of exempting it.
+Allowlist (invariant 2): /session-review is a maintainer tool that operates
+on THIS repo's own infrastructure (session transcripts). It only ever runs
+from the dev checkout, where ../../scripts/ resolves, and its helpers
+(session_extract.py et al.) are coupled repo-root tooling that is
+intentionally not shipped. A NEW ../../ reference in ANY OTHER skill is a
+shipping bug - add the helper under plugins/dev-team/scripts/ and reference
+it as ${CLAUDE_PLUGIN_ROOT}/scripts/<name> instead of exempting it.
+
+/agent-eval was in this allowlist until #1637: it's the same kind of
+maintainer-only, repo-self-referential tool, but its `allowed-tools`
+frontmatter hardcodes its script invocations as BARE `scripts/<name>.py`
+Bash permission patterns (not `${CLAUDE_PLUGIN_ROOT}/../../scripts/<name>`),
+so its body must use the bare form to match — see
+tests/repo/test_agent_implemented_by_resolves.py's
+`INTENTIONAL_BARE_INVOCATION` set for that guard.
 
 Ported from tests/repo/shipped_script_refs_test.bats (#673).
 """
@@ -41,7 +48,7 @@ PLUGIN = REPO_ROOT / "plugins" / "dev-team"
 SHIPPED_DIRS = [PLUGIN / "skills", PLUGIN / "agents", PLUGIN / "prompts"]
 
 # Skills permitted to reference repo-root tooling via ../../ (see header).
-ESCAPE_ALLOWLIST = ["skills/agent-eval/", "skills/session-review/"]
+ESCAPE_ALLOWLIST = ["skills/session-review/"]
 
 _REF_RE = re.compile(
     r"\$\{CLAUDE_PLUGIN_ROOT\}/(scripts|hooks)/[a-zA-Z0-9_./-]+\.(sh|py)"

--- a/tests/scripts/test_install_java_static_analysis.py
+++ b/tests/scripts/test_install_java_static_analysis.py
@@ -1,32 +1,39 @@
-"""Tests for scripts/install-java-static-analysis.py — the pinned, repo-local
+"""Tests for plugins/dev-team/scripts/install-java-static-analysis.py — the pinned, repo-local
 PMD installer backing the Java static-analysis lane.
 
 The installer is Python 3.8+ stdlib-only (ADR 0014) and installs a pinned
 PMD distribution into a repo-local, gitignored ``.pmd/`` directory (or
 ``PMD_INSTALL_DIR`` when set). Detection is repo-local first, then PATH.
 
-No test here touches the network: every in-process run stubs
-``urllib.request.urlretrieve`` to fail loudly, so a short-circuit path that
-accidentally reaches the download is a test failure, not a download.
+No test here touches the network. Most in-process runs use the ``installer``
+fixture, which stubs ``urllib.request.urlretrieve`` to fail loudly, so a
+short-circuit path that accidentally reaches the download is a test failure,
+not a download. The two checksum tests deliberately reach the download step
+(to exercise the SHA-256 verification) and stub ``urlretrieve`` themselves to
+write local bytes instead of touching the network.
 """
 
 from __future__ import annotations
 
 import ast
+import hashlib
 import importlib.util
 import os
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from _repo_root import REPO_ROOT
 
-SCRIPT = REPO_ROOT / "scripts" / "install-java-static-analysis.py"
+SCRIPT = REPO_ROOT / "plugins" / "dev-team" / "scripts" / "install-java-static-analysis.py"
 
 # Modules the installer may import — all stdlib, per ADR 0014.
 ALLOWED_IMPORTS = {
+    "hashlib",
+    "hmac",
     "os",
     "shutil",
     "subprocess",
@@ -75,7 +82,7 @@ def _make_launcher(install_dir: Path, version: str) -> Path:
 
 
 def test_installer_exists_and_is_stdlib_only():
-    assert SCRIPT.is_file(), "scripts/install-java-static-analysis.py missing"
+    assert SCRIPT.is_file(), "plugins/dev-team/scripts/install-java-static-analysis.py missing"
     tree = ast.parse(SCRIPT.read_text())
     imported = set()
     for node in ast.walk(tree):
@@ -86,6 +93,71 @@ def test_installer_exists_and_is_stdlib_only():
     assert imported <= ALLOWED_IMPORTS, (
         f"non-stdlib (or unexpected) imports: {sorted(imported - ALLOWED_IMPORTS)}"
     )
+
+
+def test_malformed_sha256_pin_fails_at_import_not_at_the_end_of_a_download():
+    """A wrong-length or non-hex PMD_SHA256 must be caught immediately, not
+    discovered only after a real download during a real install."""
+    src = SCRIPT.read_text().replace(
+        'PMD_SHA256 = "be8bf68f6c1d66984bd9645a93e631b78a1c2f42f5f0f8719082fead67553940"',
+        'PMD_SHA256 = "not-a-real-digest"',
+    )
+    assert "not-a-real-digest" in src, "the literal to replace has changed — update this test"
+    namespace = {"__name__": "install_java_static_analysis_malformed_pin"}
+    with pytest.raises(ValueError, match="PMD_SHA256"):
+        exec(compile(src, str(SCRIPT), "exec"), namespace)  # noqa: S102
+
+
+def test_checksum_mismatch_refuses_to_extract(monkeypatch, tmp_path, capsys):
+    """A downloaded archive with the wrong checksum must be rejected before
+    extraction — the download can be network-tampered or the pin can be
+    stale; either way, don't unzip and chmod +x an unverified artifact."""
+    module = _load_installer()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PMD_INSTALL_DIR", raising=False)
+    monkeypatch.setattr(module.shutil, "which", _fake_which({"java": "/usr/bin/java"}))
+
+    def _fake_urlretrieve(url, dest):
+        Path(dest).write_bytes(b"not the real pmd archive")
+
+    monkeypatch.setattr(module.urllib.request, "urlretrieve", _fake_urlretrieve)
+
+    assert module.main() == 1
+    err = capsys.readouterr().err.lower()
+    assert "checksum" in err or "mismatch" in err
+    assert not list((tmp_path / ".pmd").rglob("pmd*")), (
+        "must not extract the archive on checksum mismatch"
+    )
+
+
+def test_checksum_match_extracts_and_installs(monkeypatch, tmp_path, capsys):
+    """The full happy path with a real (small, fake-content) archive whose
+    checksum genuinely matches the pin: extraction runs, the launcher's
+    exec bit is restored, and the installer reports success."""
+    module = _load_installer()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PMD_INSTALL_DIR", raising=False)
+    monkeypatch.setattr(module.shutil, "which", _fake_which({"java": "/usr/bin/java"}))
+
+    archive_src = tmp_path / "src.zip"
+    with zipfile.ZipFile(archive_src, "w") as zf:
+        zf.writestr(
+            f"pmd-bin-{module.PMD_VERSION}/bin/{LAUNCHER_NAME}", "#!/bin/sh\nexit 0\n"
+        )
+    real_hash = hashlib.sha256(archive_src.read_bytes()).hexdigest()
+    monkeypatch.setattr(module, "PMD_SHA256", real_hash)
+
+    def _fake_urlretrieve(url, dest):
+        Path(dest).write_bytes(archive_src.read_bytes())
+
+    monkeypatch.setattr(module.urllib.request, "urlretrieve", _fake_urlretrieve)
+
+    assert module.main() == 0
+    launcher = tmp_path / ".pmd" / f"pmd-bin-{module.PMD_VERSION}" / "bin" / LAUNCHER_NAME
+    assert launcher.is_file()
+    if os.name != "nt":
+        assert launcher.stat().st_mode & 0o111, "exec bit must be restored"
+    assert "PMD installed" in capsys.readouterr().out
 
 
 def test_missing_java_exits_1_with_actionable_message(installer, monkeypatch, capsys):
@@ -191,7 +263,7 @@ def test_version_pin_lives_only_in_the_installer():
         if line.strip()
     }
     files.discard("plugins/dev-team/CHANGELOG.md")
-    assert files == {"scripts/install-java-static-analysis.py"}, (
+    assert files == {"plugins/dev-team/scripts/install-java-static-analysis.py"}, (
         f"PMD version literal leaked outside the installer: {sorted(files)}"
     )
 

--- a/tests/skills/test_project_init_toolchain_plan.py
+++ b/tests/skills/test_project_init_toolchain_plan.py
@@ -97,7 +97,7 @@ def test_csharp_installs_nothing_and_honors_a_global_json_pin():
 
 def test_java_wraps_the_pinned_pmd_installer_script():
     s = _install_section()
-    assert "install-java-static-analysis.py" in s
+    assert "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py" in s
     assert ".pmd/" in s
     assert ".gitignore" in s
 

--- a/tests/skills/test_static_analysis_java_lane.py
+++ b/tests/skills/test_static_analysis_java_lane.py
@@ -165,7 +165,7 @@ def test_tier1_pmd_detection_is_repo_local_first():
 
 
 def test_tier1_pmd_install_hint_names_the_repo_level_installer():
-    assert "install-java-static-analysis.py" in _pmd_tier1_entry()
+    assert "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py" in _pmd_tier1_entry()
 
 
 def test_skill_tier1_table_lists_pmd():
@@ -294,7 +294,7 @@ def test_java_guide_covers_tools_and_roles():
 
 def test_java_guide_covers_repo_level_install():
     guide = _java_guide_section()
-    assert "install-java-static-analysis.py" in guide
+    assert "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py" in guide
     assert ".pmd/" in guide
 
 
@@ -340,4 +340,4 @@ def test_dev_setup_pmd_check_is_warn_only():
 
 
 def test_dev_setup_pmd_check_names_the_installer():
-    assert "install-java-static-analysis.py" in _dev_setup_pmd_block()
+    assert "plugins/dev-team/scripts/install-java-static-analysis.py" in _dev_setup_pmd_block()


### PR DESCRIPTION
## Summary

Same root cause as #1636, different artifact type: skill markdown instead of an agent's `Implemented by:` line. A shipped skill instructing `python3 scripts/foo.py` resolves that path against the user's cwd, not the plugin — in this checkout it happens to work, on anyone else's project it doesn't.

**Two genuine defects, fixed the #1636 way (move + qualify):**
- `project-init`'s `install-java-static-analysis.py` didn't ship at all — moved into `plugins/dev-team/scripts/`, with every stale reference swept (`developer-notes.md`, `static-analysis-integration`'s reference docs, `dev-setup.sh`'s own advisory message, three test files). Since the move makes this download-extract-execute PMD installer newly reachable by end users, also hardened it: a `PMD_SHA256` pin verified against the real published release asset, checked via `hashlib`+`hmac` before extraction (module-level format guard + real tests for both the mismatch and match paths), and a narrowed exec-bit restore (two known launcher names instead of every extracted archive entry).
- `stryker-xunit-v2-shim`'s `generate_shim.py` already shipped under the skill's own `scripts/` subdirectory but was invoked unqualified — fixed.
- `quality-targets-converge`'s `gherkin_effectiveness_rollup.py` and a `verify_gherkin_quality_critic_isolation.py` reference in `knowledge/` were each invoked via a *third* unqualified form (`plugins/dev-team/scripts/...`, plain repo-relative) that matched neither the bare-path defect shape nor a `${CLAUDE_PLUGIN_ROOT}` reference — invisible to every existing guard until a dedicated sensor was built (see below).

**Three of the six reclassified as intentionally NOT `${CLAUDE_PLUGIN_ROOT}`-qualified:** `agent-audit`, `agent-eval`, and `harness-audit` invoke scripts whose whole job is checking this marketplace repo's own tree (registry sync, the `evals/` corpus — explicitly not shipped, `metrics/`), so a plugin-cache path would resolve nowhere, or — for the one case where the script does ship (`verify_tier.py`) — would silently audit the installed cache instead of the working tree `/agent-audit` exists to check. `agent-eval`'s `allowed-tools` frontmatter independently corroborates this: it hardcodes the bare strings as literal Bash permission patterns that a qualified path would stop matching.

**Guard redesign:** `tests/repo/test_agent_implemented_by_resolves.py`'s bare-invocation guard went from a single shrink-only skill-name set to two symmetric, per-`(skill, script)` exemption sets with opposite mechanically-checked premises — `INTENTIONAL_BARE_INVOCATION` (script must NOT ship) and `INTENTIONAL_WORKTREE_RELATIVE` (script must ship — new, closes the gap that let `quality-targets-converge`'s defect through undetected) — plus per-pair staleness guards, so a future unrelated bare invocation in the same skill file is still caught rather than exempted wholesale.

**One over-correction reverted:** `mutation-testing`'s `csharp_stryker_net_wrapper.py` and its slice runner stayed/returned to bare + `${CLAUDE_PLUGIN_ROOT}` forms respectively, matching what each script's own documented install/copy instructions actually require.

Four rounds of independent agent review (16-agent panel + 3 targeted verification rounds) drove this — each round found real, previously-undetected defects, including one live production bug (`quality-targets-converge`) and a bug in the guard's own redesign (`.search()` vs `.finditer()` missing multi-invocation lines).

Six follow-up issues track what's deliberately out of scope: #1652 (agent-audit's missing Bash grant), #1653 (harness-audit's executable/data conflation), #1654 (missing ADR for the path-resolution taxonomy), #1655 (guard's SKILL.md-only detection surface — one instance already found and fixed directly here), #1656 (repo-wide `${CLAUDE_PLUGIN_ROOT}` quoting inconsistency), #1657 (CI-verify the PMD_SHA256 pin against the live release asset).

Closes #1637

## Test plan

- [x] Full pytest suite across the CI directory list: 6173 passed, 44 skipped
- [x] `ruff check .` clean
- [x] `python3 scripts/check_md_references.py` clean
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` clean
- [x] `bash scripts/ci-local.sh --only=chk_python_floor` clean (173 shipped modules, real Python 3.8.20)
- [x] New tests for the PMD checksum verification (mismatch, match, and malformed-pin-fails-at-import paths)
- [x] New tests for both exemption mechanisms' staleness/premise guards
- [x] Four rounds of independent multi-agent review — all findings addressed or explicitly deferred with rationale and a filed issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)