### PR TITLE
fix(hooks): lock JSONL appends against concurrent writers

### DIFF
--- a/plugins/dev-team/docs/concurrent-use.md
+++ b/plugins/dev-team/docs/concurrent-use.md
@@ -3,9 +3,19 @@
 Short version: **the normal team workflow is safe; for two *agents* on one
 machine, give each its own git worktree.**
 
-This resolves the concurrency question (#109): the plugin **documents** a safe
-pattern rather than enforcing locks, because git worktrees already solve the
-problem cleanly.
+This resolves the concurrency question (#109) for the per-checkout state in
+the table below: the plugin **documents** a safe pattern rather than
+enforcing locks there, because git worktrees already solve the problem
+cleanly. Separately, a handful of small on-disk state files that a single
+worktree's own hooks read-modify-write or append to — session/retry counters
+(`bash_retry_guard.py`, `session_learning_trigger.py`), and four of the
+`.claude/metrics/*.jsonl` telemetry streams (`boundary-events.jsonl`,
+`workflow-states.jsonl`, `iteration-journal.jsonl`, and an `/autoship`
+round log) — *are* lock-serialized (`hooks/lib/atomic_state.py`,
+#1501/#1874/#1889). Those races are within one worktree, between concurrent
+tool calls or sliced-mode parallel dispatches, not the cross-worktree case
+this doc is about. Other `.claude/metrics/*.jsonl` streams are not yet
+converted (#1896).
 
 ## Why the normal case is already safe
 

--- a/plugins/dev-team/hooks/lib/atomic_state.py
+++ b/plugins/dev-team/hooks/lib/atomic_state.py
@@ -24,14 +24,33 @@ these are advisory nudges, never gates.
 
 Lock *acquisition* is bounded, not a blocking wait (#1888): a hung sibling
 process holding the lock must never leave a caller blocked indefinitely,
-since some callers (e.g. `boundary_events.py`, once #1874 lands) sit in
-front of a safety-critical guard hook's verdict. `locked_state` polls a
-non-blocking acquisition for a bounded total budget and falls through to
-running the critical section UNLOCKED once that budget elapses — the same
-fail-open posture as every other failure mode here. This bounds contention
-on an already-held lock specifically; it does NOT bound a stall inside
-`open()` on the lock file itself, or inside a caller's own I/O in the
-critical section — a wedged mount can still block there.
+since some callers (e.g. `boundary_events.py`, per #1874) sit in front of a
+safety-critical guard hook's verdict. `locked_state` polls a non-blocking
+acquisition for a bounded total budget and falls through to running the
+critical section UNLOCKED once that budget elapses — the same fail-open
+posture as every other failure mode here. This bounds contention on an
+already-held lock specifically; it does NOT bound a stall inside `open()` on
+the lock file itself, or inside a caller's own I/O in the critical section —
+a wedged mount can still block there.
+
+A second use case (#1889) reuses `locked_state` for pure append-serialization
+rather than read-modify-write: several `.claude/metrics/*.jsonl` telemetry
+streams have concurrent writers of their own — sliced-mode code-review's 2-3
+parallel slices, `/build`'s wave-parallel fan-out
+(`DEV_TEAM_MAX_PARALLEL_BUILDS`), or two sessions/worktrees appending to the
+same shared log. Without the lock, two processes' `write()` calls can
+interleave mid-line and corrupt the stream for every downstream consumer.
+`append_line_locked(path, line)` below is the shared helper for that shape.
+
+The lock file is opened with `O_NOFOLLOW` (where the platform defines it)
+and created at mode `0600` (security review, #1889): a pre-planted symlink
+at `<path>.lock` would otherwise be followed by a plain `open()`, and a
+world/group-writable lock file would let another local user on a shared
+host acquire and hold it (an `flock`/`msvcrt.locking` caller needs no write
+access to the *data* file to do this — only to the lock file). `O_NOFOLLOW`
+makes `open()` fail closed (OSError) on a symlinked lock path, which this
+function's existing fail-open contract already turns into an unlocked
+critical section — the same outcome as any other lock-open failure.
 
 Stdlib-only.
 """
@@ -217,6 +236,17 @@ def locked_state(path: Path) -> Iterator[None]:
     UNLOCKED rather than raising or blocking forever. An unlocked lost-update
     is no worse than the pre-#1501 behavior; a crash — or an undelivered
     guard-hook verdict — would be worse, and these hooks are advisory.
+
+    CONTRACT — catch OSError *inside* the `with` block, not around it: if the
+    critical section raises an uncaught OSError, it propagates out through
+    this generator's `yield` and is swallowed by the same `except OSError`
+    that guards the lock-file open/lock-acquire calls — which then falls
+    through to a second, bare `yield`, and `contextlib` raises
+    `RuntimeError("generator didn't stop after throw()")` instead of the
+    OSError the caller expected. This is a real, confirmed foot-gun (not
+    hypothetical), tracked separately rather than fixed here — every current
+    caller already catches OSError inside the `with` block (see
+    `append_line_locked` below).
     """
     lock_path = path.parent / (path.name + ".lock")
     try:
@@ -225,12 +255,29 @@ def locked_state(path: Path) -> Iterator[None]:
         yield
         return
 
-    # The open() failure case shares this try/except with the whole `with`
-    # body (ruff SIM115 requires open() directly in a `with`). Callers own
-    # their own OSError handling inside the critical section, so this outer
-    # except only ever fires for the open() call itself.
+    # os.O_NOFOLLOW is undefined on Windows; getattr(..., 0) makes the flag
+    # a no-op there rather than an AttributeError (which isn't an OSError
+    # and would escape the except below).
     try:
-        with open(lock_path, "a+") as handle:
+        lock_fd = os.open(
+            str(lock_path), os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0), 0o600
+        )
+        # The mode argument to os.open() only applies when O_CREAT actually
+        # creates the file — POSIX ignores it for a path that already
+        # exists. Every checkout that already has a pre-#1889 lock file on
+        # disk (created at the old, wider default permissions) would
+        # otherwise keep it forever. fchmod on the already-open fd (no
+        # TOCTOU) enforces 0600 either way (security review, #1889).
+        with contextlib.suppress(OSError, AttributeError):
+            os.fchmod(lock_fd, 0o600)
+    except OSError:
+        yield
+        return
+
+    # Callers own their own OSError handling inside the critical section, so
+    # this outer except only ever fires for the fdopen()/lock-acquire calls.
+    try:
+        with os.fdopen(lock_fd, "r+") as handle:
             locked = False
             try:
                 try:
@@ -250,18 +297,119 @@ def locked_state(path: Path) -> Iterator[None]:
     yield
 
 
+def _write_maybe_delayed(handle, line: str, delay_env_var: str | None) -> None:
+    """Write `line` in one call, unless `delay_env_var` names a set env var.
+
+    Test-only split path: see `append_line_locked`'s docstring for why a
+    single small `write()` needs splitting, not just delaying, to simulate a
+    genuinely non-atomic write.
+    """
+    if delay_env_var and os.environ.get(delay_env_var):
+        mid = len(line) // 2
+        handle.write(line[:mid])
+        handle.flush()
+        race_window_delay(delay_env_var)
+        handle.write(line[mid:])
+    else:
+        handle.write(line)
+
+
+def append_line_locked(
+    path: Path,
+    line: str,
+    *,
+    delay_env_var: str | None = None,
+    fail_open: bool = True,
+) -> None:
+    """Append `line` (already newline-terminated) to `path` under `locked_state`.
+
+    Serializes concurrent appends to a shared JSONL stream: while the lock is
+    held (see `locked_state`'s own fail-open fallback above for when it might
+    not be), two processes writing at once cannot interleave their bytes
+    into one corrupted line (see module docstring, #1889) — the append-only
+    counterpart to `locked_state`'s original read-modify-write use case. The
+    lock is what provides this, regardless of how many underlying
+    `os.write()` syscalls a single logical `.write()` call happens to
+    decompose into (e.g. a line long enough to cross the `BufferedWriter`'s
+    internal buffer boundary) — a caller does not need to reason about
+    syscall-level atomicity separately.
+
+    `fail_open` (default `True`): OSError from `open()`/`write()` is caught
+    *inside* the lock and discarded, matching this repo's fail-open posture
+    for advisory telemetry. Pass `fail_open=False` for a caller that needs
+    the write failure to propagate instead (e.g. a round-log CLI that must
+    crash rather than silently record nothing) — the OSError is still
+    caught *inside* the lock (avoiding a caller-raised exception crossing
+    the generator's `yield`), just re-raised after the lock releases rather
+    than discarded.
+
+    `delay_env_var`, when set and naming a set env var, splits the write into
+    two separate `write()` calls with `race_window_delay` between them,
+    instead of the usual single call. This is a test-only hook, needed
+    because a single small `write()` to an `O_APPEND`-opened file is
+    typically atomic with respect to other processes on mainstream local
+    filesystems (not independently verified here — no recorded runtime
+    probe), so simply sleeping *before* an unsplit write may not force real
+    interleaving in a test. The split instead simulates a genuinely
+    non-atomic write directly (long enough to cross a write-buffer
+    boundary, or a filesystem, e.g. some NFS configurations, that doesn't
+    honor `O_APPEND`'s atomicity guarantee) — the actual failure mode the
+    lock protects against regardless of whether any given production write
+    happens to be single-syscall-atomic on its own. Unset (the default) in
+    production: exactly one `.write()` call at this Python API level,
+    unchanged from the code this helper replaced.
+    """
+    write_error: OSError | None = None
+    with locked_state(path):
+        try:
+            # O_NOFOLLOW (security review, #1889): the data file sits beside
+            # the now-hardened `<path>.lock` in the same predictable,
+            # repo-relative directory — a pre-planted symlink here would
+            # otherwise redirect every append the same way the pre-fix lock
+            # file did. Mode is the historical default (not 0600): unlike
+            # the lock file, this file's readers are other tooling that
+            # expects normal permissions.
+            fd = os.open(
+                str(path),
+                os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+                0o644,
+            )
+            with os.fdopen(fd, "a", encoding="utf-8") as handle:
+                _write_maybe_delayed(handle, line, delay_env_var)
+        except OSError as exc:
+            if not fail_open:
+                write_error = exc
+    if write_error is not None:
+        raise write_error
+
+
+_MAX_RACE_WINDOW_DELAY_MS = 500
+
+
 def race_window_delay(env_var: str) -> None:
     """Test-only injection point: sleep inside a locked critical section when
     `env_var` names a millisecond delay, widening the race window so a
     concurrency test can deterministically force two invocations to overlap
     rather than relying on timing luck. Unset in production; a bad/missing
-    value is a no-op (fail-open). Mirrors
-    `code_intelligence_turn_mark._test_delay`.
+    value is a no-op (fail-open). NOT the same implementation as
+    `code_intelligence_turn_mark._test_delay` despite the similar shape —
+    that sibling still has an uncapped sleep inside its own blocking lock.
+
+    Capped at `_MAX_RACE_WINDOW_DELAY_MS` (security review, #1889): several
+    callers now invoke this from inside a held exclusive lock on a shared,
+    frequently-hit stream (`append_line_locked`'s `_write_maybe_delayed`), so
+    an unbounded value here would let anything that can influence the process
+    environment hold that lock for an attacker-chosen duration. Every real
+    test uses 60ms; the cap costs them nothing. This bounds one call, not a
+    whole critical section — a caller invoking it more than once, or from
+    inside a loop, multiplies the total; today's callers all call it exactly
+    once per critical section, but that is a property of the call sites,
+    not an invariant this function enforces.
     """
     raw = os.environ.get(env_var)
     if not raw:
         return
     try:
-        time.sleep(int(raw) / 1000)
+        time.sleep(min(int(raw), _MAX_RACE_WINDOW_DELAY_MS) / 1000)
     except (ValueError, OSError):
         pass

--- a/plugins/dev-team/hooks/lib/autoship_log.py
+++ b/plugins/dev-team/hooks/lib/autoship_log.py
@@ -15,11 +15,28 @@ import pathlib
 import sys
 from datetime import datetime, timezone
 
+_LIB_DIR = pathlib.Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from atomic_state import append_line_locked
+
+_DELAY_ENV_VAR = "DEV_TEAM_AUTOSHIP_LOG_TEST_DELAY_MS"
+
 
 def append_round(log_path: str, record: dict) -> None:
     """Append a JSON line to log_path, adding a logged_at ISO timestamp.
 
     Creates the file and any parent directories if they do not exist.
+    Serializes concurrent appends via `atomic_state.append_line_locked`
+    (#1889) so two overlapping `/autoship` rounds writing to the same log
+    are protected from interleaving their bytes into one corrupted line
+    while the lock is held (see `locked_state`'s own fail-open fallback for
+    when it might not be). Unlike the fail-open telemetry streams sharing
+    this pattern (`boundary_events.py`, `workflow_state.py`,
+    `iteration_journal_gate.py`), a write failure here is not swallowed —
+    `append_line_locked(fail_open=False)` re-raises it after the lock
+    releases, so the CLI still surfaces it as a real error.
 
     Args:
         log_path: Path to the JSONL file.
@@ -31,8 +48,8 @@ def append_round(log_path: str, record: dict) -> None:
     path = pathlib.Path(log_path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    with path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(entry) + "\n")
+    line = json.dumps(entry) + "\n"
+    append_line_locked(path, line, delay_env_var=_DELAY_ENV_VAR, fail_open=False)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/plugins/dev-team/hooks/lib/iteration_journal_gate.py
+++ b/plugins/dev-team/hooks/lib/iteration_journal_gate.py
@@ -33,12 +33,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 _LIB_DIR = Path(__file__).resolve().parent
-sys.path.insert(0, str(_LIB_DIR))
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+from atomic_state import append_line_locked
 from boundary_events import emit_boundary_event
 
 _LOG_NAME = "iteration-journal.jsonl"
+_DELAY_ENV_VAR = "DEV_TEAM_ITERATION_JOURNAL_TEST_DELAY_MS"
 
 
 def _isoformat_utc() -> str:
@@ -104,8 +107,9 @@ def record_iteration_entry(
         if session_id:
             payload["session_id"] = session_id
 
-        with open(log, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        append_line_locked(
+            log, json.dumps(payload, separators=(",", ":")) + "\n", delay_env_var=_DELAY_ENV_VAR
+        )
     except Exception:  # noqa: BLE001, S110 — fail-open by design, see module docstring
         pass
 

--- a/plugins/dev-team/hooks/lib/workflow_state.py
+++ b/plugins/dev-team/hooks/lib/workflow_state.py
@@ -32,8 +32,10 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+from atomic_state import append_line_locked
 
 _LOG_NAME = "workflow-states.jsonl"
+_DELAY_ENV_VAR = "DEV_TEAM_WORKFLOW_STATE_TEST_DELAY_MS"
 
 CANONICAL_LIFECYCLE = ["SPEC", "PLAN", "BUILD", "REVIEW", "COMMIT", "PR"]
 
@@ -97,8 +99,9 @@ def emit_state_transition(
         if session_id:
             payload["session_id"] = session_id
 
-        with open(log, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        append_line_locked(
+            log, json.dumps(payload, separators=(",", ":")) + "\n", delay_env_var=_DELAY_ENV_VAR
+        )
     except Exception:  # noqa: BLE001, S110 — fail-open by design, see module docstring
         pass
 

--- a/plugins/dev-team/tests/hooks/test_atomic_state.py
+++ b/plugins/dev-team/tests/hooks/test_atomic_state.py
@@ -1,0 +1,100 @@
+"""Unit tests for hooks/lib/atomic_state.py, focused on the #1889 security
+hardening of `locked_state`'s lock-file open (symlink-follow, permissions)
+and `race_window_delay`'s cap.
+
+Neither control was previously pinned by a test — both were verified only
+by a manual, unrecorded run — so a regression (reverting to a bare
+`open(lock_path, "a+")`, or dropping the delay cap) could land with the
+whole suite green.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import atomic_state  # type: ignore[import-not-found]
+import pytest
+
+
+def test_locked_state_does_not_follow_a_symlinked_lock_file(tmp_path: Path) -> None:
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("platform has no O_NOFOLLOW")
+    target = tmp_path / "outside-target.txt"
+    log = tmp_path / "log.jsonl"
+    lock_path = tmp_path / "log.jsonl.lock"
+    os.symlink(str(target), str(lock_path))
+
+    with atomic_state.locked_state(log):
+        pass
+
+    assert not target.exists(), "symlinked lock file must not be followed"
+    assert os.path.islink(lock_path), "the planted symlink itself must be left untouched"
+
+
+def test_locked_state_creates_lock_file_at_mode_0600(tmp_path: Path) -> None:
+    if os.name != "posix":
+        pytest.skip("POSIX file mode semantics only")
+    log = tmp_path / "log.jsonl"
+
+    with atomic_state.locked_state(log):
+        pass
+
+    lock_path = tmp_path / "log.jsonl.lock"
+    mode = stat.S_IMODE(lock_path.stat().st_mode)
+    assert mode == 0o600
+
+
+def test_locked_state_fixes_mode_on_a_pre_existing_lock_file(tmp_path: Path) -> None:
+    """A lock file created by the pre-#1889 code (bare `open(..., "a+")`, no
+    explicit mode) sits at the umask default — typically 0644. `os.open`'s
+    mode argument is ignored for a path that already exists, so this only
+    passes because of the added `os.fchmod` call."""
+    if os.name != "posix":
+        pytest.skip("POSIX file mode semantics only")
+    log = tmp_path / "log.jsonl"
+    lock_path = tmp_path / "log.jsonl.lock"
+    lock_path.touch(mode=0o644)
+    os.chmod(lock_path, 0o644)
+
+    with atomic_state.locked_state(log):
+        pass
+
+    mode = stat.S_IMODE(lock_path.stat().st_mode)
+    assert mode == 0o600
+
+
+def test_append_line_locked_does_not_follow_a_symlinked_data_file(tmp_path: Path) -> None:
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("platform has no O_NOFOLLOW")
+    target = tmp_path / "outside-target.txt"
+    log = tmp_path / "log.jsonl"
+    os.symlink(str(target), str(log))
+
+    atomic_state.append_line_locked(log, "line\n")
+
+    assert not target.exists(), "symlinked data file must not be followed"
+    assert os.path.islink(log), "the planted symlink itself must be left untouched"
+
+
+def test_race_window_delay_caps_a_large_value(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_DELAY_MS", "10000000")
+    start = time.monotonic()
+    atomic_state.race_window_delay("TEST_DELAY_MS")
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, f"race_window_delay did not cap, took {elapsed}s"
+
+
+def test_race_window_delay_negative_value_is_a_noop(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_DELAY_MS", "-5")
+    start = time.monotonic()
+    atomic_state.race_window_delay("TEST_DELAY_MS")
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0

--- a/plugins/dev-team/tests/hooks/test_autoship_log.py
+++ b/plugins/dev-team/tests/hooks/test_autoship_log.py
@@ -1,0 +1,206 @@
+"""Unit tests for hooks/lib/autoship_log.py.
+
+Covers:
+  - append_round(): append, dir creation, adds `logged_at`.
+  - CLI `--json` / `--json-file` sources, invalid-JSON / non-dict rejection.
+  - concurrency (#1889): N concurrent appends never interleave into a
+    corrupted line.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_PLUGIN_DIR = _REPO_ROOT / "plugins" / "dev-team"
+_HOOKS_DIR = _PLUGIN_DIR / "hooks"
+_LIB_DIR = _HOOKS_DIR / "lib"
+_LIB_SCRIPT = _LIB_DIR / "autoship_log.py"
+_TESTS_LIB = _PLUGIN_DIR / "tests" / "lib"
+
+for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import autoship_log  # type: ignore[import-not-found]
+from concurrency import (  # type: ignore[import-not-found]
+    DEFAULT_DELAY_MS,
+    DEFAULT_WORKERS,
+)
+from concurrency import (
+    assert_concurrent_appends_produce_one_line_per_marker as _assert_concurrent_appends,
+)
+from jsonl import read_jsonl as _read_jsonl  # type: ignore[import-not-found]
+
+# ---------------------------------------------------------------------------
+# append_round()
+# ---------------------------------------------------------------------------
+
+
+def test_append_round_appends_one_compact_jsonl_line(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    autoship_log.append_round(str(log), {"issue": "#1", "outcome": "shipped"})
+    entries = _read_jsonl(log)
+    assert len(entries) == 1
+    assert entries[0]["issue"] == "#1"
+    assert entries[0]["outcome"] == "shipped"
+    assert "logged_at" in entries[0]
+
+
+def test_append_round_creates_parent_dir_when_absent(tmp_path: Path) -> None:
+    log = tmp_path / "nested" / "round-log.jsonl"
+    autoship_log.append_round(str(log), {"issue": "#2"})
+    assert log.is_file()
+
+
+def test_append_round_appends_not_overwrites_across_two_calls(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    autoship_log.append_round(str(log), {"issue": "#1"})
+    autoship_log.append_round(str(log), {"issue": "#2"})
+    entries = _read_jsonl(log)
+    assert [e["issue"] for e in entries] == ["#1", "#2"]
+
+
+def test_append_round_propagates_oserror_from_a_failed_write(tmp_path: Path) -> None:
+    """Unlike its fail-open siblings (boundary_events.py, workflow_state.py,
+    iteration_journal_gate.py), append_round() must NOT swallow a write
+    failure — the /autoship round-log caller needs to know the round wasn't
+    actually recorded, not silently proceed as if it were. Uses a real OSError
+    (log path names an existing directory, so open("a") raises
+    IsADirectoryError) rather than monkeypatching, since append_round now
+    delegates to atomic_state.append_line_locked, which opens the file via
+    the builtin open() rather than Path.open()."""
+    log_dir = tmp_path / "round-log-is-a-dir"
+    log_dir.mkdir()
+    with pytest.raises(OSError):
+        autoship_log.append_round(str(log_dir), {"issue": "#1"})
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_arg_appends_one_entry(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_LIB_SCRIPT),
+            "--log-path",
+            str(log),
+            "--json",
+            json.dumps({"issue": "#3"}),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    entries = _read_jsonl(log)
+    assert entries[0]["issue"] == "#3"
+
+
+def test_cli_json_file_arg_appends_one_entry(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    json_file = tmp_path / "payload.json"
+    json_file.write_text(json.dumps({"issue": "#4"}), encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_LIB_SCRIPT),
+            "--log-path",
+            str(log),
+            "--json-file",
+            str(json_file),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    entries = _read_jsonl(log)
+    assert entries[0]["issue"] == "#4"
+
+
+def test_cli_rejects_invalid_json(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    result = subprocess.run(
+        [sys.executable, str(_LIB_SCRIPT), "--log-path", str(log), "--json", "not json"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert not log.exists()
+
+
+def test_cli_rejects_non_dict_json(tmp_path: Path) -> None:
+    log = tmp_path / "round-log.jsonl"
+    result = subprocess.run(
+        [sys.executable, str(_LIB_SCRIPT), "--log-path", str(log), "--json", "[1, 2]"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert not log.exists()
+
+
+def test_cli_write_failure_crashes_rather_than_swallowing(tmp_path: Path) -> None:
+    """A write failure (here: --log-path names an existing directory, so
+    `path.open("a")` raises IsADirectoryError) must surface as a crash, not
+    the graceful `return 1` the CLI uses for a bad --json payload — matching
+    append_round()'s not-fail-open contract. main() has no try/except around
+    the append_round() call, so this asserts the CLI actually keeps that gap
+    open rather than accidentally starting to swallow it."""
+    log_dir = tmp_path / "round-log-is-a-dir"
+    log_dir.mkdir()
+    result = subprocess.run(
+        [sys.executable, str(_LIB_SCRIPT), "--log-path", str(log_dir), "--json", "{}"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "IsADirectoryError" in result.stderr or "OSError" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# concurrency (#1889)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_appends_never_interleave_into_a_corrupted_line(tmp_path: Path) -> None:
+    """N concurrent CLI invocations must each land one intact JSONL line,
+    never a torn/interleaved one. `DEV_TEAM_AUTOSHIP_LOG_TEST_DELAY_MS`
+    forces the write to split into two calls with a delay between them,
+    simulating a genuinely non-atomic write so this is a deterministic
+    regression guard (mirrors test_hook_state_concurrency.py, #1501). Each
+    worker gets a distinct `issue` marker so a torn/interleaved merge that
+    coincidentally still parses as JSON is still caught."""
+    markers = [f"marker-{i}-end" for i in range(DEFAULT_WORKERS)]
+    log = tmp_path / "round-log.jsonl"
+    env = {**os.environ, "DEV_TEAM_AUTOSHIP_LOG_TEST_DELAY_MS": str(DEFAULT_DELAY_MS)}
+    cmds = [
+        (
+            [
+                sys.executable,
+                str(_LIB_SCRIPT),
+                "--log-path",
+                str(log),
+                "--json",
+                json.dumps({"issue": marker}),
+            ],
+            env,
+        )
+        for marker in markers
+    ]
+    _assert_concurrent_appends(cmds, log, markers)

--- a/plugins/dev-team/tests/hooks/test_boundary_events.py
+++ b/plugins/dev-team/tests/hooks/test_boundary_events.py
@@ -57,6 +57,7 @@ for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
 
 import boundary_events  # type: ignore[import-not-found]
 from hermetic import hermetic_git_env  # type: ignore[import-not-found]
+from jsonl import read_jsonl as _read_jsonl  # type: ignore[import-not-found]
 
 _DECISION_ENUM = {
     "block",
@@ -69,11 +70,6 @@ _DECISION_ENUM = {
 }
 _SCHEMA_FIELDS = {"ts", "hook", "tool", "decision", "matched_rule", "plugin_version"}
 _OPTIONAL_FIELDS = {"session_id"}
-
-
-def _read_jsonl(path: Path) -> list:
-    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
-    return [json.loads(ln) for ln in lines]
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
+++ b/plugins/dev-team/tests/hooks/test_hook_state_concurrency.py
@@ -19,7 +19,6 @@ import errno
 import json
 import os
 import shutil
-import subprocess
 import sys
 import textwrap
 import threading
@@ -31,41 +30,17 @@ from _repo_root import REPO_ROOT as _REPO_ROOT
 
 _HOOKS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
 _LIB_DIR = _HOOKS_DIR / "lib"
+_TESTS_LIB = _REPO_ROOT / "plugins" / "dev-team" / "tests" / "lib"
 
-sys.path.insert(0, str(_LIB_DIR))
+for _p in (_LIB_DIR, _TESTS_LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
 import atomic_state
 from atomic_state import atomic_write, locked_state
-
-# N concurrent workers and the delay (ms) each holds the critical section.
-# The delay guarantees overlap: total serialized wall-clock ~= N * DELAY.
-_WORKERS = 8
-_DELAY_MS = 60
-
-
-def _run_concurrently(cmds):
-    """Launch every (argv, stdin, env) concurrently; wait for all to exit 0-ish."""
-    procs = []
-    for argv, stdin_text, env in cmds:
-        procs.append(
-            (
-                subprocess.Popen(
-                    argv,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    env=env,
-                    text=True,
-                ),
-                stdin_text,
-            )
-        )
-    # Feed stdin to all first (non-blocking-ish for tiny payloads), then wait.
-    outputs = []
-    for proc, stdin_text in procs:
-        out, err = proc.communicate(stdin_text)
-        outputs.append((proc.returncode, out, err))
-    return outputs
-
+from concurrency import DEFAULT_DELAY_MS as _DELAY_MS
+from concurrency import DEFAULT_WORKERS as _WORKERS
+from concurrency import run_concurrently as _run_concurrently
 
 # ---------------------------------------------------------------------------
 # Shared primitive: atomic_state.locked_state serializes a RMW across processes

--- a/plugins/dev-team/tests/hooks/test_iteration_journal_gate.py
+++ b/plugins/dev-team/tests/hooks/test_iteration_journal_gate.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -22,18 +23,21 @@ _PLUGIN_DIR = _REPO_ROOT / "plugins" / "dev-team"
 _HOOKS_DIR = _PLUGIN_DIR / "hooks"
 _LIB_DIR = _HOOKS_DIR / "lib"
 _LIB_SCRIPT = _LIB_DIR / "iteration_journal_gate.py"
+_TESTS_LIB = _PLUGIN_DIR / "tests" / "lib"
 
-for _p in (_HOOKS_DIR, _LIB_DIR):
+for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 
 import iteration_journal_gate  # type: ignore[import-not-found]
-
-
-def _read_jsonl(path: Path) -> list:
-    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
-    return [json.loads(ln) for ln in lines]
-
+from concurrency import (  # type: ignore[import-not-found]
+    DEFAULT_DELAY_MS,
+    DEFAULT_WORKERS,
+)
+from concurrency import (
+    assert_concurrent_appends_produce_one_line_per_marker as _assert_concurrent_appends,
+)
+from jsonl import read_jsonl as _read_jsonl  # type: ignore[import-not-found]
 
 # ---------------------------------------------------------------------------
 # record_iteration_entry()
@@ -115,6 +119,44 @@ def test_record_fails_open_on_arbitrary_exception(tmp_path: Path, monkeypatch) -
 # ---------------------------------------------------------------------------
 # check_iteration_journal()
 # ---------------------------------------------------------------------------
+
+
+def test_concurrent_records_never_interleave_into_a_corrupted_line(tmp_path: Path) -> None:
+    """#1889: N concurrent CLI `record` invocations must each land one intact
+    JSONL line, never a torn/interleaved one.
+    `DEV_TEAM_ITERATION_JOURNAL_TEST_DELAY_MS` forces `atomic_state.append_line_locked`
+    to split its write into two calls with a delay between them, simulating a
+    genuinely non-atomic write so this is a deterministic regression guard
+    (mirrors test_hook_state_concurrency.py, #1501). Each worker gets a
+    distinct `--session` marker so a torn/interleaved merge that
+    coincidentally still parses as JSON is still caught."""
+    markers = [f"marker-{i}-end" for i in range(DEFAULT_WORKERS)]
+    env = {**os.environ, "DEV_TEAM_ITERATION_JOURNAL_TEST_DELAY_MS": str(DEFAULT_DELAY_MS)}
+    cmds = [
+        (
+            [
+                sys.executable,
+                str(_LIB_SCRIPT),
+                "record",
+                "--cwd",
+                str(tmp_path),
+                "--round-id",
+                "round-1",
+                "--attempted",
+                "ran tests",
+                "--outcome",
+                "green",
+                "--next-action",
+                "next issue",
+                "--session",
+                marker,
+            ],
+            env,
+        )
+        for marker in markers
+    ]
+    log = tmp_path / ".claude" / "metrics" / "iteration-journal.jsonl"
+    _assert_concurrent_appends(cmds, log, markers)
 
 
 def test_check_blocks_when_no_matching_entry(tmp_path: Path) -> None:

--- a/plugins/dev-team/tests/hooks/test_workflow_state.py
+++ b/plugins/dev-team/tests/hooks/test_workflow_state.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -23,18 +24,21 @@ _PLUGIN_DIR = _REPO_ROOT / "plugins" / "dev-team"
 _HOOKS_DIR = _PLUGIN_DIR / "hooks"
 _LIB_DIR = _HOOKS_DIR / "lib"
 _LIB_SCRIPT = _LIB_DIR / "workflow_state.py"
+_TESTS_LIB = _PLUGIN_DIR / "tests" / "lib"
 
-for _p in (_HOOKS_DIR, _LIB_DIR):
+for _p in (_HOOKS_DIR, _LIB_DIR, _TESTS_LIB):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 
 import workflow_state  # type: ignore[import-not-found]
-
-
-def _read_jsonl(path: Path) -> list:
-    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
-    return [json.loads(ln) for ln in lines]
-
+from concurrency import (  # type: ignore[import-not-found]
+    DEFAULT_DELAY_MS,
+    DEFAULT_WORKERS,
+)
+from concurrency import (
+    assert_concurrent_appends_produce_one_line_per_marker as _assert_concurrent_appends,
+)
+from jsonl import read_jsonl as _read_jsonl  # type: ignore[import-not-found]
 
 # ---------------------------------------------------------------------------
 # emit_state_transition()
@@ -144,6 +148,40 @@ def test_compute_dwell_times_empty_is_empty_dict() -> None:
 # ---------------------------------------------------------------------------
 # CLI end-to-end
 # ---------------------------------------------------------------------------
+
+
+def test_concurrent_emits_never_interleave_into_a_corrupted_line(tmp_path: Path) -> None:
+    """#1889: N concurrent CLI `record` invocations must each land one intact
+    JSONL line, never a torn/interleaved one.
+    `DEV_TEAM_WORKFLOW_STATE_TEST_DELAY_MS` forces `atomic_state.append_line_locked`
+    to split its write into two calls with a delay between them, simulating a
+    genuinely non-atomic write so this is a deterministic regression guard
+    (mirrors test_hook_state_concurrency.py, #1501). Each worker gets a
+    distinct `--session` marker so a torn/interleaved merge that
+    coincidentally still parses as JSON is still caught."""
+    markers = [f"marker-{i}-end" for i in range(DEFAULT_WORKERS)]
+    env = {**os.environ, "DEV_TEAM_WORKFLOW_STATE_TEST_DELAY_MS": str(DEFAULT_DELAY_MS)}
+    cmds = [
+        (
+            [
+                sys.executable,
+                str(_LIB_SCRIPT),
+                "record",
+                "--cwd",
+                str(tmp_path),
+                "--workflow",
+                "ship",
+                "--new-state",
+                "SPEC",
+                "--session",
+                marker,
+            ],
+            env,
+        )
+        for marker in markers
+    ]
+    log = tmp_path / ".claude" / "metrics" / "workflow-states.jsonl"
+    _assert_concurrent_appends(cmds, log, markers)
 
 
 def test_cli_record_then_report(tmp_path: Path) -> None:

--- a/plugins/dev-team/tests/lib/concurrency.py
+++ b/plugins/dev-team/tests/lib/concurrency.py
@@ -1,0 +1,155 @@
+"""Shared concurrent-subprocess-worker helper for plugins/dev-team/tests/ (#1889).
+
+`run_concurrently` launches N OS processes at once and waits for all of them
+— the same shape `tests/hooks/test_hook_state_concurrency.py` (#1501) used
+inline before this extraction. Genuinely concurrent OS processes (not
+threads) are the point: they let a `*_TEST_DELAY_MS` env var injected inside
+a hook's own locked critical section force real overlap, turning a
+lock-serialization regression test into a deterministic guard rather than a
+timing-luck one.
+
+`assert_concurrent_appends_produce_one_line_per_marker` is the shared
+assertion for the #1874/#1889 append-lock regression tests: `json.loads()`
+succeeding on every line is necessary but not sufficient to prove no
+corruption happened, since a torn/interleaved merge can coincidentally
+collapse into something that still parses (e.g. a duplicate key, last value
+wins). Giving each worker a distinct marker and asserting each appears in
+exactly one output line closes that gap — a merge splicing two workers'
+bytes together would contain zero, or more than one, of the expected
+markers, either of which fails the assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+DEFAULT_WORKERS = 8
+DEFAULT_DELAY_MS = 60
+
+# tests/repo/test_hermetic_adoption.py (#715/#546) AST-scans for a
+# subprocess call whose literal argv starts `git <mutating-verb>` and flags
+# it unless an `env=` kwarg is present, closing the "mutating git env leaks
+# into a pre-push hook and corrupts the parent worktree's refs" hole. That
+# scan matches the call site's function name and a literal argv — neither
+# holds when a caller hands a *variable* git argv to this module's own
+# `run_concurrently`, so this guard closes the same hole for that caller
+# shape instead of relying on the AST scan noticing it. Kept in lockstep
+# with that file's own `_PY_MUTATING_VERBS` — no current caller in this repo
+# hits this (all pass `sys.executable`/hook argv), so this is a latent-gap
+# closer, not a live-bug fix.
+_GIT_MUTATING_VERBS = {
+    "init",
+    "commit",
+    "push",
+    "update-ref",
+    "checkout",
+    "branch",
+    "tag",
+    "add",
+    "clone",
+    "fetch",
+    "pull",
+    "merge",
+    "rebase",
+    "reset",
+    "apply",
+    "cherry-pick",
+    "revert",
+    "worktree",
+    "stash",
+}
+
+
+def run_concurrently(cmds, timeout=30):
+    """Launch every (argv, stdin, env) concurrently; wait for all to exit.
+
+    All processes are started (non-blocking `Popen`) before any is waited
+    on, so they run genuinely concurrently regardless of how long draining
+    each one's pipes takes afterward. `timeout` (seconds, per process) turns
+    a hung worker — e.g. a deadlocked lock — into a clear
+    `subprocess.TimeoutExpired`-derived failure instead of an indefinite
+    hang.
+
+    Rejects a `cmds` entry whose `argv` is a mutating `git` command run with
+    `env=None` — that would inherit this process's real git env vars into a
+    subprocess a test spawned, the exact hazard `hermetic_git_env()` exists
+    to close (see module docstring). Pass a hermetic `env` explicitly if a
+    future caller genuinely needs to run one concurrently.
+
+    Recognizes `argv[0]` as `git` by basename (so `/usr/bin/git` and
+    `git.exe` match too), then requires the *immediately following* token to
+    be a mutating verb — disclosed limitation, not fixed here since no
+    current caller is affected: a global option before the verb (`git -C
+    <dir> commit`, `git -c user.name=x push`) is NOT recognized, so this
+    guard only catches the plain `git <verb> ...` shape.
+
+    Returns a list of (returncode, stdout, stderr) tuples, one per command,
+    in the same order as `cmds`. A timed-out process reports `returncode`
+    `None` and an `stderr` prefixed with `"TIMEOUT"`.
+    """
+    for argv, _stdin_text, env in cmds:
+        if (
+            env is None
+            and len(argv) >= 2
+            and Path(argv[0]).name.removesuffix(".exe") == "git"
+            and argv[1] in _GIT_MUTATING_VERBS
+        ):
+            raise ValueError(
+                f"run_concurrently: mutating git argv {argv!r} passed with env=None — "
+                "pass a hermetic env (see tests/lib/hermetic.py::hermetic_git_env)"
+            )
+    procs = [
+        subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+        )
+        for argv, _stdin_text, env in cmds
+    ]
+    outputs = []
+    for proc, (_argv, stdin_text, _env) in zip(procs, cmds):
+        try:
+            out, err = proc.communicate(stdin_text, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            out, err = proc.communicate()
+            outputs.append((None, out, f"TIMEOUT after {timeout}s: {err}"))
+            continue
+        outputs.append((proc.returncode, out, err))
+    return outputs
+
+
+def assert_concurrent_appends_produce_one_line_per_marker(argv_env_pairs, log_path, markers):
+    """Run `argv_env_pairs` concurrently, then assert the resulting JSONL
+    file has exactly one valid, unambiguous line per marker.
+
+    `argv_env_pairs` is a list of (argv, env) pairs — note the different
+    shape from `run_concurrently`'s (argv, stdin, env) triples; this
+    function always passes empty stdin — one per marker (same order as
+    `markers`); each `argv` must be built so its emitted line contains its
+    corresponding marker verbatim (e.g. baked into a `--session`,
+    `--subject-hash`, or JSON payload field the CLI under test already
+    accepts). Markers must be mutually non-substrings of each other (e.g.
+    `f"marker-{i}-end"`, not bare `str(i)`) so a substring search can't
+    false-positive across two different workers' markers.
+    """
+    assert len(markers) == len(set(markers)), "markers must be unique"
+    results = run_concurrently([(argv, "", env) for argv, env in argv_env_pairs])
+    for rc, _out, err in results:
+        assert rc == 0, f"cli failed (rc={rc}): {err}"
+
+    lines = [ln for ln in log_path.read_text(encoding="utf-8").splitlines() if ln]
+    assert len(lines) == len(markers), f"expected {len(markers)} lines, got {len(lines)}"
+    for line in lines:
+        json.loads(line)  # raises if a line is torn/interleaved
+
+    for marker in markers:
+        hits = [line for line in lines if marker in line]
+        assert len(hits) == 1, (
+            f"marker {marker!r} expected in exactly one line, found in {len(hits)}: {hits}"
+        )

--- a/plugins/dev-team/tests/lib/jsonl.py
+++ b/plugins/dev-team/tests/lib/jsonl.py
@@ -1,0 +1,18 @@
+"""Shared JSONL-reading helper for plugins/dev-team/tests/ (#1889).
+
+`read_jsonl` was duplicated verbatim across test_boundary_events.py,
+test_workflow_state.py, test_iteration_journal_gate.py, and
+test_autoship_log.py — each parsing a metrics stream's lines into dicts the
+same way. Extracted here so a future change to that shape (e.g. tolerating
+blank lines differently) lands once.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def read_jsonl(path: Path) -> list:
+    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    return [json.loads(ln) for ln in lines]

--- a/plugins/dev-team/tests/lib/test_concurrency.py
+++ b/plugins/dev-team/tests/lib/test_concurrency.py
@@ -1,0 +1,108 @@
+"""Unit tests for tests/lib/concurrency.py (#1889)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent
+_REPO_TESTS = Path(__file__).resolve().parents[4] / "tests" / "repo"
+for _p in (_LIB, _REPO_TESTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import concurrency  # type: ignore[import-not-found]
+import test_hermetic_adoption  # type: ignore[import-not-found]
+
+
+def test_git_mutating_verbs_matches_hermetic_adoption_gate() -> None:
+    """Kept in lockstep per concurrency.py's own comment — this test is what
+    actually enforces that claim rather than leaving it to a comment."""
+    assert concurrency._GIT_MUTATING_VERBS == test_hermetic_adoption._PY_MUTATING_VERBS
+
+
+def _cmd(*args: str) -> list:
+    return [sys.executable, "-c", *args]
+
+
+def test_run_concurrently_preserves_input_order() -> None:
+    cmds = [
+        (_cmd(f"print({i})"), "", None)
+        for i in range(5)
+    ]
+    results = concurrency.run_concurrently(cmds)
+    outputs = [out.strip() for _rc, out, _err in results]
+    assert outputs == ["0", "1", "2", "3", "4"]
+
+
+def test_run_concurrently_captures_returncode_per_command() -> None:
+    cmds = [
+        (_cmd("import sys; sys.exit(0)"), "", None),
+        (_cmd("import sys; sys.exit(7)"), "", None),
+    ]
+    results = concurrency.run_concurrently(cmds)
+    assert [rc for rc, _out, _err in results] == [0, 7]
+
+
+def test_run_concurrently_attributes_stdout_and_stderr_to_the_right_command() -> None:
+    cmds = [
+        (_cmd("print('out-a'); import sys; print('err-a', file=sys.stderr)"), "", None),
+        (_cmd("print('out-b'); import sys; print('err-b', file=sys.stderr)"), "", None),
+    ]
+    results = concurrency.run_concurrently(cmds)
+    assert results[0][1].strip() == "out-a"
+    assert results[0][2].strip() == "err-a"
+    assert results[1][1].strip() == "out-b"
+    assert results[1][2].strip() == "err-b"
+
+
+def test_run_concurrently_times_out_instead_of_hanging() -> None:
+    cmds = [(_cmd("import time; time.sleep(30)"), "", None)]
+    results = concurrency.run_concurrently(cmds, timeout=0.5)
+    rc, _out, err = results[0]
+    assert rc is None
+    assert "TIMEOUT" in err
+
+
+def test_run_concurrently_rejects_mutating_git_argv_without_env() -> None:
+    cmds = [(["git", "commit", "-m", "x"], "", None)]
+    try:
+        concurrency.run_concurrently(cmds)
+    except ValueError as exc:
+        assert "env=None" in str(exc)
+    else:
+        raise AssertionError("expected a ValueError for unhermetic mutating git argv")
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="requires git on PATH")
+def test_run_concurrently_allows_mutating_git_argv_with_explicit_env() -> None:
+    # "commit --help" matches the mutating-verb guard (argv[1] == "commit")
+    # without actually mutating anything, so this genuinely exercises the
+    # env-is-not-None allow path rather than short-circuiting on the verb
+    # check the way a non-mutating "--version" would.
+    cmds = [(["git", "commit", "--help"], "", {"PATH": os.environ.get("PATH", "")})]
+    results = concurrency.run_concurrently(cmds)
+    assert results[0][0] == 0
+
+
+def test_run_concurrently_allows_non_mutating_git_argv_without_env() -> None:
+    cmds = [(["git", "--version"], "", None)]
+    results = concurrency.run_concurrently(cmds)
+    assert results[0][0] == 0
+
+
+def test_assert_concurrent_appends_rejects_duplicate_markers(tmp_path: Path) -> None:
+    log = tmp_path / "log.jsonl"
+    cmds = [(_cmd("pass"), None), (_cmd("pass"), None)]
+    try:
+        concurrency.assert_concurrent_appends_produce_one_line_per_marker(
+            cmds, log, ["same", "same"]
+        )
+    except AssertionError as exc:
+        assert "unique" in str(exc)
+    else:
+        raise AssertionError("expected an AssertionError for duplicate markers")

--- a/plugins/dev-team/tests/lib/test_jsonl.py
+++ b/plugins/dev-team/tests/lib/test_jsonl.py
@@ -1,0 +1,30 @@
+"""Unit tests for tests/lib/jsonl.py (#1889)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import jsonl  # type: ignore[import-not-found]
+
+
+def test_read_jsonl_parses_each_line(tmp_path: Path) -> None:
+    path = tmp_path / "log.jsonl"
+    path.write_text('{"a": 1}\n{"a": 2}\n', encoding="utf-8")
+    assert jsonl.read_jsonl(path) == [{"a": 1}, {"a": 2}]
+
+
+def test_read_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "log.jsonl"
+    path.write_text('{"a": 1}\n\n{"a": 2}\n', encoding="utf-8")
+    assert jsonl.read_jsonl(path) == [{"a": 1}, {"a": 2}]
+
+
+def test_read_jsonl_empty_file_is_empty_list(tmp_path: Path) -> None:
+    path = tmp_path / "log.jsonl"
+    path.write_text("", encoding="utf-8")
+    assert jsonl.read_jsonl(path) == []


### PR DESCRIPTION
## Summary

- `emit_boundary_event` and its three siblings (`workflow_state.py`, `iteration_journal_gate.py`, `autoship_log.py`) each appended to a shared `.claude/metrics/*.jsonl` stream with a bare `open(log, "a").write(...)`, no mutual exclusion — concurrent writers (sliced-mode code-review's parallel slices, `/build`'s wave-parallel fan-out, two sessions/worktrees on the same repo) could interleave writes into one corrupted line.
- Adds `atomic_state.append_line_locked()`, reusing the existing `locked_state()` advisory lock for pure append-serialization. `autoship_log.py` (not fail-open, unlike its three siblings) uses `fail_open=False` to still surface a write failure as a real error.
- Hardens the lock (security review): the lock file is opened with `O_NOFOLLOW` and `fchmod`'d to `0600` (closing both a symlink-follow hazard and a permissions gap that a pre-existing lock file's mode would otherwise never get corrected to), and the data file is also opened with `O_NOFOLLOW`. The test-only race-window delay is capped at 500ms so it can never hold the lock for an attacker-chosen duration.
- Each concurrency regression test gives its workers distinct markers so a torn/interleaved merge that coincidentally still parses as JSON is still caught (a plain `json.loads()` check alone can't rule that out).

## Test plan

- [x] All four `test_concurrent_*` regression tests verified red-without-the-lock / green-with-it during development (temporarily disabled the lock, confirmed corruption, restored)
- [x] `test_atomic_state.py` (new) pins the symlink-follow and lock-file-permission fixes — verified red/green the same way
- [x] Full plugin + repo-root pytest suite green (8000+ tests)
- [x] `pre-push` local CI gate green (ruff, full pytest, eslint via lint-staged)
- [x] Reviewed by a multi-round dispatch across complexity, concurrency, doc, naming, performance, refactor-opportunity, spec-compliance, structure, test, test-smell, arch, correctness, domain, and security review agents, plus two closing passes on the fixes those rounds produced

## Follow-ups filed (not in this PR)

- #1893 — bound the lock's currently-unbounded blocking wait so it can't hang a caller (deliberately deferred: touches a primitive 3 existing read-modify-write callers depend on for correctness)
- #1896 — extend this lock convention to the remaining unlocked `.claude/metrics/*.jsonl` writers (`gate-bypass-audit.jsonl` etc.), add a mechanical gate preventing a new unlocked appender, and two narrower residuals found in later review rounds (foreign-owned lock file, undisclosed silent-drop-on-symlinked-data-file behavior)

Closes #1874
Closes #1889