### PR TITLE
fix(agents)!: add correctness-review's 6th/7th detect categories and protocol

### DIFF
--- a/evals/expected/cr-clean-baseline.json
+++ b/evals/expected/cr-clean-baseline.json
@@ -4,8 +4,12 @@
   "applicableAgents": ["correctness-review"],
   "agents": {
     "correctness-review": {
-      "expectedStatus": "pass",
-      "issueCount": { "min": 0, "max": 2 }
+      "expectedStatus": "warn",
+      "issueCount": { "min": 0, "max": 2 },
+      "_calibration": {
+        "source": "measured",
+        "note": "#1639 part 2 added Detect category 6 (unverified runtime/library claim). A measured run against this fixture found 2 genuine category-6 findings (the docstring's unprobed 'Git Bash surfaces forward slashes on Windows' claim, and the unprobed '.sh byte-parity' claim) — both suggestion-severity, no observed defect, issueCount still within the existing 0-2 budget. Per the shared output contract, any issue (even suggestion-severity) makes status 'warn' rather than 'pass', so expectedStatus was updated from 'pass' to 'warn' to match. Not a detection regression: the agent correctly declined to flag two other candidate claims in the same file (order-preservation, Python-3.8-floor) as out of category-6's scope."
+      }
     }
   }
 }

--- a/plugins/dev-team/agents/correctness-review.md
+++ b/plugins/dev-team/agents/correctness-review.md
@@ -1,7 +1,7 @@
 ---
 
 name: correctness-review
-description: Functional/behavioral defects where implementation diverges from evident intent (missing assignments, wrong operators, inverted conditions, missing guard clauses, off-by-one/boundary errors)
+description: Functional/behavioral defects where implementation diverges from evident intent (missing assignments, wrong operators, inverted conditions, missing guard clauses, off-by-one/boundary errors, unverified runtime/library claims, error-signalling divergence)
 tools: Read, Grep, Glob, mcp__codegraph__*, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_risk
 model: opus
 effort: high
@@ -15,9 +15,29 @@ Cites: [adversarial-review-protocol]
 
 Output JSON: per `${CLAUDE_PLUGIN_ROOT}/knowledge/review-agent-output-contract.md` (Whole-file load: short, canonical schema).
 
-Status: pass=implementation matches evident intent everywhere reviewed, warn=one or more suspected divergences that need human confirmation, fail=a clear behavioral defect where the code visibly contradicts its own name/comment/sibling logic
-Severity: error=the implementation will silently produce the wrong result on a realistic input path (missing assignment, non-interpolated string, missing guard, dropped boundary case, inverted condition); warning=the divergence is plausible but the evident intent is inferred rather than explicitly stated; suggestion=a minor mismatch between docstring/name and behavior with no observed defect
-Confidence: high=the evident intent is explicit (a docstring, comment, sibling branch, or unambiguous name) and the code visibly fails to satisfy it; medium=the evident intent is inferred from context (naming pattern, surrounding structure) rather than stated outright; none=not used for a finding *about reviewed content* — a finding with no articulable evident intent is dropped, not reported (see Self-Challenge). Exception: `none` is required, not dropped, for the missing-context meta-finding that `adversarial-review-protocol.md` mandates when this agent itself cannot obtain the content it needs — that finding reports this agent's own executability, not a claim about reviewed content, so this drop rule does not apply to it.
+**Status** (derive from the highest-severity finding, do not let finding volume alone change the tier):
+
+| Value | Meaning |
+|---|---|
+| `pass` | Implementation matches evident intent everywhere reviewed |
+| `warn` | One or more suspected divergences that need human confirmation, or an unverified runtime/library claim (category 6) reported with no observed defect |
+| `fail` | A clear behavioral defect where the code visibly contradicts its own name/comment/sibling logic |
+
+**Severity**:
+
+| Value | Meaning |
+|---|---|
+| `error` | The implementation will silently produce the wrong result on a realistic input path (missing assignment, non-interpolated string, missing guard, dropped boundary case, inverted condition) |
+| `warning` | The divergence is plausible but the evident intent is inferred rather than explicitly stated |
+| `suggestion` | A minor mismatch between docstring/name and behavior with no observed defect, or a category 6 (unverified runtime/library claim) finding — always capped at `suggestion` since no defect is being asserted, only missing evidence |
+
+**Confidence**:
+
+| Value | Meaning |
+|---|---|
+| `high` | The evident intent is explicit (a docstring, comment, sibling branch, or unambiguous name) and the code visibly fails to satisfy it |
+| `medium` | The evident intent is inferred from context (naming pattern, surrounding structure) rather than stated outright |
+| `none` | Not used for a finding *about reviewed content* — a finding with no articulable evident intent is dropped, not reported (see Detect preamble below). **Exception 1:** `none` is required, not dropped, for the missing-context meta-finding that `adversarial-review-protocol.md` mandates when this agent itself cannot obtain the content it needs — that finding reports this agent's own executability, not a claim about reviewed content, so this drop rule does not apply to it. **Exception 2:** `none` is likewise required, not dropped, for a category 6 (unverified runtime/library claim) finding — it reports a missing recorded probe (the same "no recorded execution probe, no citation to a spec/changelog" evidence gap category 6 itself defines), not a violated evident intent, so the evident-intent requirement does not apply to it either. |
 
 Context needs: full-file
 
