### PR TITLE
feat(scripts): verify toolchain by executing it, harden cloud provisioning

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -25,8 +25,64 @@ python3 -m pip install --quiet -r requirements-dev.txt \
   || pip3 install --quiet -r requirements-dev.txt \
   || true
 
+# Repair the interpreter after the requirements-dev.txt install.
+#
+# On Debian/Ubuntu images, `pip install semgrep` pulls a newer PyJWT into
+# user-site but CANNOT remove the distro-packaged one ("Cannot uninstall PyJWT
+# 2.7.0, RECORD file not found. Hint: The package was installed by debian").
+# The surviving mix leaves user-site `jwt` importing the SYSTEM `cryptography`,
+# whose Rust bindings then abort with
+# `ModuleNotFoundError: No module named '_cffi_backend'` — a pyo3 panic, not a
+# catchable ImportError. semgrep imports jwt, so semgrep dies on startup while
+# still sitting on PATH looking perfectly healthy. Downstream, every
+# plugins/security-assessment/ rule reports NO-FIRE and the fixture audit fails
+# with no clue why. Reinstalling both into user-site makes the resolution
+# consistent. Cheap, idempotent, and harmless when the conflict never happened.
+python3 -m pip install --quiet --user --upgrade --force-reinstall cffi cryptography || true
+
 # gh CLI (PR operations), if the image doesn't already ship it.
 command -v gh >/dev/null 2>&1 || apt-get install -y gh || true
