### PR TITLE
fix(code-review): delete shared-classifier fallbacks, fail the import loudly

### DIFF
--- a/plugins/dev-team/scripts/select_lenses.py
+++ b/plugins/dev-team/scripts/select_lenses.py
@@ -52,26 +52,33 @@ import review_roster
 # classification (a real defect a prior draft of this filter had: `.md`
 # alone made `plugins/dev-team/agents/*.md` — this very repo's shipped
 # agent behavior — read as "non-executable"). Same cross-boundary import
-# pattern that module already uses, same fail-open fallback.
+# pattern that module already uses.
 _HOOKS_LIB_DIR = _HERE.parent / "hooks" / "lib"
 if str(_HOOKS_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_LIB_DIR))
 
+# No `except ImportError` fallback (#1968). The fallback this replaced was a
+# hand-written second copy of `is_functional_config`, and nothing could catch
+# it drifting: the guard that claimed to (`test_select_lenses.py`'s
+# `test_is_functional_config_matches_doc_classification_module`) compared the
+# canonical implementation against itself whenever the import succeeded — which
+# is always, here — so sabotaging the fallback to `return False` left the whole
+# suite green. `hooks/lib/` ships inside this same plugin; an unreachable one is
+# a broken install, not a supported degraded mode.
 try:
     from doc_classification import (
         is_functional_config,  # type: ignore[import-not-found]
     )
-except ImportError:  # pragma: no cover - degraded fallback, hooks/lib unreachable
-    _FALLBACK_FUNCTIONAL_CONFIG_NAMES = frozenset({"claude.md", "agents.md"})
-    _FALLBACK_FUNCTIONAL_CONFIG_SEGMENTS = frozenset(
-        {".claude", "agents", "skills", "prompts", "knowledge", "templates"}
-    )
-
-    def is_functional_config(file_path: str) -> bool:
-        name = Path(file_path).name.lower()
-        if name in _FALLBACK_FUNCTIONAL_CONFIG_NAMES:
-            return True
-        return any(seg in _FALLBACK_FUNCTIONAL_CONFIG_SEGMENTS for seg in Path(file_path).parts)
+except ImportError as exc:  # pragma: no cover - broken install, not a supported mode
+    raise ImportError(
+        f"{__name__} requires the shared classifier 'doc_classification' from "
+        f"the dev-team plugin's hooks/lib, which could not be imported.\n"
+        f"  searched: {_HOOKS_LIB_DIR}\n"
+        f"  exists:   {_HOOKS_LIB_DIR.is_dir()}\n"
+        "This module deliberately has no fallback copy of the classifier "
+        "(#1968) — a divergent stand-in silently mis-classifies files. Fix the "
+        "install or the path rather than re-adding a local implementation."
+    ) from exc
 
 # Framework-reactivity lenses declare bare ``**/*.ts`` / ``**/*.js`` globs, but
 # their real trigger is a dependency-manifest match (``/code-review`` Step 3's

--- a/plugins/dev-team/skills/code-review/scripts/change_shape.py
+++ b/plugins/dev-team/skills/code-review/scripts/change_shape.py
@@ -73,7 +73,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from collections.abc import Iterable
 from pathlib import Path, PurePosixPath
@@ -84,70 +83,55 @@ _HOOKS_LIB_DIR = Path(__file__).resolve().parents[3] / "hooks" / "lib"
 if str(_HOOKS_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_LIB_DIR))
 