@@ -25,12 +45,70 @@ Context needs: full-file
 
 This agent answers one question: **does this code do what it evidently intends to do?** It infers intent from the code itself — the function's name, its docstring/comments, its sibling branches, and its call sites — not from an external spec (that is `spec-compliance-review`'s job, comparing code against a written spec). It does not evaluate structure, security-specific bypass patterns, naming style, or test quality. Every other review agent's lens is code *quality*; this agent's lens is: is the code's own evident promise kept?
 
+## Skip
+
+Return `{"status": "skip", "issues": [], "summary": "No behavioral logic to analyze"}` when:
+
+- Target contains only static assets, configuration, markup, or documentation with no executable logic
+- Target is generated code, vendored dependencies, or lockfiles
+
+## Protocol
+
+Run in three phases — enumerate first, classify second, group third. This
+prevents selective attention (stopping after the first plausible defect),
+anchors each finding to a specific evident-intent citation before applying
+judgment, and keeps the finding count proportional to the number of distinct
+problems rather than the number of lines reviewed.
+
+**Phase 1 — Enumerate**: Walk the full diff/file(s) under review and list
+every candidate divergence against the seven Detect categories below —
+assignments that look stale, conditionals that look inverted, guards that
+look missing, runtime/library claims with no recorded probe, documented
+error/return contracts that aren't honored, and so on — without yet deciding
+severity or confidence.
+
+**Phase 2 — Classify**: For each candidate, first identify the evident
+intent (the specific name, docstring, comment, sibling branch, or call site
+establishing what the code is supposed to do). If none exists, drop the
+candidate entirely — see the Detect preamble below (category 6 is the one
+exception: it is evidence-only by design and is never dropped for lacking an
+evident intent). Otherwise assign severity and confidence per the table
+above.
+
+**Phase 3 — Group**: Report at the granularity of distinct defects, not one
+finding per line touched. When the same evident-intent violation recurs
+across near-identical sites (e.g. the same missing guard copy-pasted into
+three call sites), a single finding listing the sites beats three
+near-duplicate findings — but never fold genuinely distinct defects
+(different evident intent, different category) into one finding.
+
+## Severity Anchors
+
+Calibrate against these worked examples before flagging real code:
+
+| Severity | Code / Claim | Violation | Evident intent |
+|---|---|---|---|
+| `error` | A loop inside `calculateAverage` accumulates into `total`, but the running-sum reassignment line is missing, so the loop body no-ops and the same initial value returns every call | Missing assignment: the sum the function's own name requires is never accumulated | Function name `calculateAverage` |
+| `error` | `` `Failed to load ${moduleName}: reason` `` — `reason` reads as a variable but is a literal | Literal-vs-interpolation: the rest of the string interpolates, this one token doesn't | The string's own mixed interpolation pattern |
+| `error` | Docstring says "raises `ValueError` on malformed input"; the function instead catches the parse error internally and returns `None` | Error-signalling divergence: the documented failure mode is silently swallowed, callers checking for the exception never see it | Docstring's own "raises" line |
+| `error` | `for (i = 0; i <= items.length; i++)` against a comment stating "0-indexed, valid range is 0 to length-1" | Boundary/off-by-one: the `<=` reads one index past the last valid index the comment defines, out-of-bounds on the final iteration | Adjacent comment stating the valid range |
+| `warning` | `if (!isValid && !force) throw new ValidationError()` — `force` was added later with no docstring update saying whether bypass is intended | Inverted/extra clause: `force` may silently loosen validation, but nothing states outright that it must never be exempted — the intent is inferred from the docstring's silence, not stated explicitly | Docstring's silence on the new clause, inferred rather than explicit |
+| `suggestion` | A comment asserts a helper `chunk()` "runs in O(n)", with no benchmark or citation recorded nearby | Unverified runtime/library claim (category 6): flags the missing evidence, not a defect — always capped at `suggestion`, per #1629's executable-claims convention | No evident intent violated — flagged for missing evidence, not a correctness defect |
+
 ## Detect
 
