### PR TITLE
fix(tests): widen bare-invocation guard and quote CLAUDE_PLUGIN_ROOT expansions

### DIFF
--- a/_content_guard_scan.py
+++ b/_content_guard_scan.py
@@ -1,0 +1,39 @@
+"""Shared file-discovery helper for the plugin-markdown content-guard tests.
+
+`tests/repo/test_bare_invocation_wide_scan.py` and
+`tests/repo/test_claude_plugin_root_quoting.py` each scan a subset of
+`plugins/dev-team/`'s markdown tree, differing only in *which*
+subdirectories they include — this is the one piece those two guards
+genuinely share (flagged by structure-review during #1655/#1656's own code
+review as duplicated verbatim); every other part of each guard (the regex
+grammar, the fence-state tracking, the exemption registry) is
+lens-specific and stays in its own file.
+
+Scoped to the repo root via the ``pythonpath = .`` entry in ``pytest.ini``,
+matching ``_repo_root.py``'s own convention (see that module's docstring),
+rather than living inside ``tests/repo/`` where ``--import-mode=importlib``
+would not make it importable by bare name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: The one scan surface both content guards share. Declared once here so the
+#: two guards can no longer silently diverge the way they did before
+#: (`test_bare_invocation_wide_scan.py` once omitted `"agents"` while its
+#: sibling included it) — `scanned_markdown_files` still takes `scan_dirs` as
+#: an explicit parameter rather than defaulting to this constant, so a
+#: future guard with a genuinely narrower surface isn't forced to match it.
+PLUGIN_MARKDOWN_SCAN_DIRS = ("skills", "docs", "knowledge", "agents")
+
+
+def scanned_markdown_files(plugin_root: Path, scan_dirs: tuple) -> list:
+    """Every `**/*.md` file under `plugin_root / sub` for each `sub` in
+    `scan_dirs` that exists, sorted within each subdirectory."""
+    files = []
+    for sub in scan_dirs:
+        root = plugin_root / sub
+        if root.is_dir():
+            files.extend(sorted(root.glob("**/*.md")))
+    return files

--- a/docs/adr/0032-shipped-script-path-resolution-taxonomy.md
+++ b/docs/adr/0032-shipped-script-path-resolution-taxonomy.md
@@ -50,7 +50,7 @@ resolution actually the right semantics for this invocation?**
 The script lives under `plugins/dev-team/scripts/` (or `hooks/`), and the
 invoking skill references it as `${CLAUDE_PLUGIN_ROOT}/scripts/<name>.py` (or
 the quoted equivalent, `"$CLAUDE_PLUGIN_ROOT/scripts/<name>.py"` — house style
-per ADR-pending #1656). This is the common case, and what #1636/#1637 fixed
+per ADR 0033). This is the common case, and what #1636/#1637 fixed
 most invocations into. `eval_ablation.py` (#1653) is the most recent addition:
 moved from repo-root into the plugin specifically so its `--find-latest`
 mode — a generic JSONL reader with no repo-shape assumption — could be
@@ -104,9 +104,31 @@ shrink-only, currently empty — the two real defects #1637 found
 remaining in the older two-way split was reclassified into category 2 above,
 not left here.
 
+### 4. Shipped for copy-out
+
+The script ships under `plugins/dev-team/`, but the invoking doc's whole
+point is instructing the OPERATOR to copy it into **their own project**
+before running it there — `skills/mutation-testing/references/languages/
+csharp-stryker-net.md` tells the reader to copy `csharp_stryker_net_wrapper.py`
+(plus its status-loop sibling) into their repo's own `scripts/` directory,
+then shows the resulting invocation as a bare `python3 scripts/
+csharp_stryker_net_wrapper.py`. That bare path is correct precisely because
+the file deliberately no longer lives in the plugin at all once copied —
+`${CLAUDE_PLUGIN_ROOT}` would be actively wrong here, not merely
+unqualified, since the invocation targets a file that exists only in the
+operator's own tree. This differs from categories 1–3: the script DOES ship
+(unlike category 2) and the reference is not portable-as-is (unlike category
+1), because the reference describes a file at its POST-copy location, not
+its shipped one.
+
+Tracked in `tests/repo/test_bare_invocation_wide_scan.py`'s
+`INTENTIONAL_WIDE_SCAN_INVOCATIONS` under the `copied-out-by-operator`
+category, premise-checked by confirming the doc still instructs the
+operator to copy the script into their own project.
+
 ## Decision
 
-Adopt this three-category (plus the category-1 sub-case) taxonomy as the
+Adopt this four-category (plus the category-1 sub-case) taxonomy as the
 one place the "does this reference need fixing" judgment is recorded, and
 require every new bare or non-standard script invocation in a shipped
 skill/agent to be classified into it — mechanically, where possible, not by
@@ -119,6 +141,9 @@ comment alone:
   deliberately still cwd-relative).
 - `KNOWN_BARE_INVOCATION` — category 3, shrink-only, never grown without a
   fix landing in the same PR.
+- `INTENTIONAL_WIDE_SCAN_INVOCATIONS`'s `copied-out-by-operator` category —
+  category 4 (ships, but the reference describes the file's post-copy
+  location in the operator's own project).
 
 The Skills Registry (`plugins/dev-team/CLAUDE.md` and `knowledge/skills-
 registry.md`) should disambiguate a skill whose primary purpose is
@@ -180,5 +205,8 @@ maintainer-only tool at a glance, not merely be correctly coded as one.
   RELATIVE`
 - `tests/repo/test_shipped_script_refs.py` — the `${CLAUDE_PLUGIN_ROOT}`
   resolver and its own allowlist
+- `tests/repo/test_bare_invocation_wide_scan.py` — widens this guard past
+  `SKILL.md` files (#1655) and tracks category 4 above
+- ADR 0033 — the quoting house style this ADR's category 1 forward-references
 - `knowledge/skills-registry.md` — `/agent-readiness`'s disambiguation
   precedent

--- a/docs/adr/0033-quote-claude-plugin-root-expansions.md
+++ b/docs/adr/0033-quote-claude-plugin-root-expansions.md
@@ -1,0 +1,81 @@
+# 33. Quote every `${CLAUDE_PLUGIN_ROOT}` expansion in a shell fence
+
+Date: 2026-08-01
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0032 names the house style for a shipped-and-portable script reference —
+`${CLAUDE_PLUGIN_ROOT}/scripts/<name>.py`, or its quoted equivalent,
+`"$CLAUDE_PLUGIN_ROOT/scripts/<name>.py"`. Its category-1 text originally
+deferred the quoting half of that sentence to a then-pending ADR for #1656
+("house style per ADR-pending #1656"); this ADR is that destination, and
+ADR 0032 now points here instead.
+
+An unquoted `${CLAUDE_PLUGIN_ROOT}/scripts/x.py` word-splits the moment the
+plugin is installed under a path containing a space — the default macOS
+`~/Library/Application Support/...` cache tree is exactly such a path. Bash
+does not word-split inside double quotes, so `"${CLAUDE_PLUGIN_ROOT}/scripts/
+x.py"` is safe regardless of what the variable expands to.
+
+#1656 found 77 unquoted instances across 28 shipped `SKILL.md`/docs/knowledge
+files and swept every one to the quoted form. A regression guard
+(`tests/repo/test_claude_plugin_root_quoting.py`) was added in the same
+change so a future edit can't reintroduce an unquoted expansion silently.
+
+## Decision
+
+Every `${CLAUDE_PLUGIN_ROOT}` (braced) or `$CLAUDE_PLUGIN_ROOT` (unbraced)
+expansion inside a `bash`/`sh`/`shell`/untagged fenced code block in a
+shipped `plugins/dev-team/{skills,docs,knowledge,agents}/**/*.md` file must
+be quoted — the whole path token, not just the variable
+(`"${CLAUDE_PLUGIN_ROOT}/scripts/x.py"`, not `${CLAUDE_PLUGIN_ROOT}"/scripts/
+x.py"` or similar partial forms).
+
+Both spellings — braced and unbraced — are in scope; this repo uses the
+braced form in most places and the unbraced form in a few (e.g.
+`sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" ...`), and both word-split identically
+when unquoted.
+
+A mention of `${CLAUDE_PLUGIN_ROOT}` outside any fence (prose, an HTML
+comment illustrating rendered output) or inside a non-shell-flavored fence
+(e.g. a `markdown`-tagged illustrative block) is not a shell invocation and
+quoting it would be meaningless — out of this decision's scope.
+
+Enforced by `tests/repo/test_claude_plugin_root_quoting.py`, which tracks
+fence state per-line (open/close toggled by the marker's own backtick-run
+length, so a shorter run nested inside a longer-fenced block — e.g.
+`skills/plan/references/plan-template.md`'s 4-backtick wrapper around a
+3-backtick example — is treated as literal content, not a real delimiter)
+and allows arbitrary leading whitespace before a fence marker, so a fence
+indented under a numbered/bulleted step (this repo's own dominant SKILL.md
+shape) is still recognized.
+
+## Consequences
+
+- ADR 0032's category-1 forward reference now resolves to something.
+- A future SKILL.md/doc edit that introduces a new, unquoted
+  `${CLAUDE_PLUGIN_ROOT}`/`$CLAUDE_PLUGIN_ROOT` reference inside a shell
+  fence fails CI rather than shipping silently.
+- Does not cover a `${CLAUDE_PLUGIN_ROOT}` reference inside a shipped `.py`
+  script's own string literals (e.g. a printed remediation hint) — those are
+  reviewed case by case against ADR 0032's taxonomy instead, since a
+  script's own working directory and mutation target (not word-splitting
+  safety) is usually the more load-bearing question there.
+- The guard verifies an OPENING quote precedes the expansion, not a balanced
+  closing one — a malformed partial form like
+  `"${CLAUDE_PLUGIN_ROOT}"/scripts/x.py` is not distinguished from the fully
+  quoted `"${CLAUDE_PLUGIN_ROOT}/scripts/x.py"`. Accepted as a residual gap:
+  the uncaught shapes are either a visible shell syntax error or already
+  word-split-safe, so this narrows what "enforced" means here without
+  narrowing what's actually safe.
+
+## References
+
+- Issue #1656 — this ADR's originating issue
+- ADR 0032 — the shipped-script path-resolution taxonomy this decision's
+  house style extends
+- `tests/repo/test_claude_plugin_root_quoting.py` — the enforcement

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@
 * [30. Use ancestor-check instead of exact-SHA comparison for mutation baseline reuse](0030-use-ancestor-check-instead-of-exact-sha-comparison-for-mutation-baseline-reuse.md)
 * [31. Raise the shipped Python floor from 3.8 to 3.10](0031-raise-shipped-python-floor-to-3-10.md)
 * [32. Shipped-script path-resolution taxonomy](0032-shipped-script-path-resolution-taxonomy.md)
+* [33. Quote every `${CLAUDE_PLUGIN_ROOT}` expansion in a shell fence](0033-quote-claude-plugin-root-expansions.md)

--- a/plugins/dev-team/agents/codebase-recon.md
+++ b/plugins/dev-team/agents/codebase-recon.md
@@ -116,7 +116,7 @@ Run these git commands (read-only). If the target is not a git repo, fill arrays
 Run the canonical enumeration pipeline to produce the authoritative list of files the recon considered in-scope. This file backs the envelope's `file_inventory` field (primitives contract 1.2.0+) and is the anchor for any consumer that wants to detect reads of files outside the recon surface (e.g., Gap 6's manifest-membership hook).
 
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/recon_inventory.py <repo-root> \
+"${CLAUDE_PLUGIN_ROOT}/scripts/recon_inventory.py" <repo-root> \
     --slug <slug> \
     --emit-main-inventory-json <tmpfile-for-main-envelope-fragment>
 ```

--- a/plugins/dev-team/docs/code-review-process.md
+++ b/plugins/dev-team/docs/code-review-process.md
@@ -216,7 +216,7 @@ The full lifecycle of these files — discovery to applied fix, including who ow
 When the review was auto-scoped to uncommitted changes, the final status is `pass` or `warn`, and step 6a's fix loop (if it ran) did not exit with actionable issues still outstanding, the orchestrator writes `.review-passed` to `.claude/memory/` — a SHA-256 hash of the staged **content** (the cached patch, not just the file list — an edit after review changes this hash and re-blocks the commit):
 
 ```bash
-HASH=$(python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py)
+HASH=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py")
 mkdir -p .claude/memory && echo "$HASH" > .claude/memory/.review-passed
 ```
 

--- a/plugins/dev-team/knowledge/gherkin-quality-review-dispatch.md
+++ b/plugins/dev-team/knowledge/gherkin-quality-review-dispatch.md
@@ -121,7 +121,7 @@ the *other* dispatch's canary. Like `evals/README.md`'s live eval gate, it is
 failure. It is not wired into any CI workflow by default. Run it locally:
 
 ```bash
-ANTHROPIC_API_KEY=sk-... python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify_gherkin_quality_critic_isolation.py
+ANTHROPIC_API_KEY=sk-... python3 "${CLAUDE_PLUGIN_ROOT}/scripts/verify_gherkin_quality_critic_isolation.py"
 ```
 
 ## Scope of this doc

--- a/plugins/dev-team/scripts/check_agent_tool_mapping.py
+++ b/plugins/dev-team/scripts/check_agent_tool_mapping.py
@@ -29,10 +29,12 @@ escape the mapping:
 A granted MCP tool whose server is absent is inert at runtime; agents fall back to
 Read/Grep/Glob.
 
-Usage:
-    python3 check_agent_tool_mapping.py [--agents-dir <path>]
-    python3 check_agent_tool_mapping.py --fix     # append missing tier tools
-    python3 check_agent_tool_mapping.py --json     # machine-readable report
+Usage (repo-root-relative — this script mutates the agent files next to
+wherever it itself resides, so it must run against the maintainer's own
+checkout, never a `${CLAUDE_PLUGIN_ROOT}`-qualified installed-cache path):
+    python3 plugins/dev-team/scripts/check_agent_tool_mapping.py [--agents-dir <path>]
+    python3 plugins/dev-team/scripts/check_agent_tool_mapping.py --fix     # append missing tier tools
+    python3 plugins/dev-team/scripts/check_agent_tool_mapping.py --json     # machine-readable report
 """
 
 from __future__ import annotations
