### PR TITLE
fix(hooks): remove second-boundary race in dispatch-window flaky test

### DIFF
--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -491,10 +491,16 @@ def test_hash_match_with_only_one_dispatch_inside_window_is_insufficient(
     h = _current_hash(repo)
     gate_path = repo / ".claude" / "memory" / ".review-passed"
     gate_path.parent.mkdir(parents=True, exist_ok=True)
-    gate_path.write_text(h)
     stale_ts = datetime.now(timezone.utc) - timedelta(seconds=_WINDOW_SECONDS + 600)
     _write_dispatch_events(repo, ["security-review"], h, ts=stale_ts)
+    # Written BEFORE the gate file so its (second-truncated) "now" timestamp
+    # can never land after `before_ts` (the gate's own mtime, also
+    # second-truncated) — writing it after was a real race under parallel
+    # test runs: a second-boundary crossing between the two statements
+    # pushed this "fresh" dispatch's timestamp past `before_ts`, excluding
+    # it from the window and dropping the in-window count from 1 to 0.
     _write_dispatch_events(repo, ["structure-review"], h)
+    gate_path.write_text(h)
     r = _run(
         {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
     )


### PR DESCRIPTION
## Summary
- `test_hash_match_with_only_one_dispatch_inside_window_is_insufficient` (`plugins/dev-team/tests/hooks/test_pre_commit_review.py`) occasionally failed under `python3 -m pytest plugins/dev-team/tests -q -n auto --dist loadgroup`, but passed in isolation and on full-suite reruns.
- Root cause: the review-gate recency window anchors on `before_ts`, the `.review-passed` gate file's mtime, truncated to whole seconds (`review_gate_corroboration.py`). The test wrote the gate file first, then wrote its "fresh" dispatch event with a default `datetime.now(timezone.utc)` timestamp computed *afterward*. `metrics_query.filter_entries` excludes any dispatch whose (second-truncated) timestamp is later than `before_ts`. Under `pytest -n auto` CPU contention, a second-boundary crossing between the two statements could push the dispatch's timestamp past `before_ts`, dropping the in-window count from 1 to 0 and producing "No genuine review-agent dispatch found" instead of the expected "Only 1 distinct review agent(s) dispatched".
- Fix: write the in-window dispatch event *before* writing the gate file, so wall-clock monotonicity guarantees its timestamp can never exceed `before_ts`. This removes the race without mocking the clock or widening any tolerance.
- Note (not fixed here, flagged for awareness): several sibling tests in the same file follow the same "gate write, then default-`ts` dispatch write" order and are theoretically exposed to the same race (e.g. `test_matching_gate_file_passes_and_is_consumed`, `test_hash_match_with_one_distinct_dispatch_blocks_as_insufficient`). They simply haven't been observed flaking because they're not sitting on as tight a boundary.

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_pre_commit_review.py -k test_hash_match_with_only_one_dispatch_inside_window_is_insufficient -q` — passes
- [x] Full file rerun x5 sequentially — all green
- [x] `python3 -m pytest plugins/dev-team/tests -q -n auto --dist loadgroup` (2810 tests) — all green
- [x] Local `pre-push` gate (`ci-local.sh`) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)