### PR TITLE
feat(hooks): enforce Python-only shipped scripts in real time

### DIFF
--- a/plugins/dev-team/hooks/hooks.json
+++ b/plugins/dev-team/hooks/hooks.json
@@ -97,6 +97,10 @@
           {
             "type": "command",
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/mutation_testing_smoke_gate.py\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/scan_bash_for_banned_scripts.py\""
           }
         ]
       },
@@ -230,6 +234,15 @@
           {
             "type": "command",
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/phase_marker.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/py.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/scan_banned_scripts.py\""
           }
         ]
       }

--- a/plugins/dev-team/hooks/scan_banned_scripts.py
+++ b/plugins/dev-team/hooks/scan_banned_scripts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""scan_banned_scripts.py — PostToolUse backstop for
+scan_bash_for_banned_scripts.py (#1755).
+
+The PreToolUse scan only intercepts a *Bash command string*; a banned
+`.sh`/`.bash`/`.bat`/`.cmd`/`.ps1` file written any other way (the `Write` or
+`Edit` tool, or a `Bash` command whose target the PreToolUse heuristic
+missed) still lands under plugins/dev-team/. This hook is the deterministic
+backstop: it runs after EVERY tool call (`*` matcher) and inspects the
+actual working tree via `git status --porcelain`, so it catches a banned
+file regardless of which tool created it.
+
+The tool call that wrote the file has already completed by the time this
+hook runs — exit 2 cannot undo that. What it does instead is what
+`docs/python-hook-contract.md`'s block contract is for: it puts the offense
+directly in front of the agent (stdout AND stderr) so the very next thing it
+does is remove or convert the file, rather than the violation surviving
+silently to code review or CI.
+
+Contract (docs/python-hook-contract.md):
+    Input : PostToolUse JSON on stdin (matcher "*" — any tool_name)
+    Output: exit 0 = clean; exit 2 = block (message on stdout AND stderr)
+
+Stdlib-only. See ADR 0014/0015.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from artifact_paths import project_root
+
+BANNED_EXTENSIONS = (".sh", ".bash", ".bat", ".cmd", ".ps1")
+SCOPED_PREFIX = "plugins/dev-team/"
+
+# Mirrors scan_bash_for_banned_scripts.py's carve-out — the two documented
+# bootstrap-shim exceptions (repo CLAUDE.md § Script authoring).
+ALLOWED_RELATIVE_PATHS = {
+    "plugins/dev-team/install.sh",
+    "plugins/dev-team/hooks/py.sh",
+}
+
+_GIT_TIMEOUT_S = 10
+
+
+def _read_stdin() -> str:
+    try:
+        return sys.stdin.read()
+    except Exception:  # noqa: BLE001 - never crash a hook on stdin read
+        return ""
+
+
+def _porcelain_paths(root: Path) -> list[str]:
+    """Every path `git status --porcelain` reports under
+    `plugins/dev-team/`, tracked or untracked. Fails open (returns `[]`) on
+    any git failure — no repo, git missing, timeout — matching every other
+    advisory hook's contract: a scan that can't run must never block."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--", SCOPED_PREFIX.rstrip("/")],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+
+    paths = []
+    for line in result.stdout.splitlines():
+        entry = line[3:] if len(line) > 3 else ""
+        # Rename lines carry "old -> new" — the new path is what's on disk.
+        if "-> " in entry:
+            entry = entry.split("-> ", 1)[1]
+        entry = entry.strip().strip('"')
+        if entry:
+            paths.append(entry)
+    return paths
+
+
+def find_banned_files(root: Path) -> list[str]:
+    hits = set()
+    for rel in _porcelain_paths(root):
+        if not rel.startswith(SCOPED_PREFIX) or rel in ALLOWED_RELATIVE_PATHS:
+            continue
+        if rel.lower().endswith(BANNED_EXTENSIONS):
+            hits.add(rel)
+    return sorted(hits)
+
+
+def main() -> int:
+    raw = _read_stdin()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    root = project_root(Path(payload.get("cwd") or "."))
+
+    hits = find_banned_files(root)
+    if not hits:
+        return 0
+
+    message = (
+        "[BLOCK] Shell script(s) present under plugins/dev-team/ — every "
+        "shipped script there must be Python 3.10+ stdlib-only (ADR "
+        "0014/0015; repo CLAUDE.md § Script authoring): " + ", ".join(hits) + ". "
+        "Remove or convert to .py, or confirm this is genuinely one of the "
+        "two documented bootstrap-shim exceptions "
+        "(plugins/dev-team/install.sh, plugins/dev-team/hooks/py.sh)."
+    )
+    sys.stdout.write(message + "\n")
+    sys.stderr.write(message + "\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/hooks/scan_bash_for_banned_scripts.py
+++ b/plugins/dev-team/hooks/scan_bash_for_banned_scripts.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""scan_bash_for_banned_scripts.py — real-time PreToolUse denial of new
+shell-script writes under plugins/dev-team/ (#1755).
+
+This repo's own CLAUDE.md states the rule ("every shipped
+plugins/dev-team/ script is Python 3.10+ stdlib-only", ADR 0014/0015) and CI
+has a `check-python-only` gate, but neither stops a `.sh`/`.bash`/`.bat`/
+`.cmd`/`.ps1` file from being written *during* a session — the violation was
+only caught later, in code review or CI. This hook closes that gap at the
+point of the `Bash` tool call itself, before the write happens.
+
+Heuristic, not exhaustive: it regex/token-scans the command string for
+redirect (`>`, `>>`), `cp`, `mv`, and `tee` write targets. A sufficiently
+obfuscated command (base64-decoded write, a wrapper script, `eval`) can
+evade it — this hook's own scan says so, deliberately, rather than implying
+a guarantee it can't back. `scan_banned_scripts.py` (PostToolUse, `*`
+matcher) is the required backstop: it inspects the real working tree after
+every tool call, catching anything this scan misses regardless of which
+tool wrote it.
+
+Contract (docs/python-hook-contract.md):
+    Input : PreToolUse JSON on stdin with tool_input.command (Bash matcher)
+    Output: exit 0 = allow; exit 2 = block (message on stdout AND stderr)
+
+Stdlib-only. See ADR 0014/0015.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from artifact_paths import project_root
+
+# The extensions this repo's CLAUDE.md forbids under plugins/dev-team/.
+BANNED_EXTENSIONS = (".sh", ".bash", ".bat", ".cmd", ".ps1")
+
+SCOPED_PREFIX = "plugins/dev-team/"
+
+# The two documented bootstrap-shim exceptions (repo CLAUDE.md § Script
+# authoring — Python only): install.sh can't itself be Python because it
+# must run before an interpreter is guaranteed on PATH, and hooks/py.sh is
+# the trampoline that resolves one. Every other invocation under
+# plugins/dev-team/ routes through py.sh, never a bare interpreter.
+ALLOWED_RELATIVE_PATHS = {
+    "plugins/dev-team/install.sh",
+    "plugins/dev-team/hooks/py.sh",
+}
+
+_REDIRECT_RE = re.compile(r">>?\s*([^\s;|&<>]+)")
+
+
+def _read_stdin() -> str:
+    try:
+        return sys.stdin.read()
+    except Exception:  # noqa: BLE001 - never crash a hook on stdin read
+        return ""
+
+
+def _has_banned_extension(path_str: str) -> bool:
+    return path_str.lower().endswith(BANNED_EXTENSIONS)
+
+
+def _redirect_targets(command: str) -> list[str]:
+    return [
+        match.group(1)
+        for match in _REDIRECT_RE.finditer(command)
+        if _has_banned_extension(match.group(1))
+    ]
+
+
+def _copy_move_tee_targets(command: str) -> list[str]:
+    """Best-effort tokenization to catch `cp`/`mv`/`tee` destinations.
+
+    Splits on shell command separators first so each simple command
+    tokenizes on its own — a single `shlex.split()` over a compound command
+    (`a && b`) would otherwise misattribute tokens across commands.
+    Malformed quoting is skipped, never crashed on: a scan error must fail
+    open, not block a legitimate command it couldn't parse.
+    """
+    targets: list[str] = []
+    for segment in re.split(r"&&|\|\||[;|]", command):
+        segment = segment.strip()
+        if not segment:
+            continue
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            continue
+        if not tokens:
+            continue
+        prog = Path(tokens[0]).name
+        args = [t for t in tokens[1:] if not t.startswith("-")]
+        if prog == "tee":
+            # tee writes to every named file, not just the last.
+            targets.extend(a for a in args if _has_banned_extension(a))
+        elif prog in ("cp", "mv"):
+            # Simple-invocation heuristic: the destination is the last
+            # positional argument. Multi-source `cp a b DEST` still resolves
+            # correctly since DEST is last regardless of source count.
+            candidates = [a for a in args if _has_banned_extension(a)]
+            if candidates:
+                targets.append(candidates[-1])
+    return targets
+
+
+def _scoped_relative_path(target: str, cwd: Path, root: Path) -> str | None:
+    """Resolve `target` (as written in the command) against `cwd`, then
+    return its path relative to `root` in POSIX form — or ``None`` when it
+    resolves outside `root` entirely."""
+    candidate = Path(target)
+    resolved = candidate if candidate.is_absolute() else (cwd / candidate)
+    try:
+        rel = resolved.resolve().relative_to(root.resolve())
+    except ValueError:
+        return None
+    return rel.as_posix()
+
+
+def find_banned_write(command: str, cwd: Path, root: Path) -> str | None:
+    """Return the first plugins/dev-team/-scoped banned-extension write
+    target in `command` (relative to `root`), or ``None``. Skips the two
+    documented bootstrap-shim carve-outs."""
+    for target in [*_redirect_targets(command), *_copy_move_tee_targets(command)]:
+        rel = _scoped_relative_path(target, cwd, root)
+        if rel is None or not rel.startswith(SCOPED_PREFIX):
+            continue
+        if rel in ALLOWED_RELATIVE_PATHS:
+            continue
+        return rel
+    return None
+
+
+def main() -> int:
+    raw = _read_stdin()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    tool_input = payload.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    cwd = Path(payload.get("cwd") or ".")
+    root = project_root(cwd)
+
+    hit = find_banned_write(command, cwd, root)
+    if hit is None:
+        return 0
+
+    message = (
+        f"[BLOCK] {hit} is a shell-script write under plugins/dev-team/. "
+        "Every shipped script there must be Python 3.10+ stdlib-only "
+        "(ADR 0014/0015; repo CLAUDE.md § Script authoring). Write a "
+        ".py module instead, or confirm this is genuinely one of the two "
+        "documented bootstrap-shim exceptions (plugins/dev-team/install.sh, "
+        "plugins/dev-team/hooks/py.sh)."
+    )
+    sys.stdout.write(message + "\n")
+    sys.stderr.write(message + "\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/settings.json
+++ b/plugins/dev-team/settings.json
@@ -113,6 +113,10 @@
           {
             "type": "command",
             "command": "sh hooks/py.sh hooks/mutation_testing_smoke_gate.py"
+          },
+          {
+            "type": "command",
+            "command": "sh hooks/py.sh hooks/scan_bash_for_banned_scripts.py"
           }
         ]
       },
@@ -246,6 +250,15 @@
           {
             "type": "command",
             "command": "sh hooks/py.sh hooks/phase_marker.py"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh hooks/py.sh hooks/scan_banned_scripts.py"
           }
         ]
       }

--- a/plugins/dev-team/tests/hooks/test_scan_banned_scripts.py
+++ b/plugins/dev-team/tests/hooks/test_scan_banned_scripts.py
@@ -1,0 +1,141 @@
+"""Unit tests for hooks/scan_banned_scripts.py (#1755).
+
+PostToolUse working-tree backstop for scan_bash_for_banned_scripts.py — runs
+after EVERY tool call and inspects `git status --porcelain`, so it catches a
+banned-extension file under plugins/dev-team/ regardless of which tool
+created it (the PreToolUse half only scans Bash command strings).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_TESTS_LIB = _REPO_ROOT / "plugins" / "dev-team" / "tests" / "lib"
+if str(_TESTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_TESTS_LIB))
+
+from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "scan_banned_scripts.py"
+
+
+def _run(cwd: Path, env: dict) -> subprocess.CompletedProcess[str]:
+    payload = {"hook_event_name": "PostToolUse", "tool_name": "Write", "cwd": str(cwd)}
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=json.dumps(payload),
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> tuple[Path, dict]:
+    """A hermetic git repo with the plugins/dev-team/ dir already present."""
+    env = hermetic_git_env(home=tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, env=env, check=True)
+    (tmp_path / "plugins" / "dev-team" / "hooks").mkdir(parents=True)
+    (tmp_path / "plugins" / "dev-team" / "hooks" / "keep.py").write_text("pass\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=tmp_path, env=env, check=True)
+    return tmp_path, env
+
+
+def test_passes_clean_repo(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    result = _run(cwd, env)
+    assert result.returncode == 0
+
+
+def test_blocks_untracked_banned_file(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "hooks" / "rogue.sh").write_text("echo hi\n")
+    result = _run(cwd, env)
+    assert result.returncode == 2
+    assert "plugins/dev-team/hooks/rogue.sh" in result.stdout
+    assert "plugins/dev-team/hooks/rogue.sh" in result.stderr
+    assert result.stdout.startswith("[BLOCK]")
+
+
+def test_blocks_staged_banned_file(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "hooks" / "rogue.bat").write_text("echo hi\n")
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/hooks/rogue.bat"], cwd=cwd, env=env, check=True
+    )
+    result = _run(cwd, env)
+    assert result.returncode == 2
+    assert "rogue.bat" in result.stdout
+
+
+def test_ignores_banned_file_outside_plugin_scope(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "scripts").mkdir()
+    (cwd / "scripts" / "dev-setup.sh").write_text("echo hi\n")
+    result = _run(cwd, env)
+    assert result.returncode == 0
+
+
+def test_allows_install_sh_carveout(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "install.sh").write_text("echo hi\n")
+    result = _run(cwd, env)
+    assert result.returncode == 0
+
+
+def test_allows_py_sh_carveout(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "hooks" / "py.sh").write_text("echo hi\n")
+    result = _run(cwd, env)
+    assert result.returncode == 0
+
+
+def test_ignores_untracked_python_file(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "hooks" / "new_module.py").write_text("pass\n")
+    result = _run(cwd, env)
+    assert result.returncode == 0
+
+
+def test_not_a_git_repo_passes_open(tmp_path: Path) -> None:
+    (tmp_path / "plugins" / "dev-team" / "hooks").mkdir(parents=True)
+    (tmp_path / "plugins" / "dev-team" / "hooks" / "rogue.sh").write_text("echo hi\n")
+    result = _run(tmp_path, {**hermetic_git_env(home=tmp_path)})
+    assert result.returncode == 0
+
+
+def test_blocks_renamed_destination(repo: tuple[Path, dict]) -> None:
+    cwd, env = repo
+    (cwd / "plugins" / "dev-team" / "hooks" / "old_name.py").write_text("pass\n")
+    subprocess.run(
+        ["git", "add", "plugins/dev-team/hooks/old_name.py"], cwd=cwd, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add old_name.py"], cwd=cwd, env=env, check=True
+    )
+    subprocess.run(
+        [
+            "git",
+            "mv",
+            "plugins/dev-team/hooks/old_name.py",
+            "plugins/dev-team/hooks/new_name.sh",
+        ],
+        cwd=cwd,
+        env=env,
+        check=True,
+    )
+    result = _run(cwd, env)
+    assert result.returncode == 2
+    assert "plugins/dev-team/hooks/new_name.sh" in result.stdout

--- a/plugins/dev-team/tests/hooks/test_scan_bash_for_banned_scripts.py
+++ b/plugins/dev-team/tests/hooks/test_scan_bash_for_banned_scripts.py
@@ -1,0 +1,151 @@
+"""Unit tests for hooks/scan_bash_for_banned_scripts.py (#1755).
+
+Real-time PreToolUse denial of new shell-script writes under
+plugins/dev-team/ — the point-of-write half of the #1755 hook pair.
+scan_banned_scripts.py (PostToolUse, the working-tree backstop) has its own
+test file.
+
+No git repo needed: `project_root()` falls back to its `start` argument
+when not inside a git repo, and pytest's `tmp_path` is never itself part of
+one, so every scenario here treats `tmp_path` as the resolved root directly.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_HOOK = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "scan_bash_for_banned_scripts.py"
+
+
+def _run(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": str(cwd),
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=json.dumps(payload),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_allows_python_write(tmp_path: Path) -> None:
+    result = _run("echo hi > plugins/dev-team/hooks/foo.py", tmp_path)
+    assert result.returncode == 0
+
+
+def test_blocks_new_shell_script_via_redirect(tmp_path: Path) -> None:
+    result = _run("echo hi > plugins/dev-team/hooks/foo.sh", tmp_path)
+    assert result.returncode == 2
+    assert "plugins/dev-team/hooks/foo.sh" in result.stdout
+    assert "plugins/dev-team/hooks/foo.sh" in result.stderr
+    assert result.stdout.startswith("[BLOCK]")
+
+
+def test_blocks_append_redirect(tmp_path: Path) -> None:
+    result = _run("echo hi >> plugins/dev-team/scripts/run.bash", tmp_path)
+    assert result.returncode == 2
+    assert "run.bash" in result.stdout
+
+
+def test_blocks_cp_destination(tmp_path: Path) -> None:
+    result = _run("cp template.txt plugins/dev-team/scripts/run.sh", tmp_path)
+    assert result.returncode == 2
+    assert "run.sh" in result.stdout
+
+
+def test_cp_multiple_sources_picks_last_arg_as_destination(tmp_path: Path) -> None:
+    result = _run("cp a.py b.py plugins/dev-team/hooks/dest.cmd", tmp_path)
+    assert result.returncode == 2
+    assert "dest.cmd" in result.stdout
+
+
+def test_flags_before_destination_are_ignored(tmp_path: Path) -> None:
+    result = _run("cp -v a.py plugins/dev-team/hooks/dest.ps1", tmp_path)
+    assert result.returncode == 2
+
+
+def test_blocks_tee_destination(tmp_path: Path) -> None:
+    result = _run("echo hi | tee plugins/dev-team/hooks/foo.sh", tmp_path)
+    assert result.returncode == 2
+    assert "foo.sh" in result.stdout
+
+
+def test_blocks_mv_destination(tmp_path: Path) -> None:
+    result = _run("mv /tmp/staged.txt plugins/dev-team/scripts/deploy.bat", tmp_path)
+    assert result.returncode == 2
+
+
+def test_allows_install_sh_carveout(tmp_path: Path) -> None:
+    result = _run("cat > plugins/dev-team/install.sh", tmp_path)
+    assert result.returncode == 0
+
+
+def test_allows_py_sh_carveout(tmp_path: Path) -> None:
+    result = _run("cp bootstrap.tpl plugins/dev-team/hooks/py.sh", tmp_path)
+    assert result.returncode == 0
+
+
+def test_ignores_repo_root_scripts_outside_plugin_scope(tmp_path: Path) -> None:
+    result = _run("echo hi > scripts/dev-setup.sh", tmp_path)
+    assert result.returncode == 0
+
+
+def test_compound_command_still_matches_redirect(tmp_path: Path) -> None:
+    result = _run(
+        "git add -A && echo done > plugins/dev-team/hooks/generated.sh", tmp_path
+    )
+    assert result.returncode == 2
+    assert "generated.sh" in result.stdout
+
+
+def test_missing_command_passes(tmp_path: Path) -> None:
+    payload = {"tool_name": "Bash", "cwd": str(tmp_path), "tool_input": {}}
+    result = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=json.dumps(payload),
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_malformed_json_stdin_passes(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input="not json{{{",
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_malformed_quoting_does_not_crash(tmp_path: Path) -> None:
+    result = _run("echo 'unterminated", tmp_path)
+    assert result.returncode == 0
+
+
+def test_empty_stdin_passes(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input="",
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- `scan_bash_for_banned_scripts.py` (PreToolUse, `Bash` matcher) regex/token-scans the command string for redirect/`cp`/`mv`/`tee` targets ending in `.sh`/`.bash`/`.bat`/`.cmd`/`.ps1` under `plugins/dev-team/` and denies the call.
- `scan_banned_scripts.py` (PostToolUse, `*` matcher) is the required backstop — it inspects the real working tree via `git status --porcelain` after every tool call, catching anything the heuristic scan misses regardless of which tool wrote it.
- Both carve out the two documented bootstrap-shim exceptions (`plugins/dev-team/install.sh`, `plugins/dev-team/hooks/py.sh`).
- Registered in both `settings.json` (older-CLI mirror) and `hooks/hooks.json` (what current Claude Code actually loads) — `tests/hooks/test_plugin_hooks_json.py` pins the two staying in sync.

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_scan_bash_for_banned_scripts.py plugins/dev-team/tests/hooks/test_scan_banned_scripts.py` — 25 new tests
- [x] `python3 -m pytest tests/hooks/test_plugin_hooks_json.py` — settings.json/hooks.json parity still holds
- [x] Full local gate: `bash scripts/ci-local.sh` — all 21 checks green (~7443 pytest across `plugins/dev-team/tests` + repo-level dirs, ruff, Python 3.10 floor, eslint)

Closes #1755
Part of #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)