### PR TITLE
refactor(hooks): dedupe bypass-flag scan in pre_commit_detect

### DIFF
--- a/plugins/dev-team/hooks/lib/pre_commit_detect.py
+++ b/plugins/dev-team/hooks/lib/pre_commit_detect.py
@@ -61,9 +61,7 @@ def is_git_commit_command(cmd: str) -> bool:
 
 def has_bypass_flag(cmd: str) -> bool:
     """Return True iff `cmd` carries `--no-verify` or a bare `-n` flag."""
-    if not cmd:
-        return False
-    return bool(_NO_VERIFY_RE.search(cmd)) or bool(_BARE_N_RE.search(cmd))
+    return bypass_flag_name(cmd) is not None
 
 
 def bypass_flag_name(cmd: str) -> str | None:


### PR DESCRIPTION
## Summary
- `has_bypass_flag()` in `plugins/dev-team/hooks/lib/pre_commit_detect.py` independently re-scanned the same two bypass-flag patterns (`--no-verify`, bare `-n`) that `bypass_flag_name()` already scans, in the same order.
- Refactored `has_bypass_flag()` to `return bypass_flag_name(cmd) is not None`, so a future third bypass flag only needs updating in one place instead of both functions in lockstep.

Found by a refactor-opportunity-review pass during review of an unrelated fix (widening git-commit detection); this duplication predates that PR and was out of its scope.

## Test plan
- [x] `python3 -m pytest plugins/dev-team/tests -k pre_commit_detect -q` — 26 passed
- [x] Full `scripts/ci-local.sh` pre-push gate — all 21 checks passed (7542 passed, 43 skipped)