### PR TITLE
feat(mutation-testing): stable dual-format mutation report with LATEST mirror

### DIFF
--- a/plugins/dev-team/skills/mutation-night-watch/SKILL.md
+++ b/plugins/dev-team/skills/mutation-night-watch/SKILL.md
@@ -100,7 +100,9 @@ they run unattended, indefinitely, until removed.
 Read `reports/mutation-nightwatch/LATEST/MORNING-SUMMARY.md` first — it
 carries per-stack status, the honest score, and any Notes (sleep inhibition,
 mechanical-repair failures) from the most recent run, regardless of that
-run's timestamped folder name. `SURVIVORS.json` alongside it is the
+run's timestamped folder name. Both files are refreshed after every module
+completes, not only when the run finishes cleanly — a mid-run kill or
+timeout still leaves whatever finished so far, never nothing. `SURVIVORS.json` alongside it is the
 machine-readable list (`{stack, module, file, line, mutator, change,
 status}` per survivor) — hand it to the `mutation-kill` agent (or triage it
 per [`mutation-testing/SKILL.md`](../mutation-testing/SKILL.md) Step 4)

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch.py
@@ -24,6 +24,9 @@ Per run:
    ``{stack, module, file, line, mutator, change, status}`` per survivor) to
    a timestamped run directory AND mirror both into a stable ``LATEST/`` dir
    so downstream tooling never needs to know the run's folder name.
+   Refreshed after every module completes (#1756), not only at the very
+   end — a mid-run kill or timeout leaves whatever finished so far, never
+   nothing.
 
 ``--detach`` re-execs the script into a new session/process group so the run
 outlives the launching terminal (same pattern as
@@ -260,9 +263,15 @@ def run_nightwatch(
     notes: list[str] = []
     results: list[stacks_lib.StackResult] = []
 
+    # Refreshed after every module completes (#1756), not only at the very
+    # end — a mid-run kill or timeout must leave whatever finished so far,
+    # not nothing. The pre-loop write covers the empty-targets case (and a
+    # kill during the very first stack's run) with at least the
+    # sleep-inhibitor NOTE, if any.
     with SleepInhibitor() if inhibit_sleep else contextlib.nullcontext() as inhibitor:
         if inhibitor is not None and inhibitor.note:
             notes.append(inhibitor.note)
+        write_reports(run_dir, latest_dir, results, started_at, notes)
         for name in targets:
             if name not in stacks_lib.SUPPORTED_STACKS:
                 results.append(
@@ -274,13 +283,14 @@ def run_nightwatch(
                         "its native report shape yet",
                     )
                 )
+                write_reports(run_dir, latest_dir, results, started_at, notes)
                 continue
             repair_note = stacks_lib.mechanical_repair(name, repo_root, run_dir)
             if repair_note:
                 notes.append(repair_note)
             results.append(stacks_lib.MEASURERS[name](repo_root, run_dir, timeout=timeout))
+            write_reports(run_dir, latest_dir, results, started_at, notes)
 
-    write_reports(run_dir, latest_dir, results, started_at, notes)
     return run_dir
 
 

--- a/tests/scripts/test_mutation_nightwatch.py
+++ b/tests/scripts/test_mutation_nightwatch.py
@@ -543,6 +543,56 @@ def test_run_nightwatch_autodetects_when_stacks_not_given(
     assert survivors_json["survivors"] == []
 
 
+def test_run_nightwatch_refreshes_reports_after_each_stack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-run kill/timeout must preserve whatever finished so far (#1756)
+    — proven here by reading LATEST/ back from inside the SECOND stack's
+    measurer, before it returns, and confirming the FIRST stack's result is
+    already on disk rather than only appearing after the whole run ends."""
+    output_dir = tmp_path / "reports" / "mutation-nightwatch"
+    seen = {}
+
+    def fake_measure_first(repo_root, run_dir, *, timeout=None):
+        return stacks_lib.StackResult("javascript", "stryker", "measured")
+
+    def fake_measure_second(repo_root, run_dir, *, timeout=None):
+        latest_summary = (output_dir / "LATEST" / "MORNING-SUMMARY.md").read_text(
+            encoding="utf-8"
+        )
+        seen["javascript_already_written"] = "javascript" in latest_summary
+        return stacks_lib.StackResult("python", "mutmut", "measured")
+
+    monkeypatch.setitem(stacks_lib.MEASURERS, "javascript", fake_measure_first)
+    monkeypatch.setitem(stacks_lib.MEASURERS, "python", fake_measure_second)
+    monkeypatch.setattr(stacks_lib, "mechanical_repair", lambda *a, **k: None)
+
+    nightwatch.run_nightwatch(
+        tmp_path,
+        output_dir,
+        stacks=["javascript", "python"],
+        inhibit_sleep=False,
+        started_at="2026-08-04T03:00:00Z",
+    )
+
+    assert seen["javascript_already_written"] is True
+
+
+def test_run_nightwatch_writes_reports_even_with_zero_targets(tmp_path: Path) -> None:
+    output_dir = tmp_path / "reports" / "mutation-nightwatch"
+    run_dir = nightwatch.run_nightwatch(
+        tmp_path,
+        output_dir,
+        stacks=[],
+        inhibit_sleep=False,
+        started_at="2026-08-04T03:00:00Z",
+    )
+    assert (run_dir / "MORNING-SUMMARY.md").exists()
+    assert (output_dir / "LATEST" / "MORNING-SUMMARY.md").exists()
+    survivors = json.loads((run_dir / "SURVIVORS.json").read_text(encoding="utf-8"))
+    assert survivors["survivors"] == []
+
+
 # =============================================================================
 # --detach
 # =============================================================================


### PR DESCRIPTION
## Summary
- `mutation_nightwatch.py`'s `run_nightwatch` now calls `write_reports()` after every stack module completes (and once before the loop starts), not only once at the very end.
- A mid-run kill or timeout now preserves whatever finished so far in both the timestamped run dir and the `LATEST/` mirror, instead of leaving nothing on disk until a clean finish.
- Updated the module docstring and the companion `mutation-night-watch` skill's Step 4 to state the refresh guarantee explicitly.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_mutation_nightwatch.py` — 43 tests (2 new: proves the first stack's result is already on disk before the second stack's measurer runs; proves a report is written even with zero targets)
- [x] Full local gate: `bash scripts/ci-local.sh` — all 21 checks green (~7443 pytest, ruff, Python 3.10 floor, eslint)

Closes #1756
Part of #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)