### PR TITLE
fix(hooks): single-read-pass ledger query for cosmetic carry-forward veto

### DIFF
--- a/plugins/dev-team/hooks/lib/review_gate_corroboration.py
+++ b/plugins/dev-team/hooks/lib/review_gate_corroboration.py
@@ -55,6 +55,7 @@ Stdlib only. See ADR 0014 / ADR 0015.
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
@@ -359,6 +360,36 @@ def _agents_with_unsuperseded_failure(
     )
 
 
+def _binding_evidence(
+    dispatches: list,
+    failures: list,
+    since: str,
+    before_ts: str,
+    registered: frozenset | None,
+) -> tuple:
+    """Compute `(agents_in_window, dispatch_failure_agents)` from dispatch/
+    failure entries ALREADY narrowed to one hash binding by the caller.
+
+    Shared by `evaluate()` and `evaluate_cosmetic_carry_forward()` (once per
+    hash binding it evaluates) — each independently re-implemented this exact
+    window-filter + positive-frozenset + `_agents_with_unsuperseded_failure`
+    sequence before this extraction (#1836 perf finding), which risked the
+    fail-closed positive/negative asymmetry — `registered_for_positive`'s
+    `None`-to-empty collapse is safe ONLY for positive evidence, never for
+    negative — silently drifting out of sync across independently
+    maintained copies.
+    """
+    in_window = metrics_query.filter_entries(dispatches, since=since, until=before_ts)
+    registered_for_positive = registered if registered is not None else frozenset()
+    agents = frozenset(
+        e["matched_rule"]
+        for e in in_window
+        if isinstance(e.get("matched_rule"), str) and e["matched_rule"] in registered_for_positive
+    )
+    dispatch_failure_agents = _agents_with_unsuperseded_failure(dispatches, failures, registered)
+    return agents, dispatch_failure_agents
+
+
 def evaluate(cwd, before_ts: str, window_seconds: int, subject_hash: str) -> LedgerEvidence:
     """Single-read-pass corroboration evaluation — the primary entry point.
 
@@ -407,20 +438,7 @@ def evaluate(cwd, before_ts: str, window_seconds: int, subject_hash: str) -> Led
     same_subject_ever = any(isinstance(e.get("matched_rule"), str) for e in dispatches)
 
     since = _since_bound(before_ts, window_seconds)
-    in_window = metrics_query.filter_entries(dispatches, since=since, until=before_ts)
     registered = _registered_agents()
-    # `registered_for_positive`: a registry-read failure (`None`) collapses
-    # to empty here — safe for POSITIVE evidence, since narrowing can only
-    # ever narrow (never widen) what counts as corroboration. `registered`
-    # itself (possibly `None`) is passed through unchanged to
-    # `_agents_with_unsuperseded_failure` below, which needs to distinguish
-    # "read failed" from "genuinely zero agents" for NEGATIVE evidence.
-    registered_for_positive = registered if registered is not None else frozenset()
-    agents = frozenset(
-        e["matched_rule"]
-        for e in in_window
-        if isinstance(e.get("matched_rule"), str) and e["matched_rule"] in registered_for_positive
-    )
 
     # Dispatch-failure negative evidence (#1763) — unbounded by the recency
     # window, per the field's own docstring. `dispatches` above is already
@@ -434,11 +452,163 @@ def evaluate(cwd, before_ts: str, window_seconds: int, subject_hash: str) -> Led
         )
         if e.get("subject_hash") == subject_hash
     ]
-    dispatch_failure_agents = _agents_with_unsuperseded_failure(
-        dispatches, same_subject_failures, registered
+    agents, dispatch_failure_agents = _binding_evidence(
+        dispatches, same_subject_failures, since, before_ts, registered
     )
 
     return LedgerEvidence(agents, any_ever, same_subject_ever, None, dispatch_failure_agents)
+
+
+class CosmeticCarryForwardEvidence(NamedTuple):
+    """Single-read-pass result for the cosmetic-delta carry-forward lens
+    (`pre_commit_review.py`'s `_cosmetic_carry_forward_verdict`, #1627/#1763):
+    the normalized-hash query for POSITIVE evidence plus dispatch-failure
+    NEGATIVE evidence unioned across the normalized hash and every raw hash
+    in `raw_hashes` (typically `(stored_raw, current_hash)`) — everything
+    that lens needs from exactly ONE `_read_ledger`/`_registered_agents()`
+    pair, replacing what used to be one `distinct_normalized_dispatches()`
+    call plus one `evaluate()` call per raw hash, each independently
+    re-reading and re-parsing the same ledger file and re-globbing the
+    registry directory (perf finding from the #1761-1763 build).
+
+    Attributes:
+        agents_in_window: distinct registered review-agent names dispatched
+            in the recency window, bound ONLY to the normalized-hash binding
+            — the raw hashes in `raw_hashes` never contribute to this field,
+            unlike `dispatch_failure_agents` below. Empty when
+            `subject_hash_normalized` is falsy, on any read failure, or when
+            nothing qualifies.
+        read_failure_reason: `None` on a successful ledger read (whether or
+            not it has qualifying entries, whether or not the registry read
+            separately failed); `"missing"`/`"unreadable"` on a ledger read
+            failure — see `_read_ledger`'s own docstring.
+        dispatch_failure_agents: the UNION of unsuperseded dispatch-failure
+            agents across EVERY hash binding checked (the normalized hash
+            AND every entry in `raw_hashes`) — unlike `agents_in_window`,
+            this field is not scoped to a single binding. On a ledger read
+            failure, a registry read failure, or a falsy/unbindable hash
+            binding, this is EXACTLY the `_UNPROVABLE_DISPATCH_FAILURE`
+            sentinel — never mixed with real agent names (see
+            `evaluate_cosmetic_carry_forward`'s own docstring for why a
+            mixed set would be unsafe) — so a caller's `==` sentinel check
+            stays valid even though this field aggregates multiple bindings.
+    """
+
+    agents_in_window: frozenset
+    read_failure_reason: str | None
+    dispatch_failure_agents: frozenset
+
+
+def evaluate_cosmetic_carry_forward(
+    cwd,
+    before_ts: str,
+    window_seconds: int,
+    subject_hash_normalized: str,
+    raw_hashes: Iterable[str],
+) -> CosmeticCarryForwardEvidence:
+    """One `_read_ledger`/`_registered_agents()` pair answers the
+    normalized-hash query (positive `agents_in_window` + its own negative
+    dispatch-failure evidence) AND the negative-only dispatch-failure query
+    for every hash in `raw_hashes`. Each binding's evidence is computed by
+    the shared `_binding_evidence()` helper — the same code `evaluate()`
+    calls — against entries and a registry snapshot already loaded into
+    memory once, not re-read per binding.
+
+    A bare `str` passed as `raw_hashes` is normalized to a 1-tuple: the
+    natural mistake for a caller passing one raw hash directly would
+    otherwise iterate its individual CHARACTERS, silently match nothing,
+    and produce a false all-clear — the opposite of this module's
+    fail-closed posture.
+
+    Fails CLOSED like every other function in this module, and — unlike
+    treating each binding independently — NEVER lets the
+    `_UNPROVABLE_DISPATCH_FAILURE` sentinel mix into a union with real agent
+    names: if the shared ledger read fails, the shared registry read fails,
+    or ANY binding (the normalized hash, or a falsy/unbindable raw hash) is
+    itself unprovable, `dispatch_failure_agents` is EXACTLY the sentinel for
+    the WHOLE result — never `{sentinel, "some-real-agent"}`, which a
+    caller's `==` sentinel check could not detect and which would let
+    `_dispatch_failure_message()` render the sentinel string as if it were
+    a real agent name (#1836 security/correctness review). This is a
+    stricter posture than resolving each binding independently — a
+    transient failure on ANY one binding blocks the whole evaluation, not
+    just that binding — the right direction for a fail-closed gate. A
+    falsy raw hash is treated the same way (unprovable), not silently
+    skipped: it cannot bind any evidence, so it cannot prove the ABSENCE of
+    a dispatch failure either — a stricter posture than the old per-call
+    `evaluate("")` this replaces, which would have matched no ledger entries
+    (an absent-`subject_hash` event stores `None`, never `""`) and returned
+    a vacuous all-clear for that binding. Callers of THIS function must not
+    let a knowingly-falsy hash reach it expecting that same all-clear —
+    `pre_commit_review.py`'s `_cosmetic_carry_forward_verdict` guards its own
+    `stored_raw` binding for exactly this reason, so this sentinel path
+    stays reserved for a genuinely malformed/unbindable input, never a
+    routine one.
+
+    Registry-read behavior note (#1461/#1763 security review): the
+    review-agent registry is sampled exactly ONCE per call, not once per
+    hash binding as the calls this function replaces did independently.
+    The fail-closed GUARANTEE is unchanged — a registry that cannot be read
+    AT THE TIME OF THIS EVALUATION still makes the whole result unprovable
+    — only the number of independent samples taken within one evaluation
+    changed, an intended consequence of the ledger-read consolidation this
+    function exists for, not a separately considered trade-off.
+    """
+    if isinstance(raw_hashes, str):
+        raw_hashes = (raw_hashes,)
+
+    entries, failure = _read_ledger(cwd)
+    if failure is not None:
+        return CosmeticCarryForwardEvidence(frozenset(), failure, _UNPROVABLE_DISPATCH_FAILURE)
+
+    registered = _registered_agents()
+    since = _since_bound(before_ts, window_seconds)
+    all_dispatches = list(
+        metrics_query.filter_entries(entries, event_type=_EVENT_TYPE, gate_outcome=_DECISION)
+    )
+    all_failures = list(
+        metrics_query.filter_entries(
+            entries, event_type=_DISPATCH_FAILURE_HOOK, gate_outcome=_DISPATCH_FAILURE_DECISION
+        )
+    )
+
+    if subject_hash_normalized:
+        normalized_dispatches = [
+            e
+            for e in all_dispatches
+            if e.get("subject_hash_normalized") == subject_hash_normalized
+        ]
+        normalized_failures = [
+            e for e in all_failures if e.get("subject_hash_normalized") == subject_hash_normalized
+        ]
+        agents, normalized_dispatch_failures = _binding_evidence(
+            normalized_dispatches, normalized_failures, since, before_ts, registered
+        )
+        failure_sets = [normalized_dispatch_failures]
+    else:
+        agents = frozenset()
+        failure_sets = [_UNPROVABLE_DISPATCH_FAILURE]
+
+    seen_hashes: set = set()
+    for raw_hash in raw_hashes:
+        if raw_hash in seen_hashes:
+            continue
+        seen_hashes.add(raw_hash)
+        if not raw_hash:
+            failure_sets.append(_UNPROVABLE_DISPATCH_FAILURE)
+            continue
+        raw_dispatches = [e for e in all_dispatches if e.get("subject_hash") == raw_hash]
+        raw_failures = [e for e in all_failures if e.get("subject_hash") == raw_hash]
+        _, raw_dispatch_failures = _binding_evidence(
+            raw_dispatches, raw_failures, since, before_ts, registered
+        )
+        failure_sets.append(raw_dispatch_failures)
+
+    if any(fs == _UNPROVABLE_DISPATCH_FAILURE for fs in failure_sets):
+        return CosmeticCarryForwardEvidence(agents, None, _UNPROVABLE_DISPATCH_FAILURE)
+
+    combined_failures = frozenset().union(*failure_sets)
+    return CosmeticCarryForwardEvidence(agents, None, combined_failures)
 
 
 def distinct_review_agent_dispatches(
@@ -464,71 +634,32 @@ def distinct_normalized_dispatches(
     paired with the unbounded-by-window dispatch-failure agent set for that
     same normalized hash (#1763).
 
-    Returns `(agents_in_window, dispatch_failure_agents)`, both `frozenset` —
-    a PUBLIC, `__all__`-exported interface change from the prior bare `set`
-    return; the sole caller (`pre_commit_review.py`'s
-    `_cosmetic_carry_forward_verdict`) unpacks the tuple.
+    Pinned convenience signature over `evaluate_cosmetic_carry_forward()`
+    (matching `distinct_review_agent_dispatches`'s own precedent as a thin
+    wrapper over `evaluate()`) — called with an empty `raw_hashes`, so its
+    union reduces to exactly the normalized binding's own evidence. Kept as
+    its own named entry point for callers that only ever have one hash to
+    check, and to keep this normalized-hash-only case covered by its own
+    direct unit tests independent of `pre_commit_review.py`'s specific
+    caller shape.
 
+    Returns `(agents_in_window, dispatch_failure_agents)`, both `frozenset`.
     Same fail-CLOSED posture and same live-registry re-validation as
     `evaluate()` — this is the raw-hash query with one field swapped, not a
-    weaker check. An empty or falsy `subject_hash_normalized` matches nothing:
-    events written before that field existed carry no value for it, and
-    treating "both sides absent" as a match would let any pre-#1627 ledger
-    corroborate any changeset. A ledger read failure returns
-    `(frozenset(), _UNPROVABLE_DISPATCH_FAILURE)` — fail CLOSED on the
+    weaker check. An empty or falsy `subject_hash_normalized` matches
+    nothing for POSITIVE evidence (events written before that field existed
+    carry no value for it, and treating "both sides absent" as a match
+    would let any pre-#1627 ledger corroborate any changeset) — negative
+    evidence in that same case is `_UNPROVABLE_DISPATCH_FAILURE`, not an
+    all-clear, since an unbindable query cannot prove absence of failure
+    either. A ledger or registry read failure returns the same
+    `(frozenset(), _UNPROVABLE_DISPATCH_FAILURE)` shape — fail CLOSED on the
     negative-evidence side exactly like `evaluate()`.
-
-    `boundary_events.py`'s `--event dispatch-failure` CLI stamps both
-    `subject_hash` and `subject_hash_normalized` on the events it writes
-    (`SKILL.md` Step 4 and `sliced-mode.md` both compute and pass the
-    normalized hash alongside the raw one), so `dispatch_failure_agents`
-    here reflects genuine data on this path, not only the read-failure
-    sentinel.
     """
-    if not subject_hash_normalized:
-        # An unbindable query cannot prove absence of failure either — the
-        # negative-evidence side must not read as an all-clear here, same
-        # fail-closed posture as the read-failure branch a few lines below
-        # (#1763 security review).
-        return frozenset(), _UNPROVABLE_DISPATCH_FAILURE
-    entries, failure = _read_ledger(cwd)
-    if failure is not None:
-        return frozenset(), _UNPROVABLE_DISPATCH_FAILURE
-    dispatches = [
-        e
-        for e in metrics_query.filter_entries(
-            entries, event_type=_EVENT_TYPE, gate_outcome=_DECISION
-        )
-        if e.get("subject_hash_normalized") == subject_hash_normalized
-    ]
-    since = _since_bound(before_ts, window_seconds)
-    in_window = metrics_query.filter_entries(dispatches, since=since, until=before_ts)
-    registered = _registered_agents()
-    # `registered_for_positive`: a registry-read failure (`None`) collapses
-    # to empty here — safe for POSITIVE evidence, since narrowing can only
-    # ever narrow (never widen) what counts as corroboration. `registered`
-    # itself (possibly `None`) is passed through unchanged to
-    # `_agents_with_unsuperseded_failure` below, which needs to distinguish
-    # "read failed" from "genuinely zero agents" for NEGATIVE evidence.
-    registered_for_positive = registered if registered is not None else frozenset()
-    agents = frozenset(
-        e["matched_rule"]
-        for e in in_window
-        if isinstance(e.get("matched_rule"), str) and e["matched_rule"] in registered_for_positive
+    evidence = evaluate_cosmetic_carry_forward(
+        cwd, before_ts, window_seconds, subject_hash_normalized, ()
     )
-
-    same_subject_failures = [
-        e
-        for e in metrics_query.filter_entries(
-            entries, event_type=_DISPATCH_FAILURE_HOOK, gate_outcome=_DISPATCH_FAILURE_DECISION
-        )
-        if e.get("subject_hash_normalized") == subject_hash_normalized
-    ]
-    dispatch_failure_agents = _agents_with_unsuperseded_failure(
-        dispatches, same_subject_failures, registered
-    )
-
-    return agents, dispatch_failure_agents
+    return evidence.agents_in_window, evidence.dispatch_failure_agents
 
 
 def _has_exemption(cwd, before_ts: str, window_seconds: int, subject_hash: str, rule: str) -> bool:
@@ -573,10 +704,12 @@ def has_single_agent_exemption(cwd, before_ts: str, window_seconds: int, subject
 
 
 __all__ = (
+    "CosmeticCarryForwardEvidence",
     "LedgerEvidence",
     "distinct_normalized_dispatches",
     "distinct_review_agent_dispatches",
     "evaluate",
+    "evaluate_cosmetic_carry_forward",
     "has_doc_only_exemption",
     "has_single_agent_exemption",
     "mtime_to_iso",

--- a/plugins/dev-team/hooks/pre_commit_review.py
+++ b/plugins/dev-team/hooks/pre_commit_review.py
@@ -178,10 +178,10 @@ try:
         _UNPROVABLE_DISPATCH_FAILURE,
     )
     from review_gate_corroboration import (  # type: ignore[import-not-found]
-        distinct_normalized_dispatches as _distinct_normalized_dispatches,
+        evaluate as _evaluate_ledger,
     )
     from review_gate_corroboration import (  # type: ignore[import-not-found]
-        evaluate as _evaluate_ledger,
+        evaluate_cosmetic_carry_forward as _evaluate_carry_forward,
     )
     from review_gate_corroboration import (  # type: ignore[import-not-found]
         has_doc_only_exemption as _has_doc_only_exemption,
@@ -263,7 +263,13 @@ except ImportError:  # pragma: no cover
     _UNPROVABLE_DISPATCH_FAILURE = _DEGRADED_DISPATCH_FAILURE_SENTINEL
 
     class _DegradedLedgerEvidence:  # type: ignore[misc]
-        """Degraded-import stand-in for `review_gate_corroboration.LedgerEvidence`.
+        """Degraded-import stand-in for BOTH `review_gate_corroboration.
+        LedgerEvidence` (via `_evaluate_ledger`) and `CosmeticCarryForwardEvidence`
+        (via `_evaluate_carry_forward`, below) — its three attributes used by
+        `_cosmetic_carry_forward_verdict` (`agents_in_window`,
+        `dispatch_failure_agents`, `read_failure_reason`) happen to be a subset
+        of `LedgerEvidence`'s own five, so one attribute-based stand-in serves
+        both NamedTuple shapes without duplicating it.
 
         A failed import means this module can't corroborate anything —
         fails CLOSED the same way the real module does on a read failure,
@@ -273,8 +279,11 @@ except ImportError:  # pragma: no cover
         Field shape (names, order) is asserted to stay in sync with the
         real `LedgerEvidence` NamedTuple by
         `test_degraded_ledger_evidence_field_shape_matches_real_ledger_evidence`
-        (#1477) — a future field added to the real shape without updating
-        this stand-in now fails a test instead of silently drifting.
+        (#1477) and, additionally, against `CosmeticCarryForwardEvidence`'s
+        own field set by that same test (#1836) — a future field added to
+        either real shape without updating this stand-in now fails a test
+        instead of silently leaving the carry-forward lens permanently
+        non-decisive with no signal.
         """
 
         agents_in_window: frozenset = frozenset()
@@ -305,15 +314,15 @@ except ImportError:  # pragma: no cover
         # as it did before #1627. Fails CLOSED like the rest of this block.
         return None
 
-    def _distinct_normalized_dispatches(  # type: ignore[misc]
-        cwd, before_ts, window_seconds, subject_hash_normalized
-    ) -> tuple:
-        # Degraded-import fallback: matches the real function's new 2-tuple
-        # shape (#1763). Empty agents_in_window keeps the carry-forward lens
-        # never decisive on positive evidence (unchanged posture); the
-        # dispatch-failure side fails CLOSED with the same sentinel
-        # `_DegradedLedgerEvidence` uses, rather than an empty/all-clear set.
-        return frozenset(), _DEGRADED_DISPATCH_FAILURE_SENTINEL
+    def _evaluate_carry_forward(  # type: ignore[misc]
+        cwd, before_ts, window_seconds, subject_hash_normalized, raw_hashes
+    ):
+        # Degraded-import fallback: reuses `_DegradedLedgerEvidence` — its
+        # `agents_in_window`/`dispatch_failure_agents`/`read_failure_reason`
+        # fields are exactly what `_cosmetic_carry_forward_verdict` reads
+        # from the real `CosmeticCarryForwardEvidence`, so the same
+        # fail-CLOSED stand-in serves both shapes without duplicating it.
+        return _DegradedLedgerEvidence()
 
 
 def emit_boundary_event(*args, **kwargs) -> None:
@@ -756,6 +765,21 @@ def _cosmetic_carry_forward_verdict(
         stored_raw, stored_normalized = _stored_gate_hashes(gate_file)
         if not stored_normalized:
             return None
+        # A malformed gate file (a blank first line paired with a non-blank
+        # second line — SKILL.md's `printf '%s\n%s\n' "$HASH" "$NORM"` could
+        # produce this if `$HASH` came back empty) must not reach
+        # `_evaluate_carry_forward` with a falsy `stored_raw` (#1836 closing-
+        # pass security/correctness review): that function now treats ANY
+        # falsy raw-hash binding as unprovable, which would render through
+        # the SAME `_UNPROVABLE_DISPATCH_FAILURE` sentinel a genuine registry
+        # read failure uses below — misattributing a malformed gate file as
+        # "could not read the registered review-agent set". Same "not
+        # decisive" treatment as the `stored_normalized` check above, not a
+        # new message: the fallback `_BLOCK_MESSAGE` rejection's own remedy
+        # (re-run /code-review, which rewrites `.review-passed` cleanly)
+        # already fixes this cause too.
+        if not stored_raw:
+            return None
 
         target = "HEAD" if unstaged_commit else "--cached"
         current_normalized = normalized_gate_hash(cwd, target)
@@ -763,32 +787,21 @@ def _cosmetic_carry_forward_verdict(
             return None
 
         before_ts = _mtime_to_iso(gate_file.stat().st_mtime)
-        agents, dispatch_failure_agents = _distinct_normalized_dispatches(
-            cwd, before_ts, WINDOW_SECONDS, current_normalized
+        # #1763: negative evidence is checked against the normalized hash
+        # AND both raw hashes — `stored_raw` (the content that was ACTUALLY
+        # reviewed; a review-time failure would be recorded against it, not
+        # `current_hash`, which by construction mismatches it on this path)
+        # and `current_hash` (in case a failure was separately recorded
+        # against today's exact content) — in case a dispatch-failure event
+        # never got a `subject_hash_normalized` stamped (the emission
+        # command computes it with `|| true`, so a normalization failure
+        # silently omits the field) and would otherwise be invisible to a
+        # normalized-only query. One `_read_ledger` call answers all three
+        # bindings (perf finding from the #1761-1763 build: this used to be
+        # three separate reads of the same file).
+        evidence = _evaluate_carry_forward(
+            cwd, before_ts, WINDOW_SECONDS, current_normalized, (stored_raw, current_hash)
         )
-        # #1763: also check RAW-hash negative evidence — a dispatch-failure
-        # event that never got a `subject_hash_normalized` stamped would
-        # otherwise be invisible to the normalized-only query above. Two
-        # raw hashes matter here, not one: `stored_raw` is the hash of the
-        # content that was ACTUALLY reviewed (when the review-time dispatch
-        # failure, if any, would have been recorded against it) — checking
-        # only `current_hash` (today's, post-cosmetic-edit hash, which by
-        # construction mismatches `stored_raw` on this path) would miss
-        # exactly the stale-but-real failure this lens exists to carry
-        # forward correctly. `current_hash` is checked too, independently,
-        # in case a failure was separately recorded against today's exact
-        # content. Union, don't replace: any source finding an unsuperseded
-        # failure vetoes.
-        stored_raw_evidence = (
-            _evaluate_ledger(cwd, before_ts, WINDOW_SECONDS, stored_raw)
-            if stored_raw
-            else None
-        )
-        current_raw_evidence = _evaluate_ledger(cwd, before_ts, WINDOW_SECONDS, current_hash)
-        raw_failure_sets = [current_raw_evidence.dispatch_failure_agents]
-        if stored_raw_evidence is not None:
-            raw_failure_sets.append(stored_raw_evidence.dispatch_failure_agents)
-        combined_dispatch_failures = dispatch_failure_agents.union(*raw_failure_sets)
 
         # #1763: the same mechanical dispatch-failure veto the main pipeline
         # applies (`_dispatch_failure_verdict`), checked here BEFORE the
@@ -805,23 +818,20 @@ def _cosmetic_carry_forward_verdict(
         # different infra problems needing different operator remediation
         # (#1763 correctness/security review — the exact mislabeling this
         # file's own `_GATE_SETUP_FAILURE_MESSAGE` comment, a few hundred
-        # lines up, argues against). The two raw-hash `LedgerEvidence`
-        # objects carry `read_failure_reason`; a ledger read failure there
-        # is checked FIRST, before assuming the sentinel means the registry.
-        if (stored_raw_evidence is not None and stored_raw_evidence.read_failure_reason) or (
-            current_raw_evidence.read_failure_reason
-        ):
+        # lines up, argues against). `evidence.read_failure_reason` is
+        # checked FIRST, before assuming the sentinel means the registry.
+        if evidence.read_failure_reason:
             return GateVerdict(False, _READ_FAILURE_MESSAGE, "dispatch-ledger-read-failure")
-        if _UNPROVABLE_DISPATCH_FAILURE in (dispatch_failure_agents, *raw_failure_sets):
+        if evidence.dispatch_failure_agents == _UNPROVABLE_DISPATCH_FAILURE:
             return GateVerdict(False, _REGISTRY_READ_FAILURE_MESSAGE, "registry-read-failure")
-        if combined_dispatch_failures:
+        if evidence.dispatch_failure_agents:
             return GateVerdict(
                 False,
-                _dispatch_failure_message(combined_dispatch_failures),
+                _dispatch_failure_message(evidence.dispatch_failure_agents),
                 "dispatch-failure-veto",
             )
 
-        if len(agents) < _MIN_DISTINCT_DISPATCHES:
+        if len(evidence.agents_in_window) < _MIN_DISTINCT_DISPATCHES:
             return None
 
         emit_boundary_event(

--- a/plugins/dev-team/tests/hooks/test_pre_commit_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_commit_review.py
@@ -1426,6 +1426,98 @@ def test_cosmetic_carry_forward_lens_vetoes_on_raw_hash_only_dispatch_failure(
     assert "Dispatch failure recorded for security-review" in r.stdout
 
 
+def test_cosmetic_carry_forward_lens_vetoes_on_current_hash_only_dispatch_failure(
+    tmp_path: Path,
+) -> None:
+    """#1836 test-review finding: the dispatch-failure veto's raw-hash union
+    checks BOTH `stored_raw` (the content actually reviewed) AND
+    `current_hash` (today's exact re-staged content) independently — a
+    failure recorded against ONLY `current_hash`, with nothing against
+    `stored_raw` or the normalized hash, must still veto. Every prior test
+    for this lens wrote the failure against `stored_raw`; this is the first
+    to pin the OTHER half of that union — without it, dropping
+    `current_hash` from the raw_hashes tuple would silently let a commit
+    with a genuine, unsuperseded dispatch failure against today's content
+    pass the gate."""
+    lib_dir = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    import review_gate_normalized_hash as _ngh  # type: ignore[import-not-found]
+
+    repo = _js_repo_with_history(tmp_path)
+    raw = _current_hash(repo)
+    normalized = _ngh.normalized_gate_hash(repo)
+    assert normalized is not None
+
+    _write_dispatch_events(repo, ["correctness-review", "structure-review"], raw)
+    log = repo / ".claude" / "metrics" / "boundary-events.jsonl"
+    lines = [json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
+    for entry in lines:
+        entry["subject_hash_normalized"] = normalized
+    log.write_text("\n".join(json.dumps(e) for e in lines) + "\n")
+
+    gate_path = repo / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(f"{raw}\n{normalized}\n")
+
+    (repo / "a.js").write_text("function f() {\n      return 2\n}\n")
+    subprocess.run(["git", "add", "a.js"], cwd=repo, env=hermetic_git_env(home=repo), check=True)
+
+    # Recorded against today's exact post-re-stage hash — NOT `raw`
+    # (stored_raw) and not the normalized hash.
+    current_hash = _current_hash(repo)
+    _write_dispatch_failure(repo, "security-review", current_hash)
+
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "Dispatch failure recorded for security-review" in r.stdout
+
+
+def test_cosmetic_carry_forward_lens_treats_blank_stored_raw_as_not_decisive(
+    tmp_path: Path,
+) -> None:
+    """#1836 closing-pass security/correctness review: a malformed
+    `.review-passed` (blank first line, valid second line) must fall
+    through to the generic `_BLOCK_MESSAGE` rejection, NOT reach
+    `_evaluate_carry_forward` with a falsy `stored_raw` — that function now
+    treats any falsy raw-hash binding as unprovable, which would render
+    through the SAME sentinel a genuine registry read failure uses,
+    misattributing a malformed gate file as "could not read the registered
+    review-agent set"."""
+    lib_dir = _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib"
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    import review_gate_normalized_hash as _ngh  # type: ignore[import-not-found]
+
+    repo = _js_repo_with_history(tmp_path)
+    raw = _current_hash(repo)
+    normalized = _ngh.normalized_gate_hash(repo)
+    assert normalized is not None
+
+    _write_dispatch_events(repo, ["correctness-review", "structure-review"], raw)
+    log = repo / ".claude" / "metrics" / "boundary-events.jsonl"
+    lines = [json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
+    for entry in lines:
+        entry["subject_hash_normalized"] = normalized
+    log.write_text("\n".join(json.dumps(e) for e in lines) + "\n")
+
+    gate_path = repo / ".claude" / "memory" / ".review-passed"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(f"\n{normalized}\n")  # blank first line, valid second
+
+    (repo / "a.js").write_text("function f() {\n      return 2\n}\n")
+    subprocess.run(["git", "add", "a.js"], cwd=repo, env=hermetic_git_env(home=repo), check=True)
+
+    r = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, cwd=repo
+    )
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert r.stdout == _pcr._BLOCK_MESSAGE
+    assert "registered review-agent set" not in r.stdout
+
+
 def test_cosmetic_carry_forward_lens_vetoes_before_the_count_check(tmp_path: Path) -> None:
     """#1763 security review: the veto must be checked BEFORE the `>= 2`
     distinct-dispatch count on the cosmetic path too — same priority order
@@ -1614,15 +1706,25 @@ def test_plugin_version_returns_unknown_when_manifest_missing(
 # fallback stand-in for `review_gate_corroboration.LedgerEvidence`) hand-
 # duplicates its field shape with no test asserting parity — a future field
 # addition to the real NamedTuple could silently leave the degraded path
-# stale without this.
+# stale without this. #1836 extends the same guard to
+# `CosmeticCarryForwardEvidence`, the second real shape this same stand-in
+# now serves (via `_evaluate_carry_forward`) — without this, a future field
+# added there but not to `_DegradedLedgerEvidence` would raise
+# `AttributeError` inside `_cosmetic_carry_forward_verdict`'s blanket
+# `except Exception: return None`, silently making the carry-forward lens
+# permanently non-decisive with no test failure and no operator-visible
+# signal.
 # ---------------------------------------------------------------------------
 
 
 def test_degraded_ledger_evidence_field_shape_matches_real_ledger_evidence() -> None:
     """Compares `_DegradedLedgerEvidence`'s field shape (names AND order)
-    against the real `review_gate_corroboration.LedgerEvidence` NamedTuple —
-    a future field added to the real shape without updating this hand-
-    written stand-in now fails a test instead of silently drifting.
+    against the real `review_gate_corroboration.LedgerEvidence` NamedTuple,
+    and additionally against `CosmeticCarryForwardEvidence`'s field set
+    (subset, since the stand-in's fields are a superset covering both real
+    shapes) — a future field added to either real shape without updating
+    this hand-written stand-in now fails a test instead of silently
+    drifting.
 
     Triggers the ImportError-fallback path in a FRESH subprocess, not via
     the in-process `sys.modules["artifact_paths"] = None` + re-exec trick
@@ -1668,6 +1770,7 @@ def test_degraded_ledger_evidence_field_shape_matches_real_ledger_evidence() -> 
     import review_gate_corroboration as _rgc  # type: ignore[import-not-found]
 
     assert degraded_fields == _rgc.LedgerEvidence._fields
+    assert set(_rgc.CosmeticCarryForwardEvidence._fields) <= set(degraded_fields)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/tests/hooks/test_review_gate_corroboration.py
+++ b/plugins/dev-team/tests/hooks/test_review_gate_corroboration.py
@@ -699,6 +699,158 @@ def test_distinct_normalized_dispatches_empty_hash_fails_closed_on_negative_evid
 
 
 # ---------------------------------------------------------------------------
+# evaluate_cosmetic_carry_forward() — single-read-pass evidence for the
+# normalized-hash binding plus every raw-hash binding (#1836 perf fix and
+# the security/correctness findings raised against its first draft: no
+# ledger/registry read-count regression, and the sentinel must never mix
+# into a union with real agent names).
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_cosmetic_carry_forward_missing_ledger_fails_closed(tmp_path: Path) -> None:
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", ("raw-a", "raw-b")
+    )
+    assert result == (frozenset(), "missing", rgc._UNPROVABLE_DISPATCH_FAILURE)
+
+
+def test_evaluate_cosmetic_carry_forward_unreadable_ledger_fails_closed(
+    tmp_path: Path,
+) -> None:
+    log = tmp_path / ".claude" / "metrics" / "boundary-events.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_bytes(b"\xff\xfe\x00not valid utf-8\x80\x81")
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", ("raw-a",)
+    )
+    assert result.read_failure_reason == "unreadable"
+    assert result.dispatch_failure_agents == rgc._UNPROVABLE_DISPATCH_FAILURE
+
+
+def test_evaluate_cosmetic_carry_forward_registry_failure_is_pure_sentinel_not_mixed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A registry-read failure must make the WHOLE result the sentinel —
+    never mixed with the real agents_in_window a positive normalized-hash
+    dispatch would otherwise contribute."""
+    _write_ledger(
+        tmp_path, [_record_normalized("2026-01-01T11:55:00Z", "security-review", "norm-hash-1")]
+    )
+    monkeypatch.setattr(rgc, "_registered_agents", lambda: None)
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", ("raw-a",)
+    )
+    assert result.read_failure_reason is None
+    assert result.dispatch_failure_agents == rgc._UNPROVABLE_DISPATCH_FAILURE
+
+
+def test_evaluate_cosmetic_carry_forward_falsy_normalized_hash_never_mixes_sentinel_with_real_raw_failure(
+    tmp_path: Path,
+) -> None:
+    """#1836 security/correctness review regression test: a falsy
+    `subject_hash_normalized` contributes the unprovable sentinel for its
+    own slot, but a genuine raw-hash dispatch-failure elsewhere must not get
+    unioned WITH that sentinel into a mixed set — the caller's `==` sentinel
+    check in `pre_commit_review.py` cannot detect a mixed set, and
+    `_dispatch_failure_message` would render the sentinel string as if it
+    were a real agent name. The whole result must be EXACTLY the sentinel."""
+    _write_ledger(tmp_path, [_dispatch_failure("2026-01-01T11:55:00Z", "security-review")])
+    result = rgc.evaluate_cosmetic_carry_forward(tmp_path, _ANCHOR, _WINDOW, "", (_HASH,))
+    assert result.agents_in_window == frozenset()
+    assert result.dispatch_failure_agents == rgc._UNPROVABLE_DISPATCH_FAILURE
+    assert "security-review" not in result.dispatch_failure_agents
+
+
+def test_evaluate_cosmetic_carry_forward_falsy_raw_hash_fails_closed_not_silently_skipped(
+    tmp_path: Path,
+) -> None:
+    """#1836 correctness/security review: a falsy raw hash cannot bind any
+    evidence, so it cannot prove the ABSENCE of a dispatch failure either —
+    silently SKIPPING it would read as an all-clear it never earned. Must
+    make the whole result unprovable, not a no-op."""
+    _write_ledger(
+        tmp_path, [_record_normalized("2026-01-01T11:55:00Z", "security-review", "norm-hash-1")]
+    )
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", ("", "raw-b")
+    )
+    assert result.dispatch_failure_agents == rgc._UNPROVABLE_DISPATCH_FAILURE
+
+
+def test_evaluate_cosmetic_carry_forward_dispatch_failure_bound_only_to_second_raw_hash(
+    tmp_path: Path,
+) -> None:
+    """Closes the fail-open gap test-review flagged: a dispatch-failure
+    recorded against ONLY the second raw hash (modeling `current_hash` when
+    `stored_raw` carries no evidence) must still surface — not just the
+    first raw hash checked."""
+    _write_ledger(tmp_path, [_dispatch_failure("2026-01-01T11:55:00Z", "security-review")])
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", ("unrelated-raw-hash", _HASH)
+    )
+    assert result.dispatch_failure_agents == frozenset({"security-review"})
+
+
+def test_evaluate_cosmetic_carry_forward_duplicate_raw_hashes_counted_once(
+    tmp_path: Path,
+) -> None:
+    _write_ledger(tmp_path, [_dispatch_failure("2026-01-01T11:55:00Z", "security-review")])
+    once = rgc.evaluate_cosmetic_carry_forward(tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", (_HASH,))
+    twice = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", (_HASH, _HASH)
+    )
+    assert once.dispatch_failure_agents == twice.dispatch_failure_agents == frozenset(
+        {"security-review"}
+    )
+
+
+def test_evaluate_cosmetic_carry_forward_bare_str_raw_hash_is_not_iterated_as_characters(
+    tmp_path: Path,
+) -> None:
+    """A bare `str` passed as `raw_hashes` (the natural mistake for a caller
+    with only one raw hash) must be treated as ONE hash, never iterated
+    character-by-character — the latter would silently match nothing and
+    produce a false all-clear."""
+    _write_ledger(tmp_path, [_dispatch_failure("2026-01-01T11:55:00Z", "security-review", _HASH)])
+    result = rgc.evaluate_cosmetic_carry_forward(tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", _HASH)
+    assert result.dispatch_failure_agents == frozenset({"security-review"})
+
+
+def test_evaluate_cosmetic_carry_forward_positive_evidence_only_from_normalized_binding(
+    tmp_path: Path,
+) -> None:
+    """A dispatch recorded only under a raw hash (never the normalized
+    hash) must never contribute to `agents_in_window` — positive evidence
+    stays scoped to the single normalized-hash binding."""
+    _write_ledger(tmp_path, [_record("2026-01-01T11:55:00Z", "security-review", _HASH)])
+    result = rgc.evaluate_cosmetic_carry_forward(
+        tmp_path, _ANCHOR, _WINDOW, "norm-hash-1", (_HASH,)
+    )
+    assert result.agents_in_window == frozenset()
+
+
+def test_evaluate_cosmetic_carry_forward_reads_ledger_exactly_once(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#1836 perf fix: one `_read_ledger` call must answer the
+    normalized-hash query AND every raw-hash binding, not one read per
+    binding. State-based assertions on the returned evidence can't observe
+    this by construction — this spy is the only thing that pins the
+    property the rewrite exists for."""
+    _write_ledger(tmp_path, [_record_normalized("2026-01-01T11:55:00Z", "security-review", "n1")])
+    calls = []
+    real_read_ledger = rgc._read_ledger
+
+    def _spy(cwd):
+        calls.append(cwd)
+        return real_read_ledger(cwd)
+
+    monkeypatch.setattr(rgc, "_read_ledger", _spy)
+    rgc.evaluate_cosmetic_carry_forward(tmp_path, _ANCHOR, _WINDOW, "n1", ("raw-a", "raw-b"))
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # mtime_to_iso()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `_cosmetic_carry_forward_verdict()` read `.claude/metrics/boundary-events.jsonl` up to 3 separate times per call (normalized-hash query, stored-raw-hash query, current-raw-hash query), introduced by #1761-1763's dispatch-failure veto work. Adds `evaluate_cosmetic_carry_forward()` to `review_gate_corroboration.py`, which reads the ledger and the review-agent registry exactly once and answers all hash bindings in one pass via a new shared `_binding_evidence()` helper, matching `evaluate()`'s existing single-read-pass principle.
- `distinct_normalized_dispatches()` now delegates to the new function instead of duplicating the same query logic a third time.
- A 14-agent review panel run against the first draft surfaced a real bug: the sentinel marking "cannot prove no dispatch failure exists" could get unioned with real agent names when the normalized-hash binding was unprovable but a raw-hash binding carried a genuine failure — defeating the caller's `== sentinel` check and letting the sentinel string render as if it were an agent name. Fixed so any unprovable binding makes the *whole* result the sentinel, never mixed. Also closes a fail-open gap where a falsy raw hash was silently skipped instead of treated as unprovable.
- A closing-pass re-review (security, correctness, structure) confirmed the mixing fix but found the falsy-raw-hash fix introduced a narrow misattribution: a malformed `.review-passed` (blank first line, valid second line) would render as "registry read failure" instead of the generic block message. Guarded `stored_raw` before the call so a malformed gate file falls through to the existing rejection instead. A second closing pass confirmed this guard closes the gap with no new regression.
- Adds direct unit tests, a ledger-read-count spy, a degraded-import field-parity guard, and e2e tests for the current_hash-only veto binding and the malformed-gate-file guard.

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_review_gate_corroboration.py plugins/dev-team/tests/hooks/test_pre_commit_review.py -q` — 142 passed
- [x] `ruff check` on all four changed files — clean
- [x] Verified the pre-existing, unrelated Python-3.9-vs-3.10-floor test failures on this machine (`test_stryker_shard_pipeline.py`, `test_run_refactor_experiment.py`, etc.) reproduce identically on a clean `origin/main` baseline under both the system interpreter and the proper `uv`-provisioned 3.10 interpreter — confirmed unrelated to this change
- [x] 14-agent `/code-review`-style panel + two closing-pass rounds against the final diff, converged with no remaining actionable findings

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)