### PR TITLE
fix(cloud-setup): resolve the repo root instead of trusting the caller's cwd

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -16,6 +16,54 @@
 # optional step is guarded with `|| true` and the script always ends with exit 0.
 set -uo pipefail
 
+# --- Anchor to the repo root ------------------------------------------------
+# Every path below is relative — requirements-dev.txt, .nvmrc, package.json (for
+# `npm ci`), scripts/verify_toolchain.py, plugins/dev-team/... — and every step
+# is guarded with `|| true` so it cannot fail session startup. Those two facts
+# combine badly: invoked from the wrong working directory, this script skips its
+# entire job in silence and still prints "cloud setup complete". That is exactly
+# the false-green class scripts/verify_toolchain.py exists to catch, so don't
+# reproduce it here.
+#
+# A caller that resolves the root and then does not `cd` to it is the common
+# shape of this bug — the value gets used to locate this file and is then
+# dropped. So resolve the root here rather than trusting the caller's cwd, and
+# VALIDATE each candidate against a marker instead of assuming the first one is
+# right. Markers are the same pair /setup Step 2 uses for its in-repo check.
+_is_repo_root() {
+  [ -n "${1:-}" ] &&
+    [ -f "$1/requirements-dev.txt" ] &&
+    [ -f "$1/plugins/dev-team/.claude-plugin/plugin.json" ]
+}
+
+# This file lives at <root>/.claude/cloud-setup.sh, so its own directory's
+# parent is the root — correct whenever it is invoked as the repo file. When the
+# BODY of this script was pasted into the cloud UI instead, BASH_SOURCE points
+# at a temp file whose parent fails the marker check, and the loop falls through
+# to the next candidate. No special-casing needed either way.
+_self_parent=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || _self_dir=""
+[ -n "$_self_dir" ] && _self_parent="$(dirname "$_self_dir")"
+
+ROOT=""
+for _cand in "$_self_parent" "${CLAUDE_PROJECT_DIR:-}" \
+             "$(git rev-parse --show-toplevel 2>/dev/null)" "$PWD"; do
+  if _is_repo_root "$_cand"; then
+    ROOT="$_cand"
+    break
+  fi
+done
+
+if [ -n "$ROOT" ]; then
+  cd "$ROOT" || { echo "cloud setup: cannot cd to $ROOT — aborting."; exit 0; }
+  echo "cloud setup: repo root = $ROOT"
+else
+  # Say so loudly rather than proceeding to no-op behind a wall of `|| true`.
+  echo "cloud setup: WARNING — could not locate the repo root (no candidate had"
+  echo "cloud setup: requirements-dev.txt + plugins/dev-team/.claude-plugin/plugin.json)."
+  echo "cloud setup: continuing from $PWD; relative steps will likely be skipped."
+fi
+
 # --- Toolchain the repo's tests/gates need ---------------------------------
 apt-get update -y || true
 apt-get install -y jq shellcheck || true

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -29,52 +29,52 @@ below run fine from the Setup script.
 
 ## The snippet to paste into the Setup script field
 