-Work through the file(s) under review looking for these five categories.
-For every candidate, first identify the "evident intent" — the specific
-name, docstring, comment, sibling branch, or call site that establishes what
-the code is supposed to do — before treating it as a finding.
+Work through the file(s) under review looking for these seven categories,
+following the Protocol above. For every candidate, first identify the
+"evident intent" — the specific name, docstring, comment, sibling branch, or
+call site that establishes what the code is supposed to do — before treating
+it as a finding. **If you cannot articulate that evident intent concretely,
+the candidate is out of scope for this agent — drop it entirely.** Do not
+downgrade it to `confidence: none` and report it as noise; a correctness
+finding with no articulable intent is not a correctness finding. **Exception:
+category 6** (unverified runtime/library claims) is evidence-only by
+design — it reports a missing recorded probe, not a violated evident
+intent — so this drop rule does not apply to it; report it at
+`confidence: none` and `severity: suggestion` instead.
 
 1. **Missing/incomplete assignment** — a variable is declared, or reused
    from an outer scope, but never (re)assigned the value that the
@@ -59,6 +137,9 @@ the code is supposed to do — before treating it as a finding.
    perform an effectful operation (write, cache, mutate) where a sibling
    function or comment establishes a condition under which that operation
    should NOT happen, but no corresponding `if`/early-return enforces it.
+   This category covers a precondition the function never checks at
+   all — contrast with category 7, which requires a check or branch that
+   *does* run.
 
    **Named sub-case — missing degenerate-input guard at function entry** —
    for a parsing or validation function whose docstring/name implies
@@ -104,6 +185,42 @@ the code is supposed to do — before treating it as a finding.
    rule stated elsewhere, so the comparison must be clause-by-clause against
    that stated rule, not a general plausibility check of the condition.
 
