### PR TITLE
feat(experiments): add batch-red-per-class arm to refactor-cadence harness

### DIFF
--- a/docs/experiments/test-cadence-validation-plan.md
+++ b/docs/experiments/test-cadence-validation-plan.md
@@ -23,29 +23,33 @@ Adding a batch-red-per-class arm to this harness does not, by itself, let
 you compare on that specific axis; treat instrumenting test-run count as
 part of the arm's setup cost, not a given.
 
-No arm in this harness is currently configured as batch-red-per-class. The
-closest existing analogue is `all-tests-first-single` ("All Tests, Then
-Code (Single Agent)") — write all tests, then all code — which the base
-campaign already measured at $2.31/cell, composite quality 0.525
-(`05-final-results.md`'s "Efficiency frontier (quality per dollar)" table;
-its mutation score alone is 0.978, in the separate "Raw metrics by arm"
-table — mutation score is not the composite figure the standing default's
-0.961 is quoted on) — worse composite quality at more
+`batch-red-per-class-single` is now configured in this harness (step 1,
+below). The closest existing analogue remains `all-tests-first-single`
+("All Tests, Then Code (Single Agent)") — write all tests, then all
+code — which the base campaign already measured at $2.31/cell, composite
+quality 0.525 (`05-final-results.md`'s "Efficiency frontier (quality per
+dollar)" table; its mutation score alone is 0.978, in the separate "Raw
+metrics by arm" table — mutation score is not the composite figure the
+standing default's 0.961 is quoted on) — worse composite quality at more
 than double `continuous-single`'s $0.99/cell (`continuous-single` is the
 harness's arm name for Code-First Small Batches, Single Agent). This
 analogue is not evidence in batch-red-per-class's favor; it only bounds
-the cost a similarly-shaped arm might run at. A dedicated
-`batch-red-per-class` arm (tests-per-unit rather than tests-for-the-whole-task)
-still needs to be added; `all-tests-first-single`'s numbers are a rough
-reference point, not a substitute for running it.
+the cost a similarly-shaped arm might run at — `all-tests-first-single`'s
+numbers are a rough reference point, not a substitute for running the new
+arm.
 
 ## Steps
 
-1. Add a `batch-red-per-class-single` arm to `run_refactor_experiment.py`
-   (name it with the harness's `-single`/`-split` authorship suffix
-   convention) alongside the existing `continuous-single` baseline arm —
-   matching claude-flow's protocol (tests written and verified-red per
-   unit, not for the whole task at once) as closely as the harness allows.
+1. **Done.** `batch-red-per-class-single` is now a configured arm in
+   `run_refactor_experiment.py`'s `ARMS` (name follows the harness's
+   `-single`/`-split` authorship suffix convention), alongside the existing
+   `continuous-single` baseline arm — matching claude-flow's protocol (tests
+   written and verified-red per unit, not for the whole task at once) as
+   closely as the harness allows. Not yet registered in
+   `run_workflow_matrix.py`'s `MATRIX`/`ARM_COST` or
+   `analyze_refactor_experiment.py`'s hardcoded arm list — step 4's report
+   uses a dedicated comparison against the raw JSONL instead of those two
+   scripts, which is why this was left as a known gap rather than fixed here.
 2. Run both arms against the same fixture tasks used in the base campaign
    (`evals/refactor-granularity/tasks/`: `cart`, `fare`, `grades`, `payroll`
    — the Experiment 04/05 corpus), at least 1 trial per task as a smoke

--- a/scripts/run_refactor_experiment.py
+++ b/scripts/run_refactor_experiment.py
@@ -5,6 +5,10 @@ Factors (and nothing more):
   - granularity:  none / one-shot / continuous refactoring
   - authorship:   single agent vs split (independent coder + tester)
   - plus the tdd-refactor reference arm
