### PR TITLE
refactor(skills): dedupe severity vocab and raw-dir path in code-review consolidate

### DIFF
--- a/plugins/dev-team/skills/code-review/scripts/consolidate.py
+++ b/plugins/dev-team/skills/code-review/scripts/consolidate.py
@@ -23,12 +23,25 @@ import json
 import sys
 from pathlib import Path
 
-# Severity ranking (extracted — step 5c's ranking lived only in prose before).
-_SEVERITY_RANK = {"suggestion": 1, "warning": 2, "error": 3}
+# Reach the sibling ledger.py regardless of cwd or sys.path mode (matches the
+# house pattern in change_shape.py/codebase_recon.py for reaching a sibling
+# module rather than relying on the implicit sys.path[0] a direct script
+# invocation provides).
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
 
-# Maps a severity to its totals bucket, derived from the same vocabulary as
-# _SEVERITY_RANK so the severity set has a single source of truth.
-_SEVERITY_BUCKET = {"error": "errors", "warning": "warnings", "suggestion": "suggestions"}
+from ledger import raw_dir
+
+# Single source of truth for the severity vocabulary (step 5c's ranking lived
+# only in prose before): each severity's rank (for highest-wins merge and
+# sorting) and its totals bucket key.
+_SEVERITY = {
+    "suggestion": (1, "suggestions"),
+    "warning": (2, "warnings"),
+    "error": (3, "errors"),
+}
+_DEFAULT_SEVERITY = "suggestion"
 
 # A review dimension recurring across at least this many slices is a theme.
 _THEME_MIN_SLICES = 2
@@ -42,7 +55,11 @@ _FINDINGS_KEYS = ("findings", "issues")
 
 
 def _rank(severity: str) -> int:
-    return _SEVERITY_RANK.get(severity, 0)
+    return _SEVERITY.get(severity, (0, ""))[0]
+
+
+def _bucket(severity: str) -> str:
+    return _SEVERITY.get(severity, _SEVERITY[_DEFAULT_SEVERITY])[1]
 
 
 def _findings_of(container: dict) -> list:
@@ -102,7 +119,7 @@ def _merge_finding(merged: dict, order: list, finding: dict) -> None:
     """
     key = _dedupe_key(finding)
     agent = finding.get("agent")
-    severity = finding.get("severity", "suggestion")
+    severity = finding.get("severity", _DEFAULT_SEVERITY)
     entry = merged.get(key)
     if entry is None:
         order.append(key)
@@ -119,6 +136,18 @@ def _merge_finding(merged: dict, order: list, finding: dict) -> None:
         entry["message"] = finding.get("message")
     if agent and agent not in entry["agents"]:
         entry["agents"].append(agent)
+
+
+def _tally_severity(totals: dict, severity: str) -> None:
+    totals[_bucket(severity)] += 1
+
+
+def _tally_theme(theme_slices: dict, theme_counts: dict, agent: str | None, slice_id) -> None:
+    """Record one finding's contribution to the recurring-theme rollup for ``agent``."""
+    if agent is None:
+        return
+    theme_slices.setdefault(agent, set()).add(slice_id)
+    theme_counts[agent] = theme_counts.get(agent, 0) + 1
 
 
 def consolidate(sections: list[dict]) -> dict:
@@ -142,12 +171,9 @@ def consolidate(sections: list[dict]) -> dict:
         if section.get("is_declarative"):
             reduced_panel_slices.append(slice_id)
         for finding in _findings_of(section):
-            severity = finding.get("severity", "suggestion")
-            totals[_SEVERITY_BUCKET.get(severity, "suggestions")] += 1
-            agent = finding.get("agent")
-            if agent is not None:
-                theme_slices.setdefault(agent, set()).add(slice_id)
-                theme_counts[agent] = theme_counts.get(agent, 0) + 1
+            severity = finding.get("severity", _DEFAULT_SEVERITY)
+            _tally_severity(totals, severity)
+            _tally_theme(theme_slices, theme_counts, finding.get("agent"), slice_id)
             _merge_finding(merged, order, finding)
 
     top_findings = [merged[k] for k in order]