+# Both shared modules are imported, never re-implemented. There is deliberately
+# no `except ImportError` fallback (#1968): a hand-written stand-in for a shared
+# classifier is a second copy of the logic that can drift from its source
+# silently, and one already did — the `is_test_file` fallback added in #1964
+# shipped folding all four indicator families into one `re.IGNORECASE` pattern
+# while `test_file_classify` compiles its step-definition regex
+# case-sensitively, so `backsteps.py` read as a step definition and an ordinary
+# source file could pass as a test. The whole suite stayed green, because every
+# other test exercised the import path that succeeds.
+#
+# `hooks/lib/` ships inside this same plugin, so an unreachable one is a broken
+# install or a moved file, not a supported degraded mode. Failing here — loudly,
+# naming the path that was searched — surfaces that immediately instead of
+# silently answering classification questions from a divergent copy.
+def _require_shared(module: str) -> ImportError:
+    """Build the diagnostic for a shared-module import that could not resolve.
+
+    The parent-count in `_HOOKS_LIB_DIR` is the fragile part (a moved file
+    changes it), so the message names the resolved path rather than leaving a
+    bare `No module named ...` to be reverse-engineered.
+    """
+    return ImportError(
+        f"{__name__} requires the shared classifier {module!r} from the "
+        f"dev-team plugin's hooks/lib, which could not be imported.\n"
+        f"  searched: {_HOOKS_LIB_DIR}\n"
+        f"  exists:   {_HOOKS_LIB_DIR.is_dir()}\n"
+        "This module deliberately has no fallback copy of the classifier "
+        "(#1968) — a divergent stand-in silently mis-classifies files. Fix the "
+        "install or the path rather than re-adding a local implementation."
+    )
+
+
 try:
     from doc_classification import (  # type: ignore[import-not-found]
         DOC_EXTENSIONS,
         DOC_ROOT_WORDS,
         is_functional_config,
     )
-except ImportError:  # pragma: no cover - degraded fallback, hooks/lib unreachable
-    DOC_EXTENSIONS = frozenset({".md", ".mdx", ".markdown", ".rst", ".txt", ".adoc"})
-    DOC_ROOT_WORDS = (
-        "readme", "changelog", "contributing", "license", "notice",
-        "authors", "code_of_conduct",
-    )
-    _FALLBACK_FUNCTIONAL_CONFIG_NAMES = frozenset({"claude.md", "agents.md"})
-    _FALLBACK_FUNCTIONAL_CONFIG_SEGMENTS = frozenset(
-        {".claude", "agents", "skills", "prompts", "knowledge", "templates"}
-    )
-
-    def is_functional_config(file_path: str) -> bool:
-        path = PurePosixPath(file_path)
-        if path.name.lower() in _FALLBACK_FUNCTIONAL_CONFIG_NAMES:
-            return True
-        return any(seg in _FALLBACK_FUNCTIONAL_CONFIG_SEGMENTS for seg in path.parts)
+except ImportError as exc:  # pragma: no cover - broken install, not a supported mode
+    raise _require_shared("doc_classification") from exc
 
 # `knowledge/test-file-indicators.md`'s single encoding, shared with the
-# refactor test-freeze guards (#1964) — same cross-boundary import pattern as
-# `doc_classification` above. Never re-implement the indicator list here: a
-# second copy is exactly what the #1477 extraction removed for the doc tables.
+# refactor test-freeze guards (#1964).
 try:
     from test_file_classify import is_test_file  # type: ignore[import-not-found]
-except ImportError:  # pragma: no cover - degraded fallback, hooks/lib unreachable
-    # Case-sensitivity is load-bearing and mirrors test_file_classify's own
-    # compilation flags exactly. The JS/TS, Python, and .feature indicators are
-    # case-INsensitive there; the step-definition indicator is case-SENSITIVE.
-    # Folding all four into one IGNORECASE pattern reads `backsteps.py` and
-    # `mysteps.js` as step definitions, which would let an ordinary source file
-    # pass as a test and over-claim `test-only` — the one direction this
-    # module's include-bias must never fail in.
-    _FALLBACK_TEST_NAME_RE = re.compile(
-        r"(\.(test|spec)\.[^./]+$"          # JS/TS  foo.test.ts
-        r"|^(test_.+|.+_test)\.py$"          # Python test_foo.py / foo_test.py
-        r"|\.feature$)",                     # Gherkin
-        re.IGNORECASE,
-    )
-    _FALLBACK_STEP_DEF_RE = re.compile(  # deliberately NOT IGNORECASE
-        r"(\.steps\.[^./]+$|StepDefinitions\.[^./]+$|Steps\.[^./]+$)"
-    )
+except ImportError as exc:  # pragma: no cover - broken install, not a supported mode
+    raise _require_shared("test_file_classify") from exc
 
-    def is_test_file(path: str, content: str | None = None) -> bool:
-        p = PurePosixPath(str(path))
-        if not p.name:
-            return False
-        if _FALLBACK_TEST_NAME_RE.search(p.name):
-            return True
-        if _FALLBACK_STEP_DEF_RE.search(p.name):
-            return True
-        if "__tests__" in p.parts:
-            return True
-        # Java class-name convention; C# needs contents we deliberately don't read.
-        return p.suffix.lower() == ".java" and p.stem.endswith(
-            ("Test", "Tests", "TestCase", "Spec")
-        )
 
