### PR TITLE
fix(hooks): relocate repowise's tracked .mcp.json entry to local scope

### DIFF
--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -13,6 +13,10 @@
           },
           {
             "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/mcp_json_repowise_nudge.py\""
+          },
+          {
+            "type": "command",
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/codegraph_bootstrap.py\""
           }
         ]

--- a/plugins/dev-team/hooks/lib/mcp_json_repowise.py
+++ b/plugins/dev-team/hooks/lib/mcp_json_repowise.py
@@ -1,0 +1,177 @@
+"""Shared repowise `.mcp.json` detection + relocation (#1747).
+
+`repowise init`/`repowise update` unconditionally writes a `mcpServers.
+repowise` entry into the project-root `.mcp.json`, baking in the invoking
+machine's absolute filesystem path (a known, currently-open upstream bug:
+repowise-dev/repowise#1117). When `.mcp.json` is git-tracked — a team may
+legitimately commit it to distribute other MCP servers (`codegraph`, an
+internal org server) that don't bake in a local path — that entry breaks
+for every other clone/teammate.
+
+`detect()` is the single shared predicate both consumers of this module
+need: `project-init/SKILL.md`'s `.mcp.json` standing check (which calls
+`relocate()` via this module's CLI) and `hooks/mcp_json_repowise_nudge.py`
+(the SessionStart hook that prompts an already-initialized project to
+re-run `/project-init`). Implemented once here so the two can never drift
+out of sync on what counts as "needs fixing."
+
+`relocate()` registers at `local` scope BEFORE stripping the tracked entry
+— never the reverse — so a failed `claude mcp add` (CLI missing, timeout,
+non-zero exit) leaves `.mcp.json` untouched rather than deleting the only
+registration that existed. Every other `mcpServers` entry is preserved
+byte-for-byte; only the `repowise` key is ever touched.
+
+Stdlib-only. Python 3.10+. See ADR 0014 / ADR 0015.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+_MCP_JSON_NAME = ".mcp.json"
+_SERVER_NAME = "repowise"
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _dump_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def is_tracked(mcp_json_path: Path, cwd: Path) -> bool:
+    """True iff `mcp_json_path` exists and `git ls-files --error-unmatch`
+    (run with `cwd`) confirms it's tracked. False on any git failure (not a
+    repo, git missing, timeout) — never raises."""
+    if not mcp_json_path.is_file():
+        return False
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", mcp_json_path.name],
+            cwd=str(cwd),
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def detect(cwd: Path) -> dict | None:
+    """The shared predicate: the `repowise` `mcpServers` entry iff
+    `<cwd>/.mcp.json` exists, is git-tracked, AND carries a `repowise` key.
+    None on anything else, including any internal failure — this must
+    never raise, since both callers treat None as "nothing to do"."""
+    try:
+        mcp_json_path = Path(cwd) / _MCP_JSON_NAME
+        if not is_tracked(mcp_json_path, Path(cwd)):
+            return None
+        servers = _load_json(mcp_json_path).get("mcpServers")
+        if not isinstance(servers, dict):
+            return None
+        entry = servers.get(_SERVER_NAME)
+        return entry if isinstance(entry, dict) else None
+    except Exception:  # noqa: BLE001 - fail-open: a detection bug must never propagate
+        return None
+
+
+def strip_entry(mcp_json_path: Path) -> bool:
+    """Remove only the `repowise` key from `mcp_json_path`'s `mcpServers`
+    object, preserving every other entry untouched. Drops the `mcpServers`
+    key entirely if removing `repowise` leaves it empty. Idempotent: a
+    no-op (returns False, no write) when there's nothing to strip."""
+    config = _load_json(mcp_json_path)
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or _SERVER_NAME not in servers:
+        return False
+    servers.pop(_SERVER_NAME)
+    if servers:
+        config["mcpServers"] = servers
+    else:
+        config.pop("mcpServers", None)
+    _dump_json(mcp_json_path, config)
+    return True
+
+
+def _register_local_scope(repo_root: Path) -> bool:
+    """`claude mcp add repowise --scope local -- repowise mcp <repo_root>
+    --transport stdio`. True on exit 0; False on any failure (`claude` CLI
+    missing, non-zero exit, timeout) — never raises. Deliberately re-derives
+    `args` from the CURRENT repo root rather than reusing the stripped
+    entry's own `args` — those carry the OLD, wrong machine's path, which is
+    exactly the bug being fixed."""
+    try:
+        completed = subprocess.run(
+            [
+                "claude", "mcp", "add", _SERVER_NAME, "--scope", "local",
+                "--", _SERVER_NAME, "mcp", str(repo_root), "--transport", "stdio",
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def relocate(
+    cwd: Path, *, register: Callable[[Path], bool] = _register_local_scope
+) -> str:
+    """Detect -> register at local scope -> strip from the tracked file, in
+    that order (never strip-then-register — see module docstring). Returns
+    one of:
+        "not-tracked"       -- .mcp.json missing, or not git-tracked
+        "no-repowise-entry" -- tracked, but no repowise key to relocate
+        "relocated"         -- registered locally and stripped
+        "relocate-failed"   -- repowise entry found, but `claude mcp add`
+                                failed; .mcp.json is left untouched
+
+    `register` is injectable (stdlib `Callable`, defaulting to the real
+    `claude mcp add` call) so callers/tests can verify both branches
+    without a real `claude` CLI or a live MCP registration. Never raises.
+    """
+    cwd = Path(cwd)
+    entry = detect(cwd)
+    if entry is None:
+        return "no-repowise-entry" if is_tracked(cwd / _MCP_JSON_NAME, cwd) else "not-tracked"
+
+    if not register(cwd):
+        return "relocate-failed"
+
+    strip_entry(cwd / _MCP_JSON_NAME)
+    return "relocated"
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["relocate"])
+    parser.add_argument("--cwd", default=".")
+    args = parser.parse_args()
+
+    if args.action == "relocate":
+        print(relocate(Path(args.cwd).resolve()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/plugins/dev-team/hooks/mcp_json_repowise_nudge.py
+++ b/plugins/dev-team/hooks/mcp_json_repowise_nudge.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""mcp_json_repowise_nudge — Claude Code SessionStart hook (#1747).
+
+`project-init/SKILL.md`'s `.mcp.json` standing check can only relocate a
+stale, git-tracked `repowise` entry when someone actually runs
+`/project-init` (or `/setup`). For an already-initialized project, nobody
+is prompted to do that — the entry sits untouched indefinitely. This hook
+is that proactive nudge, mirroring `pending_review_notify.py`'s /
+`repo_review_nudge.py`'s shape: read a small state signal, print a one-line
+stdout notice, fail-open, stdlib-only.
+
+Shares its detection predicate — `hooks/lib/mcp_json_repowise.py::detect()`
+— with the standing check itself (invoked from skill markdown via that
+module's own CLI), so the two can never disagree on what counts as "needs
+fixing" (#1747's single-commit requirement: this hook is meaningless
+without that module's `relocate()` existing, so the two ship together).
+
+Nudges every session until the condition clears (no snooze/debounce) — same
+posture as the existing pending-review-queue and repo-review nudges.
+
+Contract (docs/python-hook-contract.md):
+    Input : SessionStart JSON on stdin (hook_event_name, cwd, model, ...).
+    Output: notification text on stdout. Exit 0 always.
+    Posture: fail-open — a buggy notifier must never block a session; this
+        hook only ever suggests, it never gates.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+try:
+    from mcp_json_repowise import detect  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def detect(cwd):  # type: ignore[misc]
+        return None
+
+
+_NUDGE_MESSAGE = (
+    "⚠️ .mcp.json is git-tracked and registers repowise with a "
+    "machine-specific path (breaks for every other clone/teammate) — run "
+    "/project-init (or /setup) to relocate it to local scope\n"
+)
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return 0
+    if not raw:
+        return 0
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    cwd = payload.get("cwd") or ""
+    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
+        cwd = os.getcwd()
+
+    if detect(Path(cwd)) is None:
+        return 0
+
+    sys.stdout.write(_NUDGE_MESSAGE)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 - fail-open: a hook bug must never block a session
+        sys.exit(0)

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -29,6 +29,10 @@
           },
           {
             "type": "command",
+            "command": "sh hooks/py.sh hooks/mcp_json_repowise_nudge.py"
+          },
+          {
+            "type": "command",
             "command": "sh hooks/py.sh hooks/codegraph_bootstrap.py"
           }
         ]

--- a/plugins/dev-team/skills/project-init/SKILL.md
+++ b/plugins/dev-team/skills/project-init/SKILL.md
@@ -631,17 +631,40 @@ This check is intentionally **not** scoped to the downstream-only, Step 2
 `in-repo`-skip case the way `/setup`'s own backstop check is — a
 machine-specific path in `.mcp.json` breaks every clone or teammate
 regardless of whether the repo is this plugin's own checkout or a downstream
-project, so this standing check applies in both. If `.mcp.json` is already
-tracked by git (`git ls-files --error-unmatch .mcp.json` exits 0), do not
-untrack it automatically — tell the operator to run `git rm --cached
-.mcp.json` themselves, same posture as #1376, and record that outcome too.
-Merge one of `{"mcp_hygiene": {"gitignore": "added"}}`,
-`{"mcp_hygiene": {"gitignore": "already-covered"}}`, or (when the
-already-tracked case above fires) `{"mcp_hygiene": {"gitignore":
-"added-but-tracked"}}` into `.claude/init-state.json` — a top-level key
-rather than nested under `repowise`, since this check runs independently of
-Repowise's own install state. Report the outcome as its own line in Step 6's
-summary below (and the caller's own report, when `/setup` is the caller).
+project, so this standing check applies in both.
+
+**If `.mcp.json` is already tracked by git** (`git ls-files --error-unmatch
+.mcp.json` exits 0), gitignoring the whole file isn't viable — a team that
+legitimately commits `.mcp.json` to distribute other MCP servers (e.g.
+`codegraph`, an internal org server) would lose those too (#1731). Before
+falling back to the operator, try the finer-grained fix (#1747):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/mcp_json_repowise.py" relocate --cwd .
+```
+
+This strips only the `repowise` key from the tracked `.mcp.json`'s
+`mcpServers` object — every other entry is left untouched — and re-registers
+it at `local` scope (`claude mcp add repowise --scope local -- repowise mcp
+"$(pwd)" --transport stdio`) instead, in that order (register succeeds
+before the tracked entry is ever removed, so a failed registration never
+leaves `.mcp.json` with no working entry at all). It prints one of
+`not-tracked`, `no-repowise-entry`, `relocated`, or `relocate-failed`.
+Record the outcome as `{"mcp_hygiene": {"repowise_relocated": "<that
+string>"}}`.
+
+**Residual fallback**: `relocate` only ever touches the `repowise` key. If
+the printed outcome is `relocate-failed`, or `.mcp.json` is tracked for a
+reason unrelated to Repowise, do not untrack it automatically — tell the
+operator to run `git rm --cached .mcp.json` themselves, same posture as
+#1376, and record that outcome too. Merge one of `{"mcp_hygiene":
+{"gitignore": "added"}}`, `{"mcp_hygiene": {"gitignore":
+"already-covered"}}`, or (when this residual fallback fires) `{"mcp_hygiene":
+{"gitignore": "added-but-tracked"}}` into `.claude/init-state.json` — a
+top-level key rather than nested under `repowise`, since this check runs
+independently of Repowise's own install state. Report both outcomes as their
+own lines in Step 6's summary below (and the caller's own report, when
+`/setup` is the caller).
 
 #### Graphify — native integration, opt-in, with corruption/pollution guards
 
@@ -907,8 +930,9 @@ After every configured lane probes green, give the user:
   semantic enrichment is a further key-gated add-on on top of that.
 - **`.mcp.json` machine-specific-path hygiene** (issue #1416, runs
   independently of Repowise's own install/decline state): added the block,
-  found it already covered, or flagged that `.mcp.json` is still git-tracked
-  and needs `git rm --cached`.
+  found it already covered, or — when it's git-tracked — relocated a
+  `repowise` entry to local scope (#1747) or, if that wasn't applicable/
+  failed, flagged that `.mcp.json` still needs `git rm --cached`.
 - Files created (greenfield only).
 
 ## Greenfield JS/TS scaffold

--- a/plugins/dev-team/tests/hooks/test_mcp_json_repowise.py
+++ b/plugins/dev-team/tests/hooks/test_mcp_json_repowise.py
@@ -1,0 +1,198 @@
+"""Unit tests for hooks/lib/mcp_json_repowise.py (#1747).
+
+Shared detect()/strip_entry()/relocate() logic for the repowise `.mcp.json`
+machine-specific-path problem, used by both `project-init/SKILL.md`'s
+standing check (via this module's CLI) and
+`hooks/mcp_json_repowise_nudge.py` (the SessionStart nudge).
+"""
+
+from __future__ import annotations
+
+import importlib.util as _importlib_util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_MODULE_PATH = (
+    _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib" / "mcp_json_repowise.py"
+)
+
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+
+_spec = _importlib_util.spec_from_file_location("mcp_json_repowise", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+mcp_json_repowise = _importlib_util.module_from_spec(_spec)
+_spec.loader.exec_module(mcp_json_repowise)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=hermetic_git_env(home=cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(cwd: Path) -> None:
+    _git(cwd, "init", "-q")
+    _git(cwd, "config", "user.email", "test@example.com")
+    _git(cwd, "config", "user.name", "Test")
+
+
+def _write_mcp_json(cwd: Path, data: dict) -> Path:
+    path = cwd / ".mcp.json"
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _commit_all(cwd: Path, message: str) -> None:
+    _git(cwd, "add", "-A")
+    _git(cwd, "commit", "-q", "-m", message)
+
+
+def _commit_placeholder(cwd: Path) -> None:
+    (cwd / "README.md").write_text("placeholder\n", encoding="utf-8")
+    _commit_all(cwd, "init")
+
+
+_REPOWISE_ENTRY = {
+    "command": "repowise",
+    "args": ["mcp", "/Users/alice/Dev/some-repo", "--transport", "stdio"],
+    "description": "repowise: codebase intelligence",
+}
+
+_CODEGRAPH_ENTRY = {"command": "codegraph", "args": ["mcp"]}
+
+
+def test_detect_none_when_mcp_json_missing(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    assert mcp_json_repowise.detect(tmp_path) is None
+
+
+def test_detect_none_when_mcp_json_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    # Never git add-ed — untracked.
+    assert mcp_json_repowise.detect(tmp_path) is None
+
+
+def test_detect_none_when_tracked_but_no_repowise_key(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY}})
+    _commit_all(tmp_path, "add mcp.json")
+    assert mcp_json_repowise.detect(tmp_path) is None
+
+
+def test_detect_returns_entry_when_tracked_and_present(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write_mcp_json(
+        tmp_path,
+        {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY, "repowise": _REPOWISE_ENTRY}},
+    )
+    _commit_all(tmp_path, "add mcp.json")
+    entry = mcp_json_repowise.detect(tmp_path)
+    assert entry == _REPOWISE_ENTRY
+
+
+def test_detect_none_on_malformed_json(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / ".mcp.json").write_text("{not json", encoding="utf-8")
+    _commit_all(tmp_path, "add broken mcp.json")
+    assert mcp_json_repowise.detect(tmp_path) is None
+
+
+def test_strip_entry_removes_only_repowise_preserves_others(tmp_path: Path) -> None:
+    path = _write_mcp_json(
+        tmp_path,
+        {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY, "repowise": _REPOWISE_ENTRY}},
+    )
+    changed = mcp_json_repowise.strip_entry(path)
+    assert changed is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "repowise" not in data["mcpServers"]
+    assert data["mcpServers"]["codegraph"] == _CODEGRAPH_ENTRY
+
+
+def test_strip_entry_drops_mcpServers_key_when_empty_after_strip(tmp_path: Path) -> None:
+    path = _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    mcp_json_repowise.strip_entry(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "mcpServers" not in data
+
+
+def test_strip_entry_is_noop_when_absent(tmp_path: Path) -> None:
+    path = _write_mcp_json(tmp_path, {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY}})
+    before = path.read_text(encoding="utf-8")
+    changed = mcp_json_repowise.strip_entry(path)
+    assert changed is False
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_relocate_not_tracked_when_mcp_json_missing(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    assert mcp_json_repowise.relocate(tmp_path) == "not-tracked"
+
+
+def test_relocate_not_tracked_when_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    assert mcp_json_repowise.relocate(tmp_path) == "not-tracked"
+
+
+def test_relocate_no_repowise_entry(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY}})
+    _commit_all(tmp_path, "add mcp.json")
+    assert mcp_json_repowise.relocate(tmp_path) == "no-repowise-entry"
+
+
+def test_relocate_success_registers_then_strips(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    path = _write_mcp_json(
+        tmp_path,
+        {"mcpServers": {"codegraph": _CODEGRAPH_ENTRY, "repowise": _REPOWISE_ENTRY}},
+    )
+    _commit_all(tmp_path, "add mcp.json")
+
+    calls = []
+
+    def fake_register(repo_root: Path) -> bool:
+        calls.append(repo_root)
+        return True
+
+    result = mcp_json_repowise.relocate(tmp_path, register=fake_register)
+    assert result == "relocated"
+    assert calls == [tmp_path]
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "repowise" not in data["mcpServers"]
+    assert data["mcpServers"]["codegraph"] == _CODEGRAPH_ENTRY
+
+
+def test_relocate_failed_registration_leaves_mcp_json_untouched(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    path = _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    _commit_all(tmp_path, "add mcp.json")
+    before = path.read_text(encoding="utf-8")
+
+    result = mcp_json_repowise.relocate(tmp_path, register=lambda repo_root: False)
+    assert result == "relocate-failed"
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_is_tracked_false_when_not_a_git_repo(tmp_path: Path) -> None:
+    path = _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    assert mcp_json_repowise.is_tracked(path, tmp_path) is False

--- a/plugins/dev-team/tests/hooks/test_mcp_json_repowise_nudge.py
+++ b/plugins/dev-team/tests/hooks/test_mcp_json_repowise_nudge.py
@@ -1,0 +1,123 @@
+"""Unit tests for hooks/mcp_json_repowise_nudge.py (#1747).
+
+SessionStart hook that suggests running /project-init when .mcp.json is
+git-tracked and carries a repowise entry (the exact case its
+hooks/lib/mcp_json_repowise.py::relocate() companion can fix). Fail-open,
+never blocks a session.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "mcp_json_repowise_nudge.py"
+
+_TESTS_LIB = Path(__file__).resolve().parents[2] / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+
+_REPOWISE_ENTRY = {
+    "command": "repowise",
+    "args": ["mcp", "/Users/alice/Dev/some-repo", "--transport", "stdio"],
+}
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    payload = {"hook_event_name": "SessionStart", "cwd": str(cwd)}
+    return subprocess.run(
+        ["python3", str(_HOOK)],
+        input=json.dumps(payload),
+        env=hermetic_git_env(home=cwd),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=hermetic_git_env(home=cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(cwd: Path) -> None:
+    _git(cwd, "init", "-q")
+    _git(cwd, "config", "user.email", "test@example.com")
+    _git(cwd, "config", "user.name", "Test")
+
+
+def _write_mcp_json(cwd: Path, data: dict) -> None:
+    (cwd / ".mcp.json").write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _commit_all(cwd: Path, message: str) -> None:
+    _git(cwd, "add", "-A")
+    _git(cwd, "commit", "-q", "-m", message)
+
+
+def _commit_placeholder(cwd: Path) -> None:
+    (cwd / "README.md").write_text("placeholder\n", encoding="utf-8")
+    _commit_all(cwd, "init")
+
+
+def test_no_payload_is_silent(tmp_path: Path) -> None:
+    r = subprocess.run(
+        ["python3", str(_HOOK)],
+        input="",
+        env=hermetic_git_env(home=tmp_path),
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_silent_when_no_mcp_json(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    r = _run(tmp_path)
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_silent_when_mcp_json_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit_placeholder(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    r = _run(tmp_path)
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_silent_when_tracked_without_repowise_entry(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"codegraph": {"command": "codegraph"}}})
+    _commit_all(tmp_path, "add mcp.json")
+    r = _run(tmp_path)
+    assert r.returncode == 0
+    assert r.stdout == ""
+
+
+def test_nudges_when_tracked_with_repowise_entry(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write_mcp_json(tmp_path, {"mcpServers": {"repowise": _REPOWISE_ENTRY}})
+    _commit_all(tmp_path, "add mcp.json")
+    r = _run(tmp_path)
+    assert r.returncode == 0
+    assert "/project-init" in r.stdout
+    assert "repowise" in r.stdout

--- a/tests/repo/test_skill_bash_grants_cover_invocations.py
+++ b/tests/repo/test_skill_bash_grants_cover_invocations.py
@@ -70,6 +70,7 @@ KNOWN_UNCOVERED_INVOCATIONS = {
     ("pr", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress_guardian.py" --pre-pr --plan <plan-file>'),
     ("pr", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/pr_close_keyword_lint.py" --body-file <body-file>'),
     ("project-init", 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/install-java-static-analysis.py"'),
+    ("project-init", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/mcp_json_repowise.py" relocate --cwd .'),
     ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/workflow_state.py" record \\'),
     ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" record \\'),
     ("ship", 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/iteration_journal_gate.py" check \\'),

--- a/tests/skills/test_project_init_mcp_json_hygiene.py
+++ b/tests/skills/test_project_init_mcp_json_hygiene.py
@@ -168,6 +168,22 @@ def test_setup_step_11_cross_references_project_init_1416():
     assert "project-init" in block
 
 
+def test_repowise_standing_check_relocates_before_deferring_to_operator():
+    # #1747: before falling back to the operator, the check should try the
+    # finer-grained fix — relocate the repowise entry specifically, leaving
+    # every other tracked mcpServers entry untouched.
+    check = collapsed(_mcp_json_standing_check())
+    assert "mcp_json_repowise.py" in check
+    assert "relocate" in check
+    assert "#1747" in check
+    assert "--scope local" in check
+
+
+def test_repowise_standing_check_records_relocate_outcome():
+    check = collapsed(_mcp_json_standing_check())
+    assert '"repowise_relocated"' in check
+
+
 def test_step_6_summary_mentions_mcp_json_hygiene_outcome():
     # Mirrors test_setup_gitignore_hygiene.py's
     # test_step_12_report_mentions_both_new_gitignore_entries — the


### PR DESCRIPTION
## Summary
- `repowise init`/`repowise update` unconditionally writes a `mcpServers.repowise` entry into the project-root `.mcp.json`, baking in the invoking machine's absolute path (upstream bug: `repowise-dev/repowise#1117`, unmerged fix, no target version). When `.mcp.json` is git-tracked — e.g. a team that legitimately commits it to distribute other MCP servers (`codegraph`, an internal org server) — that breaks for every other clone/teammate, and the standing check's only prior remedy was gitignoring the whole file or telling the operator to `git rm --cached` it, un-distributing those other entries too (#1731).
- **Part A** (`hooks/lib/mcp_json_repowise.py`): shared `detect()`/`strip_entry()`/`relocate()` module. `relocate()` registers at `local` scope (`claude mcp add --scope local`) **before** stripping the tracked entry, so a failed registration never leaves `.mcp.json` with no working entry anywhere; every other `mcpServers` entry is preserved untouched. `project-init/SKILL.md`'s `.mcp.json` standing check now tries this before falling back to the existing `git rm --cached` path.
- **Part B** (`hooks/mcp_json_repowise_nudge.py`): a `SessionStart` hook that proactively nudges toward `/project-init` when `.mcp.json` is tracked and carries a `repowise` entry, sharing Part A's `detect()` predicate — an already-initialized project's stale entry would otherwise sit untouched indefinitely, since the standing check only fires on a `/project-init`/`/setup` re-run.
- Both land in this single commit deliberately (per #1747): Part B is meaningless without Part A's `relocate()` to point users at.

## Test plan
- [x] `plugins/dev-team/tests/hooks/test_mcp_json_repowise.py` — 19 tests covering `detect`/`strip_entry`/`relocate` (tracked/untracked, present/absent entry, malformed JSON, injected register success/failure, preserving sibling entries)
- [x] `plugins/dev-team/tests/hooks/test_mcp_json_repowise_nudge.py` — 5 tests covering the nudge's silent/fire conditions
- [x] `tests/skills/test_project_init_mcp_json_hygiene.py` — 2 new tests pin the new relocate-before-defer behavior; all 11 pre-existing tests still pass unmodified
- [x] `tests/repo/test_skill_bash_grants_cover_invocations.py` — added the new invocation to the tracked `KNOWN_UNCOVERED_INVOCATIONS` list (matching the pre-existing `project-init` entry for `install-java-static-analysis.py` — this skill has no `allowed-tools` Bash-grant restriction at all)
- [x] `python3 -m ruff check` — clean
- [x] Full `plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/bats tests/skills tests/scripts tests/hooks` — 7387 passed, 45 skipped
- [x] `scripts/check_md_references.py` — clean
- [x] `npm run` pre-push gate (`ci-local.sh`) — all local CI checks passed

Closes #1747