### PR TITLE
fix(hooks): isolate destructive_guard test subprocess cwd from real git state

### DIFF
--- a/tests/hooks/test_destructive_guard.py
+++ b/tests/hooks/test_destructive_guard.py
@@ -32,6 +32,14 @@ _CAREFUL_STATE = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "careful-state.
 # (falling back to the process's actual OS cwd when absent) — isolate every
 # subprocess run to a scratch dir so tests never write
 # .claude/metrics/boundary-events.jsonl into the real repo checkout.
+# This scratch dir also becomes the subprocess's real OS cwd (see _run()):
+# destructive_guard.py's branch-escalation probes (#862) shell out to `git`
+# from its own cwd with no override, so leaving it at the test runner's real
+# cwd let _current_branch()/_default_branch() both resolve to "main" on a
+# direct push to main, hard-blocking `git push --force` regardless of
+# careful mode and failing this suite's careful-inactive-is-advisory-only
+# assertion — a failure invisible on feature-branch PR runs, where the
+# checked-out branch never equals the default branch.
 _BOUNDARY_EVENTS_SCRATCH_CWD = tempfile.mkdtemp(prefix="dev-team-destructive-guard-test-")
 
 # _CAREFUL_STATE is the real, fixed path destructive_guard.py itself reads
@@ -62,6 +70,7 @@ def _run(payload: dict) -> subprocess.CompletedProcess:
         [sys.executable, str(_HOOK_PY)],
         input=json.dumps(payload).encode(),
         env=env,
+        cwd=_BOUNDARY_EVENTS_SCRATCH_CWD,
         capture_output=True,
         timeout=10,
         check=False,


### PR DESCRIPTION
## Problem

CI run https://github.com/bdfinst/agentic-dev-team/actions/runs/30843524903 (a direct push to `main`) failed the `Plugin content & hooks` job:

```
FAILED tests/hooks/test_destructive_guard.py::test_destructive_command_warns_without_blocking_when_careful_inactive - AssertionError: assert 2 == 0
```

## Root cause

`tests/hooks/test_destructive_guard.py`'s `_run()` helper invokes `destructive_guard.py` as a subprocess but never pins its working directory — the child process inherits the actual OS cwd of the pytest run (the repo checkout). `destructive_guard.py`'s branch-escalation probes (`_current_branch()` / `_default_branch()`, #862) shell out to `git` from that inherited cwd with no override.

On a PR run, the checked-out branch is a feature branch, so the two probes disagree and no escalation fires. On a direct push to `main`, both resolve to the same name, so the force-push pattern matches the default-branch escalation rule and hard-blocks (exit code 2) regardless of careful-mode state — but the test asserts the careful-inactive path is advisory-only (exit code 0). The failure is invisible on every PR-based CI run and only surfaces on pushes straight to `main`.

## Fix

Pin the subprocess's actual working directory to the same scratch tempdir already created for boundary-event isolation (`_BOUNDARY_EVENTS_SCRATCH_CWD`), so the hook's git probes run against a non-repo directory and resolve to `None`/`None` — no escalation, matching the test's advisory-only assumption regardless of which branch is checked out in the outer CI job.

## Test plan
- [x] `python3 -m pytest tests/hooks/test_destructive_guard.py plugins/dev-team/tests/hooks/test_destructive_guard.py -q` — 71 passed
- [x] Full `scripts/ci-local.sh` mirror passed via `pre-push` hook

Closes #1750
