### PR TITLE
fix(coverage-discovery): expand brace globs, normalize .sln separators, validate ** explicitly

### DIFF
--- a/plugins/dev-team/scripts/coverage_discovery_dotnet.py
+++ b/plugins/dev-team/scripts/coverage_discovery_dotnet.py
@@ -30,7 +30,11 @@ classifies `NOT_TEST` — see the plan's Risks section.
 **Security hardening.** Every resolved project path is verified to stay
 within the resolved repository root before it is read or classified — a
 `.sln` entry containing `..` or an absolute path can never cause this
-module to read or XML-parse a file outside the repository. Every `.csproj`
+module to read or XML-parse a file outside the repository. Separator
+normalization (see `_parse_sln_list_output`, issue #1828) happens before
+that check, so a backslash-separated `..\\outside\\Evil.csproj` is refused
+like its forward-slash form instead of slipping past as one opaque
+filename. Every `.csproj`
 and `Directory.Build.props` file is also screened for `<!DOCTYPE`/
 `<!ENTITY` declarations before being parsed (entity-expansion hardening) —
 neither file legitimately carries either.
@@ -128,6 +132,14 @@ def discover_dotnet_projects(repo_root):
 
     projects = []
     for rel_path in project_rel_paths:
+        absolute_problem = _absolute_entry_problem(rel_path)
+        if absolute_problem is not None:
+            return coverage_config.discovery_error(
+                f"Solution '{sln_path.name}' references project "
+                f"'{rel_path}', which {absolute_problem}. Only "
+                "solution-relative project paths are supported; refusing to "
+                "read or classify it."
+            )
         csproj_path = (root / rel_path).resolve()
         if not (csproj_path == root or root in csproj_path.parents):
             return coverage_config.discovery_error(
@@ -148,9 +160,52 @@ def discover_dotnet_projects(repo_root):
     return projects
 
 
+def _absolute_entry_problem(rel_path: str) -> str | None:
+    """Return a reason when a (already separator-normalized) `.sln` entry is an
+    absolute path rather than a solution-relative one, else `None`.
+
+    Checked explicitly rather than left to `PurePosixPath.is_absolute()`,
+    which is platform-divergent for exactly the shapes a Windows-authored
+    solution produces: a drive-letter path like `C:/Projects/App.csproj` is
+    NOT absolute on POSIX, so it would silently become a nonsense subpath of
+    the repo root and fail with a misleading "does not exist on disk" instead
+    of naming the real problem. A UNC path normalizes to a leading `//`, which
+    IS absolute on POSIX — so without this check the same input produces two
+    different diagnostics depending on the runner's OS."""
+    if len(rel_path) >= 2 and rel_path[1] == ":" and rel_path[0].isalpha():
+        return "is an absolute Windows path (drive letter)"
+    if rel_path.startswith("//"):
+        return "is an absolute UNC network path"
+    if rel_path.startswith("/"):
+        return "is an absolute path"
+    return None
+
+
 def _parse_sln_list_output(stdout: str) -> list:
-    """Parse `dotnet sln list`'s stdout into a list of project paths exactly
-    as printed, skipping the `Project(s)` header and its underline."""
+    """Parse `dotnet sln list`'s stdout into a list of repo-relative project
+    paths in POSIX form, skipping the `Project(s)` header and its underline.
+
+    **Separator normalization (issue #1828).** `dotnet sln list` echoes the
+    separators the `.sln` was authored with, and a Windows-authored solution
+    emits backslashes. On POSIX `pathlib` treats `src\\App\\App.csproj` as a
+    single opaque filename — `PurePath(...).name` returns the whole string —
+    so the `.csproj` is never found and every project in the solution fails
+    the "does not exist on disk" check even though the file is present. Since
+    most enterprise .NET solutions are Windows-authored and their CI is
+    commonly Linux, that made .NET discovery non-functional for them.
+
+    Backslashes are therefore normalized to `/` here, once, at parse time.
+    This is deliberately unconditional rather than POSIX-only: it keeps the
+    recorded path identity — the string every caller compares against
+    `included`/`excluded` entries — byte-identical across platforms, so a
+    `coverage-config.json` written on Windows still reconciles on Linux.
+    Normalizing before the caller's containment check also keeps the `..`
+    traversal guard effective on backslash-separated escapes, which
+    previously slipped past it as opaque filenames.
+
+    Accepted limitation: a genuine POSIX filename containing a literal
+    backslash would be rewritten. MSBuild solution files always use `\\` as a
+    separator, so such a path does not occur in `.sln` output."""
     projects = []
     for raw_line in stdout.splitlines():
         line = raw_line.strip()
@@ -160,7 +215,7 @@ def _parse_sln_list_output(stdout: str) -> list:
             continue
         if set(line) == {"-"}:
             continue
-        projects.append(line)
+        projects.append(line.replace("\\", "/"))
     return projects
 
 

--- a/plugins/dev-team/scripts/coverage_discovery_js.py
+++ b/plugins/dev-team/scripts/coverage_discovery_js.py
@@ -27,7 +27,25 @@ rendering, which is applied once at resolution time, not per comparison).
 **Security hardening.** Every glob-resolved package directory is verified to
 stay within the resolved repository root before it is read or classified — a
 workspace glob containing `..` can never cause this module to read or
-classify a directory outside the repository.
+classify a directory outside the repository. Brace expansion (below) happens
+*before* that containment check, so an escaping path hidden inside a single
+brace alternative (`{apps,../outside}/*`) is refused exactly like a bare
+`../outside/*`.
+
+**Brace expansion (issue #1827).** npm, yarn and pnpm all accept shell-style
+brace alternations in workspace globs (`apps/{web,api}`), but `pathlib` does
+not expand them — it looks for a literal directory named `{web,api}` and
+finds nothing. Each declared glob is therefore expanded into its
+alternatives here before being resolved. Multiple groups expand as a
+cartesian product and nested groups expand recursively, matching the package
+managers. An unbalanced brace is a `discovery_error`, never a silent
+fallthrough to zero matches.
+
+**Explicit `**` validation (issue #1832).** `**` placement is validated by
+inspecting each path component rather than by catching `ValueError` from
+`Path.glob`. CPython 3.13+ accepts a non-component `**` and treats it as
+`*`, so the exception this module previously relied on is no longer raised
+there — which turned a `discovery_error` into a silent empty result.
 
 **Minimal pnpm-workspace.yaml parser.** This module never imports PyYAML
 (stdlib-only, ADR 0014/0015) and does not implement general YAML. It
@@ -228,6 +246,146 @@ def _parse_lerna_json(path: Path):
     return packages if isinstance(packages, list) else []
 
 
+class _UnbalancedBrace(Exception):
+    """Raised internally by `_expand_braces` for a glob whose braces do not
+    pair up. Converted to a `coverage_config.discovery_error` by the caller —
+    never allowed to surface as an empty match set."""
+
+
+class _BraceExpansionTooLarge(Exception):
+    """Raised internally by `_expand_braces` for a glob whose expansion would
+    exceed `_MAX_BRACE_EXPANSIONS` alternatives or `_MAX_BRACE_NESTING` levels
+    of nesting. Converted to a `coverage_config.discovery_error` by the
+    caller. Brace expansion is a cartesian product, so a modest-looking
+    pattern (20 two-way groups) yields 2**20 globs and as many filesystem
+    walks; deep nesting recurses per level and would otherwise surface as an
+    uncaught `RecursionError` traceback rather than a discovery error."""
+
+
+# Generous enough that no legitimate npm/yarn/pnpm workspace declaration comes
+# close, small enough that a pathological `package.json` cannot turn discovery
+# into a filesystem-walk bomb.
+_MAX_BRACE_EXPANSIONS = 256
+_MAX_BRACE_NESTING = 16
+
+
+def _brace_balance_problem(pattern: str) -> str | None:
+    """Return a reason when `pattern`'s braces do not pair up, else `None`.
+
+    Validated across the WHOLE pattern in one pass, deliberately: an earlier
+    version of this module scanned only from the first `{` onward, so a stray
+    `}` to its left (`apps/}x{a,b}`) was copied verbatim into the literal
+    prefix and expanded to globs that match nothing — reintroducing the exact
+    silent-zero-packages outcome #1827 exists to prevent. Both reviewers of
+    that change caught it independently; hence a single global check rather
+    than a per-recursion one."""
+    depth = 0
+    max_depth = 0
+    for index, char in enumerate(pattern):
+        if char == "{":
+            depth += 1
+            max_depth = max(max_depth, depth)
+        elif char == "}":
+            depth -= 1
+            if depth < 0:
+                return (
+                    f"closes a brace group at position {index} that was never "
+                    "opened"
+                )
+    if depth > 0:
+        return f"leaves {depth} brace group(s) unclosed"
+    if max_depth > _MAX_BRACE_NESTING:
+        return (
+            f"nests brace groups {max_depth} deep, beyond the supported "
+            f"maximum of {_MAX_BRACE_NESTING}"
+        )
+    return None
+
+
+def _expand_braces(pattern: str) -> list:
+    """Expand shell-style brace alternations in `pattern` into the list of
+    concrete globs npm/yarn/pnpm would resolve (issue #1827).
+
+    `apps/{web,api}` -> `['apps/web', 'apps/api']`. Multiple groups expand as
+    a cartesian product; nested groups expand recursively. A pattern with no
+    braces returns itself unchanged, so this is safe to apply to every glob.
+
+    Raises `_UnbalancedBrace` when the braces do not pair up anywhere in the
+    pattern — the package managers reject those too, and treating them as a
+    literal path would silently resolve to nothing. Raises
+    `_BraceExpansionTooLarge` when the expansion would exceed
+    `_MAX_BRACE_EXPANSIONS`."""
+    problem = _brace_balance_problem(pattern)
+    if problem is not None:
+        raise _UnbalancedBrace(problem)
+    return _expand_braces_balanced(pattern)
+
+
+def _expand_braces_balanced(pattern: str) -> list:
+    """Recursive worker for `_expand_braces`, assuming `pattern`'s braces are
+    already known to balance (every sub-pattern of a balanced pattern is
+    itself balanced, so the global check runs once at entry, not per level)."""
+    open_idx = pattern.find("{")
+    if open_idx == -1:
+        return [pattern]
+
+    depth = 0
+    close_idx = -1
+    alternatives = []
+    alt_start = open_idx + 1
+    for i in range(open_idx, len(pattern)):
+        char = pattern[i]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                alternatives.append(pattern[alt_start:i])
+                close_idx = i
+                break
+        elif char == "," and depth == 1:
+            alternatives.append(pattern[alt_start:i])
+            alt_start = i + 1
+    prefix = pattern[:open_idx]
+    expanded_suffixes = _expand_braces_balanced(pattern[close_idx + 1 :])
+    expanded = []
+    for alternative in alternatives:
+        for expanded_alt in _expand_braces_balanced(alternative):
+            for suffix in expanded_suffixes:
+                expanded.append(prefix + expanded_alt + suffix)
+                if len(expanded) > _MAX_BRACE_EXPANSIONS:
+                    raise _BraceExpansionTooLarge(
+                        f"expands to more than {_MAX_BRACE_EXPANSIONS} "
+                        "alternatives"
+                    )
+    return expanded
+
+
+def _double_star_placement_problem(pattern: str) -> str | None:
+    """Return a human-readable reason when `pattern`'s `**` usage is one this
+    module refuses to resolve, else `None` (issue #1832).
+
+    Checked by inspecting path components rather than by catching `ValueError`
+    from `Path.glob`: CPython 3.13+ accepts a non-component `**` and silently
+    treats it as `*`, so the exception this module used to depend on is not
+    raised on every supported interpreter. A version-dependent guard here
+    meant a malformed glob became an empty result instead of an error."""
+    if pattern.count("**") > 1:
+        return (
+            "contains more than one '**' segment; no legitimate "
+            "npm/yarn/pnpm workspace glob needs more than one, and multiple "
+            "non-adjacent '**' segments can cause pathological "
+            "filesystem-walk cost"
+        )
+    for component in pattern.split("/"):
+        if "**" in component and component != "**":
+            return (
+                f"places '**' inside the path component {component!r}; '**' "
+                "must be an entire path component of its own"
+            )
+    return None
+
+
 def _resolve_globs_to_rel_paths(root: Path, globs: list):
     """Resolve each glob in `globs` against `root`'s filesystem, keeping
     only matches that are directories containing their own `package.json`.
@@ -235,40 +393,100 @@ def _resolve_globs_to_rel_paths(root: Path, globs: list):
     `coverage_config.discovery_error(...)` naming: the first resolved match
     found outside `root` (e.g. a glob containing `..`) — refusing to include
     or silently drop it; a glob pattern this module refuses to resolve at
-    all (an absolute path, a malformed `**` placement, or more than one
-    `**` segment); or a filesystem error encountered while resolving it."""
+    all (an absolute path, an unbalanced brace, a malformed `**` placement,
+    or more than one `**` segment); or a filesystem error encountered while
+    resolving it.
+
+    Brace alternations are expanded first (`_expand_braces`), so every check
+    below — including the containment guard — runs against each concrete
+    alternative rather than the unexpanded pattern."""
     rel_paths = set()
-    for pattern in globs:
-        if not isinstance(pattern, str) or not pattern:
+    for declared_pattern in globs:
+        if not isinstance(declared_pattern, str) or not declared_pattern:
             continue
-        if pattern.count("**") > 1:
+        # The `**` budget is enforced on the DECLARED pattern, not only on each
+        # expanded alternative: brace multiplication would otherwise smuggle
+        # several `**` walks past a per-alternative check ({**/x,**/y,**/z} is
+        # three single-`**` alternatives), defeating the cost guard's purpose.
+        if declared_pattern.count("**") > 1:
             return coverage_config.discovery_error(
-                f"Workspace glob {pattern!r} contains more than one '**' "
-                "segment; no legitimate npm/yarn/pnpm workspace glob needs "
-                "more than one, and multiple non-adjacent '**' segments can "
-                "cause pathological filesystem-walk cost. Refusing to "
+                f"Workspace glob {declared_pattern!r} contains more than one "
+                "'**' segment; no legitimate npm/yarn/pnpm workspace glob "
+                "needs more than one, and multiple non-adjacent '**' segments "
+                "can cause pathological filesystem-walk cost. Refusing to "
                 "resolve it."
             )
         try:
-            matches = list(root.glob(pattern))
-        except (ValueError, NotImplementedError, OSError) as exc:
+            expanded_patterns = _expand_braces(declared_pattern)
+        except _UnbalancedBrace as exc:
             return coverage_config.discovery_error(
-                f"Workspace glob {pattern!r} could not be resolved: {exc}"
+                f"Workspace glob {declared_pattern!r} {exc}; npm/yarn/pnpm "
+                "reject unbalanced braces too, and resolving the pattern as a "
+                "literal path would silently match nothing. Refusing to "
+                "resolve it."
             )
-        for match in matches:
-            resolved = match.resolve()
-            if not (resolved == root or root in resolved.parents):
-                return coverage_config.discovery_error(
-                    f"Workspace glob {pattern!r} resolved to "
-                    f"{str(resolved)!r}, which is outside the repository "
-                    f"root ({str(root)!r}); refusing to include it."
-                )
-            if not resolved.is_dir():
+        except _BraceExpansionTooLarge as exc:
+            return coverage_config.discovery_error(
+                f"Workspace glob {declared_pattern!r} {exc}; each alternative "
+                "costs a separate filesystem walk. Refusing to resolve it."
+            )
+        for pattern in expanded_patterns:
+            # An empty or bare-`/` alternative ({packages/*,} — legal in
+            # npm/minimatch, where it simply contributes nothing) must not
+            # reach `Path.glob`, which rejects '' outright and treats a
+            # trailing separator version-dependently. Dropping it here keeps
+            # one empty alternative from failing the whole workspace.
+            pattern = pattern.rstrip("/")
+            if not pattern:
                 continue
-            if not (resolved / "package.json").is_file():
-                continue
-            rel_paths.add(resolved.relative_to(root).as_posix())
+            result = _resolve_one_glob(root, pattern, declared_pattern, rel_paths)
+            if result is not None:
+                return result
     return sorted(rel_paths)
+
+
+def _resolve_one_glob(root: Path, pattern: str, declared_pattern: str, rel_paths: set):
+    """Resolve a single brace-expanded `pattern`, adding every qualifying
+    match to `rel_paths`. Returns `None` on success, or a
+    `coverage_config.discovery_error(...)` to propagate. `declared_pattern` is
+    the original glob as written in the manifest — named in every error
+    alongside the expanded form so a brace-expanded failure is traceable back
+    to what the operator actually declared."""
+
+    def described(reason: str) -> str:
+        if pattern == declared_pattern:
+            return f"Workspace glob {pattern!r} {reason}."
+        return (
+            f"Workspace glob {pattern!r} (expanded from "
+            f"{declared_pattern!r}) {reason}."
+        )
+
+    placement_problem = _double_star_placement_problem(pattern)
+    if placement_problem is not None:
+        return coverage_config.discovery_error(
+            described(f"{placement_problem}. Refusing to resolve it")
+        )
+    try:
+        matches = list(root.glob(pattern))
+    except (ValueError, NotImplementedError, OSError) as exc:
+        return coverage_config.discovery_error(
+            described(f"could not be resolved: {exc}")
+        )
+    for match in matches:
+        resolved = match.resolve()
+        if not (resolved == root or root in resolved.parents):
+            return coverage_config.discovery_error(
+                described(
+                    f"resolved to {str(resolved)!r}, which is outside the "
+                    f"repository root ({str(root)!r}); refusing to include it"
+                )
+            )
+        if not resolved.is_dir():
+            continue
+        if not (resolved / "package.json").is_file():
+            continue
+        rel_paths.add(resolved.relative_to(root).as_posix())
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
@@ -513,3 +513,142 @@ def test_project_path_outside_repo_root_is_discovery_error(tmp_path):
     assert result["signal"] == "error"
     assert "Outside.csproj" in result["message"]
     assert not (tmp_path / "outside").exists()
+
+
+# ---------------------------------------------------------------------------
+# Windows-authored .sln separators (issue #1828)
+#
+# `dotnet sln list` echoes the separators the .sln was authored with. A
+# Windows-authored solution emits backslashes, and on POSIX `pathlib` treats
+# `src\App\App.csproj` as ONE opaque filename — so before #1828 every project
+# in such a solution failed the "does not exist on disk" check even though the
+# file was present.
+# ---------------------------------------------------------------------------
+
+_TEST_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>
+"""
+_NOT_TEST_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup />
+</Project>
+"""
+
+
+def _two_project_repo(tmp_path: Path) -> None:
+    sln(tmp_path)
+    write(tmp_path / "src/App/App.csproj", _NOT_TEST_CSPROJ)
+    write(tmp_path / "tests/App.Tests/App.Tests.csproj", _TEST_CSPROJ)
+
+
+def test_backslash_sln_paths_resolve_and_classify(tmp_path):
+    _two_project_repo(tmp_path)
+    windows_paths = ["src\\App\\App.csproj", "tests\\App.Tests\\App.Tests.csproj"]
+
+    with stub_dotnet(windows_paths):
+        result = cdd.discover_dotnet_projects(tmp_path)
+
+    assert not isinstance(result, dict), f"expected projects, got error: {result}"
+    assert result == [
+        {"path": "src/App/App.csproj", "classification": TestClassification.NOT_TEST},
+        {
+            "path": "tests/App.Tests/App.Tests.csproj",
+            "classification": TestClassification.TEST,
+        },
+    ]
+
+
+def test_backslash_and_forward_slash_output_agree(tmp_path):
+    """The regression guard for #1828: the two separator styles name the same
+    projects, so they must produce byte-identical results."""
+    win_root = tmp_path / "win"
+    posix_root = tmp_path / "posix"
+    _two_project_repo(win_root)
+    _two_project_repo(posix_root)
+
+    with stub_dotnet(["src\\App\\App.csproj", "tests\\App.Tests\\App.Tests.csproj"]):
+        win = cdd.discover_dotnet_projects(win_root)
+    with stub_dotnet(["src/App/App.csproj", "tests/App.Tests/App.Tests.csproj"]):
+        posix = cdd.discover_dotnet_projects(posix_root)
+
+    # An independent literal alongside the comparison: `win == posix` alone is
+    # a circular oracle that would still pass if a regression made BOTH
+    # separator forms identically wrong.
+    expected = [
+        {"path": "src/App/App.csproj", "classification": TestClassification.NOT_TEST},
+        {
+            "path": "tests/App.Tests/App.Tests.csproj",
+            "classification": TestClassification.TEST,
+        },
+    ]
+    assert win == posix == expected
+
+
+def test_mixed_separators_in_one_listing_resolve(tmp_path):
+    _two_project_repo(tmp_path)
+
+    with stub_dotnet(["src\\App\\App.csproj", "tests/App.Tests/App.Tests.csproj"]):
+        result = cdd.discover_dotnet_projects(tmp_path)
+
+    assert not isinstance(result, dict), f"expected projects, got error: {result}"
+    assert [p["path"] for p in result] == [
+        "src/App/App.csproj",
+        "tests/App.Tests/App.Tests.csproj",
+    ]
+
+
+def test_traversal_guard_fires_on_backslash_escape(tmp_path):
+    """Normalization must not open a hole: a backslash-separated `..` escape
+    has to be refused exactly like its forward-slash equivalent."""
+    root = tmp_path / "repo"
+    sln(root)
+    write(tmp_path / "outside/Evil/Evil.csproj", _TEST_CSPROJ)
+
+    with stub_dotnet(["..\\outside\\Evil\\Evil.csproj"]):
+        result = cdd.discover_dotnet_projects(root)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert "outside the repository" in result["message"]
+
+
+def test_parse_sln_list_output_normalizes_separators():
+    stdout = (
+        "Project(s)\n----------\n"
+        "src\\App\\App.csproj\n"
+        "tests/App.Tests/App.Tests.csproj\n"
+    )
+
+    assert cdd._parse_sln_list_output(stdout) == [
+        "src/App/App.csproj",
+        "tests/App.Tests/App.Tests.csproj",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected_reason"),
+    [
+        ("C:\\Projects\\App\\App.csproj", "drive letter"),
+        ("\\\\server\\share\\App.csproj", "UNC"),
+        ("/absolute/App.csproj", "absolute path"),
+    ],
+)
+def test_absolute_sln_entry_is_refused_with_an_accurate_reason(
+    tmp_path, entry, expected_reason
+):
+    """Separator normalization must not turn an absolute Windows path into a
+    silently-wrong relative subpath. `C:/...` is not absolute under
+    `PurePosixPath`, so without an explicit check this failed with a
+    misleading 'does not exist on disk' on POSIX while a Windows runner
+    reported a containment violation for the same input."""
+    sln(tmp_path)
+
+    with stub_dotnet([entry]):
+        result = cdd.discover_dotnet_projects(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert expected_reason in result["message"]
+    assert "does not exist on disk" not in result["message"]

--- a/plugins/dev-team/tests/scripts/test_coverage_discovery_js.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_discovery_js.py
@@ -468,3 +468,223 @@ def test_non_string_workspaces_entry_is_skipped(tmp_path):
     result = cdj.discover_js_packages(tmp_path)
 
     assert result == [{"path": "packages/a", "classification": TestClassification.TEST}]
+
+
+# ---------------------------------------------------------------------------
+# Brace-glob expansion (issue #1827)
+#
+# npm, yarn and pnpm all accept brace alternations in workspace globs, but
+# `pathlib` does not expand them — so before #1827 an affected repo resolved
+# to ZERO packages with no error, the silent-under-report shape #1759 exists
+# to prevent.
+# ---------------------------------------------------------------------------
+
+
+def test_brace_glob_discovers_every_alternative(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["apps/{web,api}"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "apps" / "api", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert [p["path"] for p in result] == ["apps/api", "apps/web"]
+    assert all(p["classification"] is TestClassification.TEST for p in result)
+
+
+def test_brace_glob_matches_plain_star_glob_on_same_tree(tmp_path):
+    """The regression guard for #1827: brace and star forms describe the same
+    set here, so they must discover the same packages."""
+    brace_root = tmp_path / "brace"
+    star_root = tmp_path / "star"
+    for root, globs in ((brace_root, ["apps/{web,api}"]), (star_root, ["apps/*"])):
+        pkg(root, {"name": "root", "workspaces": globs})
+        pkg(root / "apps" / "web", TEST_PKG)
+        pkg(root / "apps" / "api", TEST_PKG)
+
+    brace = [p["path"] for p in cdj.discover_js_packages(brace_root)]
+    star = [p["path"] for p in cdj.discover_js_packages(star_root)]
+
+    assert brace == star == ["apps/api", "apps/web"]
+
+
+def test_multiple_brace_groups_expand_as_cartesian_product(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["{apps,libs}/{web,api}"]})
+    for top in ("apps", "libs"):
+        for leaf in ("web", "api"):
+            pkg(tmp_path / top / leaf, TEST_PKG)
+
+    result = [p["path"] for p in cdj.discover_js_packages(tmp_path)]
+
+    assert result == ["apps/api", "apps/web", "libs/api", "libs/web"]
+
+
+def test_nested_braces_expand(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["apps/{web,{api,worker}}"]})
+    for leaf in ("web", "api", "worker"):
+        pkg(tmp_path / "apps" / leaf, TEST_PKG)
+
+    result = [p["path"] for p in cdj.discover_js_packages(tmp_path)]
+
+    assert result == ["apps/api", "apps/web", "apps/worker"]
+
+
+def test_brace_glob_combines_with_star(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["{apps,libs}/*"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "libs" / "shared", NOT_TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert [p["path"] for p in result] == ["apps/web", "libs/shared"]
+
+
+@pytest.mark.parametrize(
+    "bad_glob",
+    [
+        "apps/{web,api",
+        "apps/web}",
+        "apps/{a,{b}",
+        "apps/}web{",
+        # Regression guards for the defect both reviewers caught in the first
+        # cut of this fix: a stray `}` LEFT of the first `{` was absorbed into
+        # the literal prefix, expanding to globs that match nothing — the very
+        # silent-zero outcome #1827 exists to prevent. Each of these has a
+        # well-formed group after the stray brace, so an implementation that
+        # only balance-checks from the first `{` onward accepts them.
+        "apps/}x{a,b}",
+        "{apps,libs}}/{web,api}",
+    ],
+)
+def test_unbalanced_brace_is_a_discovery_error_not_a_silent_empty(tmp_path, bad_glob):
+    pkg(tmp_path, {"name": "root", "workspaces": [bad_glob]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert "brace" in result["message"].lower()
+    assert bad_glob in result["message"]
+
+
+def test_brace_traversal_guard_still_fires_on_an_expanded_alternative(tmp_path):
+    """An escaping path hidden inside one brace alternative must still be
+    refused — expansion happens before the containment check, not instead."""
+    root = tmp_path / "repo"
+    pkg(root, {"name": "root", "workspaces": ["{apps,../outside}/*"]})
+    pkg(root / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "outside" / "evil", TEST_PKG)
+
+    result = cdj.discover_js_packages(root)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert "outside the repository" in result["message"]
+
+
+def test_empty_brace_alternative_does_not_fail_the_whole_workspace(tmp_path):
+    """`{packages/*,}` is legal in npm/minimatch — the empty alternative just
+    contributes nothing. It must not reach `Path.glob`, which rejects `''`
+    outright and would otherwise fail discovery for the entire workspace even
+    though the non-empty alternative resolved fine."""
+    pkg(tmp_path, {"name": "root", "workspaces": ["{packages/*,}"]})
+    pkg(tmp_path / "packages" / "a", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert not isinstance(result, dict), f"expected packages, got error: {result}"
+    assert [p["path"] for p in result] == ["packages/a"]
+
+
+def test_trailing_empty_alternative_keeps_the_named_packages(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["apps/{web,api,}"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "apps" / "api", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert [p["path"] for p in result] == ["apps/api", "apps/web"]
+
+
+def test_brace_multiplication_cannot_smuggle_extra_double_stars(tmp_path):
+    """The `>1 '**'` cost guard is enforced on the DECLARED glob, not only per
+    expanded alternative — otherwise `{**/x,**/y,**/z}` (three single-`**`
+    alternatives) would buy three recursive walks past a guard whose whole
+    purpose is to refuse exactly that."""
+    pkg(tmp_path, {"name": "root", "workspaces": ["{**/x,**/y,**/z}"]})
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert "'**'" in result["message"]
+
+
+def test_brace_group_combined_with_double_star_still_resolves(tmp_path):
+    """The declared-pattern budget must not reject a legitimate single-`**`
+    glob just because a brace group multiplies it."""
+    pkg(tmp_path, {"name": "root", "workspaces": ["{apps,libs}/**"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "libs" / "shared" / "nested", NOT_TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert not isinstance(result, dict), f"expected packages, got error: {result}"
+    assert [p["path"] for p in result] == ["apps/web", "libs/shared/nested"]
+
+
+def test_absolute_path_hidden_in_a_brace_alternative_is_refused(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["{apps,/etc}/*"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+
+
+def test_runaway_brace_expansion_is_a_discovery_error_not_a_walk_bomb(tmp_path):
+    """Expansion is a cartesian product; 20 two-way groups is 2**20 globs and
+    as many filesystem walks. Refuse rather than attempt it."""
+    pkg(tmp_path, {"name": "root", "workspaces": ["{a,b}" * 20 + "/*"]})
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+    assert "alternatives" in result["message"]
+
+
+def test_deeply_nested_braces_error_rather_than_raising_recursionerror(tmp_path):
+    pkg(tmp_path, {"name": "root", "workspaces": ["{" * 400 + "x" + "}" * 400]})
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert isinstance(result, dict)
+    assert result.get("signal") == "error"
+
+
+def test_brace_glob_works_via_pnpm_workspace_yaml(tmp_path):
+    """Brace expansion lives in the shared resolution path, so it must apply to
+    every workspace source — not just `package.json`."""
+    pkg(tmp_path, {"name": "root", "private": True})
+    write(tmp_path / "pnpm-workspace.yaml", "packages:\n  - 'apps/{web,api}'\n")
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "apps" / "api", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert not isinstance(result, dict), f"expected packages, got error: {result}"
+    assert [p["path"] for p in result] == ["apps/api", "apps/web"]
+
+
+def test_brace_glob_works_via_lerna_json(tmp_path):
+    pkg(tmp_path, {"name": "root", "private": True})
+    write(tmp_path / "lerna.json", {"packages": ["{apps,libs}/web"]})
+    pkg(tmp_path / "apps" / "web", TEST_PKG)
+    pkg(tmp_path / "libs" / "web", TEST_PKG)
+
+    result = cdj.discover_js_packages(tmp_path)
+
+    assert not isinstance(result, dict), f"expected packages, got error: {result}"
+    assert [p["path"] for p in result] == ["apps/web", "libs/web"]


### PR DESCRIPTION
Three defects in the multi-project coverage discovery that landed in #1822, all of the same class: a malformed or unusual input resolved to an **empty result instead of a `discovery_error`**, so a coverage baseline read "no test projects here" rather than "discovery failed".

Two were found by review during #1823 (closed as a duplicate of #1822 — the defects are in the implementation that actually landed). The third was found while fixing them: `main`'s own test for it was red on Python 3.13+.

## #1827 — brace globs discovered nothing

npm, yarn and pnpm all accept `apps/{web,api}` in `workspaces`, but `pathlib` looks for a literal directory named `{web,api}`. Verified against `main`, same tree, two real vitest packages:

| `workspaces` | discovered |
|---|---|
| `["apps/*"]` | 2 |
| `["apps/{web,api}"]` | **0, no error** |
| `["apps/web", "apps/api"]` | 2 |

Globs are now brace-expanded before resolution — cartesian product across groups, recursive for nested groups — applied in the shared resolution path so it covers `package.json`, `pnpm-workspace.yaml` and `lerna.json` alike. Expansion happens *before* the containment check, so an escape hidden in one alternative (`{apps,../outside}/*`) is refused exactly like a bare `../outside/*`.

## #1828 — Windows-authored `.sln` files broke .NET discovery on POSIX

`dotnet sln list` echoes the separators the solution was authored with, and `pathlib` treats `src\App\App.csproj` as one opaque filename (`.name` returns the whole string). Verified against `main` with identical repos, only the stubbed `sln list` output differing:

```
forward-slash -> [{src/App/App.csproj: NOT_TEST}, {tests/App.Tests/App.Tests.csproj: TEST}]
backslash     -> {"signal": "error",
                  "message": "... references project 'src\\App\\App.csproj'
                              but the file does not exist on disk."}
```

The file does exist. Most enterprise .NET solutions are Windows-authored and commonly build on Linux, so .NET discovery was non-functional for them.

Separators are normalized once at parse time, before the containment check — which also closes a gap where a backslash-separated `..` escape slipped past the traversal guard as an opaque filename. Normalization is unconditional rather than POSIX-only so the recorded path identity stays byte-identical across platforms and a `coverage-config.json` written on Windows still reconciles on Linux.

An absolute drive-letter or UNC entry is now refused by an explicit check: `C:/Projects/App.csproj` is **not** absolute under `PurePosixPath`, so it previously became a nonsense subpath of the repo root and was reported as "does not exist on disk" on POSIX while a Windows runner reported a containment violation for the same input.

## #1832 — `**` validation depended on an exception CPython 3.13 stopped raising

Malformed `**` placement was detected by catching `ValueError` from `Path.glob`. That contract changed:

| Interpreter | `Path.glob("packages/**pkg")` | result |
|---|---|---|
| 3.10 (declared floor) | raises `ValueError` | `discovery_error` |
| 3.14.6 | returns `[]` | **empty list** |

So `main` was **red on 3.13+** (`TypeError: list indices must be integers`) while passing the `Python 3.10 floor` CI job — the one interpreter where the old behavior still exists. Behaviorally it had also become a silent under-report on 3.13+, the same shape as #1827. Placement is now validated by inspecting path components, which is version-independent.

## Review found an error-severity defect in the first cut of this fix

`correctness-review` and `test-review` independently caught it: brace balance was tracked only from the first `{` onward, so a stray `}` to its left was absorbed into the literal prefix.

```
'apps/}x{a,b}'           -> ['apps/}xa', 'apps/}xb']    # matches nothing, no error
'{apps,libs}}/{web,api}' -> ['apps}/web', ...]          # matches nothing, no error
```

That reintroduced the exact silent-zero outcome #1827 exists to prevent. Balance is now validated across the whole pattern in one pass. Worth noting the parametrized case that *looked* like it covered this (`apps/}web{`) passed only because of its unclosed trailing `{` — it never exercised the stray close brace. Both shapes are now pinned explicitly.

The same review pass found two more, both fixed and pinned:

- **An empty alternative failed the entire workspace.** `{packages/*,}` is legal in npm/minimatch (the empty alternative contributes nothing) but expanded to `''`, and `Path.glob('')` raises `ValueError` — so a workspace whose non-empty alternative resolved fine failed outright.
- **Per-alternative `**` checking defeated the cost guard.** `{**/x,**/y,**/z}` is three single-`**` alternatives, so it slipped past a guard whose entire purpose is refusing multiple recursive walks. The budget is now enforced on the declared pattern as well.

Runaway expansion (a cartesian product — 20 two-way groups is 2²⁰ globs and as many filesystem walks) and pathological nesting (previously an uncaught `RecursionError` traceback) are now both `discovery_error`s.

## Verification

- **8162 passed / 45 skipped** over the full pre-push directory list at 3.14. All 45 skips accounted for: 41 from one data-driven parametrize (`test_agent_implemented_by_resolves`, agents with no `Implemented by:` line) and 4 opt-in/environment gates. None introduced here.
- The two affected suites green on a **real 3.10 floor interpreter** via `uv run --python 3.10` — the version-independence #1832 is about, and not something a 3.14-only run can demonstrate.
- `ruff` clean, `check_md_references.py` clean, knowledge index clean.
- Committed through the pre-commit hooks with no `--no-verify` and no bypass.

Every new test was confirmed red against the unfixed code before the fix went in.

## Note for a reviewer

The `test_agent_implemented_by_resolves` parametrize skipping 41 agents means that check is effectively inactive for most of the agent fleet. Pre-existing and out of scope here, but it is a real coverage hole rather than a benign skip.

Closes #1827
Closes #1828
Closes #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
