### PR TITLE
fix(mutation-testing): fold static-skip survivors into the accepted/reason model

### DIFF
--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -139,7 +139,7 @@ adjusted_score = Killed / (Killed + (Survived - Accepted) + NoCoverage)
 
 **JS/TS cross-reference.** On a JS/TS (Stryker) run with
 `--skip-static-mutants` active, accepted survivors also include the
-`--accepted-static-survivors` output — fold those entries into this same
+`--accepted-static-survivors --skip-static` output — fold those entries into this
 table and computation; see [Static-mutant
 skip](../skills/mutation-testing/references/languages/javascript-stryker.md#static-mutant-skip-skip-static-mutants)
 in `javascript-stryker.md`.

--- a/plugins/dev-team/agents/mutation-kill.md
+++ b/plugins/dev-team/agents/mutation-kill.md
@@ -137,6 +137,13 @@ raw_score      = honest_score (unchanged)
 adjusted_score = Killed / (Killed + (Survived - Accepted) + NoCoverage)
 ```
 
+**JS/TS cross-reference.** On a JS/TS (Stryker) run with
+`--skip-static-mutants` active, accepted survivors also include the
+`--accepted-static-survivors` output — fold those entries into this same
+table and computation; see [Static-mutant
+skip](../skills/mutation-testing/references/languages/javascript-stryker.md#static-mutant-skip-skip-static-mutants)
+in `javascript-stryker.md`.
+
 ## Shard vs full-run scores are not comparable
 
 Scoped per-file ("shard") runs produce far higher timeout rates than full runs

--- a/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
@@ -75,17 +75,27 @@ survivors are static must never be written as `status: "converged"`.
 
 **`adjusted_score` does account for static-skipped mutants.** After the
 existing `--skip-static --survivors-by-mutator` generation call, also call
-`mutation_report_cli.py --accepted-static-survivors --report <path> --file
-<path>` and fold each returned entry into the file's own "Accepted
-Survivors (deferred)" table and `adjusted_score` computation, exactly like
-any other `status: "accepted"` entry (see [mutation-kill.md's Accepted
-survivors: raw vs adjusted
+`mutation_report_cli.py --accepted-static-survivors --skip-static --report
+<path> --file <path>` and fold each returned entry into the file's own
+"Accepted Survivors (deferred)" table and `adjusted_score` computation,
+exactly like any other `status: "accepted"` entry (see [mutation-kill.md's
+Accepted survivors: raw vs adjusted
 score](../../../../agents/mutation-kill.md#accepted-survivors-raw-vs-adjusted-score)).
-This is now documented via the same accepted/reason mechanism used
-elsewhere in `mutation-kill` — not the undocumented, adjusted-score-invisible
-over-count the prior wording described. Clustering (`survivors_by_line()`)
-is untouched by this and stays out of scope: it has no `skip_static`
-parameter and remains unfiltered, per the #1948 gap noted above.
+`--skip-static` is required on this call: `accepted_static_survivors()`
+returns `[]` unless its `skip_static_active` evidence is `True`, so calling
+`--accepted-static-survivors` without `--skip-static` yields no accepted
+entries at all, even when static survivors exist in the report. This is now
+documented via the same accepted/reason mechanism used elsewhere in
+`mutation-kill` — not the undocumented, adjusted-score-invisible over-count
+the prior wording described. Clustering (`survivors_by_line()`) is untouched
+by this and stays out of scope: it has no `skip_static` parameter and
+remains unfiltered, per the #1948 gap noted above. **Known overlap:** because
+clustering stays unfiltered, a static survivor folded into the accepted
+table this round may simultaneously still be targeted by the
+clustering-driven generation step in that same round — this is a known,
+accepted overlap tied to #1948, not resolved here, so the adjusted score
+should not be read as a claim that every accepted survivor is untouched by
+this pass's generation.
 
 **Fallback when the field is absent.** `mutation_report_cli.py --skip-static`
 detects this itself and prints a one-line notice to stderr, distinguishing

--- a/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/javascript-stryker.md
@@ -54,10 +54,11 @@ your installed version before relying on it in an automated pipeline.)
 already produced the report — it cannot make Stryker's own run faster, and
 does not claim to. What it saves is the generation-and-verify **rounds**
 `mutation-kill` would otherwise spend chasing mutants that are expensive to
-confirm killed (each needs a full-suite re-run to verify), at the cost of a
-small, documented survivor over-count: a skipped static mutant that a
-full-suite run would have killed stays counted as an unaddressed survivor
-for this pass.
+confirm killed (each needs a full-suite re-run to verify), at the cost of
+deferring each skipped static mutant rather than eliminating it: a skipped
+static mutant that a full-suite run would have killed stays counted as an
+unaddressed survivor for this pass, folded into the accepted-survivors
+accounting below rather than dropped silently.
 
 **Scoring and convergence stay unfiltered.** Only the generation step's
 input narrows — and specifically only the mutator-grouped generation input
@@ -71,6 +72,20 @@ resolved here. The `survivors == 0` convergence exit, the
 no-improvement stop predicate, and the honest/reported scores all read the
 report's full, unfiltered survivor count — a file whose only remaining
 survivors are static must never be written as `status: "converged"`.
+
+**`adjusted_score` does account for static-skipped mutants.** After the
+existing `--skip-static --survivors-by-mutator` generation call, also call
+`mutation_report_cli.py --accepted-static-survivors --report <path> --file
+<path>` and fold each returned entry into the file's own "Accepted
+Survivors (deferred)" table and `adjusted_score` computation, exactly like
+any other `status: "accepted"` entry (see [mutation-kill.md's Accepted
+survivors: raw vs adjusted
+score](../../../../agents/mutation-kill.md#accepted-survivors-raw-vs-adjusted-score)).
+This is now documented via the same accepted/reason mechanism used
+elsewhere in `mutation-kill` — not the undocumented, adjusted-score-invisible
+over-count the prior wording described. Clustering (`survivors_by_line()`)
+is untouched by this and stays out of scope: it has no `skip_static`
+parameter and remains unfiltered, per the #1948 gap noted above.
 
 **Fallback when the field is absent.** `mutation_report_cli.py --skip-static`
 detects this itself and prints a one-line notice to stderr, distinguishing

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
@@ -56,6 +56,12 @@ STATUS_NO_COVERAGE = "NoCoverage"
 # above so the literal isn't repeated across the functions that read it.
 MUTANT_STATIC_KEY = "static"
 
+# Fixed reason string attached to every accepted-static-survivor entry
+# (see ``accepted_static_survivors``) — a static-flagged Survived mutant is
+# not equivalent and not fixed; it is deliberately deferred because killing
+# it would require a full-suite re-run rather than a single-mutant one.
+ACCEPTED_STATIC_REASON = "static — verification requires a full-suite re-run"
+
 
 @dataclass(frozen=True)
 class ScoreSummary:
@@ -298,6 +304,31 @@ def is_file_in_report(data: dict, file_path: str) -> bool:
     return _find_file_info(data, file_path) is not None
 
 
+def _resolve_survivor_line(mutant: dict) -> int | None:
+    """Resolve one mutant's source line from its ``location.start.line``
+    field, or ``None`` when that shape is missing or malformed.
+
+    Never raises: a missing/non-dict ``location``, a missing/non-dict
+    ``start``, or a ``line`` that isn't a plain ``int`` (``None``, a
+    non-int value, or a ``bool`` — ``bool`` is an ``int`` subclass in
+    Python but is never a real line number) all resolve to ``None``. This
+    matches the module's never-raise-on-bad-input posture (see the module
+    docstring, ``load_report``'s "never raises" note, and
+    ``parse_mutmut_junitxml``'s "malformed input returns empty rather than
+    raising"). Extracted from ``_survivors_by_line_from_data``'s original
+    inline unwrap so ``_accepted_static_survivors_from_data`` can reuse the
+    same hardened logic instead of duplicating it.
+    """
+    loc = mutant.get("location")
+    loc = loc if isinstance(loc, dict) else {}
+    start = loc.get("start")
+    start = start if isinstance(start, dict) else {}
+    line = start.get("line")
+    if not isinstance(line, int) or isinstance(line, bool):
+        return None
+    return line
+
+
 def _survivors_by_line_from_data(data: dict, file_path: str) -> dict:
     """Return the Survived mutants for one source file, clustered by source
     line, from an already-parsed report dict.
@@ -336,12 +367,8 @@ def _survivors_by_line_from_data(data: dict, file_path: str) -> dict:
     for mutant in info.get("mutants", []):
         if mutant.get("status") != STATUS_SURVIVED:
             continue
-        loc = mutant.get("location")
-        loc = loc if isinstance(loc, dict) else {}
-        start = loc.get("start")
-        start = start if isinstance(start, dict) else {}
-        line = start.get("line")
-        if not isinstance(line, int) or isinstance(line, bool):
+        line = _resolve_survivor_line(mutant)
+        if line is None:
             unclustered.append(mutant)
             continue
         by_line.setdefault(line, []).append(mutant)
@@ -362,6 +389,72 @@ def survivors_by_line(report_path: Path, file_path: str) -> dict:
     rule.
     """
     return _survivors_by_line_from_data(load_report(report_path), file_path)
+
+
+def _accepted_static_survivors_from_data(data: dict, file_path: str) -> list[dict]:
+    """Return each Survived mutant carrying ``static: true`` for one source
+    file as an accepted-survivor entry, from an already-parsed report dict.
+
+    Matches ``file_path`` against report keys the same way
+    ``_survivors_from_data`` does (via ``_find_file_info`` — exact key, then
+    basename). Only a mutant with ``status == STATUS_SURVIVED`` *and*
+    ``mutant.get(MUTANT_STATIC_KEY) is True`` qualifies — a
+    Killed/Timeout/NoCoverage/CompileError mutant carrying ``static: true``
+    is never returned, and a Survived mutant without the static flag is
+    never returned either.
+
+    Each entry has the shape ``{"file": file_path, "line": int | None,
+    "operator": str, "status": "accepted", "reason": ACCEPTED_STATIC_REASON}``
+    — the same shape SKILL.md's machine-readable ``survivors[]`` schema
+    already defines for accepted survivors. ``line`` is resolved via
+    ``_resolve_survivor_line`` (``None`` for any missing/malformed
+    location/start/line shape — never raises).
+
+    Returns ``[]`` when the file is not in the report or has no matching
+    survivors.
+    """
+    info = _find_file_info(data, file_path)
+    if info is None:
+        return []
+
+    return [
+        {
+            "file": file_path,
+            "line": _resolve_survivor_line(mutant),
+            "operator": mutant.get("mutatorName", ""),
+            "status": "accepted",
+            "reason": ACCEPTED_STATIC_REASON,
+        }
+        for mutant in info.get("mutants", [])
+        if mutant.get("status") == STATUS_SURVIVED
+        and mutant.get(MUTANT_STATIC_KEY) is True
+    ]
+
+
+def accepted_static_survivors(report_path: Path, file_path: str) -> list[dict]:
+    """Return each Survived mutant carrying ``static: true`` for one source
+    file, as accepted-survivor entries, from a Stryker-shaped mutation
+    report on disk.
+
+    See ``_accepted_static_survivors_from_data`` for the return shape and
+    matching rule.
+    """
+    return _accepted_static_survivors_from_data(load_report(report_path), file_path)
+
+
+def accepted_static_survivors_from_data(data: dict, file_path: str) -> list[dict]:
+    """Return each Survived mutant carrying ``static: true`` for one source
+    file, as accepted-survivor entries, from an already-parsed report dict.
+
+    Thin public wrapper around ``_accepted_static_survivors_from_data``,
+    mirroring the established pair-per-function convention set by
+    ``survivors_by_mutator``/``survivors_by_mutator_from_data``. Unlike that
+    pair, this data-based variant has no caller within the current plan (the
+    CLI always calls the ``Path``-based ``accepted_static_survivors``) — it
+    is added anyway for interface symmetry with the rest of this module's
+    public surface, not because a caller needs it yet.
+    """
+    return _accepted_static_survivors_from_data(data, file_path)
 
 
 def _files_with_status_from_data(data: dict, status: str) -> list[str]:

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
@@ -62,6 +62,12 @@ MUTANT_STATIC_KEY = "static"
 # it would require a full-suite re-run rather than a single-mutant one.
 ACCEPTED_STATIC_REASON = "static — verification requires a full-suite re-run"
 
+# ``status`` value for every accepted-static-survivor entry — a sibling
+# constant to ``ACCEPTED_STATIC_REASON`` so the entry's ``"status"`` field is
+# never a bare string literal, matching every other status value in this
+# module (``STATUS_KILLED`` etc. above).
+ACCEPTED_STATIC_ENTRY_STATUS = "accepted"
+
 
 @dataclass(frozen=True)
 class ScoreSummary:
@@ -103,25 +109,43 @@ def _iter_mutants(data: dict):
         yield from info.get("mutants", [])
 
 
+def _find_file_entry(data: dict, file_path: str) -> tuple[str, dict] | None:
+    """Return the matched ``(report_key, info)`` pair for one file from an
+    already-parsed report dict.
+
+    Matches ``file_path`` against report keys by exact match first, then by
+    basename, so a caller can pass either the full report key or just the
+    filename. Returns ``None`` when no file matches. ``report_key`` is the
+    key exactly as the report emits it — a caller that only passed a
+    basename (or an absolute path) gets back the matched report key, not an
+    echo of its own input.
+    """
+    files = data.get("files", {})
+
+    info = files.get(file_path)
+    if info is not None:
+        return file_path, info
+
+    target = Path(file_path).name
+    for key, value in files.items():
+        if Path(key).name == target:
+            return key, value
+    return None
+
+
 def _find_file_info(data: dict, file_path: str) -> dict | None:
     """Return one file's report entry (the ``{"mutants": [...]}`` dict) from
     an already-parsed report dict.
 
     Matches ``file_path`` against report keys by exact match first, then by
     basename, so a caller can pass either the full report key or just the
-    filename. Returns ``None`` when no file matches.
+    filename. Returns ``None`` when no file matches. Thin wrapper around
+    ``_find_file_entry`` that discards the matched key — callers that need
+    the matched key too (e.g. ``_accepted_static_survivors_from_data``) call
+    ``_find_file_entry`` directly instead.
     """
-    files = data.get("files", {})
-
-    info = files.get(file_path)
-    if info is not None:
-        return info
-
-    target = Path(file_path).name
-    for key, value in files.items():
-        if Path(key).name == target:
-            return value
-    return None
+    entry = _find_file_entry(data, file_path)
+    return entry[1] if entry is not None else None
 
 
 def _tally(mutants: list[dict]) -> ScoreSummary:
@@ -391,38 +415,59 @@ def survivors_by_line(report_path: Path, file_path: str) -> dict:
     return _survivors_by_line_from_data(load_report(report_path), file_path)
 
 
-def _accepted_static_survivors_from_data(data: dict, file_path: str) -> list[dict]:
+def _accepted_static_survivors_from_data(
+    data: dict, file_path: str, *, skip_static_active: bool
+) -> list[dict]:
     """Return each Survived mutant carrying ``static: true`` for one source
     file as an accepted-survivor entry, from an already-parsed report dict.
 
+    ``skip_static_active`` is the required evidence that a static-flagged
+    survivor was *deliberately* deferred, not merely present. Stryker's
+    ``static: true`` flag alone proves nothing about operator intent — the
+    deliberateness lives one layer up, in whether the CLI's own
+    ``--skip-static`` flag was active for this run. When
+    ``skip_static_active`` is ``False``, this function returns ``[]``
+    immediately, before any other computation: a run where the skip was
+    never active has no accepted survivors to report, regardless of how many
+    mutants carry ``static: true``. When ``True``, behavior matches the
+    unconditional version this function used to be.
+
     Matches ``file_path`` against report keys the same way
-    ``_survivors_from_data`` does (via ``_find_file_info`` — exact key, then
+    ``_survivors_from_data`` does (via ``_find_file_entry`` — exact key, then
     basename). Only a mutant with ``status == STATUS_SURVIVED`` *and*
     ``mutant.get(MUTANT_STATIC_KEY) is True`` qualifies — a
     Killed/Timeout/NoCoverage/CompileError mutant carrying ``static: true``
     is never returned, and a Survived mutant without the static flag is
     never returned either.
 
-    Each entry has the shape ``{"file": file_path, "line": int | None,
-    "operator": str, "status": "accepted", "reason": ACCEPTED_STATIC_REASON}``
-    — the same shape SKILL.md's machine-readable ``survivors[]`` schema
-    already defines for accepted survivors. ``line`` is resolved via
-    ``_resolve_survivor_line`` (``None`` for any missing/malformed
+    Each entry has the shape ``{"id": ..., "file": str, "line": int | None,
+    "operator": str, "status": ACCEPTED_STATIC_ENTRY_STATUS, "reason":
+    ACCEPTED_STATIC_REASON}``. ``id`` is the mutant's own ``"id"`` field
+    (``None`` when absent) — stable mutant identity, not just a file/line
+    pair. ``file`` is the *matched report key* (from ``_find_file_entry``),
+    not an echo of the caller's ``file_path`` argument — a caller that
+    passed a basename gets back the full report key. ``line`` is resolved
+    via ``_resolve_survivor_line`` (``None`` for any missing/malformed
     location/start/line shape — never raises).
 
     Returns ``[]`` when the file is not in the report or has no matching
     survivors.
     """
-    info = _find_file_info(data, file_path)
-    if info is None:
+    if not skip_static_active:
         return []
+
+    entry = _find_file_entry(data, file_path)
+    if entry is None:
+        return []
+    matched_key, info = entry
 
     return [
         {
-            "file": file_path,
+            "id": mutant.get("id"),
+            "file": matched_key,
             "line": _resolve_survivor_line(mutant),
             "operator": mutant.get("mutatorName", ""),
-            "status": "accepted",
+            "status": ACCEPTED_STATIC_ENTRY_STATUS,
             "reason": ACCEPTED_STATIC_REASON,
         }
         for mutant in info.get("mutants", [])
@@ -431,30 +476,38 @@ def _accepted_static_survivors_from_data(data: dict, file_path: str) -> list[dic
     ]
 
 
-def accepted_static_survivors(report_path: Path, file_path: str) -> list[dict]:
+def accepted_static_survivors(
+    report_path: Path, file_path: str, *, skip_static_active: bool
+) -> list[dict]:
     """Return each Survived mutant carrying ``static: true`` for one source
     file, as accepted-survivor entries, from a Stryker-shaped mutation
     report on disk.
 
-    See ``_accepted_static_survivors_from_data`` for the return shape and
-    matching rule.
+    See ``_accepted_static_survivors_from_data`` for the return shape,
+    matching rule, and the required ``skip_static_active`` gating.
     """
-    return _accepted_static_survivors_from_data(load_report(report_path), file_path)
+    return _accepted_static_survivors_from_data(
+        load_report(report_path), file_path, skip_static_active=skip_static_active
+    )
 
 
-def accepted_static_survivors_from_data(data: dict, file_path: str) -> list[dict]:
+def accepted_static_survivors_from_data(
+    data: dict, file_path: str, *, skip_static_active: bool
+) -> list[dict]:
     """Return each Survived mutant carrying ``static: true`` for one source
     file, as accepted-survivor entries, from an already-parsed report dict.
 
     Thin public wrapper around ``_accepted_static_survivors_from_data``,
     mirroring the established pair-per-function convention set by
-    ``survivors_by_mutator``/``survivors_by_mutator_from_data``. Unlike that
-    pair, this data-based variant has no caller within the current plan (the
-    CLI always calls the ``Path``-based ``accepted_static_survivors``) — it
-    is added anyway for interface symmetry with the rest of this module's
-    public surface, not because a caller needs it yet.
+    ``survivors_by_mutator``/``survivors_by_mutator_from_data``. Called by
+    the CLI's ``--accepted-static-survivors`` branch, which already holds a
+    parsed report (loaded once to run
+    ``_maybe_warn_skip_static_inapplicable`` first) and reuses that dict
+    here instead of triggering a second, redundant ``load_report`` call.
     """
-    return _accepted_static_survivors_from_data(data, file_path)
+    return _accepted_static_survivors_from_data(
+        data, file_path, skip_static_active=skip_static_active
+    )
 
 
 def _files_with_status_from_data(data: dict, status: str) -> list[str]:

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
@@ -123,15 +123,23 @@ def main(argv: list[str] | None = None) -> int:
     if args.survivors_by_line:
         result = mutation_report.survivors_by_line(report_path, args.file)
     elif args.accepted_static_survivors:
-        # Single load: reuse the same parsed dict for the inapplicable-skip
-        # diagnostic (only emitted when --skip-static was actually
-        # requested — no point warning about static-field absence when the
-        # caller didn't even claim the skip was active) and the
-        # accepted-survivor computation, instead of two separate
-        # load_report() calls.
+        # Single load: reuse the same parsed dict for the diagnostic below
+        # and the accepted-survivor computation, instead of two separate
+        # load_report() calls. When --skip-static IS set, warn if it turns
+        # out to be inapplicable; when it is NOT set,
+        # accepted_static_survivors_from_data() unconditionally returns []
+        # (skip_static_active gates it), so warn instead that the result is
+        # a guaranteed no-op — silent success here is indistinguishable
+        # from "no static survivors exist".
         data = mutation_report.load_report(report_path)
         if args.skip_static:
             _maybe_warn_skip_static_inapplicable(data, args.file)
+        else:
+            sys.stderr.write(
+                "accepted-static-survivors: --skip-static was not set — "
+                "no accepted entries reported; pass --skip-static when "
+                "the generation run actually narrowed by it\n"
+            )
         result = mutation_report.accepted_static_survivors_from_data(
             data, args.file, skip_static_active=args.skip_static
         )

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
@@ -63,7 +63,8 @@ def parse_args(argv) -> argparse.Namespace:
         action="store_true",
         help=(
             "Exclude static:true mutants — requires --survivors-by-mutator "
-            "(rejected with --survivors-by-line)."
+            "or --accepted-static-survivors (rejected with "
+            "--survivors-by-line)."
         ),
     )
     return p.parse_args(list(argv))
@@ -110,9 +111,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    if args.skip_static and not args.survivors_by_mutator:
+    if args.skip_static and args.survivors_by_line:
         sys.stderr.write(
-            "error: --skip-static is only valid with --survivors-by-mutator\n"
+            "error: --skip-static is only valid with --survivors-by-mutator "
+            "or --accepted-static-survivors\n"
         )
         return 2
 
@@ -121,7 +123,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.survivors_by_line:
         result = mutation_report.survivors_by_line(report_path, args.file)
     elif args.accepted_static_survivors:
-        result = mutation_report.accepted_static_survivors(report_path, args.file)
+        # Single load: reuse the same parsed dict for the inapplicable-skip
+        # diagnostic (only emitted when --skip-static was actually
+        # requested — no point warning about static-field absence when the
+        # caller didn't even claim the skip was active) and the
+        # accepted-survivor computation, instead of two separate
+        # load_report() calls.
+        data = mutation_report.load_report(report_path)
+        if args.skip_static:
+            _maybe_warn_skip_static_inapplicable(data, args.file)
+        result = mutation_report.accepted_static_survivors_from_data(
+            data, args.file, skip_static_active=args.skip_static
+        )
     elif args.skip_static:
         # Single load: reuse the same parsed dict for the inapplicable-skip
         # diagnostic and the survivor computation, instead of the diagnostic

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report_cli.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """mutation_report_cli.py — CLI wrapper exposing mutation_report.py's
-``survivors_by_line()`` and ``survivors_by_mutator()`` as JSON on stdout
-(#1937, Step 1.4).
+``survivors_by_line()``, ``survivors_by_mutator()``, and
+``accepted_static_survivors()`` as JSON on stdout (#1937, Step 1.4; #1940
+Step 2.2).
 
 `mutation_report.py` is a pure computation library with no argparse/
 `__main__` and no stdout output, imported by 7 sibling scripts — it gains
@@ -32,8 +33,9 @@ def parse_args(argv) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog="mutation_report_cli.py",
         description=(
-            "Print mutation_report.py's survivors_by_line() or "
-            "survivors_by_mutator() result as JSON on stdout."
+            "Print mutation_report.py's survivors_by_line(), "
+            "survivors_by_mutator(), or accepted_static_survivors() "
+            "result as JSON on stdout."
         ),
     )
     p.add_argument(
@@ -45,6 +47,14 @@ def parse_args(argv) -> argparse.Namespace:
         "--survivors-by-mutator",
         action="store_true",
         help="Report Survived mutants for --file, grouped by mutator name.",
+    )
+    p.add_argument(
+        "--accepted-static-survivors",
+        action="store_true",
+        help=(
+            "Report Survived+static:true mutants for --file as "
+            "accepted-survivor entries."
+        ),
     )
     p.add_argument("--report", required=True, metavar="PATH", help="Native mutation report path.")
     p.add_argument("--file", required=True, metavar="PATH", help="Source file to look up in the report.")
@@ -84,13 +94,23 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     args = parse_args(argv)
 
-    if args.survivors_by_line == args.survivors_by_mutator:
+    if (
+        sum(
+            [
+                args.survivors_by_line,
+                args.survivors_by_mutator,
+                args.accepted_static_survivors,
+            ]
+        )
+        != 1
+    ):
         sys.stderr.write(
-            "error: exactly one of --survivors-by-line or --survivors-by-mutator is required\n"
+            "error: exactly one of --survivors-by-line, --survivors-by-mutator, "
+            "or --accepted-static-survivors is required\n"
         )
         return 2
 
-    if args.skip_static and args.survivors_by_line:
+    if args.skip_static and not args.survivors_by_mutator:
         sys.stderr.write(
             "error: --skip-static is only valid with --survivors-by-mutator\n"
         )
@@ -100,6 +120,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.survivors_by_line:
         result = mutation_report.survivors_by_line(report_path, args.file)
+    elif args.accepted_static_survivors:
+        result = mutation_report.accepted_static_survivors(report_path, args.file)
     elif args.skip_static:
         # Single load: reuse the same parsed dict for the inapplicable-skip
         # diagnostic and the survivor computation, instead of the diagnostic

--- a/tests/agents/test_mutation_kill_agent.py
+++ b/tests/agents/test_mutation_kill_agent.py
@@ -102,7 +102,12 @@ def test_agent_body_stays_under_500_line_limit(text: str) -> None:
     # the scripted-mechanics table (arch-review finding — the table had no
     # row for the CLI wrapper despite the doc now instructing the agent to
     # call it).
-    assert len(text.splitlines()) < 641
+    # Bumped by 7 more (#1940): added a "JS/TS cross-reference" paragraph to
+    # the "Accepted survivors: raw vs adjusted score" section, pointing at
+    # javascript-stryker.md's --accepted-static-survivors mode so a
+    # --skip-static-mutants run's accepted survivors are folded into the
+    # same raw/adjusted accounting.
+    assert len(text.splitlines()) < 648
 
 
 def test_defines_honest_score_formula(text: str) -> None:

--- a/tests/scripts/test_mutation_report.py
+++ b/tests/scripts/test_mutation_report.py
@@ -831,10 +831,13 @@ def test_accepted_static_survivors_one_static_survivor_amid_others(tmp_path: Pat
         },
     )
 
-    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+    result = mutation_report.accepted_static_survivors(
+        report, "src/Widget.cs", skip_static_active=True
+    )
 
     assert result == [
         {
+            "id": "StringLiteral-Survived-True",
             "file": "src/Widget.cs",
             "line": None,
             "operator": "StringLiteral",
@@ -857,7 +860,9 @@ def test_accepted_static_survivors_multiple_static_survivors(tmp_path: Path):
         },
     )
 
-    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+    result = mutation_report.accepted_static_survivors(
+        report, "src/Widget.cs", skip_static_active=True
+    )
 
     assert len(result) == 2
     assert all(entry["status"] == "accepted" for entry in result)
@@ -868,6 +873,10 @@ def test_accepted_static_survivors_multiple_static_survivors(tmp_path: Path):
         "StringLiteral",
         "EqualityOperator",
     }
+    assert {entry["id"] for entry in result} == {
+        "StringLiteral-Survived-True",
+        "EqualityOperator-Survived-True",
+    }
 
 
 def test_accepted_static_survivors_no_static_mutants_returns_empty(tmp_path: Path):
@@ -876,7 +885,12 @@ def test_accepted_static_survivors_no_static_mutants_returns_empty(tmp_path: Pat
         {"src/Widget.cs": {"mutants": [_mutant("Survived"), _mutant("Killed")]}},
     )
 
-    assert mutation_report.accepted_static_survivors(report, "src/Widget.cs") == []
+    assert (
+        mutation_report.accepted_static_survivors(
+            report, "src/Widget.cs", skip_static_active=True
+        )
+        == []
+    )
 
 
 def test_accepted_static_survivors_file_absent_from_report_returns_empty(
@@ -887,7 +901,12 @@ def test_accepted_static_survivors_file_absent_from_report_returns_empty(
         {"src/Widget.cs": {"mutants": [_mutant_static("Survived", True)]}},
     )
 
-    assert mutation_report.accepted_static_survivors(report, "src/Nope.cs") == []
+    assert (
+        mutation_report.accepted_static_survivors(
+            report, "src/Nope.cs", skip_static_active=True
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize(
@@ -901,7 +920,12 @@ def test_accepted_static_survivors_excludes_non_survived_statuses(
         {"src/Widget.cs": {"mutants": [_mutant_static(status, True)]}},
     )
 
-    assert mutation_report.accepted_static_survivors(report, "src/Widget.cs") == []
+    assert (
+        mutation_report.accepted_static_survivors(
+            report, "src/Widget.cs", skip_static_active=True
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize(
@@ -924,7 +948,9 @@ def test_accepted_static_survivors_malformed_location_yields_line_none_without_r
         {"src/Widget.cs": {"mutants": [mutant]}},
     )
 
-    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+    result = mutation_report.accepted_static_survivors(
+        report, "src/Widget.cs", skip_static_active=True
+    )
 
     assert len(result) == 1
     assert result[0]["line"] is None
@@ -949,12 +975,75 @@ def test_accepted_static_survivors_from_data_matches_accepted_static_survivors(
     data = mutation_report.load_report(report)
 
     from_data = mutation_report.accepted_static_survivors_from_data(
-        data, "src/Widget.cs"
+        data, "src/Widget.cs", skip_static_active=True
     )
-    from_path = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+    from_path = mutation_report.accepted_static_survivors(
+        report, "src/Widget.cs", skip_static_active=True
+    )
 
     assert from_data == from_path
     assert len(from_data) == 1
+
+
+# =============================================================================
+# Scenario: accepted_static_survivors() is gated on skip_static_active — a
+# real, non-basis-having "static: true" flag is not by itself evidence that
+# the operator's --skip-static was active for this run (domain-review
+# finding, fix pass for #1940 whole-branch backstop review)
+# =============================================================================
+def test_accepted_static_survivors_skip_static_active_false_returns_empty(
+    tmp_path: Path,
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/Widget.cs": {
+                "mutants": [
+                    _mutant_static("Survived", True, mutator="StringLiteral"),
+                    _mutant_static("Survived", True, mutator="EqualityOperator"),
+                ]
+            }
+        },
+    )
+
+    assert (
+        mutation_report.accepted_static_survivors(
+            report, "src/Widget.cs", skip_static_active=False
+        )
+        == []
+    )
+    assert (
+        mutation_report.accepted_static_survivors_from_data(
+            mutation_report.load_report(report),
+            "src/Widget.cs",
+            skip_static_active=False,
+        )
+        == []
+    )
+
+
+# =============================================================================
+# Scenario: the emitted "file" is the matched report key, not an echo of the
+# caller-supplied file_path (domain-review finding: entity identity)
+# =============================================================================
+def test_accepted_static_survivors_file_is_matched_report_key_not_caller_input(
+    tmp_path: Path,
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/calculator.ts": {
+                "mutants": [_mutant_static("Survived", True, mutator="StringLiteral")]
+            }
+        },
+    )
+
+    result = mutation_report.accepted_static_survivors(
+        report, "calculator.ts", skip_static_active=True
+    )
+
+    assert len(result) == 1
+    assert result[0]["file"] == "src/calculator.ts"
 
 
 # =============================================================================

--- a/tests/scripts/test_mutation_report.py
+++ b/tests/scripts/test_mutation_report.py
@@ -811,6 +811,173 @@ def test_score_report_still_counts_static_survivor_unfiltered(tmp_path: Path):
 
 
 # =============================================================================
+# Scenario: accepted_static_survivors() models static-skipped mutants as
+# accepted survivors (Slice 2, Step 2.1 of
+# plans/mutation-testing-docs-domain-consistency-1940.md, #1929/#1940)
+# =============================================================================
+def test_accepted_static_survivors_one_static_survivor_amid_others(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/Widget.cs": {
+                "mutants": [
+                    _mutant_static("Survived", True, mutator="StringLiteral"),
+                    _mutant_static(
+                        "Survived", False, mutator="ArithmeticOperator"
+                    ),
+                    _mutant_static("Killed", True, mutator="EqualityOperator"),
+                ]
+            }
+        },
+    )
+
+    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+
+    assert result == [
+        {
+            "file": "src/Widget.cs",
+            "line": None,
+            "operator": "StringLiteral",
+            "status": "accepted",
+            "reason": mutation_report.ACCEPTED_STATIC_REASON,
+        }
+    ]
+
+
+def test_accepted_static_survivors_multiple_static_survivors(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/Widget.cs": {
+                "mutants": [
+                    _mutant_static("Survived", True, mutator="StringLiteral"),
+                    _mutant_static("Survived", True, mutator="EqualityOperator"),
+                ]
+            }
+        },
+    )
+
+    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+
+    assert len(result) == 2
+    assert all(entry["status"] == "accepted" for entry in result)
+    assert all(
+        entry["reason"] == mutation_report.ACCEPTED_STATIC_REASON for entry in result
+    )
+    assert {entry["operator"] for entry in result} == {
+        "StringLiteral",
+        "EqualityOperator",
+    }
+
+
+def test_accepted_static_survivors_no_static_mutants_returns_empty(tmp_path: Path):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {"src/Widget.cs": {"mutants": [_mutant("Survived"), _mutant("Killed")]}},
+    )
+
+    assert mutation_report.accepted_static_survivors(report, "src/Widget.cs") == []
+
+
+def test_accepted_static_survivors_file_absent_from_report_returns_empty(
+    tmp_path: Path,
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {"src/Widget.cs": {"mutants": [_mutant_static("Survived", True)]}},
+    )
+
+    assert mutation_report.accepted_static_survivors(report, "src/Nope.cs") == []
+
+
+@pytest.mark.parametrize(
+    "status", ["Killed", "Timeout", "NoCoverage", "CompileError"]
+)
+def test_accepted_static_survivors_excludes_non_survived_statuses(
+    tmp_path: Path, status: str
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {"src/Widget.cs": {"mutants": [_mutant_static(status, True)]}},
+    )
+
+    assert mutation_report.accepted_static_survivors(report, "src/Widget.cs") == []
+
+
+@pytest.mark.parametrize(
+    "mutate_mutant",
+    [
+        lambda m: m,  # no location key at all
+        lambda m: {**m, "location": "src/Widget.cs:42"},  # non-dict location
+        lambda m: {**m, "location": {"start": "42"}},  # non-dict start
+        lambda m: {**m, "location": {"start": {"line": "not-a-number"}}},
+        lambda m: {**m, "location": {"start": {"line": True}}},
+    ],
+)
+def test_accepted_static_survivors_malformed_location_yields_line_none_without_raising(
+    tmp_path: Path, mutate_mutant
+):
+    mutant = _mutant_static("Survived", True)
+    mutant = mutate_mutant(mutant)
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {"src/Widget.cs": {"mutants": [mutant]}},
+    )
+
+    result = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+
+    assert len(result) == 1
+    assert result[0]["line"] is None
+
+
+def test_accepted_static_survivors_from_data_matches_accepted_static_survivors(
+    tmp_path: Path,
+):
+    report = _write_report(
+        tmp_path / "mutation-report.json",
+        {
+            "src/Widget.cs": {
+                "mutants": [
+                    _mutant_static("Survived", True, mutator="StringLiteral"),
+                    _mutant_static(
+                        "Survived", False, mutator="ArithmeticOperator"
+                    ),
+                ]
+            }
+        },
+    )
+    data = mutation_report.load_report(report)
+
+    from_data = mutation_report.accepted_static_survivors_from_data(
+        data, "src/Widget.cs"
+    )
+    from_path = mutation_report.accepted_static_survivors(report, "src/Widget.cs")
+
+    assert from_data == from_path
+    assert len(from_data) == 1
+
+
+# =============================================================================
+# Scenario: introducing accepted_static_survivors() changes nothing about the
+# existing, unfiltered functions computed over the same fixture (regression
+# for the plan's safety-critical AC: raw/honest score and skip_static=False
+# stay fully unfiltered)
+# =============================================================================
+def test_survivors_by_mutator_default_still_returns_static_survivor_unaffected(
+    tmp_path: Path,
+):
+    report = _mixed_static_report(tmp_path)
+
+    grouped = mutation_report.survivors_by_mutator(
+        report, "src/Widget.cs", skip_static=False
+    )
+
+    assert set(grouped) == {"StringLiteral", "ArithmeticOperator"}
+    assert len(grouped["StringLiteral"]) == 1
+    assert grouped["StringLiteral"][0]["status"] == "Survived"
+
+
+# =============================================================================
 # Scenario: The module carries no repo-specific literal
 # =============================================================================
 def test_module_source_carries_no_repo_specific_literal():

--- a/tests/scripts/test_mutation_report_cli.py
+++ b/tests/scripts/test_mutation_report_cli.py
@@ -193,6 +193,62 @@ def test_skip_static_notice_when_file_absent_from_report(
 
 
 # =============================================================================
+# --accepted-static-survivors
+# =============================================================================
+
+
+def test_accepted_static_survivors_matches_library_call(
+    tmp_path: Path, capsys
+) -> None:
+    # Scope: JSON-passthrough fidelity only — see the comment on
+    # test_survivors_by_line_matches_library_call above.
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {
+            "src/calc.ts": {
+                "mutants": [
+                    _mutant("Survived", mutator="StringLiteral", static=True),
+                    _mutant("Survived", mutator="ArithmeticOperator", static=False),
+                ]
+            }
+        },
+    )
+    rc = cli.main(
+        [
+            "--accepted-static-survivors",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr()
+    assert out.err == ""
+    printed = json.loads(out.out)
+    expected = mutation_report.accepted_static_survivors(report, "src/calc.ts")
+    assert printed == expected
+
+
+def test_accepted_static_survivors_missing_report_file_is_empty_json(
+    tmp_path: Path, capsys
+) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    rc = cli.main(
+        [
+            "--accepted-static-survivors",
+            "--report",
+            str(missing),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr()
+    assert json.loads(out.out) == []
+
+
+# =============================================================================
 # Argument errors
 # =============================================================================
 
@@ -212,7 +268,8 @@ def test_both_mode_flags_is_argument_error(tmp_path: Path, capsys) -> None:
     assert rc == 2
     err = capsys.readouterr().err
     assert (
-        "exactly one of --survivors-by-line or --survivors-by-mutator" in err
+        "exactly one of --survivors-by-line, --survivors-by-mutator, "
+        "or --accepted-static-survivors" in err
     )
 
 
@@ -222,7 +279,73 @@ def test_neither_mode_flag_is_argument_error(tmp_path: Path, capsys) -> None:
     assert rc == 2
     err = capsys.readouterr().err
     assert (
-        "exactly one of --survivors-by-line or --survivors-by-mutator" in err
+        "exactly one of --survivors-by-line, --survivors-by-mutator, "
+        "or --accepted-static-survivors" in err
+    )
+
+
+def test_all_three_mode_flags_is_argument_error(tmp_path: Path, capsys) -> None:
+    report = _write_report(tmp_path / "mutation.json", {})
+    rc = cli.main(
+        [
+            "--survivors-by-line",
+            "--survivors-by-mutator",
+            "--accepted-static-survivors",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert (
+        "exactly one of --survivors-by-line, --survivors-by-mutator, "
+        "or --accepted-static-survivors" in err
+    )
+
+
+def test_accepted_static_survivors_with_survivors_by_line_is_argument_error(
+    tmp_path: Path, capsys
+) -> None:
+    report = _write_report(tmp_path / "mutation.json", {})
+    rc = cli.main(
+        [
+            "--survivors-by-line",
+            "--accepted-static-survivors",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert (
+        "exactly one of --survivors-by-line, --survivors-by-mutator, "
+        "or --accepted-static-survivors" in err
+    )
+
+
+def test_accepted_static_survivors_with_survivors_by_mutator_is_argument_error(
+    tmp_path: Path, capsys
+) -> None:
+    report = _write_report(tmp_path / "mutation.json", {})
+    rc = cli.main(
+        [
+            "--survivors-by-mutator",
+            "--accepted-static-survivors",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert (
+        "exactly one of --survivors-by-line, --survivors-by-mutator, "
+        "or --accepted-static-survivors" in err
     )
 
 
@@ -233,6 +356,25 @@ def test_skip_static_with_survivors_by_line_is_argument_error(
     rc = cli.main(
         [
             "--survivors-by-line",
+            "--skip-static",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--skip-static is only valid with --survivors-by-mutator" in err
+
+
+def test_skip_static_with_accepted_static_survivors_is_argument_error(
+    tmp_path: Path, capsys
+) -> None:
+    report = _write_report(tmp_path / "mutation.json", {})
+    rc = cli.main(
+        [
+            "--accepted-static-survivors",
             "--skip-static",
             "--report",
             str(report),

--- a/tests/scripts/test_mutation_report_cli.py
+++ b/tests/scripts/test_mutation_report_cli.py
@@ -292,6 +292,8 @@ def test_accepted_static_survivors_without_skip_static_succeeds_and_is_empty(
 ) -> None:
     # --accepted-static-survivors alone (without --skip-static) is valid,
     # not an error — it returns [] because skip_static_active is False.
+    # It's a guaranteed no-op though, so a stderr diagnostic must explain
+    # why, rather than staying silent (round-2 fix, #1940).
     report = _write_report(
         tmp_path / "mutation.json",
         {
@@ -313,7 +315,7 @@ def test_accepted_static_survivors_without_skip_static_succeeds_and_is_empty(
     )
     assert rc == 0
     out = capsys.readouterr()
-    assert out.err == ""
+    assert "no accepted entries reported" in out.err
     assert json.loads(out.out) == []
 
 

--- a/tests/scripts/test_mutation_report_cli.py
+++ b/tests/scripts/test_mutation_report_cli.py
@@ -220,13 +220,16 @@ def test_accepted_static_survivors_matches_library_call(
             str(report),
             "--file",
             "src/calc.ts",
+            "--skip-static",
         ]
     )
     assert rc == 0
     out = capsys.readouterr()
     assert out.err == ""
     printed = json.loads(out.out)
-    expected = mutation_report.accepted_static_survivors(report, "src/calc.ts")
+    expected = mutation_report.accepted_static_survivors(
+        report, "src/calc.ts", skip_static_active=True
+    )
     assert printed == expected
 
 
@@ -241,10 +244,76 @@ def test_accepted_static_survivors_missing_report_file_is_empty_json(
             str(missing),
             "--file",
             "src/calc.ts",
+            "--skip-static",
         ]
     )
     assert rc == 0
     out = capsys.readouterr()
+    assert json.loads(out.out) == []
+
+
+def test_accepted_static_survivors_with_skip_static_returns_real_results(
+    tmp_path: Path, capsys
+) -> None:
+    # --accepted-static-survivors and --skip-static together are now valid
+    # (Finding 1): skip_static_active gates the result, so a run where the
+    # skip really was active returns real, non-empty accepted-survivor
+    # entries when static survivors exist.
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {
+            "src/calc.ts": {
+                "mutants": [
+                    _mutant("Survived", mutator="StringLiteral", static=True),
+                ]
+            }
+        },
+    )
+    rc = cli.main(
+        [
+            "--accepted-static-survivors",
+            "--skip-static",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr()
+    printed = json.loads(out.out)
+    assert len(printed) == 1
+    assert printed[0]["status"] == "accepted"
+    assert printed[0]["operator"] == "StringLiteral"
+
+
+def test_accepted_static_survivors_without_skip_static_succeeds_and_is_empty(
+    tmp_path: Path, capsys
+) -> None:
+    # --accepted-static-survivors alone (without --skip-static) is valid,
+    # not an error — it returns [] because skip_static_active is False.
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {
+            "src/calc.ts": {
+                "mutants": [
+                    _mutant("Survived", mutator="StringLiteral", static=True),
+                ]
+            }
+        },
+    )
+    rc = cli.main(
+        [
+            "--accepted-static-survivors",
+            "--report",
+            str(report),
+            "--file",
+            "src/calc.ts",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr()
+    assert out.err == ""
     assert json.loads(out.out) == []
 
 
@@ -368,10 +437,28 @@ def test_skip_static_with_survivors_by_line_is_argument_error(
     assert "--skip-static is only valid with --survivors-by-mutator" in err
 
 
-def test_skip_static_with_accepted_static_survivors_is_argument_error(
+def test_skip_static_with_accepted_static_survivors_is_valid_not_an_error(
     tmp_path: Path, capsys
 ) -> None:
-    report = _write_report(tmp_path / "mutation.json", {})
+    # Finding 1 reverses the old rule: --skip-static + --accepted-static-
+    # survivors is now a valid, supported combination (it's the only way to
+    # get a non-empty result from --accepted-static-survivors), not an
+    # argument error.
+    report = _write_report(
+        tmp_path / "mutation.json",
+        {
+            "src/calc.ts": {
+                "mutants": [
+                    {
+                        "id": "StringLiteral-1",
+                        "mutatorName": "StringLiteral",
+                        "status": "Survived",
+                        "static": True,
+                    }
+                ]
+            }
+        },
+    )
     rc = cli.main(
         [
             "--accepted-static-survivors",
@@ -382,9 +469,12 @@ def test_skip_static_with_accepted_static_survivors_is_argument_error(
             "src/calc.ts",
         ]
     )
-    assert rc == 2
-    err = capsys.readouterr().err
-    assert "--skip-static is only valid with --survivors-by-mutator" in err
+    assert rc == 0
+    out = capsys.readouterr()
+    assert out.err == ""
+    printed = json.loads(out.out)
+    assert len(printed) == 1
+    assert printed[0]["status"] == "accepted"
 
 
 # =============================================================================

--- a/tests/skills/test_javascript_stryker_static_skip_doc.py
+++ b/tests/skills/test_javascript_stryker_static_skip_doc.py
@@ -108,12 +108,19 @@ def test_trade_off_does_not_claim_stryker_runs_faster(static_skip_flat: str) -> 
     """correctness-review finding, build round 1: the prior wording claimed
     'trades a smaller wall-clock (no full-suite re-run per static mutant)',
     which the post-run filter cannot deliver — Stryker has already paid
-    that cost by the time the report exists. Pin the corrected framing."""
+    that cost by the time the report exists. Pin the corrected framing.
+
+    Re-pinned (plan #1940, Step 2.3): the trade-off used to be framed as a
+    "small, documented survivor over-count" — but the over-count was never
+    actually reflected in adjusted_score, so "documented" was misleading.
+    That framing is retired in favor of "deferring ... rather than
+    eliminating", now genuinely documented via accepted_static_survivors()
+    (see test_adjusted_score_folds_in_accepted_static_survivors below)."""
     assert re.search(
         r"cannot make Stryker'?s own run faster", static_skip_flat
     )
     assert re.search(r"saves is the generation-and-verify.{0,10}rounds", static_skip_flat)
-    assert re.search(r"small, documented survivor over-count", static_skip_flat)
+    assert re.search(r"deferring each skipped static mutant", static_skip_flat)
 
 
 def test_scoring_and_convergence_stay_unfiltered(static_skip_flat: str) -> None:
@@ -126,6 +133,23 @@ def test_scoring_and_convergence_stay_unfiltered(static_skip_flat: str) -> None:
     assert re.search(r"convergence.{0,20}stay unfiltered", static_skip_flat)
     assert re.search(r"survivors == 0", static_skip_flat)
     assert re.search(r'never be written as `?status: "converged"`?', static_skip_flat)
+
+
+def test_adjusted_score_folds_in_accepted_static_survivors(static_skip_flat: str) -> None:
+    """Plan #1940, Slice 2, Step 2.3: adjusted_score now accounts for
+    static-skipped mutants via mutation_report_cli.py's
+    --accepted-static-survivors mode (added in Steps 2.1/2.2). This is a
+    real-structure check, not a bag-of-words match — it anchors the CLI
+    invocation, "fold", and adjusted_score inside one sentence/bullet so a
+    doc edit that scatters the three words across unrelated sentences still
+    fails."""
+    assert re.search(
+        r"--accepted-static-survivors[^.]*\bfold[^.]*adjusted_score",
+        static_skip_flat,
+    )
+    # Clustering stays explicitly out of scope for this fold (#1948).
+    assert re.search(r"[Cc]lustering.{0,40}untouched", static_skip_flat)
+    assert "#1948" in static_skip_flat
 
 
 def test_absent_static_field_has_a_stated_fallback(static_skip_flat: str) -> None:


### PR DESCRIPTION
## Summary

- Adds `mutation_report.accepted_static_survivors()`/`accepted_static_survivors_from_data()`, gated on an explicit `skip_static_active: bool` (required, keyword-only) so `adjusted_score` can never be inflated by a caller that merely claims — without evidence — that `--skip-static-mutants` was active. Each entry carries stable identity (`id`, and `file` resolved to the matched report key rather than echoed caller input).
- Exposes the computation via a new `--accepted-static-survivors` mode on `mutation_report_cli.py`, alongside the existing `--survivors-by-line`/`--survivors-by-mutator` modes; the mutual-exclusion check now covers all three. `--skip-static` is valid combined with `--accepted-static-survivors` (it is the required evidence flag for that mode) and still rejected with `--survivors-by-line`.
- Folds the flag into `javascript-stryker.md`'s "Static-mutant skip" section: the prior "documented over-count" framing is retired — the trade-off is now genuinely reflected in `adjusted_score` via the accepted/reason mechanism used elsewhere in `mutation-kill`. The known #1948 clustering-overlap gap (line-clustering generation stays unfiltered) is called out explicitly, not silently left implicit. `mutation-kill.md`'s own JS/TS cross-reference now names the required `--skip-static` flag too.
- A `--accepted-static-survivors` call without `--skip-static` is a guaranteed no-op (`skip_static_active=False` always returns `[]`, by design — it can't prove the evidence it wasn't given); the CLI now surfaces that on stderr instead of failing silently, so a caller can distinguish "no static survivors exist" from "you forgot the flag."
- Adds a formula-drift content guard (`tests/skills/test_mutation_score_formula_consistency.py`, landed via #1967 as a fast-track slice) that mechanically pins `honest_score`/`reported_score`/`adjusted_score` formula agreement across `mutation-score-formulas.md`, `mutation-kill.md`, and `SKILL.md`.

## Test Plan

- [x] Full pre-push pytest directory list (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks`) — 9033 passed, 47 skipped, 0 failed.
- [x] `python3 scripts/check_md_references.py` — clean.
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` — exit 0.
- [x] `mutation-kill.md` confirmed still 647/648 lines (hard ceiling, zero headroom) after its cross-reference edit.
- [x] Whole-branch `/code-review --internal` backstop (13-lens panel) run to convergence across 3 rounds: round 1 found 4 warn-status reports (domain, correctness, naming, structure) → consolidated fix; round 2 re-verification found domain-review and correctness-review independently converging on one new issue (the silent-no-op case above) → scoped fix; round 3 re-verification of both returned zero new warning/error-tier findings — only suggestion-tier, single-reviewer, report-only items remain.
- [x] Farley Score sampled across the new tests: 8.55 (Good), informational.

## Decisions & Assumptions

- #1929 (one of the two issues folded into this plan) predated #1937, which shipped a different implementation of the underlying static-skip filtering along the way. Per explicit confirmation, this PR implements #1929's original ask (folding `--skip-static-mutants` into the accepted/reason survivor model) against the now-shipped #1937 code, additively — not a redesign of #1937's filtering mechanism.
- The `skip_static_active` evidence flag is a caller's assertion about *this* invocation, not a verified attestation that the generation round's `--skip-static --survivors-by-mutator` call actually ran — no code can prove that without threading the generation run's actual arguments through. Documented as a known limitation rather than treated as a defect (domain-review, round-2 verification).
- Two suggestion-tier, non-convergent findings from the review loop were deliberately left unaddressed (report-only per this repo's severity/actionability rules): a `--skip-static` help-text wording nuance, and a `skip_static`/`skip_static_active` naming-inversion + `"status"`-key-overload readability note.

Closes #1940
Closes #1929

---
_Generated by [Claude Code](https://claude.ai/code/session_01885ZPgRcjzBtajjXtRuYFU)_