### PR TITLE
feat(ci): wire the PMD checksum verify job into opt-in-tests.yml (#1657)

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -34,6 +34,7 @@
     "Eval live regression (opt-in)": "Dispatches the real agents and costs model tokens. Runs only behind a 'run-eval' label plus ANTHROPIC_API_KEY, and skips (not fails) without them — a required check would report success on every PR that didn't opt in.",
     "Eval integration tier (opt-in)": "Same opt-in posture as the live gate: real orchestrator dispatch, real tokens, label-gated.",
     "Stryker.NET POSIX signal tests": "Path-filtered to the mutation wrapper. A path-filtered workflow reports NO status on PRs that don't match, so requiring it would deadlock every unrelated PR at 'Waiting for status to be reported'.",
+    "PMD checksum verify": "Path-filtered to the PMD installer + its checksum verifier (plus the shared weekly schedule). Same deadlock shape as the Stryker.NET signal tests above — a path-filtered workflow reports no status on unrelated PRs.",
     "Orchestrator real-subprocess test": "Schedule and workflow_dispatch only — it shells out to the real `claude` CLI, whose outcome, latency, and cost vary by host. It reports no status on a PR at all.",
     "Pytest on native Windows": "Path-filtered to the mutation wrapper for cost reasons (Windows runners), so it reports no status on unrelated PRs — same deadlock as the Stryker.NET signal tests above."
   }

--- a/.github/workflows/opt-in-tests.yml
+++ b/.github/workflows/opt-in-tests.yml
@@ -15,11 +15,22 @@ name: Opt-in tests
 #      runs only on a schedule and manual dispatch, NOT on every PR — mirroring
 #      the opt-in posture of the "Eval live regression" lane.
 #
-# The default local/pre-push run keeps skipping all three: this workflow imposes
+# A fourth, related-but-distinct lane lives in this same workflow (issue #1657):
+#   3. PMD checksum verify — downloads the real, currently-published PMD release
+#      asset and asserts its SHA-256 matches install-java-static-analysis.py's
+#      pinned PMD_SHA256. Keyless and cheap, so it runs on every PR that touches
+#      the installer (path-filtered) and on the shared weekly schedule, so an
+#      upstream re-publish under the same version tag is still caught even with
+#      no local change.
+#
+# The default local/pre-push run keeps skipping all four: this workflow imposes
 # no new requirement on any dev machine. A failure here is a real red run
-# (surfaced on the PR for the wrapper job; a failed scheduled run for the
+# (surfaced on the PR for the wrapper/PMD jobs; a failed scheduled run for the
 # orchestrator job, which GitHub notifies the repo admins about) — never a
 # silent green.
+
+permissions:
+  contents: read
 
 on:
   # path-filtered: fires the wrapper job only when the wrapper / its tests / this
@@ -30,11 +41,15 @@ on:
     paths:
       - "plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py"
       - "tests/scripts/test_csharp_stryker_net_wrapper.py"
+      - "plugins/dev-team/scripts/install-java-static-analysis.py"
+      - "scripts/verify_pmd_checksum_pin.py"
       - ".github/workflows/opt-in-tests.yml"
   pull_request:
     paths:
       - "plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py"
       - "tests/scripts/test_csharp_stryker_net_wrapper.py"
+      - "plugins/dev-team/scripts/install-java-static-analysis.py"
+      - "scripts/verify_pmd_checksum_pin.py"
       - ".github/workflows/opt-in-tests.yml"
   # Weekly heartbeat (Mondays 06:17 UTC) so both lanes exercise their code even
   # when nothing in the paths above changed.
@@ -120,3 +135,28 @@ jobs:
           python -m pytest \
             "tests/scripts/test_orchestrator.py::test_classify_real_subprocess_returns_valid_size" \
             -v -ra --tb=short
+
+  pmd-checksum-verify:
+    name: PMD checksum verify
+    # Keyless and cheap (a single download + hash), so — unlike the pricier
+    # orchestrator lane above — this runs on every PR that touches the
+    # installer (path-filtered) as well as the shared weekly schedule.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+
+      # Downloads the real, currently-published PMD release asset and asserts
+      # its SHA-256 matches install-java-static-analysis.py's pinned
+      # PMD_SHA256 — the last unverified premise in #1637's PMD-installer
+      # security hardening (issue #1657).
+      # test_checksum_mismatch_refuses_to_extract (hermetic) only proves the
+      # *rejection* path against a synthetic tampered archive; nothing in the
+      # offline suite ever re-fetches the real network artifact.
+      - name: Verify PMD_SHA256 pin against the real release asset
+        run: python3 scripts/verify_pmd_checksum_pin.py


### PR DESCRIPTION
## Summary

- Wires the `pmd-checksum-verify` job (added by #1657, PR #1704) into
  `.github/workflows/opt-in-tests.yml` and adds its
  `required-status-checks.json` exempt entry.
- This is the one piece of #1657 that couldn't be pushed from the Claude
  Code web/cloud session that did the rest of the work — its git
  credential lacked the GitHub `workflow` OAuth scope. See #1703 for the
  full explanation and the exact diff (identical to what this PR applies).
- Both hunks were already reviewed by a correctness-review + security-review
  closing pass in PR #1704 — this is a mechanical apply, not new work.

## Test Plan

- [ ] CI green on this PR (the new job itself will run, path-filtered on
      this file changing)

Closes #1703