### PR TITLE
fix(hooks): add bounded fail-open lock-acquisition budget to atomic_state.locked_state

### DIFF
--- a/plugins/dev-team/hooks/lib/atomic_state.py
+++ b/plugins/dev-team/hooks/lib/atomic_state.py
@@ -13,11 +13,25 @@ sessions/worktrees touching the same repo) can race and lose an update
   invocation instead of clobbering each other.
 
 The lock idiom (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows,
-fail-open when neither is available) is lifted from the already-proven copy
-in `hooks/code_intelligence_turn_mark.py::_sentinel_lock` so the two agree
-on behavior. Everything here is fail-open: any I/O or locking failure runs
+fail-open when neither is available) started as a copy of
+`hooks/code_intelligence_turn_mark.py::_sentinel_lock` — #1888 (below) bounded
+the acquire wait here but deliberately left that sibling's blocking wait
+alone (a PostToolUse nudge sentinel, not a safety-critical guard verdict), so
+the two no longer agree on acquire behavior; only the release-path idiom
+still matches. Everything here is fail-open: any I/O or locking failure runs
 the critical section unlocked / skips the persist rather than raising —
 these are advisory nudges, never gates.
+
+Lock *acquisition* is bounded, not a blocking wait (#1888): a hung sibling
+process holding the lock must never leave a caller blocked indefinitely,
+since some callers (e.g. `boundary_events.py`, once #1874 lands) sit in
+front of a safety-critical guard hook's verdict. `locked_state` polls a
+non-blocking acquisition for a bounded total budget and falls through to
+running the critical section UNLOCKED once that budget elapses — the same
+fail-open posture as every other failure mode here. This bounds contention
+on an already-held lock specifically; it does NOT bound a stall inside
+`open()` on the lock file itself, or inside a caller's own I/O in the
+critical section — a wedged mount can still block there.
 
 Stdlib-only.
 """
@@ -25,6 +39,7 @@ Stdlib-only.
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import tempfile
 import time
@@ -40,6 +55,40 @@ try:
     import msvcrt  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover — POSIX has no msvcrt
     msvcrt = None  # type: ignore[assignment]
+
+
+# Total time `locked_state` will poll for the lock before giving up and
+# running the critical section unlocked (#1888). Sized comfortably above any
+# legitimate contention chain this module's consumers exercise — the shared
+# concurrency regression test's worst case is 8 workers x 60ms holds (~480ms
+# of legitimate queueing; see test_lock_acquire_budget_exceeds_worst_case_
+# contention, which pins this relationship mechanically) — so normal
+# contention still fully serializes and only a genuinely stalled holder ever
+# trips the give-up path.
+_DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS = 2.0
+_LOCK_POLL_INTERVAL_SECONDS = 0.01
+
+# Hard ceiling on the test-only override below (security review, #1888): the
+# override has a floor to stop a misconfigured `0` from removing the retry,
+# but nothing stopped the OTHER direction — an arbitrarily large value would
+# reinstate exactly the unbounded wait this module exists to remove. No
+# configuration can raise the give-up bound past this.
+_MAX_LOCK_ACQUIRE_BUDGET_SECONDS = 10.0
+
+# `_try_acquire`'s non-blocking attempt raises OSError both for ordinary lock
+# contention (retry-worthy) and for conditions retrying can never fix — e.g.
+# ENOLCK/EOPNOTSUPP when flock isn't supported on the underlying filesystem
+# (some NFS/FUSE/CIFS mounts). Without this distinction, `_acquire_bounded`
+# burned the full budget on every single call on such a filesystem, which is
+# strictly worse than the pre-#1888 behavior (an immediate, un-retried
+# failure) it must not regress. Only these errnos — genuine "someone else
+# holds it" signals on POSIX (`flock`) and Windows (`msvcrt.locking`) — are
+# worth retrying; anything else gives up immediately.
+_LOCK_CONTENTION_ERRNOS = frozenset(
+    e
+    for e in (errno.EACCES, errno.EAGAIN, getattr(errno, "EWOULDBLOCK", None))
+    if e is not None
+)
 
 
 def atomic_write(path: Path, text: str) -> None:
@@ -68,6 +117,86 @@ def atomic_write(path: Path, text: str) -> None:
             os.unlink(tmp_name)
 
 
+def _lock_acquire_budget_seconds() -> float:
+    """Test-only override for the give-up budget, mirroring
+    `race_window_delay`'s env-var injection pattern below. Unset in
+    production; an unset, negative, or non-integer value (the var is
+    documented in whole milliseconds) falls back to the default (fail-open).
+    Clamped to `[_LOCK_POLL_INTERVAL_SECONDS,
+    _MAX_LOCK_ACQUIRE_BUDGET_SECONDS]`: the floor guarantees a nonzero
+    budget (not a guaranteed retry count — a first attempt that itself takes
+    longer than the floor can still see zero retries), and the ceiling
+    guarantees no override can reinstate an effectively-unbounded wait.
+    """
+    raw = os.environ.get("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS")
+    if not raw:
+        return _DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    try:
+        value_seconds = int(raw) / 1000
+    except ValueError:
+        return _DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    if value_seconds < 0:
+        return _DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    return min(
+        _MAX_LOCK_ACQUIRE_BUDGET_SECONDS,
+        max(_LOCK_POLL_INTERVAL_SECONDS, value_seconds),
+    )
+
+
+def _try_acquire(handle) -> bool:
+    """One non-blocking acquisition attempt on `handle`.
+
+    Returns True on success, False if nothing raised but no lock backend is
+    available (fcntl/msvcrt both missing) — this is the one case where
+    `_acquire_bounded` below returns without ever polling or sleeping, since
+    retrying an operation that can't succeed either way buys nothing. Raises
+    OSError when the lock is currently held elsewhere — the caller decides
+    whether to retry or give up.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    if msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        return True
+    return False
+
+
+def _release(handle) -> None:
+    """Release a lock previously acquired via `_try_acquire`, mirroring its
+    guard-clause style. Can raise OSError; the caller (`locked_state`) wraps
+    this call in its own try/except, matching the fail-open contract."""
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return
+    if msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _acquire_bounded(handle) -> bool:
+    """Poll `_try_acquire` until it succeeds, the acquire budget elapses, or
+    (immediately, no polling) `_try_acquire` signals a condition retrying
+    can't fix — no lock backend at all, or an OSError that isn't ordinary
+    contention (see `_LOCK_CONTENTION_ERRNOS`).
+
+    Returns True once the lock is held, False if the budget ran out with the
+    lock still held elsewhere, no backend exists, or a non-contention
+    OSError occurred (the caller runs unlocked in every False case).
+    """
+    deadline = time.monotonic() + _lock_acquire_budget_seconds()
+    while True:
+        try:
+            return _try_acquire(handle)
+        except OSError as exc:
+            if exc.errno not in _LOCK_CONTENTION_ERRNOS:
+                return False
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_LOCK_POLL_INTERVAL_SECONDS)
+
+
 @contextlib.contextmanager
 def locked_state(path: Path) -> Iterator[None]:
     """Hold an exclusive advisory lock for a full read-modify-write cycle.
@@ -78,10 +207,16 @@ def locked_state(path: Path) -> Iterator[None]:
     hooks target both — ADR 0014/0015). The lock file lives beside `path` as
     `<path>.lock`.
 
-    Fail-open: a missing `fcntl` *and* `msvcrt`, or any OSError opening/locking
-    the lock file, falls through to running the critical section UNLOCKED
-    rather than raising. An unlocked lost-update is no worse than the
-    pre-#1501 behavior; a crash would be worse, and these hooks are advisory.
+    Acquisition is bounded, not a blocking wait (#1888): a stalled holder
+    trips a fail-open give-up after `_lock_acquire_budget_seconds()` of
+    polling rather than blocking a caller indefinitely.
+
+    Fail-open: a missing `fcntl` *and* `msvcrt`, an OSError creating the lock
+    file's parent directory or opening the lock file, or a lock that can't be
+    acquired within budget, all fall through to running the critical section
+    UNLOCKED rather than raising or blocking forever. An unlocked lost-update
+    is no worse than the pre-#1501 behavior; a crash — or an undelivered
+    guard-hook verdict — would be worse, and these hooks are advisory.
     """
     lock_path = path.parent / (path.name + ".lock")
     try:
@@ -99,24 +234,14 @@ def locked_state(path: Path) -> Iterator[None]:
             locked = False
             try:
                 try:
-                    if fcntl is not None:
-                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-                        locked = True
-                    elif msvcrt is not None:
-                        handle.seek(0)
-                        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-                        locked = True
+                    locked = _acquire_bounded(handle)
                 except OSError:
                     locked = False
                 yield
             finally:
                 if locked:
                     try:
-                        if fcntl is not None:
-                            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-                        elif msvcrt is not None:
-                            handle.seek(0)
-                            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                        _release(handle)
                     except OSError:
                         pass
             return

--- a/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
+++ b/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
@@ -15,12 +15,15 @@ regression guards, not timing-luck tests.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import shutil
 import subprocess
 import sys
 import textwrap
+import threading
+import time
 
 import pytest
 
@@ -28,6 +31,10 @@ from _repo_root import REPO_ROOT as _REPO_ROOT
 
 _HOOKS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
 _LIB_DIR = _HOOKS_DIR / "lib"
+
+sys.path.insert(0, str(_LIB_DIR))
+import atomic_state
+from atomic_state import atomic_write, locked_state
 
 # N concurrent workers and the delay (ms) each holds the critical section.
 # The delay guarantees overlap: total serialized wall-clock ~= N * DELAY.
@@ -170,4 +177,131 @@ def test_session_learning_trigger_no_lost_increments(tmp_path):
     counter = json.loads(state.read_text())["counter"]
     assert counter == _WORKERS, (
         f"lost-update race: expected counter {_WORKERS}, got {counter}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# locked_state gives up after a bounded budget rather than blocking forever
+# on a stalled holder (#1888 — security review of #1874).
+# ---------------------------------------------------------------------------
+
+
+def test_locked_state_gives_up_after_stalled_holder(tmp_path, monkeypatch):
+    state_file = tmp_path / "counter.json"
+    state_file.write_text("{}")
+
+    # `fcntl.flock` locks are scoped to the open file description, not the
+    # process (POSIX) — two separate `open()` calls from two threads in this
+    # one process genuinely contend, the same as two separate processes
+    # would. That is what makes an in-process holder thread a valid stand-in
+    # for a stalled cross-process holder here.
+    hold_seconds = 0.4
+    budget_ms = 50
+    acquired = threading.Event()
+
+    def _hold_lock():
+        with locked_state(state_file):
+            acquired.set()
+            time.sleep(hold_seconds)
+
+    holder = threading.Thread(target=_hold_lock)
+    holder.start()
+    try:
+        assert acquired.wait(timeout=2), "holder thread never acquired the lock"
+
+        # Small budget so the test runs fast; production uses the 2s default.
+        monkeypatch.setenv("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS", str(budget_ms))
+        start = time.monotonic()
+        with locked_state(state_file):
+            elapsed = time.monotonic() - start
+            # The give-up path must still do real work unlocked, not just
+            # return early — prove it via the same primitive callers use.
+            atomic_write(state_file, json.dumps({"gave_up": True}))
+    finally:
+        holder.join(timeout=2)
+    assert not holder.is_alive(), "holder thread never released the lock"
+
+    budget_s = budget_ms / 1000
+    # Lower bound proves genuine contention was hit (the give-up path actually
+    # ran), not just that the second acquire happened to be fast on its own —
+    # `_acquire_bounded` only returns False after `monotonic() >= deadline`.
+    assert elapsed >= budget_s, (
+        f"locked_state returned after only {elapsed:.3f}s against a "
+        f"{budget_ms}ms budget — the second acquire may never have contended "
+        "with the holder, so this test wouldn't catch a regression"
+    )
+    # Generous multiple of the configured budget (not of hold_seconds, which
+    # only exists to guarantee overlap) — bounds the give-up latency against
+    # what was actually configured, with margin for scheduler/CI jitter.
+    max_elapsed = budget_s * 4
+    assert elapsed < max_elapsed, (
+        f"locked_state blocked for {elapsed:.3f}s despite a {budget_ms}ms "
+        "acquire budget — a stalled holder must not block a caller "
+        "indefinitely"
+    )
+    assert json.loads(state_file.read_text()) == {"gave_up": True}
+
+
+def test_lock_acquire_budget_exceeds_worst_case_contention():
+    # Mechanical link (not prose) between the production default and the
+    # regression tests' worst-case legitimate queueing above, so widening
+    # _WORKERS/_DELAY_MS fails loudly here instead of leaving a stale comment.
+    worst_case_contention_seconds = _WORKERS * _DELAY_MS / 1000
+    assert (
+        worst_case_contention_seconds
+        < atomic_state._DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    )
+
+
+def test_lock_acquire_budget_invalid_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS", "not-a-number")
+    assert (
+        atomic_state._lock_acquire_budget_seconds()
+        == atomic_state._DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    )
+
+
+def test_lock_acquire_budget_negative_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS", "-5")
+    assert (
+        atomic_state._lock_acquire_budget_seconds()
+        == atomic_state._DEFAULT_LOCK_ACQUIRE_BUDGET_SECONDS
+    )
+
+
+def test_lock_acquire_budget_clamped_to_ceiling(monkeypatch):
+    monkeypatch.setenv("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS", "999999999")
+    assert (
+        atomic_state._lock_acquire_budget_seconds()
+        == atomic_state._MAX_LOCK_ACQUIRE_BUDGET_SECONDS
+    )
+
+
+def test_try_acquire_returns_false_with_no_lock_backend(tmp_path, monkeypatch):
+    monkeypatch.setattr(atomic_state, "fcntl", None)
+    monkeypatch.setattr(atomic_state, "msvcrt", None)
+    lock_path = tmp_path / "state.lock"
+    with open(lock_path, "a+") as handle:
+        assert atomic_state._try_acquire(handle) is False
+
+
+def test_acquire_bounded_gives_up_immediately_on_non_contention_error(
+    tmp_path, monkeypatch
+):
+    # A non-contention OSError (e.g. ENOLCK/EOPNOTSUPP on a filesystem that
+    # doesn't support flock) must give up right away, not burn the full
+    # budget retrying an operation that can never succeed.
+    def _raise_enolck(_handle):
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(atomic_state, "_try_acquire", _raise_enolck)
+    monkeypatch.setenv("DEV_TEAM_LOCK_ACQUIRE_BUDGET_TEST_MS", "2000")
+    lock_path = tmp_path / "state.lock"
+    with open(lock_path, "a+") as handle:
+        start = time.monotonic()
+        assert atomic_state._acquire_bounded(handle) is False
+        elapsed = time.monotonic() - start
+    assert elapsed < 0.1, (
+        f"gave up after {elapsed:.3f}s — a non-contention OSError should "
+        "return immediately, not retry for the full budget"
     )


### PR DESCRIPTION
## Summary

- `atomic_state.locked_state` acquired its cross-process advisory lock with an unbounded blocking `fcntl.flock`/`msvcrt.locking` call. A stalled holder (stuck disk, wedged NFS, a hung sibling process) could leave any caller — including a safety-critical guard hook, once `boundary_events.py` wires through this primitive in #1874 — blocked indefinitely before it ever delivers its verdict.
- `locked_state` now polls a non-blocking acquisition for a bounded budget (default 2s, clamped to `[10ms, 10s]` via a test-only override), then falls through to running the critical section unlocked, matching the module's existing fail-open posture.
- Distinguishes genuine lock contention from non-recoverable errnos (`ENOLCK`/`EOPNOTSUPP` on filesystems without `flock` support) so those give up immediately instead of burning the full budget on every call.
- A 14-agent, two-wave code-review pass (plus two closing-pass re-verification rounds) found and fixed several related issues in the same diff: no ceiling on the budget override, a docstring overclaim about guaranteed retries, an env-var name that didn't match this codebase's test-only-knob convention, and a test assertion that could pass without ever forcing real lock contention.
- Two pre-existing, out-of-scope defects the same review surfaced are tracked separately rather than mixed into this diff: #1892 (a caller-raised `OSError` can be masked as `RuntimeError`) and a [comment on #1874](https://github.com/bdfinst/agentic-dev-team/issues/1874#issuecomment-5193226826) (per-caller budget tuning and give-up observability for whoever implements it).

Closes #1888

## Test plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_hook_state_concurrency.py -v` — 10/10 pass, including a new stalled-holder regression test and coverage for the new fail-open branches (invalid/negative/ceiling-clamped budget values, no-lock-backend, non-contention errno)
- [x] Repeated 5x locally — no flakes
- [x] Full pre-push gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks`) — 8302 passed, 45 skipped
- [x] `ruff check .` — clean