### PR TITLE
fix(skills): enforce Conventional Commit titles in every issue-creating skill

### DIFF
--- a/.github/workflows/issue-title-lint.yml
+++ b/.github/workflows/issue-title-lint.yml
@@ -6,7 +6,7 @@ name: Issue title lint
 # commits (commitlint.config.js). GitHub has no "required check" for issues, so
 # this is a visible backstop: it labels a non-conforming title and comments the
 # fix once, then clears the label when the title is corrected. The primary,
-# proactive enforcement is in the issue-creating skills (issues-from-plan,
+# proactive enforcement is in the issue-creating skills (specs, issues-from-plan,
 # issues-from-assessment), which lint titles before `gh issue create`.
 
 on:

--- a/plugins/dev-team/skills/issues-from-assessment/SKILL.md
+++ b/plugins/dev-team/skills/issues-from-assessment/SKILL.md
@@ -102,11 +102,11 @@ Contents: the assessment summary (components table, target pre-merge gate, link 
 
 Two modes share the same control flow; only the create-call differs. Every tracker label carries `<workflow>` as its leading token so an operator scanning a mixed board can tell which workflow authored an issue.
 
-**Tracker mode.** For each child in dependency order, call the resolved CLI. Lift the GitHub pattern verbatim from `/issues-from-plan`:
+**Tracker mode.** For each child in dependency order, call the resolved CLI. Lift the GitHub pattern verbatim from `/issues-from-plan`, **including its Conventional Commit title rule** — GitHub is the only tracker here bound to `commitlint.config.js`/`issue-title-lint.yml`; ADO/GitLab/Jira titles keep the plain `[<phase-tag>] <component>` form from step 2 unchanged. For GitHub, prefix that same phase-tag title with a type — `test:` fits every phase here (audit/baseline/refactor-for-testability/de-duplicate/re-scope are all test-suite work): `test: [Baseline] <component>`. Verify with `printf '%s' "<title>" | npx commitlint --verbose` before creating.
 
 ```bash
 # GitHub — github.com
-gh issue create --title "<title>" --body "$(cat <<'EOF'
+gh issue create --title "test: [<phase-tag>] <title>" --body "$(cat <<'EOF'
 ## What to Build
 
 <one-paragraph behavior description>

--- a/plugins/dev-team/skills/issues-from-plan/SKILL.md
+++ b/plugins/dev-team/skills/issues-from-plan/SKILL.md
@@ -51,7 +51,15 @@ Then locate the plan's **spec** (the linked spec artifact or `docs/specs/<...>.m
 
 For each unit of work, draft an issue with:
 
-- **Title**: Short, action-oriented (e.g., "Add user authentication endpoint")
+- **Title**: a Conventional Commit — `<type>: <short, action-oriented summary>`
+  (e.g., `feat: add user authentication endpoint`), matching
+  `commitlint.config.js`'s ruleset. These titles seed branch names, PR
+  titles, and release versions once the sub-issue's PR merges, and
+  `.github/workflows/issue-title-lint.yml` labels
+  `needs-conventional-title` on anything that doesn't conform — check
+  proactively instead of relying on that backstop:
+  `printf '%s' "<title>" | npx commitlint --verbose`. If it exits non-zero,
+  fix the title before creating the issue.
 - **Body**:
   - What to build (behavior description, not implementation details)
   - Acceptance criteria as checkboxes

--- a/plugins/dev-team/skills/specs/SKILL.md
+++ b/plugins/dev-team/skills/specs/SKILL.md
@@ -208,14 +208,28 @@ All gap and ambiguity findings from the Ambiguity Resolution Protocol, with thei
 
 #### Persist to GitHub issue
 
-1. **Slugify** the feature name (same rule as above) — used to derive the issue title and search query, not a file path.
-2. **Search** for an existing open issue: `gh issue list --search "Spec: <Feature Name> in:title" --state open`. If this call itself exits non-zero, treat it as a hard failure — **never** as "zero matches" (that would risk silently creating a duplicate issue) — report the failure and its cause to chat, and fall back to **Persist to file** above with the already-composed content so the approved spec is never lost.
+**Issue titles are Conventional Commits, not `Spec: <Feature Name>`.** These
+issues become epics — their titles seed branch names, PR titles, and (once
+their sub-issues land) release versions, so they must pass the same
+commitlint ruleset as a commit message (`.github/workflows/issue-title-lint.yml`
+enforces this after the fact by labeling `needs-conventional-title`; do not
+rely on that backstop — lint proactively, before `gh issue create`, so the
+label is never needed). Compose the title as `<type>(spec): <Feature Name>`
+— `type` is almost always `feat` (a spec describing new behavior) or `docs`
+(a spec that is itself the only deliverable, no code follows); pick
+whichever matches the work the spec actually describes, never default
+blindly to one. Example: `feat(spec): User Login with MFA`. Verify with
+`printf '%s' "<composed title>" | npx commitlint --verbose` before creating
+or renaming — if it exits non-zero, fix the title, don't create anyway.
+
+1. **Slugify** the feature name (same rule as above) — used to derive the search query, not a file path or the title itself.
+2. **Search** for an existing open issue: `gh issue list --search "<Feature Name> in:title" --state open`. If this call itself exits non-zero, treat it as a hard failure — **never** as "zero matches" (that would risk silently creating a duplicate issue) — report the failure and its cause to chat, and fall back to **Persist to file** above with the already-composed content so the approved spec is never lost.
 3. **Branch on the match count**:
    - **Zero matches** → proceed straight to create (step 4).
    - **Exactly one match** → interactive: ask "Found existing issue #N for this spec — update it in place, or create a new one?"; non-interactive (no usable TTY): default to **updating** that single match in place (never create a duplicate) and log the auto-choice.
    - **Two or more matches** → interactive: surface every matching issue and ask which to update, or whether to create a new one instead — never silently pick one; non-interactive: default to **creating** a new issue and explicitly log the ambiguity (which candidate issues it did not act on).
-4. **Compose** the issue body using the same structure as the file template above (Intent Description, Architecture Specification, Acceptance Criteria, Ambiguity Log, Consistency Gate), titled `Spec: <Feature Name>`.
-5. **Create** (`gh issue create --title "Spec: <Feature Name>" --body "<composed body>"`) or **update** (`gh issue edit <N> --body "<composed body>"`) per step 3's decision.
+4. **Compose** the issue body using the same structure as the file template above (Intent Description, Architecture Specification, Acceptance Criteria, Ambiguity Log, Consistency Gate), titled `<type>(spec): <Feature Name>` per the rule above.
+5. **Create** (`gh issue create --title "<type>(spec): <Feature Name>" --body "<composed body>"`) or **update** (`gh issue edit <N> --body "<composed body>"`) per step 3's decision. Updating an existing issue's body never touches its title — if the existing title predates this convention, rename it too (`gh issue edit <N> --title "..."`) rather than leaving a stale non-conventional title behind.
 6. If the create/update call exits non-zero, report the failure and its cause to chat, do **not** claim success, and fall back to **Persist to file** above with the already-composed content.
 7. On success, **print** the resulting issue URL to chat — do not write `docs/specs/<slug>.md` on this path.
 


### PR DESCRIPTION
## Summary
- Renamed #1766 and #1767 (both titled `Spec: ...`, flagged by `needs-conventional-title`) to `docs(spec): ...`.
- The actual defect source was `specs/SKILL.md`'s hardcoded `Spec: <Feature Name>` issue-title template — it never produced a conventional title. Fixed the template, the search query that reuses it, and added an explicit rule (with a `commitlint --verbose` proactive check) so it can't regress.
- `.github/workflows/issue-title-lint.yml`'s own comment claimed `issues-from-plan` and `issues-from-assessment` already lint titles proactively before `gh issue create` — neither actually mentioned commitlint/conventional anywhere; the claim was aspirational. Added the real guidance to both, plus `specs`, and updated the workflow comment's skill list to match.
- `issues-from-plan`'s own example title (`"Add user authentication endpoint"`) was itself non-conventional — fixed to `feat: add user authentication endpoint`.
- `issues-from-assessment` is multi-tracker (ADO/GitHub/GitLab/Jira); scoped the fix to its GitHub branch only — non-GitHub trackers keep their existing `[<phase-tag>] <component>` titles unchanged, since Conventional Commits is a GitHub/commitlint-specific convention here, not a cross-tracker one.

## Test plan
- [x] Verified both renamed titles pass `commitlint --verbose` and the `needs-conventional-title` label cleared automatically
- [x] `python3 scripts/check_md_references.py`, `test_skill_bash_grants_cover_invocations.py`, `test_knowledge_index*.py` — no regressions from the doc edits
- [x] Full local gate: `bash scripts/ci-local.sh` — all 21 checks green (~7466 pytest, ruff, Python 3.10 floor, eslint)

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
