### PR TITLE
fix(hooks): isolate test_emit_swallows_bad_cwd_type from real checkout

### DIFF
--- a/plugins/dev-team/tests/hooks/test_boundary_events.py
+++ b/plugins/dev-team/tests/hooks/test_boundary_events.py
@@ -138,9 +138,10 @@ def test_emit_fails_open_on_arbitrary_exception(tmp_path: Path, monkeypatch) -> 
     assert not (tmp_path / ".claude" / "metrics" / "boundary-events.jsonl").exists()
 
 
-def test_emit_swallows_bad_cwd_type(monkeypatch) -> None:
+def test_emit_swallows_bad_cwd_type(tmp_path: Path, monkeypatch) -> None:
     """An unusable `cwd` (e.g. None with no real cwd fallback failing) must
     still not raise — fail-open covers the whole call, not just I/O."""
+    monkeypatch.setattr(boundary_events.Path, "cwd", lambda: tmp_path)
     boundary_events.emit_boundary_event(None, "h", "Bash", "warn", "r")
 
 


### PR DESCRIPTION
## Summary
- `test_emit_swallows_bad_cwd_type` called `emit_boundary_event(None, ...)`, which falls back to `Path.cwd()` — so the test was appending a real "warn" event to the actual checkout's `.claude/metrics/boundary-events.jsonl` on every run instead of writing into a sandbox.
- Monkeypatches `Path.cwd` to `tmp_path`, matching every sibling test in the file.

Found by test-review as a pre-existing, non-hermetic test during an unrelated PR's backstop review.

## Test plan
- [x] `pytest plugins/dev-team/tests/hooks/test_boundary_events.py::test_emit_swallows_bad_cwd_type` passes
- [x] Full `scripts/ci-local.sh` pre-push gate passed (ruff, Python 3.10 floor slice, full plugin test suite)