### PR TITLE
fix(hooks): fix stacked heredoc opener and closer whitespace bugs in normalizer

### DIFF
--- a/plugins/dev-team/hooks/lib/review_gate_normalized_hash.py
+++ b/plugins/dev-team/hooks/lib/review_gate_normalized_hash.py
@@ -70,6 +70,31 @@ errs closed: a Python reindent, or an indentation fix on a quoted line,
 simply doesn't get carry-forward — costing one re-dispatch rather than
 weakening the gate.
 
+## Unquoted heredoc bodies (#1638)
+
+The quote-character rule above is what keeps string DATA out of the cosmetic
+bucket — but it only sees quote characters, and Ruby's `<<~SQL`, PHP's
+`<<<TXT`, and Perl's `<<EOF` heredocs carry a data body with no quote
+character anywhere on its lines. `_heredoc_body_marks` tracks each
+language's opener/closer grammar per hunk side (`_HEREDOC_GRAMMARS`,
+extension-keyed so PHP's three-angle-bracket form can never cross-match
+Ruby/Perl's two-angle-bracket form) and forces every line between an opener
+and its closer to byte-exact comparison, bypassing `_canonical_line`'s
+collapsible/quote-char rules entirely.
+
+Failing closed here means two things, both load-bearing:
+
+- **An opener with no closer inside the visible hunk side marks every
+  remaining line, not just up to end-of-context.** The true close may be
+  outside what this hunk shows; the safe assumption is that it hasn't
+  closed yet, so nothing after it is eligible for whitespace collapsing.
+- **An opener could be invisible entirely** — more than a few lines of
+  context above the first line this function ever sees. `normalized_gate_hash`
+  closes that gap at the source instead of guessing: it requests
+  `--unified=100000` context, so for any realistically-sized file every
+  hunk spans start-to-end and an opener anywhere earlier in the file is
+  always part of the same hunk `_heredoc_body_marks` reasons over.
+
 ## What the canonical form must contain to bind a subject (#1631 review)
 
 The first draft of this module compared, per file, the flat list of removed
@@ -195,14 +220,155 @@ _WHITESPACE_INSIGNIFICANT_EXTENSIONS = frozenset(
     }
 )
 
-#: KNOWN RESIDUAL (#1631 review). The quote-character rule in
+#: Shared by `_HEREDOC_GRAMMARS` below — see that dict's own comment for the
+#: grammar contract. Ruby's `<<~`/`<<-`/bare, HCL's `<<-`/bare, and Perl's
+#: `<<~`/bare all share this exact closer rule.
+def _bareish_heredoc_close(line: str, ident: str, modifier: str) -> bool:
+    """Shared closer for grammars whose only modifier axis is "must the
+    closing line sit in column 0". No modifier means the opener demands an
+    unindented closer (`line == ident`); `~`/`-` means the closer may be
+    indented (`line.lstrip() == ident`).
+
+    Leading whitespace only — never `.strip()`. A real heredoc terminator
+    (Ruby, Perl, HCL) is the identifier and nothing else on the line; text
+    AFTER it, including trailing whitespace, means the line is not a
+    terminator at all. Stripping trailing whitespace here would false-close
+    on a body line like `"  SQL  "` (trailing spaces) and dump every
+    subsequent body line back into whitespace collapsing — the "more body,
+    never fewer" rule this grammar exists to uphold, breached by the exact
+    kind of over-eager closer match that rule warns against."""
+    return line == ident if modifier == "" else line.lstrip() == ident
+
+
+#: Per-language heredoc grammars (#1638). The quote-character rule in
 #: `_canonical_line` is what keeps string data out of the cosmetic bucket,
-#: and it does not see an unquoted heredoc body — Ruby's `<<~SQL`, PHP's
+#: and it does not see an UNQUOTED heredoc body — Ruby's `<<~SQL`, PHP's
 #: `<<<TXT`, Perl's `<<EOF`. Reindenting a line inside one is a data change
