### PR TITLE
fix(hooks): repoint pre-commit knowledge-index guard at the Python builder

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,13 +11,33 @@ cd "$ROOT" || exit 1
 #    knowledge/**.md or skills/**/SKILL.md change index.json; staging it here
 #    guarantees the regenerated index is committed and pushed rather than left
 #    as an uncommitted change after a commit or push runs the builder.
-if [ -x plugins/dev-team/hooks/lib/build-knowledge-index.sh ]; then
-  if ! plugins/dev-team/hooks/lib/build-knowledge-index.sh; then
-    echo "pre-commit: knowledge-index rebuild failed" >&2
-    exit 1
-  fi
-  git add plugins/dev-team/knowledge/index.json
+#    The builder reads the working tree, not the index, so an unstaged or
+#    untracked corpus file would let the rebuilt index diverge from what
+#    this commit actually contains — refuse rather than stage a mismatch.
+command -v python3 >/dev/null 2>&1 || { echo "pre-commit: python3 not found on PATH — run bash scripts/dev-setup.sh" >&2; exit 1; }
+UNSTAGED=$(git diff --name-only) || { echo "pre-commit: git diff failed" >&2; exit 1; }
+UNTRACKED=$(git ls-files --others --exclude-standard) || { echo "pre-commit: git ls-files failed" >&2; exit 1; }
+# Filter through the same corpus regex the builder itself trusts
+# (knowledge_index_paths.py) rather than a hand-rolled git pathspec glob —
+# a plain '*' pathspec crosses '/', so it would also flag non-corpus files
+# nested under knowledge/<subdir>/*.md that the builder never scans.
+CORPUS_DIRTY=$(printf '%s\n%s\n' "$UNSTAGED" "$UNTRACKED" | python3 -c '
+import sys
+sys.path.insert(0, "plugins/dev-team/hooks/lib")
+from knowledge_index_paths import filter_corpus_paths
+paths = [line.rstrip("\n") for line in sys.stdin if line.strip()]
+print("\n".join(filter_corpus_paths(paths)))
+') || { echo "pre-commit: corpus-dirty check failed to run" >&2; exit 1; }
+if [ -n "$CORPUS_DIRTY" ]; then
+  echo "pre-commit: unstaged/untracked knowledge-corpus files would make the rebuilt index.json not match this commit — stage or stash them first:" >&2
+  echo "$CORPUS_DIRTY" >&2
+  exit 1
 fi
+if ! python3 plugins/dev-team/hooks/lib/build_knowledge_index.py; then
+  echo "pre-commit: knowledge-index rebuild failed" >&2
+  exit 1
+fi
+git add plugins/dev-team/knowledge/index.json || { echo "pre-commit: staging index.json failed" >&2; exit 1; }
 
 # 2. Run lint-staged: eslint --fix on staged JS/TS files and ruff check --fix
 #    on staged Python files, with the autofixes automatically re-staged (see

--- a/scripts/run-ablation.sh
+++ b/scripts/run-ablation.sh
@@ -24,7 +24,7 @@ for t in claude gh jq python3 git; do command -v "$t" >/dev/null 2>&1 || { echo 
 [ -n "${ANTHROPIC_API_KEY:-}${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || { echo "no API credentials set." >&2; exit 2; }
 
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
-INDEX="plugins/dev-team/hooks/lib/build-knowledge-index.sh"
+INDEX="plugins/dev-team/hooks/lib/build_knowledge_index.py"
 
 mkdir -p .claude/evals
 ln -sfn "$PWD/evals/fixtures" .claude/evals/fixtures
@@ -53,15 +53,15 @@ _dispatch "$WORK/with.json" || exit 1
 
 echo "== ablating $KFILE (hiding + rebuilding index) =="
 mv "$KPATH" "$WORK/ablated.md"
-bash "$INDEX" >/dev/null 2>&1 || true
+python3 "$INDEX" >/dev/null 2>&1 || true
 # restore on any exit from here
-trap 'mv "$WORK/ablated.md" "$KPATH" 2>/dev/null; bash "$INDEX" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
+trap 'mv "$WORK/ablated.md" "$KPATH" 2>/dev/null; python3 "$INDEX" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
 
 echo "== ablated run (knowledge removed) =="
 _dispatch "$WORK/without.json" || exit 1
 
 echo "== restoring $KFILE =="
-mv "$WORK/ablated.md" "$KPATH"; bash "$INDEX" >/dev/null 2>&1 || true
+mv "$WORK/ablated.md" "$KPATH"; python3 "$INDEX" >/dev/null 2>&1 || true
 trap 'rm -rf "$WORK"' EXIT
 
 echo "== retrieval value =="


### PR DESCRIPTION
## Summary

- `.husky/pre-commit`'s Step 1 guarded the knowledge-index rebuild on `[ -x plugins/dev-team/hooks/lib/build-knowledge-index.sh ]`, but that `.sh` file was deleted by the ADR 0014/0015 bash-removal effort. The guard was always false, so the rebuild-and-restage step (`git add plugins/dev-team/knowledge/index.json`) never fired — freshness drift was only ever caught later, at pre-push/CI.
- Repointed at the real builder, `plugins/dev-team/hooks/lib/build_knowledge_index.py`, and dropped the dead guard.
- Fixed the same dead `.sh` reference in `scripts/run-ablation.sh`, and a stale docstring in `plugins/dev-team/hooks/knowledge_index.py` that still named the dead path as its default builder (the code's actual default was already correct).
- Since making this step actually run surfaced two more real defects (found by an independent code-review panel, fixed and re-verified in the same PR — see Test plan): the rebuild reads the *working tree*, not the index, so an unstaged/untracked knowledge-corpus file could let the rebuilt `index.json` diverge from what the commit actually contains — now refused rather than silently staged. Also added a `python3` prerequisite guard, and made the new corpus-dirty check itself fail closed (not silently open) if it can't run.

## Test plan

- [x] `shellcheck` and `sh -n` clean on both shell files
- [x] Full repo pytest gate (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks`): 8530 passed
- [x] `check_md_references.py` and the knowledge-index freshness check clean
- [x] Manually forced the exact failure the fix exists to prevent (reverted the guard, staged a heading edit, confirmed `index.json` was *not* restaged) before reapplying the fix and confirming it *was*
- [x] Manually forced an unstaged/untracked corpus edit and confirmed the new guard blocks it, while an edit to a non-corpus nested `.md` file does not false-positive
- [x] Manually forced the corpus-dirty check's own dependency (`knowledge_index_paths.py`) to fail import and confirmed the hook now fails closed instead of silently proceeding
- [x] Independent code-review panel (security-review, correctness-review, spec-compliance-review, doc-review) dispatched; 2 fix-loop rounds; final closing pass passes clean with zero new findings
- [x] `pre-push` local CI mirror (`scripts/ci-local.sh`) passes in full, including the shipped Python 3.10 floor test slice

Closes #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)