### PR TITLE
feat(scripts): wire orchestrator.py Implement phase to real persona dispatch

### DIFF
--- a/docs/adr/0013-llm-driven-orchestration-over-deterministic-workflow-scripts.md
+++ b/docs/adr/0013-llm-driven-orchestration-over-deterministic-workflow-scripts.md
@@ -94,3 +94,49 @@ architecture.
 **Easier:** Adding new agents, changing routing rules, and adjusting human gates
 requires editing markdown skill files rather than releasing JavaScript. The pipeline
 can adapt to mid-run judgment calls that structural computation cannot anticipate.
+
+## Amendment (2026-08-02): `orchestrator.py`'s deterministic `CODE_REVIEW_PANEL` dispatch
+
+Epic #1648/spec #1707 ("Wire orchestrator.py to Real Agent Dispatch") wired
+`plugins/dev-team/scripts/orchestrator.py`'s Implement phase
+(`_dispatch_implement_verification`) to dispatch a fixed three-agent panel
+(`doc-review`, `arch-review`, `token-efficiency-review`) plus `tech-writer`
+on every successful Implement wave, with no per-run selection judgment, via
+a deterministic Python script rather than LLM judgment — the first place
+this codebase drives a `CODE_REVIEW_PANEL`-shaped
+fan-out from code instead of from the `/code-review` skill's own runtime
+reasoning.
+
+This does not contradict the Decision above, for the same reason [ADR
+0020](0020-fold-mutation-pipeline-into-the-plugin.md) already drew the line
+for the mutation-kill pipeline: ADR 0013 protects the **fan-out dispatch
+decision inside the interactive `/build` and `/code-review` skills** —
+whether and how to spawn sub-agents when a human-in-the-loop session is
+driving the Research→Plan→Implement pipeline, where mid-run
+judgment (serializing two nominally-independent slices, collapsing a wave
+after an unexpected conflict, re-planning instead of fixing) has real
+adaptation value a script cannot supply. `orchestrator.py` is not that skill
+and does not replace it: `/code-review`, invoked interactively, is
+completely unchanged by this work and still fans out exactly as this ADR
+decided. `orchestrator.py` is a separate, standalone, headless CLI script —
+`Enforcement: script` on `agents/orchestrator.md`, a body-level convention
+documented in `plugins/dev-team/docs/agent_info.md` (§Non-standard body
+declarations) and enforced by `skills/agent-audit/SKILL.md`, already carried
+by four other
+agents (`progress-guardian`, `token-efficiency-review`,
+`claude-setup-review`, `codebase-recon`) — and `orchestrator.py`'s own
+Research and Plan phases were already script-driven before this slice, so
+its Implement phase now dispatches that same fixed panel every time it
+runs (on every successful wave — see the Known gap below), with no
+per-run adaptation: no serialization judgment, no wave-collapse decision, no
+re-planning branch. Its control flow carries no adaptation value to lose,
+the same category ADR 0020 already carved out. Scripting a fixed,
+judgment-free fan-out inside a pre-existing standalone script is not the
+move this ADR declined.
+
+**Known gap, not a contradiction of this amendment:** `orchestrator.py`'s
+dispatch does not yet read or gate on the panel's `review_status` verdicts
+(a `fail` verdict has the same observable outcome as a clean pass today) —
+tracked against spec #1707/a future slice in
+`agents/orchestrator.md`'s Implement-phase Script gap paragraph, not
+resolved by this amendment.

--- a/plugins/dev-team/agents/orchestrator.md
+++ b/plugins/dev-team/agents/orchestrator.md
@@ -418,6 +418,91 @@ not yet implemented.
 - **Human gate**: Human reviews the final output. If the plan was good, implementation review is lightweight.
 - **Context**: If implementation is large, compact mid-phase — update the plan progress file with completed steps and continue in a fresh context
 