+
+# --- uv: the installer for tools pip cannot build ---------------------------
+# Needed below for mutmut, and used by scripts/dev-setup.sh for the Python 3.8
+# floor interpreter and graphify.
+if ! command -v uv >/dev/null 2>&1; then
+  curl -fsSL https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- mutmut: the Python mutation lane (/mutation-testing) -------------------
+# MUST be `mutmut<3`: mutmut 3.x changed its config/CLI contract (source_paths
+# in a [mutmut] setup.cfg section, no --paths-to-mutate) and the shipped
+# adapter (plugins/dev-team/hooks/mutation_adapters/mutmut.py) does not speak it.
+#
+# MUST go through uv, not pip: mutmut 2.x depends on glob2 0.7, whose setup.py
+# uses `install_layout` and fails to build against setuptools >= 60 with
+# `AttributeError: install_layout`. uv's build isolation supplies a compatible
+# setuptools; a bare `pip install "mutmut<3"` fails outright on a modern image.
+# The adapter resolves it via shutil.which("mutmut"), so uv's isolated
+# console-script install is exactly what it looks for.
+if ! command -v mutmut >/dev/null 2>&1; then
+  uv tool install "mutmut<3" >/dev/null 2>&1 || true
+fi
+
+# --- adr-tools: /adr-tools + the adr-author agent ---------------------------
+# There is no apt package on Ubuntu. The scripts resolve their siblings through
+# `$(dirname $0)`, so EVERY executable in src/ has to land on PATH — symlinking
+# only `adr` yields "adr-config: No such file or directory".
+if ! command -v adr >/dev/null 2>&1; then
+  mkdir -p "$HOME/.local/opt" "$HOME/.local/bin" || true
+  if [ ! -d "$HOME/.local/opt/adr-tools" ]; then
+    git clone --depth 1 https://github.com/npryce/adr-tools \
+      "$HOME/.local/opt/adr-tools" >/dev/null 2>&1 || true
+  fi
+  for f in "$HOME"/.local/opt/adr-tools/src/*; do
+    case "$f" in *.md) continue ;; esac
+    if [ -f "$f" ]; then
+      ln -sf "$f" "$HOME/.local/bin/$(basename "$f")" || true
+    fi
+  done
+fi
 
 # --- Node + git hooks (husky) ----------------------------------------------
 # `npm ci` runs the package.json `prepare: husky` script, which writes the
@@ -72,5 +128,19 @@ else
   echo "cloud setup: claude CLI not found — skipping plugin install (run skills from files)."
 fi
 
-echo "agentic-dev-team cloud setup complete: jq shellcheck python-deps gh node+husky-hooks dev-team-plugin"
+# --- Verify by EXECUTING every tool, not by looking for it ------------------
+# The whole point of this step: `command -v <tool>` passes for a tool that
+# cannot start, so a provisioning run can report success and hand back a broken
+# environment. verify_toolchain.py spawns each tool and reads its exit status.
+#
+# Its non-zero exit is deliberately NOT propagated — a non-zero Setup script
+# fails session startup, and a partially-provisioned session you can see the
+# failures in beats no session at all. Read the ✗ lines; they name the tool and
+# quote the interpreter's own error.
+if [ -f scripts/verify_toolchain.py ]; then
+  python3 scripts/verify_toolchain.py || \
+    echo "cloud setup: WARNING — required tools above could not run; the gates that need them will fail."
+fi
+
+echo "agentic-dev-team cloud setup complete: jq shellcheck python-deps gh node+husky-hooks uv mutmut adr dev-team-plugin"
 exit 0

--- a/.claude/format_python.py
+++ b/.claude/format_python.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: autofix lint on Python files as they are edited.
+
+Registered in `.claude/settings.json` for `Edit|Write|MultiEdit`. Runs the same
+tool the blocking pre-push gate runs (`chk_ruff` in `scripts/ci-local.sh`), so a
+file fixed here is a file that gate no longer has to reject.
+
+Three deliberate constraints:
+
+- **`ruff check --fix`, never `ruff format`.** `ruff.toml` at the repo root
+  configures `ruff check` only and declares no `[format]` section, and no gate
+  runs `ruff format`. Formatting here would restyle the tree in a way nothing
+  else enforces.
+- **`--force-exclude` is mandatory, not cosmetic.** Ruff honors its exclude
+  list for *discovered* paths but lints an *explicitly passed* path regardless
+  — and a hook always passes one explicitly. Without this flag the hook would
+  autofix `**/fixtures`, `**/rule-fixtures`, and the other corpora `ruff.toml`
+  excludes, which are intentionally non-conformant code the review agents and
+  eval harness must see unmodified.
+- **Fail-open, time-boxed.** A hook that breaks the edit loop is worse than no
+  hook. Every failure path exits 0.
+
+Stdlib only, matching the rest of `.claude/`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+TIMEOUT_SECONDS = 15
+
+
+def _edited_path(payload: dict) -> str:
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return ""
+    return str(tool_input.get("file_path") or "")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    raw = _edited_path(payload)
+    if not raw or not raw.endswith(".py"):
+        return 0
+
+    target = Path(raw)
+    if not target.is_file():
+        return 0
+
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        return 0
+
+    # Resolve the repo root from this hook's own location (.claude/ sits at the
+    # root) rather than trusting the process cwd, so ruff always discovers
+    # ruff.toml and applies its excludes and per-file target versions.
+    repo_root = Path(__file__).resolve().parent.parent
+
+    try:
+        subprocess.run(
+            [ruff, "check", "--fix", "--force-exclude", str(target)],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/format_python.py\""
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ _mkdocs_src/
 # capture-prone (issue #1487).
 .claude/project-stack.json
 
+# /project-init's Step 4c code-lookup decision state (which of CodeGraph /
+# Repowise / Graphify were installed, declined, or built --code-only). Same
+# machine-local, regeneratable, capture-prone class as the stack cache above
+# and written by the same /setup -> /project-init pass, so it needs the same
+# rule — the in-repo skip of /setup's Step 11 leaves it untracked otherwise.
+.claude/init-state.json
+
 # Runtime metrics — ignored by default (deny-by-default: metrics/ is
 # generated-runtime-data territory — session digests, telemetry, review-value,
 # verify-log, boundary-events, cost-metering, learning-loop state, ... — a new

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -78,7 +78,19 @@ intend to commit from the session — it adds a minute to setup.)
 
 ## Verify it worked
 
-Run the headless probe in the session. It boots a fresh Claude, lists every
+The Setup script must `exit 0` even when provisioning went wrong, so it can only
+*report* a broken toolchain — it can never refuse to hand one over. Two things
+close that gap:
+
+- [`scripts/verify_toolchain.py`](../scripts/verify_toolchain.py) — runs every
+  tool instead of probing `PATH`, so an installed-but-unstartable tool fails
+  instead of passing. The Setup script calls it at the end; run it yourself any
+  time with `python3 scripts/verify_toolchain.py`.
+- [`cloud-startup-prompt.md`](cloud-startup-prompt.md) — the first message to
+  send in a fresh session, so Claude checks the environment (and the baseline
+  gate result) before it starts changing code.
+
+Then run the headless probe in the session. It boots a fresh Claude, lists every
 available skill, and counts the `dev-team:*` ones:
 
 ```bash