-# The lenses this gate can skip. Both are code-only lenses that no-op on diffs
-# with no executable logic to reason about.
 LOW_YIELD_LENSES = ["performance-review", "correctness-review"]
 
 # Lenses to skip when EVERY changed file is provably a test file (#1964).

--- a/plugins/dev-team/tests/scripts/test_change_shape.py
+++ b/plugins/dev-team/tests/scripts/test_change_shape.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import ClassVar
 
 import pytest
 
@@ -203,78 +202,3 @@ class TestTestOnlyCli:
         rc = change_shape.main(["--files", "README.md"])
         assert rc == 0
         assert "isTestOnly" in json.loads(capsys.readouterr().out)
-
-
-class TestDegradedFallbackParity:
-    """The `hooks/lib`-unreachable fallback must agree with the shared
-    classifier it stands in for (#1964).
-
-    This is not theoretical tidiness. The fallback originally folded all four
-    indicator families into one `re.IGNORECASE` pattern, but
-    `test_file_classify` compiles its step-definition regex case-SENSITIVELY —
-    so `backsteps.py` and `mysteps.js` classified as step definitions. That is
-    an ordinary source file passing as a test, which over-claims `test-only`:
-    the one direction this module's include-bias must never fail in. Every
-    other test in this file exercises the primary path and passed throughout,
-    so only a differential test catches it.
-    """
-
-    @staticmethod
-    def _fallback_module():
-        """Load change_shape with `hooks/lib` unimportable, forcing the
-        `except ImportError` branch."""
-        import importlib.util
-
-        hooks_lib = str((_PLUGIN_ROOT / "hooks" / "lib").resolve())
-        saved_path, saved_mods = list(sys.path), {}
-        sys.path = [p for p in sys.path if p != hooks_lib]
-        for name in ("test_file_classify", "doc_classification"):
-            saved_mods[name] = sys.modules.get(name, "__absent__")
-            sys.modules[name] = None  # force ImportError on import
-        try:
-            spec = importlib.util.spec_from_file_location(
-                "change_shape_degraded",
-                _PLUGIN_ROOT / "skills" / "code-review" / "scripts" / "change_shape.py",
-            )
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            return module
-        finally:
-            sys.path = saved_path
-            for name, prev in saved_mods.items():
-                if prev == "__absent__":
-                    sys.modules.pop(name, None)
-                else:
-                    sys.modules[name] = prev
-
-    #: Names chosen to straddle every indicator family AND its case variants —
-    #: the axis the original defect hid behind.
-    _CORPUS: ClassVar[list[str]] = [
-        "tests/a.test.js", "tests/A.TEST.JS", "src/b.spec.ts",
-        "tests/test_a.py", "tests/b_test.py", "tests/TEST_A.PY",
-        "features/x.feature", "features/X.FEATURE",
-        "steps/x.steps.js", "steps/x.STEPS.js",
-        "a/FooSteps.js", "a/foosteps.js", "a/mysteps.js", "a/backsteps.py",
-        "a/FooStepDefinitions.cs", "a/foostepdefinitions.cs",
-        "pkg/__tests__/a.js", "pkg/__TESTS__/a.js",
-        "src/FooTest.java", "src/FooTests.java", "src/FooSpec.java", "src/Foo.java",
-        "tests/FooTests.cs", "tests/conftest.py", "src/prod.js",
-        "README.md", "weird.xyz", "no_extension", "",
-    ]
-
-    @pytest.mark.parametrize("path", _CORPUS, ids=lambda p: p or "<empty>")
-    def test_fallback_matches_shared_classifier(self, path):
-        from test_file_classify import is_test_file as shared
-
-        degraded = self._fallback_module()
-        expected = bool(shared(path, content="")) if path else False
-        assert degraded._is_provably_test_file(path) is expected, (
-            f"degraded fallback disagrees with test_file_classify on {path!r}"
-        )
-
-    def test_fallback_never_over_claims_a_plain_source_file(self):
-        """Direction matters more than agreement: a false positive here turns
-        a mixed diff into a `test-only` one."""
-        degraded = self._fallback_module()
-        for source in ("a/backsteps.py", "a/mysteps.js", "src/prod.js", "a/foosteps.js"):
-            assert degraded._is_provably_test_file(source) is False, source