+**Implementation status.** `orchestrator.py`'s `run_pipeline` dispatches
+this phase via `_default_phase_implement` immediately after Plan completes,
+for every `standard`/`complex`-classified task — the same classification-
+driven scope Research and Plan already use (the `trivial` fast-path is
+`run_pipeline`'s only *classification*-driven branch point; `--fail-wave`,
+`--dispatch-personas`, and the no-prior-state `--resume` guard are separate,
+test/debug-only early-return paths, not part of this classification logic).
+See the Implement persona roster
+subsection below for what the script actually dispatches, and its Script
+gap paragraph for what the agent-facing policy above still describes that
+the script does not yet implement.
+
+#### Implement persona roster (`orchestrator.py`'s `SOFTWARE_ENGINEER_PERSONA`/`TECH_WRITER_PERSONA`)
+
+`orchestrator.py`'s `_default_phase_implement` — the `Enforcement: script`
+deterministic implementation of this phase — composes two helpers for every
+`standard`/`complex`-classified task. `_dispatch_implement_wave` dispatches
+`SOFTWARE_ENGINEER_PERSONA` (`software-engineer`) once, for the sole
+synthetic slice in `IMPLEMENT_WAVE_SLICES` (`("implement-1",)`), via the
+existing `dispatch_personas` (reused verbatim rather than a second
+hand-rolled `asyncio.gather`/`BaseException`-normalization copy), with the
+Plan phase's aggregated state as context. Each result is tagged with its
+`"slice"` key before `reconcile()` runs directly against the wave's results;
+a `status: "failed"` entry raises `WaveError`, which propagates uncaught out
+of `_dispatch_implement_wave` — `_run_phase`'s `write_progress` call never
+runs for a failed wave, so the phase's state file stays absent and a
+subsequent `--resume` run retries Implement from scratch. `run_pipeline`
+catches `WaveError` at its own call site, prints
+`ERROR: wave barrier failed on slice '<failing_slice>'` followed by
+`Resume with: python3 <script-path> --resume` (via the shared
+`_print_wave_failure` helper, also used by the `--fail-wave` test/debug
+simulation branch, which deliberately prints an unrelated `'slice-1'` name
+since it doesn't go through `IMPLEMENT_WAVE_SLICES`), and returns exit code
+1. The wave's own stderr WARNING (labeled `"Implement"`) uses different
+wording than Research/Plan's non-fatal WARNINGs — `(wave barrier will
+fail)`, not `(recorded, non-fatal)` — since a wave failure here is neither:
+it is about to raise `WaveError` uncaught and end the process.
+
+On a successful wave (no failed slice), `_dispatch_implement_verification`
+dispatches the existing `CODE_REVIEW_PANEL` (`doc-review`, `arch-review`,
+`token-efficiency-review`) and `TECH_WRITER_PERSONA` (`tech-writer`) — both
+via `dispatch_personas`, never a bare `dispatch_persona` call, so an
+unexpected throwable from either is normalized into a failure stub instead
+of escaping past `run_pipeline`'s `except WaveError` and discarding a
+successful wave's results — against the wave's own results as context. Both
+dispatches receive the task classification, the original request text, and
+the wave's dispatch-result metadata (persona/status/slice per entry) — not
+the actual changeset diff or the affected documentation files, so neither
+call performs a real code review or doc pass today — narrower than their
+names promise, mirroring the same narrowing Phase 2's
+`plan-review-*` critics already carry against a rendered plan document. A
+second, independent `_warn_on_failed_personas` call (labeled
+`"Implement review"`, genuinely non-fatal this time) surfaces a failed
+review-panel member or a failed tech-writer dispatch as a stderr WARNING —
+exit code stays 0, and the state file still records the failed entry
+verbatim — mirroring the same non-fatal-failure-visibility convention
+Research and Plan already established.
+
+**Script gap.** `_dispatch_implement_wave` dispatches a single synthetic
+slice representing "the whole task," not real per-plan-step decomposition —
+Phase 2's persisted shape (`orchestrator-plan.json`) has no
+machine-parseable ordered list of implementation steps to derive
+`IMPLEMENT_WAVE_SLICES` from. The script also does not implement the
+three-stage inline review loop described above (`spec-reviewer` →
+`quality-reviewer` → browser verification), nor the final `/code-review`
+`fail`/`warn`/`pass` branching before its doc-review pass — the review
+panel's `review_status` verdicts are persisted but not read or gated on;
+a `fail` verdict has the same observable outcome (exit 0, state persisted)
+as a clean pass. All of the above (the inline review loop, the
+`/code-review` branching, real per-step decomposition, and verdict gating)
+remain the operator's own responsibility today; tracked against spec
+#1707/a future slice. Separately: `--resume` after a wave failure
+re-dispatches `software-engineer` against a working tree that may already
+carry partial edits from the failed attempt (a realistic case under
+`PERSONA_DISPATCH_TIMEOUT_S`'s unverified 60s placeholder — see follow-up
+#1716) — reconciling that state is the operator's own responsibility today,
+not something this script checks or compensates for. This phase's dispatch
+of `CODE_REVIEW_PANEL` is also the first place in this script where a
+`/code-review`-shaped fan-out is driven deterministically rather than by
+skill instructions. This is a deliberate, spec-#1707-scoped choice, not an
+oversight against [ADR 0013](../../../docs/adr/0013-llm-driven-orchestration-over-deterministic-workflow-scripts.md#amendment-2026-08-02-orchestratorpys-deterministic-code_review_panel-dispatch)'s
+LLM-driven-orchestration preference — see that ADR's amendment for why this
+standalone script's fixed, judgment-free panel dispatch does not replace or
+contradict the interactive `/code-review` skill's own unchanged fan-out.
+
 #### Review Depth by Complexity
 
 Each plan step includes a **Complexity** classification that controls review depth:

--- a/plugins/dev-team/scripts/orchestrator.py
+++ b/plugins/dev-team/scripts/orchestrator.py
@@ -99,6 +99,29 @@ CRITICS_SKIPPED_ALL_CORE_FAILED = "all_core_personas_failed"
 # literal at each call/test site.
 SECURITY_ENGINEER_PERSONA = "security-engineer"
 
+# The Implement-phase wave persona and its post-success doc-verification
+# persona (see _default_phase_implement below). Named for the same reason
+# SECURITY_ENGINEER_PERSONA is: avoid re-typing the literal at each
+# call/test site.
+SOFTWARE_ENGINEER_PERSONA = "software-engineer"
+TECH_WRITER_PERSONA = "tech-writer"
+
+# Implement-phase wave slice roster (see _dispatch_implement_wave below). A
+# tuple, matching RESEARCH_PERSONAS/PLAN_CORE_PERSONAS's own convention.
+# Load-bearing, not decorative: persisted into orchestrator-implement.json
+# and printed verbatim in the operator-facing "wave barrier failed on slice
+# '<name>'" message. One definition on the production side (test_orchestrator
+# pins its exact value directly below, alongside SOFTWARE_ENGINEER_PERSONA/
+# TECH_WRITER_PERSONA's own pinning tests) — most test sites deliberately
+# still pin the literal value independently rather than importing this
+# constant, matching how this file's persona constants are pinned rather
+# than merely referenced. A single synthetic slice representing "the whole
+# task" today (see the Script gap in agents/orchestrator.md for why); the
+# --fail-wave simulation branch below deliberately prints a different,
+# unrelated slice name ("slice-1") since it doesn't go through this
+# constant at all.
+IMPLEMENT_WAVE_SLICES = ("implement-1",)
+
 # Timeouts (seconds) for the two `claude -p` subprocess dispatch sites below.
 # Unverified placeholders, not measured against a real dispatch — see
 # follow-up #1716.
@@ -106,20 +129,26 @@ CLASSIFY_TIMEOUT_S = 30
 PERSONA_DISPATCH_TIMEOUT_S = 60
 
 
-def _warn_on_failed_personas(phase_label: str, results: list) -> None:
+def _warn_on_failed_personas(phase_label: str, results: list, fatal: bool = False) -> None:
     """Print a single stderr WARNING naming every failed persona in results,
     or nothing at all if none failed.
 
-    Shared by _default_phase_research and _default_phase_plan so the
-    degraded-but-non-fatal WARNING message has one normative
-    formatting/behavior definition instead of two independently maintained
-    copies — deferred from Research's own Slice 2 landing pending Plan's
-    own implementation existing to compare against (now it does).
+    Shared by _default_phase_research, _default_phase_plan, and
+    _default_phase_implement so the WARNING message has one normative
+    formatting/behavior definition instead of independently maintained
+    copies. Research/Plan's failures (and Implement's post-success review
+    group) are genuinely recorded and non-fatal, which is the default
+    wording — but the Implement wave dispatch is a different case: a
+    failure there is about to raise WaveError uncaught (the state file is
+    never written) and end the process with exit code 1, so `fatal=True`
+    selects wording that says so instead of falsely claiming
+    "(recorded, non-fatal)".
     """
     failed_personas = [r["persona"] for r in results if r.get("status") == "failed"]
     if failed_personas:
+        suffix = "wave barrier will fail" if fatal else "recorded, non-fatal"
         print(
-            f"WARNING: {phase_label} persona dispatch failed (recorded, non-fatal): {', '.join(failed_personas)}",
+            f"WARNING: {phase_label} persona dispatch failed ({suffix}): {', '.join(failed_personas)}",
             file=sys.stderr,
         )
 
@@ -314,6 +343,103 @@ async def _default_phase_plan(
 
 
 # ---------------------------------------------------------------------------
+# Implement phase
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_implement_wave(
+    request: str, task: dict, plan_state: dict, skip_llm: bool
+) -> list:
+    """Dispatch the Implement-phase wave and reconcile its results.
+
+    Dispatches SOFTWARE_ENGINEER_PERSONA once per IMPLEMENT_WAVE_SLICES entry
+    via dispatch_personas — reused verbatim rather than a hand-rolled second
+    copy of its gather/BaseException-normalization logic. The `* len(...)`
+    below is what keeps `personas` index-aligned with IMPLEMENT_WAVE_SLICES
+    for the "slice" tagging that follows — a real invariant, not decorative,
+    even though both are length 1 today (see IMPLEMENT_WAVE_SLICES's own
+    comment for why). reconcile() raises WaveError uncaught (no try/except
+    here) on any failed slice, so _run_phase's write_progress call never
+    runs for a failed wave — the phase's state file stays absent and a
+    subsequent --resume run retries Implement from scratch.
+    """
+    results = await dispatch_personas(
+        [SOFTWARE_ENGINEER_PERSONA] * len(IMPLEMENT_WAVE_SLICES),
+        plan={"task": task, "request": request, "plan_state": plan_state},
+        skip_llm=skip_llm,
+    )
+    for slice_name, result in zip(IMPLEMENT_WAVE_SLICES, results):
+        result["slice"] = slice_name
+    # fatal=True: this failure is about to raise WaveError uncaught (state
+    # never persisted, exit code 1) — the opposite of the "recorded,
+    # non-fatal" wording _warn_on_failed_personas defaults to.
+    _warn_on_failed_personas("Implement", results, fatal=True)
+    await reconcile(results, list(IMPLEMENT_WAVE_SLICES))  # raises WaveError; propagates uncaught
+    return results
+
+
+async def _dispatch_implement_verification(
+    request: str, task: dict, results: list, skip_llm: bool
+) -> tuple:
+    """Dispatch post-success review-panel + tech-writer verification.
+
+    Only reached after _dispatch_implement_wave's reconcile() succeeds.
+    Both go through dispatch_personas (never a bare dispatch_persona call),
+    so an unexpected throwable from either is normalized to a failure stub
+    rather than escaping past run_pipeline's `except WaveError` and
+    discarding a successful wave's results. A second, independent
+    _warn_on_failed_personas call ("Implement review", genuinely non-fatal)
+    surfaces a failed member of either dispatch as a stderr WARNING,
+    mirroring Research/Plan's own non-fatal-failure-visibility convention.
+    """
+    verification_payload = {
+        "task": task,
+        "request": request,
+        "implement_results": results,
+    }
+    review_results = await dispatch_personas(
+        CODE_REVIEW_PANEL, plan=verification_payload, skip_llm=skip_llm
+    )
+    (tech_writer_result,) = await dispatch_personas(
+        [TECH_WRITER_PERSONA],
+        plan=verification_payload,
+        skip_llm=skip_llm,
+    )
+    _warn_on_failed_personas("Implement review", review_results + [tech_writer_result])
+    return review_results, tech_writer_result
+
+
+async def _default_phase_implement(
+    request: str, task: dict, plan_state: dict, skip_llm: bool
+) -> dict:
+    """Dispatch the Implement-phase wave, reconcile it, then verify on success.
+
+    Composes two independently-changing concerns (see their own docstrings):
+    _dispatch_implement_wave (the wave-dispatch/reconcile barrier, whose
+    per-step decomposition is tracked future work — see the Script gap in
+    agents/orchestrator.md) and _dispatch_implement_verification (a stable
+    concern that shouldn't need to move when that lands).
+    """
+    results = await _dispatch_implement_wave(request, task, plan_state, skip_llm)
+    review_results, tech_writer_result = await _dispatch_implement_verification(
+        request, task, results, skip_llm
+    )
+    return {
+        "wave_slices": list(IMPLEMENT_WAVE_SLICES),
+        "results": results,
+        # list(...), not a bare reference: review_personas is persisted,
+        # and a future in-memory consumer mutating this list would
+        # otherwise corrupt the shared module constant CODE_REVIEW_PANEL
+        # for the rest of the process (same rationale as critic_personas
+        # in _default_phase_plan above).
+        "review_personas": list(CODE_REVIEW_PANEL),
+        "review_results": review_results,
+        "tech_writer_result": tech_writer_result,
+        "skip_llm": skip_llm,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Persona dispatch and wave barrier
 # ---------------------------------------------------------------------------
 
@@ -488,11 +614,23 @@ async def reconcile(results: list, wave_slices: list) -> None:
         )
 
 
+def _print_wave_failure(failing_slice: str) -> None:
+    """Print the shared two-line wave-barrier-failure message to stderr.
+
+    Shared by the --fail-wave simulation branch and the real WaveError-catch
+    site in run_pipeline so the resume-hint message has one normative
+    definition instead of two independently maintained copies of the same
+    two print() calls.
+    """
+    print(f"ERROR: wave barrier failed on slice '{failing_slice}'", file=sys.stderr)
+    print(f"Resume with: python3 {SCRIPTS / 'orchestrator.py'} --resume", file=sys.stderr)
+
+
 def _resolve_default(fn, default_fn):
     """Return fn if the caller supplied one, else default_fn.
 
-    Shared by run_pipeline's phase_research_fn/phase_plan_fn injection
-    points so a third (Implement, in a later slice) doesn't add a fourth
+    Shared by run_pipeline's phase_research_fn/phase_plan_fn/
+    phase_implement_fn injection points so each doesn't add its own
     hand-written `if X_fn is None: X_fn = ...` branch to run_pipeline's own
     body, each one pushing its cyclomatic complexity and parameter count
     higher.
@@ -508,8 +646,8 @@ async def _run_phase(
     Reads the phase's prior state from disk when resuming; otherwise calls
     phase_fn with fn_args and persists the result via write_progress. This is
     the shape run_pipeline previously hand-inlined once for Research
-    (Slice 2) — extracted here so a second (Plan) and third (Implement, in a
-    later slice) call site reuse one definition instead of re-copying it.
+    (Slice 2) — extracted here so the Plan and Implement call sites reuse
+    one definition instead of re-copying it.
     """
     state = read_progress(phase_name, memory_dir) if resume else None
     if state is None:
@@ -531,6 +669,7 @@ async def run_pipeline(
     classify_fn=None,
     phase_research_fn=None,
     phase_plan_fn=None,
+    phase_implement_fn=None,
     fail_wave: bool = False,
     dispatch_personas_flag: bool = False,
 ) -> int:
@@ -545,6 +684,7 @@ async def run_pipeline(
 
     phase_research_fn = _resolve_default(phase_research_fn, _default_phase_research)
     phase_plan_fn = _resolve_default(phase_plan_fn, _default_phase_plan)
+    phase_implement_fn = _resolve_default(phase_implement_fn, _default_phase_implement)
 
     # Fast path for trivial tasks
     if task.get("size") == "trivial":
@@ -563,11 +703,7 @@ async def run_pipeline(
 
     # Wave barrier failure simulation (for testing)
     if fail_wave:
-        print("ERROR: wave barrier failed on slice 'slice-1'", file=sys.stderr)
-        print(
-            f"Resume with: python3 {SCRIPTS / 'orchestrator.py'} --resume",
-            file=sys.stderr,
-        )
+        _print_wave_failure("slice-1")
         return 1
 
     # Persona dispatch (for testing --dispatch-personas flag)
@@ -585,9 +721,18 @@ async def run_pipeline(
     )
 
     # Phase 2: Plan
-    await _run_phase(
+    plan_state = await _run_phase(
         "plan", phase_plan_fn, memory_dir, resume, request, task, research_state, skip_llm
     )
+
+    # Phase 3: Implement
+    try:
+        await _run_phase(
+            "implement", phase_implement_fn, memory_dir, resume, request, task, plan_state, skip_llm
+        )
+    except WaveError as exc:
+        _print_wave_failure(exc.failing_slice)
+        return 1
 
     return 0
 

--- a/tests/scripts/test_orchestrator.py
+++ b/tests/scripts/test_orchestrator.py
@@ -124,6 +124,24 @@ def test_plan_core_personas_is_exactly_the_three_always_on_trio():
     assert orch.PLAN_CORE_PERSONAS == ("product-manager", "architect", "qa-engineer")
 
 
+def test_implement_persona_is_exactly_software_engineer():
+    """SOFTWARE_ENGINEER_PERSONA must equal exactly "software-engineer", matching
+    SECURITY_ENGINEER_PERSONA's own exact-equality pinning pattern."""
+    assert orch.SOFTWARE_ENGINEER_PERSONA == "software-engineer"
+
+
+def test_tech_writer_persona_is_exactly_tech_writer():
+    """TECH_WRITER_PERSONA must equal exactly "tech-writer"."""
+    assert orch.TECH_WRITER_PERSONA == "tech-writer"
+
+
+def test_implement_wave_slices_is_exactly_the_single_synthetic_slice():
+    """IMPLEMENT_WAVE_SLICES must equal exactly ("implement-1",) — the one
+    normative definition of this persisted, operator-facing slice name,
+    matching the persona constants' own exact-equality pinning pattern."""
+    assert orch.IMPLEMENT_WAVE_SLICES == ("implement-1",)
+
+
 @pytest.mark.parametrize(
     "persona",
     [
@@ -132,6 +150,8 @@ def test_plan_core_personas_is_exactly_the_three_always_on_trio():
         *orch.DEFAULT_PERSONAS,
         *orch.CODE_REVIEW_PANEL,
         orch.SECURITY_ENGINEER_PERSONA,
+        orch.SOFTWARE_ENGINEER_PERSONA,
+        orch.TECH_WRITER_PERSONA,
     ],
 )
 def test_every_dispatchable_persona_resolves_to_a_real_agent(persona):
@@ -1145,17 +1165,21 @@ async def test_resume_skips_dispatch_and_leaves_file_unchanged_with_real_researc
     Research dispatch entirely and leaves the file unchanged, re-verified
     against the real (non-stub) research function.
 
-    Scoped to Research alone via a no-op phase_plan_fn stub: this test
-    pre-seeds only orchestrator-research.json (no orchestrator-plan.json),
-    which is also the realistic "Research done, Plan pending" partial-resume
-    shape — Plan-phase dispatch behavior for that shape has its own
-    dedicated coverage (test_resume_with_research_done_dispatches_plan_using_resumed_research_state
+    Scoped to Research alone via no-op phase_plan_fn/phase_implement_fn
+    stubs: this test pre-seeds only orchestrator-research.json (no
+    orchestrator-plan.json or orchestrator-implement.json), which is also
+    the realistic "Research done, Plan pending" partial-resume shape —
+    Plan-phase dispatch behavior for that shape has its own dedicated
+    coverage (test_resume_with_research_done_dispatches_plan_using_resumed_research_state
     below); this test's purpose stays narrowly "Research's own resume-skip
-    still works", so it must not depend on how Plan's real dispatch
-    handles a bare, non-list-returning mock_dispatch."""
+    still works", so it must not depend on how Plan's or Implement's real
+    dispatch handles a bare, non-list-returning mock_dispatch."""
 
     async def noop_phase_plan_fn(request, task, research_state, skip_llm):
         return {"stub": "plan"}
+
+    async def noop_phase_implement_fn(request, task, plan_state, skip_llm):
+        return {"stub": "implement"}
 
     with tempfile.TemporaryDirectory() as tmp:
         memory_dir = Path(tmp)
@@ -1175,6 +1199,7 @@ async def test_resume_skips_dispatch_and_leaves_file_unchanged_with_real_researc
                 resume=True,
                 classify_fn=lambda req: {"size": "standard"},
                 phase_plan_fn=noop_phase_plan_fn,
+                phase_implement_fn=noop_phase_implement_fn,
             )
 
         post_run_contents = orch.phase_state_path("research", memory_dir).read_text()
@@ -1197,11 +1222,13 @@ async def test_default_phase_research_records_one_failed_persona_verbatim_withou
     roster — a mutant that joined `personas` instead of `failed_personas`
     would still pass those two degenerate tests but fail this one.
 
-    Scoped to Research alone via a no-op phase_plan_fn stub: dispatch_personas
-    is patched globally (it must be, to fake Research's own dispatch), so
-    without a stub the same fake would also serve Plan's two dispatch calls
-    and merge a second, Plan-labeled WARNING into this test's stderr —
-    muddying what this test is actually asserting."""
+    Scoped to Research alone via no-op phase_plan_fn/phase_implement_fn
+    stubs: dispatch_personas is patched globally (it must be, to fake
+    Research's own dispatch), so without stubs the same fake would also
+    serve Plan's and Implement's dispatch calls — merging extra WARNINGs
+    into this test's stderr and (for Implement) breaking on the
+    slice-tagging/reconcile() machinery since fake_results carries no
+    "slice" key — muddying what this test is actually asserting."""
     fake_results = [
         {"persona": "codebase-recon", "status": "success"},
         {"persona": "architect", "status": "failed", "error": "llm_unavailable"},
@@ -1214,6 +1241,9 @@ async def test_default_phase_research_records_one_failed_persona_verbatim_withou
     async def noop_phase_plan_fn(request, task, research_state, skip_llm):
         return {"stub": "plan"}
 
+    async def noop_phase_implement_fn(request, task, plan_state, skip_llm):
+        return {"stub": "implement"}
+
     with (
         patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
         tempfile.TemporaryDirectory() as tmp,
@@ -1225,6 +1255,7 @@ async def test_default_phase_research_records_one_failed_persona_verbatim_withou
             skip_llm=True,
             classify_fn=lambda req: {"size": "standard"},
             phase_plan_fn=noop_phase_plan_fn,
+            phase_implement_fn=noop_phase_implement_fn,
         )
         state = orch.read_progress("research", memory_dir)
 
@@ -1248,10 +1279,11 @@ async def test_default_phase_research_records_all_personas_failed_verbatim_witho
     run where every persona failed would look identical, on the console, to
     one that fully succeeded.
 
-    Scoped to Research alone via a no-op phase_plan_fn stub — see the
-    identical rationale on test_default_phase_research_records_one_failed_persona_verbatim_without_raising
-    above: without it, this same fake would also serve Plan's dispatch
-    calls and merge a second WARNING into this test's stderr."""
+    Scoped to Research alone via no-op phase_plan_fn/phase_implement_fn
+    stubs — see the identical rationale on
+    test_default_phase_research_records_one_failed_persona_verbatim_without_raising
+    above: without them, this same fake would also serve Plan's and
+    Implement's dispatch calls."""
     fake_results = [
         {"persona": "codebase-recon", "status": "failed", "error": "llm_unavailable"},
         {"persona": "architect", "status": "failed", "error": "llm_unavailable"},
@@ -1268,6 +1300,9 @@ async def test_default_phase_research_records_all_personas_failed_verbatim_witho
     async def noop_phase_plan_fn(request, task, research_state, skip_llm):
         return {"stub": "plan"}
 
+    async def noop_phase_implement_fn(request, task, plan_state, skip_llm):
+        return {"stub": "implement"}
+
     with (
         patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
         tempfile.TemporaryDirectory() as tmp,
@@ -1279,6 +1314,7 @@ async def test_default_phase_research_records_all_personas_failed_verbatim_witho
             skip_llm=True,
             classify_fn=lambda req: {"size": "standard"},
             phase_plan_fn=noop_phase_plan_fn,
+            phase_implement_fn=noop_phase_implement_fn,
         )
         state = orch.read_progress("research", memory_dir)
 
@@ -1676,7 +1712,16 @@ async def test_resume_with_existing_plan_state_skips_plan_dispatch_entirely():
     byte-identical to its pre-run contents. Asserted via call-count, not
     just content equality — deterministic skip_llm=True stub output means a
     broken resume guard that redundantly re-dispatches would still produce
-    byte-identical content."""
+    byte-identical content.
+
+    Scoped to Plan alone via a no-op phase_implement_fn stub: no
+    orchestrator-implement.json is pre-seeded here, so without the stub the
+    real Implement phase would also call the unconfigured dispatch_personas
+    mock and break this test's assert_not_called()."""
+
+    async def noop_phase_implement_fn(request, task, plan_state, skip_llm):
+        return {"stub": "implement"}
+
     with tempfile.TemporaryDirectory() as tmp:
         memory_dir = Path(tmp)
         orch.write_progress(
@@ -1700,6 +1745,7 @@ async def test_resume_with_existing_plan_state_skips_plan_dispatch_entirely():
                 skip_llm=True,
                 resume=True,
                 classify_fn=lambda req: {"size": "standard"},
+                phase_implement_fn=noop_phase_implement_fn,
             )
 
         post_run_contents = orch.phase_state_path("plan", memory_dir).read_text()
@@ -1716,13 +1762,22 @@ async def test_resume_with_research_done_dispatches_plan_using_resumed_research_
     disk-read Research state — not a freshly re-dispatched one — as the
     core trio's "research" payload value. dispatch_personas must not have
     been called with RESEARCH_PERSONAS during this run (Research itself
-    stays skipped; only Plan dispatches)."""
+    stays skipped; only Plan dispatches).
+
+    Scoped to Plan alone via a no-op phase_implement_fn stub: no
+    orchestrator-implement.json is pre-seeded either, so without the stub
+    the real Implement phase would also dispatch through this same fake and
+    inflate `calls` beyond the two Plan-phase dispatches this test asserts
+    on."""
     calls = []
     prior_research_state = {
         "personas": ["codebase-recon", "architect", "data-flow-tracer"],
         "results": [{"persona": "codebase-recon", "status": "success"}],
         "skip_llm": True,
     }
+
+    async def noop_phase_implement_fn(request, task, plan_state, skip_llm):
+        return {"stub": "implement"}
 
     with tempfile.TemporaryDirectory() as tmp:
         memory_dir = Path(tmp)
@@ -1739,6 +1794,7 @@ async def test_resume_with_research_done_dispatches_plan_using_resumed_research_
                 skip_llm=True,
                 resume=True,
                 classify_fn=lambda req: {"size": "standard"},
+                phase_implement_fn=noop_phase_implement_fn,
             )
 
         plan_state = orch.read_progress("plan", memory_dir)
@@ -1833,3 +1889,979 @@ async def test_skip_llm_true_plan_results_have_no_output_or_review_status_field(
         assert "output" not in r
         assert "review_status" not in r
     assert state["skip_llm"] is True
+
+
+# ---------------------------------------------------------------------------
+# Step 1.2 — _default_phase_implement() unit tests (direct calls, fakes for
+# dispatch_persona / dispatch_personas)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_wave_payload_has_task_request_and_plan():
+    """The wave dispatch_personas call's plan payload must be
+    {"task": task, "request": request, "plan_state": plan_state}, checked
+    directly on the call arguments."""
+    calls = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        calls.append({"personas": list(personas), "plan": plan, "skip_llm": skip_llm})
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    task = {"size": "standard"}
+    plan_state = {"core_results": []}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+    ):
+        await orch._default_phase_implement(
+            "add a login form", task, plan_state, skip_llm=True
+        )
+
+    wave_call = calls[0]
+    assert wave_call["personas"] == [orch.SOFTWARE_ENGINEER_PERSONA]
+    assert wave_call["plan"] == {
+        "task": task,
+        "request": "add a login form",
+        "plan_state": plan_state,
+    }
+    assert wave_call["skip_llm"] is True
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_verification_payload_has_task_request_and_implement_results():
+    """The post-success CODE_REVIEW_PANEL and tech-writer dispatch_personas
+    calls' plan payloads must each be exactly
+    {"task": task, "request": request, "implement_results": results} — where
+    "results" is the wave dispatch's own returned results list. Previously
+    only the wave's own payload shape was asserted anywhere in this file."""
+    calls = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        calls.append({"personas": list(personas), "plan": plan})
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    task = {"size": "standard"}
+    plan_state = {"core_results": []}
+
+    with patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas):
+        result = await orch._default_phase_implement(
+            "add a login form", task, plan_state, skip_llm=True
+        )
+
+    expected_payload = {
+        "task": task,
+        "request": "add a login form",
+        "implement_results": result["results"],
+    }
+    panel_call = next(c for c in calls if c["personas"] == list(orch.CODE_REVIEW_PANEL))
+    tech_writer_call = next(c for c in calls if c["personas"] == [orch.TECH_WRITER_PERSONA])
+    assert panel_call["plan"] == expected_payload
+    assert tech_writer_call["plan"] == expected_payload
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_results_carry_slice_key():
+    """Each wave result must have its "slice" key set (matching its
+    position in wave_slices) before reconcile() runs — reconcile() indexes
+    r["slice"] directly, not via .get."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+    ):
+        result = await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    assert result["results"] == [
+        {"persona": "software-engineer", "status": "success", "slice": "implement-1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_failed_wave_raises_wave_error_and_skips_review():
+    """A failed wave slice must raise WaveError with failing_slice ==
+    "implement-1" and must never reach the review-panel/tech-writer
+    dispatch calls. Both post-wave dispatches (CODE_REVIEW_PANEL and
+    TECH_WRITER_PERSONA) go through dispatch_personas, so a single
+    unconditional "any non-wave call" branch in the fake below catches
+    either — no separate dispatch_persona fake is needed or reachable,
+    since dispatch_persona is only ever called from inside the real
+    dispatch_personas, which is fully replaced here."""
+    post_wave_calls = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.SOFTWARE_ENGINEER_PERSONA]:
+            return [
+                {
+                    "persona": "software-engineer",
+                    "status": "failed",
+                    "error": "llm_unavailable",
+                }
+            ]
+        post_wave_calls.append(list(personas))
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        pytest.raises(orch.WaveError) as exc_info,
+    ):
+        await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    assert exc_info.value.failing_slice == "implement-1"
+    assert post_wave_calls == []
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_wave_exception_converted_to_dispatch_exception_and_raises():
+    """An exception raised by dispatch_persona during the wave call is
+    converted, via dispatch_personas' own real return_exceptions=True gather
+    normalization (reused, not re-derived — dispatch_personas itself is NOT
+    patched here), to a "dispatch_exception" failure stub that still
+    carries the correct "slice" key and still raises WaveError."""
+    captured = {}
+    real_reconcile = orch.reconcile
+
+    async def spying_reconcile(results, wave_slices):
+        captured["results"] = results
+        await real_reconcile(results, wave_slices)
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        raise RuntimeError("boom")
+
+    with (
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        patch.object(orch, "reconcile", side_effect=spying_reconcile),
+        pytest.raises(orch.WaveError) as exc_info,
+    ):
+        await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=False
+        )
+
+    assert exc_info.value.failing_slice == "implement-1"
+    assert captured["results"] == [
+        {
+            "persona": "software-engineer",
+            "status": "failed",
+            "error": "dispatch_exception",
+            "slice": "implement-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_successful_wave_dispatches_in_order():
+    """A successful wave must dispatch_personas([SOFTWARE_ENGINEER_PERSONA]) then
+    dispatch_personas(CODE_REVIEW_PANEL) then
+    dispatch_personas([TECH_WRITER_PERSONA]), in that order — tech-writer
+    goes through dispatch_personas (plural), not a bare dispatch_persona
+    call, per _dispatch_implement_verification."""
+    call_order = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        call_order.append(("dispatch_personas", list(personas)))
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas):
+        await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    assert call_order == [
+        ("dispatch_personas", [orch.SOFTWARE_ENGINEER_PERSONA]),
+        ("dispatch_personas", list(orch.CODE_REVIEW_PANEL)),
+        ("dispatch_personas", [orch.TECH_WRITER_PERSONA]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_failed_review_panel_persona_warns_and_is_recorded(
+    capsys,
+):
+    """A failed review-panel entry (via the dispatch_personas fake) must
+    trigger the second, independent _warn_on_failed_personas("Implement
+    review", ...) call and still be recorded verbatim in review_results."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.SOFTWARE_ENGINEER_PERSONA]:
+            return [{"persona": "software-engineer", "status": "success"}]
+        return [
+            {"persona": p, "status": "failed" if p == "arch-review" else "success"}
+            for p in personas
+        ]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+    ):
+        result = await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    stderr = capsys.readouterr().err
+    assert (
+        "WARNING: Implement review persona dispatch failed (recorded, non-fatal): arch-review"
+        in stderr
+    )
+    assert any(
+        r["persona"] == "arch-review" and r["status"] == "failed"
+        for r in result["review_results"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_failed_tech_writer_warns_and_is_recorded(capsys):
+    """A failed tech-writer dispatch (via the dispatch_personas fake) must
+    trigger the second, independent _warn_on_failed_personas("Implement
+    review", ...) call and still be recorded verbatim as tech_writer_result."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.TECH_WRITER_PERSONA]:
+            return [
+                {
+                    "persona": "tech-writer",
+                    "status": "failed",
+                    "error": "llm_unavailable",
+                }
+            ]
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas):
+        result = await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    stderr = capsys.readouterr().err
+    assert (
+        "WARNING: Implement review persona dispatch failed (recorded, non-fatal): tech-writer"
+        in stderr
+    )
+    assert result["tech_writer_result"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_no_warning_when_all_succeed(capsys):
+    """No WARNING of either label ("Implement" or "Implement review") fires
+    when every dispatch across both groups succeeds."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+    ):
+        await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    stderr = capsys.readouterr().err
+    assert "WARNING: Implement persona dispatch failed" not in stderr
+    assert "WARNING: Implement review persona dispatch failed" not in stderr
+
+
+@pytest.mark.asyncio
+async def test_default_phase_implement_returns_expected_persisted_shape():
+    """_default_phase_implement's return value must have exactly the
+    persisted shape: wave_slices, results, review_personas, review_results,
+    tech_writer_result, skip_llm."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+    ):
+        result = await orch._default_phase_implement(
+            "add a login form", {"size": "standard"}, {}, skip_llm=True
+        )
+
+    assert set(result.keys()) == {
+        "wave_slices",
+        "results",
+        "review_personas",
+        "review_results",
+        "tech_writer_result",
+        "skip_llm",
+    }
+    assert result["wave_slices"] == ["implement-1"]
+    assert result["review_personas"] == list(orch.CODE_REVIEW_PANEL)
+    assert result["review_personas"] is not orch.CODE_REVIEW_PANEL
+    assert result["skip_llm"] is True
+
+
+# ---------------------------------------------------------------------------
+# Step 1.2 — run_pipeline wiring: phase_implement_fn / orchestrator-implement.json
+# (translating the plan's Gherkin scenario block into real pytest tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_standard_task_writes_implement_state():
+    """Standard-classified task dispatches the Implement-phase wave after
+    Plan, matching the Gherkin scenario's exact observables."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    assert state["wave_slices"] == ["implement-1"]
+    assert len(state["results"]) == 1
+    assert state["results"][0]["status"] == "success"
+    assert state["results"][0]["slice"] == "implement-1"
+    assert state["review_personas"] == list(orch.CODE_REVIEW_PANEL)
+    assert len(state["review_results"]) == len(orch.CODE_REVIEW_PANEL)
+    assert all(r["status"] == "success" for r in state["review_results"])
+    assert state["tech_writer_result"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_complex_task_dispatches_same_implement_wave():
+    """Complex-classified task dispatches the identical single-slice
+    Implement-phase wave — the only branch point in run_pipeline is the
+    trivial fast-path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="redesign the payment pipeline",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "complex"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    assert state["wave_slices"] == ["implement-1"]
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_trivial_task_never_writes_implement_state():
+    """Trivial-classified task never reaches the Implement phase: no
+    orchestrator-implement.json file is written and exit code is 0 — also
+    re-verifying dispatch_personas/dispatch_persona are never called at all
+    (Research and Plan are skipped too, not just Implement)."""
+    with (
+        patch.object(orch, "dispatch_personas") as mock_dispatch_personas,
+        patch.object(orch, "dispatch_persona") as mock_dispatch_persona,
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="fix a typo",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "trivial"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    mock_dispatch_personas.assert_not_called()
+    mock_dispatch_persona.assert_not_called()
+    assert state is None
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_implement_wave_payload_carries_plan_phase_state():
+    """The Implement-phase dispatch receives the Plan phase's aggregated
+    state: the software-engineer call's plan payload has a "plan_state" key
+    equal to the written orchestrator-plan.json contents, and "task"/
+    "request" keys matching the classified task dict and request text."""
+    calls = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        calls.append({"personas": list(personas), "plan": plan})
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    task = {"size": "standard"}
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: task,
+        )
+        plan_state = orch.read_progress("plan", memory_dir)
+
+    assert exit_code == 0
+    wave_call = next(c for c in calls if c["personas"] == [orch.SOFTWARE_ENGINEER_PERSONA])
+    assert wave_call["plan"]["plan_state"] == plan_state
+    assert wave_call["plan"]["task"] == task
+    assert wave_call["plan"]["request"] == "add a login form"
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_failed_wave_slice_warning_precedes_error_and_skips_review(
+    capsys,
+):
+    """A failed wave slice's WARNING prints before WaveError turns into exit
+    code 1: the WARNING appears exactly once and before the ERROR line,
+    stderr contains "Resume with:", exit code is 1, no
+    orchestrator-implement.json file is written, and the review panel and
+    tech-writer are never dispatched. This test runs the full pipeline
+    (Research and Plan dispatch for real, through this same fake), so the
+    post-wave tracking below matches only the two known post-wave rosters
+    (CODE_REVIEW_PANEL, [TECH_WRITER_PERSONA]) rather than any non-wave
+    call — both go through dispatch_personas, so this one check catches
+    either; no separate dispatch_persona fake is reachable, since it is
+    only ever called from inside the real dispatch_personas, which is
+    fully replaced here."""
+    post_wave_calls = []
+    post_wave_rosters = (list(orch.CODE_REVIEW_PANEL), [orch.TECH_WRITER_PERSONA])
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.SOFTWARE_ENGINEER_PERSONA]:
+            return [
+                {
+                    "persona": "software-engineer",
+                    "status": "failed",
+                    "error": "llm_unavailable",
+                }
+            ]
+        if list(personas) in post_wave_rosters:
+            post_wave_calls.append(list(personas))
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    stderr = capsys.readouterr().err
+    warning_marker = (
+        "WARNING: Implement persona dispatch failed (wave barrier will fail): "
+        "software-engineer"
+    )
+    error_marker = "ERROR: wave barrier failed on slice 'implement-1'"
+    assert stderr.count(warning_marker) == 1
+    assert error_marker in stderr
+    assert stderr.index(warning_marker) < stderr.index(error_marker)
+    assert "Resume with:" in stderr
+    assert exit_code == 1
+    assert state is None
+    assert post_wave_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_wave_dispatch_exception_results_in_wave_error_exit_1(
+    capsys,
+):
+    """An exception raised during the wave dispatch is converted to a
+    dispatch_exception failure by dispatch_personas' own real
+    return_exceptions=True normalization, then reaches reconcile() like any
+    other failed slice — stderr shows the ERROR message, exit code is 1, and
+    no orchestrator-implement.json file is written.
+
+    ASSUMPTION (recorded per this repo's convention of naming under-specified
+    plan details explicitly rather than resolving them silently): the plan's
+    Gherkin literally says "a fake dispatch_personas that raises RuntimeError
+    for the software-engineer call". Patching dispatch_personas itself
+    wholesale to raise would propagate the RuntimeError straight out of
+    _default_phase_implement's `results = await dispatch_personas(...)` line
+    uncaught — past run_pipeline's `except WaveError` (which only catches
+    WaveError, not a bare RuntimeError) — contradicting the scenario's own
+    stated observable (stderr's ERROR message, exit code 1). Patching
+    dispatch_persona instead (leaving the real, unpatched dispatch_personas'
+    gather/return_exceptions=True path intact, exactly as the plan's own
+    "(the dispatch_exception status value itself is asserted at the
+    _default_phase_implement unit-test level...)" parenthetical describes)
+    is the only wiring that produces the scenario's literal stated outcome.
+
+    Scoped to Implement alone via no-op phase_research_fn/phase_plan_fn
+    stubs — matching the established convention elsewhere in this file
+    (e.g. test_default_phase_research_records_one_failed_persona_verbatim_without_raising):
+    without them, this same globally-raising dispatch_persona patch would
+    also fail every Research and Plan persona dispatch, which is unrelated
+    to what this test verifies."""
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        raise RuntimeError("boom")
+
+    async def noop_phase_research_fn(request, task, skip_llm):
+        return {"stub": "research"}
+
+    async def noop_phase_plan_fn(request, task, research_state, skip_llm):
+        return {"stub": "plan"}
+
+    with (
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+            phase_research_fn=noop_phase_research_fn,
+            phase_plan_fn=noop_phase_plan_fn,
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    stderr = capsys.readouterr().err
+    assert "ERROR: wave barrier failed on slice 'implement-1'" in stderr
+    assert exit_code == 1
+    assert state is None
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_resume_retries_implement_from_scratch_after_wave_error():
+    """--resume retries the Implement phase from scratch after a real
+    WaveError failure: the first run exits 1 with no orchestrator-
+    implement.json written; a second run with --resume re-dispatches
+    software-engineer (not a skip) and succeeds, proving the uncaught-
+    WaveError-propagation design's real payoff — a failed wave leaves no
+    trace for _run_phase to find."""
+    call_count = {"n": 0}
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.SOFTWARE_ENGINEER_PERSONA]:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [
+                    {
+                        "persona": "software-engineer",
+                        "status": "failed",
+                        "error": "llm_unavailable",
+                    }
+                ]
+            return [{"persona": "software-engineer", "status": "success"}]
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code_1 = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state_after_failure = orch.read_progress("implement", memory_dir)
+
+        exit_code_2 = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            resume=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state_after_resume = orch.read_progress("implement", memory_dir)
+
+    assert exit_code_1 == 1
+    assert state_after_failure is None
+    assert call_count["n"] == 2, "dispatch_personas must be called again for software-engineer"
+    assert exit_code_2 == 0
+    assert state_after_resume["results"][0]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_successful_wave_dispatches_engineer_then_panel_then_tech_writer_in_order():
+    """A successful wave dispatches software-engineer, then the code-review
+    panel, then tech-writer, in that order — verified end-to-end through
+    run_pipeline via a dependency-injected fake that records call order.
+    tech-writer is dispatched via dispatch_personas (plural), not a bare
+    dispatch_persona call — see _dispatch_implement_verification."""
+    call_order = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        call_order.append(("dispatch_personas", list(personas)))
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+
+    assert exit_code == 0
+    wave_index = call_order.index(("dispatch_personas", [orch.SOFTWARE_ENGINEER_PERSONA]))
+    panel_index = call_order.index(("dispatch_personas", list(orch.CODE_REVIEW_PANEL)))
+    tech_writer_index = call_order.index(("dispatch_personas", [orch.TECH_WRITER_PERSONA]))
+    assert wave_index < panel_index < tech_writer_index
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_failed_review_panel_persona_is_recorded_non_fatal(capsys):
+    """A failed review-panel persona is recorded, non-fatal, with its own
+    warning: stderr contains the Implement-review WARNING for "arch-review",
+    exit code is 0, and orchestrator-implement.json's "review_results"
+    contains a status "failed" entry for "arch-review"."""
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        if list(personas) == [orch.SOFTWARE_ENGINEER_PERSONA]:
+            return [{"persona": "software-engineer", "status": "success"}]
+        if list(personas) == list(orch.CODE_REVIEW_PANEL):
+            return [
+                {"persona": p, "status": "failed" if p == "arch-review" else "success"}
+                for p in personas
+            ]
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    stderr = capsys.readouterr().err
+    assert (
+        "WARNING: Implement review persona dispatch failed (recorded, non-fatal): arch-review"
+        in stderr
+    )
+    assert exit_code == 0
+    assert any(
+        r["persona"] == "arch-review" and r["status"] == "failed"
+        for r in state["review_results"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_failed_tech_writer_is_recorded_non_fatal(capsys):
+    """A failed tech-writer dispatch is recorded, non-fatal, with its own
+    warning: stderr contains the Implement-review WARNING for "tech-writer",
+    exit code is 0, and orchestrator-implement.json's "tech_writer_result"
+    has status "failed". The fake dispatch_persona only fails for
+    "tech-writer" (not every persona) since dispatch_persona is also the
+    function the real dispatch_personas calls internally for Research,
+    Plan, and the wave/review-panel dispatches in this same run — failing
+    universally would break those groups too."""
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        if persona == orch.TECH_WRITER_PERSONA:
+            return {"persona": persona, "status": "failed", "error": "llm_unavailable"}
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    stderr = capsys.readouterr().err
+    assert (
+        "WARNING: Implement review persona dispatch failed (recorded, non-fatal): tech-writer"
+        in stderr
+    )
+    assert exit_code == 0
+    assert state["tech_writer_result"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_no_implement_warning_when_all_dispatches_succeed(capsys):
+    """No Implement WARNING is printed when every dispatch in both groups
+    succeeds."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+
+    assert exit_code == 0
+    stderr = capsys.readouterr().err
+    assert "WARNING: Implement persona dispatch failed" not in stderr
+    assert "WARNING: Implement review persona dispatch failed" not in stderr
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_skip_llm_true_implement_state_has_no_output_or_review_status_fields():
+    """--skip-llm short-circuits Implement dispatch with no live CLI output:
+    each entry in "results", "review_results", and "tech_writer_result" has
+    status "success" with no "output" or "review_status" field, and
+    orchestrator-implement.json's "skip_llm" key is exactly True."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    for r in state["results"] + state["review_results"] + [state["tech_writer_result"]]:
+        assert r["status"] == "success"
+        assert "output" not in r
+        assert "review_status" not in r
+    assert state["skip_llm"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_skip_llm_false_is_forwarded_to_every_implement_dispatch_call():
+    """skip_llm=False is forwarded to every Implement-phase dispatch call
+    (dependency-injected fakes for both dispatch_persona and
+    dispatch_personas; no live CLI call is made) and recorded verbatim in
+    the persisted "skip_llm" key."""
+    skip_llm_values = []
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        skip_llm_values.append(skip_llm)
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    async def fake_dispatch_persona(persona, plan, skip_llm=False):
+        skip_llm_values.append(skip_llm)
+        return {"persona": persona, "status": "success"}
+
+    with (
+        patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas),
+        patch.object(orch, "dispatch_persona", side_effect=fake_dispatch_persona),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=False,
+            classify_fn=lambda req: {"size": "standard"},
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    assert all(v is False for v in skip_llm_values)
+    assert state["skip_llm"] is False
+
+
+@pytest.mark.asyncio
+async def test_resume_with_existing_implement_state_skips_implement_dispatch_entirely():
+    """--resume with existing orchestrator-research.json,
+    orchestrator-plan.json, and orchestrator-implement.json already present
+    skips Implement-phase dispatch entirely: neither dispatch_persona nor
+    dispatch_personas is called, and orchestrator-implement.json is
+    byte-identical to its pre-run contents. Re-verified against the real
+    (non-stub) _default_phase_implement, asserting on call count directly —
+    not just output-content equality — mirroring the Slice 3 precedent for
+    why content equality alone cannot prove a resume guard fired under
+    deterministic --skip-llm stub output."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        orch.write_progress(
+            "research", {"personas": [], "results": [], "skip_llm": True}, memory_dir
+        )
+        orch.write_progress(
+            "plan",
+            {
+                "core_personas": list(orch.PLAN_CORE_PERSONAS),
+                "core_results": [],
+                "critic_personas": orch.DEFAULT_PERSONAS,
+                "critic_results": [],
+                "critics_skipped_reason": None,
+                "skip_llm": True,
+            },
+            memory_dir,
+        )
+        prior_implement_state = {
+            "wave_slices": ["implement-1"],
+            "results": [
+                {"persona": "software-engineer", "status": "success", "slice": "implement-1"}
+            ],
+            "review_personas": list(orch.CODE_REVIEW_PANEL),
+            "review_results": [
+                {"persona": p, "status": "success"} for p in orch.CODE_REVIEW_PANEL
+            ],
+            "tech_writer_result": {"persona": "tech-writer", "status": "success"},
+            "skip_llm": True,
+        }
+        orch.write_progress("implement", prior_implement_state, memory_dir)
+        pre_run_contents = orch.phase_state_path("implement", memory_dir).read_text()
+
+        with (
+            patch.object(orch, "dispatch_personas") as mock_dispatch_personas,
+            patch.object(orch, "dispatch_persona") as mock_dispatch_persona,
+        ):
+            exit_code = await orch.run_pipeline(
+                request="add a login form",
+                memory_dir=memory_dir,
+                skip_llm=True,
+                resume=True,
+                classify_fn=lambda req: {"size": "standard"},
+            )
+
+        post_run_contents = orch.phase_state_path("implement", memory_dir).read_text()
+
+    assert exit_code == 0
+    mock_dispatch_personas.assert_not_called()
+    mock_dispatch_persona.assert_not_called()
+    assert post_run_contents == pre_run_contents
+
+
+@pytest.mark.asyncio
+async def test_resume_with_plan_done_dispatches_implement_using_resumed_plan_state():
+    """--resume with Plan done but Implement pending dispatches Implement
+    using the resumed plan state: the software-engineer call's plan
+    payload's "plan_state" key equals the existing orchestrator-plan.json
+    contents (not a freshly re-dispatched one), and orchestrator-implement.json
+    is written. Re-verified against the real (non-stub) _default_phase_implement,
+    asserting on dispatch_personas' call count directly (the tech-writer
+    call, dispatched via dispatch_personas, plural) — not just
+    output-content equality."""
+    calls = []
+    prior_plan_state = {
+        "core_personas": list(orch.PLAN_CORE_PERSONAS),
+        "core_results": [{"persona": "product-manager", "status": "success"}],
+        "critic_personas": orch.DEFAULT_PERSONAS,
+        "critic_results": [],
+        "critics_skipped_reason": None,
+        "skip_llm": True,
+    }
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        calls.append({"personas": list(personas), "plan": plan})
+        return [{"persona": p, "status": "success"} for p in personas]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        orch.write_progress(
+            "research", {"personas": [], "results": [], "skip_llm": True}, memory_dir
+        )
+        orch.write_progress("plan", prior_plan_state, memory_dir)
+
+        with patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas):
+            exit_code = await orch.run_pipeline(
+                request="add a login form",
+                memory_dir=memory_dir,
+                skip_llm=True,
+                resume=True,
+                classify_fn=lambda req: {"size": "standard"},
+            )
+
+        implement_state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    wave_call = next(c for c in calls if c["personas"] == [orch.SOFTWARE_ENGINEER_PERSONA])
+    assert wave_call["plan"]["plan_state"] == prior_plan_state
+    assert implement_state is not None
+    assert any(c["personas"] == [orch.TECH_WRITER_PERSONA] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_stub_phase_implement_fn_is_honored_end_to_end_through_run_pipeline():
+    """A stub phase_implement_fn returning a fixed sentinel result dict must
+    have that exact sentinel written to orchestrator-implement.json —
+    mirroring the existing stub_research/stub_plan-through-run_pipeline test
+    pattern. skip_llm=True is also passed so neither Research nor Plan risks
+    a live claude CLI call in this test."""
+    sentinel = {"sentinel": "implement-result", "results": [], "review_results": []}
+
+    async def stub_implement(request, task, plan_state, skip_llm):
+        return sentinel
+
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+            phase_implement_fn=stub_implement,
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    assert exit_code == 0
+    assert state == sentinel
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_wave_error_from_injected_phase_implement_fn_prints_message_and_exits_1(
+    capsys,
+):
+    """A WaveError-raising phase_implement_fn (patched directly, not via the
+    real dispatch fakes) results in exit code 1, the two-line stderr
+    message, and no orchestrator-implement.json written."""
+
+    async def failing_phase_implement_fn(request, task, plan_state, skip_llm):
+        raise orch.WaveError(failing_slice="implement-1", succeeded=[])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        exit_code = await orch.run_pipeline(
+            request="add a login form",
+            memory_dir=memory_dir,
+            skip_llm=True,
+            classify_fn=lambda req: {"size": "standard"},
+            phase_implement_fn=failing_phase_implement_fn,
+        )
+        state = orch.read_progress("implement", memory_dir)
+
+    stderr = capsys.readouterr().err
+    assert "ERROR: wave barrier failed on slice 'implement-1'" in stderr
+    assert f"Resume with: python3 {orch.SCRIPTS / 'orchestrator.py'} --resume" in stderr
+    assert exit_code == 1
+    assert state is None


### PR DESCRIPTION
## Summary

- Wire `orchestrator.py`'s Implement phase (Phase 3, the epic's final phase) to real agent dispatch: `_dispatch_implement_wave` dispatches `software-engineer` for a single-slice wave and calls the first real invocation of `reconcile()`/`WaveError` (defined in Slice 1, never called until now) — a failed slice raises uncaught, so no state persists and `--resume` retries from scratch; `run_pipeline` catches it and returns exit code 1 with the shared resume-hint message.
- On a successful wave, `_dispatch_implement_verification` dispatches the existing `CODE_REVIEW_PANEL` + `tech-writer`, both through `dispatch_personas` so an unexpected exception can't escape past the `WaveError` handler and discard a successful wave's results.
- `agents/orchestrator.md` documents the new persona roster and script gap; an ADR 0013 amendment reconciles this being the first script-driven `/code-review`-shaped fan-out in this codebase with the existing LLM-driven-orchestration decision.

## Test Plan

- [x] `python3 -m pytest tests/scripts/test_orchestrator.py tests/scripts/test_orchestrator_cli.py tests/agents/test_agent_audit_integration_validation.py tests/agents/test_agent_audit_metadata.py -v` — 154 passed
- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks -q` — 7275 passed, 47 skipped
- [x] `python3 -m ruff check` on all changed files — clean
- [x] Full local CI gate (`scripts/ci-local.sh`) — all checks pass (7202 passed, 45 skipped in the plugin unit-test step)

