### PR TITLE
fix(agents): settle category as the canonical finding taxonomy field

### DIFF
--- a/plugins/dev-team/agents/security-review.md
+++ b/plugins/dev-team/agents/security-review.md
@@ -16,7 +16,7 @@ Cites:
 - accepted-risks-schema
 - adversarial-review-protocol
 
-Output JSON (extends the shared contract in `${CLAUDE_PLUGIN_ROOT}/knowledge/review-agent-output-contract.md` with a `category` field. Whole-file load: short, canonical schema):
+Output JSON (the canonical `category` field from the shared contract in `${CLAUDE_PLUGIN_ROOT}/knowledge/review-agent-output-contract.md`, populated with this agent's own OWASP taxonomy below. Whole-file load: short, canonical schema):
 
 ```json
 {"status": "pass|warn|fail|skip", "issues": [{"category": "A<NN>.<slug>", "severity": "error|warning|suggestion", "confidence": "high|medium|none", "file": "", "line": 0, "message": "", "suggestedFix": ""}], "summary": ""}

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -1205,8 +1205,12 @@
   },
   "plugins/dev-team/knowledge/review-agent-output-contract.md": {
     "Canonical schema": {
-      "summary": "**pass**: zero issues",
+      "summary": "`category` is optional per finding — omit it rather than emit an empty",
       "anchor": "canonical-schema"
+    },
+    "`category` (#1639)": {
+      "summary": "A short, stable tag identifying the *kind* of finding within an agent's own",
+      "anchor": "category-1639"
     },
     "Status values": {
       "summary": "**pass**: zero issues",

--- a/plugins/dev-team/knowledge/review-agent-output-contract.md
+++ b/plugins/dev-team/knowledge/review-agent-output-contract.md
@@ -7,8 +7,61 @@ the contract can't drift between the ~20 agents that share it.
 ## Canonical schema
 
 ```json
-{"status": "pass|warn|fail|skip", "issues": [{"severity": "error|warning|suggestion", "confidence": "high|medium|none", "file": "", "line": 0, "message": "", "suggestedFix": ""}], "summary": ""}
+{"status": "pass|warn|fail|skip", "issues": [{"category": "", "severity": "error|warning|suggestion", "confidence": "high|medium|none", "file": "", "line": 0, "message": "", "suggestedFix": ""}], "summary": ""}
 ```
+
+`category` is optional per finding — omit it rather than emit an empty
+string when a finding genuinely has no natural taxonomy tag.
+
+## `category` (#1639)
+
+A short, stable tag identifying the *kind* of finding within an agent's own
+taxonomy — not a cross-agent enum, and not required to be a strict
+linter-style rule ID. Its purpose is round-to-round finding identity:
+`skills/code-review/scripts/finding_signature.py`'s `signature()` hashes
+`(agent, file, category, normalized-message)`, with the finding's `line`
+compared separately at a `±3` tolerance by `same_finding()` rather than
+folded into the hash. Message normalization strips quoted spans and numbers
+by design, so two genuinely *different* findings from the same agent, same
+file, and within a few lines of each other can normalize to the same text
+(e.g. two distinct missing-guard-clause defects a couple of lines apart
+whose messages differ only in the quoted identifier that normalization
+strips). Without `category` to tell them apart, those collide into one
+signature, and — because they also fall inside the `±3` proximity window —
+a later round's genuinely new defect matches a prior round's key and reads
+as `carried` rather than new, silently suppressing a fix round the
+loop-until-dry/severity-floor termination rules #1625 added were supposed to
+run.
+
+Each agent defines its own taxonomy in its own body — see each agent's
+`## Detect` (or equivalent) section for its specific category values. Three
+worked examples already shipping on this contract (kept in sync with the
+named agent files by `tests/repo/test_review_agent_output_contract_examples.py`):
+
+- **`security-review`**: `"category": "A<NN>.<slug>"` (the OWASP category the
+  finding maps to), e.g. `"A03.sql-injection"`.
+- **`ai-provenance-review`**: `"category": "verification-debt|regeneration-risk"`.
+- **`spec-compliance-review`**: `"category": "unmet-criterion|uncovered-scenario|scope-violation|plan-deviation"`.
+
+Four more agents converge on the same field name independently: the
+`plan-review-*` critics (`plan-review-design`, `plan-review-parallelization`,
+`plan-review-strategic`, `plan-review-ux`) each emit their own `category`
+values too, on a different `{"verdict", "issues"}` schema dispatched by
+`/plan` rather than this contract's `{"status", "issues"}` shape — not a
+fourth spelling to reconcile, but further evidence the name reads naturally
+across this repo's own review agents.
+
+A new agent that reports findings across more than one natural taxonomy
+bucket should add its own `category` values the same way — a short,
+lower-case, hyphenated tag per bucket, documented in the agent's own body —
+rather than leaving the field unset.
+
+**Not the same `category` as `apply-fixes`'s correction-prompt schema.**
+`skills/apply-fixes/SKILL.md`'s correction-prompt `category` field holds the
+*reporting agent's name* (e.g. `"structure-review"`), grouping fixes for
+display — a different concept that happens to share this field name in a
+downstream artifact generated *from* findings. Do not assume a correction
+prompt's `category` carries a finding's taxonomy tag through unchanged.
 
 ## Status values
 
@@ -38,13 +91,14 @@ raise the tier. Every other agent uses the default rule above.
 ## Documented per-agent extensions
 
 A handful of agents extend the canonical schema with extra fields specific
-to their domain. These are intentional, documented exceptions — not drift:
+to their domain, beyond the canonical `category` documented above. These are
+intentional, documented exceptions — not drift:
 
-- **`security-review`**: adds `"category": "A<NN>.<slug>"` to each issue
-  (the OWASP category the finding maps to).
 - **`test-smell-review`**: adds `"smell": ""` and
   `"remedyFamily": "fixture-construction|result-verification|test-organization|test-refactoring|null"`
-  to each issue.
+  to each issue. `smell` is this agent's own taxonomy tag but is not read by
+  `signature()`'s `category`/`rule`/`ruleId` fallback chain, so its findings
+  currently hash with an empty taxonomy component — tracked in #1692.
 
 An agent that needs a new field beyond these documents it here rather than
 drifting silently.

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -558,7 +558,7 @@ Reported as `ledger_reset` on every call (`null` when a stored ledger was
 legitimately resumed). The script fails **toward** a reset: an unreadable or
 malformed state file starts fresh. Starting fresh costs at most one extra
 round; reusing a wrong ledger silently skips one. A finding's signature is
-`(agent, file, rule/category, normalized message)` with the line compared at
+`(agent, file, category, normalized message)` with the line compared at
 ±3 rather than hashed — see the script's own docstring for why the line is
 deliberately outside the hash.
 

--- a/plugins/dev-team/skills/code-review/scripts/finding_signature.py
+++ b/plugins/dev-team/skills/code-review/scripts/finding_signature.py
@@ -23,7 +23,7 @@ result the severity floor and loop-until-dry rules must not get. Proximity
 is not an equivalence relation, so it cannot be folded into a hash without
 introducing boundary artifacts.
 
-So `signature()` hashes the *stable* identity — agent, file, rule/category,
+So `signature()` hashes the *stable* identity — agent, file, category,
 and the normalized message — and the line is carried alongside it in
 `FindingKey`. `same_finding()` then applies the true ±`LINE_TOLERANCE`
 proximity test. Callers that want one hashable key for set membership use
@@ -116,13 +116,23 @@ def _normalize_path(value) -> str:
 
 
 def signature(finding: dict) -> str:
-    """Stable identity hash for one finding: agent, file, rule/category, and
-    the normalized message. Deliberately excludes the line number."""
+    """Stable identity hash for one finding: agent, file, category, and the
+    normalized message. Deliberately excludes the line number.
+
+    `category` is the canonical taxonomy field (#1639) — settled on `category`
+    rather than `rule` because that is what the three agents on this contract
+    already emitting one (`security-review`, `ai-provenance-review`,
+    `spec-compliance-review`) already spell it as, so no existing agent needed
+    to migrate. `rule` and `ruleId` remain accepted fallbacks for a finding
+    shaped by a future agent or an external tool that uses the more
+    conventional linter-rule name — never required, never the preferred
+    spelling to emit.
+    """
     agent = str(finding.get("agent") or finding.get("agentName") or "")
     path = _normalize_path(finding.get("file"))
-    rule = str(finding.get("rule") or finding.get("category") or finding.get("ruleId") or "")
+    category = str(finding.get("category") or finding.get("rule") or finding.get("ruleId") or "")
     message = normalize_message(finding.get("message"))
-    payload = f"{agent.lower()}\x1f{path}\x1f{rule.lower()}\x1f{message}"
+    payload = f"{agent.lower()}\x1f{path}\x1f{category.lower()}\x1f{message}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/plugins/dev-team/tests/scripts/test_finding_signature.py
+++ b/plugins/dev-team/tests/scripts/test_finding_signature.py
@@ -79,6 +79,40 @@ class TestSignatureStability:
     def test_different_files_are_distinct_findings(self):
         assert fs.signature(_f(file="src/a.js")) != fs.signature(_f(file="src/b.js"))
 
+    def test_category_alone_is_read_the_same_way_rule_is(self):
+        # `category` is the canonical taxonomy field (#1639); a finding that
+        # only sets `category` (no `rule` at all) must hash identically to
+        # the equivalent `rule=`-only finding — the two are the same field
+        # under different names, not two independent pieces of identity.
+        del_rule = _f()
+        del del_rule["rule"]
+        with_category = {**del_rule, "category": "missing-guard"}
+        assert fs.signature(with_category) == fs.signature(_f(rule="missing-guard"))
+
+    def test_category_takes_priority_over_rule_when_both_are_present(self):
+        # #1639 settled `category` as canonical; `rule`/`ruleId` are legacy
+        # fallbacks only. When a finding somehow carries both (a producer
+        # migrating, or an external tool), `category` must win — pinning the
+        # fallback order `signature()` actually implements, not just the
+        # order that happens to produce the same result when only one field
+        # is set (the common case every other test in this class exercises).
+        a = _f(category="unmet-criterion", rule="missing-guard")
+        b = _f(category="unmet-criterion", rule="something-else-entirely")
+        assert fs.signature(a) == fs.signature(b)
+
+        different_category = _f(category="different-category", rule="missing-guard")
+        assert fs.signature(a) != fs.signature(different_category)
+
+    def test_rule_id_is_used_only_when_category_and_rule_are_both_absent(self):
+        # Unlike test_category_takes_priority_over_rule_when_both_are_present
+        # above, this does NOT exercise the category-vs-rule ordering —
+        # both are absent here, so it only pins ruleId's own terminal-
+        # fallback role (true before and after #1639's reorder).
+        del_rule = _f()
+        del del_rule["rule"]
+        rule_id_only = {**del_rule, "ruleId": "missing-guard"}
+        assert fs.signature(rule_id_only) == fs.signature(_f(rule="missing-guard"))
+
     def test_leading_dot_slash_does_not_change_the_signature(self):
         assert fs.signature(_f(file="./src/cache.js")) == fs.signature(_f(file="src/cache.js"))
 

--- a/tests/repo/test_review_agent_output_contract_examples.py
+++ b/tests/repo/test_review_agent_output_contract_examples.py
@@ -1,0 +1,117 @@
+"""Keeps `review-agent-output-contract.md`'s `category` worked examples in
+sync with the real agent files they cite (#1639).
+
+The contract doc enumerates each example agent's `category` value set inline
+so a reader doesn't have to open every agent file to see the shape — but
+that means the same taxonomy string now exists in two places with nothing
+tying them together. A domain-review pass on #1639 flagged this: the
+contract doc's own text says "each agent defines its own taxonomy in its own
+body", immediately followed by copies of three agents' values inline, with
+no gate keeping the copy honest if an agent's taxonomy changes later.
+
+The first draft of this gate checked substring containment against a
+hand-typed expected value — a second review round caught that this only
+catches a *removed*/*renamed* value, not an *appended* one: if
+`ai-provenance-review.md` grew a third category value, both the old
+substring and the doc's now-incomplete copy would still contain each other,
+and the test would stay green while the doc silently went stale. Fixed by
+extracting the enum agents' full current value straight from their own file
+via regex — so there is nothing to keep in sync by hand for those two.
+
+A third round then caught that checking `value in CONTRACT` was still bare
+substring containment, just with the operands swapped: if the agent's own
+value ever *shrinks* (e.g. `spec-compliance-review` drops
+`|plan-deviation`), the shrunk extracted value is still a substring of the
+doc's now-stale, wider copy, so the check passes while the doc keeps
+advertising a category the agent no longer emits. Fixed by asserting on the
+exact quoted JSON fragment (`"category": "<value>"`, trailing quote
+included) rather than the bare value — a shrunk value's fragment ends its
+own closing quote right where the doc's stale text continues with more
+members instead, so it no longer matches.
+
+`security-review` doesn't fit the closed-enum shape: its own schema line,
+and the contract doc's own citation of it, both show the generic
+`A<NN>.<slug>` pattern plus one worked example (`A03.sql-injection`), not an
+enum to extract — kept as a literal pin for that reason, documented inline
+below.
+"""
+
+from __future__ import annotations
+
+import re
+
+from _repo_root import REPO_ROOT
+
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "dev-team"
+CONTRACT = (PLUGIN_ROOT / "knowledge" / "review-agent-output-contract.md").read_text(
+    encoding="utf-8"
+)
+
+#: Matches this repo's `"category": "<value>"` schema-line convention.
+_CATEGORY_VALUE_RE = re.compile(r'"category":\s*"([^"]+)"')
+
+
+def _extract_category_enum(agent_file: str) -> str:
+    """The full `category` value from `agent_file`'s own schema line.
+
+    Extracting rather than hand-typing the expected value means a future
+    agent taxonomy change is automatically picked up here — the only thing
+    that can go stale is the contract doc, which is exactly what these tests
+    exist to catch.
+
+    Requires exactly one `"category": "..."` match in the file. `.search()`
+    alone would silently take the first of several (as security-review.md
+    genuinely has, at its schema line plus three concrete examples) — for
+    the two enum agents this pins today that would be a false assumption to
+    hold silently, so an agent gaining a second `"category":` occurrence
+    fails loudly here instead of quietly changing which one gets compared.
+    """
+    text = (PLUGIN_ROOT / "agents" / agent_file).read_text(encoding="utf-8")
+    matches = _CATEGORY_VALUE_RE.findall(text)
+    assert matches, f'{agent_file}: no `"category": "..."` schema line found to extract'
+    assert len(matches) == 1, (
+        f"{agent_file}: expected exactly one \"category\": \"...\" occurrence to "
+        f"extract from, found {len(matches)}: {matches!r} — this agent no longer "
+        "fits the closed-enum-with-one-schema-line shape this helper assumes"
+    )
+    return matches[0]
+
+
+#: Agents whose full `category` value is a closed, extractable enum — kept
+#: in sync automatically via `_extract_category_enum`.
+_ENUM_WORKED_EXAMPLES = ("ai-provenance-review.md", "spec-compliance-review.md")
+
+#: `security-review`'s contract-doc citation is the generic `A<NN>.<slug>`
+#: pattern plus one illustrative concrete value, not a closed enum — pinned
+#: as a literal substring instead of extracted. Shrink-only: if the pattern
+#: or the chosen example changes, update both sides in the same change.
+_SECURITY_REVIEW_PATTERN = "A<NN>.<slug>"
+_SECURITY_REVIEW_EXAMPLE = "A03.sql-injection"
+
+
+def test_enum_worked_examples_are_quoted_in_full_by_the_contract_doc():
+    missing = []
+    for agent_file in _ENUM_WORKED_EXAMPLES:
+        value = _extract_category_enum(agent_file)
+        # The exact quoted fragment, trailing quote included — not the bare
+        # value — so a doc copy that's merely a truncated prefix of the
+        # agent's real (possibly since-widened) value doesn't false-pass.
+        fragment = f'"category": "{value}"'
+        if fragment not in CONTRACT:
+            missing.append(f"{agent_file}: current category value {value!r} not found in review-agent-output-contract.md")
+    assert not missing, (
+        "review-agent-output-contract.md's category worked examples are "
+        "stale — an agent's taxonomy changed and the doc's copy wasn't "
+        "updated to match:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_security_review_pattern_and_example_are_quoted_by_the_contract_doc():
+    agent_text = (PLUGIN_ROOT / "agents" / "security-review.md").read_text(encoding="utf-8")
+    for value in (_SECURITY_REVIEW_PATTERN, _SECURITY_REVIEW_EXAMPLE):
+        assert value in agent_text, f"security-review.md no longer contains {value!r}"
+        assert value in CONTRACT, (
+            f"review-agent-output-contract.md no longer quotes {value!r} — "
+            "update _SECURITY_REVIEW_PATTERN/_SECURITY_REVIEW_EXAMPLE or "
+            "restore the citation"
+        )


### PR DESCRIPTION
## Summary

- Issue #1639, part 1 of 2 (the rule-ID contract change, landing ahead of the correctness-review agent-file edits, which are a deliberately separate follow-up PR per the issue's own "Recommended split").
- Settles `category` (not `rule`, the issue's own title) as the canonical per-finding taxonomy field in `plugins/dev-team/knowledge/review-agent-output-contract.md` — chosen because 3 of ~23 review agents (`security-review`, `ai-provenance-review`, `spec-compliance-review`) already emit `category`, so none of them needed to migrate.
- Reorders `finding_signature.py`'s `signature()` to check `category` first, keeping `rule`/`ruleId` as legacy fallbacks. Without a taxonomy field, message normalization's stripping of quoted spans/numbers can make two genuinely different findings (same agent, same file, within a few lines of each other) normalize to the same text — colliding into one signature and silently suppressing a fix round the loop-until-dry/severity-floor rules (#1625) exist to enforce.
- Adds a mechanical content guard (`tests/repo/test_review_agent_output_contract_examples.py`) keeping the contract doc's worked examples in sync with the real agent files — extracts each enum agent's current value via regex and checks the exact quoted fragment, so the guard catches an agent's taxonomy being added to, removed from, or narrowed without a matching doc update.
- Files a follow-up issue (#1692) for `test-smell-review`'s `smell` field, which predates this change and is unrelated to what #1639 asks for — its findings are invisible to `signature()`'s taxonomy component either way, before or after this fix.

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 6854 passed
- [x] `bash scripts/ci-local.sh` — all checks pass
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Verified by hand-simulation that the new content-guard test catches an agent's taxonomy value being appended to, removed, or merely narrowed (not just a bare-substring false pass)
- [x] Five rounds of 15-agent code-review panel + closing-pass verification, each round finding and fixing a real issue (an inverted causal claim in the rationale, two vacuous test sensors, a stale "two examples" count vs. three bullets, a mislabeled test name, and the append/shrink blind spots in the content guard)

Closes #1639


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoK6Gu6T7xUj7HiLZYeQGE)_