+  - plus two test-first batch variants (ARMS' `batch` key): "big" (all tests for
+    the whole task, then all code — all-tests-first-*) and "per-class" (tests
+    batched and verified-red per class/unit, then implemented, before the next
+    unit — batch-red-per-class-single, issue #1727)
 INVARIANT (all arms): refactoring never changes the tests. Clear specs only. No
 spec-plan-build arm. No reuse of prior scripts or data.
 
@@ -46,11 +50,14 @@ MAX_MUTANTS = 25
 # ── arms: corrected design ───────────────────────────────────────────────
 # INVARIANT in every arm: refactoring restructures production code only and leaves
 # the tests unchanged. Tests change only to express new behavior (the change chain),
-# never during a refactor step. We vary granularity x authorship; ordering is fixed
-# to test-after except for the tdd-refactor reference (test-first). Enforcement: a
-# separate refactor dispatch has any test-file edits reverted to the pre-refactor
-# ("green") snapshot. Inline-refactor arms (continuous, tdd) can't be reverted
-# mid-dispatch, so their refactor-commit test churn is recorded as a violation flag.
+# never during a refactor step. We vary granularity x authorship; ordering is
+# test-after for the granularity x authorship cells — the tdd-refactor reference and
+# the batch arms (all-tests-first-*, batch-red-per-class-single) are test-first,
+# differentiated by the `batch` key (absent = per-behavior TDD, "big" = whole-task,
+# "per-class" = per-unit). Enforcement: a separate refactor dispatch has any
+# test-file edits reverted to the pre-refactor ("green") snapshot. Inline-refactor
+# arms (continuous, tdd) can't be reverted mid-dispatch, so their refactor-commit
+# test churn is recorded as a violation flag.
 PYTEST_RULE = (
     " Write tests as pytest tests in files named test_*.py so they run with "
     "`python -m pytest -q`. Keep production code in the module named in the spec."
@@ -63,6 +70,14 @@ REFACTOR_RULE = (
     "delete any test_*.py file — the existing tests must keep passing. Commit refactor "
     "steps with a message starting 'refactor:'."
 )
+NO_REFACTOR_YET_RULE = " Do NOT refactor yet — a separate refactoring step follows."
+
+# `batch` values for test-first arms — shared between ARMS and the prompt builders
+# below so a typo raises instead of silently falling through to the strict-TDD
+# prompt (which would then double up refactoring: per-behavior inline AND the
+# separate one-shot dispatch).
+BATCH_BIG = "big"
+BATCH_PER_CLASS = "per-class"
 
 # granularity x authorship (+ ordering); reference arm flagged
 ARMS = {
@@ -85,9 +100,19 @@ ARMS = {
     # carries the "refactor after each iteration" rule; batch="big" selects the
     # write-all-tests-then-all-code prompt instead of the incremental TDD loop.
     "all-tests-first-single": {"granularity": "one-shot", "authorship": "single",
-                                   "ordering": "test-first", "batch": "big"},
+                                   "ordering": "test-first", "batch": BATCH_BIG},
     "all-tests-first-split": {"granularity": "one-shot", "authorship": "split",
-                                  "ordering": "test-first", "batch": "big"},
+                                  "ordering": "test-first", "batch": BATCH_BIG},
+    # Issue #1727: claude-flow's batch-red-per-class protocol — RED/GREEN batched
+    # per class/unit (not per behavior like tdd-refactor, not for the whole task
+    # like all-tests-first-single). Reuses the one-shot mechanism for the separate,
+    # revertable refactor step; batch="per-class" selects the per-unit prompt. No
+    # split (independent tester/coder) counterpart: the split test-first path
+    # (_do_stage's tester_first_prompt/coder_topass_prompt) doesn't consult `batch`
+    # at all, so a "-split" arm would silently run big-batch prompts under a
+    # per-class label — deliberately out of scope for #1727, not an oversight.
+    "batch-red-per-class-single": {"granularity": "one-shot", "authorship": "single",
+                                       "ordering": "test-first", "batch": BATCH_PER_CLASS},
 }
 
 # Arms whose refactoring is interleaved inside the write dispatch — cannot be
@@ -95,27 +120,51 @@ ARMS = {
 INLINE_REFACTOR = {"tdd-refactor", "continuous-single"}
 
 
+def _test_first_big_write_prompt(spec: str) -> str:
+    return (f"Implement the spec in {spec} test-first in one batch: FIRST write a "
+            "complete pytest suite covering every behavior in the spec, including edge "
+            "and boundary cases (all tests fail — no production code exists yet). THEN "
+            "write the production code until the whole suite passes."
+            + NO_REFACTOR_YET_RULE + PYTEST_RULE + GREEN_RULE)
+
+
+def _test_first_per_class_write_prompt(spec: str) -> str:
+    return (f"Implement the spec in {spec} using batch-red-per-class TDD: identify the "
+            "distinct classes/units the spec describes. For EACH one, in turn: FIRST "
+            "write a complete batch of pytest tests covering that unit's behavior, "
+            "including edge cases (verify they fail — no implementation for that unit "
+            "exists yet), THEN write the production code for that unit until its tests "
+            "pass. Only move to the next unit once the current one is green. Do NOT "
+            "write tests for more than one unit before implementing any of them."
+            + NO_REFACTOR_YET_RULE + PYTEST_RULE + GREEN_RULE)
+
+
+_TEST_FIRST_WRITE_BUILDERS = {
+    BATCH_BIG: _test_first_big_write_prompt,
+    BATCH_PER_CLASS: _test_first_per_class_write_prompt,
+}
+
+
 def write_prompt_single(arm: str, spec: str) -> str:
     a = ARMS[arm]
     if a["ordering"] == "test-first":
-        if a.get("batch") == "big":
-            return (f"Implement the spec in {spec} test-first in one batch: FIRST write a "
-                    "complete pytest suite covering every behavior in the spec, including edge "
-                    "and boundary cases (all tests fail — no production code exists yet). THEN "
-                    "write the production code until the whole suite passes. Do NOT refactor "
-                    "yet — a separate refactoring step follows." + PYTEST_RULE + GREEN_RULE)
-        return (f"Implement the spec in {spec} using strict TDD: for each behavior write "
-                "a failing test (RED), the minimum code to pass (GREEN), then REFACTOR "
-                "the production code before the next behavior. Make the acceptance "
-                "behavior correct." + PYTEST_RULE + GREEN_RULE + REFACTOR_RULE)
+        batch = a.get("batch")
+        if batch is None:
+            return (f"Implement the spec in {spec} using strict TDD: for each behavior write "
+                    "a failing test (RED), the minimum code to pass (GREEN), then REFACTOR "
+                    "the production code before the next behavior. Make the acceptance "
+                    "behavior correct." + PYTEST_RULE + GREEN_RULE + REFACTOR_RULE)
+        builder = _TEST_FIRST_WRITE_BUILDERS.get(batch)
+        if builder is None:
+            raise ValueError(f"arm {arm!r}: unrecognized batch {batch!r}")
+        return builder(spec)
     body = (f"Implement the spec in {spec}. Write the production code, then a pytest suite "
             "covering the behavior, until all tests pass.")
     if a["granularity"] == "continuous":
         body += (" Build incrementally: after each behavior is green, refactor the "
                  "production code (without changing any test) before the next.")
         return body + PYTEST_RULE + GREEN_RULE + REFACTOR_RULE
-    body += (" Do NOT refactor yet — a separate refactoring step follows."
-             if a["granularity"] == "one-shot" else " Do not refactor.")
+    body += (NO_REFACTOR_YET_RULE if a["granularity"] == "one-shot" else " Do not refactor.")
     return body + PYTEST_RULE + GREEN_RULE
 
 
@@ -141,26 +190,48 @@ def refactor_prompt(doc: str) -> str:
             "pass unchanged. Commit each step with a message starting 'refactor:'.")
 
 
+def _test_first_big_change_prompt(change: str) -> str:
+    return (f"This is an existing, working feature. Apply the change in {change} "
+            "test-first in one batch: FIRST add or update tests covering the new "
+            "behavior (they fail), THEN change the production code until all tests "
+            "pass." + NO_REFACTOR_YET_RULE + PYTEST_RULE + GREEN_RULE)
+
+
+def _test_first_per_class_change_prompt(change: str) -> str:
+    return (f"This is an existing, working feature. Apply the change in {change} using "
+            "batch-red-per-class TDD: identify the distinct classes/units the change "
+            "touches. For EACH one, in turn: FIRST add or update a batch of tests "
+            "covering that unit's new behavior (verify they fail), THEN update that "
+            "unit's production code until its tests pass. Only move to the next unit "
+            "once the current one is green." + NO_REFACTOR_YET_RULE + PYTEST_RULE
+            + GREEN_RULE)
+
+
+_TEST_FIRST_CHANGE_BUILDERS = {
+    BATCH_BIG: _test_first_big_change_prompt,
+    BATCH_PER_CLASS: _test_first_per_class_change_prompt,
+}
+
+
 def change_write_prompt(arm: str, change: str) -> str:
     a = ARMS[arm]
     if a["ordering"] == "test-first":
-        if a.get("batch") == "big":
-            return (f"This is an existing, working feature. Apply the change in {change} "
-                    "test-first in one batch: FIRST add or update tests covering the new "
-                    "behavior (they fail), THEN change the production code until all tests "
-                    "pass. Do NOT refactor yet — a separate refactoring step follows."
-                    + PYTEST_RULE + GREEN_RULE)
-        return (f"This is an existing feature. Apply the change in {change} with strict "
-                "TDD: RED for the new behavior, GREEN, then REFACTOR the production code "
-                "without changing existing tests." + PYTEST_RULE + GREEN_RULE
-                + REFACTOR_RULE)
+        batch = a.get("batch")
+        if batch is None:
+            return (f"This is an existing feature. Apply the change in {change} with strict "
+                    "TDD: RED for the new behavior, GREEN, then REFACTOR the production code "
+                    "without changing existing tests." + PYTEST_RULE + GREEN_RULE
+                    + REFACTOR_RULE)
+        builder = _TEST_FIRST_CHANGE_BUILDERS.get(batch)
+        if builder is None:
+            raise ValueError(f"arm {arm!r}: unrecognized batch {batch!r}")
+        return builder(change)
     base = (f"This is an existing, working feature. Apply the change in {change}. Update "
             "or add tests for the NEW behavior and keep all tests passing.")
     if a["granularity"] == "continuous":
         base += " After it is green, refactor the production code without changing tests."
         return base + PYTEST_RULE + GREEN_RULE + REFACTOR_RULE
-    base += (" Do NOT refactor yet — a separate refactoring step follows."
-             if a["granularity"] == "one-shot" else " Do not refactor.")
+    base += (NO_REFACTOR_YET_RULE if a["granularity"] == "one-shot" else " Do not refactor.")
     return base + PYTEST_RULE + GREEN_RULE
 
 
@@ -569,6 +640,15 @@ def _do_stage(workdir, arm, doc, model, env, run_root, cell, change):
                                   raw("-refactor")))
             attempted = enforce_refactor(workdir, green)
     elif a["ordering"] == "test-first":  # split, test-first (W4): tests authored first