@@ -195,7 +197,7 @@ def main(argv=None) -> int:
         print("FAIL: non-review agents missing their tier's code-intelligence tools:")
         for name, missing in offenders.items():
             print(f"  - {name}: missing {', '.join(missing)}")
-        print("\nRun: python3 scripts/check_agent_tool_mapping.py --fix")
+        print("\nRun: python3 plugins/dev-team/scripts/check_agent_tool_mapping.py --fix")
     if unclassified:
         print("FAIL: team agents in neither the mapping nor the exclusion list "
               "(classify each into TIER_CONFIG or EXCLUSIONS):")

--- a/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
+++ b/plugins/dev-team/scripts/check_review_agent_mcp_tools.py
@@ -36,10 +36,12 @@ so it can't be missed.
 Exit 0 if every review agent's grant matches its tier and the skill prose is
 present. Exit 1 (detection) or applies fixes (--fix) otherwise.
 
-Usage:
-    python3 check_review_agent_mcp_tools.py [--agents-dir <path>] [--skill-file <path>]
-    python3 check_review_agent_mcp_tools.py --fix        # append missing tool names
-    python3 check_review_agent_mcp_tools.py --json        # machine-readable report
+Usage (repo-root-relative — this script mutates the agent files next to
+wherever it itself resides, so it must run against the maintainer's own
+checkout, never a `${CLAUDE_PLUGIN_ROOT}`-qualified installed-cache path):
+    python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py [--agents-dir <path>] [--skill-file <path>]
+    python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py --fix        # append missing tool names
+    python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py --json        # machine-readable report
 """
 
 # Keeps PEP 585 annotations (`list[Path]`, `dict[str, list[str]]`) as strings,
@@ -308,7 +310,7 @@ def main() -> int:
         print("FAIL: review agents missing their required code-intelligence MCP tools in tools::")
         for name, missing in offenders.items():
             print(f"  - {name}: missing {', '.join(missing)}")
-        print("\nRun: python3 scripts/check_review_agent_mcp_tools.py --fix")
+        print("\nRun: python3 plugins/dev-team/scripts/check_review_agent_mcp_tools.py --fix")
     if forbidden:
         print("FAIL: exempt review agents granted forbidden code-intelligence MCP tools (should have none):")
         for name, tools in forbidden.items():

--- a/plugins/dev-team/skills/agent-audit/SKILL.md
+++ b/plugins/dev-team/skills/agent-audit/SKILL.md
@@ -14,8 +14,8 @@ allowed-tools: >-
        python3 scripts/check_registry_sync.py *,
        python3 plugins/dev-team/scripts/verify_tier.py *,
        python3 -m pytest tests/agents/test_agent_knowledge_anchor.py,
-       python3 ${CLAUDE_PLUGIN_ROOT}/scripts/claude_setup_review.py *,
-       python3 ${CLAUDE_PLUGIN_ROOT}/scripts/token_efficiency_review.py *)
+       python3 "${CLAUDE_PLUGIN_ROOT}/scripts/claude_setup_review.py" *,
+       python3 "${CLAUDE_PLUGIN_ROOT}/scripts/token_efficiency_review.py" *)
 ---
 
 # Agent Audit
@@ -202,15 +202,17 @@ Include the result in the agent report table under a `Skills-Tool` column.
    - FAIL if a code-reading agent's `tools:` line is missing one or more of the five names, or an agent on disk is in neither roster (unclassified).
    - PASS if every code-reading agent grants all five and every agent on disk is classified.
 
-**Mechanics for invariants 2–4**: all three delegate to `${CLAUDE_PLUGIN_ROOT}/scripts/lib/mcp_tool_grants.py`'s shared `run_grants_check` (single read+parse pass per agent, both for detection and `--fix`) and, under `--json`, report the same envelope (`check`/`evaluated`/`offenders`/`unclassified`/`fixed`/`unfixable`/`ok`/`notes`) so results are comparable across the three checks.
+**Mechanics for invariants 2–4**: all three delegate to `plugins/dev-team/scripts/lib/mcp_tool_grants.py`'s shared `run_grants_check` (single read+parse pass per agent, both for detection and `--fix`) and, under `--json`, report the same envelope (`check`/`evaluated`/`offenders`/`unclassified`/`fixed`/`unfixable`/`ok`/`notes`) so results are comparable across the three checks.
 
 | Invariant | Report column | Delegated script | Config source of truth | Unclassified handling |
 |---|---|---|---|---|
-| 2. Code-intelligence (review agents) | `Code-Intel` | `${CLAUDE_PLUGIN_ROOT}/scripts/check_review_agent_mcp_tools.py` | `MCP_TOOL_NAMES` | n/a — glob-discovered, no roster |
-| 3. Code-intelligence mapping (non-review) | `Mapping` | `${CLAUDE_PLUGIN_ROOT}/scripts/check_agent_tool_mapping.py` | `TIER_CONFIG` / `EXCLUSIONS` | reported, not auto-fixed |
+| 2. Code-intelligence (review agents) | `Code-Intel` | `plugins/dev-team/scripts/check_review_agent_mcp_tools.py` | `MCP_TOOL_NAMES` | n/a — glob-discovered, no roster |
+| 3. Code-intelligence mapping (non-review) | `Mapping` | `plugins/dev-team/scripts/check_agent_tool_mapping.py` | `TIER_CONFIG` / `EXCLUSIONS` | reported, not auto-fixed |
 | 4. Code-intelligence (security-assessment) | `SA-MCP` | `plugins/dev-team/scripts/check_security_assessment_mcp_tools.py` | `CODE_READING_AGENTS` / `NON_CODE_READING_AGENTS` | reported, not auto-fixed |
 
 Include each invariant's result in the agent report table under its column above. Invariant 4 is additionally wired into `scripts/ci-local.sh` as `chk_sa_mcp_tools`, so drift fails CI, not just this manual audit pass.
+
+All three delegated scripts above are repo-root-relative, not `${CLAUDE_PLUGIN_ROOT}`-qualified — same working-tree-vs-cache reasoning as `verify_tier.py` above (§2b): each mutates agent files resolved relative to its own `__file__`, so a `${CLAUDE_PLUGIN_ROOT}`-qualified invocation would silently edit the installed plugin cache's copy instead of the operator's own checkout.
 
 **Fix (when `--fix` is passed)**: run the delegated script above with `--fix` — it appends its missing tool names to `tools:` (merge, never replacing existing grants such as `Read, Grep, Glob`/`Skill`). Unclassified agents, where applicable, are reported, not auto-fixed — classify each into the config or exclusion list named above. Report `FIXED: <agent> — added <tool names>`.
 
@@ -326,14 +328,14 @@ semantic checks. Run these scripts for a fast, CI-safe structural pass:
 bands, duplicate rules):
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/claude_setup_review.py --plugin-root <plugin-root-path>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/claude_setup_review.py" --plugin-root <plugin-root-path>
 ```
 
 **Token-efficiency review** (file line counts, CLAUDE.md size, LLM
 anti-patterns):
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/token_efficiency_review.py --files <path>...
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/token_efficiency_review.py" --files <path>...
 ```
 
 Both scripts exit 0 and emit JSON findings to stdout. Surface any `error`

--- a/plugins/dev-team/skills/agent-eval/SKILL.md
+++ b/plugins/dev-team/skills/agent-eval/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: >-
   Read, Grep, Glob,
   Bash(readlink *, ls *, date *, mkdir *, command -v claude, claude -p *,
        python3 scripts/eval_cache.py *, python3 scripts/run_integration_eval.py *,
-       python3 scripts/eval_variance.py *, python3 ${CLAUDE_PLUGIN_ROOT}/scripts/eval_ablation.py *,
+       python3 scripts/eval_variance.py *, python3 "$CLAUDE_PLUGIN_ROOT/scripts/eval_ablation.py" *,
        python3 scripts/citation_lint.py *),
   Skill(review-agent *), Skill(test-design-advisor *)
 ---

--- a/plugins/dev-team/skills/agent-readiness/SKILL.md
+++ b/plugins/dev-team/skills/agent-readiness/SKILL.md
@@ -43,7 +43,7 @@ as `deferred` and excluded from the renormalized overall score.
 ## Run
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/agent-readiness/scanner.py [REPO_PATH] \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/agent-readiness/scanner.py" [REPO_PATH] \
   [--json out.json] [--markdown out.md]
 ```
 

--- a/plugins/dev-team/skills/autoship/SKILL.md
+++ b/plugins/dev-team/skills/autoship/SKILL.md
@@ -66,7 +66,7 @@ to `autoship:blocked` before discovery, so they are not counted against
 `--max-issues` and are instead queued for human triage.
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/autoship_reclaim.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/autoship_reclaim.py" \
   [--dry-run]           # pass when --dry-run was given
 ```
 
@@ -78,7 +78,7 @@ reclaim failure is non-fatal — log the error and continue to discovery.
 Run the discovery script to select the issues this round will process.
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/autoship_discover.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/autoship_discover.py" \
   --max-issues <N> \
   --max-cost-usd <max_cost_usd> \
   [--label <label>]     # pass when --label was given
@@ -172,7 +172,7 @@ After a non-blocked `/ship` completes, record the start ISO timestamp that was
 captured just before invoking `/ship` in Step 3c, then run the classifier:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/classify_ship_outcome.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/classify_ship_outcome.py" \
   --review-value .claude/metrics/review-value.jsonl \
   --verify-log   metrics/verify-log.jsonl \
   --since        <start_iso>
@@ -192,14 +192,14 @@ this issue and confirm the gate allows advancement — this is a hard block,
 not the advisory `progress-guardian` gate:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py record \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" record \
   --round-id "<round_id>" \
   --attempted "<short note: what was attempted>" \
   --outcome "<short note: shipped|failed|blocked|unrecognized>" \
   --next-action "<short note: next issue or stop>" \
   --session "$CLAUDE_SESSION_ID"
 
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py check \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" check \
   --round-id "<round_id>" \
   --session "$CLAUDE_SESSION_ID"
 ```
@@ -215,7 +215,7 @@ Append one entry per issue to `.claude/metrics/autoship-log.jsonl` using the log
 library:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/autoship_log.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/autoship_log.py" \
   --log-path .claude/metrics/autoship-log.jsonl \
   --json '{"round_id":"<round_id>","issue":<number>,"status":"<status>","blocked_reason":"<reason_or_null>"}'
 ```

--- a/plugins/dev-team/skills/build/SKILL.md
+++ b/plugins/dev-team/skills/build/SKILL.md
@@ -110,7 +110,7 @@ Work the plan **wave by wave** (the plan's `## Parallelization` section, derived
 **Base-ref check (top-level session, before any subagent dispatch).** Worktree subagents (`isolation: "worktree"`) must branch from the caller's local HEAD, not `origin/<default>`, so the `docs/specs/<slug>.md` (when the spec was file-persisted — see `/specs`' GitHub-issue persistence path for the alternative, which leaves no local file to miss) and `plans/<slug>.md` files `/ship` just produced are visible to them (issue #553). This is controlled by Claude Code's `worktree.baseRef` setting, which is honored only at project (`.claude/settings.json`) or user (`~/.claude/settings.json`) scope — **not** at plugin or project-local scope (`docs/spikes/worktree-baseref-head-spike.md`). `/build` cannot set this on the user's behalf, so it runs a read-only detect-and-warn **in this top-level `/build` session, before any subagent dispatch**, so the warning is visible in the human-facing transcript:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_worktree_baseref.py detect   # prints head|fresh|unset|unknown
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/build_worktree_baseref.py" detect   # prints head|fresh|unset|unknown
 ```
 
 - **`head`** → no warning. Proceed.
@@ -138,8 +138,8 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_worktree_baseref.py detect   # print
 **Resolve the wave schedule and concurrency first:**
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_wave.py <plan-file>          # ordered waves + members
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_jobs.py --wave-width <W> [--jobs N]  # effective concurrency
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/build_wave.py" <plan-file>          # ordered waves + members
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/build_jobs.py" --wave-width <W> [--jobs N]  # effective concurrency
 ```
 
 `build_jobs.py` resolves `min(--jobs, DEV_TEAM_MAX_PARALLEL_BUILDS, wave width)`. Parallel fan-out is **opt-in**: when neither `--jobs` nor `DEV_TEAM_MAX_PARALLEL_BUILDS` is set, the **default is sequential** (effective 1) — fan-out never *saves* tokens, it trades them for wall-clock (#1515). Opt in with `--jobs N` (bounded only by wave width) or `DEV_TEAM_MAX_PARALLEL_BUILDS` (an explicit env value is honored verbatim, never re-capped); non-positive/non-integer values clamp to 1. **Sequential fallback:** when effective concurrency is **1** (the unset default, a fully-dependent plan, `--jobs 1`, or max 1), build slices one at a time in a single worktree in dependency order — **no worktree fan-out, no reconcile step** (today's behavior exactly).
@@ -259,7 +259,7 @@ A "done" step that only passed its own tests is not the same as a feature that w
 When the slice declares `**Invariants:**`, run them **after** the slice's own suite is green (sub-step 5) and its review checkpoint(s) have run (sub-steps 4/6) — invariants check what must stay green *beyond* the slice's new acceptance tests, so they gate on top of everything else, not instead of it:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/run_invariants.py --plan <plan-file> --slice <id> --repo <worktree>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run_invariants.py" --plan <plan-file> --slice <id> --repo <worktree>
 ```
 
 A non-zero exit **fails the slice gate exactly like a red test** — fix it or escalate (Escalation section below), never step over it, and never flip the slice checkbox to `[x]` until it's green. A slice with no `Invariants` line runs its gate unchanged (the script itself no-ops with "No invariants declared" — nothing to enforce). Invariant commands run as-is from the repo root; the plan author owns their portability, same trust model as the plan's own test commands.

--- a/plugins/dev-team/skills/cd-test-architecture/SKILL.md
+++ b/plugins/dev-team/skills/cd-test-architecture/SKILL.md
@@ -173,7 +173,7 @@ Coverage` section (issue #1450), run here against this skill's own
 configuration:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py --file <report-path> --config cd-test-architecture
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py" --file <report-path> --config cd-test-architecture
 ```
 
 Print the gate's result as its own report section: `OK: all 8

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -136,9 +136,9 @@ If **every** target file is documentation, short-circuit:
 1. Emit: `Documentation-only changeset ({N} files) — skipping code review. Re-run with --force --reason "<text>" to review anyway.`
 2. If the review was auto-scoped to uncommitted changes, write the `.review-passed` gate file (per step 9) so the pre-commit hook allows the commit. **Contemporaneously** (before or immediately after that write), record the doc-only exemption as an explicit, auditable boundary event — the `.review-passed` gate's dispatch-ledger corroboration (#1461) reads this event, bound to the gate's own hash, to let the doc-only path stay exempt from agent-dispatch evidence without being a silent, unaccountable code-path skip:
    ```bash
-   HASH=$(python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py)
+   HASH=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py")
    mkdir -p .claude/memory && echo "$HASH" > .claude/memory/.review-passed
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/boundary_events.py --event doc-only --subject-hash "$HASH"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/boundary_events.py" --event doc-only --subject-hash "$HASH"
    ```
 3. In `--json` mode, emit `{"status": "skipped", "reason": "documentation-only", "files": [<list>]}` instead.
 4. **Stop.** Do not run pre-flight gates, static analysis, or any agent.
@@ -230,7 +230,7 @@ Otherwise read the roster from the **Review Agents** section of `knowledge/agent
 **Agent eligibility is resolved by `select_lenses.py` (#1523).** Run:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/select_lenses.py --files <target files>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/select_lenses.py" --files <target files>
 ```
 
 Take its `lenses` array as the Scope-eligible roster, and **surface its `warnings`** in the review output (an agent missing its `Scope:` declaration is included include-biased and named — never silently dropped). The resolver reads each review agent's body-level `Scope:` declaration — `Scope: always` (eligible for any non-empty changeset) or a glob list (eligible only when at least one target file matches a declared glob). `Scope:` is a body declaration, not frontmatter (`agent-contract.json`). This is the single source of truth shared with `/build`'s inline checkpoints: adding or changing an agent's trigger scope needs only an edit to that agent's own body — zero edits to this skill. (The framework-reactivity agents react/vue/angular are **not** in the resolver's roster; they are governed by the manifest rule below. `ai-provenance-review` **is** resolver-governed via its own `Scope: always` declaration.)
@@ -700,8 +700,8 @@ For issues NOT auto-fixed (confidence: none, auto-fix failed, or suggestions), g
 If the review was auto-scoped to uncommitted changes and the overall status is `pass` or `warn` **and step 6a did not exit with actionable issues outstanding** — whether via the iteration limit or the "not converging" exit, both of which are escalations, per that step's Exit conditions table (regardless of whether those outstanding issues are only `warning`-severity — either escalation overrides `warn` for this condition specifically, since escalating and then writing a passing gate anyway would silently defeat the escalation) — write `.review-passed` to `.claude/memory/` so the pre-commit hook allows the next commit. Use the **shared gate-hash helper** so the writer and the pre-commit hook compute the hash identically — it hashes the staged **content** (the cached patch), not just the file paths (#193), so any edit after review invalidates the gate:
 
 ```bash
-HASH=$(python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py)
-NORM=$(python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_normalized_hash.py || true)
+HASH=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_hash.py")
+NORM=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/review_gate_normalized_hash.py" || true)
 mkdir -p .claude/memory && printf '%s\n%s\n' "$HASH" "$NORM" > .claude/memory/.review-passed
 ```
 
@@ -719,7 +719,7 @@ back to today's behavior — that is the intended failure mode, not an error.
 **If `--agent <name>` was used** (a sanctioned single-agent review — it deliberately dispatches exactly 1 agent, which can never clear the dispatch-ledger gate's `>= 2` distinct-dispatch floor on its own), record that as an explicit, auditable exemption event bound to this same hash **contemporaneously** with the write above — same pattern as the doc-only short-circuit's exemption event (step 1a):
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/boundary_events.py --event single-agent --subject-hash "$HASH"
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/boundary_events.py" --event single-agent --subject-hash "$HASH"
 ```
 
 This step only runs when the review was auto-scoped to uncommitted changes (see the gate condition above), and that path already staged these changes in step 1, before any agent was dispatched — that ordering, not a re-stage here, is what makes this hash match the `subject_hash` `agent_dispatch_ledger.py` recorded at dispatch time (#1461), refreshed by step 6a's own re-staging when a fix loop ran. Do not `git add` a different file set at this point: staging something here that wasn't already staged (and therefore wasn't the reviewed, dispatch-hashed content) would write a gate hash with no corroborating dispatch evidence behind it.

--- a/plugins/dev-team/skills/cost-report/SKILL.md
+++ b/plugins/dev-team/skills/cost-report/SKILL.md
@@ -27,7 +27,7 @@ data.
    know the current transcript path), run an exact per-agent report:
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py report --transcript <path>
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" report --transcript <path>
    ```
 
    Otherwise show the most recently recorded session from the metrics log
@@ -44,7 +44,7 @@ data.
 
    ```bash
    log=".claude/metrics/cost-metering.jsonl"; [ -f "$log" ] || log="metrics/cost-metering.jsonl"
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py regression \
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" regression \
      --log "$log" --tolerance 0.5
    ```
 
@@ -60,7 +60,7 @@ data.
 
    ```bash
    log=".claude/metrics/cost-metering.jsonl"; [ -f "$log" ] || log="metrics/cost-metering.jsonl"
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py regression \
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" regression \
      --log "$log" --tolerance 0.5 --window 10
    ```
 
@@ -128,7 +128,7 @@ turns the marker sequence into a per-phase ratio:
 
 ```bash
 log=".claude/metrics/phase-markers.jsonl"; [ -f "$log" ] || log="metrics/phase-markers.jsonl"
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py phase-report --log "$log"
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" phase-report --log "$log"
 ```
 
 Report the per-phase `resident_tokens`, `spent_tokens` (output generated during
@@ -163,7 +163,7 @@ text, code, file paths, or tool payloads. `metrics/cost-metering.jsonl` and
 
    ```bash
    log=".claude/metrics/cost-metering.jsonl"; [ -f "$log" ] || log="metrics/cost-metering.jsonl"
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py pace \
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" pace \
      --log "$log" --budget 100 --period-days 30 --window-days 7
    ```
 

--- a/plugins/dev-team/skills/gherkin-derive/SKILL.md
+++ b/plugins/dev-team/skills/gherkin-derive/SKILL.md
@@ -135,7 +135,7 @@ single project-wide directory probe; this skill composes the per-surface
 path, it never asks the script to resolve one itself:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_bdd_convention.py
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/detect_bdd_convention.py"
 ```
 
 A `"dir": null` result (`"signal": "none"`) means the script found no usable
@@ -226,7 +226,7 @@ Then call `gherkin_feature_merge.py check-stale` to decide match/mismatch
 deterministically, never by eyeballing the comparison yourself:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_feature_merge.py check-stale \
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_feature_merge.py" check-stale \
   --existing <dir>/<surface>.feature --feature-title "<surface>" \
   --observed "<scenario title>=<observed value>" --json
 ```
@@ -260,7 +260,7 @@ table above) to a scratch candidates file, then invoke
 `gherkin_stub_merge.py merge`:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_merge.py merge \
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_merge.py" merge \
   --existing <dir>/<surface>_steps.<ext> --candidates <scratch-file> \
   --ext <.js|.ts|.mjs|.cjs|.java|.cs|.go> --json
 ```
@@ -303,7 +303,7 @@ cause it is):
   file on disk:
 
   ```
-  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_feature_merge.py merge \
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_feature_merge.py" merge \
     --existing <dir>/<surface>.feature --candidates <scratch-file> \
     --feature-title "<surface>" --json
   ```
@@ -477,7 +477,7 @@ fills them in (that happens later, in `/test-improve` Phase 5 or whatever
 follow-up work the operator does after a standalone run). Run the gate:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_gate.py --dir <step-definitions-dir>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_gate.py" --dir <step-definitions-dir>
 ```
 
 - **Pending stubs remain → print one consolidated statement as the FIRST
@@ -533,7 +533,7 @@ whenever `.feature` files exist, independent of whether `bdd-runner` mode
 wired a runner:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_failure_path_gate.py --dir <feature-files-dir>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_failure_path_gate.py" --dir <feature-files-dir>
 ```
 
 Print the gate's result as its own report section, never folded into the
@@ -554,7 +554,7 @@ immediately above — not `bdd-runner`-only, since the collision this checks
 for exists whenever `.feature` files exist:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_cross_feature_duplicate_titles_gate.py --dir <feature-files-dir>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_cross_feature_duplicate_titles_gate.py" --dir <feature-files-dir>
 ```
 
 Print the gate's result as its own report section, never folded into the
@@ -577,7 +577,7 @@ binding mode, since the mandatory in-depth analysis (Step 2) happens before
 mode-specific output does:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py --file <inventory-path>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py" --file <inventory-path>
 ```
 
 Print the gate's result as its own report section: `OK: all 8 analysis

--- a/plugins/dev-team/skills/harness-audit/SKILL.md
+++ b/plugins/dev-team/skills/harness-audit/SKILL.md
@@ -326,7 +326,7 @@ computation):
 
 ```bash
 changelog=".claude/metrics/config-changelog.jsonl"; [ -f "$changelog" ] || changelog="metrics/config-changelog.jsonl"
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/harness-audit/scripts/lesson_validate.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/harness-audit/scripts/lesson_validate.py" \
   --changelog "$changelog" \
   --digest metrics/session-digest.jsonl \
   --apply -o memory/lesson-validation.json
@@ -384,7 +384,7 @@ Review the current pipeline for components that may be unnecessary overhead:
 
    ```bash
    log=".claude/metrics/phase-markers.jsonl"; [ -f "$log" ] || log="metrics/phase-markers.jsonl"
-   [ -f "$log" ] && python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py phase-report --log "$log" --json
+   [ -f "$log" ] && python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/cost_meter.py" phase-report --log "$log" --json
    ```
 
    A phase with a high `resident_to_spent_ratio` spent proportionally little fresh generation while carrying a large resident context — cite it in § Orchestration Simplification Opportunities as a compaction/scoping candidate. This is a session-scoped proxy (resident is sampled at the `/handoff` boundary — see `skills/cost-report/SKILL.md` § Context pollution), not exact per-phase accounting.

--- a/plugins/dev-team/skills/harness-e2e-check/SKILL.md
+++ b/plugins/dev-team/skills/harness-e2e-check/SKILL.md
@@ -73,7 +73,7 @@ check, and the citation-lint suite. All clean.
 ### Item 3 — `/build` end-to-end smoke test
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/harness-e2e-check/scripts/make_toy_repo.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/harness-e2e-check/scripts/make_toy_repo.py" \
   --target <scratch>/toy-repo --date "$(date +%F)"
 ```
 
@@ -111,9 +111,9 @@ flipped (which would mean someone fixed it without updating the watchlist).
 ### Item 5 — `feedback-learning` + `harness-audit` combined run
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/harness-e2e-check/scripts/make_lesson_fixtures.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/harness-e2e-check/scripts/make_lesson_fixtures.py" \
   --target <scratch>/lesson-fixture --mode validated
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/harness-audit/scripts/lesson_validate.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/harness-audit/scripts/lesson_validate.py" \
   --changelog <scratch>/lesson-fixture/metrics/config-changelog.jsonl \
   --digest <scratch>/lesson-fixture/metrics/session-digest.jsonl \
   --apply -o <scratch>/lesson-fixture/memory/lesson-validation.json

--- a/plugins/dev-team/skills/issues-from-plan/SKILL.md
+++ b/plugins/dev-team/skills/issues-from-plan/SKILL.md
@@ -40,7 +40,7 @@ If no plan is found, ask the user to point you to one.
 Read the plan and identify each **slice** (`### Slice <id>:`), its acceptance criteria, and the shared architectural decisions. Derive the dependency links from the **DAG, not file order** — do not hand-infer them:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/issue_deps.py <plan-file>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/issue_deps.py" <plan-file>
 ```
 
 This returns `{ "<slice>": ["<dep slice>", ...] }` — each slice's direct predecessors. A slice listed earlier in the file carries **no** dependency on a later one unless the DAG says so.

--- a/plugins/dev-team/skills/long-eval/SKILL.md
+++ b/plugins/dev-team/skills/long-eval/SKILL.md
@@ -81,7 +81,7 @@ is **never persisted**, so `cells()` reconstructs it each launch.
 2. **Launch it durably** (backgrounded, from the repo root):
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/skills/long-eval/run_eval.py ensure-alive \
+   python3 "${CLAUDE_PLUGIN_ROOT}/skills/long-eval/run_eval.py" ensure-alive \
      --module <path-to-your-module.py> \
      --out .claude/evals/<slug>
    ```
@@ -96,7 +96,7 @@ is **never persisted**, so `cells()` reconstructs it each launch.
    progress with `status` (add `--json` for a machine-readable line):
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/skills/long-eval/run_eval.py status \
+   python3 "${CLAUDE_PLUGIN_ROOT}/skills/long-eval/run_eval.py" status \
      --out .claude/evals/<slug>
    ```
 

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -79,7 +79,7 @@ The v2 shim is the only path that gives the mutant-kill **loop** per-test covera
 - **coverage impact** — `neutral` (excluding the test from the shim changes no coverage — e.g. `Explicit=true` tests are skipped by default, **provided the run does not enable explicit tests** via `-explicit` / `xunit.runner.json` `explicit=on`) vs `bearing` (the test runs and covers code, so excluding it inflates the loop's survivor set and makes it generate redundant tests).
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/xunit_v3_feature_detector.py <test-project>/**/*.cs --json
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/xunit_v3_feature_detector.py" <test-project>/**/*.cs --json
 ```
 
 **Human gate — always ask, never auto-drop.** Present the full classified list every run, even when every hit is coverage-neutral. For each test the operator chooses whether to exclude it from the shim for the duration of the loop; nothing is deactivated silently. Coverage-bearing tests are flagged with the lines that go dark if excluded. The detector's `summary.recommendation` is **advisory** sizing only (few + neutral → shim path is reasonable; many or coverage-bearing → prefer skipping the loop for a single-pass `coverage-analysis: off` advisory) — the human always decides.
@@ -384,7 +384,7 @@ around them.
 ### Invocation
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py" \
   --slices-config mutation-slices.json \
   --slice <name>       # a single configured slice by name
   --slice all          # every configured slice, resuming past terminal ones

--- a/plugins/dev-team/skills/plan/SKILL.md
+++ b/plugins/dev-team/skills/plan/SKILL.md
@@ -92,7 +92,7 @@ Create `plans/` if it doesn't exist. When writing the plan file, populate the `#
 Then derive the waves — never hand-author them:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan_waves.py <plan-file>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plan_waves.py" <plan-file>
 ```
 
 Render the `## Parallelization` Mermaid DAG + wave table and the wave-grouped
@@ -168,7 +168,7 @@ directory, run the export **from the repo root** (destinations resolve against
 the invocation cwd):
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan_gherkin_export.py <plan-file>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plan_gherkin_export.py" <plan-file>
 ```
 
 Show its summary (destination, files written, overwritten, stale removed) to
@@ -183,7 +183,7 @@ script no-ops with a note).
 After approval, classify the origin remote — **only** offer issue creation on an actual GitHub host:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/git_origin_host.py
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/git_origin_host.py"
 ```
 
 - **`github`** → prompt **once**, showing the count: *"Open 1 parent issue and N linked slice issues from this plan? [y/N]"* (N = number of slices). The default is **No**. Invoke `/issues-from-plan` **only on explicit `y`**; on No (or anything else), create nothing and continue.

--- a/plugins/dev-team/skills/plan/references/gherkin-persistence.md
+++ b/plugins/dev-team/skills/plan/references/gherkin-persistence.md
@@ -12,7 +12,7 @@ after approval (step 6 of `SKILL.md`).
 2. **Detect the target project's BDD convention** — from the repo root, run:
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_bdd_convention.py
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/detect_bdd_convention.py"
    ```
 
    Precedence is conservative — feature-files > manifest > none: existing

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -44,7 +44,7 @@ Verify:
 If a plan file is present (check `plans/` for the most recently modified approved or implemented plan), run the plan completion gate:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py --pre-pr --plan <plan-file>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py" --pre-pr --plan <plan-file>
 ```
 
 A non-zero exit means incomplete steps remain; stop and surface the findings — do not open the PR until all steps are `[x]`.
@@ -137,7 +137,7 @@ is deferred to #124", "see #123 for the rest of this work" — never
 Before calling `gh pr create`, lint the drafted body for accidental matches:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py --body-file <body-file>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py" --body-file <body-file>
 ```
 
 This is advisory only (always exits 0). If it prints warnings, rephrase the

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -173,7 +173,7 @@ pipx install, never `npm install -g`.
   hand:
 
   ```bash
-  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py"
   ```
 
   It installs a pinned PMD distribution into the repo-local, gitignored

--- a/plugins/dev-team/skills/quality-targets-converge/SKILL.md
+++ b/plugins/dev-team/skills/quality-targets-converge/SKILL.md
@@ -201,7 +201,7 @@ there is a standing signal on whether the derived scenarios track real
 coverage/mutation movement (issue #1296):
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_effectiveness_rollup.py \
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_effectiveness_rollup.py" \
   --gherkin-md .claude/memory/<workflow>/<slug>/gherkin.md \
   --bindings-json .claude/memory/<workflow>/<slug>/gherkin-bindings.json \
   --baseline-coverage .dev-team-reports/<workflow>/<slug>/data/baseline-coverage.json \

--- a/plugins/dev-team/skills/run-report/SKILL.md
+++ b/plugins/dev-team/skills/run-report/SKILL.md
@@ -35,7 +35,7 @@ limitations below.
    `boundary-events.jsonl` and `workflow-states.jsonl`:
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/run_report.py report --session <id>
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/run_report.py" report --session <id>
    ```
 
 2. **Present a readable summary, not raw JSON.** Render the JSON the library

--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -113,14 +113,14 @@ conflated with every other machine's sessions.
 repository** (the cross-machine "database", Delta D) is configured:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh --check
+bash "${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh" --check
 ```
 
 - **Exit 0** → a repo is configured. Run the sync to push this machine's digest
   and pull the others, then continue:
 
   ```bash
-  bash ${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh
+  bash "${CLAUDE_PLUGIN_ROOT}/../../scripts/telemetry-sync.sh"
   ```
 
 - **Exit 3** → no repo configured. **Ask the user** for the telemetry repo
@@ -140,8 +140,8 @@ Never invent a URL or enable anything without the user's explicit location.
 Run the extractor to produce the local digest:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
-  --plugin-root ${CLAUDE_PLUGIN_ROOT} -o memory/session-digest.json
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  --plugin-root "${CLAUDE_PLUGIN_ROOT}" -o memory/session-digest.json
 ```
 
 (Pass `--transcript <file>` or `--cwd <path>` through from `$ARGUMENTS`.) If the
@@ -160,8 +160,8 @@ doesn't weigh into current-version suggestions:
 
 ```bash
 CLONE="${DEV_TEAM_TELEMETRY_CLONE:-$HOME/.claude/.dev-team/agent-telemetry}"
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
-  --plugin-root ${CLAUDE_PLUGIN_ROOT} --rollup "$CLONE/digests" \
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  --plugin-root "${CLAUDE_PLUGIN_ROOT}" --rollup "$CLONE/digests" \
   --version-scope current-and-previous \
   -o memory/telemetry-rollup.json
 ```
@@ -175,8 +175,8 @@ Then compute the **frequency → lever escalation** (Delta C, #179) — recurren
 decides how strong a response each friction earns — with the same version scope:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
-  --plugin-root ${CLAUDE_PLUGIN_ROOT} --escalate "$CLONE/digests" \
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  --plugin-root "${CLAUDE_PLUGIN_ROOT}" --escalate "$CLONE/digests" \
   --version-scope current-and-previous \
   -o memory/telemetry-escalation.json
 ```
@@ -192,8 +192,8 @@ the pre-commit review gate correlate with more rework across sessions? — again
 version-scoped:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
-  --plugin-root ${CLAUDE_PLUGIN_ROOT} --correlate "$CLONE/digests" \
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  --plugin-root "${CLAUDE_PLUGIN_ROOT}" --correlate "$CLONE/digests" \
   --version-scope current-and-previous \
   -o memory/gate-correlation.json
 ```
@@ -223,7 +223,7 @@ where it never runs.
 1. Flag the worst sessions (deterministic, zero model tokens):
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_rawlog.py \
+   python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_rawlog.py" \
      --flag "$CLONE/digests" --top 5 -o memory/worst-sessions.json
    ```
 
@@ -245,7 +245,7 @@ where it never runs.
    not report) any finding with violations:
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_rawlog.py \
+   python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_rawlog.py" \
      --validate memory/tier2-findings.json
    ```
 
@@ -276,8 +276,8 @@ Append one metrics-only summary record to the trend stream so `/harness-audit`
 can consume real-session data over time:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py \
-  --plugin-root ${CLAUDE_PLUGIN_ROOT} --append metrics/session-digest.jsonl >/dev/null
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  --plugin-root "${CLAUDE_PLUGIN_ROOT}" --append metrics/session-digest.jsonl >/dev/null
 ```
 
 The appended record holds aggregate counts only — no file names, prompts, or

--- a/plugins/dev-team/skills/ship/SKILL.md
+++ b/plugins/dev-team/skills/ship/SKILL.md
@@ -56,7 +56,7 @@ At the start of each phase below (2-6), append one state-transition event so
 even when a phase resumes/monitors rather than running fresh:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/workflow_state.py record \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/workflow_state.py" record \
   --workflow ship --prior-state <PRIOR> --new-state <NEW> --session "$CLAUDE_SESSION_ID"
 ```
 
@@ -73,14 +73,14 @@ decision entry and confirm the gate allows advancement — a hard block,
 distinct from the advisory, plan-step-keyed `progress-guardian` gate:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py record \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" record \
   --round-id "<issue-identifier>" \
   --attempted "<short note: which phase just ran>" \
   --outcome "<short note: passed|failed|blocked>" \
   --next-action "<short note: next phase or stop>" \
   --session "$CLAUDE_SESSION_ID"
 
-python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py check \
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" check \
   --round-id "<issue-identifier>" \
   --session "$CLAUDE_SESSION_ID"
 ```

--- a/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/language-setup.md
@@ -182,7 +182,7 @@ Registered by #810.
 From your project root (requires a JDK/JRE — `java` on PATH):
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py"
 ```
 
 Installs a pinned PMD distribution into the repo-local **`.pmd/`**

--- a/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
+++ b/plugins/dev-team/skills/stryker-xunit-v2-shim/SKILL.md
@@ -74,7 +74,7 @@ xunit.v2 stack, setting `RootNamespace`/`AssemblyName`, adding the linked-`Compi
 glob and the product `ProjectReference`) plus a `stryker-config.json`:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/stryker-xunit-v2-shim/scripts/generate_shim.py tests/<TestProject>/<TestProject>.csproj \
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/stryker-xunit-v2-shim/scripts/generate_shim.py" tests/<TestProject>/<TestProject>.csproj \
   --mutate-exclude '**/gRPC/**/*.cs' --mutate-exclude '**/Caching/**/*.cs'
 ```
 

--- a/plugins/dev-team/skills/telemetry/SKILL.md
+++ b/plugins/dev-team/skills/telemetry/SKILL.md
@@ -63,7 +63,7 @@ network egress here, that work belongs in `/session-review` instead.
 3. **report** — summarize the event log:
 
    ```bash
-   python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/telemetry_report.py \
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/telemetry_report.py" \
      --log "$HOME/.claude/metrics/telemetry.jsonl"
    ```
 

--- a/plugins/dev-team/skills/test-improve/SKILL.md
+++ b/plugins/dev-team/skills/test-improve/SKILL.md
@@ -239,7 +239,7 @@ explicitly.
 calling the helper — do **not** infer it in prose:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/test_improve_resume.py <repo-path>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/test_improve_resume.py" <repo-path>
 ```
 
 The helper resolves the slug from `<repo-path>` (its last path segment), scans
@@ -571,7 +571,7 @@ After **all Phase-5 Stories have closed**, and only when Phase 0 selected
 reported closed — a hard gate, not prose:
 
 ```
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_gate.py --dir <step-definitions-dir>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_stub_gate.py" --dir <step-definitions-dir>
 ```
 
 (`<step-definitions-dir>` is wherever test-improve's own Phase 3 —

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,7 +15,8 @@ addopts = --import-mode=importlib
 # tests/skills -> skill_doc_helpers, tests/agents -> _plugin_dirs, tests/scripts ->
 # _mutation_test_helpers (shared SCRIPTS_DIR/FORBIDDEN_LITERALS constants,
 # issue #1554), repo root -> _repo_root (shared REPO_ROOT constant, replacing per-file
-# Path(__file__).resolve().parents[N] computation across the test corpus).
+# Path(__file__).resolve().parents[N] computation across the test corpus) and
+# _content_guard_scan (shared plugin-markdown scan surface, issues #1655/#1656).
 pythonpath =
     .
     tests/bats

--- a/tests/repo/test_bare_invocation_wide_scan.py
+++ b/tests/repo/test_bare_invocation_wide_scan.py
@@ -1,0 +1,463 @@
+r"""Widens `test_agent_implemented_by_resolves.py`'s bare-invocation guard
+past `SKILL.md` files and the `python3 scripts/....py` shape it alone
+matches (#1655).
+
+That guard only globs `plugins/dev-team/skills/*/SKILL.md` and only matches
+`python3?\\s+scripts/....py`. Three real gaps followed from those two
+narrownesses, found during #1637's own triage:
+
+1. **Shipped maintainer docs** under `plugins/dev-team/docs/`:
+   `eval-maintenance.md`, `eval-running-guide.md`, `telemetry-ci-access.md`
+   all carry bare `python3`/`bash` invocations — dev-team-maintainer-only
+   docs, never scanned at all.
+2. **Skills' own `references/*.md` files**, not just the top-level
+   `SKILL.md` — the glob's `*/SKILL.md` shape doesn't reach a directory
+   below the skill root.
+3. **Other invocation forms** — `bash scripts/x.sh`, `./scripts/x.py`, and
+   line-continuation (`python3 \\` + the path on the next line) all evade
+   `_BARE_INVOCATION`'s single-line, `python3?`-only pattern.
+
+This file adds `plugins/dev-team/docs/`, `plugins/dev-team/knowledge/`,
+`plugins/dev-team/agents/`, and every skill's `**/*.md` (covering
+`references/`) to the scanned set — the same surface
+`test_claude_plugin_root_quoting.py` scans, via the shared
+`_content_guard_scan.scanned_markdown_files` helper — and recognizes
+`bash`/`sh`/`./` prefixes plus a genuine `\`-continued line pair —
+deliberately NOT a blob-wide regex allowing an unconditional multi-line
+gap, which a first draft of this file tried and which matched a fenced code
+block's own opening ` ```bash ` line against an unrelated invocation two
+lines later. Continuation is only recognized when the FIRST line itself
+ends in a real trailing backslash.
+
+## Relationship to the original guard
+
+This file does not re-implement `INTENTIONAL_BARE_INVOCATION`/
+`INTENTIONAL_WORKTREE_RELATIVE` — it imports and reuses them, so a
+`SKILL.md` pair already classified there is not double-tracked here under a
+second, parallel registry that could drift out of sync. Every genuinely NEW
+exemption this wider scan needs — docs-only maintainer references, and one
+instance of a materially different kind (below) — is tracked in
+`INTENTIONAL_WIDE_SCAN_INVOCATIONS`, keyed by `(relative_path,
+invocation_line, category)`. Like its two siblings, every entry is a
+justified exemption, never a defect awaiting a fix — nothing in it is
+expected to reach zero — but per this repo's own "mechanically, not by
+comment alone" discipline (docs/adr/0032), each category carries its own
+premise test (below) re-checking the reason the exemption holds, not just
+that the line still reproduces.
+
+## A fourth path-resolution case
+
+ADR 0032 § "4. Shipped for copy-out" — tracked here under the
+`_COPIED_OUT_BY_OPERATOR` category, premise-checked by
+`test_copied_out_exemption_still_instructs_operator_to_copy`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+from _content_guard_scan import PLUGIN_MARKDOWN_SCAN_DIRS, scanned_markdown_files
+from _repo_root import REPO_ROOT
+
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "dev-team"
+
+
+def _load_sibling_module(name: str):
+    """Load a sibling test module by file path, not bare-name import.
+
+    This repo's `pytest.ini` sets `--import-mode=importlib` specifically so
+    same-named test modules across two trees never collide at collection
+    time — deliberately, per that config's own comment, at the cost of never
+    putting a test file's own directory on `sys.path`. A bare
+    `from test_agent_implemented_by_resolves import ...` is therefore
+    unresolvable by design, not an oversight to work around; loading by path
+    is the pattern this repo's own tests already use for the same reason
+    (e.g. `test_import_probe_shipped.py`, `test_codebase_recon.py`).
+    """
+    path = Path(__file__).resolve().parent / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not load sibling module {name}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_original_guard = _load_sibling_module("test_agent_implemented_by_resolves")
+INTENTIONAL_BARE_INVOCATION = _original_guard.INTENTIONAL_BARE_INVOCATION
+INTENTIONAL_WORKTREE_RELATIVE = _original_guard.INTENTIONAL_WORKTREE_RELATIVE
+
+SCANNED_FILES = scanned_markdown_files(PLUGIN_ROOT, PLUGIN_MARKDOWN_SCAN_DIRS)
+assert len(SCANNED_FILES) > 100, (
+    f"only {len(SCANNED_FILES)} files found under {PLUGIN_MARKDOWN_SCAN_DIRS} — "
+    "a typo'd or missing scan dir would silently disable this guard entirely"
+)
+
+#: A prefix token directly followed by a bare `scripts/....py`/`.sh` target on
+#: the SAME line. `(?<![\w/$}{.])` stops a match starting mid-path (e.g. the
+#: "bash" inside "```bash" alone, with no following scripts/ on that same
+#: line, never matches this — it only fires when scripts/... genuinely
+#: follows the prefix directly). `./` needs no separating whitespace
+#: (`./scripts/x.py`, not `./ scripts/x.py`); the other three prefixes do.
+_SAME_LINE_INVOCATION_RE = re.compile(
+    r"(?<![\w/$}{.])(?:(?:python3?|bash|sh)\s+|\./)(scripts/[\w./-]+\.(?:py|sh))"
+)
+#: A line that both names one of the prefixes and ends in a real shell
+#: line-continuation backslash — the opener half of a two-line invocation.
+_CONTINUATION_OPENER_RE = re.compile(r"(?<![\w/$}{.])(?:python3?|bash|sh)\b.*\\\s*$")
+#: The continued line must itself START with the bare script path (allowing
+#: leading whitespace) — a `\`-ended line followed by unrelated prose is not
+#: a continuation this pattern should absorb.
+_CONTINUATION_TARGET_RE = re.compile(r"^\s*(scripts/[\w./-]+\.(?:py|sh))\b")
+
+
+def _same_line_matches(line: str):
+    """[(line_text, subpath), ...] for every same-line bare invocation on
+    `line` — a line may carry more than one invocation (e.g. two script
+    paths in a comma-separated `allowed-tools`-style list), and each is
+    reported independently rather than the line being treated as a single
+    unit. `subpath` has its `scripts/` prefix stripped, matching
+    `INTENTIONAL_BARE_INVOCATION`/`INTENTIONAL_WORKTREE_RELATIVE`'s own
+    keying convention (see the original guard's own docstring)."""
+    return [
+        (line.strip(), match.group(1)[len("scripts/") :])
+        for match in _SAME_LINE_INVOCATION_RE.finditer(line)
+    ]
+
+
+def _continuation_match(line: str, next_line: str):
+    """`(joined_text, subpath)` if `line` ends in a genuine continuation
+    backslash and `next_line` itself starts with a bare script path;
+    `None` otherwise (no continuation, or `next_line` already qualifies the
+    path with `${CLAUDE_PLUGIN_ROOT}`/`$CLAUDE_PLUGIN_ROOT`)."""
+    if not _CONTINUATION_OPENER_RE.search(line):
+        return None
+    target = _CONTINUATION_TARGET_RE.match(next_line)
+    if not target or "CLAUDE_PLUGIN_ROOT" in next_line:
+        return None
+    return (f"{line.strip()} \\ {next_line.strip()}", target.group(1)[len("scripts/") :])
+
+
+def _wide_scan_matches(path):
+    """[(lineno, line_text, subpath), ...] for every bare invocation in
+    `path`, same-line or genuinely `\\`-continued.
+
+    Each line is checked independently for same-line matches (there may be
+    several) and, separately, for a continuation into the next line — a
+    qualified invocation (`${CLAUDE_PLUGIN_ROOT}`/`$CLAUDE_PLUGIN_ROOT`)
+    elsewhere on the SAME line never suppresses a genuine bare invocation
+    also present on it, since `_SAME_LINE_INVOCATION_RE` only matches where
+    `scripts/...` genuinely follows a prefix directly — a qualified
+    invocation's `${CLAUDE_PLUGIN_ROOT}/` prefix never satisfies that.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    hits = []
+    for i, line in enumerate(lines):
+        for line_text, subpath in _same_line_matches(line):
+            hits.append((i + 1, line_text, subpath))
+        if i + 1 < len(lines):
+            continuation = _continuation_match(line, lines[i + 1])
+            if continuation is not None:
+                hits.append((i + 1, continuation[0], continuation[1]))
+    return hits
+
+
+#: Categories for `INTENTIONAL_WIDE_SCAN_INVOCATIONS`, each with its own
+#: premise test below (docs/adr/0032's "mechanically, not by comment alone").
+_MONOREPO_ONLY = "monorepo-only"
+_BRANCH_LOCAL = "branch-local"
+_COPIED_OUT_BY_OPERATOR = "copied-out-by-operator"
+
+#: (relative-to-plugin-root path, exact invocation line as `_wide_scan_matches`
+#: reports it, category) triples exempted from the wide scan, beyond whatever
+#: `INTENTIONAL_BARE_INVOCATION`/`INTENTIONAL_WORKTREE_RELATIVE` already
+#: covers for `SKILL.md` files. Justified exemptions, not tracked defects —
+#: like the two sibling registries, nothing here is expected to shrink to
+#: zero on its own; an entry is removed only when the invocation itself is
+#: removed or requalified (checked by `test_no_stale_wide_scan_exemptions`),
+#: and each category's premise is re-checked below rather than trusted from
+#: the comment alone.
+INTENTIONAL_WIDE_SCAN_INVOCATIONS = {
+    # _MONOREPO_ONLY — these scripts only exist at, and only make sense run
+    # from, this repo's own root; none of them ship under
+    # plugins/dev-team/scripts/, matching agent-eval's own established
+    # exemption for the same scripts. Premise checked by
+    # test_monorepo_only_exemptions_scripts_do_not_ship.
+    (
+        "docs/eval-maintenance.md",
+        "3. `python3 scripts/eval_grade.py --check-corpus` (every expectation must be",
+        _MONOREPO_ONLY,
+    ),
+    (
+        "docs/eval-running-guide.md",
+        "bash scripts/run-full-eval.sh [TRIALS]   # default TRIALS=1; default mode = full sweep",
+        _MONOREPO_ONLY,
+    ),
+    ("docs/eval-running-guide.md", "bash scripts/run-full-eval.sh", _MONOREPO_ONLY),
+    (
+        "docs/eval-running-guide.md",
+        "bash scripts/run-full-eval.sh 5 --agent security-review   # just this agent, 5 trials",
+        _MONOREPO_ONLY,
+    ),
+    (
+        "docs/eval-running-guide.md",
+        "bash scripts/run-full-eval.sh 5 --agent arch-review       # next time, another agent",
+        _MONOREPO_ONLY,
+    ),
+    (
+        "docs/eval-running-guide.md",
+        "bash scripts/eval-changed.sh BASE HEAD   # evals only the agents/skills the diff touched",
+        _MONOREPO_ONLY,
+    ),
+    # These two are same-line matches whose trailing backslash continues into
+    # more CLI flags, not a second script-path line — the scanner records
+    # only the opener line itself, not a joined pair.
+    (
+        "docs/eval-running-guide.md",
+        "python3 scripts/eval_variance.py --trials-dir <dir-of-trial-actuals> \\",
+        _MONOREPO_ONLY,
+    ),
+    (
+        "docs/telemetry-ci-access.md",
+        "python3 scripts/session_extract.py --cost-log /tmp/telemetry/digests \\",
+        _MONOREPO_ONLY,
+    ),
+    (
+        "docs/telemetry-ci-access.md",
+        "run: bash scripts/ci-local.sh --only=chk_cost_regression",
+        _MONOREPO_ONLY,
+    ),
+    # _BRANCH_LOCAL — setup/SKILL.md's dev-setup.sh call is reached ONLY
+    # inside the Step 2 `in-repo` branch: it fires exclusively when /setup
+    # has already detected it is running inside this monorepo's own
+    # checkout, so a bare, repo-root-relative path is the correct (and only
+    # working) form. Premise checked by
+    # test_branch_local_exemption_is_still_gated_behind_in_repo_detection.
+    ("skills/setup/SKILL.md", "bash scripts/dev-setup.sh", _BRANCH_LOCAL),
+    # _COPIED_OUT_BY_OPERATOR — a fourth, distinct case (see module
+    # docstring): documentation instructing the OPERATOR to copy this file
+    # into THEIR OWN project before running it there — the bare path is
+    # correct because the file deliberately no longer lives in the plugin
+    # once copied. Premise checked by
+    # test_copied_out_exemption_still_instructs_operator_to_copy.
+    (
+        "skills/mutation-testing/references/languages/csharp-stryker-net.md",
+        "python3 scripts/csharp_stryker_net_wrapper.py \\",
+        _COPIED_OUT_BY_OPERATOR,
+    ),
+}
+
+
+def _is_known_skill_pair_exemption(rel_path: str, subpath: str) -> bool:
+    """True if `rel_path` is a `skills/<name>/SKILL.md` already classified by
+    the original guard's own registries — reused, not duplicated."""
+    match = re.fullmatch(r"skills/([^/]+)/SKILL\.md", rel_path)
+    if not match:
+        return False
+    skill_name = match.group(1)
+    return (skill_name, subpath) in INTENTIONAL_BARE_INVOCATION or (
+        skill_name,
+        subpath,
+    ) in INTENTIONAL_WORKTREE_RELATIVE
+
+
+def _wide_scan_exemption_lines(rel_path: str):
+    return {line for path, line, _category in INTENTIONAL_WIDE_SCAN_INVOCATIONS if path == rel_path}
+
+
+@pytest.mark.parametrize("path", SCANNED_FILES, ids=lambda p: p.relative_to(PLUGIN_ROOT).as_posix())
+def test_wide_scan_bare_invocations_are_all_exempted_or_absent(path):
+    rel = path.relative_to(PLUGIN_ROOT).as_posix()
+    exempt_lines = _wide_scan_exemption_lines(rel)
+    offenders = [
+        f"{lineno}: {line}"
+        for lineno, line, subpath in _wide_scan_matches(path)
+        if not _is_known_skill_pair_exemption(rel, subpath) and line not in exempt_lines
+    ]
+    assert not offenders, (
+        f"{rel}: invokes a plugin script by a bare relative path outside any "
+        "documented exemption; use ${{CLAUDE_PLUGIN_ROOT}}/scripts/… or add a "
+        "justified entry to INTENTIONAL_WIDE_SCAN_INVOCATIONS:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_stale_wide_scan_exemptions():
+    """Shrink-only: an exemption whose exact line no longer appears in its
+    file has been fixed (or the line changed) — remove it here rather than
+    let it become unchecked, permanent slack."""
+    still_present = set()
+    for path in SCANNED_FILES:
+        rel = path.relative_to(PLUGIN_ROOT).as_posix()
+        for _lineno, line, _subpath in _wide_scan_matches(path):
+            for entry in INTENTIONAL_WIDE_SCAN_INVOCATIONS:
+                if entry[0] == rel and entry[1] == line:
+                    still_present.add(entry)
+    stale = INTENTIONAL_WIDE_SCAN_INVOCATIONS - still_present
+    assert not stale, (
+        "INTENTIONAL_WIDE_SCAN_INVOCATIONS entries no longer reproduce — remove them:\n"
+        + "\n".join(f"  {rel!r}: {line!r} ({category})" for rel, line, category in sorted(stale))
+    )
+
+
+def test_wide_scan_exemption_paths_exist_on_disk():
+    for rel, _line, _category in INTENTIONAL_WIDE_SCAN_INVOCATIONS:
+        assert (PLUGIN_ROOT / rel).is_file(), f"exempted path missing: {rel}"
+
+
+def _exempted_subpath(rel_path: str, line: str) -> str | None:
+    """The `subpath` `_wide_scan_matches` computed for this exact
+    `(rel_path, line)` pair — re-derived rather than hand-transcribed a
+    second time, so a premise check can never disagree with the scanner
+    about which script an entry actually names."""
+    for _lineno, matched_line, subpath in _wide_scan_matches(PLUGIN_ROOT / rel_path):
+        if matched_line == line:
+            return subpath
+    return None
+
+
+def test_monorepo_only_exemptions_scripts_do_not_ship():
+    """Premise for `_MONOREPO_ONLY` entries: the named script must not exist
+    under `plugins/dev-team/scripts/` — the moment it does, it ships, and a
+    bare invocation of it becomes a real #1637-shaped defect rather than a
+    correct monorepo-only reference."""
+    for rel_path, line, category in INTENTIONAL_WIDE_SCAN_INVOCATIONS:
+        if category != _MONOREPO_ONLY:
+            continue
+        subpath = _exempted_subpath(rel_path, line)
+        assert subpath is not None, f"{rel_path}: exemption line no longer matches any invocation: {line!r}"
+        assert not (PLUGIN_ROOT / "scripts" / subpath).is_file(), (
+            f"{subpath} now ships under plugins/dev-team/scripts/ — the monorepo-only "
+            f"premise behind {rel_path}'s exemption no longer holds; qualify the "
+            "invocation with ${CLAUDE_PLUGIN_ROOT} instead of keeping this exemption."
+        )
+
+
+def test_branch_local_exemption_is_still_gated_behind_in_repo_detection():
+    """Premise for `_BRANCH_LOCAL` entries: the exempted invocation must
+    still sit after the file's own in-repo-detection branch, not run
+    unconditionally."""
+    for rel_path, line, category in INTENTIONAL_WIDE_SCAN_INVOCATIONS:
+        if category != _BRANCH_LOCAL:
+            continue
+        lines = (PLUGIN_ROOT / rel_path).read_text(encoding="utf-8").splitlines()
+        matching = [i for i, text in enumerate(lines) if line in text]
+        assert matching, f"{rel_path}: exemption line no longer found: {line!r}"
+        preceding = "\n".join(lines[: matching[0]])
+        assert "in-repo" in preceding, (
+            f"{rel_path}: the branch-local exemption for {line!r} no longer sits after an "
+            "'in-repo' detection branch — the premise that this invocation only ever runs "
+            "inside this monorepo's own checkout no longer holds."
+        )
+
+
+def test_copied_out_exemption_still_instructs_operator_to_copy():
+    """Premise for `_COPIED_OUT_BY_OPERATOR` entries: the doc must still
+    tell the operator to copy the script into their OWN project — the
+    premise that makes a bare path correct rather than merely unqualified."""
+    for rel_path, _line, category in INTENTIONAL_WIDE_SCAN_INVOCATIONS:
+        if category != _COPIED_OUT_BY_OPERATOR:
+            continue
+        text = (PLUGIN_ROOT / rel_path).read_text(encoding="utf-8")
+        assert "your repo" in text or "your project" in text, (
+            f"{rel_path} no longer instructs the operator to copy the script into their own "
+            "project — the premise behind its bare-invocation exemption no longer holds."
+        )
+
+
+class TestGenuineTwoLineContinuation:
+    """No file in the shipped tree currently exercises the shape #1655 named
+    as a gap — `python3 \\` alone on one line, the bare `scripts/...` path
+    starting the NEXT line (as opposed to every real instance found here,
+    where the interpreter and the path share one line and only trailing
+    FLAGS continue). Exercised synthetically so this branch of
+    `_wide_scan_matches` isn't untested, unreachable-looking code."""
+
+    def test_a_path_starting_the_continued_line_is_caught(self, tmp_path):
+        fixture = tmp_path / "fixture.md"
+        fixture.write_text(
+            "```bash\n"
+            "python3 \\\n"
+            "  scripts/some_future_script.py --flag value\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        hits = _wide_scan_matches(fixture)
+        assert len(hits) == 1
+        lineno, line, subpath = hits[0]
+        assert lineno == 2
+        assert subpath == "some_future_script.py"
+        assert "scripts/some_future_script.py" in line
+
+    def test_a_trailing_backslash_followed_by_prose_is_not_a_false_positive(self, tmp_path):
+        """A `\\`-ended line whose next line is NOT a bare script path (just
+        continuation prose, or a CLI flag) must not be absorbed as if it
+        were one — matching every real instance actually found in this
+        repo's own docs, where the interpreter+path already share one line
+        and only trailing flags continue."""
+        fixture = tmp_path / "fixture.md"
+        fixture.write_text(
+            "```bash\n"
+            "python3 scripts/real_script.py --flag \\\n"
+            "  --another-flag value\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        hits = _wide_scan_matches(fixture)
+        assert len(hits) == 1
+        lineno, _line, subpath = hits[0]
+        assert lineno == 2  # the same-line match, not a continuation join
+        assert subpath == "real_script.py"
+
+    def test_continuation_opener_with_non_script_next_line_is_not_absorbed(self, tmp_path):
+        """The genuine negative branch of the continuation check: an opener
+        line with NO same-line invocation (so `_same_line_matches` finds
+        nothing and the scanner actually reaches the continuation check),
+        followed by a next line that is prose rather than a bare script
+        path. Must produce zero hits."""
+        fixture = tmp_path / "fixture.md"
+        fixture.write_text(
+            "```bash\n"
+            "bash \\\n"
+            "  some prose that is not a script path\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        assert _wide_scan_matches(fixture) == []
+
+
+class TestSameLineDotSlashInvocation:
+    """`./scripts/x.py` (no separating whitespace between the prefix and the
+    path) is one of the three invocation forms #1655's own docstring names
+    as a gap this file closes — pinned so a regex refactor can't silently
+    make it unreachable again."""
+
+    def test_dot_slash_prefix_with_no_space_is_caught(self, tmp_path):
+        fixture = tmp_path / "fixture.md"
+        fixture.write_text("```bash\n./scripts/some_future_script.py --flag\n```\n", encoding="utf-8")
+        hits = _wide_scan_matches(fixture)
+        assert len(hits) == 1
+        assert hits[0][2] == "some_future_script.py"
+
+
+class TestSameLineMultipleInvocations:
+    """A qualified invocation elsewhere on the SAME line must never suppress
+    a genuine bare invocation also on it — the whole-line suppression an
+    earlier draft used (`if "CLAUDE_PLUGIN_ROOT" not in line`) hid exactly
+    this shape; see `plugins/dev-team/skills/agent-eval/SKILL.md`'s own
+    comma-separated allowed-tools line for a live (already-exempted)
+    instance of it."""
+
+    def test_bare_invocation_sharing_a_line_with_a_qualified_one_is_still_caught(self, tmp_path):
+        fixture = tmp_path / "fixture.md"
+        fixture.write_text(
+            "```bash\n"
+            "python3 scripts/bare_one.py *, python3 ${CLAUDE_PLUGIN_ROOT}/scripts/qualified_one.py *,\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        hits = _wide_scan_matches(fixture)
+        assert len(hits) == 1
+        assert hits[0][2] == "bare_one.py"

--- a/tests/repo/test_claude_plugin_root_quoting.py
+++ b/tests/repo/test_claude_plugin_root_quoting.py
@@ -1,0 +1,187 @@
+"""Content guard for #1656: every `${CLAUDE_PLUGIN_ROOT}` expansion inside a
+shell-flavored fenced code block must be quoted.
+
+An unquoted `${CLAUDE_PLUGIN_ROOT}/scripts/x.py` breaks under word-splitting
+the moment the plugin is installed under a path containing a space (the
+default macOS `~/Library/Application Support/...` cache tree is exactly such
+a path). #1656 swept every existing instance to `"${CLAUDE_PLUGIN_ROOT}/..."`
+across 28 files; this guard is the regression test that keeps a future
+SKILL.md/doc edit from reintroducing an unquoted one.
+
+Scope is deliberately narrow: only `bash`/`sh`/`shell`/untagged fenced code
+blocks are checked. A `${CLAUDE_PLUGIN_ROOT}` mention inside a `markdown`-
+tagged illustrative block (e.g. `skills/pr/SKILL.md`'s own HTML-comment
+example of what a rendered artifact looks like) or in prose outside any
+fence is not a shell invocation and quoting it would be meaningless.
+
+Fence tracking is per-line, matching this repo's own established lesson
+(see `test_bare_invocation_wide_scan.py`'s docstring) that a blob-wide regex
+can bridge a fence's own opening line with an unrelated line beyond it.
+
+**Residual gap (ADR 0033's Consequences):** `_UNQUOTED_EXPANSION_RE` checks
+for an OPENING quote only, not a balanced closing one — a malformed partial
+form like `"${CLAUDE_PLUGIN_ROOT}"/scripts/x.py` is not distinguished from
+the fully quoted form. Accepted: the uncaught shapes are either a visible
+shell syntax error or already word-split-safe.
+
+**Fences indented inside a list item are still fences.** A first draft of
+this guard anchored the fence regex at column 0 (`^```...`), which made every
+fence indented under a numbered/bulleted step — the majority shape in this
+repo's own SKILL.md files, e.g. `skills/cost-report/SKILL.md`'s numbered
+steps — invisible to the scanner: `in_fence` never flipped, so nothing
+inside those blocks was ever checked. Verified against the real tree before
+fixing (a gate that cannot fail is worse than no gate): several of the
+lines #1656's own sweep quoted sit inside exactly such indented fences.
+`_FENCE_RE` therefore allows arbitrary leading whitespace before the marker.
+
+**Both the braced and unbraced spellings are in scope.** This repo's own
+convention (ADR 0032) uses `${CLAUDE_PLUGIN_ROOT}` in most places but
+`$CLAUDE_PLUGIN_ROOT` (no braces) in a few — both word-split identically
+when unquoted, so `_UNQUOTED_EXPANSION_RE` matches either form.
+
+**A fence's own marker length matters.** `skills/plan/references/plan-template.md`
+wraps its whole example in a 4-backtick fence specifically so a real
+3-backtick fence can appear, unescaped, as literal template content inside
+it. Recognizing only exactly-3-backtick markers would mis-toggle on that
+inner content, opening/closing "fences" that are actually just template
+text. `_FENCE_RE` captures the marker's own backtick-run length, and a
+candidate closer only closes the currently-open fence when its run is at
+least as long as the opener's — shorter backtick runs nested inside a
+longer-fenced block are literal content, not real delimiters.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from _content_guard_scan import PLUGIN_MARKDOWN_SCAN_DIRS, scanned_markdown_files
+from _repo_root import REPO_ROOT
+
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "dev-team"
+_SHELL_LANGS = {"", "bash", "sh", "shell"}
+
+_FENCE_RE = re.compile(r"^\s*(`{3,})(\w*)\s*$")
+_UNQUOTED_EXPANSION_RE = re.compile(r'(?<!")\$\{?CLAUDE_PLUGIN_ROOT\}?\b')
+
+SCANNED_FILES = scanned_markdown_files(PLUGIN_ROOT, PLUGIN_MARKDOWN_SCAN_DIRS)
+assert len(SCANNED_FILES) > 100, (
+    f"only {len(SCANNED_FILES)} files found under {PLUGIN_MARKDOWN_SCAN_DIRS} — "
+    "a typo'd or missing scan dir would silently disable this guard entirely"
+)
+
+
+def _unquoted_expansions(text: str):
+    """[(lineno, line_text), ...] for every unquoted `${CLAUDE_PLUGIN_ROOT}`
+    found inside a bash/sh/shell/untagged fenced code block in `text`."""
+    lines = text.splitlines()
+    hits = []
+    in_fence = False
+    lang = None
+    opener_marker_len = 0
+    for lineno, line in enumerate(lines, start=1):
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            marker_len = len(fence_match.group(1))
+            if in_fence:
+                if marker_len >= opener_marker_len:
+                    in_fence = False
+                    lang = None
+                    opener_marker_len = 0
+                # A shorter run nested inside a longer-fenced block is
+                # literal content (e.g. a 3-backtick example inside a
+                # 4-backtick wrapper), not a real delimiter — fall through
+                # without toggling.
+            else:
+                in_fence = True
+                lang = fence_match.group(2).lower()
+                opener_marker_len = marker_len
+            continue
+        if in_fence and lang in _SHELL_LANGS and _UNQUOTED_EXPANSION_RE.search(line):
+            hits.append((lineno, line.strip()))
+    return hits
+
+
+@pytest.mark.parametrize("path", SCANNED_FILES, ids=lambda p: p.relative_to(PLUGIN_ROOT).as_posix())
+def test_claude_plugin_root_is_quoted_in_shell_fences(path):
+    rel = path.relative_to(PLUGIN_ROOT).as_posix()
+    offenders = _unquoted_expansions(path.read_text(encoding="utf-8"))
+    assert not offenders, (
+        f"{rel}: unquoted ${{CLAUDE_PLUGIN_ROOT}} inside a shell fenced code "
+        'block — quote it as "${CLAUDE_PLUGIN_ROOT}/..." so the path survives '
+        "word-splitting once installed under a space-containing path:\n  "
+        + "\n  ".join(f"{lineno}: {line}" for lineno, line in offenders)
+    )
+
+
+class TestFenceScopingBehavior:
+    """Synthetic fixtures proving the scanner flags unquoted expansions only
+    inside shell-flavored fences, and never inside a non-shell fence or bare
+    prose — mirroring the fence-boundary lesson from
+    `test_bare_invocation_wide_scan.py`."""
+
+    def test_unquoted_expansion_in_bash_fence_is_flagged(self):
+        text = "```bash\npython3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py\n```\n"
+        hits = _unquoted_expansions(text)
+        assert len(hits) == 1
+        assert hits[0][0] == 2
+
+    def test_quoted_expansion_in_bash_fence_is_not_flagged(self):
+        text = '```bash\npython3 "${CLAUDE_PLUGIN_ROOT}/scripts/x.py"\n```\n'
+        assert _unquoted_expansions(text) == []
+
+    def test_untagged_fence_is_still_scanned(self):
+        text = "```\npython3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py\n```\n"
+        hits = _unquoted_expansions(text)
+        assert len(hits) == 1
+
+    def test_non_shell_fence_is_not_scanned(self):
+        text = "```markdown\n<!-- Per ${CLAUDE_PLUGIN_ROOT}/knowledge/x.md -->\n```\n"
+        assert _unquoted_expansions(text) == []
+
+    def test_prose_outside_any_fence_is_not_scanned(self):
+        text = "See ${CLAUDE_PLUGIN_ROOT}/scripts/x.py for details.\n"
+        assert _unquoted_expansions(text) == []
+
+    def test_fence_indented_inside_a_list_item_is_still_scanned(self):
+        """Regression fixture: an earlier draft anchored `_FENCE_RE` at
+        column 0, so a fence indented under a numbered/bulleted step (this
+        repo's own dominant SKILL.md shape) was invisible — see module
+        docstring."""
+        text = (
+            "1. Do the thing:\n\n"
+            "   ```bash\n"
+            "   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py\n"
+            "   ```\n"
+        )
+        hits = _unquoted_expansions(text)
+        assert len(hits) == 1
+        assert hits[0][0] == 4
+
+    def test_unbraced_expansion_is_also_scanned(self):
+        """`$CLAUDE_PLUGIN_ROOT/path` (no braces) word-splits identically to
+        the braced form when unquoted — both spellings are in scope."""
+        text = "```bash\npython3 $CLAUDE_PLUGIN_ROOT/scripts/x.py\n```\n"
+        hits = _unquoted_expansions(text)
+        assert len(hits) == 1
+
+    def test_quoted_unbraced_expansion_is_not_flagged(self):
+        text = '```bash\npython3 "$CLAUDE_PLUGIN_ROOT/scripts/x.py"\n```\n'
+        assert _unquoted_expansions(text) == []
+
+    def test_shorter_fence_nested_inside_a_longer_one_is_literal_content(self):
+        """Regression fixture for `skills/plan/references/plan-template.md`'s
+        shape: a 4-backtick outer fence wrapping a 3-backtick example as
+        literal text. The inner ```-lines must not be mistaken for real
+        fence delimiters, and content between them (still inside the outer
+        `markdown`-tagged fence) must not be scanned."""
+        text = (
+            "````markdown\n"
+            "Example:\n"
+            "```bash\n"
+            "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py\n"
+            "```\n"
+            "````\n"
+        )
+        assert _unquoted_expansions(text) == []

--- a/tests/repo/test_skill_bash_grants_cover_invocations.py
+++ b/tests/repo/test_skill_bash_grants_cover_invocations.py
@@ -58,19 +58,22 @@ SKILLS = sorted(SKILLS_DIR.glob("*/SKILL.md"))
 #: leave it stale. `agent-audit` must never appear here again (#1652).
 KNOWN_UNCOVERED_INVOCATIONS = {
     ("apply-test-doubles", 'sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/plugin_version.py"'),
-    ("cd-test-architecture", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py --file <report-path> --config cd-test-architecture"),
+    # Quoting updated by #1656's sweep (SKILL bodies only — allowed-tools
+    # grant patterns are unaffected by quoting, see _unquoted() above; these
+    # remain uncovered by any grant either way).
+    ("cd-test-architecture", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/gherkin_analysis_coverage_gate.py" --file <report-path> --config cd-test-architecture'),
     ("cd-test-architecture", 'sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" .dev-team-reports/cd-test-architecture-<app>.md'),
     ("harness-audit", 'sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" <the-output-path>'),
-    ("plan", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan_waves.py <plan-file>"),
-    ("plan", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan_gherkin_export.py <plan-file>"),
-    ("plan", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/git_origin_host.py"),
-    ("pr", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py --pre-pr --plan <plan-file>"),
-    ("pr", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py --body-file <body-file>"),
-    ("project-init", "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py"),
-    ("ship", "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/workflow_state.py record \\"),
-    ("ship", "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py record \\"),
-    ("ship", "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py check \\"),
-    ("stryker-xunit-v2-shim", "python3 ${CLAUDE_PLUGIN_ROOT}/skills/stryker-xunit-v2-shim/scripts/generate_shim.py tests/<TestProject>/<TestProject>.csproj \\"),
+    ("plan", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plan_waves.py" <plan-file>'),
+    ("plan", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plan_gherkin_export.py" <plan-file>'),
+    ("plan", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/git_origin_host.py"'),
+    ("pr", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py" --pre-pr --plan <plan-file>'),
+    ("pr", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py" --body-file <body-file>'),
+    ("project-init", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py"'),
+    ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/workflow_state.py" record \\'),
+    ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" record \\'),
+    ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" check \\'),
+    ("stryker-xunit-v2-shim", 'python3 "${CLAUDE_PLUGIN_ROOT}/skills/stryker-xunit-v2-shim/scripts/generate_shim.py" tests/<TestProject>/<TestProject>.csproj \\'),
     ("test-health", 'sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/hooks/lib/report_pdf.py" .dev-team-reports/test-health-<date>.md'),
     ("ubiquitous-language", 'python3 .claude/skills/ubiquitous-language/scripts/collect_domain_signals.py "$ARGUMENTS"'),
 }
@@ -118,6 +121,19 @@ def _body_invocations(body: str) -> list:
     return invocations
 
 
+def _unquoted(text: str) -> str:
+    """Drop ASCII quote characters before comparing. Quoting a path (`"$VAR/
+    scripts/foo.py"` vs. an unquoted `$VAR/scripts/foo.py`) is a shell-syntax
+    nicety — it changes nothing about which executable and path get
+    invoked, and a grant author may quote one side of a comparison without
+    the other (#1656's quoting sweep touched SKILL bodies, not their own
+    `allowed-tools` grant patterns, precisely because the two were never
+    required to match character-for-character). Stripping quotes from both
+    sides before comparing keeps this guard about coverage, not a
+    string-identical-formatting requirement it never needed to enforce."""
+    return text.replace('"', "").replace("'", "")
+
+
 def _covered(invocation: str, patterns: list) -> bool:
     """True if `invocation` matches one of `patterns`.
 
@@ -126,7 +142,10 @@ def _covered(invocation: str, patterns: list) -> bool:
     prefix match is therefore the correct and sufficient test; nothing here
     needs full glob semantics.
     """
-    return any(invocation.startswith(pattern.rstrip("*").strip()) for pattern in patterns)
+    invocation = _unquoted(invocation)
+    return any(
+        invocation.startswith(_unquoted(pattern.rstrip("*").strip())) for pattern in patterns
+    )
 
 
 def _uncovered_invocations_by_skill():

--- a/tests/scripts/test_build_pr_integration.py
+++ b/tests/scripts/test_build_pr_integration.py
@@ -25,7 +25,11 @@ def test_build_skill_does_not_dispatch_progress_guardian_agent() -> None:
 
 
 def test_pr_skill_references_progress_guardian_py_pre_pr() -> None:
-    assert "scripts/progress_guardian.py --pre-pr" in PR_SKILL.read_text()
+    # An optional closing quote may sit between the script path and its flag
+    # (e.g. `"${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py" --pre-pr`,
+    # per #1656's quoting sweep) — quoting doesn't change which command runs,
+    # so this check tolerates it rather than requiring one exact spelling.
+    assert re.search(r'scripts/progress_guardian\.py"?[ \t]+--pre-pr', PR_SKILL.read_text())
 
 
 def test_pr_skill_does_not_dispatch_progress_guardian_agent() -> None:


### PR DESCRIPTION
## Summary

- Widens the bare-relative-path invocation guard past `skills/*/SKILL.md` to also cover plugin `docs/`, `knowledge/` references, `agents/`, and every skill's `references/*.md`, recognizing `bash`/`sh`/`./` prefixes and genuine line-continuation invocations (#1655).
- Sweeps every unquoted `${CLAUDE_PLUGIN_ROOT}`/`$CLAUDE_PLUGIN_ROOT` expansion inside shell-flavored fenced code blocks across 28+ shipped files to the quoted form, with a new regression guard recognizing indented fences, nested/4-backtick fences, and both spellings (#1656). Adds ADR 0033 recording the quoting house style plus a fourth path-resolution category on ADR 0032 for scripts shipped so operators can copy them out.
- Fixes two adjacent defects a 16-agent code-review panel (plus three closing-pass verification rounds) surfaced: two maintainer scripts printed a `${CLAUDE_PLUGIN_ROOT}`-qualified `--fix` remediation hint that would have silently mutated the installed plugin cache instead of the operator's own checkout, and two skills' `allowed-tools` Bash grants had drifted out of sync with their now-quoted invocation bodies.
- Files a follow-up issue (#1686) for the lower-severity, non-blocking findings deliberately deferred out of this PR (registry keying, cross-test-module import style, a residual quoting-regex edge case, and a stale #1652 prose note).

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 6834 passed
- [x] `python3 -m ruff check .` — clean
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `bash scripts/ci-local.sh` — all 21 checks pass, including the Python 3.10 floor import probe
- [x] Verified the widened guards actually widen coverage (not just pass vacuously): confirmed indented/4-backtick fences that were previously invisible now scan real, previously-unguarded lines the #1656 sweep already quoted, with zero new offenders found
- [x] 16-agent code-review panel + two closing-pass verification rounds (7 more agent dispatches) confirmed every fix, with zero outstanding findings in the final pass

Closes #1655
Closes #1656


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoK6Gu6T7xUj7HiLZYeQGE)_