### PR TITLE
fix(hooks): repo_review_nudge should trigger on % of codebase changed

### DIFF
--- a/plugins/dev-team/hooks/repo_review_nudge.py
+++ b/plugins/dev-team/hooks/repo_review_nudge.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""repo_review_nudge — Claude Code SessionStart hook (#1739/#1743).
+"""repo_review_nudge — Claude Code SessionStart hook (#1739/#1743/#1746).
 
 `/repo-review` (#1733/#1735) tracks drift in
 `.claude/memory/repo-review-state.json` (`{"last_commit", "last_run_at"}`)
@@ -31,6 +31,23 @@ deleted lines are comparatively low-risk.
   the empty tree again — which makes "never run" resolve to exactly 100%
   (the whole current codebase is unreviewed) with no special-cased branch.
 
+**Pure percentage fails at both size extremes (#1746)**, so the trigger is
+three-part, percentage in the middle with absolute floor/ceiling guards on
+either side:
+
+    trigger = added >= MAX_ADDED_LINES
+              OR (added >= MIN_ADDED_LINES AND percent >= PERCENT_THRESHOLD)
+
+- **Floor** (`MIN_ADDED_LINES`): below it, never nudge regardless of
+  percentage — otherwise a trivial change in a small repo (a few dozen
+  lines can already be 10%+ of a tiny codebase) reads as "the codebase
+  changed," which is naggy, not useful.
+- **Ceiling** (`MAX_ADDED_LINES`): above it, always nudge regardless of
+  percentage — otherwise a huge repo's percent threshold could take dozens
+  of sessions to reach, and the nudge goes silently dormant exactly where
+  drift review matters most.
+- Between the two, the percentage rule applies as before.
+
 **`last_commit` is untrusted input, validated before touching any git
 command (#1743).** `.claude/memory/repo-review-state.json` is written by
 `/repo-review`, but nothing stops a hostile PR from committing its own copy
@@ -42,11 +59,12 @@ still be misparsed as a git flag rather than a revspec (argument
 injection). Any value not matching `^[0-9a-fA-F]{7,40}$` is treated exactly
 like "no prior state".
 
-Env seams:
-    DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD  percentage threshold (default
-        10, meaning 10%) — a starting guess, not an empirically measured
-        number (no real cadence data exists yet); override if live usage
-        shows it's too tight or too loose.
+Env seams (all starting guesses, not empirically measured — no real
+cadence data exists yet; override if live usage shows any of them too
+tight or too loose):
+    DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD  percentage threshold, default 10
+    DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES    anti-nagging floor, default 200
+    DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES    anti-silence ceiling, default 5000
 
 Contract (docs/python-hook-contract.md):
     Input : SessionStart JSON on stdin (hook_event_name, cwd, model, ...).
@@ -74,6 +92,8 @@ if str(_LIB_DIR) not in sys.path:
 import artifact_paths
 
 _DEFAULT_THRESHOLD_PERCENT = 10.0
+_DEFAULT_MIN_ADDED_LINES = 200
+_DEFAULT_MAX_ADDED_LINES = 5000
 
 # Same trust-boundary guard `skills/repo-review/SKILL.md` applies to this
 # exact field before it touches any git command (#1743).
@@ -95,6 +115,43 @@ def _threshold_percent() -> float:
     except (TypeError, ValueError):
         return _DEFAULT_THRESHOLD_PERCENT
     return value if value > 0 else _DEFAULT_THRESHOLD_PERCENT
+
+
+def _min_added_lines() -> int:
+    """Anti-nagging floor from DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES,
+    falling back to _DEFAULT_MIN_ADDED_LINES on anything that isn't a
+    non-negative int."""
+    raw = os.environ.get("DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_ADDED_LINES
+    return value if value >= 0 else _DEFAULT_MIN_ADDED_LINES
+
+
+def _max_added_lines() -> int:
+    """Anti-silence ceiling from DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES,
+    falling back to _DEFAULT_MAX_ADDED_LINES on anything that isn't a
+    positive int."""
+    raw = os.environ.get("DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_ADDED_LINES
+    return value if value > 0 else _DEFAULT_MAX_ADDED_LINES
+
+
+def _should_nudge(percent: float, added: int) -> bool:
+    """Three-part trigger (#1746): the ceiling overrides everything (a
+    huge absolute change always warrants a nudge, however small a
+    percentage it is of a huge repo); short of that, the floor suppresses
+    the percentage rule for a trivial absolute change (however large a
+    percentage it is of a tiny repo)."""
+    if added >= _max_added_lines():
+        return True
+    if added < _min_added_lines():
+        return False
+    return percent >= _threshold_percent()
 
 
 def _is_git_repo(cwd: str) -> bool:
@@ -227,7 +284,7 @@ def main() -> int:
     if result is None:
         return 0
     percent, added, total = result
-    if percent < _threshold_percent():
+    if not _should_nudge(percent, added):
         return 0
 
     sys.stdout.write(_nudge_message(percent, added, total))

--- a/plugins/dev-team/hooks/repo_review_nudge.py
+++ b/plugins/dev-team/hooks/repo_review_nudge.py
@@ -44,7 +44,7 @@ like "no prior state".
 
 Env seams:
     DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD  percentage threshold (default
-        1, meaning 1%) — a starting guess, not an empirically measured
+        10, meaning 10%) — a starting guess, not an empirically measured
         number (no real cadence data exists yet); override if live usage
         shows it's too tight or too loose.
 
@@ -73,7 +73,7 @@ if str(_LIB_DIR) not in sys.path:
 
 import artifact_paths
 
-_DEFAULT_THRESHOLD_PERCENT = 1.0
+_DEFAULT_THRESHOLD_PERCENT = 10.0
 
 # Same trust-boundary guard `skills/repo-review/SKILL.md` applies to this
 # exact field before it touches any git command (#1743).

--- a/plugins/dev-team/hooks/repo_review_nudge.py
+++ b/plugins/dev-team/hooks/repo_review_nudge.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""repo_review_nudge — Claude Code SessionStart hook (#1739).
+"""repo_review_nudge — Claude Code SessionStart hook (#1739/#1743).
 
 `/repo-review` (#1733/#1735) tracks drift in
 `.claude/memory/repo-review-state.json` (`{"last_commit", "last_run_at"}`)
@@ -8,24 +8,45 @@ crossed a threshold worth acting on. This hook is that proactive nudge,
 mirroring `pending_review_notify.py`'s shape: read a small state signal,
 print a one-line stdout notice, fail-open, stdlib-only.
 
-Drift signal: **added lines since `last_commit`**, not commit count and not
-elapsed time — a single commit can carry thousands of added lines, and a
-week can pass with none; the drift this skill's roster cares about (file/
-CLAUDE.md size, verification debt, component duplication) tracks how much
-code actually changed, not how many commits or how much wall-clock it took
-to change it. Computed via `git diff --numstat <last_commit>..HEAD`, summing
-only the added-lines column — matching `change_size.py`'s own established
-rationale in this codebase: added lines are unverified, newly introduced
-content; deleted lines are comparatively low-risk. No prior state, or
-`last_commit` no longer resolving (rewritten history), both read as "never
-run": the signal falls back to added lines from the repository's very first
-commit (diffed against git's empty-tree object) to HEAD.
+Drift signal: **percentage of the codebase changed since `last_commit`**,
+not an absolute line count, commit count, or elapsed time (#1743). An
+absolute line count doesn't scale with repo size — a fixed threshold is
+noise for a small repo and meaningless for a huge one; a percentage of the
+current codebase is the size-independent version of the same "how much
+actually changed" signal #1739 established.
+
+    percentage = added_lines_since_baseline / total_current_loc * 100
+
+Both quantities come from `git diff --numstat <revspec>`, summing only the
+added-lines column — matching `change_size.py`'s own established rationale
+in this codebase: added lines are unverified, newly introduced content;
+deleted lines are comparatively low-risk.
+
+- `total_current_loc`: diffed from git's empty-tree object to HEAD. Every
+  line in HEAD is necessarily an "addition" relative to nothing, so this
+  doubles as a cheap, accurate current-LOC count with no need to `wc -l`
+  every tracked file.
+- `added_lines_since_baseline`: baseline is `last_commit` if on record and
+  it both passes validation and is still reachable (see below); otherwise
+  the empty tree again — which makes "never run" resolve to exactly 100%
+  (the whole current codebase is unreviewed) with no special-cased branch.
+
+**`last_commit` is untrusted input, validated before touching any git
+command (#1743).** `.claude/memory/repo-review-state.json` is written by
+`/repo-review`, but nothing stops a hostile PR from committing its own copy
+with an arbitrary string (see `skills/repo-review/SKILL.md`'s own matching
+guard) — this hook reads the same file. `last_commit` is never
+shell-interpolated (subprocess args, not a shell string), so classic shell
+injection doesn't apply, but an unvalidated value starting with `-` could
+still be misparsed as a git flag rather than a revspec (argument
+injection). Any value not matching `^[0-9a-fA-F]{7,40}$` is treated exactly
+like "no prior state".
 
 Env seams:
-    DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD  added-lines threshold (default
-        2000) — a starting guess, not an empirically measured number (no
-        real cadence data exists yet); override if live usage shows it's
-        too tight or too loose.
+    DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD  percentage threshold (default
+        1, meaning 1%) — a starting guess, not an empirically measured
+        number (no real cadence data exists yet); override if live usage
+        shows it's too tight or too loose.
 
 Contract (docs/python-hook-contract.md):
     Input : SessionStart JSON on stdin (hook_event_name, cwd, model, ...).
@@ -40,6 +61,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -51,26 +73,28 @@ if str(_LIB_DIR) not in sys.path:
 
 import artifact_paths
 
-_DEFAULT_THRESHOLD = 2000
+_DEFAULT_THRESHOLD_PERCENT = 1.0
+
+# Same trust-boundary guard `skills/repo-review/SKILL.md` applies to this
+# exact field before it touches any git command (#1743).
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 
 # The hash of an empty git tree object — identical in every git repository,
 # always resolvable, and needs no repo-specific root-commit lookup (which
-# can return more than one commit in a history with multiple roots). Diffing
-# against it gives "every added line since the repository began", the
-# correct "never run" fallback signal.
+# can return more than one commit in a history with multiple roots).
 _EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
-def _threshold() -> int:
-    """Added-lines threshold from DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD,
-    falling back to _DEFAULT_THRESHOLD on anything that isn't a positive
-    int."""
-    raw = os.environ.get("DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD", "")
+def _threshold_percent() -> float:
+    """Percentage threshold from DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD,
+    falling back to _DEFAULT_THRESHOLD_PERCENT on anything that isn't a
+    positive number."""
+    raw = os.environ.get("DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD", "")
     try:
-        value = int(raw)
+        value = float(raw)
     except (TypeError, ValueError):
-        return _DEFAULT_THRESHOLD
-    return value if value > 0 else _DEFAULT_THRESHOLD
+        return _DEFAULT_THRESHOLD_PERCENT
+    return value if value > 0 else _DEFAULT_THRESHOLD_PERCENT
 
 
 def _is_git_repo(cwd: str) -> bool:
@@ -129,6 +153,9 @@ def _added_lines(cwd: str, revspec: str) -> int | None:
 
 
 def _load_last_commit(cwd: str) -> str | None:
+    """The recorded `last_commit`, or None for "no prior state" — including
+    when the field fails the commit-sha shape check (#1743): the state file
+    is untrusted input, not just possibly absent."""
     state_file = artifact_paths.resolve_file(
         "memory", "repo-review-state.json", cwd, migrate=False
     )
@@ -141,29 +168,37 @@ def _load_last_commit(cwd: str) -> str | None:
     if not isinstance(data, dict):
         return None
     last_commit = data.get("last_commit")
-    return last_commit if isinstance(last_commit, str) and last_commit else None
+    if not isinstance(last_commit, str) or not _COMMIT_SHA_RE.match(last_commit):
+        return None
+    return last_commit
 
 
-def _drift_lines(cwd: str) -> int | None:
-    """Added lines since the last /repo-review run, or since the
-    repository's first commit when there is no prior run or `last_commit`
-    no longer resolves (rewritten history) — both read as "never run".
-    None on git failure."""
+def _drift_percentage(cwd: str) -> tuple[float, int, int] | None:
+    """(percentage, added, total) since the last /repo-review run, or since
+    the repository's first commit when there is no prior run, `last_commit`
+    fails validation, or it no longer resolves (rewritten history) — all
+    read as "never run", which correctly yields exactly 100%. None on git
+    failure (unreachable HEAD, corrupt index, git not installed, timeout)."""
+    total = _added_lines(cwd, f"{_EMPTY_TREE}..HEAD")
+    if total is None or total <= 0:
+        return None
+
     last_commit = _load_last_commit(cwd)
+    added = None
     if last_commit is not None:
-        count = _added_lines(cwd, f"{last_commit}..HEAD")
-        if count is not None:
-            return count
-    # No prior state, or last_commit didn't resolve — fall back to added
-    # lines since the repository began.
-    return _added_lines(cwd, f"{_EMPTY_TREE}..HEAD")
+        added = _added_lines(cwd, f"{last_commit}..HEAD")
+    if added is None:
+        added = total  # no prior state / unreachable last_commit => "never run"
+
+    return (added / total) * 100, added, total
 
 
-def _nudge_message(added: int) -> str:
+def _nudge_message(percent: float, added: int, total: int) -> str:
     return (
-        f"\U0001f300 ~{added} added line(s) since the last /repo-review — "
-        "consider running it to catch drift no per-diff review sees "
-        "(file/CLAUDE.md size, verification debt, component duplication)\n"
+        f"\U0001f300 ~{percent:.1f}% of the codebase ({added:,} of {total:,} "
+        "lines) has changed since the last /repo-review — consider running "
+        "it to catch drift no per-diff review sees (file/CLAUDE.md size, "
+        "verification debt, component duplication)\n"
     )
 
 
@@ -188,11 +223,14 @@ def main() -> int:
     if not _is_git_repo(cwd):
         return 0
 
-    added = _drift_lines(cwd)
-    if added is None or added < _threshold():
+    result = _drift_percentage(cwd)
+    if result is None:
+        return 0
+    percent, added, total = result
+    if percent < _threshold_percent():
         return 0
 
-    sys.stdout.write(_nudge_message(added))
+    sys.stdout.write(_nudge_message(percent, added, total))
     return 0
 
 

--- a/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
@@ -1,9 +1,11 @@
-"""Unit tests for hooks/repo_review_nudge.py (#1739/#1743).
+"""Unit tests for hooks/repo_review_nudge.py (#1739/#1743/#1746).
 
-SessionStart hook that suggests running /repo-review when the percentage of
-the codebase changed since the last recorded run (or since the repo's
-first commit, if never run — which always resolves to exactly 100%) crosses
-a threshold. Fail-open, never blocks a session.
+SessionStart hook that suggests running /repo-review once its three-part
+trigger fires: an absolute ceiling (always nudge above it, regardless of
+percentage), an absolute floor (never nudge below it, regardless of
+percentage), and a percentage-of-codebase-changed rule in between. "Never
+run" always resolves to exactly 100% changed. Fail-open, never blocks a
+session.
 """
 
 from __future__ import annotations
@@ -22,6 +24,15 @@ if str(_TESTS_LIB) not in sys.path:
     sys.path.insert(0, str(_TESTS_LIB))
 
 from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+
+# Disables the floor/ceiling guards (0 = no minimum, a huge number = an
+# unreachable maximum in these tiny fixture repos) so tests that exist to
+# pin the *percentage* rule aren't coupled to the floor/ceiling defaults —
+# those get their own dedicated tests below.
+_PERCENT_ONLY_ENV = {
+    "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "0",
+    "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "999999",
+}
 
 
 def _run(cwd: Path, extra_env: dict | None = None) -> subprocess.CompletedProcess[str]:
@@ -103,7 +114,7 @@ def test_no_payload_is_silent(tmp_path: Path) -> None:
 def test_never_run_is_always_100_percent(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     _commit_lines(tmp_path, "a.txt", 50, "first commit")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
     assert "100.0%" in r.stdout
@@ -113,7 +124,7 @@ def test_never_run_is_always_100_percent(tmp_path: Path) -> None:
 def test_never_run_silent_when_threshold_exceeds_100(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     _commit_lines(tmp_path, "a.txt", 50, "first commit")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "150"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "150"})
     assert r.returncode == 0
     assert r.stdout == ""
 
@@ -124,7 +135,7 @@ def test_below_threshold_since_last_run_is_silent(tmp_path: Path) -> None:
     _write_state(tmp_path, last)
     _commit_lines(tmp_path, "b.txt", 10, "small follow-up")
     # 10 added / 100 total = 10% — below a 50% threshold.
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "50"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "50"})
     assert r.returncode == 0
     assert r.stdout == ""
 
@@ -135,7 +146,7 @@ def test_above_threshold_since_last_run_nudges(tmp_path: Path) -> None:
     _write_state(tmp_path, last)
     _commit_lines(tmp_path, "b.txt", 10, "small follow-up")
     # 10 added / 100 total = 10% — above a 5% threshold.
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
     assert "10.0%" in r.stdout
@@ -145,7 +156,7 @@ def test_unreachable_last_commit_falls_back_to_100_percent(tmp_path: Path) -> No
     _init_repo(tmp_path)
     _commit_lines(tmp_path, "a.txt", 40, "first commit")
     _write_state(tmp_path, "0" * 40)  # syntactically valid shape, but unreachable
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
     assert "100.0%" in r.stdout
@@ -159,7 +170,7 @@ def test_invalid_last_commit_shape_treated_as_never_run(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     _commit_lines(tmp_path, "a.txt", 40, "first commit")
     _write_state(tmp_path, "-not-a-real-sha")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
     assert "100.0%" in r.stdout
@@ -171,17 +182,120 @@ def test_malformed_state_file_treated_as_never_run(tmp_path: Path) -> None:
     state_dir = tmp_path / ".claude" / "memory"
     state_dir.mkdir(parents=True, exist_ok=True)
     (state_dir / "repo-review-state.json").write_text("{not json")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
 
 
-def test_default_threshold_used_when_env_var_invalid(tmp_path: Path) -> None:
+def test_default_percent_threshold_used_when_env_var_invalid(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     last = _commit_lines(tmp_path, "a.txt", 1000, "large baseline")
     _write_state(tmp_path, last)
     _commit_lines(tmp_path, "b.txt", 5, "tiny follow-up")
     # 5 added / 1005 total =~ 0.5% — below the 10% default.
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "not-a-number"})
+    r = _run(tmp_path, {**_PERCENT_ONLY_ENV, "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "not-a-number"})
     assert r.returncode == 0
     assert r.stdout == ""
+
+
+# --- Floor (#1746): suppress nagging on small repos -------------------------
+
+
+def test_floor_suppresses_nudge_even_above_percent_threshold(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 40, "baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 10, "trivial follow-up")
+    # 10 added / 50 total = 20% — well above a 5% threshold, but 10 added
+    # lines is below a 50-line floor: must stay silent regardless.
+    r = _run(
+        tmp_path,
+        {
+            "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5",
+            "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "50",
+            "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "999999",
+        },
+    )
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_floor_allows_nudge_once_added_meets_it(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 40, "baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 60, "substantial follow-up")
+    # 60 added / 100 total = 60% — above both a 5% threshold and a 50-line floor.
+    r = _run(
+        tmp_path,
+        {
+            "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5",
+            "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "50",
+            "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "999999",
+        },
+    )
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "60.0%" in r.stdout
+
+
+def test_invalid_min_added_lines_falls_back_to_default_floor(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 40, "baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 50, "follow-up under the real 200-line default floor")
+    # 50 added / 90 total =~ 55.6% — comfortably above a 5% threshold, but
+    # 50 added lines is below the real default floor (200): an invalid
+    # override must fall back to that default, not disable the floor.
+    r = _run(
+        tmp_path,
+        {
+            "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5",
+            "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "not-a-number",
+            "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "999999",
+        },
+    )
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+# --- Ceiling (#1746): don't go silent on large repos ------------------------
+
+
+def test_ceiling_forces_nudge_even_below_percent_threshold(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    last = _commit_lines(tmp_path, "a.txt", 2000, "large baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 60, "follow-up")
+    # 60 added / 2060 total =~ 2.9% — below a 10% threshold, but 60 added
+    # lines is above a 50-line ceiling: must nudge regardless.
+    r = _run(
+        tmp_path,
+        {
+            "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "10",
+            "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "0",
+            "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "50",
+        },
+    )
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+
+
+def test_default_ceiling_forces_nudge_despite_unreachable_percent_threshold(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    # Never run => 100%, but an absurdly high percent threshold means the
+    # percent rule alone could never fire. The real default ceiling (5000)
+    # must still force a nudge on its own.
+    _commit_lines(tmp_path, "a.txt", 5001, "very large first commit")
+    r = _run(
+        tmp_path,
+        {
+            "DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "99999",
+            "DEV_TEAM_REPO_REVIEW_MIN_ADDED_LINES": "0",
+            "DEV_TEAM_REPO_REVIEW_MAX_ADDED_LINES": "not-a-number",
+        },
+    )
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout

--- a/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
@@ -181,7 +181,7 @@ def test_default_threshold_used_when_env_var_invalid(tmp_path: Path) -> None:
     last = _commit_lines(tmp_path, "a.txt", 1000, "large baseline")
     _write_state(tmp_path, last)
     _commit_lines(tmp_path, "b.txt", 5, "tiny follow-up")
-    # 5 added / 1005 total =~ 0.5% — below the 1% default.
+    # 5 added / 1005 total =~ 0.5% — below the 10% default.
     r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "not-a-number"})
     assert r.returncode == 0
     assert r.stdout == ""

--- a/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_repo_review_nudge.py
@@ -1,8 +1,9 @@
-"""Unit tests for hooks/repo_review_nudge.py (#1739).
+"""Unit tests for hooks/repo_review_nudge.py (#1739/#1743).
 
-SessionStart hook that suggests running /repo-review when added lines since
-the last recorded run (or since the repo's first commit, if never run)
-cross a threshold. Fail-open, never blocks a session.
+SessionStart hook that suggests running /repo-review when the percentage of
+the codebase changed since the last recorded run (or since the repo's
+first commit, if never run — which always resolves to exactly 100%) crosses
+a threshold. Fail-open, never blocks a session.
 """
 
 from __future__ import annotations
@@ -99,52 +100,69 @@ def test_no_payload_is_silent(tmp_path: Path) -> None:
     assert r.stdout == ""
 
 
-def test_never_run_below_threshold_is_silent(tmp_path: Path) -> None:
+def test_never_run_is_always_100_percent(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    _commit_lines(tmp_path, "a.txt", 5, "small first commit")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "2000"})
+    _commit_lines(tmp_path, "a.txt", 50, "first commit")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "100.0%" in r.stdout
+    assert "50" in r.stdout  # added and total are both 50 lines
+
+
+def test_never_run_silent_when_threshold_exceeds_100(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 50, "first commit")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "150"})
     assert r.returncode == 0
     assert r.stdout == ""
 
 
-def test_never_run_above_threshold_nudges(tmp_path: Path) -> None:
-    _init_repo(tmp_path)
-    _commit_lines(tmp_path, "a.txt", 50, "first commit")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
-    assert r.returncode == 0
-    assert "/repo-review" in r.stdout
-    assert "50" in r.stdout
-
-
 def test_below_threshold_since_last_run_is_silent(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    last = _commit_lines(tmp_path, "a.txt", 5, "baseline")
+    last = _commit_lines(tmp_path, "a.txt", 90, "baseline")
     _write_state(tmp_path, last)
-    _commit_lines(tmp_path, "b.txt", 5, "small follow-up")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "2000"})
+    _commit_lines(tmp_path, "b.txt", 10, "small follow-up")
+    # 10 added / 100 total = 10% — below a 50% threshold.
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "50"})
     assert r.returncode == 0
     assert r.stdout == ""
 
 
 def test_above_threshold_since_last_run_nudges(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    last = _commit_lines(tmp_path, "a.txt", 5, "baseline")
+    last = _commit_lines(tmp_path, "a.txt", 90, "baseline")
     _write_state(tmp_path, last)
-    _commit_lines(tmp_path, "b.txt", 30, "big follow-up")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    _commit_lines(tmp_path, "b.txt", 10, "small follow-up")
+    # 10 added / 100 total = 10% — above a 5% threshold.
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
-    assert "30" in r.stdout
+    assert "10.0%" in r.stdout
 
 
-def test_unreachable_last_commit_falls_back_to_first_commit(tmp_path: Path) -> None:
+def test_unreachable_last_commit_falls_back_to_100_percent(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     _commit_lines(tmp_path, "a.txt", 40, "first commit")
-    _write_state(tmp_path, "0" * 40)  # a syntactically valid but unreachable sha
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    _write_state(tmp_path, "0" * 40)  # syntactically valid shape, but unreachable
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
-    assert "40" in r.stdout
+    assert "100.0%" in r.stdout
+
+
+def test_invalid_last_commit_shape_treated_as_never_run(tmp_path: Path) -> None:
+    """#1743: last_commit is untrusted input — a value that doesn't match
+    the commit-sha shape (e.g. one a hostile state file could plant to try
+    an argument-injection-flavored revspec) must never reach git at all,
+    and must fall back to "no prior state" exactly like a missing file."""
+    _init_repo(tmp_path)
+    _commit_lines(tmp_path, "a.txt", 40, "first commit")
+    _write_state(tmp_path, "-not-a-real-sha")
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
+    assert r.returncode == 0
+    assert "/repo-review" in r.stdout
+    assert "100.0%" in r.stdout
 
 
 def test_malformed_state_file_treated_as_never_run(tmp_path: Path) -> None:
@@ -153,14 +171,17 @@ def test_malformed_state_file_treated_as_never_run(tmp_path: Path) -> None:
     state_dir = tmp_path / ".claude" / "memory"
     state_dir.mkdir(parents=True, exist_ok=True)
     (state_dir / "repo-review-state.json").write_text("{not json")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "10"})
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "5"})
     assert r.returncode == 0
     assert "/repo-review" in r.stdout
 
 
 def test_default_threshold_used_when_env_var_invalid(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    _commit_lines(tmp_path, "a.txt", 5, "small first commit")
-    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD": "not-a-number"})
+    last = _commit_lines(tmp_path, "a.txt", 1000, "large baseline")
+    _write_state(tmp_path, last)
+    _commit_lines(tmp_path, "b.txt", 5, "tiny follow-up")
+    # 5 added / 1005 total =~ 0.5% — below the 1% default.
+    r = _run(tmp_path, {"DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD": "not-a-number"})
     assert r.returncode == 0
-    assert r.stdout == ""  # 5 lines is far below the 2000-line default
+    assert r.stdout == ""


### PR DESCRIPTION
## Summary
- Replaces the absolute added-lines threshold in `repo_review_nudge.py` with a size-independent **percentage of the codebase changed**: `added_lines_since_baseline / total_current_loc * 100`.
- `total_current_loc` reuses the same added-lines counter, diffed against git's empty-tree object — no extra `wc -l` pass needed.
- "Never run" now resolves to exactly 100% (added == total) instead of a special-cased branch.
- Renames `DEV_TEAM_REPO_REVIEW_LINE_THRESHOLD` → `DEV_TEAM_REPO_REVIEW_PERCENT_THRESHOLD` (default `1`, meaning 1%).
- Also fixes a gap noticed while updating this: `last_commit` from `.claude/memory/repo-review-state.json` is untrusted input (the file is meant to be gitignored, but a hostile PR could still force-add one), and `skills/repo-review/SKILL.md` (merged in #1742) already validates it against `^[0-9a-fA-F]{7,40}$` before touching any git command. This hook read the same file without that check — added the identical validation.

## Test plan
- [x] `plugins/dev-team/tests/hooks/test_repo_review_nudge.py` — 10 tests, rewritten for percentage semantics (never-run == 100%, below/above threshold since last run, unreachable last_commit, invalid last_commit shape treated as never-run, malformed state file, invalid env var falls back to the 1% default)
- [x] `python3 -m ruff check` — clean
- [x] Full `plugins/dev-team/tests/hooks tests/hooks tests/repo` — 2945 passed, 46 skipped

Closes #1743
Part of #1735