### PR TITLE
fix(session-review): guard the dev-checkout-only extractor dependency

### DIFF
--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5497,8 +5497,12 @@
       "anchor": "argument-arguments"
     },
     "Steps": {
-      "summary": "Before running fresh analysis, check whether background analysis has produced",
+      "summary": "`/session-review` is maintainer-only tooling that operates on this repo's own",
       "anchor": "steps"
+    },
+    "Pre-flight — dev-checkout guard (#1779)": {
+      "summary": "`/session-review` is maintainer-only tooling that operates on this repo's own",
+      "anchor": "pre-flight-dev-checkout-guard-1779"
     },
     "0. Queued Findings — surface pending-review queue before fresh analysis": {
       "summary": "Before running fresh analysis, check whether background analysis has produced",

--- a/plugins/dev-team/skills/session-review/SKILL.md
+++ b/plugins/dev-team/skills/session-review/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 argument-hint: "[--cwd <path>] [--transcript <file>] [--out <report>] [--cross-machine]"
 user-invocable: true
 allowed-tools: >-
-  Read, Glob, Bash(python3 *, date *, mkdir *), Write, Agent
+  Read, Glob, Bash(python3 *, date *, mkdir *, test *, echo *, bash *), Write, Agent
 ---
 
 # Session Review (#131)
@@ -46,6 +46,30 @@ You have been invoked with the `/session-review` command.
 - `--cross-machine`: opt into cross-machine telemetry sync + rollup (#1480). **Absent by default** — a plain `/session-review` analyzes only this machine's local digest. See Step 1.
 
 ## Steps
+
+### Pre-flight — dev-checkout guard (#1779)
+
+`/session-review` is maintainer-only tooling that operates on this repo's own
+infrastructure — its extractor (`session_extract.py`, `eval_rawlog.py`) is
+deliberately monorepo-only, never shipped inside the plugin (see
+`tests/repo/test_shipped_script_refs.py`'s `ESCAPE_ALLOWLIST` for the
+rationale). Before Step 0 — this Pre-flight section runs first — check that
+the extractor actually exists at the path every later command references:
+
+```bash
+test -f "${CLAUDE_PLUGIN_ROOT}/../../scripts/session_extract.py" \
+  && test -f "${CLAUDE_PLUGIN_ROOT}/../../scripts/eval_rawlog.py" \
+  && echo present || echo absent
+```
+
+If `absent` (the normal case for every downstream install, and any dev
+checkout missing the repo-root `scripts/` tree — e.g. a shallow or
+sparse clone), stop here and tell the user plainly: "`/session-review`
+requires the `agentic-dev-team` monorepo dev checkout (it mines this repo's
+own session telemetry) — not available from an installed plugin cache." Do
+not proceed to Step 0 or run any command that references
+`session_extract.py`; a raw `FileNotFoundError` traceback is not an
+acceptable substitute for this message.
 
 ### 0. Queued Findings — surface pending-review queue before fresh analysis
 

--- a/tests/skills/test_session_review_dev_checkout_guard.py
+++ b/tests/skills/test_session_review_dev_checkout_guard.py
@@ -1,0 +1,57 @@
+"""#1779 — `/session-review` must guard its dev-checkout-only dependency
+(`scripts/session_extract.py`) instead of letting a downstream install hit a
+raw `FileNotFoundError`.
+
+`session_extract.py`/`eval_rawlog.py` are deliberately monorepo-only tooling
+that is never shipped inside the plugin (`tests/repo/test_shipped_script_refs.py`'s
+`ESCAPE_ALLOWLIST` documents why) — the original bug report proposed packaging
+them, which would violate that existing, tested design decision. The actual
+fix is a pre-flight guard that reports the real cause clearly instead of a
+raw traceback.
+"""
+
+from __future__ import annotations
+
+import re
+
+from skill_doc_helpers import PLUGIN_ROOT, collapsed
+
+SESSION_REVIEW = (PLUGIN_ROOT / "skills" / "session-review" / "SKILL.md").read_text(
+    encoding="utf-8"
+)
+
+
+def test_pre_flight_guard_checks_for_session_extract_presence():
+    body = collapsed(SESSION_REVIEW)
+    section = re.search(r"Pre-flight — dev-checkout guard.*?(?=###|\Z)", body, flags=re.DOTALL)
+    assert section, "expected a Pre-flight guard section before Step 0/2"
+    assert "session_extract.py" in section.group(0)
+    assert "eval_rawlog.py" in section.group(0)
+
+
+def test_frontmatter_allowlists_test_and_echo_for_the_guard():
+    frontmatter = SESSION_REVIEW.split("---")[1]
+    assert "test *" in frontmatter
+    assert "echo *" in frontmatter
+
+
+def test_frontmatter_allowlists_bash_for_telemetry_sync():
+    # Pre-existing gap (not introduced by #1779): Step 1's telemetry-sync.sh
+    # calls were never in the Bash allowlist either.
+    frontmatter = SESSION_REVIEW.split("---")[1]
+    assert "bash *" in frontmatter
+
+
+def test_pre_flight_guard_states_the_clear_user_facing_message():
+    body = collapsed(SESSION_REVIEW)
+    section = re.search(r"Pre-flight — dev-checkout guard.*?(?=###|\Z)", body, flags=re.DOTALL)
+    assert section
+    assert "monorepo dev checkout" in section.group(0)
+    assert "not available from an installed plugin cache" in section.group(0)
+
+
+def test_pre_flight_guard_forbids_a_raw_traceback():
+    body = collapsed(SESSION_REVIEW)
+    section = re.search(r"Pre-flight — dev-checkout guard.*?(?=###|\Z)", body, flags=re.DOTALL)
+    assert section
+    assert "FileNotFoundError" in section.group(0)


### PR DESCRIPTION
Closes #1779

## Summary
The original bug report proposed packaging `session_extract.py`/`eval_rawlog.py` into the shipped plugin. That would violate an existing, documented, tested design decision: `tests/repo/test_shipped_script_refs.py`'s `ESCAPE_ALLOWLIST` states these scripts are deliberately monorepo-only maintainer tooling, never shipped.

Instead: added a Pre-flight guard to `/session-review` that checks for both scripts before Step 0/2 ever reference them, and reports a clear message ("requires the monorepo dev checkout... not available from an installed plugin cache") instead of a raw `FileNotFoundError`. Also fixed two pre-existing gaps found while implementing the guard: the skill's own `allowed-tools` frontmatter was missing `test *`/`echo *` (needed by the new guard) and `bash *` (needed by Step 1's pre-existing `telemetry-sync.sh` call, which was never actually permitted).

## Test plan
- [x] New content-check tests: `test_session_review_dev_checkout_guard.py` (5 assertions)
- [x] Full suite green: 7600 passed, 43 pre-existing skips
- [x] Light review (doc-review, correctness-review) — found and fixed the allowed-tools gap that would have made the guard itself unable to run under a restrictive allowlist