@@ -185,9 +211,8 @@ def _read_sections(root: str) -> tuple[list, list]:
     Returns ``(sections, malformed_paths)``. A malformed artifact is collected
     into ``malformed_paths`` (reported by the caller), never silently dropped.
     """
-    raw_dir = Path(root) / ".dev-team-reports" / "code-review" / "raw"
     sections, malformed = [], []
-    for path in sorted(glob.glob(str(raw_dir / "section-*.json"))):
+    for path in sorted(glob.glob(str(raw_dir(root) / "section-*.json"))):
         try:
             obj = json.loads(Path(path).read_text())
         except (json.JSONDecodeError, OSError):

--- a/plugins/dev-team/skills/code-review/scripts/ledger.py
+++ b/plugins/dev-team/skills/code-review/scripts/ledger.py
@@ -40,8 +40,12 @@ def ledger_path(root: str) -> Path:
     return _cr_dir(root) / "ledger.json"
 
 
+def raw_dir(root: str) -> Path:
+    return _cr_dir(root) / "raw"
+
+
 def section_path(root: str, slice_id: str) -> Path:
-    return _cr_dir(root) / "raw" / f"section-{slice_id}.json"
+    return raw_dir(root) / f"section-{slice_id}.json"
 
 
 def _atomic_write_json(path: Path, obj) -> None:

--- a/plugins/dev-team/tests/scripts/test_consolidate.py
+++ b/plugins/dev-team/tests/scripts/test_consolidate.py
@@ -19,6 +19,7 @@ sys.path.insert(
 )
 
 import consolidate
+import ledger
 
 
 def _section(sid, findings, is_declarative=False, panel=None):
@@ -107,8 +108,36 @@ def test_overall_status_reflects_highest_severity():
     assert consolidate.consolidate([_section("0001", [_f("a", 1, "suggestion", "x")])])["overall"] == "pass"
 
 
+def test_finding_with_no_agent_is_tallied_but_not_a_theme():
+    # Two slices, both with the same agentless finding shape: this is the
+    # case that would actually reach recurringThemes (>= _THEME_MIN_SLICES)
+    # if _tally_theme's `if agent is None: return` guard were ever removed.
+    finding = {"file": "a", "line": 1, "severity": "warning", "message": "msg"}
+    sections = [_section("0001", [finding]), _section("0002", [dict(finding, line=2)])]
+    result = consolidate.consolidate(sections)
+    assert result["totals"]["warnings"] == 2
+    assert all(f["agents"] == [] for f in result["topFindings"])
+    assert result["recurringThemes"] == []
+
+
+def test_unknown_severity_falls_back_to_suggestion_bucket_but_not_rank():
+    # _bucket() falls back to "suggestion"'s bucket; _rank() falls back to 0,
+    # one below "suggestion"'s own rank of 1 — the two fallbacks deliberately
+    # disagree (preserved unchanged from the pre-refactor two-dict version).
+    result = consolidate.consolidate([_section("0001", [_f("a", 1, "critical", "x")])])
+    assert result["totals"]["suggestions"] == 1
+    assert result["overall"] == "pass"
+    assert consolidate._rank("critical") == 0
+
+
+def test_missing_severity_defaults_to_suggestion():
+    finding = {"file": "a", "line": 1, "agent": "x", "message": "msg"}
+    result = consolidate.consolidate([_section("0001", [finding])])
+    assert result["totals"]["suggestions"] == 1
+
+
 def test_main_reports_malformed_artifact_not_silently_dropped(tmp_path, capsys):
-    raw = tmp_path / ".dev-team-reports" / "code-review" / "raw"
+    raw = ledger.raw_dir(str(tmp_path))
     raw.mkdir(parents=True)
     (raw / "section-0001.json").write_text(json.dumps(_section("0001", [_f("a", 1, "warning", "x")])))
     (raw / "section-0002.json").write_text("{ this is not valid json")
@@ -123,7 +152,7 @@ def test_main_reports_malformed_artifact_not_silently_dropped(tmp_path, capsys):
 
 
 def test_main_treats_wrong_shape_json_as_malformed(tmp_path, capsys):
-    raw = tmp_path / ".dev-team-reports" / "code-review" / "raw"
+    raw = ledger.raw_dir(str(tmp_path))
     raw.mkdir(parents=True)
     (raw / "section-0001.json").write_text(json.dumps(_section("0001", [])))
     # Valid JSON, wrong shape (a list) — must be reported, not crash consolidate().

--- a/plugins/dev-team/tests/scripts/test_ledger.py
+++ b/plugins/dev-team/tests/scripts/test_ledger.py
@@ -40,6 +40,11 @@ def test_init_records_all_slices_pending_with_cap(tmp_path):
     assert ledger.ledger_path(str(tmp_path)).exists()
 
 
+def test_raw_dir_resolves_under_consolidated_root(tmp_path):
+    assert ledger.raw_dir(str(tmp_path)) == tmp_path / ".dev-team-reports" / "code-review" / "raw"
+    assert ledger.section_path(str(tmp_path), "0001").parent == ledger.raw_dir(str(tmp_path))
+
+
 def test_write_section_creates_artifact_and_flips_status(tmp_path):
     ledger.init_ledger(_slices(), cap=50, root=str(tmp_path))
     findings = [{"severity": "warning", "file": "src/a.ts", "line": 3, "message": "x"}]

--- a/tests/skills/test_dev_team_reports_consolidation.py
+++ b/tests/skills/test_dev_team_reports_consolidation.py
@@ -145,8 +145,9 @@ def test_ledger_and_consolidate_scripts_target_consolidated_root():
         "consolidate.py must not reference the legacy bare DEV_TEAM_REPORTS/ "
         "path literal"
     )
-    assert '".dev-team-reports"' in CONSOLIDATE_PY, (
-        "consolidate.py's raw_dir resolution must target .dev-team-reports/"
+    assert "from ledger import raw_dir" in CONSOLIDATE_PY, (
+        "consolidate.py must resolve raw/ via ledger.py's single-home "
+        "raw_dir(), not re-derive the .dev-team-reports/ literal itself"
     )
 
 


### PR DESCRIPTION
## Summary

- Fixes three structure-review findings on `consolidate.py`/`ledger.py` (single-source the raw-dir path via `ledger.raw_dir()`, split `consolidate()`'s per-section loop into per-concern helpers, collapse the duplicated severity-rank/bucket dicts into one mapping).
- Retargets the content-guard test that pinned the old path literal to assert the new delegation instead (the guard was broken by the path-ownership move — found and confirmed by four independent review agents).
- Hardens the new sibling import (`from ledger import raw_dir`) with an explicit `sys.path` guard matching this directory's house pattern.
- Adds test coverage for the `agent=None` path and the unknown/missing-severity fallback path surfaced during review, and fixes a mutation-verified weak test along the way.

## Review

Ran the full `/code-review` flow: 14-agent initial panel, a 6-agent closing pass verifying every fix against the cumulative diff, and a second 2-agent closing pass after one more fix. One plausible-looking ruff-E402 blocker raised by two agents was mechanically checked and refuted by running the actual `python3 -m ruff check .` gate. All actionable findings were fixed; several pre-existing, cross-cutting issues (severity-vocab duplication in `review_round_log.py`, DTO schema gaps, fail-open severity handling) were deliberately deferred as follow-up rather than expanding this PR's scope — see `.dev-team-reports/code-review.md` (local, gitignored) for the full trail.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/scripts tests/skills -q` — 2532+ passed
- [x] `python3 -m ruff check .` — clean
- [x] `python3 -m mypy` on both changed source files — clean
- [x] Standalone `python3 consolidate.py --root <dir>` — verified working
- [x] Full local CI mirror (`scripts/ci-local.sh`, pre-push) — all 21 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)