-#: this module would read as formatting. Narrower than the indentation-
-#: significance hazard (which moves code between blocks) and it needs the
-#: same language awareness that defers comment stripping to v2, so it is
-#: recorded here rather than papered over with a heuristic.
+#: this module would otherwise read as formatting.
+#:
+#: Each entry is `(open_re, is_close)`: `open_re` matches an opener anywhere
+#: on a line, capturing the modifier (group 1) and the delimiter identifier
+#: (group 2); `is_close(line, ident, modifier)` decides whether a later line
+#: closes that specific heredoc. Deliberately erring toward MORE lines
+#: counting as heredoc body, never fewer — see `_heredoc_body_marks`'s
+#: docstring for why the closing-match direction matters (an early false
+#: close would let real body content fall back to normal whitespace
+#: collapsing, which is the hazard this exists to close).
+#: Keyed by extension, not by a single cross-language regex, so PHP's `<<<`
+#: and Ruby/Perl's `<<` can never cross-match each other's grammar. `.tf`/
+#: `.hcl` alias to `.rb`'s tuple rather than `.pl`'s: Terraform/HCL heredocs
+#: support the bare and dash (`<<-EOT`) forms but not the squiggly one, and
+#: only `.rb`'s regex captures a dash modifier — `.pl`'s does not, so it
+#: would silently fail to match `<<-EOT` at all.
+#:
+#: Ruby/Perl's bare `<<` is also their shift/append ("shovel") operator
+#: (`arr << item`, `x << 2`), but every real style guide writes that with
+#: spaces around it. A heredoc opener has no space before an UNQUOTED
+#: delimiter, so the identifier group starting immediately after `<<` (no
+#: `\s*`) structurally cannot match the idiomatic spaced operator form.
+#: Verified directly: `arr << item` and `x << 2` do not match; only the
+#: unidiomatic no-space `arr<<item` would, which costs a rare false-positive
+#: carry-forward loss. Perl's grammar carries two exceptions, both in the
+#: SAFE (over-detection, never under-detection) direction:
+#: - A space IS legal (and not deprecated) before a QUOTED delimiter
+#:   (`print << "EOF";`), so `.pl`'s regex allows whitespace only when
+#:   immediately followed by a quote character — never bare — keeping the
+#:   shovel-operator distinction intact while still matching this real
+#:   heredoc form.
+#: - A backslash-quoted delimiter (`print <<\EOF;`, perlop's no-interpolation
+#:   shorthand for `<<'EOF'`) is matched by including `\` alongside `'`/`"`
+#:   in the optional marker class. Over-matching an opener costs at most a
+#:   spurious carry-forward loss (marking replaces a line with itself,
+#:   byte-exact, never creating a collision); missing one is the unsafe
+#:   direction this whole grammar exists to close.
+_HEREDOC_GRAMMARS = {
+    ".rb": (
+        re.compile(r"<<([~-]?)['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?"),
+        _bareish_heredoc_close,
+    ),
+    ".pl": (
+        re.compile(r"<<(~?)(?:\s+(?=['\"]))?['\"\\]?([A-Za-z_][A-Za-z0-9_]*)['\"]?"),
+        _bareish_heredoc_close,
+    ),
+    ".php": (
+        # The leading `()` is an empty capture group, not a mistake: it pads
+        # PHP's regex so the delimiter identifier still lands in group 2,
+        # matching the `.rb`/`.pl` group numbering that `_heredoc_body_marks`
+        # unpacks uniformly across every grammar. PHP has no modifier axis.
+        re.compile(r"<<<\s*()['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?"),
+        # `.lstrip()` (never `.strip()` — see `_bareish_heredoc_close`'s
+        # docstring for why trailing whitespace must not be stripped) plus
+        # `.rstrip(";,)")` for a real PHP heredoc closer, which may be
+        # trailed by a statement terminator, an array-element comma, or a
+        # call-argument close-paren. Known, accepted residual: this still
+        # makes PHP's close check looser than the "more body, never less"
+        # rule above for trailing PUNCTUATION — a body line reading exactly
+        # `TXT)` would false-close. Not fixed here: distinguishing "closer
+        # plus trailing punctuation" from "body line matching that shape"
+        # needs the actual PHP closer grammar (identifier alone on the line,
+        # optionally re-indented per PHP 7.3+), not a per-language regex
+        # tweak.
+        lambda line, ident, _modifier: line.lstrip().rstrip(";,)") == ident,
+    ),
+}
+_HEREDOC_GRAMMARS[".pm"] = _HEREDOC_GRAMMARS[".pl"]
+_HEREDOC_GRAMMARS[".tf"] = _HEREDOC_GRAMMARS[".hcl"] = _HEREDOC_GRAMMARS[".rb"]
+
+
+def _heredoc_body_marks(lines: list, suffix: str) -> list:
+    """Return one bool per entry in `lines`: True where the line is inside an
+    unquoted heredoc body (or is an unresolved opener's tail — see below),
+    and must therefore be compared byte-exact regardless of the
+    collapsible/quote-char rules `_canonical_line` otherwise applies.
+
+    Tracks a FIFO queue of pending `(ident, modifier)` pairs, not a single
+    one: stacked openers on one line are ordinary idioms (Ruby
+    `assert_equal(<<~A, <<~B)`, Perl `print <<A, <<B;`), and their bodies
+    close in the same order the openers appeared. Marking only the first of
+    several openers — losing the rest to ordinary whitespace collapsing —
+    is exactly the hazard this function exists to close, so every opener
+    found while the queue is empty is enqueued, not just the first match on
+    the line.
+
+    Fails closed on an unmatched opener: if a heredoc opens within `lines`
+    but no closing delimiter is found before `lines` ends, every remaining
+    line is marked True. The true close may lie outside what this hunk's
+    side shows; the safe assumption is that it has not closed yet.
+    `normalized_gate_hash` additionally requests full-file diff context (see
+    its docstring) so that in real use an opener earlier in the same file is
+    always part of the same hunk as any body line it covers — this function
+    only needs to reason within one hunk side, never across hunks.
+
+    A line that closes the head of the queue is not re-scanned for a new
+    opener of its own. Sound only because every `is_close` in
+    `_HEREDOC_GRAMMARS` requires the entire (stripped) line to equal the
+    ident, so a closing line can never also carry an opener — there is no
+    "fresh opener on the closer's line" case to miss today. A grammar with a
+    looser closer would need the opener scan to run on the closing line too,
+    or the following body would silently fall back to whitespace
+    collapsing.
+
+    An opener line itself is never marked — evident intent, and it usually
+    carries no body content (`sql = <<~SQL`) — only lines strictly after it,
+    through and including whatever line closes it.
+    """
+    grammar = _HEREDOC_GRAMMARS.get(suffix)
+    if grammar is None:
+        return [False] * len(lines)
+    open_re, is_close = grammar
+    marks = [False] * len(lines)
+    pending: list = []  # FIFO of (ident, modifier); bodies close in this order
+    for i, line in enumerate(lines):
+        if pending:
+            marks[i] = True
+            ident, modifier = pending[0]
+            if is_close(line, ident, modifier):
+                pending.pop(0)
+            continue
+        for match in open_re.finditer(line):
+            pending.append((match.group(2), match.group(1)))
+    return marks
+
 
 #: Field/record separators for the canonical serialization. Chosen from the
 #: ASCII separator block because they are vanishingly rare in source, but NOT
