### PR TITLE
feat(static-analysis): naming, accessibility, and performance probes

### DIFF
--- a/evals/static-analysis-tools/validate.py
+++ b/evals/static-analysis-tools/validate.py
@@ -40,7 +40,26 @@ TOOL_TIER_MAP: dict[str, str] = {
     # Custom scripts shipped by dev-team (P2 Step 3b partial)
     "entropy-check": "secrets",
     "model-hash-verify": "ml",
+    # Language linters (#1979). Both were absent, so every ruff and oxlint
+    # finding fell through to the "generic" tier — contradicting the ids their
+    # own entries in references/tool-configs.md advertise (`oxlint.js.<rule>`,
+    # and the `<tool>.python.<rule>` shape mypy's entry documents).
+    "ruff": "python",
+    "oxlint": "js",
 }
+
+#: Rule ids shaped `plugin(rule)` — oxlint's format, e.g. `jsx-a11y(alt-text)`
+#: or `eslint(no-magic-numbers)`. Without this case `kebab()` flattens the
+#: parentheses into hyphens (`oxlint.js.jsx-a11y-alt-text`), which is
+#: schema-valid but loses the plugin/rule boundary. Keeping the plugin as the
+#: tier segment is what lets a consumer select oxlint's plugin-scoped findings
+#: by prefix — `oxlint.jsx-a11y.*` is #1979's accessibility lane, and
+#: `oxlint.react-perf.*` part of its performance one. Note the limit: rules
+#: oxlint reports under the `eslint` plugin share one segment regardless of
+#: concern, so `oxlint.eslint.no-await-in-loop` (performance) and
+#: `oxlint.eslint.no-unused-vars` (correctness) are told apart by leaf name,
+#: not by prefix.
+_PLUGIN_RULE_RE = re.compile(r"^([A-Za-z0-9_-]+)\(([^()]+)\)$")
 
 SEVERITY_MAP: dict[str, str] = {
     "error": "error",
@@ -57,14 +76,34 @@ def kebab(s: str) -> str:
 
 def build_rule_id(driver_name: str, raw_rule_id: str, tier_override: str | None = None) -> str:
     """Apply the rule-id prefix rules from references/sarif-parser.md."""
-    driver_l = driver_name.lower().strip()
+    # The driver name is kebab-cased, not merely lower-cased: it becomes the
+    # first schema segment, and a driver reporting itself as "ox lint" or
+    # "Semgrep OSS" would otherwise emit a rule id with a space in it, which
+    # fails the envelope pattern. A no-op for every tool actually wired up
+    # (all are already single lowercase words).
+    # `or "unknown-tool"`: the driver is the one segment that is never empty-
+    # guarded elsewhere, and `parse_sarif` rejects only a *falsy* driver name —
+    # a whitespace-only or non-Latin one reaches here and would emit a leading
+    # dot (`.generic.n802`). Symmetric with the two guards below.
+    driver_l = kebab(driver_name) or "unknown-tool"
+    plugin_rule = _PLUGIN_RULE_RE.match(raw_rule_id.strip())
+    if plugin_rule:
+        # `plugin(rule)` (oxlint). The plugin becomes the tier segment, so the
+        # namespace survives instead of being hyphen-flattened.
+        plugin, rule = (kebab(g) for g in plugin_rule.groups())
+        if plugin and rule:
+            return f"{driver_l}.{plugin}.{rule}"
     if "." in raw_rule_id:
         # Structured rule id (e.g. semgrep's python.django.audit.sql-injection).
         # Preserve dot structure; kebab-case each segment independently.
         parts = [kebab(p) for p in raw_rule_id.split(".") if p]
         return f"{driver_l}." + ".".join(parts)
     tier = tier_override or TOOL_TIER_MAP.get(driver_l, "generic")
-    return f"{driver_l}.{tier}.{kebab(raw_rule_id)}"
+    # A rule id that kebabs to nothing (empty string, punctuation-only, a
+    # non-Latin script) would leave a trailing dot and an empty final segment,
+    # which the envelope pattern rejects. Name it rather than emit an invalid
+    # finding: the location and message still carry the useful information.
+    return f"{driver_l}.{tier}.{kebab(raw_rule_id) or 'unknown'}"
 
 
 def trivy_tier_for_rule(raw_rule_id: str) -> str:

--- a/evals/static-analysis-tools/validate.py
+++ b/evals/static-analysis-tools/validate.py
@@ -21,9 +21,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from jsonschema import Draft202012Validator
-from referencing import Registry, Resource
-from referencing.jsonschema import DRAFT202012
+# `jsonschema`/`referencing` are imported lazily, inside the two functions that
+# actually validate, rather than at module scope. Only the validation path
+# needs them; the rule-id and parsing helpers are pure. Importing them here
+# made the whole module unimportable without the dependency, which broke two
+# consumers that never validate: `scripts/lib/normalize_findings.py`, and the
+# CI job running `tests/scripts/` — that job installs pytest alone, so a test
+# importing this module for `build_rule_id` failed at collection.
 
 REPO = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = REPO / "plugins/dev-team/knowledge/schemas/unified-finding-v1.json"
@@ -209,7 +213,10 @@ def parse_sarif(sarif_doc: dict[str, Any]) -> list[dict[str, Any]]:
     return findings
 
 
-def load_schema_registry() -> tuple[dict[str, Any], Registry]:
+def load_schema_registry() -> tuple[dict[str, Any], Any]:
+    from referencing import Registry, Resource
+    from referencing.jsonschema import DRAFT202012
+
     with SCHEMA_PATH.open() as f:
         schema = json.load(f)
     resource = Resource(contents=schema, specification=DRAFT202012)
@@ -259,6 +266,8 @@ def check_install_hints() -> int:
 
 
 def run() -> int:
+    from jsonschema import Draft202012Validator
+
     schema, registry = load_schema_registry()
     validator = Draft202012Validator(schema, registry=registry)
 

--- a/plugins/dev-team/agents/a11y-review.md
+++ b/plugins/dev-team/agents/a11y-review.md
@@ -104,3 +104,15 @@ Append confidence level (High/Medium/Low) to the `summary` field.
 ## Ignore
 
 Code style, naming, test coverage, performance (handled by other agents)
+
+**Anything the static-analysis pre-pass already reported (#1979).** When the
+run supplies pre-pass findings, honor their "do not re-report" framing — the
+`oxlint.jsx-a11y.*` rules cover a real slice of the `## Detect` list above
+mechanically: missing `alt` attributes, invalid anchor `href`s, click handlers
+with no keyboard equivalent, and static elements carrying handlers without a
+role. A violation already named in that table is settled. What remains yours
+is what a per-element linter cannot see: focus order and focus management
+across a flow, whether an accessible name is *meaningful* rather than merely
+present, live-region and announcement behavior, color and contrast decisions,
+and whether the whole interaction is operable by keyboard end to end. On a
+target with no oxlint lane, the mechanical checks are still yours too.

--- a/plugins/dev-team/agents/naming-review.md
+++ b/plugins/dev-team/agents/naming-review.md
@@ -116,3 +116,18 @@ Append confidence level (High/Medium/Low) to the `summary` field.
 ## Ignore
 
 Structure, tests, domain modeling (handled by other agents)
+
+**Anything the static-analysis pre-pass already reported (#1979).** When the
+run supplies pre-pass findings, they arrive with "do not re-report" framing —
+honor it here specifically, because two of this agent's own checks now have a
+deterministic source on the Python side: `ruff.python.plr2004` (magic values
+in comparisons) and `ruff.python.n8xx` (PEP 8 naming conventions). A literal
+or a snake_case violation already named in that table is settled; re-reporting
+it spends a dispatch to restate a measurement. What remains yours is the part
+no linter can compute — whether a *well-formed* name actually reveals intent,
+whether a boolean reads as a predicate, whether two names in the same module
+mean the same thing, and whether a flagged constant has a meaningful name
+available at all. On stacks with no such lane (or where the project has not
+opted into the JS/TS equivalents — see
+[`../skills/static-analysis-integration/references/tool-configs.md`](../skills/static-analysis-integration/references/tool-configs.md)),
+these checks are still entirely yours.

--- a/plugins/dev-team/agents/performance-review.md
+++ b/plugins/dev-team/agents/performance-review.md
@@ -81,3 +81,17 @@ Append confidence level (High/Medium/Low) to the `summary` field.
 ## Ignore
 
 Code structure, naming, tests, domain modeling, security, concurrency (handled by other agents)
+
+**Anything the static-analysis pre-pass already reported (#1979).** When the
+run supplies pre-pass findings, honor their "do not re-report" framing. Two
+sources now feed this lens deterministically: `oxlint.eslint.no-await-in-loop`
+and `oxlint.react-perf.*` on the JS/TS side, and — when the Repowise MCP tools
+are available — `get_health`'s static I/O-in-loop / N+1 findings, injected as
+context rather than fetched per dispatch. **Do not go looking for those
+findings yourself when they are already in the table**; in particular, the
+Self-Challenge item asking whether you checked every loop and I/O site is
+satisfied for the sites the pre-pass already named. What remains yours is
+everything the static view cannot settle: whether a flagged loop is actually
+hot, algorithmic complexity across call boundaries, unbounded growth and
+lifetime questions, missing timeouts and retry amplification, and resource
+leaks. Absent those lanes, the whole list is yours as before.

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -147,7 +147,7 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | Quality Targets Converge | `skills/quality-targets-converge/SKILL.md` | ~5,540 | `/test-improve` (Phase 8), QA Engineer, Software Engineer |
 | Semantic Duplication Scan | `skills/semantic-duplication-scan/SKILL.md` | ~3,163 | Orchestrator, Software Engineer, Architect |
 | Specs | `skills/specs/SKILL.md` | ~4,553 | Product Manager, Architect, QA Engineer, Orchestrator |
-| Static Analysis Integration | `skills/static-analysis-integration/SKILL.md` | 3,056 | Orchestrator, `/code-review` |
+| Static Analysis Integration | `skills/static-analysis-integration/SKILL.md` | 3,792 | Orchestrator, `/code-review` |
 | Stryker xunit.v2 Shim | `skills/stryker-xunit-v2-shim/SKILL.md` | ~3,945 | `/mutation-testing`, `/test-improve` (mutation on .NET/xunit.v3), QA Engineer, standalone |
 | Systematic Debugging | `skills/systematic-debugging/SKILL.md` | 2,129 | Software Engineer, QA Engineer |
 | Test Audit + Disable | `skills/test-audit-disable/SKILL.md` | ~1,619 | Standalone worker; QA Engineer |

--- a/plugins/dev-team/knowledge/index.json
+++ b/plugins/dev-team/knowledge/index.json
@@ -5810,6 +5810,10 @@
       "summary": "Shipped in P2 Step 3b for tools without upstream SARIF.",
       "anchor": "tier-3-bespoke-json-adapters"
     },
+    "Convention, accessibility, and performance probes (#1979)": {
+      "summary": "Two **additional invocations of tools already in the tiers above** — no new binaries, no new adapters, no network.",
+      "anchor": "convention-accessibility-and-performance-probes-1979"
+    },
     "Tier 4 — legacy (pre-SARIF)": {
       "summary": "ESLint / tsc remain callable via native JSON for older flows.",
       "anchor": "tier-4-legacy-pre-sarif"

--- a/plugins/dev-team/skills/static-analysis-integration/SKILL.md
+++ b/plugins/dev-team/skills/static-analysis-integration/SKILL.md
@@ -49,6 +49,19 @@ Shipped in P2 Step 3b for tools without upstream SARIF. Each adapter ≤ 40 LOC.
 
 mypy (≥ 1.11, `mypy --output json`) normalizes via `adapters/mypy-adapter.py` — rule ids `mypy.python.<error-code>`; on older mypy (no `--output json`) the adapter degrades to a skip-with-warning. Language-conditional like ruff (see step 1). Invocation and field mapping in `references/tool-configs.md`.
 
+### Convention, accessibility, and performance probes (#1979)
+
+Two **additional invocations of tools already in the tiers above** — no new binaries, no new adapters, no network. Each exists to hand review agents a deterministic finding where a lens would otherwise re-derive one by inference, and each is separate from its tool's main lane so the main lane keeps reflecting the project's own gating configuration:
+
+| Probe | Invocation | Displaces |
+|---|---|---|
+| ruff convention | `ruff check --select N,PLR2004 --output-format sarif .` | the mechanical half of `naming-review` (PEP 8 naming, magic values in comparisons) |
+| oxlint frontend | `npx oxlint --jsx-a11y-plugin --react-plugin --react-perf-plugin -D perf --format sarif .` | the mechanical half of `a11y-review`; feeds `performance-review` on the JS/TS side (`no-await-in-loop` is the N+1 shape) |
+
+Both are language-conditional, never `[REQUIRED]`, and never gate — they are context, exactly like the rest of the pre-pass. Invocation details, the measured calibration behind them, and the JS/TS magic-number opt-in are in `references/tool-configs.md`.
+
+**Cross-language performance context.** When the Repowise MCP tools are available, the caller injects `get_health`'s static I/O-in-loop / N+1 findings into the pre-pass context alongside these, rather than having `performance-review` fetch them per dispatch. **Semgrep's registry performance rulesets (`p/performance`) are deliberately NOT used**: resolving a registry pack requires an outbound call to `semgrep.dev`, which would break the offline posture § 1b establishes for this pre-pass — and the pack the spike named does not resolve at all (`--config p/performance` returns HTTP 404, verified on semgrep 1.174.0). Shipping our own performance rules is possible but is a separate piece of work: every rule this repo ships needs passing/failing fixtures under the `semgrep rule fixtures` CI gate. The oxlint `perf` lane covers the JS/TS side offline; anything beyond it stays with the agent.
+
 **lizard** (complexity metrics) normalizes via `adapters/lizard-adapter.py` — rule ids `lizard.complexity.<metric>`; **jscpd** (copy-paste duplication) via `adapters/jscpd-adapter.py` — rule id `jscpd.duplication.clone`. Both are Tier 3 by this file's own taxonomy (bespoke adapter, not SARIF-native), but both are *baseline* capabilities rather than optional extras: they are the deterministic source for the two metric families the review panel would otherwise re-derive by inference on every run — function complexity/size/parameter count, and duplicated blocks (#1974). Neither is language-conditional; lizard covers ~15 languages and jscpd ~150, so both are probed on every target set. Invocation, thresholds, and field mapping in `references/tool-configs.md`.
 
 ### Tier 4 — legacy (pre-SARIF)

--- a/plugins/dev-team/skills/static-analysis-integration/references/sarif-parser.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/sarif-parser.md
@@ -8,7 +8,7 @@ Shared normalization layer for every SARIF-emitting tool in the static-analysis 
 
 | Unified finding field | SARIF source | Transform |
 |---|---|---|
-| `rule_id` | `runs[r].tool.driver.name` + `results[i].ruleId` | Format: `<driver_name_lower>.<ruleId_kebab>`; if `results[i].properties.language` is set, insert it as the middle segment |
+| `rule_id` | `runs[r].tool.driver.name` + `results[i].ruleId` | Format: `<driver_name_kebab>.<middle>.<ruleId_kebab>` — see **Rule id prefix conventions** below for what fills the middle segment |
 | `file` | `results[i].locations[0].physicalLocation.artifactLocation.uri` | Strip `file://` prefix; resolve `uriBaseId` if present; ensure repo-relative POSIX path |
 | `line` | `results[i].locations[0].physicalLocation.region.startLine` | Integer, 1-indexed |
 | `severity` | `results[i].level` | Map: `error`→`error`, `warning`→`warning`, `note`→`suggestion`, `none` or absent→`info` |
@@ -31,7 +31,9 @@ Shared normalization layer for every SARIF-emitting tool in the static-analysis 
 
 ## Rule id prefix conventions
 
-Every unified rule_id follows the schema pattern `^[a-z0-9_-]+(\.[a-z0-9_-]+)+$` — at least two dot-separated segments. The parser applies two rules depending on whether the raw SARIF ruleId is already structured (contains dots).
+Every unified rule_id follows the schema pattern `^[a-z0-9_-]+(\.[a-z0-9_-]+)+$` — at least two dot-separated segments. The parser applies the rules below depending on the shape of the raw SARIF ruleId.
+
+The middle segment comes from the raw ruleId's own structure, its plugin, or the tool → tier map — **never** from `results[i].properties.language`. An earlier version of the field table above named that property as the source; no implementation ever read it, and the tier map is what every fixture and both consumers actually exercise.
 
 **Raw ruleId contains dots (semgrep-style):** preserve the structure. Each segment is kebab-cased independently.
 
@@ -39,6 +41,23 @@ Every unified rule_id follows the schema pattern `^[a-z0-9_-]+(\.[a-z0-9_-]+)+$`
 raw: python.django.audit.sql-injection
 out: semgrep.python.django.audit.sql-injection
 ```
+
+**Raw ruleId is `plugin(rule)`-shaped (oxlint):** the plugin becomes the tier segment, so the namespace survives.
+
+```
+raw: jsx-a11y(alt-text)        out: oxlint.jsx-a11y.alt-text
+raw: eslint(no-magic-numbers)  out: oxlint.eslint.no-magic-numbers
+raw: react-perf(jsx-no-new-object-as-prop)
+                               out: oxlint.react-perf.jsx-no-new-object-as-prop
+```
+
+This branch is checked **before** the dotted and flat cases. Without it the
+parentheses are hyphen-flattened by `kebab()` into a single segment
+(`oxlint.js.jsx-a11y-alt-text`) — schema-valid, but it erases the boundary
+that lets a consumer tell an accessibility finding from a performance one,
+which is exactly what #1979's two oxlint concerns need. A malformed shape
+(empty half, nested parentheses) falls through to the rules below rather than
+producing a partial id.
 
 **Raw ruleId is flat:** the parser inserts a capability-tier segment from its tool → tier map.
 
@@ -49,8 +68,26 @@ out: semgrep.python.django.audit.sql-injection
 | trivy | `iac` for config findings; `cve` for CVE findings; `supply-chain` for vuln findings |
 | hadolint | `dockerfile` |
 | actionlint | `workflows` |
+| ruff | `python` |
+| oxlint | `js` (fallback only — a `plugin(rule)` id uses its plugin instead) |
 | entropy-check | `secrets` (custom script — passphrase entropy + cross-env reuse) |
 | model-hash-verify | `ml` (custom script — ML model integrity + provenance) |
+
+`ruff` and `oxlint` were absent from this map until #1979, so every finding
+from the two language linters was emitted under the `generic` fallback,
+contradicting the ids their own entries in `tool-configs.md` advertise.
+
+**Degenerate inputs still produce a valid id.** Two rules keep the output
+inside the schema pattern no matter what a driver reports, because a rule id
+that fails validation costs the whole finding — file, line, and message
+included — even when those are perfectly usable:
+
+- The **driver name is kebab-cased** into the first segment, so a tool
+  identifying itself as `Semgrep OSS` yields `semgrep-oss.…` rather than
+  embedding a space. A no-op for every tool wired up today.
+- A **rule id that kebabs to nothing** (empty string, punctuation only, a
+  non-Latin script) becomes the literal segment `unknown` rather than an
+  empty trailing segment: `oxlint.js.unknown`, never `oxlint.js.`.
 
 ```
 raw: aws-access-key        out: gitleaks.secrets.aws-access-key

--- a/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
+++ b/plugins/dev-team/skills/static-analysis-integration/references/tool-configs.md
@@ -217,8 +217,26 @@ ruff check --output-format sarif .
 - **Detection**: `command -v ruff`
 - **Capability tier**: Python lint + autofix
 - **Presence**: language-conditional, never `[REQUIRED]` — dispatch ruff, and surface its missing-tool install hint, only when `.py` files are in the target set. A non-Python repo never sees a "ruff missing" warning, consistent with the skill's "absence is never a pipeline failure" constraint.
-- **Config resolution**: the project's own `ruff.toml`/`pyproject.toml` wins when present (Ruff's default config discovery — no override flags); Ruff's defaults otherwise. The plugin pins no curated rule set — the project owns its quality bar.
+- **Config resolution**: the project's own `ruff.toml`/`pyproject.toml` wins when present (Ruff's default config discovery — no override flags); Ruff's defaults otherwise. The plugin pins no curated rule set — the project owns its **gating** bar. The convention probe below is a separate, non-gating invocation and does not change that.
 - **Adapter**: none; consumed raw by the shared SARIF parser.
+
+#### Convention probe (naming + magic values)
+
+A **second, separate** ruff invocation whose only job is to give review agents
+deterministic naming and magic-value findings (#1979). Kept apart from the
+lane above on purpose: that one reflects the project's own quality bar, this
+one adds review context and never gates.
+
+```bash
+ruff check --select N,PLR2004 --output-format sarif .
+```
+
+- **Displaces**: the mechanical half of `naming-review` — PEP 8 naming conventions (`N801`/`N802`/`N803`…) and magic values in comparisons (`PLR2004`), which that agent lists among its own checks and would otherwise re-derive by inference on every run. Intent-revealing-name judgment stays with the agent.
+- **`--select`, not `--extend-select`** (verified on ruff 0.16.4): `--select` *replaces* the rule set for this invocation, so the probe emits only `N`/`PLR2004` findings and does not duplicate the main lane's output. `--extend-select` would re-report every rule the project already enables.
+- **Project scoping is preserved.** Verified: the project's `exclude` (vendored directories stay unscanned), its `per-file-ignores`, and inline `# noqa: N802` comments are all still honored under `--select`. Only a blanket `ignore = ["N802"]` in project config is overridden — a deliberate trade, since suppressing a convention in CI is not the same as declining to hear about it in review. A project that disagrees suppresses these through the pre-pass's own mechanism, `ACCEPTED-RISKS.md` (SKILL.md step 5).
+- **Thresholds need no tuning**: `PLR2004`'s defaults already ignore `0`, `1`, and `-1` (verified), so it flags unexplained domain constants — `if amount > 1000` — rather than every literal.
+- **Rule ids**: `ruff.python.n802`, `ruff.python.plr2004`, … (see the `ruff` row of the tier map in `sarif-parser.md`).
+- **Presence**: language-conditional and non-gating, exactly like the main ruff lane. No extra install — same binary.
 
 ## Tier 2 — optional SARIF adapters (shipped in P2 Step 3b)
 
@@ -237,8 +255,54 @@ npx oxlint --format sarif .
 - **Install hint**: `oxlint — JS/TS linting. install: npm install --save-dev oxlint`
 - **Detection**: `npx --no-install oxlint --version` (or `node_modules/.bin/oxlint`) — oxlint is a project-local npm devDependency, not a global binary, so PATH probes (`command -v`) would miss it.
 - **Capability tier**: JS/TS linting
-- **Adapter**: none; consumed raw by the shared SARIF parser (`sarif-parser.md`), which prefixes rule ids as `oxlint.js.<rule-id>` (`runs[*].tool.driver.name` is `oxlint`; SARIF `ruleId` values look like `eslint(no-unused-vars)`).
+- **Adapter**: none; consumed raw by the shared SARIF parser (`sarif-parser.md`). `runs[*].tool.driver.name` is `oxlint` — the string `TOOL_TIER_MAP` is keyed by, observed on oxlint 1.80.0 — and its SARIF `ruleId` values are `plugin(rule)`-shaped (`eslint(no-unused-vars)`, `jsx-a11y(alt-text)`, observed on the same version). The parser maps that shape to `oxlint.<plugin>.<rule>` — e.g. `oxlint.eslint.no-unused-vars`, `oxlint.jsx-a11y.alt-text`. A rule id with no parentheses falls back to the tool's tier segment, `oxlint.js.<rule-id>`. (Before #1979 the parser had neither branch: `oxlint` was missing from the tier map and the parentheses were hyphen-flattened, so findings were emitted as `oxlint.generic.jsx-a11y-alt-text`.)
 - **Coexistence with legacy ESLint (Tier 4)**: this entry sits alongside the ESLint entry, not replacing it. When a project runs both, the same finding can arrive twice — the dedup chain (SKILL.md step 4) ranks oxlint ahead of the legacy JS tools. While both run, add [`eslint-plugin-oxlint`](https://github.com/oxc-project/eslint-plugin-oxlint) to the ESLint config to turn off ESLint rules oxlint already covers, so the ESLint pass only pays for the plugin-only remainder.
+
+#### Frontend probe (accessibility + performance)
+
+A **second, separate** oxlint invocation that turns on the plugins the main
+lane leaves off, giving review agents deterministic accessibility and
+performance findings (#1979). One invocation covers both concerns because
+oxlint ships them natively — no `eslint-plugin-jsx-a11y` install, no config
+file, no network.
+
+```bash
+npx oxlint --jsx-a11y-plugin --react-plugin --react-perf-plugin -D perf --format sarif .
+```
+
+- **Displaces**: the mechanical half of `a11y-review` (missing `alt`, invalid `href`, click handlers with no keyboard equivalent, static elements with handlers and no role) and feeds `performance-review` on the JS/TS side. Verified on oxlint 1.80.0 against a fixture component: 4 `jsx-a11y` findings and 2 `react-perf` findings, including `alt-text` and `jsx-no-new-function-as-prop`.
+- **`-D perf` is the performance half**: it promotes oxlint's `perf` category, whose most valuable member for this panel is `no-await-in-loop` — the classic **N+1 / I/O-in-loop shape** the spike names. `--react-perf-plugin` adds the render-path rules (`jsx-no-new-object-as-prop`, `jsx-no-new-function-as-prop`).
+- **Correctness overlap is expected and harmless**: this invocation also re-emits the default `correctness` category the main lane already reports. Those arrive with identical `rule_id`/`file`/`line` and are removed by the dedup step (SKILL.md step 4), so the net contribution is the a11y and perf findings.
+- **`-D jsx-a11y` does NOT isolate the a11y rules** — `jsx-a11y` is a plugin, not a category, so `-A all -D jsx-a11y` yields zero findings (verified). That is why the two concerns share one invocation rather than running as two narrower ones.
+- **Rule ids**: `oxlint.jsx-a11y.*` and `oxlint.react-perf.*` / `oxlint.eslint.no-await-in-loop`. The plugin segment is what lets a consumer separate the accessibility findings from the performance ones — see the `plugin(rule)` case in `sarif-parser.md`.
+- **Presence**: dispatched only when the target set contains JS/TS/JSX files, and never `[REQUIRED]` — same posture as the main oxlint lane.
+
+##### Naming and magic numbers on the JS/TS side: project-configured, not forced
+
+oxlint implements `eslint(no-magic-numbers)`, but it takes **no rule options
+on the command line**, and the rule's unconfigured default flags `0` and `1`.
+Measured over this repo's own 40 TS/JS eval files: 152 findings, **35% of them
+the values `0`, `1`, `-1`, or `2`** — noise that would swamp the injection and
+tell `naming-review` nothing it should act on. Python's `PLR2004` needs no
+such care because its defaults already exclude those values, which is why the
+ruff convention probe above runs unconditionally and this does not.
+
+So the JS/TS naming and magic-value rules are an **opt-in the project owns**,
+configured where the options actually live:
+
+```jsonc
+// .oxlintrc.json
+{
+  "rules": {
+    "no-magic-numbers": ["warn", { "ignore": [0, 1, -1], "ignoreArrayIndexes": true }],
+    "@typescript-eslint/naming-convention": "warn"
+  }
+}
+```
+
+With that in place the **main** oxlint lane reports them and they reach agents
+through the normal path — no extra invocation, and the project keeps control
+of the thresholds it has to live with.
 
 #### When a project may drop ESLint entirely
 

--- a/tests/scripts/test_sarif_rule_ids.py
+++ b/tests/scripts/test_sarif_rule_ids.py
@@ -1,0 +1,165 @@
+"""Rule-id construction in the shared SARIF parser (#1979).
+
+`build_rule_id` implements `references/sarif-parser.md`'s prefix conventions
+and is what every static-analysis lane's findings are keyed by — dedup, the
+ACCEPTED-RISKS suppression rules, and the agent-facing injection all read it.
+It had no test at all, and two defects were living in that gap: `ruff` and
+`oxlint` were missing from `TOOL_TIER_MAP`, so their findings were emitted
+under a `generic` tier that contradicts the ids their own tool-configs entries
+advertise; and oxlint's `plugin(rule)` id shape was hyphen-flattened, losing
+the plugin namespace that tells an accessibility finding from a performance
+one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+sys.path.insert(0, str(REPO_ROOT / "evals" / "static-analysis-tools"))
+import validate
+
+SCHEMA = json.loads(
+    (
+        REPO_ROOT
+        / "plugins/dev-team/knowledge/schemas/unified-finding-v1.json"
+    ).read_text()
+)
+#: The envelope's own `rule_id` constraint — the oracle here, not a restatement.
+RULE_ID_PATTERN = re.compile(SCHEMA["properties"]["rule_id"]["pattern"])
+
+
+@pytest.mark.parametrize(
+    "driver,raw,expected",
+    [
+        # oxlint's `plugin(rule)` shape: the plugin becomes the tier segment.
+        ("oxlint", "jsx-a11y(alt-text)", "oxlint.jsx-a11y.alt-text"),
+        ("oxlint", "eslint(no-magic-numbers)", "oxlint.eslint.no-magic-numbers"),
+        ("oxlint", "eslint(no-await-in-loop)", "oxlint.eslint.no-await-in-loop"),
+        ("oxlint", "oxc(no-map-spread)", "oxlint.oxc.no-map-spread"),
+        # Flat ids still take the tool's tier from TOOL_TIER_MAP.
+        ("oxlint", "some-flat-rule", "oxlint.js.some-flat-rule"),
+        ("ruff", "N802", "ruff.python.n802"),
+        ("ruff", "PLR2004", "ruff.python.plr2004"),
+        # Pre-existing conventions must be untouched by the new branch.
+        (
+            "semgrep",
+            "python.django.audit.sql-injection",
+            "semgrep.python.django.audit.sql-injection",
+        ),
+        ("gitleaks", "aws-access-key", "gitleaks.secrets.aws-access-key"),
+        ("hadolint", "DL3008", "hadolint.dockerfile.dl3008"),
+    ],
+)
+def test_rule_id_construction(driver, raw, expected):
+    assert validate.build_rule_id(driver, raw) == expected
+
+
+@pytest.mark.parametrize(
+    "driver,raw",
+    [
+        ("oxlint", "jsx-a11y(alt-text)"),
+        ("oxlint", "eslint(no-magic-numbers)"),
+        ("oxlint", "weird((nested))"),      # unmatched shape must still be valid
+        ("oxlint", "trailing()"),           # empty rule half
+        ("ruff", "N802"),
+        ("ruff", "ANN101"),
+        ("semgrep", "python.lang.security.audit.eval-detected"),
+        ("trivy", "CVE-2024-1234"),
+        ("unknown-tool", "SOME_RULE"),
+        # Degenerate inputs. Each produced a schema-INVALID id before #1979:
+        # a driver name with a space landed a space in the first segment, and
+        # a rule id that kebabs to nothing left an empty trailing segment.
+        ("ox lint", "a(b)"),
+        ("Semgrep OSS", "py.rule"),
+        ("oxlint", ""),
+        ("oxlint", "()"),
+        ("oxlint", "日本語"),
+        ("oxlint", "---"),
+        ("日本語", "N802"),          # driver that kebabs to nothing
+        ("   ", "a(b)"),
+    ],
+)
+def test_every_rule_id_satisfies_the_envelope_pattern(driver, raw):
+    """The schema is the oracle: a rule_id that fails this pattern makes the
+    whole finding invalid, and the parser is required to emit only valid
+    findings."""
+    rule_id = validate.build_rule_id(driver, raw)
+    assert RULE_ID_PATTERN.match(rule_id), f"{raw!r} -> {rule_id!r}"
+
+
+def test_ruff_and_oxlint_are_not_emitted_under_the_generic_tier():
+    """Regression: both were absent from TOOL_TIER_MAP, so every finding from
+    the two language linters carried a `generic` segment while their
+    tool-configs entries documented `python`/`js`."""
+    assert validate.TOOL_TIER_MAP["ruff"] == "python"
+    assert validate.TOOL_TIER_MAP["oxlint"] == "js"
+    assert "generic" not in validate.build_rule_id("ruff", "N802")
+    assert "generic" not in validate.build_rule_id("oxlint", "no-debugger")
+
+
+def test_a_rule_id_that_kebabs_to_nothing_is_named_rather_than_left_empty():
+    """`oxlint.js.` — a trailing dot with an empty segment — fails the
+    envelope pattern, so the whole finding would be dropped by the validating
+    parser even though its file, line, and message are perfectly usable."""
+    assert validate.build_rule_id("oxlint", "") == "oxlint.js.unknown"
+    assert validate.build_rule_id("oxlint", "()") == "oxlint.js.unknown"
+
+
+def test_a_driver_name_is_kebab_cased_into_the_first_segment():
+    """A tool reporting itself as `Semgrep OSS` must not put a space in the
+    rule id. No-op for every tool actually wired up."""
+    assert validate.build_rule_id("Semgrep OSS", "py.rule") == "semgrep-oss.py.rule"
+    assert validate.build_rule_id("semgrep", "py.rule") == "semgrep.py.rule"
+
+
+def test_the_plugin_segment_makes_oxlint_findings_selectable_by_prefix():
+    """What preserving `plugin(rule)` actually buys: the plugin-scoped lanes
+    are addressable by prefix. Asserted as a prefix match rather than
+    "not a11y" — the weaker form was satisfied by the hyphen-flattened id
+    this branch exists to replace, so it could not have failed."""
+    assert validate.build_rule_id("oxlint", "jsx-a11y(alt-text)").startswith(
+        "oxlint.jsx-a11y."
+    )
+    assert validate.build_rule_id(
+        "oxlint", "react-perf(jsx-no-new-object-as-prop)"
+    ).startswith("oxlint.react-perf.")
+
+
+def test_the_eslint_plugin_segment_does_not_separate_concerns():
+    """The honest limit of the branch, pinned so the rationale cannot drift
+    into overclaiming: oxlint files both a performance rule and a correctness
+    rule under its `eslint` plugin, so those two are distinguished by leaf
+    name, not by prefix."""
+    perf = validate.build_rule_id("oxlint", "eslint(no-await-in-loop)")
+    correctness = validate.build_rule_id("oxlint", "eslint(no-unused-vars)")
+    assert perf.rsplit(".", 1)[0] == correctness.rsplit(".", 1)[0] == "oxlint.eslint"
+    assert perf != correctness
+
+
+def test_a_driver_name_that_kebabs_to_nothing_is_named_too():
+    """The driver is the one segment with no empty guard until #1979, and
+    `parse_sarif` rejects only a falsy driver name — whitespace or a
+    non-Latin name reaches the builder and would emit a leading dot."""
+    for driver in ("日本語", "   ", "---"):
+        rule_id = validate.build_rule_id(driver, "N802")
+        assert rule_id.startswith("unknown-tool."), rule_id
+        assert RULE_ID_PATTERN.match(rule_id)
+
+
+def test_normalize_findings_shares_this_parser_rather_than_copying_it():
+    """`scripts/lib/normalize_findings.py` imports the same builder, so the
+    conventions cannot drift between the eval validator and the pre-pass."""
+    path = REPO_ROOT / "scripts" / "lib" / "normalize_findings.py"
+    source = path.read_text(encoding="utf-8")
+    assert "from validate import" in source
+    spec = importlib.util.spec_from_file_location("normalize_findings_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.TOOL_TIER_MAP["oxlint"] == "js"

--- a/tests/scripts/test_sarif_rule_ids.py
+++ b/tests/scripts/test_sarif_rule_ids.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import subprocess
 import sys
+import textwrap
 
 import pytest
 
@@ -151,6 +153,32 @@ def test_a_driver_name_that_kebabs_to_nothing_is_named_too():
         rule_id = validate.build_rule_id(driver, "N802")
         assert rule_id.startswith("unknown-tool."), rule_id
         assert RULE_ID_PATTERN.match(rule_id)
+
+
+def test_the_module_imports_without_the_jsonschema_dependency():
+    """Regression: `validate.py` imported `jsonschema`/`referencing` at module
+    scope, so importing it purely for `build_rule_id` required a dependency
+    the validation path alone needs. That broke this very file's collection in
+    the `Plugin content & hooks` CI job, which installs pytest and nothing
+    else — a green local run (where the dep is present) could not catch it.
+    Run in a subprocess with the modules forced unimportable."""
+    probe = textwrap.dedent(
+        """
+        import sys
+        for mod in ("jsonschema", "referencing", "referencing.jsonschema"):
+            sys.modules[mod] = None
+        sys.path.insert(0, %r)
+        import validate
+        assert validate.build_rule_id("ruff", "N802") == "ruff.python.n802"
+        print("OK")
+        """
+    ) % str(REPO_ROOT / "evals" / "static-analysis-tools")
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+    assert "OK" in result.stdout
 
 
 def test_normalize_findings_shares_this_parser_rather_than_copying_it():

--- a/tests/skills/test_static_analysis_convention_lanes.py
+++ b/tests/skills/test_static_analysis_convention_lanes.py
@@ -1,0 +1,278 @@
+"""The convention / accessibility / performance probes (#1979).
+
+Two extra invocations of tools already in the tiers — `ruff --select
+N,PLR2004` and oxlint with its jsx-a11y/react-perf plugins — hand review
+agents deterministic findings where `naming-review`, `a11y-review`, and
+`performance-review` would otherwise re-derive them by inference.
+
+Where the tool is guaranteed present in CI (ruff is a declared dev
+dependency) these are **behavioral** tests that run it: a documented claim
+about a tool's behavior is worth only as much as the run that confirms it,
+and the calibration claims here — that `PLR2004` ignores `0`/`1`, that
+`--select` does not duplicate the main lane — are exactly the kind that rot
+silently. oxlint is not installed in CI, so its probes are skip-guarded and
+the documentation contract is asserted instead.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+_SAI = REPO_ROOT / "plugins/dev-team/skills/static-analysis-integration"
+SKILL = _SAI / "SKILL.md"
+CONFIGS = _SAI / "references" / "tool-configs.md"
+PARSER = _SAI / "references" / "sarif-parser.md"
+AGENTS = REPO_ROOT / "plugins/dev-team/agents"
+
+RUFF_PROBE = "ruff check --select N,PLR2004 --output-format sarif ."
+OXLINT_PROBE = (
+    "npx oxlint --jsx-a11y-plugin --react-plugin --react-perf-plugin "
+    "-D perf --format sarif ."
+)
+
+
+def _ruff_sarif(target_dir) -> list[dict]:
+    """Run the documented convention probe and return its SARIF results.
+
+    Also asserts the driver name, because that string is the key
+    `TOOL_TIER_MAP` is looked up by: if ruff ever renamed itself, every
+    finding would silently fall back to the `generic` tier — the exact defect
+    #1979 fixed — with the rule-id unit tests still green, since they pass the
+    driver name in by hand.
+    """
+    proc = subprocess.run(
+        ["python3", "-m", "ruff", "check", "--select", "N,PLR2004",
+         "--output-format", "sarif", "."],
+        cwd=str(target_dir), capture_output=True, text=True, timeout=120, check=False,
+    )
+    doc = json.loads(proc.stdout)
+    assert doc["runs"][0]["tool"]["driver"]["name"] == "ruff"
+    return doc["runs"][0]["results"]
+
+
+def _rule_ids(results) -> set:
+    return {r["ruleId"] for r in results}
+
+
+# --------------------------------------------------------------------------
+# ruff convention probe — behavioral (ruff is a declared dev dependency)
+# --------------------------------------------------------------------------
+def test_convention_probe_reports_naming_and_magic_values(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nselect = ["E", "F"]\n')
+    (tmp_path / "svc.py").write_text(
+        "def BadlyNamedFunction(X):\n"
+        "    if X > 1000:\n"
+        "        return X\n"
+        "    return 0\n"
+    )
+    rules = _rule_ids(_ruff_sarif(tmp_path))
+    assert "N802" in rules, "PEP 8 function-name convention not reported"
+    assert "N803" in rules, "PEP 8 argument-name convention not reported"
+    assert "PLR2004" in rules, "magic value in comparison not reported"
+
+
+def test_convention_probe_finds_rules_the_project_has_not_enabled(tmp_path):
+    """The whole point: a project whose own config selects only E/F still
+    yields naming and magic-value context for the agents. If this stopped
+    holding, the lane would be displacing nothing."""
+    (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nselect = ["E", "F"]\n')
+    (tmp_path / "svc.py").write_text("def BadName(x):\n    return x > 1000\n")
+    project_run = subprocess.run(
+        ["python3", "-m", "ruff", "check", "--output-format", "sarif", "."],
+        cwd=str(tmp_path), capture_output=True, text=True, timeout=120, check=False,
+    )
+    assert _rule_ids(json.loads(project_run.stdout)["runs"][0]["results"]) == set()
+    assert _rule_ids(_ruff_sarif(tmp_path))
+
+
+def test_magic_value_rule_ignores_trivial_literals(tmp_path):
+    """The calibration claim in tool-configs: PLR2004's defaults exclude 0, 1
+    and -1, which is why this probe runs unconditionally while the JS/TS
+    equivalent is a project opt-in. Ruff changing that default would flood the
+    injection, so it is pinned rather than trusted."""
+    (tmp_path / "svc.py").write_text(
+        "def f(xs):\n"
+        "    if len(xs) == 0:\n"
+        "        return 1\n"
+        "    if len(xs) == -1:\n"
+        "        return 0\n"
+        "    return len(xs) > 1000\n"
+    )
+    results = _ruff_sarif(tmp_path)
+    messages = [r["message"]["text"] for r in results if r["ruleId"] == "PLR2004"]
+    assert any("1000" in m for m in messages), "the real magic value was missed"
+    for trivial in ("`0`", "`1`", "`-1`"):
+        assert not any(trivial in m for m in messages), f"{trivial} should be ignored"
+
+
+def test_select_does_not_re_report_what_the_main_lane_already_covers(tmp_path):
+    """`--select` (not `--extend-select`) is what keeps the probe's output
+    disjoint from the main lane's, so the two invocations do not each pay to
+    report the project's own configured rules."""
+    (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nselect = ["F"]\n')
+    (tmp_path / "svc.py").write_text("import os\n\n\ndef Bad(x):\n    return x > 1000\n")
+    rules = _rule_ids(_ruff_sarif(tmp_path))
+    assert "F401" not in rules, "probe re-reported a main-lane rule (unused import)"
+    assert rules <= {"N801", "N802", "N803", "N806", "N815", "PLR2004"}
+
+
+def test_project_scoping_survives_the_probe(tmp_path):
+    """A project's excludes and per-file-ignores must still apply — the probe
+    adds rules, it does not take over config resolution."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff.lint]\nselect = ["E"]\n'
+        'per-file-ignores = {"legacy.py" = ["N"]}\n'
+        "\n[tool.ruff]\nexclude = [\"vendored\"]\n"
+    )
+    (tmp_path / "vendored").mkdir()
+    body = "def BadName(X):\n    return X\n"
+    (tmp_path / "vendored" / "v.py").write_text(body)
+    (tmp_path / "legacy.py").write_text(body)
+    (tmp_path / "current.py").write_text(body)
+    files = {
+        r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        for r in _ruff_sarif(tmp_path)
+    }
+    assert any("current.py" in f for f in files)
+    assert not any("vendored" in f for f in files), "project exclude was overridden"
+    assert not any("legacy.py" in f for f in files), "per-file-ignores was overridden"
+
+
+def test_inline_noqa_still_suppresses_a_probe_finding(tmp_path):
+    """The per-site escape hatch a developer reaches for first."""
+    (tmp_path / "svc.py").write_text("def ExemptedName(x):  # noqa: N802\n    return x\n")
+    assert "N802" not in _rule_ids(_ruff_sarif(tmp_path))
+
+
+# --------------------------------------------------------------------------
+# oxlint frontend probe — behavioral where available, contract otherwise
+# --------------------------------------------------------------------------
+def _oxlint_binary() -> str | None:
+    """oxlint is documented as a project-local devDependency, so a bare PATH
+    probe is not sufficient on its own — tool-configs' own Detection bullet
+    says exactly that. Check the repo-local bin first, then PATH."""
+    local = REPO_ROOT / "node_modules" / ".bin" / "oxlint"
+    if local.is_file():
+        return str(local)
+    return shutil.which("oxlint")
+
+
+oxlint_required = pytest.mark.skipif(
+    _oxlint_binary() is None,
+    reason="oxlint is a project-local devDependency, not present in this environment",
+)
+
+
+def _oxlint_sarif(target_dir) -> list[dict]:
+    proc = subprocess.run(
+        [_oxlint_binary(), "--jsx-a11y-plugin", "--react-plugin", "--react-perf-plugin",
+         "-D", "perf", "--format", "sarif", "."],
+        cwd=str(target_dir), capture_output=True, text=True, timeout=120, check=False,
+    )
+    doc = json.loads(proc.stdout)
+    # Same reason as the ruff probe: this is the TOOL_TIER_MAP lookup key.
+    assert doc["runs"][0]["tool"]["driver"]["name"] == "oxlint"
+    return doc["runs"][0]["results"]
+
+
+@oxlint_required
+def test_frontend_probe_reports_accessibility_violations(tmp_path):
+    (tmp_path / "Widget.jsx").write_text(
+        "export function Widget({ onPick }) {\n"
+        "  return (\n"
+        "    <div onClick={onPick}>\n"
+        '      <img src="/logo.png" />\n'
+        "    </div>\n"
+        "  )\n"
+        "}\n"
+    )
+    plugins = {r["ruleId"].split("(")[0] for r in _oxlint_sarif(tmp_path)}
+    assert "jsx-a11y" in plugins
+    assert any("alt-text" in r["ruleId"] for r in _oxlint_sarif(tmp_path))
+
+
+@oxlint_required
+def test_frontend_probe_reports_the_n_plus_one_shape(tmp_path):
+    """`no-await-in-loop` is the I/O-in-loop / N+1 pattern the spike names as
+    performance-review's mechanical half."""
+    (tmp_path / "load.js").write_text(
+        "export async function load(ids) {\n"
+        "  const out = []\n"
+        "  for (const id of ids) {\n"
+        "    out.push(await fetch(id))\n"
+        "  }\n"
+        "  return out\n"
+        "}\n"
+    )
+    assert any("no-await-in-loop" in r["ruleId"] for r in _oxlint_sarif(tmp_path))
+
+
+# --------------------------------------------------------------------------
+# Registration contracts
+# --------------------------------------------------------------------------
+def test_both_probes_are_registered_in_the_skill_and_the_configs():
+    skill, configs = SKILL.read_text(), CONFIGS.read_text()
+    assert RUFF_PROBE in skill and RUFF_PROBE in configs
+    assert OXLINT_PROBE in skill
+    for flag in ("--jsx-a11y-plugin", "--react-perf-plugin", "-D perf"):
+        assert flag in configs, f"{flag} not documented in tool-configs"
+
+
+def test_the_probes_add_no_new_tool_to_the_dedup_chain():
+    """Both reuse binaries already in the chain, so the precedence order — and
+    the two tests that pin it — are deliberately untouched."""
+    chain = (
+        "semgrep > gitleaks > trivy > hadolint > actionlint "
+        "> ruff > mypy > oxlint > (legacy ESLint > tsc) > lizard > jscpd"
+    )
+    assert chain in SKILL.read_text()
+
+
+def test_semgrep_registry_performance_packs_are_explicitly_declined():
+    """The spike suggested `p/performance`; resolving a registry pack needs an
+    outbound call, which the pre-pass's offline posture forbids. The reason is
+    recorded so the option is not silently re-added later."""
+    skill = SKILL.read_text()
+    assert "p/performance" in skill
+    assert "offline" in skill.lower()
+
+
+def test_parser_documents_the_plugin_rule_shape_and_the_two_tier_rows():
+    parser = PARSER.read_text()
+    assert "oxlint.jsx-a11y.alt-text" in parser
+    assert "| ruff | `python` |" in parser
+    assert "| oxlint | `js`" in parser
+
+
+def test_the_jsts_magic_number_optin_records_the_measurement_behind_it():
+    """A project-config opt-in rather than a forced rule, because the
+    unconfigured default is mostly trivial values. The number is what makes
+    that a decision instead of a preference."""
+    configs = CONFIGS.read_text()
+    assert "no-magic-numbers" in configs
+    assert "35%" in configs
+    assert '"ignore": [0, 1, -1]' in configs
+
+
+@pytest.mark.parametrize(
+    "agent,marker",
+    [
+        ("naming-review", "ruff.python.plr2004"),
+        ("a11y-review", "oxlint.jsx-a11y."),
+        ("performance-review", "oxlint.eslint.no-await-in-loop"),
+    ],
+)
+def test_each_displaced_lens_is_told_not_to_re_report_the_lane(agent, marker):
+    """Acceptance criterion: the charters must not contradict the injection's
+    'do not re-report' framing — each names the rule ids that now arrive
+    pre-computed, and what judgment remains its own."""
+    text = (AGENTS / f"{agent}.md").read_text()
+    assert "static-analysis pre-pass" in text
+    assert "do not re-report" in text.lower()
+    assert marker in text

--- a/tests/skills/test_static_analysis_convention_lanes.py
+++ b/tests/skills/test_static_analysis_convention_lanes.py
@@ -5,13 +5,21 @@ N,PLR2004` and oxlint with its jsx-a11y/react-perf plugins — hand review
 agents deterministic findings where `naming-review`, `a11y-review`, and
 `performance-review` would otherwise re-derive them by inference.
 
-Where the tool is guaranteed present in CI (ruff is a declared dev
-dependency) these are **behavioral** tests that run it: a documented claim
+These are **behavioral** tests that run the real binaries: a documented claim
 about a tool's behavior is worth only as much as the run that confirms it,
 and the calibration claims here — that `PLR2004` ignores `0`/`1`, that
 `--select` does not duplicate the main lane — are exactly the kind that rot
-silently. oxlint is not installed in CI, so its probes are skip-guarded and
-the documentation contract is asserted instead.
+silently.
+
+Both tools are skip-guarded, and the ruff guard is NOT redundant caution.
+`requirements-dev.txt` governs developer machines and the `scripts/ci-local.sh`
+pre-push gate (which hard-requires ruff), **not** GitHub CI: each CI job
+installs its own narrow dependency set, and no job that runs pytest installs
+ruff — the `Lint (ruff + eslint)` job has it but runs no tests, while
+`Python ceiling` runs the suite under a uv-managed interpreter where
+`python3 -m ruff` does not resolve at all. An earlier version of this file
+assumed otherwise and turned that job red. So the real coverage guarantee
+here is the pre-push gate every contributor runs, not a CI job.
 """
 
 from __future__ import annotations
@@ -19,6 +27,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -37,6 +46,30 @@ OXLINT_PROBE = (
 )
 
 
+def _resolve_ruff() -> list[str] | None:
+    """A runnable ruff invocation, or None. Probed rather than assumed: a
+    bare `python3 -m ruff` resolves on a dev machine and not under the
+    uv-managed interpreter the `Python ceiling` job builds."""
+    for candidate in (["ruff"], [sys.executable, "-m", "ruff"], ["python3", "-m", "ruff"]):
+        try:
+            probe = subprocess.run(
+                [*candidate, "--version"], capture_output=True, text=True,
+                timeout=60, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if probe.returncode == 0:
+            return candidate
+    return None
+
+
+RUFF_CMD = _resolve_ruff()
+ruff_required = pytest.mark.skipif(
+    RUFF_CMD is None,
+    reason="ruff not runnable here; the pre-push gate (ci-local.sh) requires it",
+)
+
+
 def _ruff_sarif(target_dir) -> list[dict]:
     """Run the documented convention probe and return its SARIF results.
 
@@ -47,9 +80,14 @@ def _ruff_sarif(target_dir) -> list[dict]:
     driver name in by hand.
     """
     proc = subprocess.run(
-        ["python3", "-m", "ruff", "check", "--select", "N,PLR2004",
-         "--output-format", "sarif", "."],
+        [*RUFF_CMD, "check", "--select", "N,PLR2004", "--output-format", "sarif", "."],
         cwd=str(target_dir), capture_output=True, text=True, timeout=120, check=False,
+    )
+    # Fail with the tool's own error rather than an opaque JSONDecodeError —
+    # empty stdout means ruff never ran, which is a different problem from
+    # ruff running and reporting nothing.
+    assert proc.stdout.strip(), (
+        f"ruff produced no stdout (exit {proc.returncode}). stderr:\n{proc.stderr}"
     )
     doc = json.loads(proc.stdout)
     assert doc["runs"][0]["tool"]["driver"]["name"] == "ruff"
@@ -61,8 +99,10 @@ def _rule_ids(results) -> set:
 
 
 # --------------------------------------------------------------------------
-# ruff convention probe — behavioral (ruff is a declared dev dependency)
+# ruff convention probe — behavioral, skip-guarded (see the module docstring
+# on why a CI job running pytest is not a job that has ruff)
 # --------------------------------------------------------------------------
+@ruff_required
 def test_convention_probe_reports_naming_and_magic_values(tmp_path):
     (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nselect = ["E", "F"]\n')
     (tmp_path / "svc.py").write_text(
@@ -77,6 +117,7 @@ def test_convention_probe_reports_naming_and_magic_values(tmp_path):
     assert "PLR2004" in rules, "magic value in comparison not reported"
 
 
+@ruff_required
 def test_convention_probe_finds_rules_the_project_has_not_enabled(tmp_path):
     """The whole point: a project whose own config selects only E/F still
     yields naming and magic-value context for the agents. If this stopped
@@ -84,13 +125,14 @@ def test_convention_probe_finds_rules_the_project_has_not_enabled(tmp_path):
     (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nselect = ["E", "F"]\n')
     (tmp_path / "svc.py").write_text("def BadName(x):\n    return x > 1000\n")
     project_run = subprocess.run(
-        ["python3", "-m", "ruff", "check", "--output-format", "sarif", "."],
+        [*RUFF_CMD, "check", "--output-format", "sarif", "."],
         cwd=str(tmp_path), capture_output=True, text=True, timeout=120, check=False,
     )
     assert _rule_ids(json.loads(project_run.stdout)["runs"][0]["results"]) == set()
     assert _rule_ids(_ruff_sarif(tmp_path))
 
 
+@ruff_required
 def test_magic_value_rule_ignores_trivial_literals(tmp_path):
     """The calibration claim in tool-configs: PLR2004's defaults exclude 0, 1
     and -1, which is why this probe runs unconditionally while the JS/TS
@@ -111,6 +153,7 @@ def test_magic_value_rule_ignores_trivial_literals(tmp_path):
         assert not any(trivial in m for m in messages), f"{trivial} should be ignored"
 
 
+@ruff_required
 def test_select_does_not_re_report_what_the_main_lane_already_covers(tmp_path):
     """`--select` (not `--extend-select`) is what keeps the probe's output
     disjoint from the main lane's, so the two invocations do not each pay to
@@ -122,6 +165,7 @@ def test_select_does_not_re_report_what_the_main_lane_already_covers(tmp_path):
     assert rules <= {"N801", "N802", "N803", "N806", "N815", "PLR2004"}
 
 
+@ruff_required
 def test_project_scoping_survives_the_probe(tmp_path):
     """A project's excludes and per-file-ignores must still apply — the probe
     adds rules, it does not take over config resolution."""
@@ -144,6 +188,7 @@ def test_project_scoping_survives_the_probe(tmp_path):
     assert not any("legacy.py" in f for f in files), "per-file-ignores was overridden"
 
 
+@ruff_required
 def test_inline_noqa_still_suppresses_a_probe_finding(tmp_path):
     """The per-site escape hatch a developer reaches for first."""
     (tmp_path / "svc.py").write_text("def ExemptedName(x):  # noqa: N802\n    return x\n")


### PR DESCRIPTION
## Summary

- Adds the three deterministic displacements of [#1979](https://github.com/bdfinst/agentic-dev-team/issues/1979) as **two extra invocations of tools already in the tiers** — no new binaries, no new adapters, no network. Each hands review agents a measurement where a lens would otherwise re-derive one by inference.
- **ruff convention probe** — `ruff check --select N,PLR2004 --output-format sarif .` displaces the mechanical half of `naming-review` (PEP 8 naming, magic values in comparisons).
- **oxlint frontend probe** — `--jsx-a11y-plugin --react-plugin --react-perf-plugin -D perf` displaces the mechanical half of `a11y-review` and feeds `performance-review`; oxlint ships both plugins natively, so there is no `eslint-plugin-jsx-a11y` install and no config file.
- Fixes three untested defects in the shared SARIF parser that these lanes depend on. `build_rule_id` had **no test at all**.

### Design decisions, each backed by a run rather than an assumption

**The convention probe is a separate invocation, not a change to the main ruff lane.** That lane's entry states "the plugin pins no curated rule set — the project owns its quality bar", and silently reversing it would be wrong. The probe adds review context and never gates; the main lane still reflects the project's own configuration. Verified on ruff 0.16.x: `--select` (not `--extend-select`) keeps the probe's output **disjoint** from the main lane's, and the project's `exclude`, `per-file-ignores`, and inline `# noqa` are all still honored. Only a blanket `ignore` is overridden, and `ACCEPTED-RISKS.md` is the escape hatch for that.

**JS/TS naming and magic numbers are a project-config opt-in, not a forced rule.** oxlint implements `no-magic-numbers` but takes **no rule options on the command line**, and its unconfigured default flags `0` and `1`. Measured over this repo's 40 TS/JS eval files: 152 findings, **35% of them the values 0, 1, -1, or 2** — noise that would swamp the injection. Python's `PLR2004` needs no such care because its defaults already exclude those, which is exactly why the two sides are treated differently. The `.oxlintrc.json` snippet that enables it properly is documented instead.

**Semgrep registry performance packs are explicitly declined.** Resolving one requires an outbound call to `semgrep.dev`, breaking the offline posture § 1b establishes — and the pack the spike named returns **HTTP 404** anyway (verified on semgrep 1.174.0). oxlint's `perf` category covers the JS/TS side offline, with `no-await-in-loop` as the N+1 shape; Repowise `get_health` covers the cross-language case as injected context.

### Three parser defects fixed, none of which had a test

- `ruff` and `oxlint` were **missing from `TOOL_TIER_MAP`**, so every finding from the two language linters was emitted under a `generic` tier while their own entries advertised `ruff.python.*` / `oxlint.js.*`.
- oxlint's `plugin(rule)` ids were **hyphen-flattened** (`oxlint.generic.jsx-a11y-alt-text`), erasing the plugin namespace the a11y lane is selected by.
- The **driver segment** and an **empty rule id** could each produce a schema-invalid `rule_id` (`.generic.n802`, `oxlint.js.`). That silently drops the whole finding in `normalize_findings.py`, which never validates before writing.

### Self-review found four more

`correctness-review` and `doc-review` were dispatched at this branch's diff and every finding was reproduced before fixing: the driver segment lacked the empty-guard its two siblings had; the tier-map keys rested on **unprobed** driver names (now asserted from real SARIF — both are exactly `ruff` and `oxlint`, observed on 0.16.1 / 1.80.0); the plugin-namespace rationale **overstated** what it delivers (oxlint files perf and correctness rules under the same `eslint` plugin, so those are told apart by leaf name, not prefix — now pinned honestly); and the parser's field table documented a `properties.language` middle segment that no implementation ever read.

### CI then found two more, and corrected a premise in this PR

Both were environment assumptions a local run structurally cannot catch, since the dev machine is a superset:

1. **`validate.py` imported `jsonschema`/`referencing` at module scope**, so a test importing it purely for `build_rule_id` failed at *collection* in `Plugin content & hooks`, which installs pytest and nothing else. Both imports are now lazy, inside the two functions that validate — which also drops a dependency `scripts/lib/normalize_findings.py` was carrying transitively for nothing.
2. **The ruff behavioral tests assumed ruff was present in CI.** It is not: `requirements-dev.txt` governs developer machines and the `ci-local.sh` pre-push gate, **not** GitHub CI, where each job installs its own narrow set — and no job that runs pytest installs ruff. They are now skip-guarded with a probed invocation, and assert non-empty stdout so a tool that never ran fails with its own stderr rather than an opaque `JSONDecodeError`.

An earlier revision of this Test Plan claimed those tests run in CI. That claim was wrong and is corrected below: their real guarantee is the pre-push gate every contributor runs. Verified by reproducing the ceiling job with `uv run --python 3.14` — the six tests skip with a named reason when ruff is off PATH, and pass when it is on.

## Test Plan

- [x] Full `scripts/ci-local.sh` pre-push gate green — **9,092 tests passed**, ruff, shellcheck, Python 3.10 floor
- [x] All **15 CI checks green**, including `Python ceiling` and `Plugin content & hooks` (the two that caught the environment defects above)
- [x] The ruff probe's claims are **behavioral tests against the real binary** — the disjointness of `--select`, the `0`/`1`/`-1` calibration, and the survival of `exclude` / `per-file-ignores` / `# noqa` each have a test that fails if ruff's behavior changes. They run in the pre-push gate (which hard-requires ruff) and skip in CI, which has no ruff in any pytest-running job.
- [x] oxlint probes verified against oxlint 1.80.0 (4 `jsx-a11y` findings incl. `alt-text`, 2 `react-perf`, `no-await-in-loop`); skip-guarded, with the guard checking `node_modules/.bin` first per the documented detection method
- [x] `build_rule_id` now covered: exact-output tests for every tool convention, plus a sweep asserting **every** id satisfies the envelope pattern — with the schema itself as the oracle, including degenerate drivers and rule ids
- [x] `check_md_references.py`, knowledge index, and agent-registry token counts all current
- [x] Up to date with `main`

Closes #1979
Part of #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85