### PR TITLE
fix(cost-meter): add claude-opus-5 pricing and surface unpriced models durably

### DIFF
--- a/plugins/dev-team/hooks/lib/cost_meter.py
+++ b/plugins/dev-team/hooks/lib/cost_meter.py
@@ -391,7 +391,18 @@ def _accumulate_lines(
 
         rate = _rate(pricing, model)
         cost = _cost(usage, rate, pricing) if rate else 0.0
-        if not rate and model != "unknown":
+        # Excludes zero-token records from `unpriced_models` (#1830 fix
+        # review), not just the literal "unknown" placeholder: the harness
+        # writes assistant records with `model: "<synthetic>"` and every usage
+        # field zero for interrupt/auth-failure notices (verified: present in
+        # every local session transcript). Those records are not billable —
+        # zero tokens cost zero regardless of whether the model has a pricing
+        # entry — so flagging them as "unpriced" would fire on nearly every
+        # session and bury the real signal (a genuinely billable model with no
+        # rate) under permanent noise. Gating on token presence rather than
+        # naming "<synthetic>" specifically also covers any future
+        # harness-internal pseudo-model without another denylist edit.
+        if not rate and model != "unknown" and any(usage.get(f) for f in _TOKEN_FIELDS):
             unpriced_models.add(model)
 
         for bucket, key in (
@@ -651,6 +662,16 @@ def cmd_record(args, pricing) -> int:
         "by_model": _slim(summary["by_model"]),
         "by_thread": _slim(summary["by_thread"]),
         "by_agent_type": _slim(summary["by_agent_type"]),
+        # Always present, even when empty (#1830). This field was computed and
+        # warned about in `report`, and persisted to the incremental state file,
+        # but omitted from the durable line — which is the ONLY thing every
+        # downstream consumer reads: /autoship's `--max-cost-usd` gate,
+        # `regression`, and `pace`. A model with no pricing entry therefore
+        # contributed $0.00 to a budget ceiling and was indistinguishable from
+        # one that is genuinely free. Emitting `[]` rather than omitting the key
+        # on the clean path matters too: a consumer can then treat absence as
+        # "this record predates the check" instead of "nothing was unpriced".
+        "unpriced_models": summary["unpriced_models"],
     }
     log = Path(args.log)
     log.parent.mkdir(parents=True, exist_ok=True)
@@ -659,11 +680,34 @@ def cmd_record(args, pricing) -> int:
     return 0
 
 
-def cmd_regression(args, pricing) -> int:
-    log = Path(args.log)
-    if not log.is_file():
-        print("no metrics log yet; nothing to compare")
-        return 0
+def _warn_unpriced(entries: list) -> None:
+    """Print a warning naming every model that contributed $0.00 to the records
+    being summarized because it has no pricing entry (#1830).
+
+    Any verdict computed over such records understates real spend, so say so
+    rather than reporting a number that reads as complete. Records written
+    before `unpriced_models` was added to the durable line simply lack the key
+    and contribute nothing here — silence means "no unpriced model was seen in
+    the records that carry the field", not "every record was checked"."""
+    unpriced = sorted(
+        {
+            model
+            for entry in entries
+            for model in (entry.get("unpriced_models") or [])
+            if isinstance(model, str)
+        }
+    )
+    if not unpriced:
+        return
+    print(
+        f"⚠ model(s) that priced at $0.00 in these records: "
+        f"{', '.join(unpriced)} — the figures below UNDERSTATE real cost. If "
+        "they are absent from knowledge/model-pricing.json, add them; if they "
+        "were added recently, re-record the affected sessions."
+    )
+
+
+def _read_log_entries(log: Path) -> list:
     entries = []
     for line in log.read_text().splitlines():
         line = line.strip()
@@ -673,6 +717,16 @@ def cmd_regression(args, pricing) -> int:
             entries.append(json.loads(line))
         except json.JSONDecodeError:
             continue
+    return entries
+
+
+def cmd_regression(args, pricing) -> int:
+    log = Path(args.log)
+    if not log.is_file():
+        print("no metrics log yet; nothing to compare")
+        return 0
+    entries = _read_log_entries(log)
+    _warn_unpriced(entries)
     costs = [e.get("total", {}).get("cost_usd", 0.0) for e in entries]
     if len(costs) < 2:
         print(f"only {len(costs)} session(s) logged; need >=2 to compare")
@@ -718,18 +772,17 @@ def cmd_pace(args, pricing) -> int:
     now = datetime.now(timezone.utc)
     window_start = now - timedelta(days=args.window_days)
     in_window = []
-    for line in log.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            e = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+    windowed_entries = []
+    for e in _read_log_entries(log):
         ts = _parse_ts(e.get("timestamp", ""))
         cost = e.get("total", {}).get("cost_usd", 0.0)
         if ts is not None and ts >= window_start:
             in_window.append((ts, cost))
+            windowed_entries.append(e)
+
+    # Scoped to the window, not the whole log: a budget projection understates
+    # only when an unpriced model appears in the records it actually sums (#1830).
+    _warn_unpriced(windowed_entries)
 
     spend = round(sum(c for _, c in in_window), 6)
     print(f"# Account pace — last {args.window_days} day(s)")

--- a/plugins/dev-team/knowledge/model-pricing.json
+++ b/plugins/dev-team/knowledge/model-pricing.json
@@ -1,20 +1,22 @@
 {
-  "_comment": "Per-million-token USD pricing for the cost meter (issue #102). Keyed by model snapshot ID (and tier alias). input/output are $ per 1M tokens; cache_write_multiplier (5-min TTL) and cache_read_multiplier are applied to the input rate per Anthropic's prompt-caching pricing (write 1.25x, read 0.1x). Source: Claude API reference, cached 2026-07-20; 5-family rates from the claude-api skill model catalog (Sonnet 5 $3/$15 standard, Fable 5 $10/$50), cached 2026-07-20. Claude Sonnet 5 carries an introductory rate of $2/$10 per MTok through 2026-08-31; the $3/$15 entered here is the standard post-intro sticker (the named instrument uses the durable rate). Update when pricing changes; this is the named instrument for any cost claim.",
-  "source": "platform.claude.com/docs/en/pricing (via claude-api skill cache 2026-07-20)",
+  "_comment": "Per-million-token USD pricing for the cost meter (issue #102). Keyed by model snapshot ID (and tier alias). input/output are $ per 1M tokens; cache_write_multiplier (5-min TTL) and cache_read_multiplier are applied to the input rate per Anthropic's prompt-caching pricing (write 1.25x, read 0.1x). Source: Claude API reference, cached 2026-08-05; 5-family rates from the claude-api skill model catalog (Opus 5 $5/$25, Fable 5 and Mythos 5 $10/$50, Sonnet 5 $3/$15 standard), cached 2026-08-05. Claude Sonnet 5 carries an introductory rate of $2/$10 per MTok through 2026-08-31; the $3/$15 entered here is the standard post-intro sticker (the named instrument uses the durable rate, and over-reporting is the safe direction for a budget ceiling). A model absent from `models` prices at $0.00, which silently disables any cost cap built on this file for exactly the model doing the work — claude-opus-5 was missing while it was this repo's default, so /autoship's --max-cost-usd read 4.7% of real spend (issue #1830). Anything absent here is now named in each cost-metering record's `unpriced_models` field and by tests/repo/test_cost_meter.py; add new model IDs in the same commit that starts using them. cache_write_multiplier covers the 5-minute TTL only — the 1-hour TTL is 2x, which this file does not model. Update when pricing changes; this is the named instrument for any cost claim.",
+  "source": "platform.claude.com/docs/en/pricing (via claude-api skill cache 2026-08-05)",
   "cache_write_multiplier": 1.25,
   "cache_read_multiplier": 0.1,
   "models": {
+    "claude-opus-5":     { "input": 5.0, "output": 25.0 },
     "claude-opus-4-8":   { "input": 5.0, "output": 25.0 },
     "claude-opus-4-7":   { "input": 5.0, "output": 25.0 },
     "claude-opus-4-6":   { "input": 5.0, "output": 25.0 },
     "claude-fable-5":    { "input": 10.0, "output": 50.0 },
+    "claude-mythos-5":   { "input": 10.0, "output": 50.0 },
     "claude-sonnet-5":   { "input": 3.0, "output": 15.0 },
     "claude-sonnet-4-6": { "input": 3.0, "output": 15.0 },
     "claude-haiku-4-5":  { "input": 1.0, "output": 5.0 },
     "claude-haiku-4-5-20251001": { "input": 1.0, "output": 5.0 }
   },
   "aliases": {
-    "opus": "claude-opus-4-8",
+    "opus": "claude-opus-5",
     "sonnet": "claude-sonnet-5",
     "haiku": "claude-haiku-4-5"
   }

--- a/tests/repo/test_cost_meter.py
+++ b/tests/repo/test_cost_meter.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import UTC
 from pathlib import Path
 
 import pytest
@@ -400,3 +401,242 @@ def test_settings_json_registers_cost_meter_py_on_stop_and_subagentstop() -> Non
         for h in entry["hooks"]
     ]
     assert any("cost_meter.py" in c for c in subagent_stop_hooks)
+
+
+# ---------------------------------------------------------------------------
+# Unpriced models must be loud in the DURABLE record, not just `report` (#1830)
+#
+# `unpriced_models` was computed, warned about in `report`, and persisted to the
+# incremental state file — but omitted from the jsonl line every downstream
+# consumer actually reads (/autoship's `--max-cost-usd` gate, /cost-report's
+# regression and pace). A model with no pricing entry therefore contributed
+# $0.00 to a budget ceiling with nothing anywhere to say so.
+# ---------------------------------------------------------------------------
+
+UNPRICED_TRANSCRIPT = (
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "model": "totally-made-up-model",
+                "usage": {"input_tokens": 900000, "output_tokens": 700000},
+            },
+        }
+    )
+    + "\n"
+)
+
+
+def test_record_line_names_unpriced_models(tmp_path: Path) -> None:
+    """The durable log line is what /autoship's cost cap reads. Without this
+    field an unpriced model is indistinguishable from a genuinely free one."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(UNPRICED_TRANSCRIPT)
+    log = tmp_path / "log.jsonl"
+
+    res = _run("record", "--transcript", str(transcript), "--log", str(log))
+
+    assert res.returncode == 0, res.stdout + res.stderr
+    line = json.loads(log.read_text().splitlines()[-1])
+    assert line["unpriced_models"] == ["totally-made-up-model"], line
+    # The zero cost is real — the point is that it is now attributable.
+    assert line["by_model"]["totally-made-up-model"]["cost_usd"] == 0.0
+
+
+def test_record_line_reports_no_unpriced_models_when_all_are_priced(
+    case: Path,
+) -> None:
+    """The field is always present, so a consumer can trust its absence to mean
+    'not checked' rather than 'nothing unpriced'."""
+    log = case / "log.jsonl"
+
+    res = _run("record", "--transcript", str(case / "t.jsonl"), "--log", str(log))
+
+    assert res.returncode == 0, res.stdout + res.stderr
+    line = json.loads(log.read_text().splitlines()[-1])
+    assert line["unpriced_models"] == []
+
+
+def test_synthetic_zero_token_records_are_never_flagged_as_unpriced(
+    case: Path,
+) -> None:
+    """Regression guard for the defect correctness-review caught in the first
+    cut of this fix: the harness writes assistant records with
+    `model: "<synthetic>"` and every usage field zero for interrupt/
+    auth-failure notices — present in every real session transcript. Those
+    cost nothing regardless of pricing-table coverage, so flagging them as
+    unpriced would fire on nearly every session and bury the real signal."""
+    synthetic = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "model": "<synthetic>",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+        }
+    )
+    transcript = case / "t.jsonl"
+    transcript.write_text(transcript.read_text() + synthetic + "\n")
+    log = case / "log.jsonl"
+
+    res = _run("record", "--transcript", str(transcript), "--log", str(log))
+
+    assert res.returncode == 0, res.stdout + res.stderr
+    line = json.loads(log.read_text().splitlines()[-1])
+    assert "<synthetic>" not in line["unpriced_models"], line
+
+
+def test_regression_surfaces_an_unpriced_model_from_the_log(tmp_path: Path) -> None:
+    """A cost-regression verdict computed over records containing unpriced
+    models is not trustworthy — say so rather than comparing silently."""
+    log = tmp_path / "log.jsonl"
+    entries = [
+        {
+            "timestamp": f"2026-08-01T00:00:0{i}Z",
+            "transcript": "t.jsonl",
+            "total": {"cost_usd": 1.0, "messages": 1},
+            "by_model": {},
+            "by_thread": {},
+            "by_agent_type": {},
+            "unpriced_models": [] if i < 2 else ["totally-made-up-model"],
+        }
+        for i in range(3)
+    ]
+    log.write_text("".join(json.dumps(e) + "\n" for e in entries))
+
+    res = _run("regression", "--log", str(log), "--tolerance", "0.5")
+
+    assert res.returncode == 0, res.stdout + res.stderr
+    combined = res.stdout + res.stderr
+    # Co-occurrence on the SAME line, not two independent substring checks —
+    # a message that named the model on one line and "unpriced" on an
+    # unrelated line (or asserted the opposite) would pass two separate
+    # membership checks without actually conveying the intended warning.
+    assert any(
+        "totally-made-up-model" in line and "UNDERSTATE" in line
+        for line in combined.splitlines()
+    ), combined
+
+
+# ---------------------------------------------------------------------------
+# The pricing table is the named instrument — it must know the models in use
+# ---------------------------------------------------------------------------
+
+PRICING_PATH = (
+    REPO_ROOT / "plugins" / "dev-team" / "knowledge" / "model-pricing.json"
+)
+
+
+def _pricing() -> dict:
+    return json.loads(PRICING_PATH.read_text())
+
+
+def test_pace_warns_only_for_unpriced_models_inside_the_window(tmp_path: Path) -> None:
+    """`cmd_pace` deliberately scopes `_warn_unpriced` to `windowed_entries`,
+    not the whole log (a budget projection only understates when an unpriced
+    model appears in the records it actually sums). Prove the scoping is real:
+    an unpriced model outside --window-days must not be named."""
+    from datetime import datetime, timedelta
+
+    log = tmp_path / "log.jsonl"
+    now = datetime.now(UTC)
+    outside = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    inside = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    entries = [
+        {
+            "timestamp": outside,
+            "transcript": "old.jsonl",
+            "total": {"cost_usd": 1.0, "messages": 1},
+            "unpriced_models": ["stale-model-outside-window"],
+        },
+        {
+            "timestamp": inside,
+            "transcript": "new.jsonl",
+            "total": {"cost_usd": 1.0, "messages": 1},
+            "unpriced_models": ["fresh-model-inside-window"],
+        },
+    ]
+    log.write_text("".join(json.dumps(e) + "\n" for e in entries))
+
+    res = _run("pace", "--log", str(log), "--window-days", "7", "--period-days", "30")
+
+    assert res.returncode == 0, res.stdout + res.stderr
+    combined = res.stdout + res.stderr
+    assert "fresh-model-inside-window" in combined, combined
+    assert "stale-model-outside-window" not in combined, combined
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-haiku-4-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    ],
+)
+def test_every_current_model_has_a_pricing_entry(model_id: str) -> None:
+    """A missing entry prices that model's spend at $0.00, which makes any cost
+    ceiling built on this file unenforceable for exactly the model doing the
+    work. `claude-opus-5` was absent while it was this repo's default model."""
+    models = _pricing()["models"]
+    assert model_id in models, (
+        f"{model_id!r} has no pricing entry — its spend would price at $0.00. "
+        f"Known: {sorted(models)}"
+    )
+    rate = models[model_id]
+    assert rate["input"] > 0 and rate["output"] > 0, rate
+
+
+def test_every_alias_resolves_to_a_priced_model() -> None:
+    pricing = _pricing()
+    models, aliases = pricing["models"], pricing.get("aliases", {})
+    dangling = {a: t for a, t in aliases.items() if t not in models}
+    assert not dangling, f"aliases pointing at absent models: {dangling}"
+
+
+def test_the_opus_alias_points_at_the_current_default_opus() -> None:
+    """The alias is what a bare `opus` in a transcript resolves to; leaving it
+    on a superseded snapshot silently prices new spend at the old model."""
+    pricing = _pricing()
+    assert pricing["aliases"]["opus"] == "claude-opus-5"
+
+
+def test_regression_and_pace_tolerate_pre_existing_log_lines_with_no_unpriced_key(
+    tmp_path: Path,
+) -> None:
+    """`unpriced_models` was added to the durable line by this fix. Log files
+    written before it exist and never carry the key at all — not `[]`, absent
+    entirely. Neither command may crash on that, and neither may misread the
+    absence as an unpriced model."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    recent = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    pre_existing_lines = [
+        # No `unpriced_models` key at all — the pre-fix shape.
+        {"timestamp": recent, "transcript": "old1.jsonl", "total": {"cost_usd": 1.0, "messages": 1}},
+        {"timestamp": recent, "transcript": "old2.jsonl", "total": {"cost_usd": 1.2, "messages": 1}},
+        {"timestamp": recent, "transcript": "old3.jsonl", "total": {"cost_usd": 0.9, "messages": 1}},
+    ]
+
+    log = tmp_path / "log.jsonl"
+    log.write_text("".join(json.dumps(e) + "\n" for e in pre_existing_lines))
+    res = _run("regression", "--log", str(log), "--tolerance", "0.5")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "unpriced" not in (res.stdout + res.stderr).lower()
+
+    pace_log = tmp_path / "pace_log.jsonl"
+    pace_log.write_text("".join(json.dumps(e) + "\n" for e in pre_existing_lines))
+    res = _run(
+        "pace", "--log", str(pace_log), "--window-days", "7", "--period-days", "30"
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "unpriced" not in (res.stdout + res.stderr).lower()


### PR DESCRIPTION
`knowledge/model-pricing.json` had no entry for `claude-opus-5` while it was this repo's default model. Every token from it priced at **$0.00**. Verified on this session's own transcript, before/after:

| | total | `claude-opus-5` | flagged |
|---|---|---|---|
| `main`'s pricing | $9.70 | $0.00 on 1.1M+ output tokens | — |
| with the fix | $287.64 | correctly priced | — |

A ~30x understatement. Any `--max-cost-usd` cap built on this file (`/autoship`) was unenforceable for the dominant model. Also adds `claude-mythos-5` (same family, same $10/$50 as `fable-5`) and repoints the `opus` alias from `claude-opus-4-8` to `claude-opus-5`.

## The second, quieter bug

`cost_meter.py` already computed an `unpriced_models` set and warned about it in `report`, and persisted it to the incremental state file — but never wrote it into the **durable JSONL line** `record` appends, which is the only artifact `/autoship`'s cost cap and `/cost-report`'s `regression`/`pace` actually read. An unpriced model was invisible to every consumer that matters, even before the pricing gap existed.

Fixed: `unpriced_models` now rides the durable line — always present, `[]` when clean, so a consumer can tell "checked, found nothing" from "predates the check." A shared `_warn_unpriced` helper is wired into both `regression` and `pace`, so a verdict computed over records containing an unpriced model says so rather than reporting silently. `pace` scopes the warning to `windowed_entries`, not the whole log, matching what it actually projects from.

## Review found a real defect in the first cut, before it shipped

`correctness-review` caught it: the harness writes assistant records with `model: "<synthetic>"` and every usage field zero — interrupt and auth-failure notices. Verified present in **every** local session transcript. The original gate excluded only the literal `"unknown"` placeholder, so `<synthetic>` was flagged as unpriced on nearly every session — a warning that fires constantly cannot signal the one case it exists to catch.

Fixed by gating on token presence (`any(usage.get(f) for f in _TOKEN_FIELDS)`) rather than a name denylist, which is durable against any future zero-token pseudo-model without another edit.

## Proof it can fail

Per this repo's own rule: removing `claude-opus-5` from the table and reverting the alias turns the new pinning tests red; restoring them turns green.

## Test review closed five more gaps

- A regression test for the `<synthetic>` false positive.
- A test proving `pace`'s window-scoping is real — an unpriced model outside `--window-days` is never named.
- `claude-mythos-5` added to the pricing-coverage parametrize list (it was in the pricing file but not pinned by a test).
- A backward-compat test for pre-existing log lines with no `unpriced_models` key at all.
- One assertion tightened from two independent substring checks to same-line co-occurrence — the original would have passed even if the model name and the word "unpriced" landed on unrelated lines.

## Verification

- **8263 passed / 50 skipped** over the full pre-push directory list.
- `ruff` clean, `check_md_references.py` clean, knowledge index clean.
- Committed through the pre-commit hooks, no bypass.

## Filed separately, deliberately not bundled here

- `plugins/dev-team/hooks/context_ceiling_guard.py`'s `_LARGE_WINDOW_RE` doesn't list `opus-5`, so it falls back to the conservative 200K-window default for the current default model. Same class of staleness as this issue, but a different mechanism and worth its own confirmation of Opus 5's real context window before editing.
- `test_every_current_model_has_a_pricing_entry`'s parametrize list is a hand-maintained set of IDs — it can catch a deletion but not a *new* model nobody remembered to add, which is exactly how `claude-opus-5` went missing. A deterministic source (reading model IDs out of a recorded transcript fixture, or the model catalog) would close that gap properly; noted rather than attempted here to keep this PR to the reported defect.

Closes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