+        # This path doesn't consult `batch` — it only implements the whole-task
+        # write-all-tests-then-code protocol. Fail loud rather than silently
+        # mislabeling a future per-class-split arm's rows (issue #1727).
+        if a.get("batch") not in (None, BATCH_BIG):
+            raise ValueError(
+                f"arm {arm!r}: batch {a['batch']!r} is not honored on the split "
+                "test-first path (tester_first_prompt/coder_topass_prompt implement "
+                "only the whole-task protocol)"
+            )
         tp = change_tester_first_prompt(doc) if change else tester_first_prompt(doc)
         parts.append(dispatch(workdir, tp, model, env, raw("-tester")))
         commit_all(workdir, "checkpoint: tests-first (red)")

--- a/tests/scripts/test_run_refactor_experiment.py
+++ b/tests/scripts/test_run_refactor_experiment.py
@@ -24,7 +24,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-import run_refactor_experiment as exp  # noqa: E402
+import run_refactor_experiment as exp
 
 
 @pytest.mark.parametrize("arm", list(exp.ARMS))

--- a/tests/scripts/test_run_refactor_experiment.py
+++ b/tests/scripts/test_run_refactor_experiment.py
@@ -1,0 +1,136 @@
+"""Pytest tests for scripts/run_refactor_experiment.py's prompt builders (#1727).
+
+`--skip-dispatch` (the harness's own "free self-test") does NOT exercise
+write_prompt_single/change_write_prompt: run_build/run_change gate the call into
+_do_stage behind `if not skip:`, so a syntax error or broken concatenation in a
+new arm's prompt branch would pass that self-test undetected (caught in review —
+see the harness's ARMS docstring for the arm taxonomy these tests pin). These
+tests call the prompt builders directly, no dispatch, no API cost.
+
+The per-class prompt assertions below pin phrasing against the fidelity
+requirement in docs/experiments/test-cadence-validation-plan.md: "tests written
+and verified-red per unit, not for the whole task at once" — the prompt text IS
+the experimental treatment, so these are treatment-fidelity checks, not
+incidental string-equality tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import run_refactor_experiment as exp  # noqa: E402
+
+
+@pytest.mark.parametrize("arm", list(exp.ARMS))
+def test_every_arm_produces_nonempty_build_and_change_prompts(arm):
+    build = exp.write_prompt_single(arm, "spec_clear.md")
+    change = exp.change_write_prompt(arm, "change1.md")
+    assert build and "spec_clear.md" in build
+    assert change and "change1.md" in change
+
+
+def test_batch_red_per_class_single_is_test_first_one_shot_single():
+    a = exp.ARMS["batch-red-per-class-single"]
+    assert a["ordering"] == "test-first"
+    assert a["granularity"] == "one-shot"
+    assert a["authorship"] == "single"
+    assert a["batch"] == exp.BATCH_PER_CLASS
+    # one-shot arms use the separate, revertable refactor dispatch — never inline.
+    assert "batch-red-per-class-single" not in exp.INLINE_REFACTOR
+
+
+def test_no_batch_red_per_class_split_arm():
+    # The split test-first path (_do_stage) doesn't consult `batch` at all — see
+    # that function's guard. A "-split" counterpart is deliberately out of scope
+    # for #1727, not an oversight; this pins the absence as a checked invariant.
+    assert "batch-red-per-class-split" not in exp.ARMS
+
+
+def test_split_test_first_path_rejects_unhonored_batch_value():
+    # _do_stage's split test-first branch only implements the whole-task
+    # (batch=big) protocol; a per-class batch value must fail loud, not
+    # silently mislabel rows with a protocol it never actually ran.
+    exp.ARMS["_test_bogus_split_arm"] = {
+        "granularity": "one-shot", "authorship": "split",
+        "ordering": "test-first", "batch": exp.BATCH_PER_CLASS,
+    }
+    try:
+        import tempfile
+        from pathlib import Path
+
+        workdir = Path(tempfile.mkdtemp())
+        run_root = Path(tempfile.mkdtemp())
+        with pytest.raises(ValueError, match="not honored on the split test-first path"):
+            exp._do_stage(workdir, "_test_bogus_split_arm", "spec_clear.md", "model",
+                           {}, run_root, "cell", False)
+    finally:
+        del exp.ARMS["_test_bogus_split_arm"]
+
+
+def test_every_test_first_one_shot_arm_has_a_registered_batch_builder():
+    # `batch is None` is a legitimate default only for continuous arms
+    # (tdd-refactor) — a test-first, one-shot arm that omits `batch` would
+    # silently fall through to the strict-TDD prompt AND still run the
+    # separate one-shot refactor dispatch (double refactoring). Every
+    # test-first/one-shot arm must have a batch registered in both tables.
+    for arm, a in exp.ARMS.items():
+        if a["ordering"] == "test-first" and a["granularity"] == "one-shot":
+            assert "batch" in a, f"{arm}: test-first/one-shot arm missing `batch`"
+            assert a["batch"] in exp._TEST_FIRST_WRITE_BUILDERS, arm
+            assert a["batch"] in exp._TEST_FIRST_CHANGE_BUILDERS, arm
+
+
+def test_batch_red_per_class_build_prompt_sequences_per_unit():
+    prompt = exp.write_prompt_single("batch-red-per-class-single", "spec_clear.md")
+    assert "distinct classes/units" in prompt
+    assert "Only move to the next unit once the current one is green" in prompt
+    assert "Do NOT write tests for more than one unit before implementing any of them" in prompt
+    assert "Do NOT refactor yet" in prompt
+    # distinct from the whole-task batching protocol it sits beside in ARMS
+    assert "in one batch" not in prompt
+
+
+def test_batch_red_per_class_change_prompt_sequences_per_unit():
+    prompt = exp.change_write_prompt("batch-red-per-class-single", "change1.md")
+    assert "distinct classes/units the change" in prompt
+    assert "Only move to the next unit once the current one is green" in prompt
+    assert "Do NOT refactor yet" in prompt
+
+
+def test_unrecognized_batch_value_raises_instead_of_silently_falling_through():
+    """A typo in `batch` must fail loud, not silently run the strict-TDD prompt
+    (which would then double up refactoring: inline REFACTOR_RULE *and* the
+    separate one-shot dispatch enforce_refactor() issues for one-shot arms)."""
+    exp.ARMS["_test_bogus_arm"] = {
+        "granularity": "one-shot", "authorship": "single",
+        "ordering": "test-first", "batch": "not-a-real-batch-value",
+    }
+    try:
+        with pytest.raises(ValueError, match="unrecognized batch"):
+            exp.write_prompt_single("_test_bogus_arm", "spec_clear.md")
+        with pytest.raises(ValueError, match="unrecognized batch"):
+            exp.change_write_prompt("_test_bogus_arm", "change1.md")
+    finally:
+        del exp.ARMS["_test_bogus_arm"]
+
+
+def test_test_first_arm_with_no_batch_key_uses_strict_tdd_prompt():
+    # tdd-refactor has ordering=test-first and no `batch` key at all.
+    assert "batch" not in exp.ARMS["tdd-refactor"]
+    prompt = exp.write_prompt_single("tdd-refactor", "spec_clear.md")
+    assert "strict TDD" in prompt
+    assert "REFACTOR the production code before the next behavior" in prompt
+
+
+def test_all_tests_first_and_batch_red_per_class_prompts_are_distinct():
+    big = exp.write_prompt_single("all-tests-first-single", "spec_clear.md")
+    per_class = exp.write_prompt_single("batch-red-per-class-single", "spec_clear.md")
+    assert big != per_class
+    assert "in one batch" in big
+    assert "in one batch" not in per_class


### PR DESCRIPTION
## Summary

- Adds `batch-red-per-class-single` to `scripts/run_refactor_experiment.py`'s `ARMS`, matching claude-flow's batch-red-per-class protocol (tests batched and verified-red per class/unit, then implemented, before the next unit) as closely as the existing harness allows — completes step 1 of the runbook in `docs/experiments/test-cadence-validation-plan.md`.
- Reuses the one-shot granularity mechanism (separate, revertable refactor dispatch) since the protocol itself is silent on refactor cadence; the split test-first path now raises rather than silently ignoring an unhonored `batch` value, matching a new fail-loud guard added to the single-authorship dispatch (a typo in `batch` now raises instead of silently falling through to the wrong prompt).
- Adds `tests/scripts/test_run_refactor_experiment.py` (19 tests) covering every arm's prompt builders — the harness's own `--skip-dispatch` self-test never exercises `write_prompt_single`/`change_write_prompt`, so this closes a real coverage gap surfaced in review. Verified byte-identical prompt output for all 9 pre-existing arms across the refactor (no behavior change to already-collected campaign data).

## Test Plan

- [x] `pytest tests/scripts/test_run_refactor_experiment.py -q` — 19 passed
- [x] `python3 scripts/run_refactor_experiment.py --skip-dispatch` — all 10 arms wire through end-to-end (free self-test, no API cost)
- [x] `ruff check` / `python3 -m py_compile` clean
- [x] Diffed old vs. new prompt-builder output for every pre-existing arm — byte-identical
- [ ] Real comparison campaign (`batch-red-per-class-single` vs. `continuous-single` baseline) against the Experiment 04/05 fixture tasks — funded run (~$25-60), tracked as a follow-up on this branch/issue before #1727 closes

## Notes

This PR covers step 1 only ("add the arm to the harness"). Steps 2-4 of the runbook (run the funded campaign, compare cost/quality, write the result to `docs/experiments/` and update `RECOMMENDATIONS.md`/ADR 0017 if warranted) follow in a subsequent commit on this branch once the real campaign completes — issue #1727 stays open until that lands, per its own "do not implement the gate until the experiment has run" condition.

Part of #1727


---
_Generated by [Claude Code](https://claude.ai/code/session_01SuytkRHXSr3QTeByTnjRD2)_