### PR TITLE
fix(skills): /setup's mutmut install and version probes cannot succeed

### DIFF
--- a/plugins/dev-team/skills/setup/SKILL.md
+++ b/plugins/dev-team/skills/setup/SKILL.md
@@ -679,19 +679,42 @@ If `python3` or `pip` is not found, tell the user: "Python 3 with pip is
 required for mutmut. Install it from <https://www.python.org> and re-run
 `/setup`."
 
-**Check if mutmut is already installed in the active environment:**
+**Check if mutmut is already installed:**
 
 ```bash
-python3 -m mutmut --version 2>/dev/null || mutmut --version 2>/dev/null
+mutmut version 2>/dev/null || python3 -m mutmut version 2>/dev/null
 ```
 
-**If not installed, install it locally — scoped to the active virtual
-environment, never `--user` or system-wide** (that puts mutmut in a location
-whose `PATH` presence depends on shell config, the silent-failure trap this
-step exists to avoid). **Pin `mutmut<3`** — mutmut 3.x ships an incompatible
-config/CLI contract (`source_paths` in a `[mutmut]` setup.cfg section, no
-`--paths-to-mutate` flag) that the shipped adapter
-(`hooks/mutation_adapters/mutmut.py`) does not speak:
+Use the `version` **subcommand**, not `--version`. mutmut 2.x — the range this
+step pins — has no `--version` flag and exits 2 on it, so a `--version` probe
+reports "not installed" for a perfectly good install and this step reinstalls
+on every run.
+
+**If not installed, install it — isolated, never `--user` or system-wide** (that
+puts mutmut in a location whose `PATH` presence depends on shell config, the
+silent-failure trap this step exists to avoid). **Pin `mutmut<3`** — mutmut 3.x
+ships an incompatible config/CLI contract (`source_paths` in a `[mutmut]`
+setup.cfg section, no `--paths-to-mutate` flag) that the shipped adapter
+(`hooks/mutation_adapters/mutmut.py`) does not speak.
+
+**Prefer `uv`, because `pip` cannot build this pin on a current toolchain.**
+mutmut 2.x depends on `glob2` 0.7, whose `setup.py` uses `install_layout` and
+fails against setuptools >= 60 with `AttributeError: install_layout`, ending in
+`Could not build wheels for mutmut, glob2`. That is not an edge case — it is
+every machine with a modern setuptools. uv supplies a compatible setuptools
+inside its own build isolation and succeeds where pip cannot:
+
+```bash
+uv tool install "mutmut<3"
+```
+
+uv installs the console script into an isolated environment and puts `mutmut`
+on `PATH`, which is exactly what the adapter looks for: `_mutmut_argv()` in
+`hooks/mutation_adapters/mutmut.py` resolves `shutil.which("mutmut")` first and
+only falls back to `python3 -m mutmut`.
+
+If `uv` is unavailable, fall back to pip **inside an activated virtualenv**
+(never `--user`), accepting that it only succeeds on setuptools < 60:
 
 ```bash
 python3 -m pip install "mutmut<3"
@@ -705,7 +728,7 @@ dev-dependency flow instead of a bare `pip install`.
 **Verify:**
 
 ```bash
-python3 -m mutmut --version 2>/dev/null || mutmut --version
+mutmut version 2>/dev/null || python3 -m mutmut version
 ```
 
 ---


### PR DESCRIPTION
Closes the mutmut item in #1670, and carries a `Release-As: 11.3.1` footer to correct the pending release version — see **Release correction** below.

Part of #1670

## Summary

Three defects in `/setup`'s Python mutation section, all found by running it rather than reading it.

- **The documented install cannot succeed on a current toolchain.** mutmut 2.x — the range this step deliberately pins, because 3.x changed the config/CLI contract `hooks/mutation_adapters/mutmut.py` speaks — depends on `glob2` 0.7, whose `setup.py` uses `install_layout` and fails against setuptools >= 60 with `AttributeError: install_layout` → `Could not build wheels for mutmut, glob2`. That is every machine with a modern setuptools, not an edge case. Now prefers `uv tool install "mutmut<3"` (uv supplies a compatible setuptools in its own build isolation), keeping pip-in-a-virtualenv as the documented fallback. uv puts the console script on `PATH`, which is what the adapter resolves first — `_mutmut_argv()` checks `shutil.which("mutmut")` before falling back to `python3 -m mutmut`.
- **Both probes tested a flag that does not exist.** The "already installed" check and the "verify" step used `mutmut --version`. mutmut 2.x has no such flag and **exits 2** on it, so the check reported "not installed" for a perfectly good install — reinstalling on every run — and the verify step could never confirm success. Both now use the `version` subcommand that 2.x actually provides.
- **The guidance contradicted its own command.** It said "scoped to the active virtual environment, never `--user` or system-wide" while showing a bare `pip install` that hits whatever interpreter happens to be active. The isolation intent is now stated with a command that delivers it.

## Test Plan

- [x] Probe behavior established by execution, against the pinned version (mutmut 2.5.1): `mutmut --version` → **exit 2**; `mutmut version` → **exit 0** (`mutmut version 2.5.1`); `python3 -m mutmut version` → exit 1 under a uv install.
- [x] `uv tool install "mutmut<3"` verified to succeed on this container (setuptools 68.1.2) where `python3 -m pip install "mutmut<3"` fails at the `glob2` wheel build.
- [x] Adapter compatibility confirmed at the source: `shutil.which("mutmut")` resolves the uv-installed script, so `_mutmut_argv()` takes its primary branch.
- [x] `bash scripts/ci-local.sh` — all local CI checks passed (6125 passed, 43 skipped), and again on pre-push.

## Release correction

The pending release PR #1642 currently targets **11.4.0**. That minor bump is driven entirely by two commits typed `feat` that are both corrective work:

- `03742a20` — `feat(evals): fix 8 more evals/expected/*.json fixture pointers...` (its own subject begins with "fix"); it touches 4 files under `plugins/dev-team/`, which is why release-please attributes it to this package and why it drives the version
- `e5a3432` — `feat(scripts): verify toolchain by executing it...` (#1669)

With both treated as fixes, all 8 unreleased commits are fixes, so the correct bump is a patch. Neither message can be rewritten — both are squash-merged onto protected `main` — so this uses the `Release-As:` footer that CLAUDE.md documents for exactly this recovery. The footer applies to the package whose files the commit touches, which is why it rides on this `plugins/dev-team/` fix rather than an empty marker commit.

**Do not edit this PR's title or strip the trailing footer line before merging.** This PR squash-merges, so whether the footer reaches `main` depends on how the squash commit is composed. It is present both in the branch commit message and as the bare final line of this description, so it survives either the "PR title and description" or the "PR title and commit details" setting. Removing it from both silently reverts the release to 11.4.0 with no other signal.

**Still needs a human step at merge time.** `Release-As:` overrides the version only — it does not move changelog entries. Those two commits will still be listed under **Features** in #1642. Correcting that means hand-editing #1642's `CHANGELOG.md` **immediately before merging it**, because release-please regenerates the file on every new commit to `main` and will clobber an earlier edit.

Release-As: 11.3.1