### PR TITLE
fix(scripts): revert Repowise's unexpected .claude/CLAUDE.md writes

### DIFF
--- a/plugins/dev-team/scripts/lib/claude_md_guard.py
+++ b/plugins/dev-team/scripts/lib/claude_md_guard.py
@@ -1,12 +1,12 @@
-"""Snapshot/diff/restore guard for `graphify install --project` (#846).
+"""Snapshot/diff/restore guards for tools that touch a project's `CLAUDE.md`.
 
-`graphify install --project` rewrites the target repo's `CLAUDE.md` to add a
-`## graphify` section. Its updater matches the literal `## graphify` header
-text and replaces everything between it and the next `##` heading — a known
-bug can over-delete, removing pre-existing unrelated content along with the
-stale graphify section.
+Two distinct guards live here, for two distinct contracts:
 
-This module implements the guard `project-init`'s Step 4c documents:
+**`run_install_with_guard`** — for `graphify install --project` (#846), which
+rewrites the target repo's `CLAUDE.md` to add a `## graphify` section. Its
+updater matches the literal `## graphify` header text and replaces everything
+between it and the next `##` heading — a known bug can over-delete, removing
+pre-existing unrelated content along with the stale graphify section.
 
 1. Snapshot `CLAUDE.md` before running the installer.
 2. Diff the snapshot against the post-install file.
@@ -14,6 +14,20 @@ This module implements the guard `project-init`'s Step 4c documents:
    canonical `## graphify` section text at EOF instead of trusting the
    installer's in-place edit.
 4. If nothing was lost, leave the installer's output as-is.
+
+**`run_install_reverting_unexpected_writes`** — for `repowise init` (#1670
+item 3), which is documented (`project-init/SKILL.md`'s Step 4c prompt) as a
+purely keyless, nothing-committed local index under `.repowise/`, but is
+known to also append a `## Codebase Intelligence for <project> (Repowise)`
+section straight into the tracked `.claude/CLAUDE.md` — content whose
+project-name header text isn't fixed across repos the way graphify's is, so
+there's no stable section marker to scope a corruption check to. Unlike the
+`run_install_with_guard` contract, this one does not tolerate the write at
+all: `CLAUDE.md` is expected to be **completely untouched**, so ANY diff —
+added or removed lines, even a write followed by the installer itself
+raising — is reverted in full. The reverted-or-not outcome and any added
+lines are returned separately, so a deletion-only write is never mistaken
+for a no-op.
 
 Stdlib-only, per ADR 0014/0015 (Python for cross-OS scripts).
 """
@@ -51,6 +65,22 @@ def _protected_lines(text: str) -> list[str]:
     return lines[:start] + lines[end:]
 
 
+def _lines_only_in(candidate_lines: list[str], baseline_counts: Counter) -> list[str]:
+    """Multiset-diff kernel shared by `find_missing_lines`/`find_added_lines`:
+    lines in `candidate_lines` that occur more often there than in
+    `baseline_counts`. Order-preserving relative to `candidate_lines`. A line
+    appearing twice in the candidate but only once in the baseline is
+    reported once.
+    """
+    diff: list[str] = []
+    seen = Counter()
+    for line in candidate_lines:
+        seen[line] += 1
+        if seen[line] > baseline_counts[line]:
+            diff.append(line)
+    return diff
+
+
 def find_missing_lines(old_text: str, new_text: str) -> list[str]:
     """Return lines present in `old_text` (outside its `## graphify` section)
     but missing (by multiset) from `new_text`.
@@ -58,15 +88,7 @@ def find_missing_lines(old_text: str, new_text: str) -> list[str]:
     Order-preserving relative to `old_text`. A line that appears twice in
     `old_text` but only once in `new_text` is reported as missing once.
     """
-    old_lines = _protected_lines(old_text)
-    new_counts = Counter(new_text.splitlines())
-    missing: list[str] = []
-    seen = Counter()
-    for line in old_lines:
-        seen[line] += 1
-        if seen[line] > new_counts[line]:
-            missing.append(line)
-    return missing
+    return _lines_only_in(_protected_lines(old_text), Counter(new_text.splitlines()))
 
 
 def run_install_with_guard(
@@ -98,3 +120,72 @@ def run_install_with_guard(
     repaired += canonical_section
     claude_md_path.write_text(repaired, encoding="utf-8")
     return True
+
+
+def find_added_lines(old_text: str, new_text: str) -> list[str]:
+    """Return lines present in `new_text` but missing (by multiset) from
+    `old_text`. Order-preserving relative to `new_text`.
+
+    Unlike `find_missing_lines`, this does NOT exclude any section — the
+    Repowise contract this serves tolerates no section at all (see the module
+    docstring), so excluding a `## graphify` body here would under-report a
+    genuine addition landing inside one. Not a strict mirror of
+    `find_missing_lines` for that reason; both share their multiset-diff
+    logic via `_lines_only_in`.
+    """
+    return _lines_only_in(new_text.splitlines(), Counter(old_text.splitlines()))
+
+
+def _read_or_none(path: Path) -> str | None:
+    """Read `path`'s text, or `None` if it does not exist.
+
+    A single call rather than a separate `exists()` + `read_text()` pair, so
+    there is no window between the two where the file could be removed out
+    from under this guard.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def run_install_reverting_unexpected_writes(
+    claude_md_path: Path,
+    installer: Callable[[], None],
+) -> tuple[bool, list[str]]:
+    """Run `installer()` against `claude_md_path`, reverting ANY write it made.
+
+    Unlike `run_install_with_guard`, which expects and tolerates changes
+    scoped to one known section, this treats `claude_md_path` as a file the
+    installer must leave completely untouched. If `installer()` changed it at
+    all (added or removed lines, or created/deleted the file), the pre-run
+    state is restored — the file is rewritten to its snapshot, or deleted if
+    it did not exist beforehand.
+
+    Returns `(reverted, added)`: `reverted` is True iff anything changed and
+    was undone. `added` lists any lines the installer had added — it is empty
+    both when nothing changed AND when the installer only removed lines, so
+    callers MUST branch on `reverted`, never on `bool(added)`, to decide
+    whether anything happened (a deletion-only write still needs reporting).
+
+    The revert runs even if `installer()` itself raises partway through a
+    write — the compare-and-restore happens in a `finally` block, and the
+    original exception still propagates once it completes.
+    """
+    snapshot = _read_or_none(claude_md_path)
+    reverted = False
+    added: list[str] = []
+
+    try:
+        installer()
+    finally:
+        post_install = _read_or_none(claude_md_path)
+        if post_install != snapshot:
+            reverted = True
+            added = find_added_lines(snapshot or "", post_install or "")
+            if snapshot is not None:
+                claude_md_path.write_text(snapshot, encoding="utf-8")
+            elif post_install is not None:
+                claude_md_path.unlink()
+
+    return reverted, added

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -302,7 +302,10 @@ to re-prompt`).
     - CodeGraph  — personal, user-level MCP; nothing committed to the repo.
                    Keyless: `npm install -g @colbymchenry/codegraph` + `codegraph init .`.
     - Repowise   — local keyless index under .repowise/ (gitignored); MCP server.
-                   Keyless: `init . --no-prose -y`, no API key requested.
+                   Keyless: `init . --no-prose -y`, no API key requested. Its
+                   own installer is known to also try writing a section into
+                   the tracked .claude/CLAUDE.md; the guard below reverts that
+                   automatically, so nothing lands in the repo either way.
   ```
 
 **Under `--yes`, treat the keyless-pair prompt as yes** and install the whole
@@ -517,6 +520,29 @@ check (#1367) makes below.
    `args` array baking in this machine's absolute filesystem path — the
    **standing check below** (not gated behind this install branch) covers it
    regardless of whether `.mcp.json` existed before this run.
+2b. **CLAUDE.md write guard (#1670 item 3).** The same `repowise init` call
+   is also known to append a `## Codebase Intelligence for <project>
+   (Repowise)` section straight into the tracked `.claude/CLAUDE.md`,
+   contradicting this skill's own Step 4c prompt. `.claude/CLAUDE.md` is
+   expected to be **completely untouched** by this step — unlike Graphify's
+   own guard (below), there's no stable section header to scope a
+   corruption check to (the header bakes in the project name), so nothing
+   about the write is tolerated. Wrap step 2 in the reverting guard instead
+   of running it bare: `scripts/lib/claude_md_guard.py`'s
+   `run_install_reverting_unexpected_writes` (unit-tested at
+   `tests/scripts/test_claude_md_guard.py`) snapshots `.claude/CLAUDE.md`,
+   runs the installer, and — if it changed at all, even if the installer
+   itself then raises — restores the snapshot (or removes the file, if it
+   did not exist before). It returns `(reverted, added)`: branch on
+   `reverted`, not on whether `added` is non-empty — a write that only
+   *removes* lines still reverts and still needs reporting, even though it
+   adds nothing. If `reverted` is True, print one line for the operator
+   giving only the **count** of added lines, never their content verbatim
+   (e.g. `Repowise attempted to write N line(s) to .claude/CLAUDE.md —
+   reverted; nothing committed`, or the same sentence with "an unexpected
+   change" in place of "N line(s)" when nothing was added) — so silence is
+   never mistaken for "nothing happened." If `reverted` is False, this step
+   is a no-op and nothing is printed.
 3. Register the MCP server for this Claude Code installation (user scope), the
    same way any personal MCP server is added — point the user at
    `claude mcp add --help` for the exact invocation. **Server-name caveat:**

--- a/plugins/dev-team/tests/scripts/test_claude_md_guard.py
+++ b/plugins/dev-team/tests/scripts/test_claude_md_guard.py
@@ -1,12 +1,19 @@
-"""Unit tests for scripts/lib/claude_md_guard.py (#846).
+"""Unit tests for scripts/lib/claude_md_guard.py (#846, #1670 item 3).
 
-Validates the snapshot -> diff -> restore-or-append guard project-init's
-Step 4c wraps around `graphify install --project`. Does NOT exercise the
-real graphify binary (not installed in this sandbox) — it stubs a
-"corrupting installer" that reproduces the documented over-deletion bug
-(matches literal `## graphify` and deletes through the next `##` heading,
-including content that should have survived) and asserts the guard never
-loses pre-existing content.
+Validates two distinct guards:
+
+- The snapshot -> diff -> restore-or-append guard project-init's Step 4c
+  wraps around `graphify install --project`. Does NOT exercise the real
+  graphify binary (not installed in this sandbox) — it stubs a "corrupting
+  installer" that reproduces the documented over-deletion bug (matches
+  literal `## graphify` and deletes through the next `##` heading, including
+  content that should have survived) and asserts the guard never loses
+  pre-existing content.
+- The snapshot -> diff -> full-revert guard for `repowise init`, which is
+  documented as writing nothing to the repo but is known to append a section
+  to `.claude/CLAUDE.md` anyway (#1670 item 3). Stubs a "writing installer"
+  that reproduces that append and asserts the guard reverts it completely,
+  reporting exactly what was reverted.
 """
 
 from __future__ import annotations
@@ -140,3 +147,153 @@ def test_guard_leaves_clean_install_untouched(tmp_path: Path):
         if line.strip() == "stale graphify section from a previous run":
             continue  # this line is expected to be replaced by a clean install
         assert line in final_lines, f"lost pre-existing line: {line!r}"
+
+
+REPOWISE_SECTION = """\
+## Codebase Intelligence for agentic-dev-team (Repowise)
+Indexed at commit deadbeef on 2026-01-01. Health score: 87/100.
+"""
+
+
+def _repowise_writing_installer(path: Path) -> None:
+    """Reproduce Repowise's real behavior: append an unannounced section to
+    the tracked CLAUDE.md, on top of whatever else it does (index build,
+    .mcp.json write) that this guard doesn't need to know about."""
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if not existing.endswith("\n"):
+        existing += "\n"
+    path.write_text(existing + "\n" + REPOWISE_SECTION, encoding="utf-8")
+
+
+def _no_op_installer(path: Path) -> None:
+    """A well-behaved installer that genuinely writes nothing to CLAUDE.md."""
+
+
+def _removing_installer(path: Path) -> None:
+    """An installer that only DELETES existing content, adding nothing — the
+    diff shape `added` alone cannot report (#1670 item 3 review finding: a
+    deletion-only revert must not look like a no-op to the caller)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    trimmed = [line for line in lines if line.strip() != "content a"]
+    path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+
+
+def _raising_installer(path: Path) -> None:
+    """An installer that writes its section and then fails partway through —
+    e.g. a real index-build error after the CLAUDE.md append already
+    happened. The guard must still revert the write before the exception
+    propagates."""
+    _repowise_writing_installer(path)
+    raise RuntimeError("simulated repowise index-build failure")
+
+
+def test_find_added_lines_detects_new_content():
+    old = "a\nb\n"
+    new = "a\nb\nc\n"
+    assert claude_md_guard.find_added_lines(old, new) == ["c"]
+
+
+def test_find_added_lines_none_added():
+    old = "a\nb\nc\n"
+    new = "a\nb\n"
+    assert claude_md_guard.find_added_lines(old, new) == []
+
+
+def test_find_added_lines_duplicate_line_counted_once():
+    old = "a\n"
+    new = "a\na\na\n"
+    assert claude_md_guard.find_added_lines(old, new) == ["a", "a"]
+
+
+def test_find_missing_lines_duplicate_line_counted_once():
+    old = "a\na\na\n"
+    new = "a\n"
+    assert claude_md_guard.find_missing_lines(old, new) == ["a", "a"]
+
+
+def test_reverting_guard_undoes_an_unexpected_write(tmp_path: Path):
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(FIXTURE_CLAUDE_MD, encoding="utf-8")
+
+    reverted, added = claude_md_guard.run_install_reverting_unexpected_writes(
+        claude_md,
+        installer=lambda: _repowise_writing_installer(claude_md),
+    )
+
+    assert reverted is True
+    # _repowise_writing_installer inserts one blank-line separator before the
+    # section, same as run_install_with_guard's own canonical_section append.
+    assert added == ["", *REPOWISE_SECTION.splitlines()]
+
+    final_text = claude_md.read_text(encoding="utf-8")
+    assert final_text == FIXTURE_CLAUDE_MD
+    assert "Codebase Intelligence" not in final_text
+
+
+def test_reverting_guard_leaves_a_true_no_op_untouched(tmp_path: Path):
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(FIXTURE_CLAUDE_MD, encoding="utf-8")
+
+    reverted, added = claude_md_guard.run_install_reverting_unexpected_writes(
+        claude_md,
+        installer=lambda: _no_op_installer(claude_md),
+    )
+
+    assert reverted is False
+    assert added == []
+    assert claude_md.read_text(encoding="utf-8") == FIXTURE_CLAUDE_MD
+
+
+def test_reverting_guard_deletes_a_file_the_installer_created(tmp_path: Path):
+    """CLAUDE.md may not exist at all before the first `repowise init` in a
+    repo that has none yet — the guard must remove the file it created, not
+    leave the unexpected write in place because "restore the snapshot" has
+    nothing to restore to."""
+    claude_md = tmp_path / "CLAUDE.md"
+    assert not claude_md.exists()
+
+    reverted, added = claude_md_guard.run_install_reverting_unexpected_writes(
+        claude_md,
+        installer=lambda: claude_md.write_text(REPOWISE_SECTION, encoding="utf-8"),
+    )
+
+    assert reverted is True
+    assert added == REPOWISE_SECTION.splitlines()
+    assert not claude_md.exists()
+
+
+def test_reverting_guard_reports_a_deletion_only_write_as_reverted(tmp_path: Path):
+    """A write that only REMOVES lines (no additions) must still report
+    `reverted=True` — `added` alone is `[]` for both this case and a true
+    no-op, so the caller cannot use `bool(added)` to tell them apart."""
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(FIXTURE_CLAUDE_MD, encoding="utf-8")
+
+    reverted, added = claude_md_guard.run_install_reverting_unexpected_writes(
+        claude_md,
+        installer=lambda: _removing_installer(claude_md),
+    )
+
+    assert reverted is True
+    assert added == []
+    assert claude_md.read_text(encoding="utf-8") == FIXTURE_CLAUDE_MD
+
+
+def test_reverting_guard_restores_even_when_installer_raises(tmp_path: Path):
+    """A real `repowise init` can append its section and then fail later in
+    the same run (index-build error, network, tool crash) — the guard must
+    still revert the write, and the original exception must still surface
+    to the caller rather than being swallowed."""
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(FIXTURE_CLAUDE_MD, encoding="utf-8")
+
+    try:
+        claude_md_guard.run_install_reverting_unexpected_writes(
+            claude_md,
+            installer=lambda: _raising_installer(claude_md),
+        )
+        raise AssertionError("expected the installer's RuntimeError to propagate")
+    except RuntimeError as exc:
+        assert "simulated repowise index-build failure" in str(exc)
+
+    assert claude_md.read_text(encoding="utf-8") == FIXTURE_CLAUDE_MD

--- a/tests/skills/test_project_init_repowise_claude_md_guard.py
+++ b/tests/skills/test_project_init_repowise_claude_md_guard.py
@@ -1,0 +1,87 @@
+"""#1670 item 3 — Repowise's `repowise init` install step must be wrapped in
+the `.claude/CLAUDE.md` write-reverting guard, not run bare.
+
+Step 2b's prose IS the enforcement mechanism here — nothing in the shipped
+tree calls `run_install_reverting_unexpected_writes` except an executing
+agent following this paragraph. Every sibling behavioral claim in this
+sub-section already has a structural-sensor content guard (e.g.
+`test_project_init_mcp_json_hygiene.py` pins the #1416 standing check down
+to its marker string and phrasing) — this file is that same sensor for the
+CLAUDE.md write guard, so a future reword/renumber/cleanup pass can't
+silently drop the wiring while `claude_md_guard.py`'s own unit tests
+(`plugins/dev-team/tests/scripts/test_claude_md_guard.py`) stay green (those
+verify the function works, not that anything in the shipped skill calls it).
+
+Same structural-sensor style as tests/skills/test_project_init_mcp_json_hygiene.py
+— pure text greps over shipped SKILL.md prose.
+"""
+
+from __future__ import annotations
+
+from skill_doc_helpers import PLUGIN_ROOT, collapsed, section_outside_code
+
+PROJECT_INIT = (PLUGIN_ROOT / "skills" / "project-init" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+
+
+def _claude_md_write_guard_step() -> str:
+    """Bound to just step 2b's own paragraph — not the whole Repowise
+    sub-section — so a false pass can't come from `run_install_with_guard`
+    or `.claude/CLAUDE.md` incidentally appearing elsewhere in this file
+    (the Graphify sub-section's own guard, or Step 4c's prompt table)."""
+    return section_outside_code(
+        PROJECT_INIT,
+        r"^2b\. \*\*CLAUDE\.md write guard",
+        boundary_pattern=r"^3\. ",
+        include_start_line=True,
+    )
+
+
+def test_repowise_install_step_wraps_the_reverting_guard():
+    step = collapsed(_claude_md_write_guard_step())
+    assert "run_install_reverting_unexpected_writes" in step
+    assert "scripts/lib/claude_md_guard.py" in step
+    assert "#1670" in step
+
+
+def test_repowise_claude_md_expected_completely_untouched():
+    step = collapsed(_claude_md_write_guard_step())
+    assert "completely untouched" in step
+
+
+def test_repowise_guard_contract_branches_on_reverted_not_added():
+    # The whole point of #1670 item 3's fix: a deletion-only write still
+    # reverts and still needs reporting, even though it adds nothing — the
+    # caller must not use `bool(added)` as the "did anything happen" signal.
+    step = collapsed(_claude_md_write_guard_step())
+    assert "(reverted, added)" in step
+    assert "branch on" in step and "reverted" in step
+
+
+def test_repowise_guard_operator_message_reports_count_not_content():
+    # Repowise-authored text is untrusted third-party content — the operator
+    # message must report only a count, never echo the reverted lines
+    # verbatim (security-review finding, #1670 item 3 follow-up).
+    step = collapsed(_claude_md_write_guard_step())
+    assert "count" in step
+    assert "never" in step and "content verbatim" in step
+
+
+def test_repowise_guard_reverts_even_if_installer_raises():
+    step = collapsed(_claude_md_write_guard_step())
+    assert "even if the installer itself then raises" in step
+
+
+def test_repowise_subsection_still_notes_the_mcp_json_write_awareness():
+    # Guard against step 2b accidentally swallowing or displacing the
+    # pre-existing Step 2 sentence about the .mcp.json write (#1416/#1376) —
+    # both live in the same install-steps block and must both survive.
+    full_block = section_outside_code(
+        PROJECT_INIT,
+        r"^\*\*Install steps \(executed only when the all-or-none group is accepted\):\*\*",
+        boundary_pattern=r"^\*\*Detection probe",
+    )
+    text = collapsed(full_block)
+    assert ".mcp.json" in text
+    assert "run_install_reverting_unexpected_writes" in text


### PR DESCRIPTION
## Summary

- `repowise init` (run by `project-init/SKILL.md`'s Repowise install step) is documented as writing nothing to the repo — "local keyless index under `.repowise/` (gitignored)" — but is known to also append a `## Codebase Intelligence for <project> (Repowise)` section straight into the tracked `.claude/CLAUDE.md`, with an embedded index date, commit SHA, and health score that go stale immediately.
- Adds a snapshot/diff/full-revert guard (`claude_md_guard.py`'s new `run_install_reverting_unexpected_writes`) alongside the module's existing graphify corruption-repair guard, and wires it into the Repowise install step (`project-init/SKILL.md` step 2b). Reverts on ANY diff — added or removed lines, even a write followed by the installer itself raising — and reports `(reverted, added)` independently so a deletion-only write is never mistaken for a no-op.
- A 16-agent code-review panel (plus a 5-agent closing-pass verification round) caught and confirmed the fix for two real bugs during development: the guard's return value originally conflated "nothing changed" with "reverted a deletion-only diff", and `installer()` was called with no exception handling, so a partial write followed by an installer failure left the unwanted content committed (fail-open). Both are fixed and covered by new tests.
- A new content-guard test (`tests/skills/test_project_init_repowise_claude_md_guard.py`) pins the SKILL.md wiring itself, since nothing in the shipped tree calls the guard function except that skill's own prose — a future reword/renumber pass could otherwise silently drop it while the library's own unit tests stayed green.

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 6849 passed
- [x] `bash scripts/ci-local.sh` — all checks pass
- [x] `python3 scripts/check_md_references.py` — clean
- [x] New guard behavior verified against all state transitions by hand-trace in the closing-pass review (file created/deleted/modified/untouched, deletion-only write, installer raising mid-write) — each backed by a dedicated unit test in `plugins/dev-team/tests/scripts/test_claude_md_guard.py`
- [x] 16-agent code-review panel + 5-agent closing-pass verification confirmed both fixes closed, with zero blocking findings in the final pass

Closes #1670


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoK6Gu6T7xUj7HiLZYeQGE)_