+6. **Unverified runtime/library claim** — a comment or docstring asserts a
+   specific runtime or standard-library behavior ("this call is O(n²)",
+   "this method mutates its receiver", "the receiver must be an Object or
+   it throws", "this sort is stable") that nothing in the file shows was
+   actually verified — no recorded execution probe, no citation to a
+   spec/changelog. Per #1629's executable-claims convention, **flag that
+   the claim carries no recorded probe — do not adjudicate whether the
+   claim itself is true or false.** This agent's tool grant is read-only
+   (no execution capability — see its frontmatter `tools:` line), so
+   judging the claim directly would be a guess dressed up as a finding.
+   Report the claim's location and quote it; leave the correctness verdict
+   to a human, or to a probe recorded elsewhere in the file. This category
+   is evidence-only — see the exception in the Detect preamble above and
+   the Confidence table's second exception. When the claim sits in a file
+   whose authorship looks AI-generated, defer to `ai-provenance-review`'s
+   verification-debt lens instead of double-reporting the same gap.
+
+7. **Error-signalling divergence** — a docstring or comment states that a
+   function raises/throws a specific exception, or returns a specific
+   sentinel/documented value on a given branch, but a branch the code
+   actually evaluates doesn't honor that contract: the exception is caught
+   internally and swallowed (a default is returned instead), or a branch
+   that IS reached returns something other than its documented value, or
+   returns nothing at all despite executing that branch's body. Distinct
+   from category 3 (missing guard/validation), which covers a precondition
+   the function never checks in the first place — this category requires
+   a check or branch that *does* run, whose result is then signalled
+   wrongly. Distinct from `doc-review`'s comment-drift lens: this category
+   owns the case where the code's behavior is wrong relative to a
+   documented error/return contract the code itself evidently intends to
+   honor (fix the code); `doc-review` owns the case where the
+   documentation is merely stale relative to already-correct behavior (fix
+   the doc). When the intended direction is genuinely ambiguous, use
+   `confidence: medium` and say which artifact you believe is
+   authoritative.
+
 ## Self-Challenge
 
 After producing findings, run the shared challenger loop in
@@ -113,11 +230,15 @@ correctness-review-specific challenge before finalizing each finding:
 
 - For every candidate finding, can you cite the *specific* docstring line,
   comment, sibling function/branch, or unambiguous name that establishes the
-  evident intended behavior being violated? Quote it in the `message`.
-- If you cannot articulate that evident intent concretely, the finding is
-  **out of scope for this agent — drop it entirely**. Do not downgrade it to
-  `confidence: none` and report it as noise; a correctness finding with no
-  articulable intent is not a correctness finding.
+  evident intended behavior being violated? Quote it in the `message` (the
+  Detect preamble's drop-if-no-articulable-intent rule already governs
+  whether the finding exists at all — this challenge is about the citation's
+  specificity).
+- For a category 7 candidate, did you confirm the branch that mishandles
+  the documented contract is actually reached/evaluated, rather than the
+  precondition simply never being checked (that's category 3, not 7)? If a
+  `doc-review` finding on the same lines is equally plausible, did you state
+  which artifact — the code or the docs — you believe is authoritative?
 - Did you check that the finding isn't better explained as intentional
   (e.g., a guard the caller already performs, a boundary the type system
   already rules out)? If genuinely ambiguous, use `confidence: medium` and
@@ -131,13 +252,6 @@ correctness-review-specific challenge before finalizing each finding:
 
 Append confidence level (High/Medium/Low) to the `summary` field.
 
-## Skip
-
-Return `{"status": "skip", "issues": [], "summary": "No behavioral logic to analyze"}` when:
-
-- Target contains only static assets, configuration, markup, or documentation with no executable logic
-- Target is generated code, vendored dependencies, or lockfiles
-
 ## Ignore
 
 Code style and naming (`naming-review`), structure/DRY/coupling
@@ -145,4 +259,6 @@ Code style and naming (`naming-review`), structure/DRY/coupling
 conditionals (`security-review`), test quality (`test-review`),
 business-boundary/DDD placement (`domain-review`), spec-to-code matching
 against an explicit written spec (`spec-compliance-review`), refactoring
-opportunities (`refactor-opportunity-review`).
+opportunities (`refactor-opportunity-review`), documentation that is merely
+stale relative to already-correct behavior (`doc-review` — see category 7's
+own deference clause for the discriminator when both could apply).

--- a/tests/agents/test_correctness_review_category_count.py
+++ b/tests/agents/test_correctness_review_category_count.py
@@ -1,0 +1,69 @@
+"""Pins the spelled-out Detect category count in correctness-review.md to the
+actual number of numbered items (#1639 follow-up finding).
+
+Adding categories 6 and 7 required updating two hardcoded "seven" mentions
+(Protocol Phase 1, the Detect preamble) by hand, with nothing tying either
+number to the real count of numbered items below it. A future add/remove
+would have nothing but author diligence keeping them in sync — the same
+"gate that cannot fail" risk this repo's own CLAUDE.md warns about — so a
+stale count would silently instruct the agent to stop enumerating early.
+"""
+
+from __future__ import annotations
+
+import re
+
+from _repo_root import REPO_ROOT
+
+AGENT = (
+    REPO_ROOT / "plugins" / "dev-team" / "agents" / "correctness-review.md"
+)
+
+_NUMBERED_CATEGORY_RE = re.compile(r"^\d+\. \*\*", re.MULTILINE)
+_SPELLED_OUT = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+
+
+def _text() -> str:
+    return AGENT.read_text(encoding="utf-8")
+
+
+def _detect_category_count(text: str) -> int:
+    detect_section = text.split("## Detect", 1)[1].split("\n## ", 1)[0]
+    return len(_NUMBERED_CATEGORY_RE.findall(detect_section))
+
+
+def test_detect_preamble_count_matches_numbered_categories() -> None:
+    text = _text()
+    actual = _detect_category_count(text)
+    match = re.search(r"looking for these (\w+) categories", text)
+    assert match, "Detect preamble's category-count phrase not found"
+    stated = _SPELLED_OUT.get(match.group(1).lower())
+    assert stated is not None, f"unrecognized spelled-out number: {match.group(1)!r}"
+    assert stated == actual, (
+        f"Detect preamble says {match.group(1)!r} ({stated}) but the Detect "
+        f"section has {actual} numbered categories — update the preamble"
+    )
+
+
+def test_protocol_phase_1_count_matches_numbered_categories() -> None:
+    text = _text()
+    actual = _detect_category_count(text)
+    match = re.search(r"against the (\w+) Detect categories below", text)
+    assert match, "Protocol Phase 1's category-count phrase not found"
+    stated = _SPELLED_OUT.get(match.group(1).lower())
+    assert stated is not None, f"unrecognized spelled-out number: {match.group(1)!r}"
+    assert stated == actual, (
+        f"Protocol Phase 1 says {match.group(1)!r} ({stated}) but the Detect "
+        f"section has {actual} numbered categories — update Phase 1"
+    )


### PR DESCRIPTION
## Summary

- Part 2 of #1639 (part 1, the `category`/rule-ID contract change, landed in #1693). Implements items 2-6: a 6th Detect category (unverified runtime/library claim, #1629's executable-claims convention), a 7th (error-signalling divergence, distinct from category 3's missing-precondition case), a `## Protocol` section and `## Severity Anchors` table modeled on `naming-review.md`, and promotes the drop-if-no-articulable-intent rule into the Detect preamble while converting the Status/Severity/Confidence prose into tables (preserving the `confidence: none` missing-context exception verbatim).
- Does **not** opt `correctness-review` into the verification-mode tier-down, per the issue's explicit constraint (pending #1624's data).
- A 16-agent review panel plus two follow-up verification rounds found and fixed real defects the first draft introduced: category 6 was originally **unreachable** (the evident-intent drop rule deleted every category-6 candidate by construction) — fixed with explicit exceptions across the Detect preamble, Protocol Phase 2, and the Confidence/Severity/Status tables. Also fixed: a factually-incorrect Severity Anchors code example (correct 0-indexed loop code mislabeled as an off-by-one defect), anchor/table severity mismatches, an unreachable "commit message" trigger (this agent has no git access), a misstated tool-grant citation, an overlapping category 3/7 boundary, and undeclared scope overlap with `doc-review` and `ai-provenance-review` (both now carry deference clauses). Added a content-guard test pinning the Detect category count so it can't silently drift from the numbered list again.
- **Reopened #1639 first**: PR #1693 said "Closes #1639" despite being explicitly only part 1 of 2, which auto-closed the issue before this half landed.
- **Breaking eval-corpus change**: an empirical run against the `cr-clean-baseline` fixture (previously "no known correctness defects") found two genuine category-6 findings (unprobed runtime claims already in that file). `cr-clean-baseline.json`'s `expectedStatus` flips from `pass` to `warn` to match, with a `_calibration` note recording the measured run — `issueCount` stays within its existing 0-2 budget. Per issue #101's eval-corpus-is-the-semver-contract convention, this requires a major bump (`fix!:` + `BREAKING CHANGE:` footer).
- Filed #1695 (eval fixtures for categories 6/7, deferred pending a measured run per the calibration-provenance convention) and #1696 (Protocol/Self-Challenge preamble duplicated across ~20 review agents — pre-existing, out of scope here) as follow-ups.

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 6856 passed
- [x] `bash scripts/ci-local.sh` — all checks pass (including the eval-corpus semver contract check, which correctly caught the `cr-clean-baseline` verdict flip)
- [x] `python3 scripts/check_md_references.py` — clean
- [x] `python3 scripts/validate_agent_contract.py plugins/dev-team/agents/correctness-review.md` — pass
- [x] `python3 scripts/check_registry_sync.py` — in sync
- [x] Empirically verified the `cr-clean-baseline` eval fixture against the fixed agent (not just asserted) — found 2 genuine category-6 findings, updated the fixture's expectation to match
- [x] Hand-verified the new `test_correctness_review_category_count.py` content guard actually fails on a stale count before trusting it
- [x] 16-agent code-review panel, a 3-agent closing-pass verifying every prior finding was actually resolved, and a final 2-agent round after last-mile wording fixes — all `status: pass` with zero new findings on the last two rounds

Closes #1639

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoK6Gu6T7xUj7HiLZYeQGE)_