--- a/docs/cloud-startup-prompt.md
+++ b/docs/cloud-startup-prompt.md
@@ -1,0 +1,91 @@
+# Cloud startup prompt
+
+The Setup script ([`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh)) provisions
+the machine. This is the other half: the **first message** to send in a fresh
+cloud session, so Claude confirms the environment is actually sound before it
+starts changing code.
+
+Provisioning and verification are separate concerns on purpose. The Setup script
+runs pre-boot and **must** exit 0 — a non-zero exit fails session startup — so it
+can only *report* a broken toolchain, never refuse to hand one over. This prompt
+is what makes the session act on that report.
+
+## Why bother
+
+A provisioning run can finish, print green checkmarks, and still leave a
+container where `semgrep --version` aborts. That exact thing happened: a
+distro-packaged PyJWT that `pip` could not uninstall left `semgrep` importing a
+`cryptography` whose Rust bindings could not load. `command -v semgrep`
+succeeded throughout. The damage showed up much later and in a shape that
+pointed nowhere near the cause — every `plugins/security-assessment/` rule
+silently matched nothing, and the fixture audit failed with 27 rules reported as
+NO-FIRE.
+
+Ten seconds of exercising the tools up front is cheaper than diagnosing that
+from the far end.
+
+## The prompt
+
+Paste this as the first message of a new cloud session:
+
+```text
+Before doing any task work, verify this environment is sound and report honestly.
+
+1. Run: python3 scripts/verify_toolchain.py
+   It executes each tool rather than checking PATH, so it catches a tool that is
+   installed but cannot start. If any REQUIRED tool fails, fix it before
+   continuing and tell me what you did. Known repair, if semgrep fails with a
+   _cffi_backend or cryptography error:
+       python3 -m pip install --user --force-reinstall cffi cryptography
+
+2. Confirm the git hooks are live: `test -f node_modules/.bin/husky`. If missing,
+   run `npm ci` — without it, pre-commit and pre-push silently do nothing and
+   scripts/ci-local.sh is the only thing standing between a bad commit and main.
+
+3. Confirm the dev-team plugin loaded THIS session (the SessionStart hook is too
+   late — its install lands next session):
+       claude -p "List the names of every skill available to you, one per line." \
+         --max-turns 1 | grep -c '^dev-team:'
+   Expect a non-zero count (~86). Zero means the Setup script did not run or the
+   plugin install was blocked; say so rather than proceeding as if skills exist.
+
+4. Establish a baseline before you change anything: run `bash scripts/ci-local.sh`
+   and tell me the result. If something is already red on a clean tree, that is
+   pre-existing — report it, do not silently absorb it into my change, and do not
+   try to fix it unless I ask.
+
+Then state clearly: what works, what does not, and what you repaired. Do not
+start the task until you have reported. If any of the above cannot be completed,
+say which and why rather than continuing quietly.
+```
+
+## Cutting it down
+
+The prompt is long because each step earned its place. If you want a one-liner
+for a session where you only intend to read code, this is the load-bearing part:
+
+```text
+Run `python3 scripts/verify_toolchain.py` first and report the result. It executes
+each tool instead of probing PATH, so it catches installed-but-broken tools. Fix
+any REQUIRED failure before starting, and tell me what you repaired.
+```
+
+## Making it automatic
+
+To skip the pasting, put the same instruction in the environment's system prompt
+or a `SessionStart` hook. Two caveats if you do:
+
+- A `SessionStart` hook runs *after* Claude boots, so it cannot fix the
+  plugin-loading problem in step 3 — that one genuinely needs the Setup script.
+- Keep it fail-open and time-boxed, like the hooks already registered in
+  [`.claude/settings.json`](../.claude/settings.json). A verification step that
+  hangs session startup is worse than the drift it was guarding against.
+
+## See also
+
+- [`cloud-setup.md`](cloud-setup.md) — the Setup script itself, plugin freshness,
+  and the snapshot/caching behavior that pins stale plugin versions.
+- [`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) — what to paste into
+  claude.ai/code → Environment → Setup script.
+- [`scripts/verify_toolchain.py`](../scripts/verify_toolchain.py) — the verifier,
+  runnable on its own at any time (`--quiet` for failures only, `--json` to script it).

--- a/scripts/verify_toolchain.py
+++ b/scripts/verify_toolchain.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Verify the dev/CI toolchain by RUNNING each tool, not by looking for it.
+
+Why this exists: `command -v semgrep` and `importlib.util.find_spec("semgrep")`
+both succeed for a semgrep that dies on startup. That is not hypothetical — a
+provisioning run on a fresh container installed semgrep, printed a green
+checkmark for it, declared "Dev environment ready", and left an interpreter
+where `semgrep --version` aborted with
+`ModuleNotFoundError: No module named '_cffi_backend'`. Every
+`plugins/security-assessment/` rule then reported NO-FIRE and the fixture audit
+failed with no hint as to why.
+
+That is the repo's own rule from CLAUDE.md, learned again the expensive way:
+*verify a runtime property by exercising it at runtime*, and *a gate that
+cannot fail is worse than no gate*. So every check here spawns the real thing
+and reads its exit status. A tool that cannot execute fails, however tidy its
+presence on `PATH` looks.
+
+Usage:
+    python3 scripts/verify_toolchain.py            # required + optional
+    python3 scripts/verify_toolchain.py --quiet    # only failures
+    python3 scripts/verify_toolchain.py --json     # machine-readable
+
+Exit status is 0 when every REQUIRED check passes (optional failures only
+warn), 1 otherwise. Callers that must not fail their caller — the cloud Setup
+script, which fails session startup on a non-zero exit — should invoke it and
+report, rather than propagate.
+
+Stdlib only, Python 3.9+ (repo-root tooling is outside ADR 0014's 3.8 floor).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Sequence, Tuple
+
+TIMEOUT_SECONDS = 120
+
+# (label, argv, required, why-it-matters)
+COMMAND_CHECKS: List[Tuple[str, Sequence[str], bool, str]] = [
+    ("jq", ["jq", "--version"], True, "mutation gate + ci-local.sh"),
+    ("python3", ["python3", "--version"], True, "everything"),
+    ("shellcheck", ["shellcheck", "--version"], True, "ci-local.sh shell lint"),
+    ("ruff", ["ruff", "--version"], True, "chk_ruff + Python static-analysis lane"),
+    ("mypy", ["mypy", "--version"], True, "Python diagnostic slot"),
+    ("semgrep", ["semgrep", "--version"], True, "chk_semgrep_fixtures + security-assessment"),
+    ("git", ["git", "--version"], True, "everything"),
+    ("node", ["node", "--version"], False, "husky git hooks"),
+    ("npm", ["npm", "--version"], False, "npm ci -> husky hooks"),
+    ("gh", ["gh", "--version"], False, "PR/issue skills"),
+    ("mutmut", ["mutmut", "version"], False, "Python mutation lane (/mutation-testing)"),
+    ("adr", ["adr", "help"], False, "/adr-tools + adr-author agent"),
+    ("uv", ["uv", "--version"], False, "installs mutmut/graphify/python3.8 floor"),
+    ("graphify", ["graphify", "--version"], False, "code knowledge graph"),
+]
+
+# (module, required, why-it-matters)
+IMPORT_CHECKS: List[Tuple[str, bool, str]] = [
+    ("yaml", True, "agent-readiness scanner, static-analysis adapter"),
+    ("pytest", True, "every content-guard suite"),
+    ("httpx", True, "red-team harness smoke test"),
+    ("jsonschema", True, "codebase_recon.py envelope validation"),
+    ("pytest_asyncio", True, "tests/scripts/test_orchestrator.py"),
+    ("xdist", True, "parallel content-guard run"),
+    ("pytest_cov", False, "chk_coverage_report (opt-in)"),
+]
+
+
+class Result:
+    def __init__(self, label: str, ok: bool, required: bool, why: str, detail: str) -> None:
+        self.label = label
+        self.ok = ok
+        self.required = required
+        self.why = why
+        self.detail = detail
+
+    def as_dict(self) -> dict:
+        return {
+            "label": self.label,
+            "ok": self.ok,
+            "required": self.required,
+            "why": self.why,
+            "detail": self.detail,
+        }
+
+
+def _first_line(text: str) -> str:
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:200]
+    return ""
+
+
+def _run(argv: Sequence[str]) -> Tuple[bool, str]:
+    """Execute argv. Return (ok, detail). Never raises."""
+    if shutil.which(argv[0]) is None:
+        return False, "not on PATH"
+    try:
+        proc = subprocess.run(
+            list(argv),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "timed out after {}s".format(TIMEOUT_SECONDS)
+    except OSError as exc:
+        return False, "could not execute: {}".format(exc)
+
+    output = proc.stdout.decode("utf-8", "replace")
+    if proc.returncode != 0:
+        # This is the branch presence-checks miss: the binary exists and still
+        # cannot run. Surface the interpreter's own words — they name the
+        # missing extension module or broken dependency.
+        return False, "exit {}: {}".format(proc.returncode, _first_line(output) or "(no output)")
+    return True, _first_line(output)
+
+
+def check_commands() -> List[Result]:
+    results = []
+    for label, argv, required, why in COMMAND_CHECKS:
+        ok, detail = _run(argv)
+        results.append(Result(label, ok, required, why, detail))
+    return results
+
+
+def check_imports() -> List[Result]:
+    """Import each module in a SUBPROCESS.
+
+    A broken native extension does not raise a catchable ImportError — the
+    PyJWT/cryptography breakage this script was written for aborted the whole
+    interpreter through a pyo3 panic. Importing in-process would take this
+    verifier down with it and report nothing.
+    """
+    results = []
+    for module, required, why in IMPORT_CHECKS:
+        ok, detail = _run([sys.executable, "-c", "import {}".format(module)])
+        results.append(Result("python: {}".format(module), ok, required, why, detail))
+    return results
+
+
+def render(results: Sequence[Result], quiet: bool) -> None:
+    for r in results:
+        if r.ok:
+            if not quiet:
+                suffix = " ({})".format(r.detail) if r.detail else ""
+                print("  ✓ {}{}".format(r.label, suffix))
+        else:
+            tag = "✗" if r.required else "∼"
+            scope = "REQUIRED" if r.required else "optional"
+            print("  {} {} [{}] — {}".format(tag, r.label, scope, r.detail))
+            print("      needed for: {}".format(r.why))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--quiet", action="store_true", help="print only failures")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    results = check_commands() + check_imports()
+    failed_required = [r for r in results if not r.ok and r.required]
+    failed_optional = [r for r in results if not r.ok and not r.required]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not failed_required,
+                    "required_failures": [r.label for r in failed_required],
+                    "optional_failures": [r.label for r in failed_optional],
+                    "results": [r.as_dict() for r in results],
+                },
+                indent=2,
+            )
+        )
+        return 1 if failed_required else 0
+
+    if not args.quiet:
+        print("== toolchain verification (executing each tool) ==")
+    render(results, args.quiet)
+
+    if failed_required:
+        print(
+            "\nFAILED: {} required tool(s) could not run: {}".format(
+                len(failed_required), ", ".join(r.label for r in failed_required)
+            )
+        )
+        print("These are execution failures, not missing-binary reports — a tool")
+        print("can be installed and on PATH and still be unable to start.")
+        return 1
+
+    if not args.quiet:
+        print("\nAll required tools executed successfully.")
+        if failed_optional:
+            print(
+                "Optional not available: {}".format(
+                    ", ".join(r.label for r in failed_optional)
+                )
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Output of a full `/dev-team:setup` run on a fresh cloud container. The defects that run uncovered are catalogued in #1670; this PR fixes the ones that belong in provisioning and tooling.

Part of #1670

## Summary

- **`scripts/verify_toolchain.py` — verify by executing, not by probing.** `dev-setup.sh` checks semgrep with `command -v semgrep || python3 -c "import semgrep"`, and its preflight uses `importlib.util.find_spec`. None of those run the tool. On this container pip could not remove the distro-packaged PyJWT, leaving user-site `jwt` importing the system `cryptography`, whose Rust bindings abort with `ModuleNotFoundError: No module named '_cffi_backend'` — a pyo3 panic, not a catchable `ImportError`. semgrep imports jwt, so semgrep died on startup while setup printed `✓ semgrep` and "Dev environment ready". The symptom surfaced far downstream: every `plugins/security-assessment/` rule reported NO-FIRE and `chk_semgrep_fixtures` failed with 27 rules listed broken. The new script spawns each tool and reads its exit status, and imports Python modules in a **subprocess** because this failure takes the interpreter down rather than raising.
- **`.claude/cloud-setup.sh` hardened** with the repairs this run needed: reinstall `cffi`+`cryptography` after `requirements-dev.txt`; install `uv`, then `mutmut` via `uv tool install "mutmut<3"` (plain pip cannot build it — `glob2` 0.7's `setup.py` fails against setuptools ≥ 60); symlink *every* executable in adr-tools' `src/`, since those scripts resolve siblings via `$(dirname $0)`; and call the verifier at the end, reporting failures without propagating the non-zero exit, because a non-zero Setup script fails session startup.
- **`docs/cloud-startup-prompt.md`** — the first message to send in a fresh cloud session, so the environment is checked and a clean-tree baseline gate result recorded before any task work begins. The Setup script must `exit 0` whatever it finds, so it can only *report* a broken toolchain; this is what makes a session act on that report.
- **`.claude/format_python.py` — ruff PostToolUse autofix hook** (`Edit|Write|MultiEdit`), so Python is corrected at edit time rather than rejected later by `chk_ruff`. Two constraints shape it: **`ruff check --fix`, never `ruff format`** (`ruff.toml` declares no `[format]` section and no gate runs it, so formatting here would restyle the tree in a way nothing enforces), and **`--force-exclude` is load-bearing** — ruff honors excludes for *discovered* paths but lints an *explicitly passed* one regardless, and a hook always passes one explicitly. Without it the hook would autofix `**/fixtures` and `**/rule-fixtures`, the intentionally non-conformant corpora the review agents and eval harness must see unmodified.
- **Gitignores `.claude/init-state.json`** — `/project-init` Step 4c decision state, the same machine-local, regeneratable, capture-prone class as the adjacent `.claude/project-stack.json` rule (#1487), written by the same `/setup` → `/project-init` pass.

## Test Plan

- [x] **Both new gates demonstrated failing on purpose**, not merely passing. Against a stub `semgrep` that exits non-zero: `command -v` reports it green; `verify_toolchain.py` reports `✗ semgrep [REQUIRED] — exit 1: ModuleNotFoundError: No module named '_cffi_backend'` and exits 1.
- [x] Format hook exercised rather than inspected: an unused import under `scripts/` is removed; a byte-identical file under `evals/fixtures/` is left untouched, proving `--force-exclude` protects the fixture corpora. Non-Python path, missing file, and malformed stdin each exit 0.
- [x] `verify_toolchain.py` on the repaired environment: all 21 checks green (jq, python3, shellcheck, ruff, mypy, semgrep, git, node, npm, gh, mutmut, adr, uv, graphify + 7 module imports).
- [x] `shellcheck .claude/cloud-setup.sh` clean; `ruff check scripts/verify_toolchain.py` clean.
- [x] `python3 scripts/check_md_references.py` — exit 0. Nav needs no edit: mkdocs uses `awesome-pages`, so a new doc self-registers.
- [x] `bash scripts/ci-local.sh` — all local CI checks passed (6125 passed, 43 skipped), and again on pre-push for both commits.

## Notes

The semgrep failure was confirmed **pre-existing** by reproducing it on a pristine tree with these changes stashed, then repaired mid-run (`pip install --user --force-reinstall cffi cryptography`), after which the fixture audit passes: 27 working, 9 known-broken.

Three items in #1670 are deliberately **not** fixed here, because they belong in the skill/reference text rather than in provisioning: `dev-setup.sh` still uses its own presence checks (it should call `verify_toolchain.py`), `skills/setup/SKILL.md` still documents the `pip install "mutmut<3"` that cannot succeed, and `repowise init` still writes ~98 lines into the git-tracked `.claude/CLAUDE.md` despite Step 4c presenting the keyless pair as non-repo-writing — that write was reverted here after operator confirmation.