@@ -254,16 +420,23 @@ def _is_documentation(path: str) -> bool:
     return is_doc_only_changeset([path])
 
 
+def _extension(path: str) -> str | None:
+    """Lowercased extension including the dot, or None for an extensionless
+    file — shared by `_whitespace_collapsible` and the heredoc grammar
+    lookup so the two never disagree about what a path's extension is."""
+    name = str(path or "").replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if "." not in name:
+        return None
+    return "." + name.rsplit(".", 1)[-1]
+
+
 def _whitespace_collapsible(path: str) -> bool:
     """True only for extensions this module can prove are brace/keyword-
     delimited. Everything else — including every unknown extension and every
     extensionless file — is compared byte-exactly. Fail-closed by default:
     the safe answer to "is this language's indentation meaningless?" is no."""
-    name = str(path or "").replace("\\", "/").rsplit("/", 1)[-1].lower()
-    if "." not in name:
-        return False
-    suffix = "." + name.rsplit(".", 1)[-1]
-    if suffix in _INDENT_SIGNIFICANT_EXTENSIONS:
+    suffix = _extension(path)
+    if suffix is None or suffix in _INDENT_SIGNIFICANT_EXTENSIONS:
         return False
     return suffix in _WHITESPACE_INSIGNIFICANT_EXTENSIONS
 
@@ -468,29 +641,41 @@ def normalize_patch(patch_text: str) -> str | None:
         return None
 
     records = []