-claude.ai/code → Environment → **Setup script**. The script below always exits
-without error (a non-zero exit **fails** session startup). It uses a
-repo-committed bootstrap when one exists, and otherwise installs the plugin
-directly. It **refreshes** the plugin (re-pulls the catalog and `plugin update`)
-rather than only installing — because `plugin install` is a no-op once a version
-is cached, and the reused environment snapshot would otherwise pin the first
-version forever (see [Keeping the plugin version current](#keeping-the-plugin-version-current)):
+claude.ai/code → Environment → **Setup script**. Paste this **delegating**
+trampoline — it keeps the UI field stable and lets the real logic live in the
+repo, so improvements ship by merging a PR rather than by editing environment
+config and forcing a snapshot rebuild:
 
 ```bash
 #!/bin/bash
 set -uo pipefail
-MARKETPLACE_REPO="bdfinst/agentic-dev-team"
-PLUGIN="dev-team@bfinster"
-MARKET="bfinster"
+
 ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-BOOTSTRAP="$ROOT/.claude/scripts/dev-team-bootstrap.sh"
-if [ -f "$BOOTSTRAP" ]; then
-  bash "$BOOTSTRAP" || echo "[setup] bootstrap reported issues — continuing."
-  exit 0
-fi
-echo "[setup] no $BOOTSTRAP — installing/refreshing dev-team inline for this session."
-if command -v claude >/dev/null 2>&1; then
-  claude plugin marketplace add    "$MARKETPLACE_REPO"    >/dev/null 2>&1 || true
-  claude plugin marketplace update "$MARKET"              >/dev/null 2>&1 || true
-  claude plugin install              "$PLUGIN"            >/dev/null 2>&1 || true
-  claude plugin update  --scope user "$PLUGIN"            >/dev/null 2>&1 || true
-  # Enable auto-update so later releases refresh at launch without a snapshot rebuild.
-  AU="$ROOT/plugins/dev-team/skills/upgrade/scripts/enable_autoupdate.py"
-  [ -f "$AU" ] && python3 "$AU" --enable >/dev/null 2>&1 || true
+cd "$ROOT" || { echo "[env-setup] cannot cd to $ROOT — skipping setup."; exit 0; }
+
+SETUP="$ROOT/.claude/cloud-setup.sh"
+if [ -f "$SETUP" ]; then
+  # Always exits 0 by design — a non-zero Setup script FAILS session startup.
+  # Read its ✗ lines (from scripts/verify_toolchain.py) for real failures.
+  bash "$SETUP"
+else
+  echo "[env-setup] MISSING: $SETUP — repo hasn't adopted the dev-team cloud setup."
+  npm ci || true   # fallback so the husky git hooks still land
 fi
 exit 0
 ```
 
-> This snippet now enables marketplace auto-update itself (via the plugin's
-> `skills/upgrade/scripts/enable_autoupdate.py`). Pasting the body of
-> [`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) instead additionally
-> installs this repo's test/gate toolchain and reports version drift — see below.
+[`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) is the actual work:
+this repo's test/gate toolchain (`jq`, `shellcheck`, the Python dev deps, `gh`,
+`uv`, `mutmut`, `adr`), Node 24+ plus `npm ci` for the git hooks
+(`pre-commit`, `pre-push`, `commit-msg`), the plugin install/refresh, and a
+closing [`scripts/verify_toolchain.py`](../scripts/verify_toolchain.py) pass.
+It **refreshes** the plugin (re-pulls the catalog and `plugin update`) rather
+than only installing — `plugin install` is a no-op once a version is cached, and
+the reused snapshot would otherwise pin the first version forever (see
+[Keeping the plugin version current](#keeping-the-plugin-version-current)).
 
-If you also want this repo's test/gate toolchain (`jq`, `shellcheck`,
-the Python dev deps, `gh`) in the same step, paste the body of
-[`.claude/cloud-setup.sh`](../.claude/cloud-setup.sh) instead — it installs the
-toolchain *and* the plugin, and follows the same exit-0 discipline. It also
-installs Node 24+ and runs `npm ci`, which sets up the git hooks
-(`pre-commit`, `pre-push`, `commit-msg`) so commits and pushes in the cloud
-session run the same checks you'd run locally. (Skip this only if you don't
-intend to commit from the session — it adds a minute to setup.)
+Two details worth knowing:
+
+- **`cd "$ROOT"` in the trampoline is not decoration.** Resolving `$ROOT`, using
+  it only to locate the script, and then not `cd`-ing there is an easy mistake —
+  and a quiet one. `cloud-setup.sh`'s paths are relative and its steps are all
+  guarded with `|| true`, so from the wrong directory it skips everything and
+  still prints `cloud setup complete`. The script now resolves and validates its
+  own root as a backstop, but the `cd` keeps the two independent.
+- **Pasting the body of `cloud-setup.sh` directly still works** if you'd rather
+  not delegate. Its root resolution validates each candidate against a marker
+  file, so it detects that it is running from a pasted temp file and falls back
+  to the working directory. You then give up the ship-by-merge property above.
 
 ## Verify it worked
 


### PR DESCRIPTION
Follow-up to #1669, from reviewing the Setup script actually configured in claude.ai/code → Environment.

Part of #1670

## Summary

- **`cloud-setup.sh` now resolves its own repo root.** Its paths are all relative — `requirements-dev.txt`, `.nvmrc`, `package.json` (for `npm ci`), `scripts/verify_toolchain.py`, `plugins/dev-team/skills/upgrade/...` — and every step is guarded with `|| true` so it cannot fail session startup. Those two properties combine badly: run from the wrong working directory it skips its entire job in silence and still prints `cloud setup complete`. That is the same false-green class `verify_toolchain.py` was added in #1669 to catch, reproduced in the script that calls it. Reachable today: the documented trampoline resolves the root, uses it to locate the script, then invokes it **without `cd`-ing there**, so the resolved value is dropped and cwd is whatever the harness supplied. It works only because that currently happens to be the root.
- Candidates are **validated against a marker pair** (`requirements-dev.txt` + `plugins/dev-team/.claude-plugin/plugin.json` — the same pair `/setup` Step 2 uses for its in-repo check), not assumed. Order: this file's own parent directory, `CLAUDE_PROJECT_DIR`, `git rev-parse --show-toplevel`, `$PWD`. When none validates it says so loudly rather than no-opping behind the wall of `|| true`. The `BASH_SOURCE` candidate is what makes pasted-body mode work with no special case — pasted into the cloud UI, `BASH_SOURCE` points at a temp file whose parent fails the marker check and the loop falls through.
- **`docs/cloud-setup.md`: removed a dead code path.** Its pasteable snippet branched on `$ROOT/.claude/scripts/dev-team-bootstrap.sh`, which does not exist anywhere in the repo — so that branch never ran and the snippet always fell through to its inline fallback. Replaced with the delegating trampoline that actually works, which also keeps the UI field stable so future changes ship by merging a PR rather than by editing environment config.

## Test Plan

- [x] All four resolution paths exercised, not just the happy one:
  - invoked from `/` as the repo file → resolves via `BASH_SOURCE` parent
  - invoked from the repo root → resolves
  - copied outside the repo and run from the root (pasted-body mode) → marker check rejects the temp parent, falls through, resolves
  - run from `/tmp` with no repo in reach → warns explicitly instead of continuing silently
- [x] `shellcheck .claude/cloud-setup.sh` clean; `bash -n` clean.
- [x] `python3 scripts/check_md_references.py` — exit 0. No `dev-team-bootstrap` references remain in tracked files (the one remaining hit is in gitignored `_mkdocs_src/`, a stale docs-assemble artifact).
- [x] `bash scripts/ci-local.sh` — all local CI checks passed (6125 passed, 43 skipped), and again on pre-push.

## Notes

The `cd "$ROOT"` in the documented trampoline is now redundant with the script's own resolution. Both are kept deliberately: the trampoline lives in environment config that this repo cannot test or update, so the script should not depend on it being correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPX5S5YPQr6FS91pdxUGB4)_