### PR TITLE
refactor(tests): extract shared bash-invocation parser for floor/ceiling gate tests

### DIFF
--- a/_ci_local_invocation.py
+++ b/_ci_local_invocation.py
@@ -1,0 +1,250 @@
+"""Shared `scripts/ci-local.sh` source parsers for the floor/ceiling gate
+tests — a bash-invocation parser (`invocation()`/`lines_after_invocation()`)
+and a registry-array parser (`check_registry()`).
+
+`tests/repo/test_python_floor.py` (`chk_python_floor`) and
+`tests/repo/test_python_ceiling.py` (`chk_python_ceiling`) each need to find
+a shell function's `-m pytest` invocation, walk its backslash
+line-continuations the way bash itself does, and split it into
+`(prefix, pytest's own arguments, tokens after a "||" tail)` — the shape
+each gate's tests pin against, since any of those three pieces silently
+narrowing what actually runs is exactly the failure mode both gates exist to
+catch. The two test files independently grew near-line-for-line-identical
+parsers for this (`_floor_invocation` / `_floor_check_body` /
+`_without_comments` vs. `_ceiling_invocation` / `_ceiling_check_body` /
+`_without_comments`), and a fix to one — the comment-stripping-before-
+continuation-walk bug caught during #1876/#1885's review — had to be
+ported to the other by hand rather than being inherited automatically.
+Flagged independently by structure-review, test-review, test-smell-review,
+and arch-review during that PR's review (#1887); arch-review additionally
+found the two files' `CHECKS=(`/`OPTIONAL_CHECKS=(` registry-array parsing
+(`check_registry` below) was a second, still-live instance of the same
+duplication class.
+
+Scoped to the repo root via the `pythonpath = .` entry in `pytest.ini`,
+matching `_content_guard_scan.py`'s own convention (the closest precedent: a
+helper shared by exactly two `tests/repo/` files) — a `tests/repo/`-local
+sibling would also work with its own `pythonpath` entry, but the repo-root
+entry already exists and needs no addition.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class PytestInvocation(NamedTuple):
+    """`invocation()`'s result. Tuple-compatible (`== ([], [], [])` and
+    `prefix, args, tail = ...` both still work) so this is purely additive
+    over the plain-tuple shape both consumers already pinned."""
+
+    prefix: list[str]
+    args: list[str]
+    tail: list[str]
+
+
+def check_body(ci_local: str, fn_name: str) -> str:
+    """The text of the bash function `fn_name`'s body.
+
+    Bounded from the function's header to the next top-level `chk_`-prefixed
+    function definition — every check in `scripts/ci-local.sh` follows that
+    naming convention, so this window reliably stops at the next one without
+    needing to parse bash scoping. If `fn_name` is not actually defined in
+    `ci_local`, the header split is a no-op but the second split still runs —
+    so the result is everything up to the first `chk_`-prefixed function
+    ANYWHERE in `ci_local`, not the whole input unchanged. For the real
+    `scripts/ci-local.sh` (preamble, then `chk_` functions in sequence) that
+    happens to equal the preamble; it is not guaranteed for arbitrary text.
+    Every current caller pins `fn_name`'s existence separately, so this
+    stays a plain split rather than raising."""
+    return ci_local.split(f"{fn_name}()", 1)[-1].split("\nchk_", 1)[0]
+
+
+def check_registry(ci_local: str, array_name: str) -> str:
+    """The text of a bash array declaration named `array_name` (e.g.
+    `CHECKS` or `OPTIONAL_CHECKS`), from the line that starts with
+    `<array_name>=(` to the line that starts with `)`.
+
+    The opening delimiter is anchored to a line start (`\\n{array_name}=(`,
+    with `ci_local` conceptually prefixed by a newline so a declaration at
+    byte 0 still matches): an unanchored substring match would let `CHECKS`
+    match inside `OPTIONAL_CHECKS=(` too, since one name is a substring of
+    the other, and only today's declaration order in `scripts/ci-local.sh`
+    would keep that accidentally correct. The closing delimiter is anchored
+    the same way for the same reason the module docstring's history already
+    explains: check labels contain literal parens (like `"(run-all.sh)"`),
+    so an unanchored `)` split truncates the array at the first check whose
+    label happens to include one.
+
+    Raises `ValueError` if `array_name` is not declared at a line start at
+    all, or if its declaration is never followed by a line starting with
+    `)` — both guard the same "x" not in registry vacuous-pass shape a
+    silent wrong-window fallback would otherwise produce, at each end of
+    the span. Unlike `check_body`, no current caller of this function
+    separately confirms the array's existence."""
+    marker = f"\n{array_name}=("
+    haystack = "\n" + ci_local
+    if marker not in haystack:
+        raise ValueError(f"{array_name}=( is not declared at the start of a line")
+    remainder = haystack.split(marker, 1)[-1]
+    if "\n)" not in remainder:
+        raise ValueError(f"{array_name}=( is never closed by a line starting with )")
+    return remainder.split("\n)", 1)[0]
+
+
+def synthetic_check(fn_name: str, body: str) -> str:
+    """A minimal `ci-local.sh` fragment shaped so `check_body(text, fn_name)`
+    finds its window — a bash function named `fn_name` wrapping `body`,
+    followed by a sentinel next function so the window has a real end."""
+    return f"{fn_name}() {{\n{body}\n}}\n\nchk_next() {{ :; }}\n"
+
+
+def without_comments(text: str) -> str:
+    """`text` with whole-line comments removed.
+
+    Whole-line only — an inline trailing comment on a real code line still
+    counts, so a suppressor cannot hide a narrowing flag behind one. Note
+    `invocation()` and `lines_after_invocation()` deliberately do NOT run
+    their own continuation-walk through this function first: inside a
+    continued command a `#` line truncates the command rather than
+    commenting itself out, so there its tokens must survive."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _marker_span(lines: list[str]) -> tuple[int, int] | None:
+    """The `(start, end)` line-index span, within `lines`, of the continued
+    command containing the sole `-m pytest` marker — walked outward while
+    lines continue, the way bash reads a backslash-continued command.
+
+    Continuation is tested on the RAW line: bash reads a `\\` followed by a
+    space as an escaped space that ENDS the command, so a trailing space
+    after a backslash must end the span here too, or a command the shell had
+    truncated would be read as spanning further than it really does.
+
+    `-m pytest` must appear on exactly one non-comment LINE for a span to be
+    returned at all — a same-line duplicate (two markers, or a decoy on the
+    same line as the real call) is not itself rejected here; it is caught
+    downstream instead, by the callers' own prefix/argument equality pins
+    against whichever marker `invocation()` anchors on. Returns `None` when
+    no line qualifies or more than one does, which both callers below turn
+    into a loud failure rather than a guessed one.
+    """
+    marks = [
+        i
+        for i, line in enumerate(lines)
+        if "-m pytest" in line and not line.lstrip().startswith("#")
+    ]
+    if len(marks) != 1:
+        return None
+    start = end = marks[0]
+    while start > 0 and lines[start - 1].endswith("\\"):
+        start -= 1
+    while end < len(lines) - 1 and lines[end].endswith("\\"):
+        end += 1
+    return start, end
+
+
+def _tokenize_span(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Every whitespace-separated token in `lines` (a continuation span),
+    split into `(tokens before any "||", tokens after it)`.
+
+    Pulled out of `invocation()` so that function's own loop nesting stays
+    shallow — this is the one place a `\\`-continuation line is stripped of
+    its trailing backslash and split, and the one place a `"||"` token
+    switches the accumulator from `tokens` to `tail` rather than being kept
+    itself."""
+    tokens: list[str] = []
+    tail: list[str] = []
+    seen_or = False
+    for line in lines:
+        for token in line.removesuffix("\\").split():
+            if token == "||":
+                seen_or = True
+                continue
+            (tail if seen_or else tokens).append(token)
+    return tokens, tail
+
+
+def invocation(ci_local: str, fn_name: str) -> PytestInvocation:
+    """`fn_name`'s pytest command, split at `-m pytest` and at any `||`.
+
+    Returns `(tokens before the marker, pytest's own arguments, tokens after
+    a "||" on the same continued command)`. All three matter independently:
+    the prefix decides which interpreter runs and which ambient environment
+    survives, the arguments decide what pytest actually collects and runs,
+    and a non-empty tail means the invocation's exit status is no longer
+    pytest's own.
+
+    Tokenizing is whitespace-based, so a behaviour-preserving reflow of the
+    continuation does not fail a caller's pin whose subject never changed.
+
+    Comments are deliberately NOT stripped before walking the continuation
+    or tokenizing (only `_marker_span`'s own marker SCAN excludes them, so a
+    comment merely mentioning `-m pytest` cannot supply a decoy match): a
+    `#` line carrying a trailing backslash does not comment itself out of a
+    continued command, it truncates the command there, so pytest would
+    receive only the arguments above it. Stripping that comment line first
+    would silently splice the surrounding continuation lines back together
+    and report a full argument list for an invocation the real shell had cut
+    short — the exact outcome every gate this module backs must never
+    produce. The comment's own tokens flow into `tokens`/`tail` like any
+    other token, where a caller's own allowlist or equality check against
+    them is what actually rejects them.
+
+    Tokens after `||` are returned separately rather than dropped, so a
+    failure path that discards or replaces the verdict (`-q || printf
+    'failed'`) is visible to the caller instead of silently passing through
+    as an unconditional run.
+
+    Returns `PytestInvocation([], [], [])` when the marker is missing,
+    ambiguous, or not immediately followed by `pytest`. A command truncated
+    exactly at `-m pytest`, with no trailing arguments at all, is NOT
+    specially rejected either — it returns `(prefix, [], tail)` rather than
+    the empty form, relying on a caller's own argument-equality pin (never a
+    denylist) to still fail on the empty `args`.
+    """
+    lines = check_body(ci_local, fn_name).splitlines()
+    span = _marker_span(lines)
+    if span is None:
+        return PytestInvocation([], [], [])
+    start, end = span
+    tokens, tail = _tokenize_span(lines[start : end + 1])
+    if "-m" not in tokens:
+        return PytestInvocation([], [], [])
+    marker = tokens.index("-m")
+    if tokens[marker + 1 : marker + 2] != ["pytest"]:
+        return PytestInvocation([], [], [])
+    return PytestInvocation(tokens[:marker], tokens[marker + 2 :], tail)
+
+
+def lines_after_invocation(ci_local: str, fn_name: str) -> list[str]:
+    """Real code lines in `fn_name`'s body strictly after the (possibly
+    multi-line) pytest invocation ends.
+
+    A bash function returns its LAST command's status, and `ci-local.sh`
+    runs without `set -e`, so any statement appended after the invocation —
+    a stray `printf`, a `true`, an unconditional `return 0` — silently
+    becomes the gate's verdict instead of pytest's own exit code. The
+    function's closing `}` is not a statement, and a trailing comment has no
+    bearing on what bash actually executes, so both are excluded from the
+    result — unlike `invocation()`'s own continuation span, where excluding
+    a comment could hide a narrowing bypass; here it can only stop this
+    rule's own documentation from tripping the check.
+
+    Returns a one-element sentinel list when the marker is missing or
+    ambiguous (mirroring `invocation()`'s empty-`PytestInvocation` return),
+    since there is no invocation boundary to measure "after" from."""
+    lines = check_body(ci_local, fn_name).splitlines()
+    span = _marker_span(lines)
+    if span is None:
+        return ["<unparseable: -m pytest marker not found exactly once>"]
+    _, end = span
+    return [
+        stripped
+        for line in lines[end + 1 :]
+        if (stripped := line.strip())
+        and stripped != "}"
+        and not stripped.startswith("#")
+    ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,7 +16,10 @@ addopts = --import-mode=importlib
 # _mutation_test_helpers (shared SCRIPTS_DIR/FORBIDDEN_LITERALS constants,
 # issue #1554), repo root -> _repo_root (shared REPO_ROOT constant, replacing per-file
 # Path(__file__).resolve().parents[N] computation across the test corpus) and
-# _content_guard_scan (shared plugin-markdown scan surface, issues #1655/#1656).
+# _content_guard_scan (shared plugin-markdown scan surface, issues #1655/#1656),
+# and _ci_local_invocation (shared ci-local.sh source parsers — a
+# pytest-invocation parser and a registry-array parser — for the
+# floor/ceiling gate tests, issue #1887).
 pythonpath =
     .
     tests/stack_aware

--- a/tests/repo/test_ci_local_invocation.py
+++ b/tests/repo/test_ci_local_invocation.py
@@ -1,0 +1,182 @@
+"""Direct tests of the shared `_ci_local_invocation` parser (#1887).
+
+`test_python_floor.py` and `test_python_ceiling.py` both pin this parser
+against their own gate's synthetic bodies — `TestTheSliceParserItself` and
+`TestTheCeilingParserItself` respectively — but neither pins the parser's
+OWN contract under a neutral name. Flagged independently by test-smell-review,
+test-review, domain-review, and arch-review during #1887's own review: the
+production-code duplication the module was extracted to remove had, without
+this file, simply moved one layer up into the two consumers' near-identical
+parser-edge-case tests. This file is additive, not a replacement — it does
+not remove or narrow either consumer's existing test classes, which the
+extraction requires to keep passing byte-for-byte on their pre-existing
+assertions; it only gives the shared module a test surface of its own, using
+a neutral synthetic function name (`chk_neutral`) rather than either gate's.
+
+`without_comments()` is deliberately NOT re-tested here: it already has
+exactly one canonical test, in `test_python_floor.py`'s
+`test_without_comments_strips_whole_lines_but_keeps_inline_ones`, whose own
+docstring notes it is shared with `test_python_ceiling.py` via this module —
+duplicating it a third time here would be the same test-effort duplication
+this file exists to stop adding to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from _ci_local_invocation import (
+    PytestInvocation,
+    check_body,
+    check_registry,
+    invocation,
+    lines_after_invocation,
+    synthetic_check,
+)
+
+#: A name belonging to neither real gate, so a passing test here can never be
+#: mistaken for coverage of gate-specific behavior (that stays in each
+#: consumer's own test class).
+NEUTRAL_FN = "chk_neutral"
+
+
+def test_check_body_finds_the_named_function():
+    text = synthetic_check(NEUTRAL_FN, "  echo hi")
+    assert check_body(text, NEUTRAL_FN) == " {\n  echo hi\n}\n"
+
+
+def test_check_body_stops_before_the_next_chk_function():
+    text = "chk_a() {\n  first\n}\nchk_b() {\n  second\n}\n"
+    assert "second" not in check_body(text, "chk_a")
+
+
+def test_check_body_with_an_unknown_function_name_stops_at_the_first_chk_anyway():
+    """The documented fallback (test-review, #1887): with `fn_name` absent,
+    the FIRST split is a no-op (no separator found, so it returns the whole
+    input), but the SECOND split still runs — truncating at the first
+    `"\\nchk_"` anywhere in that unchanged input, not just after `fn_name`'s
+    own header. So this does NOT reliably return the whole input unchanged;
+    it returns everything up to the first OTHER `chk_`-prefixed function,
+    which for the real `scripts/ci-local.sh` (preamble, then chk_ functions
+    in sequence) happens to equal the preamble, but is not guaranteed for
+    arbitrary text where the first function is itself `chk_`-prefixed and
+    isn't `fn_name` — exactly this synthetic case. Every current caller
+    separately pins `f"{fn_name}()" in ci_local` before trusting this
+    function's result, so this fallback shape is pinned here directly
+    rather than only by inference."""
+    text = synthetic_check(NEUTRAL_FN, "  echo hi")
+    assert check_body(text, "chk_missing") == "chk_neutral() {\n  echo hi\n}\n"
+
+
+def test_check_registry_splits_at_the_closing_paren_line():
+    text = 'CHECKS=(\n  "chk_a (label)"\n  "chk_b"\n)\nOPTIONAL_CHECKS=(\n  "chk_c"\n)\n'
+    assert check_registry(text, "CHECKS") == '\n  "chk_a (label)"\n  "chk_b"'
+    assert check_registry(text, "OPTIONAL_CHECKS") == '\n  "chk_c"'
+
+
+def test_check_registry_is_anchored_against_the_name_collision():
+    """`CHECKS` is a substring of `OPTIONAL_CHECKS`, so an unanchored match
+    would let `check_registry(text, "CHECKS")` land inside
+    `OPTIONAL_CHECKS=(` too. Declared first here (reversed from the test
+    above and from `scripts/ci-local.sh`'s own order) specifically so this
+    case cannot pass by declaration-order coincidence the way the
+    unanchored version once did (domain-review, correctness-review,
+    arch-review — all three independently, #1887)."""
+    text = 'OPTIONAL_CHECKS=(\n  "chk_c"\n)\nCHECKS=(\n  "chk_a"\n)\n'
+    assert check_registry(text, "CHECKS") == '\n  "chk_a"'
+    assert check_registry(text, "OPTIONAL_CHECKS") == '\n  "chk_c"'
+
+
+def test_check_registry_raises_when_the_array_name_is_absent():
+    """Unlike `check_body`'s documented (if imprecise) fallback,
+    `check_registry` raises rather than silently returning a wrong window —
+    added after security-review and domain-review both independently found
+    that a silent fallback here let a negative membership assertion
+    (`"x" not in registry`) pass vacuously against text that was not the
+    named array at all (#1887)."""
+    text = 'CHECKS=(\n  "chk_a"\n)\n'
+    with pytest.raises(ValueError):
+        check_registry(text, "OPTIONAL_CHECKS")
+
+
+def test_check_registry_raises_when_the_declaration_is_never_closed():
+    """The closing delimiter needs the same guard as the opening one
+    (domain-review, second closing pass, #1887): an unclosed array — no
+    line starting with `)` anywhere after the declaration — would
+    otherwise silently return an over-wide window (everything to EOF, or
+    to the next line-start `)` belonging to a DIFFERENT array), the exact
+    vacuous-pass shape the opening-delimiter guard was added to prevent,
+    just at the other end of the span."""
+    text = 'CHECKS=(\n  "chk_a"\n'
+    with pytest.raises(ValueError):
+        check_registry(text, "CHECKS")
+
+
+def test_check_registry_raises_for_an_indented_declaration():
+    """A declaration that IS present but not anchored at a line start (an
+    indented reassignment, a `declare`/`readonly` prefix) is not the
+    line-start form this function's anchor requires — it should raise
+    the same as a genuinely absent array, not silently match a DIFFERENT,
+    unrelated `)`-terminated block below it (domain-review, #1887)."""
+    text = '  CHECKS=(\n  "chk_a"\n)\n'
+    with pytest.raises(ValueError):
+        check_registry(text, "CHECKS")
+
+
+def test_invocation_reads_prefix_args_and_tail():
+    body = synthetic_check(
+        NEUTRAL_FN,
+        "  FOO= uv run -m pytest \\\n    tests/a \\\n    -q || return 1",
+    )
+    result = invocation(body, NEUTRAL_FN)
+    assert result == PytestInvocation(["FOO=", "uv", "run"], ["tests/a", "-q"], ["return", "1"])
+    # PytestInvocation is tuple-compatible: unpacking and plain-tuple equality
+    # both still work, which is the whole point of it being a NamedTuple —
+    # but named-field access is the one thing a plain tuple couldn't do, so
+    # that needs its own assertion rather than riding along on the others.
+    prefix, args, tail = result
+    assert (prefix, args, tail) == (["FOO=", "uv", "run"], ["tests/a", "-q"], ["return", "1"])
+    assert result.prefix == ["FOO=", "uv", "run"]
+    assert result.args == ["tests/a", "-q"]
+    assert result.tail == ["return", "1"]
+
+
+def test_invocation_is_unparseable_without_a_single_marker():
+    assert invocation(synthetic_check(NEUTRAL_FN, "  echo hi"), NEUTRAL_FN) == ([], [], [])
+    two_markers = "  uv run -m pytest a -q\n  uv run -m pytest b -q"
+    assert invocation(synthetic_check(NEUTRAL_FN, two_markers), NEUTRAL_FN) == ([], [], [])
+
+
+def test_invocation_does_not_specially_reject_zero_trailing_args():
+    """A command truncated exactly at `-m pytest` is not treated as
+    unparseable — it returns empty `args` rather than the fully-empty form,
+    documented as a deliberate choice in `invocation()`'s own docstring
+    (correctness-review, #1887)."""
+    body = synthetic_check(NEUTRAL_FN, "  uv run -m pytest")
+    assert invocation(body, NEUTRAL_FN) == (["uv", "run"], [], [])
+
+
+def test_lines_after_invocation_finds_a_trailing_statement():
+    body = synthetic_check(NEUTRAL_FN, "  uv run -m pytest tests/a -q\n  echo done")
+    assert lines_after_invocation(body, NEUTRAL_FN) == ["echo done"]
+
+
+def test_lines_after_invocation_is_empty_for_the_clean_case():
+    body = synthetic_check(NEUTRAL_FN, "  uv run -m pytest tests/a -q")
+    assert lines_after_invocation(body, NEUTRAL_FN) == []
+
+
+def test_lines_after_invocation_returns_the_sentinel_when_unparseable():
+    """The one branch neither consumer's synthetic-body tests exercised
+    (test-review, #1887): a missing/ambiguous marker means there is no
+    invocation boundary to measure "after" from at all. Covers both ways
+    `_marker_span` returns `None` — missing entirely, and ambiguous (two
+    markers) — since they are logically distinct per its own docstring,
+    even though both currently produce the identical sentinel here."""
+    sentinel = ["<unparseable: -m pytest marker not found exactly once>"]
+    missing = synthetic_check(NEUTRAL_FN, "  echo hi")
+    assert lines_after_invocation(missing, NEUTRAL_FN) == sentinel
+    two_markers = synthetic_check(
+        NEUTRAL_FN, "  uv run -m pytest a -q\n  uv run -m pytest b -q"
+    )
+    assert lines_after_invocation(two_markers, NEUTRAL_FN) == sentinel

--- a/tests/repo/test_python_ceiling.py
+++ b/tests/repo/test_python_ceiling.py
@@ -37,9 +37,21 @@ import re
 
 import pytest
 
+from _ci_local_invocation import (
+    PytestInvocation,
+    check_body,
+    check_registry,
+    invocation,
+    lines_after_invocation,
+    synthetic_check,
+    without_comments,
+)
 from _repo_root import REPO_ROOT
 
 CI_LOCAL = REPO_ROOT / "scripts" / "ci-local.sh"
+
+#: The bash function name every parser call below is scoped to.
+CEILING_FN = "chk_python_ceiling"
 
 #: Mirrors `test_python_floor.py`'s `FLOOR_DOTTED` — the single declaration
 #: of the ceiling version, held equal to `PYTHON_CEILING`'s actual value in
@@ -106,136 +118,44 @@ def ci_local() -> str:
 
 
 def _ceiling_check_body(ci_local: str) -> str:
-    """The text of `chk_python_ceiling`'s function body.
-
-    Bounded the same way `test_python_floor.py`'s `_floor_check_body` bounds
-    `chk_python_floor`'s: from the function header to the next top-level
-    `chk_`-prefixed function definition."""
-    return ci_local.split("chk_python_ceiling()", 1)[-1].split("\nchk_", 1)[0]
+    """The text of `chk_python_ceiling`'s function body. Thin wrapper over
+    the shared `check_body()` in `_ci_local_invocation`."""
+    return check_body(ci_local, CEILING_FN)
 
 
-def _without_comments(text: str) -> str:
-    """`text` with whole-line comments removed. Whole-line only, so an inline
-    trailing comment on a real code line still counts — a suppressor cannot
-    hide a narrowing flag behind one."""
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-
-
-def _ceiling_invocation(ci_local: str) -> tuple[list[str], list[str], list[str]]:
+def _ceiling_invocation(ci_local: str) -> PytestInvocation:
     """`chk_python_ceiling`'s pytest command, split at `-m pytest` and at any
-    trailing `||`.
-
-    Mirrors `test_python_floor.py`'s `_floor_invocation`: returns `(tokens
-    before the marker, pytest's own arguments, tokens after a "||" on the same
-    continued command)`. All three matter independently — the prefix decides
-    which interpreter runs and which ambient env survives, the arguments
-    decide what pytest actually collects and runs, and a non-empty tail means
-    the invocation's exit status is no longer pytest's own.
-
-    Comments are deliberately NOT stripped before walking continuation or
-    tokenizing — same reasoning `test_python_floor.py::_floor_invocation`
-    gives for its identical choice: a `#` line carrying a trailing backslash
-    does not comment itself out of a continued command, it truncates the
-    command there, so pytest would receive only the arguments above it. If
-    this parser stripped that comment line first, it would silently splice
-    the surrounding continuation lines back together and report a full
-    argument list for an invocation the real shell had cut short — the exact
-    outcome this gate must never produce. Comments are excluded only from the
-    marker SCAN below (`not line.lstrip().startswith("#")`), so a comment
-    merely mentioning `-m pytest` cannot supply a decoy match; their tokens
-    still flow into `tokens`/`tail` when they fall inside the continuation
-    span, where the equality checks below reject them.
-
-    Returns `([], [], [])` when the marker is missing, ambiguous, or not
-    followed by `pytest` — an empty parse fails every assertion loudly rather
-    than reporting a false pass.
-    """
-    lines = _ceiling_check_body(ci_local).splitlines()
-    marks = [
-        i
-        for i, line in enumerate(lines)
-        if "-m pytest" in line and not line.lstrip().startswith("#")
-    ]
-    if len(marks) != 1:
-        return [], [], []
-    start = end = marks[0]
-    while start > 0 and lines[start - 1].endswith("\\"):
-        start -= 1
-    while end < len(lines) - 1 and lines[end].endswith("\\"):
-        end += 1
-    tokens: list[str] = []
-    tail: list[str] = []
-    seen_or = False
-    for line in lines[start : end + 1]:
-        for token in line.removesuffix("\\").split():
-            if token == "||":
-                seen_or = True
-                continue
-            (tail if seen_or else tokens).append(token)
-    if "-m" not in tokens:
-        return [], [], []
-    marker = tokens.index("-m")
-    if tokens[marker + 1 : marker + 2] != ["pytest"]:
-        return [], [], []
-    return tokens[:marker], tokens[marker + 2 :], tail
+    trailing `||`. Thin wrapper over the shared parser in
+    `_ci_local_invocation` — see `invocation()` there for the full boundary
+    rules (backslash continuation, the single-marker requirement, why
+    comments are not stripped first, and why the `||` tail is returned
+    rather than dropped). Mirrors `test_python_floor.py`'s `_floor_invocation`,
+    which wraps the same shared function for `chk_python_floor`."""
+    return invocation(ci_local, CEILING_FN)
 
 
 def _ceiling_invocation_prefix(ci_local: str) -> list[str]:
     """Everything the command says before `-m pytest`."""
-    return _ceiling_invocation(ci_local)[0]
+    return _ceiling_invocation(ci_local).prefix
 
 
 def _ceiling_invocation_args(ci_local: str) -> list[str]:
     """Every argument pytest itself receives, after `-m pytest`."""
-    return _ceiling_invocation(ci_local)[1]
+    return _ceiling_invocation(ci_local).args
 
 
 def _ceiling_invocation_tail(ci_local: str) -> list[str]:
     """Everything the command says after a `||` — the failure path, if any."""
-    return _ceiling_invocation(ci_local)[2]
+    return _ceiling_invocation(ci_local).tail
 
 
 def _ceiling_lines_after_invocation(ci_local: str) -> list[str]:
     """Real code lines in the function body strictly after the (possibly
-    multi-line) pytest invocation ends.
-
-    A bash function returns its LAST command's status, and ci-local.sh runs
-    without `set -e`, so any statement appended after the invocation — a
-    stray `printf`, a `true`, an unconditional `return 0` — silently becomes
-    this gate's verdict instead of pytest's own exit code. The function's
-    closing `}` is not a statement. A comment line strictly after the
-    invocation IS excluded here — unlike `_ceiling_invocation`'s tokenizing
-    span, a trailing comment has no bearing on what bash actually executes,
-    so excluding it here cannot hide a narrowing bypass the way stripping it
-    from the invocation's own span would; it only stops this rule's own
-    documentation from tripping the check.
-
-    Marker-scan shares `_ceiling_invocation`'s comment-exclusion rule (a
-    comment merely mentioning `-m pytest` is not a decoy match) but, like
-    that function, does NOT strip comments before walking the continuation —
-    a truncating mid-invocation comment must still end the span here at the
-    same point it ends it there, or the two views of "where the invocation
-    ends" could disagree."""
-    lines = _ceiling_check_body(ci_local).splitlines()
-    marks = [
-        i
-        for i, line in enumerate(lines)
-        if "-m pytest" in line and not line.lstrip().startswith("#")
-    ]
-    if len(marks) != 1:
-        return ["<unparseable: -m pytest marker not found exactly once>"]
-    end = marks[0]
-    while end < len(lines) - 1 and lines[end].endswith("\\"):
-        end += 1
-    return [
-        stripped
-        for line in lines[end + 1 :]
-        if (stripped := line.strip())
-        and stripped != "}"
-        and not stripped.startswith("#")
-    ]
+    multi-line) pytest invocation ends. Thin wrapper over the shared
+    `lines_after_invocation()` in `_ci_local_invocation` — see that
+    function's docstring for why a trailing statement matters and why a
+    trailing comment is excluded from the result."""
+    return lines_after_invocation(ci_local, CEILING_FN)
 
 
 class TestTheCeilingCheckClearsAmbientPytestEnv:
@@ -259,8 +179,8 @@ class TestTheCeilingCheckClearsAmbientPytestEnv:
         this check ever moves into the default CHECKS array, that is a real
         decision to make deliberately, not something that should slip in
         silently."""
-        registry = ci_local.split("CHECKS=(", 1)[-1].split("\n)", 1)[0]
-        optional = ci_local.split("OPTIONAL_CHECKS=(", 1)[-1].split("\n)", 1)[0]
+        registry = check_registry(ci_local, "CHECKS")
+        optional = check_registry(ci_local, "OPTIONAL_CHECKS")
         assert "chk_python_ceiling" not in registry
         assert "chk_python_ceiling" in optional
 
@@ -302,7 +222,7 @@ class TestTheCeilingCheckClearsAmbientPytestEnv:
         what that variable resolves to. Mirrors
         `test_python_floor.py::TestTheFloorIsProvenByRunningIt::
         test_the_check_uses_a_real_interpreter`'s identical pin for `py310`."""
-        body = _without_comments(_ceiling_check_body(ci_local))
+        body = without_comments(_ceiling_check_body(ci_local))
         assert re.findall(r"\bpyceil=\S*", body) == [
             'pyceil="$(_resolve_python_ceiling)"'
         ], (
@@ -391,7 +311,7 @@ class TestTheCeilingCheckClearsAmbientPytestEnv:
         gate green on a path that never runs the suite at all — a stronger
         and more direct failure mode than a discarded verdict below the
         invocation, which the previous test covers."""
-        body = _without_comments(_ceiling_check_body(ci_local))
+        body = without_comments(_ceiling_check_body(ci_local))
         assert "return 0" not in body, (
             "chk_python_ceiling must never return 0 except by reaching the "
             "end of its pytest invocation; an early `return 0` makes the "
@@ -407,8 +327,10 @@ class TestTheCeilingParserItself:
     `test_python_floor.py::TestTheSliceParserItself` pins its own parser."""
 
     @staticmethod
-    def _synthetic(invocation: str) -> str:
-        return f"chk_python_ceiling() {{\n{invocation}\n}}\n\nchk_next() {{ :; }}\n"
+    def _synthetic(body: str) -> str:
+        """Thin wrapper over the shared `synthetic_check()` in
+        `_ci_local_invocation`."""
+        return synthetic_check(CEILING_FN, body)
 
     def test_it_reads_the_prefix_and_args(self):
         body = self._synthetic(

--- a/tests/repo/test_python_floor.py
+++ b/tests/repo/test_python_floor.py
@@ -79,7 +79,19 @@ import re
 
 import pytest
 
+from _ci_local_invocation import (
+    PytestInvocation,
+    check_body,
+    check_registry,
+    invocation,
+    lines_after_invocation,
+    synthetic_check,
+    without_comments,
+)
 from _repo_root import REPO_ROOT
+
+#: The bash function name every parser call below is scoped to.
+FLOOR_FN = "chk_python_floor"
 
 RUFF_CONFIG = REPO_ROOT / "ruff.toml"
 # The current floor version's ADR of record (ADR 0031), not ADR 0014 where the
@@ -151,21 +163,6 @@ def ci_workflow() -> str:
     return CI_WORKFLOW.read_text(encoding="utf-8")
 
 
-def _without_comments(text: str) -> str:
-    """`text` with whole-line comments removed.
-
-    Shared by every scan that looks for real shell code, because this function's
-    body is mostly prose: documenting a rule must never break it. Whole-line only
-    — an inline trailing comment stays, which errs strict rather than permissive
-    (a suppressor cannot hide behind it). Note the slice parser deliberately does
-    NOT use this: inside a continued command a `#` line truncates the command
-    rather than commenting itself out, so there its tokens must survive.
-    """
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-
-
 def _only_lists(workflow: str) -> list[list[str]]:
     """Every `--only=<comma-list>` argument actually invoked in the
     workflow, split into its component check names. Comment lines are
@@ -175,7 +172,7 @@ def _only_lists(workflow: str) -> list[list[str]]:
     not satisfy a caller looking for the real invocation."""
     return [
         lst.split(",")
-        for lst in re.findall(r"--only=([\w,-]+)", _without_comments(workflow))
+        for lst in re.findall(r"--only=([\w,-]+)", without_comments(workflow))
     ]
 
 
@@ -212,84 +209,29 @@ FLOOR_INVOCATION_PREFIX = (
 )
 
 
-def _floor_invocation(ci_local: str) -> tuple[list[str], list[str], list[str]]:
-    """`chk_python_floor`'s pytest command, split at `-m pytest`.
-
-    Returns `(tokens before the marker, pytest's arguments, tokens after `||`)`.
-    All three halves are returned because each can silently gut the gate on its
-    own: the prefix decides which interpreter runs and which plugins load, the
-    arguments decide what is collected, and the `||` tail decides whether a
-    failure is even reported.
-
-    Boundaries are the shell's, not a guess:
-
-    - The command is found from its `-m pytest` line and walked outward while
-      lines continue. Continuation is tested on the RAW line: bash reads `\\`
-      followed by a space as an escaped space that ENDS the command, so a
-      trailing space after a backslash must end the span here too, or this
-      parser would report nine paths for a command the shell had truncated.
-    - `-m pytest` must appear exactly once outside comments. Anchoring on the
-      first of several would let a decoy invocation, or a `printf` mentioning it,
-      supply the paths while the real call passed a subset.
-    - Tokenizing is whitespace-based, so a behaviour-preserving reflow does not
-      fail a test whose subject never changed.
-    - Tokens after `||` are returned separately rather than dropped. Discarding
-      them left the whole region unasserted, so `-q || printf 'failed'` reported
-      a failing slice as success while every test stayed green.
-    - Comments are NOT stripped inside the command. A `#` line carrying a
-      trailing backslash does not comment itself out — it truncates the command
-      there, so pytest receives only the arguments above it. Its tokens are left
-      in, where the argument allowlist rejects them; dropping them would report
-      a full slice for a two-file run, the one outcome this gate must never
-      produce.
-
-    Returns `([], [], [])` when the marker is missing, ambiguous, argument-less,
-    or not followed by `pytest`. An empty parse fails every assertion loudly,
-    which is the safe direction.
+def _floor_invocation(ci_local: str) -> PytestInvocation:
+    """`chk_python_floor`'s pytest command, split at `-m pytest` and at any
+    `||`. Thin wrapper over the shared parser in `_ci_local_invocation` —
+    see `invocation()` there for the full boundary rules (backslash
+    continuation, the single-marker requirement, why comments are not
+    stripped first, and why the `||` tail is returned rather than dropped).
     """
-    lines = _floor_check_body(ci_local).splitlines()
-    marks = [
-        i
-        for i, line in enumerate(lines)
-        if "-m pytest" in line and not line.lstrip().startswith("#")
-    ]
-    if len(marks) != 1:
-        return [], [], []
-    start = end = marks[0]
-    while start > 0 and lines[start - 1].endswith("\\"):
-        start -= 1
-    while end < len(lines) - 1 and lines[end].endswith("\\"):
-        end += 1
-    tokens: list[str] = []
-    tail: list[str] = []
-    seen_or = False
-    for line in lines[start : end + 1]:
-        for token in line.removesuffix("\\").split():
-            if token == "||":
-                seen_or = True
-                continue
-            (tail if seen_or else tokens).append(token)
-    if tokens[-2:] == ["-m", "pytest"] or "-m" not in tokens:
-        return [], [], []
-    marker = tokens.index("-m")
-    if tokens[marker + 1] != "pytest":
-        return [], [], []
-    return tokens[:marker], tokens[marker + 2 :], tail
+    return invocation(ci_local, FLOOR_FN)
 
 
 def _floor_invocation_prefix(ci_local: str) -> list[str]:
     """Everything the command says before `-m pytest`."""
-    return _floor_invocation(ci_local)[0]
+    return _floor_invocation(ci_local).prefix
 
 
 def _floor_invocation_tail(ci_local: str) -> list[str]:
     """Everything the command says after `||` — the failure path."""
-    return _floor_invocation(ci_local)[2]
+    return _floor_invocation(ci_local).tail
 
 
 def _floor_slice_files(ci_local: str) -> list[str]:
     """The slice's test-file paths, in the order pytest receives them."""
-    return [t for t in _floor_invocation(ci_local)[1] if _SLICE_PATH_RE.fullmatch(t)]
+    return [t for t in _floor_invocation(ci_local).args if _SLICE_PATH_RE.fullmatch(t)]
 
 
 def _floor_slice_extra_args(ci_local: str) -> list[str]:
@@ -303,7 +245,7 @@ def _floor_slice_extra_args(ci_local: str) -> list[str]:
     flags at all, such as a truncating comment's own tokens.
     """
     return [
-        t for t in _floor_invocation(ci_local)[1] if not _SLICE_PATH_RE.fullmatch(t)
+        t for t in _floor_invocation(ci_local).args if not _SLICE_PATH_RE.fullmatch(t)
     ]
 
 
@@ -343,7 +285,9 @@ class TestTheFloorIsDeclaredOnce:
 
 
 def _floor_check_body(ci_local: str) -> str:
-    return ci_local.split("chk_python_floor()", 1)[-1].split("\nchk_", 1)[0]
+    """The text of `chk_python_floor`'s function body. Thin wrapper over the
+    shared `check_body()` in `_ci_local_invocation`."""
+    return check_body(ci_local, FLOOR_FN)
 
 
 class TestTheFloorIsProvenByRunningIt:
@@ -366,9 +310,7 @@ class TestTheFloorIsProvenByRunningIt:
     def test_the_check_runs_in_the_default_gate(self, ci_local):
         """Opt-in-only checks live in a separate array and never run unless
         named. The floor must not be one of them."""
-        # Split on a line that is exactly `)`; check labels contain literal
-        # parens ("(run-all.sh)"), so a bare `)` split truncates the array.
-        registry = ci_local.split("CHECKS=(", 1)[-1].split("\n)", 1)[0]
+        registry = check_registry(ci_local, "CHECKS")
         assert "chk_python_floor" in registry, (
             "the floor check must be in the always-run CHECKS array, not opt-in"
         )
@@ -381,7 +323,7 @@ class TestTheFloorIsProvenByRunningIt:
         # would run every stage of this gate on the dev interpreter with all tests
         # green. Pin the single assignment and its source.
         assert re.findall(
-            r"\bpy310=\S*", _without_comments(body)
+            r"\bpy310=\S*", without_comments(body)
         ) == ['py310="$(_resolve_python310)"'], (
             "py310 must be assigned exactly once, from _resolve_python310. "
             "Reassigning it silently runs the whole gate off-floor."
@@ -480,19 +422,7 @@ class TestTheFloorIsProvenByRunningIt:
         `_resolve_python310`'s own `return 0` sits above `chk_python_floor()` and
         is correctly outside `_floor_check_body`'s window."""
         body = _floor_check_body(ci_local)
-        lines = body.splitlines()
-        end = next(
-            i
-            for i, line in enumerate(lines)
-            if "-m pytest" in line and not line.lstrip().startswith("#")
-        )
-        while end < len(lines) - 1 and lines[end].endswith("\\"):
-            end += 1
-        trailing = [
-            line
-            for line in lines[end + 1 :]
-            if line.strip() and line.strip() != "}" and not line.lstrip().startswith("#")
-        ]
+        trailing = lines_after_invocation(ci_local, FLOOR_FN)
         assert not trailing, (
             f"chk_python_floor runs {trailing} after its pytest invocation. A bash "
             "function returns its LAST command's status and ci-local.sh runs "
@@ -514,7 +444,7 @@ class TestTheFloorIsProvenByRunningIt:
         # constrains lines AFTER the command, so a `return 0` guard above it (or a
         # softened uv branch) would leave the gate green on machines that never run
         # the slice. Every legitimate guard here returns 1.
-        code = _without_comments(body)
+        code = without_comments(body)
         assert "return 0" not in code, (
             "chk_python_floor must never return 0 except by reaching the end of "
             "its pytest invocation; an early `return 0` makes the gate pass "
@@ -541,19 +471,22 @@ class TestTheFloorIsProvenByRunningIt:
         )
 
 
-def _synthetic_floor_check(invocation: str) -> str:
-    """A minimal `ci-local.sh` shaped so `_floor_check_body` finds its window."""
-    return f"chk_python_floor() {{\n{invocation}\n}}\n\nchk_next() {{ :; }}\n"
+def _synthetic_floor_check(body: str) -> str:
+    """A minimal `ci-local.sh` shaped so `_floor_check_body` finds its
+    window. Thin wrapper over the shared `synthetic_check()` in
+    `_ci_local_invocation`."""
+    return synthetic_check(FLOOR_FN, body)
 
 
 def test_without_comments_strips_whole_lines_but_keeps_inline_ones():
-    """`_without_comments` now backs three separate guards — the `--only=` scan,
-    the `py310=` single-assignment pin, and the verdict-suppression scan — so a
-    bug in it would defang all three at once. Whole-line stripping is what makes
-    documenting a rule safe; keeping inline comments is what stops a suppressor
-    hiding behind one on a live code line."""
+    """`without_comments` (shared with `test_python_ceiling.py` via
+    `_ci_local_invocation`) backs three separate guards here — the `--only=`
+    scan, the `py310=` single-assignment pin, and the verdict-suppression
+    scan — so a bug in it would defang all three at once. Whole-line
+    stripping is what makes documenting a rule safe; keeping inline comments
+    is what stops a suppressor hiding behind one on a live code line."""
     text = "# whole line\n  # indented whole line\ncode()  # inline stays\nmore()"
-    assert _without_comments(text) == "code()  # inline stays\nmore()"
+    assert without_comments(text) == "code()  # inline stays\nmore()"
 
 
 class TestTheSliceParserItself:


### PR DESCRIPTION
## Summary

`tests/repo/test_python_floor.py` and `tests/repo/test_python_ceiling.py` each independently implemented a parser for finding a bash function's `-m pytest` invocation (walking backslash continuations, splitting into prefix/args/`||`-tail). A fix to one — the comment-stripping bug caught during #1876/#1885's review — had to be manually ported to the other. Four independent review agents (structure-review, test-review, test-smell-review, arch-review) flagged this during #1885's review.

Extracts `_ci_local_invocation.py` at the repo root (matching `_repo_root.py`/`_content_guard_scan.py`'s existing convention — `--import-mode=importlib` doesn't add `tests/repo/` to `sys.path`, so a sibling helper there wouldn't be importable by bare name), exposing `check_body`/`invocation`/`lines_after_invocation`/`without_comments`/`check_registry`/`synthetic_check`.

## Review process

Dispatched a 14-agent `/code-review` panel against the extraction, then three closing-pass rounds (the pre-commit dispatch-ledger requires fresh corroborating dispatches at each new staged hash after a fix). ~20 agent dispatches total. Findings applied:

- `synthetic_check(fn_name, body)` replaces the two files' near-identical synthetic-body-builder helpers
- `check_registry(ci_local, array_name)` replaces the two files' identical `CHECKS=(`/`OPTIONAL_CHECKS=(` parsing — a **second**, still-live instance of the same duplication class this PR targets, caught by arch-review. Both delimiters are anchored to a line start and raise `ValueError` when missing, closing a substring-collision risk (`CHECKS` is a substring of `OPTIONAL_CHECKS`, independently caught by domain-review, correctness-review, and arch-review) and a vacuous-pass risk in ceiling's negative membership assertion (security-review)
- `invocation()` now returns a tuple-compatible `PytestInvocation` `NamedTuple`; both consumers' wrapper functions use named-field access instead of positional indexing
- `invocation()`'s inner tokenizing loop extracted to `_tokenize_span` to reduce nesting depth
- Several docstring/naming corrections (a shadowed `invocation` parameter renamed to `body`, `check_body`'s docstring corrected — it does not return input unchanged for an unknown `fn_name` — `check_registry`'s docstring, module framing broadened beyond just "invocation")
- Added `tests/repo/test_ci_local_invocation.py` testing the shared module directly under a neutral synthetic function name, including branches neither consumer exercised — **purely additive**; `TestTheSliceParserItself` and `TestTheCeilingParserItself` are unchanged and pass byte-for-byte on their pre-existing assertions (both files' full test suites keep passing byte-for-byte, +14 new tests)

Deferred as tracked follow-ups: #1895

## Test plan

- [x] Both files' full pre-existing test suites pass byte-for-byte (45 tests)
- [x] New `tests/repo/test_ci_local_invocation.py` passes (14 tests)
- [x] Real `scripts/ci-local.sh` behavior confirmed unchanged (`chk_python_floor`/`chk_python_ceiling` resolve to the same `CHECKS`/`OPTIONAL_CHECKS` windows)
- [x] Full local CI gate (`scripts/ci-local.sh`, 21 checks): all passed, 8275 passed / 43 skipped
- [x] `ruff check` clean
- [x] Rebased onto `main` after #1885 merged; no conflicts

Closes #1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)