Closes #1722
Part of #1707
Part of #1648

## Decisions & Assumptions

- Non-interactive `/plan` and `/build` auto-approval (Auto Mode, no TTY) — both the plan-status gate and the acceptance-criteria gate auto-passed with the bypass logged to `.claude/metrics/config-changelog.jsonl`, per the human-oversight-protocol audit-trail schema.
- **Single-slice wave** (`wave_slices = ["implement-1"]`, a synthetic slice representing "the whole task"): Phase 2's persisted output has no machine-parseable ordered step list to derive real per-step slices from — inventing a fake decomposition (e.g. treating each of Plan's 3 core-trio personas as a "step") would be actively wrong, not just simplistic, since those are three personas' independent framings of the same plan, not sequential implementation units. This exercises the real `reconcile()`/`WaveError`/`dispatch_personas` machinery honestly against a wave of size one rather than inventing multi-step logic the current data model doesn't support. Adversarially reviewed twice during plan review; both plan-review critics approved.
- **`WaveError` propagates uncaught** from `_dispatch_implement_wave` through `_run_phase` (which does not catch it) up to a single `try`/`except` in `run_pipeline` — so a failed wave leaves no `orchestrator-implement.json` on disk at all, making a subsequent `--resume` retry the phase from scratch rather than persisting a partial "wave_error" record that would break that contract.
- Review-panel/tech-writer verification is **advisory only**: `review_status` verdicts are parsed and persisted but not read or gated on — a `fail` verdict has the same observable outcome (exit 0, state persisted) as a clean pass. Matches this script's existing pattern (Research/Plan's own dispatch outputs are similarly non-gating) and is explicitly disclosed as a Script gap, not fixed in this slice.
- `orchestrator.py`'s file-size/modularization question (now ~700 lines) is **not** addressed here — Slice 3's plan committed to evaluating a module split "before or during Slice 4"; rather than re-defer that a third time with no durable record, the concrete split proposal and deferral history are now preserved in tracked issue **#1723** rather than evaporating with this plan's transient file.
- Deferred to follow-up, not fixed in this PR (all suggestion/warning-tier, none blocking, matching this epic's own established proportionality precedent): three security-review findings (review-panel verdicts not gated on; no `security-review` persona in the Implement panel despite Research's own conditional `security-engineer` dispatch; no audit trail for a wave failure after `software-engineer` may have already mutated the working tree); a test-fixture-duplication cleanup (15+ near-identical inline dispatch fakes not reusing this file's own established helper pattern); `reconcile()`'s unenforced `"slice"`-key invariant and `run_pipeline`'s growing parameter count (tracked against #1723 alongside the module-split question).

## Evidence Bundle

**Checks run**
- `pytest tests/scripts/test_orchestrator.py tests/scripts/test_orchestrator_cli.py tests/agents/test_agent_audit_integration_validation.py tests/agents/test_agent_audit_metadata.py -v` — 154 passed
- `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks -q` — 7275 passed, 47 skipped
- `ruff check` on all changed files — clean
- `scripts/ci-local.sh` (full local CI gate, including the Python 3.10-floor test slice) — all pass
- Code review: 16-agent batched slice checkpoint, a 10-agent closing pass on the resulting fix round, and further targeted corroboration passes on a final ADR-wording fix batch — all converged clean or suggestion-tier only. Full detail in the plan file's Code Review Summary section.

**Scope notes**
- No `tsconfig.json` in this repo — TypeScript type-check step not applicable.
- This PR is Slice 4 of 4 (the final slice) for spec #1707. Spec #1707 also has an open, unrelated sub-issue (#1716, deferred Research-phase follow-up findings) — merging this PR does not by itself close spec #1707 or epic #1648 until #1716 is also resolved or descoped.

**Untested regions**
- Not measured — no coverage tool configured for this Python codebase's test suite.

**Residual risks**
- None escalated. All review findings this slice either were fixed (see commit history and the plan's Code Review Summary) or are logged as deferred follow-up above, matching the same proportionality precedent this epic's earlier slices (Slice 2 PR #1718, Slice 3 PR #1721) already established.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAZn5shEx6zjqov4nz3fjZ)_