--- a/tests/repo/test_shared_classifier_no_fallback.py
+++ b/tests/repo/test_shared_classifier_no_fallback.py
@@ -1,0 +1,156 @@
+"""The shared-classifier modules must be imported, never re-implemented (#1968).
+
+`change_shape.py` and `select_lenses.py` each used to carry a hand-written
+`except ImportError` fallback duplicating a `hooks/lib/` classifier. Two things
+were wrong with that:
+
+1. **It could drift silently, and did.** The `is_test_file` fallback added in
+   #1964 shipped folding all four indicator families into one `re.IGNORECASE`
+   pattern, while `test_file_classify` compiles its step-definition regex
+   case-sensitively — so `backsteps.py` read as a step definition and an
+   ordinary source file could pass as a test.
+2. **The guard that claimed to catch drift could not fail.** When the import
+   succeeds — always, in this repo — `test_is_functional_config_matches_
+   doc_classification_module` compared the canonical implementation against
+   itself. Sabotaging the fallback to `return False` left the whole suite
+   green. `CLAUDE.md`: "A gate that cannot fail is worse than no gate."
+
+`hooks/lib/` ships inside the same plugin as its consumers, so an unreachable
+one is a broken install, not a supported degraded mode. The fallbacks are gone
+and the import now fails loudly. These tests keep it that way: a reintroduced
+fallback is a structural regression, not a style choice.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+_PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+
+#: Consumer modules that import a shared classifier across the hooks/lib
+#: boundary, and the shared module names each one requires.
+CONSUMERS = {
+    _PLUGIN / "skills" / "code-review" / "scripts" / "change_shape.py": (
+        "doc_classification",
+        "test_file_classify",
+    ),
+    _PLUGIN / "scripts" / "select_lenses.py": ("doc_classification",),
+}
+
+#: Names the deleted fallbacks defined. Any of these reappearing in a consumer
+#: means a local re-implementation came back.
+FORBIDDEN_FALLBACK_NAMES = (
+    "_FALLBACK_FUNCTIONAL_CONFIG_NAMES",
+    "_FALLBACK_FUNCTIONAL_CONFIG_SEGMENTS",
+    "_FALLBACK_TEST_NAME_RE",
+    "_FALLBACK_STEP_DEF_RE",
+)
+
+
+def _import_handlers(tree: ast.AST, shared: tuple[str, ...]) -> list[ast.ExceptHandler]:
+    """Every `except ImportError` handler guarding an import of `shared`."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        imported = {
+            n.module
+            for stmt in node.body
+            for n in ast.walk(stmt)
+            if isinstance(n, ast.ImportFrom) and n.module
+        } | {
+            alias.name
+            for stmt in node.body
+            for n in ast.walk(stmt)
+            if isinstance(n, ast.Import)
+            for alias in n.names
+        }
+        if imported & set(shared):
+            found.extend(node.handlers)
+    return found
+
+
+@pytest.mark.parametrize("path,shared", CONSUMERS.items(), ids=lambda v: getattr(v, "name", v))
+def test_shared_import_has_no_fallback_body(path, shared):
+    """The handler may only re-raise — never define a stand-in."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    handlers = _import_handlers(tree, shared)
+    assert handlers, f"{path.name}: no guarded import of {shared} found"
+    for handler in handlers:
+        for stmt in handler.body:
+            assert isinstance(stmt, ast.Raise), (
+                f"{path.name}: the ImportError handler for {shared} contains a "
+                f"{type(stmt).__name__} — it must only re-raise. A fallback "
+                f"implementation here is a second copy of the classifier that "
+                f"can drift from its source (#1968)."
+            )
+
+
+@pytest.mark.parametrize("path,shared", CONSUMERS.items(), ids=lambda v: getattr(v, "name", v))
+def test_no_local_reimplementation_of_shared_classifiers(path, shared):
+    src = path.read_text(encoding="utf-8")
+    for name in FORBIDDEN_FALLBACK_NAMES:
+        assert name not in src, (
+            f"{path.name} defines {name!r} — a local re-implementation of a "
+            f"hooks/lib classifier. Import it instead (#1968)."
+        )
+
+
+@pytest.mark.parametrize("path,shared", CONSUMERS.items(), ids=lambda v: getattr(v, "name", v))
+def test_import_failure_is_loud_and_names_the_searched_path(path, shared, tmp_path):
+    """Run the module in a subprocess with hooks/lib unreachable and assert it
+    dies with a diagnostic — not a bare ModuleNotFoundError, and never a
+    silent degrade. This is the behavior the deleted fallbacks suppressed."""
+    probe = textwrap.dedent(f"""
+        import importlib.util, sys
+        for _n in {list(shared)!r}:
+            sys.modules[_n] = None          # force ImportError on import
+        spec = importlib.util.spec_from_file_location("probe_mod", {str(path)!r})
+        m = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(m)
+        except ImportError as exc:
+            print("RAISED", exc)
+            sys.exit(0)
+        print("NO_RAISE")
+        sys.exit(1)
+    """)
+    script = tmp_path / "probe.py"
+    script.write_text(probe)
+    res = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert res.returncode == 0, (
+        f"{path.name} did not raise on an unreachable shared module: "
+        f"{res.stdout}{res.stderr}"
+    )
+    out = res.stdout
+    assert "RAISED" in out
+    # The diagnostic must name the path it searched — the parent-count in the
+    # sys.path setup is the fragile part when a file moves, and a bare
+    # "No module named X" leaves that to be reverse-engineered.
+    assert "hooks/lib" in out or "hooks\\lib" in out, f"no searched path in: {out}"
+    assert "#1968" in out, f"diagnostic does not point at the rationale: {out}"
+
+
+def test_consumers_still_import_and_classify_normally():
+    """The happy path is unaffected: with hooks/lib reachable (the real case),
+    both modules import and classify as before."""
+    for path in CONSUMERS:
+        spec = importlib.util.spec_from_file_location(f"ok_{path.stem}", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert module.is_functional_config("plugins/dev-team/agents/foo.md") is True
+        assert module.is_functional_config("docs/x.md") is False

--- a/tests/scripts/test_select_lenses.py
+++ b/tests/scripts/test_select_lenses.py
@@ -216,29 +216,6 @@ def test_non_executable_file_never_true_for_functional_claude_config():
         assert not SL._is_non_executable_file(f), f"{f} is functional config, must stay executable"
 
 
-def test_is_functional_config_matches_doc_classification_module():
-    # Guards against the shared-logic drift doc_classification.py's own
-    # docstring names as this module family's known failure mode: if
-    # select_lenses.py's import succeeded (the normal case, exercised here
-    # since select_lenses.py's own hooks/lib is reachable in this repo),
-    # its `is_functional_config` must behave identically to the canonical
-    # source's — otherwise select_lenses.py's ImportError-fallback copy
-    # (hardcoded for the case hooks/lib is unreachable) has silently
-    # drifted from it.
-    doc_classification_path = (
-        _REPO_ROOT / "plugins" / "dev-team" / "hooks" / "lib" / "doc_classification.py"
-    )
-    spec = importlib.util.spec_from_file_location("doc_classification", doc_classification_path)
-    real = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(real)
-    for f in (
-        "plugins/dev-team/agents/foo.md", ".claude/settings.json",
-        "plugins/dev-team/templates/agents/python.md", "CLAUDE.md",
-        "docs/x.md", "README.md",
-    ):
-        assert SL.is_functional_config(f) == real.is_functional_config(f), f
-
-
 def test_non_executable_skip_eligible_justification_matches_agent_skip_clause():
     # Mechanically re-verifies NON_EXECUTABLE_SKIP_ELIGIBLE's own MAINTENANCE
     # comment ("re-verify against the named agent's own Skip clause before


### PR DESCRIPTION
## Summary

- **Deletes both hand-written `except ImportError` fallbacks** that duplicated `hooks/lib/` classifiers — `change_shape.py`'s copies of `doc_classification` and `test_file_classify`, and `select_lenses.py`'s copy of `is_functional_config`. The import now raises with a diagnostic naming the `hooks/lib` path it searched and whether that path exists.
- **Removes the two tests that policed code which no longer exists**: the vacuous drift guard, and #1964's `TestDegradedFallbackParity`. Replaces them with `tests/repo/test_shared_classifier_no_fallback.py`, which enforces the *absence* of a fallback structurally.
- **Net −108 lines.** This removes a drift surface; it does not fix a live mis-classification (see below).

`hooks/lib/` ships inside the same plugin as both consumers, so an unreachable one is a broken install or a moved file — not a supported degraded mode. Failing there is honest; a silently-drifted duplicate is not.

### Why removal, rather than a better guard

**The duplicates could drift silently, and one did.** The `is_test_file` fallback added in #1964 shipped folding all four indicator families into one `re.IGNORECASE` pattern, while `test_file_classify` compiles its step-definition regex case-sensitively. So `backsteps.py` and `mysteps.js` classified as step definitions — an ordinary source file passing as a test, over-claiming `test-only` in the one direction that module's include-bias must never fail in. Every other test exercised the import path that succeeds, so the whole 8,900-test suite stayed green.

**The guard that claimed to catch drift could not fail.** `test_is_functional_config_matches_doc_classification_module` compared the canonical implementation against itself whenever the import succeeded — which is always, in this repo. Verified by sabotage: setting the fallback to `return False` (maximal drift) left that test *and all 151 related tests* green. `CLAUDE.md`: *"A gate that cannot fail is worse than no gate. It reads as a guarantee and delivers none."*

### Scope, stated honestly

**Neither `doc_classification` fallback was actually diverging.** I differential-tested both against the canonical module over a 17-path corpus spanning `CLAUDE.md`, `AGENTS.md`, `.claude/`, `templates/`, `knowledge/`, `skills/`, plus docs/source/config controls — zero divergence. Only the `is_test_file` copy had drifted, and that was already fixed in #1964.

**Deliberately out of scope:** the repo's other `except ImportError` blocks are a different shape and are untouched — platform-conditional imports (`fcntl`/`msvcrt`), optional third-party degradation, and sentinel-assigning hook fallbacks (`atomic_state = None`, no-op telemetry emitters). Hooks in particular are fail-open by design: one that hard-fails can block a user's commit. This PR covers only the class in #1968 — fallbacks that hand-write a *duplicate implementation* of a shared classifier.

### Shape of the replacement

The guard is kept but may only re-raise. A bare module-level import isn't available here: `plugins/dev-team/skills/**` is **not** in `ruff.toml`'s E402 per-file-ignore list (unlike `hooks/**` and `scripts/**`), and the import genuinely cannot precede the `sys.path` setup. Verified empirically — the bare form trips E402, the guarded form does not. The message names the resolved path because the `parents[N]` count is the fragile part when a file moves, and a bare `No module named ...` leaves that to be reverse-engineered.

## Test Plan

- [x] `scripts/ci-local.sh` — **All local CI checks passed** (every check ✓, none skipped except the BASE/HEAD-range one that needs a CI range).
- [x] New gate **verified to fail on purpose**: reintroducing a fallback in `select_lenses.py` turns 2 tests red; removing it returns them green.
- [x] New gate asserts three properties — every shared-import handler contains nothing but a `raise` (AST-parsed, not grep), no `_FALLBACK_*` re-implementation reappears, and the failure is loud and carries the searched path (exercised in a subprocess with the shared modules forced unimportable).
- [x] Happy path unaffected: both modules import and classify identically; `change_shape.py` CLI re-smoked across test-only / mixed / docs-only inputs.
- [x] `import_probe_shipped.py` — 200 shipped modules import cleanly.
- [x] `check_md_references.py` exit 0; `build_knowledge_index.py` exit 0; `ruff` clean; both edited shipped modules compile under the **3.10 floor** via `uv`.

### One process note

While removing `TestDegradedFallbackParity` I used inverted string-slice indices, which duplicated two test classes instead of deleting one (280 → 329 lines). Python would have silently shadowed the earlier copies, so pytest would have run only the later ones — green, and wrong. Caught by checking the class list and line count against `HEAD` immediately after the edit; restored from git and redone with an assertion that the target class is actually last. Flagging it because the failure mode — a structurally broken test file that still passes — is the same class of silent-green problem this PR exists to remove.

Closes #1968

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATmEcq5yKUeYKXsnKu772z)_