### PR TITLE
feat(mutation-testing): committed, human-approved mutation exclude-policy bootstrap

### DIFF
--- a/plugins/dev-team/skills/mutation-night-watch/SKILL.md
+++ b/plugins/dev-team/skills/mutation-night-watch/SKILL.md
@@ -113,6 +113,20 @@ all this run (tool missing, timed out, or crashed before writing its native
 report) — its prior night's `SURVIVORS.json` entries (if any) are stale, not
 confirmed-fixed; re-run that stack before trusting a "clean" reading.
 
+**Exclude-policy proposal, if present.** When the summary's Notes mention no
+committed `mutation-exclude-policy.json` was found, review
+`reports/mutation-nightwatch/LATEST/EXCLUDE-POLICY-PROPOSAL.json` — its
+`always` entries carry a filename-convention hint (DI wiring, middleware,
+generated code), its `propose_and_ask` entries are signal-only and need a
+human look. Approve what you agree with:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/mutation-testing/scripts/mutation_exclude_policy.py" --approve reports/mutation-nightwatch/LATEST/EXCLUDE-POLICY-PROPOSAL.json --repo-root .
+```
+
+This is the only code path that writes the committed policy file — the
+night-watch run itself only ever drafts a proposal, never approves one.
+
 ## When not to apply
 
 - No mutation tool is set up yet for any stack → run

--- a/plugins/dev-team/skills/mutation-testing/SKILL.md
+++ b/plugins/dev-team/skills/mutation-testing/SKILL.md
@@ -17,6 +17,8 @@ This file describes the language-agnostic workflow and the data contract. **Per-
 
 **Unattended, LLM-free overnight measurement.** [`scripts/mutation_nightwatch.py`](scripts/mutation_nightwatch.py) (detection/repair/measurement mechanics split into [`scripts/mutation_nightwatch_stacks.py`](scripts/mutation_nightwatch_stacks.py)) is a third, report-only mode alongside `mutation-kill`'s interactive and `--headless` fixing modes — no generation, no LLM, no commits, so it can run overnight unattended. See the companion [`mutation-night-watch`](../mutation-night-watch/SKILL.md) skill for launch/detach/schedule guidance.
 
+**Committed, human-approved exclude-policy bootstrap.** When no `mutation-exclude-policy.json` exists at the repo root yet, a night-watch run drafts one via [`scripts/mutation_exclude_policy.py`](scripts/mutation_exclude_policy.py) — the same two-signal judgment (score < 15%, NoCoverage > 50%, filename hint promotes to a stronger tier) `mutation-kill`'s own [Infrastructure exclusion detection](../../agents/mutation-kill.md#infrastructure-exclusion-detection-before-the-loop-starts) applies, but persisted as a source-controlled file instead of a build-output-only convergence log. The night-watch run only ever drafts a proposal alongside its other reports; `mutation_exclude_policy.py --approve` is the only code path that writes the committed file, and it is never called unattended.
+
 ## Constraints
 
 - **Always ask the user before running.** Present the time estimate and scope; get explicit approval. Mutation testing can be slow — never surprise the user.

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_exclude_policy.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_exclude_policy.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""mutation_exclude_policy.py — committed, human-approved mutation
+exclude-policy bootstrap (#1757).
+
+`mutation-kill`'s "Infrastructure exclusion detection"
+(agents/mutation-kill.md) already flags likely-infrastructure files at run
+time — DI wiring, exception handlers, middleware, generated code — but its
+decision persists only to a typically-gitignored build-output path
+(`StrykerOutput/mutation-kill-convergence.json`), so it's lost across a
+fresh clone or a new CI runner. This module drafts the SAME two-signal
+judgment as a standalone, committed, source-controlled policy file instead —
+durable across machines.
+
+**Never writes the committed policy file without human approval.** This is
+the one hard constraint the whole module exists to satisfy: an unattended
+night-watch run can *draft* a proposal (``draft_policy`` + a plain
+``write_json`` to any path the caller chooses), but the ONLY code path that
+writes ``mutation-exclude-policy.json`` at the repo root is :func:`approve`,
+invoked deliberately via ``--approve`` — never called from
+``mutation_nightwatch.py``'s unattended loop.
+
+Two-signal rule, ported verbatim from `mutation-kill`'s own "Infrastructure
+exclusion detection" section — BOTH must hold before a file is even
+considered; neither alone is sufficient:
+
+- ``honest score < 15%``
+- ``NoCoverage > 50%`` of effective mutants (killed + survived + no_coverage)
+
+A filename match against a known DI/wiring/generated-code naming convention
+is a **hint that strengthens the tier**, never a requirement: it promotes a
+flagged file from ``propose_and_ask`` to ``always``, but its absence never
+blocks the numeric signals from flagging a file in the first place — mirrors
+`mutation-kill.md`'s "named convention vs. signal-only" framing exactly.
+
+Stdlib-only. See ADR 0014.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from pathlib import Path
+
+import mutation_report
+
+POLICY_FILENAME = "mutation-exclude-policy.json"
+
+# Ported verbatim from agents/mutation-kill.md's "Infrastructure exclusion
+# detection" section — the single source of truth for these two numbers.
+SCORE_THRESHOLD_PCT = 15.0
+NO_COVERAGE_THRESHOLD_PCT = 50.0
+
+# Filename hints per stack. The C# list is copied verbatim from
+# mutation-kill.md; the javascript list is a parallel, analogous set for a
+# second stack mutation_report.py can already score — see SUPPORTED_STACKS
+# in mutation_nightwatch_stacks.py.
+FILENAME_HINTS: dict[str, list[str]] = {
+    "csharp": [
+        "Startup.cs",
+        "Program.cs",
+        "*Filter.cs",
+        "*Middleware.cs",
+        "*Logger*.cs",
+        "*HealthCheck*.cs",
+        "*.Designer.cs",
+        "*Module.cs",
+        "*Container.cs",
+        "*Registration.cs",
+        "*Bootstrap*.cs",
+        "*DependencyInjection*.cs",
+    ],
+    "javascript": [
+        "main.ts",
+        "main.js",
+        "*.module.ts",
+        "*.config.js",
+        "*.config.ts",
+        "*Middleware.ts",
+        "*Logger*.ts",
+        "*Container.ts",
+    ],
+}
+
+
+def _matching_hint(filename: str, stack: str) -> str | None:
+    """Return the first filename-hint pattern that matches, or ``None``."""
+    for pattern in FILENAME_HINTS.get(stack, ()):
+        if fnmatch.fnmatch(filename, pattern):
+            return pattern
+    return None
+
+
+def draft_entries(report_path: Path, stack: str) -> list[dict]:
+    """Apply the two-signal rule to every file in `report_path`'s native
+    report, returning one ``{file, stack, tier, reason}`` entry per flagged
+    file. A file with zero effective mutants (killed+survived+no_coverage)
+    yields no scoring signal and is never flagged."""
+    data = mutation_report.load_report(report_path)
+    entries = []
+    for file_key in sorted(data.get("files", {})):
+        summary = mutation_report.score_report_for_file(report_path, file_key)
+        effective = summary.killed + summary.survived + summary.no_coverage
+        if effective == 0:
+            continue
+        no_coverage_pct = (summary.no_coverage / effective) * 100
+        # Both signals must hold — failing either alone must never flag.
+        if summary.honest_score >= SCORE_THRESHOLD_PCT:
+            continue
+        if no_coverage_pct <= NO_COVERAGE_THRESHOLD_PCT:
+            continue
+
+        hint = _matching_hint(Path(file_key).name, stack)
+        if hint:
+            tier = "always"
+            reason = (
+                f"named convention: {hint} (score {summary.honest_score:.1f}%, "
+                f"NoCoverage {no_coverage_pct:.1f}%)"
+            )
+        else:
+            tier = "propose_and_ask"
+            reason = (
+                f"signal-only: score {summary.honest_score:.1f}%, NoCoverage "
+                f"{no_coverage_pct:.1f}% (no filename match)"
+            )
+        entries.append({"file": file_key, "stack": stack, "tier": tier, "reason": reason})
+    return entries
+
+
+def draft_policy(report_paths: dict[str, Path]) -> dict:
+    """Draft a two-tier exclude policy from one native report per stack.
+
+    ``report_paths`` maps stack name -> native report path. A stack with no
+    on-disk native report path (mutmut/python — see
+    ``mutation_nightwatch_stacks.StackResult.report_path``'s docstring) is
+    simply absent from the mapping; it is never guessed at.
+    """
+    always: list[dict] = []
+    propose_and_ask: list[dict] = []
+    for stack, report_path in sorted(report_paths.items()):
+        for entry in draft_entries(report_path, stack):
+            (always if entry["tier"] == "always" else propose_and_ask).append(entry)
+    return {"schema_version": 1, "always": always, "propose_and_ask": propose_and_ask}
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def approve(draft_path: Path, repo_root: Path) -> Path:
+    """Write the approved draft as the committed policy file at
+    `repo_root`. The ONLY code path that writes `POLICY_FILENAME` at the
+    repo root — see the module docstring's approval-gate constraint."""
+    draft = json.loads(draft_path.read_text(encoding="utf-8"))
+    policy_path = repo_root / POLICY_FILENAME
+    write_json(policy_path, draft)
+    return policy_path
+
+
+def parse_args(argv) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="mutation_exclude_policy.py",
+        description=(
+            "Draft (never auto-write) a two-tier mutation exclude policy from "
+            "native mutation reports; write the committed policy file only "
+            "on --approve."
+        ),
+    )
+    p.add_argument(
+        "--report",
+        action="append",
+        default=[],
+        metavar="STACK=PATH",
+        help="One native report path per stack, e.g. "
+        "javascript=reports/mutation/mutation.json. Repeatable.",
+    )
+    p.add_argument("--draft", action="store_true", help="Draft mode.")
+    p.add_argument("--out", help="Where to write the draft (--draft mode).")
+    p.add_argument(
+        "--approve", metavar="DRAFT_PATH", help="Approve a draft, writing the committed policy file."
+    )
+    p.add_argument(
+        "--repo-root", default=".", help="Repo root (--approve mode; default: cwd)"
+    )
+    return p.parse_args(list(argv))
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = parse_args(argv)
+
+    if args.approve:
+        policy_path = approve(Path(args.approve), Path(args.repo_root).resolve())
+        print(f"approved: wrote {policy_path}")
+        return 0
+
+    if args.draft:
+        if not args.out:
+            sys.stderr.write("error: --draft requires --out\n")
+            return 2
+        report_paths = {}
+        for item in args.report:
+            if "=" not in item:
+                sys.stderr.write(f"error: --report must be STACK=PATH, got {item!r}\n")
+                return 2
+            stack, _, path_str = item.partition("=")
+            report_paths[stack] = Path(path_str)
+        policy = draft_policy(report_paths)
+        write_json(Path(args.out), policy)
+        print(f"drafted: wrote {args.out}")
+        return 0
+
+    sys.stderr.write("error: pass --draft or --approve\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch.py
@@ -60,6 +60,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import mutation_exclude_policy
 import mutation_nightwatch_stacks as stacks_lib
 from mutation_kill_shared import _timeout_from_env
 
@@ -291,7 +292,45 @@ def run_nightwatch(
             results.append(stacks_lib.MEASURERS[name](repo_root, run_dir, timeout=timeout))
             write_reports(run_dir, latest_dir, results, started_at, notes)
 
+        _draft_exclude_policy_if_missing(repo_root, run_dir, latest_dir, results, notes)
+        write_reports(run_dir, latest_dir, results, started_at, notes)
+
     return run_dir
+
+
+def _draft_exclude_policy_if_missing(
+    repo_root: Path,
+    run_dir: Path,
+    latest_dir: Path,
+    results: list[stacks_lib.StackResult],
+    notes: list[str],
+) -> None:
+    """Draft a mutation-exclude-policy.json proposal when no committed
+    policy file exists yet (#1757) — never writes the committed file
+    itself. Only ``mutation_exclude_policy.py --approve``, run deliberately
+    by a human, writes ``mutation-exclude-policy.json`` at the repo root;
+    this unattended path only ever produces a proposal alongside the run's
+    other reports.
+    """
+    if (repo_root / mutation_exclude_policy.POLICY_FILENAME).exists():
+        return
+    report_paths = {r.stack: r.report_path for r in results if r.report_path is not None}
+    if not report_paths:
+        return
+    policy = mutation_exclude_policy.draft_policy(report_paths)
+    if not policy["always"] and not policy["propose_and_ask"]:
+        return
+
+    draft_name = "EXCLUDE-POLICY-PROPOSAL.json"
+    draft_path = run_dir / draft_name
+    mutation_exclude_policy.write_json(draft_path, policy)
+    mutation_exclude_policy.write_json(latest_dir / draft_name, policy)
+    notes.append(
+        f"NOTE: no committed {mutation_exclude_policy.POLICY_FILENAME} found — drafted a "
+        f"proposal ({len(policy['always'])} always-exclude, "
+        f"{len(policy['propose_and_ask'])} propose-and-ask) at {draft_path}. Review and "
+        f"approve with `mutation_exclude_policy.py --approve <path> --repo-root {repo_root}`."
+    )
 
 
 # =============================================================================

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch_stacks.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_nightwatch_stacks.py
@@ -203,6 +203,14 @@ class StackResult:
     summary: mutation_report.ScoreSummary | None = None
     survivors: list[dict] = field(default_factory=list)
     duration_seconds: float = 0.0
+    # The native report path on disk, when the tool produces one at a fixed
+    # convention path (Stryker-shaped JSON: javascript, csharp). ``None``
+    # for mutmut (python) — junitxml is captured in-memory, not written to
+    # a fixed path — and for any non-"measured" status. Consumed by
+    # mutation_exclude_policy.py's per-file drafting (#1757), which needs
+    # the native report to compute a per-file score, not just the
+    # already-flattened `survivors` list.
+    report_path: Path | None = None
 
 
 def _flat_survivors(report_path: Path, stack: str) -> list[dict]:
@@ -279,6 +287,7 @@ def measure_javascript(
         summary=mutation_report.score_report(report_path),
         survivors=_flat_survivors(report_path, "javascript"),
         duration_seconds=duration,
+        report_path=report_path,
     )
 
 
@@ -380,6 +389,7 @@ def measure_csharp(
         summary=mutation_report.score_report(report_path),
         survivors=_flat_survivors(report_path, "csharp"),
         duration_seconds=duration,
+        report_path=report_path,
     )
 
 

--- a/tests/scripts/test_mutation_exclude_policy.py
+++ b/tests/scripts/test_mutation_exclude_policy.py
@@ -1,0 +1,239 @@
+"""Pytest tests for mutation_exclude_policy.py — the committed,
+human-approved mutation exclude-policy bootstrap (#1757).
+
+The two-signal rule (score < 15%, NoCoverage > 50%) is ported verbatim from
+agents/mutation-kill.md's "Infrastructure exclusion detection" section;
+these tests pin the same numbers this module's docstring cites.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from _mutation_test_helpers import SCRIPTS_DIR
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mutation_exclude_policy as policy
+
+
+def _write_report(path: Path, files: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"files": files}), encoding="utf-8")
+    return path
+
+
+def _mutants(killed=0, survived=0, no_coverage=0, timeout=0) -> list[dict]:
+    out = []
+    for _ in range(killed):
+        out.append({"status": "Killed", "mutatorName": "X"})
+    for _ in range(survived):
+        out.append({"status": "Survived", "mutatorName": "X"})
+    for _ in range(no_coverage):
+        out.append({"status": "NoCoverage", "mutatorName": "X"})
+    for _ in range(timeout):
+        out.append({"status": "Timeout", "mutatorName": "X"})
+    return out
+
+
+# =============================================================================
+# Two-signal rule
+# =============================================================================
+
+
+def test_flags_when_both_signals_hold(tmp_path: Path) -> None:
+    # score = 1/10 = 10% (< 15%); NoCoverage = 9/10 = 90% (> 50%)
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Startup.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    entries = policy.draft_entries(report, "csharp")
+    assert len(entries) == 1
+    assert entries[0]["file"] == "src/Startup.cs"
+
+
+def test_does_not_flag_when_only_score_signal_holds(tmp_path: Path) -> None:
+    # score = 1/10 = 10% (< 15%) but NoCoverage = 0% (not > 50%)
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Real.cs": {"mutants": _mutants(killed=1, survived=9)}},
+    )
+    assert policy.draft_entries(report, "csharp") == []
+
+
+def test_does_not_flag_when_only_no_coverage_signal_holds(tmp_path: Path) -> None:
+    # score = 5/10 = 50% (not < 15%) even though NoCoverage = 50%... use a
+    # combination where NoCoverage > 50% but score is still high.
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Real.cs": {"mutants": _mutants(killed=9, no_coverage=9)}},
+    )
+    # score = 9/18 = 50% -> not < 15%, so must not flag despite NoCoverage 50%.
+    assert policy.draft_entries(report, "csharp") == []
+
+
+def test_zero_effective_mutants_never_flagged(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Ignored.cs": {"mutants": _mutants(timeout=5)}},
+    )
+    assert policy.draft_entries(report, "csharp") == []
+
+
+# =============================================================================
+# Filename hint tiering
+# =============================================================================
+
+
+def test_filename_hint_promotes_to_always_tier(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Startup.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    entries = policy.draft_entries(report, "csharp")
+    assert entries[0]["tier"] == "always"
+    assert "named convention" in entries[0]["reason"]
+
+
+def test_no_filename_hint_stays_propose_and_ask(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/OrderProcessor.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    entries = policy.draft_entries(report, "csharp")
+    assert entries[0]["tier"] == "propose_and_ask"
+    assert "signal-only" in entries[0]["reason"]
+
+
+def test_javascript_hint_list_applies_too(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/app.module.ts": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    entries = policy.draft_entries(report, "javascript")
+    assert entries[0]["tier"] == "always"
+
+
+def test_unknown_stack_has_no_hints_stays_propose_and_ask(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Startup.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    entries = policy.draft_entries(report, "java")
+    assert entries[0]["tier"] == "propose_and_ask"
+
+
+# =============================================================================
+# draft_policy aggregation
+# =============================================================================
+
+
+def test_draft_policy_aggregates_across_stacks(tmp_path: Path) -> None:
+    js_report = _write_report(
+        tmp_path / "js.json",
+        {"src/main.ts": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    cs_report = _write_report(
+        tmp_path / "cs.json",
+        {"src/OrderProcessor.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    result = policy.draft_policy({"javascript": js_report, "csharp": cs_report})
+    assert result["schema_version"] == 1
+    assert len(result["always"]) == 1
+    assert result["always"][0]["file"] == "src/main.ts"
+    assert len(result["propose_and_ask"]) == 1
+    assert result["propose_and_ask"][0]["file"] == "src/OrderProcessor.cs"
+
+
+def test_draft_policy_empty_when_nothing_flagged(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Real.cs": {"mutants": _mutants(killed=9, survived=1)}},
+    )
+    result = policy.draft_policy({"csharp": report})
+    assert result == {"schema_version": 1, "always": [], "propose_and_ask": []}
+
+
+# =============================================================================
+# write_json / approve — the human-approval gate
+# =============================================================================
+
+
+def test_write_json_creates_parent_dirs(tmp_path: Path) -> None:
+    out = tmp_path / "nested" / "dir" / "draft.json"
+    policy.write_json(out, {"a": 1})
+    assert json.loads(out.read_text(encoding="utf-8")) == {"a": 1}
+
+
+def test_approve_writes_committed_policy_at_repo_root(tmp_path: Path) -> None:
+    draft_path = tmp_path / "draft.json"
+    draft = {"schema_version": 1, "always": [{"file": "a"}], "propose_and_ask": []}
+    policy.write_json(draft_path, draft)
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    written = policy.approve(draft_path, repo_root)
+
+    assert written == repo_root / policy.POLICY_FILENAME
+    assert json.loads(written.read_text(encoding="utf-8")) == draft
+
+
+def test_draft_policy_never_writes_to_a_repo_root(tmp_path: Path) -> None:
+    """draft_policy/draft_entries must never touch the filesystem at all —
+    the human-approval gate depends on drafting being a pure, read-only
+    computation. approve() is the only writer of the committed file."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Startup.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    policy.draft_policy({"csharp": report})
+    assert not (repo_root / policy.POLICY_FILENAME).exists()
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+
+def test_main_draft_requires_out(capsys) -> None:
+    rc = policy.main(["--draft"])
+    assert rc == 2
+    assert "requires --out" in capsys.readouterr().err
+
+
+def test_main_draft_writes_output(tmp_path: Path, capsys) -> None:
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {"src/Startup.cs": {"mutants": _mutants(killed=1, no_coverage=9)}},
+    )
+    out = tmp_path / "out.json"
+    rc = policy.main(["--draft", "--report", f"csharp={report}", "--out", str(out)])
+    assert rc == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert len(written["always"]) == 1
+
+
+def test_main_draft_rejects_malformed_report_arg(tmp_path: Path, capsys) -> None:
+    rc = policy.main(["--draft", "--report", "not-a-kv-pair", "--out", str(tmp_path / "o.json")])
+    assert rc == 2
+    assert "STACK=PATH" in capsys.readouterr().err
+
+
+def test_main_approve_writes_policy(tmp_path: Path, capsys) -> None:
+    draft_path = tmp_path / "draft.json"
+    policy.write_json(draft_path, {"schema_version": 1, "always": [], "propose_and_ask": []})
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    rc = policy.main(["--approve", str(draft_path), "--repo-root", str(repo_root)])
+    assert rc == 0
+    assert (repo_root / policy.POLICY_FILENAME).exists()
+
+
+def test_main_with_no_mode_errors(capsys) -> None:
+    rc = policy.main([])
+    assert rc == 2
+    assert "--draft or --approve" in capsys.readouterr().err

--- a/tests/scripts/test_mutation_nightwatch.py
+++ b/tests/scripts/test_mutation_nightwatch.py
@@ -594,6 +594,131 @@ def test_run_nightwatch_writes_reports_even_with_zero_targets(tmp_path: Path) ->
 
 
 # =============================================================================
+# Exclude-policy drafting (#1757) — never writes the committed file itself
+# =============================================================================
+
+
+def _write_flaggable_report(path: Path) -> None:
+    """A report with one file matching both the score<15%/NoCoverage>50%
+    signals AND a known csharp filename hint (Startup.cs) — always tier."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "src/Startup.cs": {
+                        "mutants": [{"status": "Killed"}]
+                        + [{"status": "NoCoverage"}] * 9
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_run_nightwatch_drafts_exclude_policy_proposal_when_none_committed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report_path = tmp_path / "reports" / "mutation" / "mutation.json"
+    _write_flaggable_report(report_path)
+
+    def fake_measure(repo_root, run_dir, *, timeout=None):
+        return stacks_lib.StackResult(
+            "javascript", "stryker", "measured", report_path=report_path
+        )
+
+    monkeypatch.setitem(stacks_lib.MEASURERS, "javascript", fake_measure)
+    monkeypatch.setattr(stacks_lib, "mechanical_repair", lambda *a, **k: None)
+
+    output_dir = tmp_path / "reports" / "mutation-nightwatch"
+    run_dir = nightwatch.run_nightwatch(
+        tmp_path,
+        output_dir,
+        stacks=["javascript"],
+        inhibit_sleep=False,
+        started_at="2026-08-04T03:00:00Z",
+    )
+
+    draft_run = run_dir / "EXCLUDE-POLICY-PROPOSAL.json"
+    draft_latest = output_dir / "LATEST" / "EXCLUDE-POLICY-PROPOSAL.json"
+    assert draft_run.exists()
+    assert draft_latest.exists()
+    drafted = json.loads(draft_run.read_text(encoding="utf-8"))
+    # Startup.cs has no javascript filename hint (the stack here is
+    # javascript, not csharp) — the two numeric signals still flag it, just
+    # into the weaker propose_and_ask tier. Tier promotion itself is
+    # covered by test_mutation_exclude_policy.py's unit tests.
+    assert len(drafted["propose_and_ask"]) == 1
+    assert drafted["propose_and_ask"][0]["file"] == "src/Startup.cs"
+
+    summary = (run_dir / "MORNING-SUMMARY.md").read_text(encoding="utf-8")
+    assert "drafted a" in summary
+    assert "mutation-exclude-policy.json" in summary
+
+    # The approval-gated committed file must NEVER be written by the
+    # unattended run itself.
+    assert not (tmp_path / "mutation-exclude-policy.json").exists()
+
+
+def test_run_nightwatch_skips_drafting_when_policy_already_committed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "mutation-exclude-policy.json").write_text("{}", encoding="utf-8")
+    report_path = tmp_path / "reports" / "mutation" / "mutation.json"
+    _write_flaggable_report(report_path)
+
+    def fake_measure(repo_root, run_dir, *, timeout=None):
+        return stacks_lib.StackResult(
+            "javascript", "stryker", "measured", report_path=report_path
+        )
+
+    monkeypatch.setitem(stacks_lib.MEASURERS, "javascript", fake_measure)
+    monkeypatch.setattr(stacks_lib, "mechanical_repair", lambda *a, **k: None)
+
+    output_dir = tmp_path / "reports" / "mutation-nightwatch"
+    run_dir = nightwatch.run_nightwatch(
+        tmp_path,
+        output_dir,
+        stacks=["javascript"],
+        inhibit_sleep=False,
+        started_at="2026-08-04T03:00:00Z",
+    )
+
+    assert not (run_dir / "EXCLUDE-POLICY-PROPOSAL.json").exists()
+
+
+def test_run_nightwatch_drafts_nothing_when_no_files_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report_path = tmp_path / "reports" / "mutation" / "mutation.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(
+        json.dumps({"files": {"src/Real.ts": {"mutants": [{"status": "Killed"}] * 10}}}),
+        encoding="utf-8",
+    )
+
+    def fake_measure(repo_root, run_dir, *, timeout=None):
+        return stacks_lib.StackResult(
+            "javascript", "stryker", "measured", report_path=report_path
+        )
+
+    monkeypatch.setitem(stacks_lib.MEASURERS, "javascript", fake_measure)
+    monkeypatch.setattr(stacks_lib, "mechanical_repair", lambda *a, **k: None)
+
+    output_dir = tmp_path / "reports" / "mutation-nightwatch"
+    run_dir = nightwatch.run_nightwatch(
+        tmp_path,
+        output_dir,
+        stacks=["javascript"],
+        inhibit_sleep=False,
+        started_at="2026-08-04T03:00:00Z",
+    )
+
+    assert not (run_dir / "EXCLUDE-POLICY-PROPOSAL.json").exists()
+
+
+# =============================================================================
 # --detach
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `mutation_exclude_policy.py`: drafts a two-tier (`always` / `propose_and_ask`) mutation exclude policy using the same two-signal judgment `mutation-kill`'s own "Infrastructure exclusion detection" applies — honest score < 15% AND NoCoverage > 50% (neither alone is sufficient); a filename-convention hint (ported from `agents/mutation-kill.md`'s C# list, plus an analogous JS list) promotes a flagged file to the stronger `always` tier.
- Wires into `mutation_nightwatch.py`'s `run_nightwatch`: when no `mutation-exclude-policy.json` is committed at the repo root yet, the run drafts a proposal (`EXCLUDE-POLICY-PROPOSAL.json`) alongside its other reports and surfaces a NOTE in the summary — never writes the committed file itself.
- `mutation_exclude_policy.py --approve <draft> --repo-root .` is the *only* code path that writes the committed policy file — a human runs it deliberately; the unattended night-watch path can never reach it.
- Adds a `report_path` field to `StackResult` (javascript/csharp only — mutmut has no on-disk native report) so the drafter can compute a per-file score without re-deriving report-path conventions.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_mutation_exclude_policy.py tests/scripts/test_mutation_nightwatch.py` — 80 tests (18 new for the policy module, 3 new for the `run_nightwatch` wiring, including a test that the committed file is never written by the unattended path)
- [x] Full local gate: `bash scripts/ci-local.sh` — all 21 checks green (~7439 pytest, ruff, Python 3.10 floor, eslint)

**Depends on #1756** (this branch was cut before #1756 merged, so it will need a rebase once #1756 lands — both touch `run_nightwatch`'s loop-end area).

Closes #1757
Part of #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)