-    for section in sorted(sections, key=lambda s: s.name):
-        name = section.name
-        if section.has_real_path and _is_documentation(name):
-            continue
-        collapsible = _whitespace_collapsible(name)
-        parts = list(section.structural)
-        if section.binary:
-            # The blob SHAs are the only content signal a textual diff
-            # exposes for a binary file, and without them any binary
-            # replacement is invisible to this digest.
-            parts.append(section.index_line or "binary")
-        for old_lines, new_lines in section.hunks:
-            old_canon = [_canonical_line(ln, collapsible) for ln in old_lines]
-            new_canon = [_canonical_line(ln, collapsible) for ln in new_lines]
-            if old_canon == new_canon:
-                # This hunk's two sides canonicalize identically — its whole
-                # delta was formatting.
+    try:
+        for section in sorted(sections, key=lambda s: s.name):
+            name = section.name
+            if section.has_real_path and _is_documentation(name):
                 continue
-            parts.append("\n".join(old_canon))
-            parts.append("\n".join(new_canon))
-        if not parts:
-            continue
-        records.append(_encode([name] + parts))
+            collapsible = _whitespace_collapsible(name)
+            suffix = _extension(name)
+            parts = list(section.structural)
+            if section.binary:
+                # The blob SHAs are the only content signal a textual diff
+                # exposes for a binary file, and without them any binary
+                # replacement is invisible to this digest.
+                parts.append(section.index_line or "binary")
+            for old_lines, new_lines in section.hunks:
+                old_heredoc = _heredoc_body_marks(old_lines, suffix)
+                new_heredoc = _heredoc_body_marks(new_lines, suffix)
+                old_canon = [
+                    ln if marked else _canonical_line(ln, collapsible)
+                    for ln, marked in zip(old_lines, old_heredoc)
+                ]
+                new_canon = [
+                    ln if marked else _canonical_line(ln, collapsible)
+                    for ln, marked in zip(new_lines, new_heredoc)
+                ]
+                if old_canon == new_canon:
+                    # This hunk's two sides canonicalize identically — its
+                    # whole delta was formatting.
+                    continue
+                parts.append("\n".join(old_canon))
+                parts.append("\n".join(new_canon))
+            if not parts:
+                continue
+            records.append(_encode([name] + parts))
+    except Exception:  # noqa: BLE001 - fail closed, see module docstring
+        return None
     return _RECORD_SEP.join(_encode([record]) for record in records)
 
 
@@ -503,6 +688,20 @@ def normalized_gate_hash(cwd=None, target: str = "--cached") -> str | None:
     otherwise collapse this function's input to empty for every changeset,
     turning the normalized hash into a constant — the same subject-binding
     bypass `review_gate_hash()`'s docstring documents at length.
