### PR TITLE
chore(ci): require the four PR checks that only reported

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,12 +12,14 @@ name: Docs checks
 # `chk_nav_integrity` is the fast subset every developer can run before pushing.
 
 on:
-  # No 'paths' filter, on purpose. nav-integrity and body-links are REQUIRED
-  # status checks, and a path-filtered workflow reports NO status on PRs that
-  # don't match the filter — deadlocking every unrelated PR at "Waiting for
-  # status to be reported" (it can never go green). Both jobs are cheap and
-  # hermetic (assemble + mkdocs build + offline lychee), so they run on every
-  # PR and always report. (Same rationale as agent-eval.yml's free gates.)
+  # No 'paths' filter, on purpose. Both jobs' `name:`s are REQUIRED status-check
+  # contexts in the `main` ruleset ("Docs nav integrity", "Docs link check"), and
+  # a path-filtered workflow reports NO status on PRs that don't match the filter
+  # — deadlocking every unrelated PR at "Waiting for status to be reported" (it
+  # can never go green). Both jobs are cheap and hermetic (assemble + mkdocs
+  # build + offline lychee), so they run on every PR and always report. (Same
+  # rationale as agent-eval.yml's free gates.) Renaming either job needs a
+  # matching ruleset update, or the check still reports but stops blocking.
   pull_request:
   push:
     branches: [main]

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -138,14 +138,12 @@ jobs:
   # existing `uv python find 3.10` branch in ci-local.sh) and never touches
   # PATH's `python3`.
   #
-  # This job's `name:` is the status-check context branch protection would
-  # match on (see agent-eval.yml and pr-title-lint.yml for the same
-  # convention, where the ruleset entry already exists). It is NOT yet
-  # listed as a required check in the `main` ruleset — until it is, a red
-  # run here reports in the PR checks list but does not block merge, so a
-  # push that bypasses local hooks isn't fully caught yet. Once added, a
-  # rename here needs a matching ruleset update, or the check silently stops
-  # blocking while still reporting green.
+  # This job's `name:` IS the status-check context branch protection matches
+  # on, and it is listed as a required check in the `main` ruleset (same
+  # convention as agent-eval.yml and pr-title-lint.yml), so a red run here
+  # blocks merge — which is what catches a push that bypassed local hooks.
+  # A rename here needs a matching ruleset update, or the check silently
+  # stops blocking while still reporting green.
   python-floor:
     name: Python 3.10 floor
     runs-on: ubuntu-latest
@@ -278,6 +276,10 @@ jobs:
   # ruff is installed from requirements-dev.txt, which pins it exactly, and
   # chk_ruff invokes `python3 -m ruff` rather than a PATH binary, so this job
   # and a contributor's machine cannot disagree about what "clean" means.
+  #
+  # This job's `name:` is a required status-check context in the `main`
+  # ruleset — renaming it here without updating the ruleset leaves a check
+  # that still reports but no longer blocks.
   lint:
     name: Lint (ruff + eslint)
     runs-on: ubuntu-latest

--- a/tests/repo/test_python_floor.py
+++ b/tests/repo/test_python_floor.py
@@ -36,9 +36,8 @@ byte-compile and import every shipped module. That check runs in the default
 gate, so the pre-push hook enforces it on every push — and, since #1635, a
 dedicated `python-floor` job in `.github/workflows/plugin-tests.yml` also
 runs it on every PR, so a push that bypasses local hooks (`--no-verify`, a
-hookless cloud session) is still caught by CI. Making a red run actually
-block a GitHub-UI merge needs the job's name added to `main`'s
-required-status-check ruleset — a follow-up, not yet configured.
+hookless cloud session) is still caught by CI. That job's name is a required
+status check on `main`, so a red run blocks a GitHub-UI merge too.
 
 What follows pins those parts to each other. It deliberately contains no
 opinion about which APIs are too new; that question belongs to the
@@ -208,8 +207,9 @@ class TestTheFloorIsCheckedInCI:
     that bypasses hooks — --no-verify, a hookless cloud session — must still
     be run by something, which means a CI job has to name chk_python_floor
     in its own --only= list explicitly. (Blocking a GitHub-UI merge on a red
-    run additionally needs the job in main's required-status-check ruleset
-    — a follow-up, not something a test in this repo can pin.)"""
+    run additionally needs the job in main's required-status-check ruleset,
+    where it now is — repo settings live outside the tree, so no test here
+    can pin that half.)"""
 
     def test_a_ci_job_runs_the_floor_check(self, ci_workflow):
         """A bare `in workflow` check passes on any mention of the name — a
@@ -255,9 +255,9 @@ class TestTheFloorIsCheckedInCI:
         step's first key, as it is here, which `^\\s*` cannot absorb, so
         this pattern doesn't match it. The version here is deliberately a
         literal built from FLOOR_DOTTED at assertion time, not hardcoded:
-        this string will be the status-check context the `main` ruleset
-        matches once the job is added there (see the module docstring above
-        — not yet configured), so a future floor bump (ADR 0031's own
+        this string IS the status-check context the `main` ruleset matches
+        on (see the module docstring above), so a future floor bump (ADR 0031's
+        own
         successor) must update the workflow job name deliberately — this
         test failing IS that reminder, not something to silence by hardcoding
         a stale version here instead."""


### PR DESCRIPTION
## What

Four jobs run on **every** PR with no `paths:` filter — hermetic, always reporting — but were absent from the `main` ruleset's `required_status_checks`. A red run showed in the PR checks list and merged anyway:

| Job | Workflow |
| --- | --- |
| `Python 3.10 floor` | `plugin-tests.yml` |
| `Lint (ruff + eslint)` | `plugin-tests.yml` |
| `Docs nav integrity` | `link-check.yml` |
| `Docs link check` | `link-check.yml` |

All four have been added to the ruleset (8 → 12 required contexts). That change is repo settings, applied out-of-tree; this PR is the in-tree half.

## Why these four, and not the others

- `Eval live regression (opt-in)` / `Eval integration tier (opt-in)` — secret-gated and cost-bearing; skip-not-fail by design.
- `Pytest on native Windows`, `Stryker.NET POSIX signal tests` — path-filtered, so they report *no* status on unrelated PRs. Requiring them would deadlock every PR that doesn't touch the wrapper at "Waiting for status to be reported". They'd need an always-reporting skip-shim first.
- `Orchestrator real-subprocess test` — schedule/dispatch only.
- `Docs deploy`, `Release Please`, `Epic auto-close`, `Issue title lint` — not PR-triggered; can't be required contexts.

## Changes

- `plugin-tests.yml` — the `python-floor` comment said the job was "NOT yet listed as a required check"; it now is. Added the same rename warning to `lint`.
- `link-check.yml` — the header already asserted both jobs were REQUIRED status checks and dropped its `paths:` filter on that basis. It was wrong when written: the workflow paid the cost of running on every PR and got none of the blocking benefit. Now true, and names the two contexts explicitly.
- `tests/repo/test_python_floor.py` — three docstrings described the ruleset entry as "a follow-up, not yet configured".

Comment-and-docstring only — no job, step, or assertion logic changed. A rename of any of these four job names now needs a matching ruleset update, or the check keeps reporting green while silently no longer blocking; each comment says so at the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)