### PR TITLE
feat(hooks): SessionStart nudge suggesting /repo-review on drift

### DIFF
--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -9,6 +9,10 @@
           },
           {
             "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/repo_review_nudge.py\""
+          },
+          {
+            "type": "command",
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_bootstrap.py\""
           }
         ]

--- a/plugins/dev-team/hooks/repo_review_nudge.py
+++ b/plugins/dev-team/hooks/repo_review_nudge.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""repo_review_nudge — Claude Code SessionStart hook (#1739).
+
+`/repo-review` (#1733/#1735) tracks drift in
+`.claude/memory/repo-review-state.json` (`{"last_commit", "last_run_at"}`)
+but is invoked manually — nothing proactively tells the operator drift has
+crossed a threshold worth acting on. This hook is that proactive nudge,
+mirroring `pending_review_notify.py`'s shape: read a small state signal,
+print a one-line stdout notice, fail-open, stdlib-only.
+
+Drift signal: **added lines since `last_commit`**, not commit count and not
+elapsed time — a single commit can carry thousands of added lines, and a
+week can pass with none; the drift this skill's roster cares about (file/
+CLAUDE.md size, verification debt, component duplication) tracks how much
+code actually changed, not how many commits or how much wall-clock it took
+to change it. Computed via `git diff --numstat <last_commit>..HEAD`, summing
+only the added-lines column — matching `change_size.py`'s own established
+rationale in this codebase: added lines are unverified, newly introduced
+content; deleted lines are comparatively low-risk. No prior state, or
+`last_commit` no longer resolving (rewritten history), both read as "never
+run": the signal falls back to added lines from the repository's very first
+commit (diffed against git's empty-tree object) to HEAD.
+
+Env seams:
+    DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD  added-lines threshold (default
+        2000) — a starting guess, not an empirically measured number (no
+        real cadence data exists yet); override if live usage shows it's
+        too tight or too loose.
+
+Contract (docs/python-hook-contract.md):
+    Input : SessionStart JSON on stdin (hook_event_name, cwd, model, ...).
+    Output: notification text on stdout. Exit 0 always.
+    Posture: fail-open — a buggy notifier must never block a session; this
+        hook only ever suggests, it never gates.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import artifact_paths
+
+_DEFAULT_THRESHOLD = 2000
+
+# The hash of an empty git tree object — identical in every git repository,
+# always resolvable, and needs no repo-specific root-commit lookup (which
+# can return more than one commit in a history with multiple roots). Diffing
+# against it gives "every added line since the repository began", the
+# correct "never run" fallback signal.
+_EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+def _threshold() -> int:
+    """Added-lines threshold from DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD,
+    falling back to _DEFAULT_THRESHOLD on anything that isn't a positive
+    int."""
+    raw = os.environ.get("DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_THRESHOLD
+    return value if value > 0 else _DEFAULT_THRESHOLD
+
+
+def _is_git_repo(cwd: str) -> bool:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def _added_lines(cwd: str, revspec: str) -> int | None:
+    """Sum of `git diff --numstat <revspec>`'s added-lines column.
+
+    None on any git failure (unreachable ref, corrupt index, git not
+    installed, timeout) or on any unparseable line — a binary-file marker
+    (`-\t-\tpath`) or a malformed row disqualifies the whole count rather
+    than silently under-counting, matching `change_size.py`'s own
+    fail-safe-by-construction posture.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "diff", "--numstat", revspec],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+
+    total = 0
+    for line in completed.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            return None
+        added_field = parts[0]
+        if added_field == "-":  # binary file — no line-count signal
+            return None
+        try:
+            total += int(added_field)
+        except ValueError:
+            return None
+    return total
+
+
+def _load_last_commit(cwd: str) -> str | None:
+    state_file = artifact_paths.resolve_file(
+        "memory", "repo-review-state.json", cwd, migrate=False
+    )
+    if not state_file.is_file():
+        return None
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    last_commit = data.get("last_commit")
+    return last_commit if isinstance(last_commit, str) and last_commit else None
+
+
+def _drift_lines(cwd: str) -> int | None:
+    """Added lines since the last /repo-review run, or since the
+    repository's first commit when there is no prior run or `last_commit`
+    no longer resolves (rewritten history) — both read as "never run".
+    None on git failure."""
+    last_commit = _load_last_commit(cwd)
+    if last_commit is not None:
+        count = _added_lines(cwd, f"{last_commit}..HEAD")
+        if count is not None:
+            return count
+    # No prior state, or last_commit didn't resolve — fall back to added
+    # lines since the repository began.
+    return _added_lines(cwd, f"{_EMPTY_TREE}..HEAD")
+
+
+def _nudge_message(added: int) -> str:
+    return (
+        f"\U0001f300 ~{added} added line(s) since the last /repo-review — "
+        "consider running it to catch drift no per-diff review sees "
+        "(file/CLAUDE.md size, verification debt, component duplication)\n"
+    )
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return 0
+    if not raw:
+        return 0
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    cwd = payload.get("cwd") or ""
+    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
+        cwd = os.getcwd()
+
+    if not _is_git_repo(cwd):
+        return 0
+
+    added = _drift_lines(cwd)
+    if added is None or added < _threshold():
+        return 0
+
+    sys.stdout.write(_nudge_message(added))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 - fail-open: a hook bug must never block a session
+        sys.exit(0)

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -25,6 +25,10 @@
           },
           {
             "type": "command",
+            "command": "sh hooks/py.sh hooks/repo_review_nudge.py"
+          },
+          {
+            "type": "command",
             "command": "sh hooks/py.sh hooks/codegraph_bootstrap.py"
           }
         ]

--- a/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
@@ -1,0 +1,166 @@
+"""Unit tests for hooks/repo_review_nudge.py (#1739).
+
+SessionStart hook that suggests running /repo-review when added lines since
+the last recorded run (or since the repo's first commit, if never run)
+cross a threshold. Fail-open, never blocks a session.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "repo_review_nudge.py"
+
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+
+
+def _run(cwd: Path, extra_env: dict | None = None) -> subprocess.CompletedProcess[str]:
+    env = hermetic_git_env(home=cwd)
+    if extra_env:
+        env.update(extra_env)
+    payload = {"hook_event_name": "SessionStart", "cwd": str(cwd)}
+    return subprocess.run(
+        ["python3", str(_HOOK)],
+        input=json.dumps(payload),
+        env=env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=hermetic_git_env(home=cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(cwd: Path) -> None:
+    _git(cwd, "init", "-q")
+    _git(cwd, "config", "user.email", "test@example.com")
+    _git(cwd, "config", "user.name", "Test")
+
+
+def _commit_lines(cwd: Path, filename: str, line_count: int, message: str) -> str:
+    (cwd / filename).write_text("\n".join(f"line {i}" for i in range(line_count)) + "\n")
+    _git(cwd, "add", filename)
+    _git(cwd, "commit", "-q", "-m", message)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(cwd),
+        env=hermetic_git_env(home=cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_state(cwd: Path, last_commit: str) -> None:
+    state_dir = cwd / ".claude" / "memory"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "repo-review-state.json").write_text(
+        json.dumps({"last_commit": last_commit, "last_run_at": "2026-01-01T00:00:00Z"})
+    )
+
+
+def test_non_git_directory_is_silent(tmp_path: Path) -> None:
+    r = _run(tmp_path)
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_no_payload_is_silent(tmp_path: Path) -> None:
+    r = subprocess.run(
+        ["python3", str(_HOOK)],
+        input="",
+        env=hermetic_git_env(home=tmp_path),
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_never_run_below_threshold_is_silent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 5, "small first commit")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "2000"})
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_never_run_above_threshold_nudges(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 50, "first commit")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "50" in r.stdout
+
+
+def test_below_threshold_since_last_run_is_silent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 5, "baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 5, "small follow-up")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "2000"})
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_above_threshold_since_last_run_nudges(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 5, "baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 30, "big follow-up")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "30" in r.stdout
+
+
+def test_unreachable_last_commit_falls_back_to_first_commit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 40, "first commit")
+    _write_state(tmp_path, "0" * 40)  # a syntactically valid but unreachable sha
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "40" in r.stdout
+
+
+def test_malformed_state_file_treated_as_never_run(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 40, "first commit")
+    state_dir = tmp_path / ".claude" / "memory"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "repo-review-state.json").write_text("{not json")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+
+
+def test_default_threshold_used_when_env_var_invalid(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 5, "small first commit")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "not-a-number"})
+    assert r.returncode == 0
+    assert r.stdout == ""  # 5 lines is far below the 2000-line default


### PR DESCRIPTION
## Summary
- New `SessionStart` hook `repo_review_nudge.py`: suggests running `/repo-review` once added lines since the last recorded run (or since the repo's first commit, if `/repo-review` has never run) cross a threshold.
- Trigger metric is **added-line volume**, deliberately not commit count and not elapsed time — a single commit can carry thousands of lines, a week can pass with none; the drift `/repo-review`'s roster tracks (file/CLAUDE.md size, verification debt, component duplication) depends on how much code changed, not how many commits or how much wall-clock it took.
- Default threshold 2000 added lines, overridable via `DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD` — a starting guess, not empirically measured; flagged as such in the module docstring.
- Fail-open throughout (non-git dir, unreadable/malformed state, unreachable `last_commit`, any git failure → silent, never blocks a session).
- Degrades gracefully today: `/repo-review` itself (#1733/#1735) is still in progress on another branch, so `.claude/memory/repo-review-state.json` doesn't exist yet in most repos — this hook reads that as "never run" and nudges off total added lines since the repo began, same as it will once that skill lands.

## Test plan
- [x] `plugins/dev-team/tests/hooks/test_repo_review_nudge.py` — 9 new tests (non-git dir, no payload, never-run above/below threshold, since-last-run above/below threshold, unreachable last_commit fallback, malformed state file, invalid env var falls back to default)
- [x] `python3 -m ruff check` — clean
- [x] `tests/hooks/test_plugin_hooks_json.py` — settings.json/hooks.json mirror registration test (required updating hooks.json's own SessionStart block to match)
- [x] Full `plugins/dev-team/tests/hooks tests/hooks tests/repo` — 2852 passed, 46 skipped

Closes #1739
Part of #1735