+
+    Also passes `--unified=100000` (#1638): `_heredoc_body_marks` reasons
+    only within one hunk side, never across hunks, so a heredoc opener more
+    than the default 3 lines of context above a changed body line would
+    otherwise be invisible to it — the exact "opened outside the visible
+    hunk" hazard the heredoc handling has to fail closed against. Requesting
+    enough context to cover any realistically-sized file makes each file's
+    changes arrive as one hunk spanning start to end, so an opener anywhere
+    earlier in the file is always part of the same hunk as any body line it
+    covers. This is strictly safer than the default, never less: wider
+    context only ever MERGES hunks, and a merged hunk whose two sides still
+    canonicalize identically was purely formatting regardless of how many
+    original hunks it absorbed (see the "costs some invariance, never
+    safety" trade already accepted for fixes 2-3 in the module docstring).
 
     `target` mirrors `review_gate_hash()`/`working_tree_gate_hash()`'s split:
     `--cached` for an ordinary staged commit, `HEAD` for the `git commit
@@ -525,7 +724,7 @@ def normalized_gate_hash(cwd=None, target: str = "--cached") -> str | None:
     """
     try:
         completed = run_safe_git_diff(
-            ["--no-color", "--no-ext-diff", "--no-textconv"],
+            ["--no-color", "--no-ext-diff", "--no-textconv", "--unified=100000"],
             cwd=cwd,
             text=False,
             target=target,

--- a/plugins/dev-team/tests/hooks/test_review_gate_normalized_hash.py
+++ b/plugins/dev-team/tests/hooks/test_review_gate_normalized_hash.py
@@ -167,6 +167,327 @@ class TestNormalizePatch:
         assert ngh.normalized_gate_hash(tmp_path) is None
 
 
+class TestHeredocBodies:
+    """#1638. Unquoted heredoc bodies carry no quote character, so the rule
+    in `_canonical_line` that keeps string data out of the cosmetic bucket
+    never sees them. Each language test opens, reindents, and closes a
+    heredoc within one hunk — the shape `_heredoc_body_marks` reasons over."""
+
+    def test_ruby_squiggly_heredoc_reindent_survives(self):
+        before = _patch(
+            "a.rb",
+            ["sql = <<~SQL", "  SELECT * FROM users WHERE role = admin", "SQL"],
+            ["sql = <<~SQL", "  SELECT * FROM users WHERE role = admin", "SQL"],
+        )
+        after = _patch(
+            "a.rb",
+            ["sql = <<~SQL", "  SELECT * FROM users WHERE role = admin", "SQL"],
+            ["sql = <<~SQL", "    SELECT * FROM users WHERE role = admin", "SQL"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_ruby_dash_heredoc_reindent_survives(self):
+        before = _patch("a.rb", ["x = <<-EOF", "  body", "  EOF"], ["x = <<-EOF", "  body", "  EOF"])
+        after = _patch("a.rb", ["x = <<-EOF", "  body", "  EOF"], ["x = <<-EOF", "    body", "  EOF"])
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+
+    def test_ruby_bare_heredoc_reindent_survives(self):
+        before = _patch("a.rb", ["x = <<EOF", "  body", "EOF"], ["x = <<EOF", "  body", "EOF"])
+        after = _patch("a.rb", ["x = <<EOF", "  body", "EOF"], ["x = <<EOF", "    body", "EOF"])
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+
+    def test_php_heredoc_reindent_survives(self):
+        before = _patch(
+            "a.php",
+            ["$msg = <<<TXT", "  Dear customer, your balance is overdue", "TXT;"],
+            ["$msg = <<<TXT", "  Dear customer, your balance is overdue", "TXT;"],
+        )
+        after = _patch(
+            "a.php",
+            ["$msg = <<<TXT", "  Dear customer, your balance is overdue", "TXT;"],
+            ["$msg = <<<TXT", "    Dear customer, your balance is overdue", "TXT;"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_perl_shell_style_heredoc_reindent_survives(self):
+        """Perl and shell share the `<<EOF` grammar (the issue's own grouping
+        of the two); `.pl`/`.pm` are the tracked extension, matching
+        `_WHITESPACE_INSIGNIFICANT_EXTENSIONS`."""
+        before = _patch(
+            "a.pl",
+            ["my $t = <<EOF;", "  literal text that matters", "EOF"],
+            ["my $t = <<EOF;", "  literal text that matters", "EOF"],
+        )
+        after = _patch(
+            "a.pl",
+            ["my $t = <<EOF;", "  literal text that matters", "EOF"],
+            ["my $t = <<EOF;", "    literal text that matters", "EOF"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_perl_spaced_quoted_heredoc_opener_reindent_survives(self):
+        """Perl legally allows whitespace before a QUOTED delimiter
+        (`print << "EOF";`) — only the bare spaced form (`<< EOF`) is
+        deprecated/fatal. The `.pl` regex must still catch this: missing it
+        would be a false negative on a real heredoc, the unsafe direction."""
+        before = _patch(
+            "a.pl",
+            ['print << "EOF";', "  literal text that matters", "EOF"],
+            ['print << "EOF";', "  literal text that matters", "EOF"],
+        )
+        after = _patch(
+            "a.pl",
+            ['print << "EOF";', "  literal text that matters", "EOF"],
+            ['print << "EOF";', "    literal text that matters", "EOF"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_perl_backslash_quoted_heredoc_opener_reindent_survives(self):
+        """`<<\\EOF` (perlop: no-interpolation shorthand for `<<'EOF'`) must
+        still be recognized as an opener — missing it is a false negative on
+        a real heredoc, the unsafe direction this grammar exists to close."""
+        before = _patch(
+            "a.pl",
+            ["print <<\\EOF;", "  literal text that matters", "EOF"],
+            ["print <<\\EOF;", "  literal text that matters", "EOF"],
+        )
+        after = _patch(
+            "a.pl",
+            ["print <<\\EOF;", "  literal text that matters", "EOF"],
+            ["print <<\\EOF;", "    literal text that matters", "EOF"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_indented_closer_with_trailing_whitespace_does_not_false_close(self):
+        """#1638 regression: `_bareish_heredoc_close` used `.strip()` for the
+        indent-tolerant (`~`/`-`) forms, which also strips TRAILING
+        whitespace — so a body line reading exactly the identifier plus
+        trailing spaces (`"  SQL  "`) falsely closed the heredoc, dumping
+        every later body line back into whitespace collapsing. A real
+        terminator is the identifier and nothing else on the line."""
+        before = _patch(
+            "a.rb",
+            ["sql = <<~SQL", "  SELECT 1", "  SQL  ", "    secret data", "SQL"],
+            ["sql = <<~SQL", "  SELECT 1", "  SQL  ", "    secret data", "SQL"],
+        )
+        after = _patch(
+            "a.rb",
+            ["sql = <<~SQL", "  SELECT 1", "  SQL  ", "    secret data", "SQL"],
+            ["sql = <<~SQL", "  SELECT 1", "  SQL  ", "        secret data", "SQL"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_php_closer_with_trailing_whitespace_does_not_false_close(self):
+        """#1638 regression: the PHP closer carried the identical
+        trailing-whitespace false-close defect just fixed in
+        `_bareish_heredoc_close` — `.strip()` (not `.lstrip()`) let a body
+        line reading the identifier plus trailing spaces close the heredoc
+        early."""
+        before = _patch(
+            "a.php",
+            ["$m = <<<TXT", "  Dear customer", "  TXT  ", "    secret data", "TXT;"],
+            ["$m = <<<TXT", "  Dear customer", "  TXT  ", "    secret data", "TXT;"],
+        )
+        after = _patch(
+            "a.php",
+            ["$m = <<<TXT", "  Dear customer", "  TXT  ", "    secret data", "TXT;"],
+            ["$m = <<<TXT", "  Dear customer", "  TXT  ", "        secret data", "TXT;"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_perl_module_extension_uses_the_same_grammar_as_pl(self):
+        assert ngh._HEREDOC_GRAMMARS[".pm"] is ngh._HEREDOC_GRAMMARS[".pl"]
+
+    @pytest.mark.parametrize("suffix", [".tf", ".hcl"])
+    def test_terraform_and_hcl_alias_the_ruby_style_grammar(self, suffix):
+        """Terraform/HCL heredocs (`<<EOT` / `<<-EOT`) share Ruby's exact
+        opener/closer grammar — not Perl's, whose regex has no dash-modifier
+        capture and would silently fail to match `<<-EOT` at all."""
+        assert ngh._HEREDOC_GRAMMARS[suffix] is ngh._HEREDOC_GRAMMARS[".rb"]
+
+    def test_terraform_heredoc_reindent_survives(self):
+        before = _patch(
+            "main.tf",
+            ["user_data = <<-EOF", "  #!/bin/bash", "  echo hi", "EOF"],
+            ["user_data = <<-EOF", "  #!/bin/bash", "  echo hi", "EOF"],
+        )
+        after = _patch(
+            "main.tf",
+            ["user_data = <<-EOF", "  #!/bin/bash", "  echo hi", "EOF"],
+            ["user_data = <<-EOF", "  #!/bin/bash", "    echo hi", "EOF"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_an_opener_with_no_close_inside_the_hunk_fails_closed(self):
+        """The true closer might be outside this hunk's side entirely; the
+        safe assumption is that every line after an unresolved opener is
+        still inside the heredoc body, not eligible for collapsing. Only the
+        FAR line is reindented — leaving the near line byte-identical between
+        before/after — so a regression that only marks the line immediately
+        after the opener (rather than every remaining line) would still be
+        caught here."""
+        before = _patch("a.rb", ["x = <<~SQL", "  line one", "  line two"], ["x = <<~SQL", "  line one", "  line two"])
+        after = _patch("a.rb", ["x = <<~SQL", "  line one", "  line two"], ["x = <<~SQL", "  line one", "    line two"])
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_ordinary_reindented_code_outside_a_heredoc_still_collapses(self):
+        """Regression guard: the heredoc handling must not make Ruby/PHP/Perl
+        stop getting carry-forward for perfectly ordinary reindents."""
+        assert ngh.normalize_patch(_patch("a.rb", ["  x = 1"], ["x = 1"])) == ""
+        assert ngh.normalize_patch(_patch("a.php", ["  $x = 1;"], ["$x = 1;"])) == ""
+        assert ngh.normalize_patch(_patch("a.pl", ["  $x = 1;"], ["$x = 1;"])) == ""
+
+    @pytest.mark.parametrize(
+        "suffix,line",
+        [
+            (".rb", "arr << item"),
+            (".rb", "x << y"),
+            (".rb", "result = a << 2"),
+            (".pl", "arr << item"),
+            (".pl", "x << y"),
+            (".pl", "result = a << 2"),
+        ],
+    )
+    def test_idiomatic_spaced_shift_or_shovel_is_never_mistaken_for_a_heredoc(self, suffix, line):
+        """Ruby/Perl's `<<` is also their shift/append operator, always
+        written with spaces by convention. A heredoc opener has no space
+        between `<<` and its delimiter, so the idiomatic spaced form must
+        never be misread as one. Exercised through the public API: if the
+        regex falsely opened a heredoc on `line`, the ordinary reindent right
+        after it would be swept into the (fail-closed, byte-exact) heredoc
+        body and stop collapsing — this asserts it still collapses to ""."""
+        before = _patch(f"a{suffix}", ["  x = 1"], ["x = 1"], context=[line])
+        assert ngh.normalize_patch(before) == "", (
+            f"{line!r} on {suffix} must not open a phantom heredoc that blocks "
+            "carry-forward for an unrelated ordinary reindent in the same hunk"
+        )
+
+    def test_two_heredocs_opened_on_one_line_both_get_body_tracking(self):
+        """#1638 regression: the original fix tracked only ONE pending
+        heredoc via `.search()` (leftmost match), so a line with two stacked
+        openers — an ordinary idiom (`print <<A, <<B;`) — left the SECOND
+        heredoc's body unmarked and collapsible. Reindenting body b alone
+        must still survive normalization."""
+        before = _patch(
+            "a.pl",
+            ["print <<A, <<B;", "  body a", "A", "  body b", "B"],
+            ["print <<A, <<B;", "  body a", "A", "  body b", "B"],
+        )
+        after = _patch(
+            "a.pl",
+            ["print <<A, <<B;", "  body a", "A", "  body b", "B"],
+            ["print <<A, <<B;", "  body a", "A", "      body b", "B"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_two_sequential_heredocs_in_one_hunk_each_get_body_tracking(self):
+        before = _patch(
+            "a.rb",
+            ["a = <<~A", "  body a", "A", "b = <<~B", "  body b", "B"],
+            ["a = <<~A", "  body a", "A", "b = <<~B", "  body b", "B"],
+        )
+        after = _patch(
+            "a.rb",
+            ["a = <<~A", "  body a", "A", "b = <<~B", "  body b", "B"],
+            ["a = <<~A", "  body a", "A", "b = <<~B", "      body b", "B"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_php_nowdoc_single_quoted_delimiter_reindent_survives(self):
+        before = _patch(
+            "a.php",
+            ["$msg = <<<'TXT'", "  Dear customer, your balance is overdue", "TXT;"],
+            ["$msg = <<<'TXT'", "  Dear customer, your balance is overdue", "TXT;"],
+        )
+        after = _patch(
+            "a.php",
+            ["$msg = <<<'TXT'", "  Dear customer, your balance is overdue", "TXT;"],
+            ["$msg = <<<'TXT'", "    Dear customer, your balance is overdue", "TXT;"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_body_line_containing_identifier_as_substring_does_not_false_close(self):
+        before = _patch(
+            "a.rb",
+            ["x = <<~SQL", "  SQL is fun to write", "SQL"],
+            ["x = <<~SQL", "  SQL is fun to write", "SQL"],
+        )
+        after = _patch(
+            "a.rb",
+            ["x = <<~SQL", "  SQL is fun to write", "SQL"],
+            ["x = <<~SQL", "    SQL is fun to write", "SQL"],
+        )
+        assert ngh.normalize_patch(before) != ngh.normalize_patch(after)
+        assert ngh.normalize_patch(after) not in ("", None)
+
+    def test_reindenting_staged_ruby_heredoc_body_leaves_the_normalized_hash_changed(
+        self, tmp_path
+    ):
+        """End to end against real git, with an opener far enough above the
+        changed line that it would be invisible under git's default 3-line
+        hunk context — the exact hazard `normalized_gate_hash`'s
+        `--unified=100000` closes. Padding sits BETWEEN the opener and the
+        edited line, not after it, so this genuinely exercises the gap."""
+        env = hermetic_git_env(home=tmp_path)
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, env=env, check=True)
+
+        lines = ["sql = <<~SQL"]
+        lines += [f"  -- padding comment {i}" for i in range(10)]
+        lines.append("  SELECT * FROM users WHERE role = admin")
+        lines.append("SQL")
+        (tmp_path / "a.rb").write_text("\n".join(lines) + "\n")
+        subprocess.run(["git", "add", "a.rb"], cwd=tmp_path, env=env, check=True)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, env=env, check=True)
+
+        lines[-2] = "      SELECT * FROM users WHERE role = admin"
+        (tmp_path / "a.rb").write_text("\n".join(lines) + "\n")
+
+        # Confirm the setup actually creates the gap this test is for, using
+        # the actual UNSTAGED edit (captured only now, after the write —
+        # capturing it earlier on the clean post-commit tree would make this
+        # assertion vacuously true regardless of the padding size): with
+        # git's default 3-line hunk context, the opener 11 lines above the
+        # edited line must not appear among the hunk's BODY lines (the ones
+        # `normalize_patch` actually consumes). `@@ ... @@` header lines are
+        # excluded from this check on purpose — git appends a heuristic
+        # "nearest preceding line" section heading to the header for
+        # readability (confirmed here: it echoes `sql = <<~SQL`), but that
+        # heading is never fed to `_heredoc_body_marks`; only `+`/`-`/` `
+        # body lines are, and the assertion must mirror what the module
+        # under test actually sees, not raw diff text.
+        default_diff = subprocess.run(
+            ["git", "diff"], cwd=tmp_path, env=env, capture_output=True, text=True, check=True
+        )
+        body_lines = "\n".join(
+            ln for ln in default_diff.stdout.splitlines() if not ln.startswith("@@")
+        )
+        assert "<<~SQL" not in body_lines, (
+            "setup didn't create the gap: the opener leaked into the default-context "
+            "diff's body lines before the edit, so this test wouldn't exercise "
+            "--unified=100000"
+        )
+
+        subprocess.run(["git", "add", "a.rb"], cwd=tmp_path, env=env, check=True)
+        assert ngh.normalized_gate_hash(tmp_path) is not None, (
+            "a heredoc-body reindent must never normalize to nothing, even when its "
+            "opener sits outside git's default hunk context"
+        )
+
+
 class TestNormalizationCollisions:
     """#1631 adversarial review. Each test pins one collision where two
     behaviorally DIFFERENT changesets normalized to the same digest, letting


### PR DESCRIPTION
## Summary

- The cosmetic-delta gate normalizer (`review_gate_normalized_hash.py`) read a reindented heredoc body as formatting when its opener/closer grammar had no quote character to signal real data (Ruby `<<~SQL`, PHP `<<<TXT`, Perl `<<EOF`).
- Adds per-language heredoc grammars (`_HEREDOC_GRAMMARS`) and a FIFO-tracked body-marking pass (`_heredoc_body_marks`) so heredoc body lines are always compared byte-exact, never collapsed as whitespace.
- Fixes two real defects found during review, both in the unsafe (gate-bypass) direction:
  - The initial draft tracked only one pending heredoc via `.search()`, so a line with two stacked openers (e.g. Perl `print <<A, <<B;`) lost the second heredoc's body to whitespace collapsing. Rewritten to a FIFO queue via `finditer()`.
  - The shared/PHP closer predicates used `.strip()`, which also strips trailing whitespace, letting a body line reading exactly the identifier plus trailing spaces falsely close the heredoc. Fixed to `.lstrip()` (leading only).
- Widens Perl's opener regex to catch its legal spaced-quoted (`print << "EOF";`) and backslash-quoted (`print <<\EOF;`) delimiter forms.
- Aliases Terraform/HCL (`.tf`/`.hcl`) to Ruby's grammar (shares the `<<EOT`/`<<-EOT` form).
- Widens `normalized_gate_hash`'s git-diff context to `--unified=100000` so a heredoc opener is never invisible to the hunk `_heredoc_body_marks` reasons over.

Closes #1638

## Test plan

- [x] 24 new/updated tests in `TestHeredocBodies` covering every language/grammar variant, the FIFO stacked-opener fix, the trailing-whitespace closer fix (Ruby + PHP), Perl's spaced/backslash opener forms, Terraform/HCL, PHP nowdoc, substring-identifier non-false-close, and a real end-to-end git test for the `--unified=100000` context gap.
- [x] Full local gate suite green (`scripts/ci-local.sh`: pytest, ruff, `check_md_references.py`, `build_knowledge_index.py`, Python 3.8 floor).
- [x] Manually reverted each fix and confirmed its regression test fails against the pre-fix code (FIFO bug, trailing-whitespace bug, vacuous e2e test guard).
- [x] Reviewed by a 16-agent `/code-review` panel plus three confirmation rounds addressing findings.