### PR TITLE
fix(farley-score): clarify scoring criteria and add worked examples

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -3662,13 +3662,13 @@
       "summary": "Each property is scored 1-10:",
       "anchor": "the-8-properties"
     },
-    "Scoring": {
-      "summary": "Total weight: 9.0.",
-      "anchor": "scoring"
+    "Scoring anchors — score from evidence, not intuition": {
+      "summary": "Every property score must be justified by a specific line, assertion, or absence you can point to.",
+      "anchor": "scoring-anchors-score-from-evidence-not-intuition"
     },
-    "Per-test score": {
-      "summary": "Total weight: 9.0.",
-      "anchor": "per-test-score"
+    "Weighting": {
+      "summary": "Total weight: 9.0 (or the reduced total when a property is scored `Unknown` per the First rule above — recompute both numerator and denominator without it).",
+      "anchor": "weighting"
     },
     "Score interpretation": {
       "summary": "| Range | Rating | Action |",
@@ -3679,11 +3679,23 @@
       "anchor": "suite-level-score"
     },
     "Output Format": {
-      "summary": "**test-review agent**: Checks coverage and assertion quality; this skill adds quantitative scoring",
+      "summary": "Each row here summarizes one test; the per-property table backing it — every property scored with a citation — is computed the same way as the Worked Example below and must exist even when only this summary row is reported.",
       "anchor": "output-format"
     },
+    "Worked Example": {
+      "summary": "Same test, scored the correct way and an ambiguous way that requires a correction.",
+      "anchor": "worked-example"
+    },
+    "Correct scoring output": {
+      "summary": "This is exactly the shape that forces a correction, for three concrete reasons:",
+      "anchor": "correct-scoring-output"
+    },
+    "Incorrect / ambiguous scoring output (avoid this)": {
+      "summary": "This is exactly the shape that forces a correction, for three concrete reasons:",
+      "anchor": "incorrect-ambiguous-scoring-output-avoid-this"
+    },
     "Integration": {
-      "summary": "**test-review agent**: Checks coverage and assertion quality; this skill adds quantitative scoring",
+      "summary": "**test-review agent**: Farley Score is computed at orchestrator level (`/test-design` for existing tests, `/build` Step 7 for branch tests) — not invoked directly from test-review.",
       "anchor": "integration"
     }
   },

--- a/plugins/dev-team/skills/farley-score/SKILL.md
+++ b/plugins/dev-team/skills/farley-score/SKILL.md
@@ -35,15 +35,33 @@ Each property is scored 1-10:
 | 7 | **Fast** | 0.8 | Does it run quickly enough for the feedback loop? Unit tests <100ms, integration tests <5s, E2E tests <30s. |
 | 8 | **First** | 1.0 | Was it written before or alongside the implementation (TDD)? Evidence: test commit predates implementation, test names describe behavior not implementation. |
 
-## Scoring
+### Scoring anchors — score from evidence, not intuition
 
-### Per-test score
+Every property score must be justified by a specific line, assertion, or absence you can point to. **A score with no citation is a guess — re-read the test before assigning it.** Use these fixed anchors for every property:
+
+| Band | Meaning | Example |
+|------|---------|---------|
+| 1-2 (Critical) | The property is actively violated | Repeatable scored 2: test calls `Date.now()` with no injected clock |
+| 3-4 (Weak) | A real strength is present, but a violation still dominates | Maintainable scored 4: uses a builder for setup, but an assertion still reaches into a private internal field |
+| 5-6 (Partial) | The property holds in general but has a specific counter-example in this test | Understandable scored 6: AAA structure is clear, but the assertion message is generic (`expect(result).toBeTruthy()`) |
+| 7-8 (Solid) | An affirmative strength is cited, and a specific counter-example — a minor gap, not a violation — keeps it below Exemplary | Granular scored 8: asserts the specific error code, but no message text — a failure still needs the source to interpret why |
+| 9-10 (Exemplary) | No counter-example found AND an affirmative strength cited | Atomic scored 10: exactly one behavior verified, no interdependency with other tests |
+
+**9-10**: no counter-example found AND an affirmative strength cited. **Below 9**: a specific counter-example is required, UNLESS a strength justifies pulling a 1-2 score up into the 3-6 range.
+
+**Property-specific rules that remove the most common ambiguity:**
+
+- **First**: commit history is the primary evidence. When commit history is unavailable (e.g. reviewing a working tree with no VCS access), do not guess a number — fall back to the observable proxy: does the test name describe *behavior* (`should reject invalid email format`) or *mechanism* (`calls validateEmail with a regex`)? Behavior-named tests score 7-8 on this proxy alone (not 9-10 — the proxy is weaker evidence than commit history). If neither commit history nor a readable test name is available, mark the property `Unknown`, drop it from both the numerator and the weight total in the Farley Score formula, and state in the output that it was excluded — never substitute a default (e.g. 5) for missing evidence.
+- **Necessary**: "duplicates another test" must name the specific other test by identifier. Never mark a test not-necessary from a hunch that "something else probably covers this."
+- **Atomic**: multiple assertions on the *same* result object are one behavior, not a violation — do not penalize this pattern (see property description).
+
+### Weighting
 
 ```
 Farley Score = (sum of property_score × weight) / (sum of weights)
 ```
 
-Total weight: 9.0. Maximum score: 10.0.
+Total weight: 9.0 (or the reduced total when a property is scored `Unknown` per the First rule above — recompute both numerator and denominator without it). Maximum score: 10.0. This produces a 1-10 scale — never multiply by 10 or present it as a percentage.
 
 ### Score interpretation
 
@@ -86,8 +104,59 @@ Average the per-test scores. Report the distribution (how many Exemplary, Good, 
 | `test edge case` | 5.1 | Necessary (3) | Unclear what edge case — specify the condition |
 ```
 
+Each row here summarizes one test; the per-property table backing it — every property scored with a citation — is computed the same way as the Worked Example below and must exist even when only this summary row is reported.
+
+## Worked Example
+
+Same test, scored the correct way and an ambiguous way that requires a correction. Use the correct version as the literal template; the incorrect version names the specific defects that made past outputs get redirected.
+
+**Test under review:**
+
+```js
+test('should reject invalid email format', () => {
+  const result = validateEmail('not-an-email');
+  expect(result.isValid).toBe(false);
+  expect(result.error).toBe('INVALID_FORMAT');
+});
+```
+
+### Correct scoring output
+
+```markdown
+| Property | Score | Weight | Citation |
+|----------|-------|--------|----------|
+| Understandable | 9 | 1.5 | Name states the behavior; single arrange-act-assert block, no hidden setup |
+| Maintainable | 8 | 1.5 | Asserts on the public `result` shape, not `validateEmail`'s internals, but the literal `'not-an-email'` input is inlined rather than named — a reader must infer why this string was chosen |
+| Repeatable | 10 | 1.2 | Pure function call — no time, network, or shared state |
+| Atomic | 9 | 1.0 | One behavior (rejecting a bad format); both assertions target the same result object |
+| Necessary | 8 | 1.0 | Real edge case; no other test in the file asserts `INVALID_FORMAT`, but the test doesn't state why this specific malformed string was chosen over other invalid formats |
+| Granular | 8 | 1.0 | Asserts the specific error code, but no message text — a failure still needs the source to interpret why |
+| Fast | 10 | 0.8 | Unit test, no I/O |
+| First | 7 | 1.0 | No commit history available; falling back to the name proxy — behavior-named, so 7-8 per the First rule, not 9-10 |
+
+Farley Score = (9×1.5 + 8×1.5 + 10×1.2 + 9×1.0 + 8×1.0 + 8×1.0 + 10×0.8 + 7×1.0) / 9.0 = 77.5 / 9.0 = **8.6 (Good)**
+
+| Test | Score | Weakest Property | Suggestion |
+|------|-------|-------------------|------------|
+| `should reject invalid email format` | 8.6 | First (7) | Confirm test predates implementation via commit history when available |
+```
+
+### Incorrect / ambiguous scoring output (avoid this)
+
+```markdown
+| Test | Score | Weakest Property | Suggestion |
+|------|-------|-------------------|------------|
+| `should reject invalid email format` | 7 | — | Looks fine overall |
+```
+
+This is exactly the shape that forces a correction, for three concrete reasons:
+
+1. **No per-property breakdown.** For a test scored individually — not summarized in a suite's Per-Test Scores table — a single number with no property scores or citations cannot be audited or reproduced; there is no way to tell if `7` came from the weighted formula or was guessed.
+2. **`Weakest Property` left blank.** The Output Format table requires naming the weakest property so the suggestion is actionable; `—` gives the reader nothing to act on.
+3. **No arithmetic shown.** The correct output's total (77.5 / 9.0 = 8.6) is checkable by re-adding the eight weighted rows; `7` with no visible sum is unverifiable and, per the Scoring anchors rule above, a score with no citation is a guess.
+
 ## Integration
 
-- **test-review agent**: Checks coverage and assertion quality; this skill adds quantitative scoring
+- **test-review agent**: Farley Score is computed at orchestrator level (`/test-design` for existing tests, `/build` Step 7 for branch tests) — not invoked directly from test-review.
 - **QA Engineer agent**: Uses Farley Score in quality reports
 - **Mutation testing skill**: Farley Score complements mutation score — high Farley + low mutation = assertions too weak

--- a/plugins/dev-team/tests/skills/test_farley_score_worked_example.py
+++ b/plugins/dev-team/tests/skills/test_farley_score_worked_example.py
@@ -1,0 +1,78 @@
+"""Content checks for farley-score/SKILL.md's clarified scoring criteria and
+worked example (issue #1776) — high correction-to-invocation ratio was caused
+by ambiguous scoring logic and an unclear expected output shape.
+"""
+
+from __future__ import annotations
+
+from _repo_root import REPO_ROOT
+
+SKILL = REPO_ROOT / "plugins" / "dev-team" / "skills" / "farley-score" / "SKILL.md"
+
+
+def _text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def test_scoring_anchors_section_present() -> None:
+    text = _text()
+    assert "### Scoring anchors — score from evidence, not intuition" in text, (
+        "farley-score/SKILL.md is missing the scoring-anchors clarification "
+        "for the 8-property rubric"
+    )
+    assert "A score with no citation is a guess" in text, (
+        "scoring anchors section must state that every score needs a citation"
+    )
+
+
+def test_first_property_unknown_fallback_rule_present() -> None:
+    text = _text()
+    assert "mark the property `Unknown`" in text, (
+        "farley-score/SKILL.md is missing the explicit fallback rule for "
+        "scoring 'First' when commit history is unavailable"
+    )
+    assert "never substitute a default (e.g. 5) for missing evidence" in text, (
+        "the Unknown fallback rule must forbid substituting a default score"
+    )
+
+
+def test_weighting_clarification_present() -> None:
+    text = _text()
+    assert "never multiply by 10 or present it as a percentage" in text, (
+        "farley-score/SKILL.md is missing the weighting clarification that "
+        "the Farley Score is a 1-10 scale, not a percentage"
+    )
+
+
+def test_worked_example_section_present() -> None:
+    text = _text()
+    assert "## Worked Example" in text, (
+        "farley-score/SKILL.md is missing a Worked Example section"
+    )
+    assert "### Correct scoring output" in text, (
+        "Worked Example must contain a correct scoring output subsection"
+    )
+    assert (
+        "### Incorrect / ambiguous scoring output (avoid this)" in text
+    ), "Worked Example must contrast a correct output against an incorrect/ambiguous one"
+
+
+def test_worked_example_shows_verifiable_arithmetic() -> None:
+    text = _text()
+    assert "77.5 / 9.0 = **8.6 (Good)**" in text, (
+        "the correct worked example must show the full weighted-sum arithmetic "
+        "so the score is independently verifiable"
+    )
+
+
+def test_worked_example_names_incorrect_output_defects() -> None:
+    text = _text()
+    assert "No per-property breakdown." in text, (
+        "the incorrect example must name the missing per-property breakdown as a defect"
+    )
+    assert "`Weakest Property` left blank." in text, (
+        "the incorrect example must name the blank Weakest Property field as a defect"
+    )
+    assert "No arithmetic shown." in text, (
+        "the incorrect example must name the missing arithmetic as a defect"
+    )


### PR DESCRIPTION
Closes #1776

## Summary
- Added scoring anchors (evidence bands 1-2/3-4/5-6/7-8/9-10) and property-specific disambiguation rules (First's Unknown fallback, Necessary's must-name-the-duplicate rule, Atomic's multi-assertion clarification).
- Added a Worked Example contrasting a correct, fully-cited scoring output against an incorrect/ambiguous one with 3 named defects.
- Fixed the Integration section's inaccurate claim that test-review invokes Farley Score directly (it doesn't — orchestrator-level only).

## Test plan
- [x] New content-check test: `test_farley_score_worked_example.py` (6 assertions)
- [x] Full suite green: 7591 passed, 43 pre-existing skips
- [x] 2-round light review (doc-review, correctness-review) — both passed after fixing a band-table/worked-example internal contradiction the first draft introduced
- [x] Worked-example arithmetic hand-verified correct (77.5 / 9.0 = 8.6)
