### PR TITLE
perf(code-review): build one shared context pack per review panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ _mkdocs_src/
 
 # EnterWorktree tool scratch dirs (per-agent git worktrees, not repo content)
 .claude/worktrees/
+.claude/review-context/
 
 # Per-session turn-state tracked by the code-intelligence nudge hooks — never repo content
 .claude/code-intelligence-turn-state.json

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -427,8 +427,25 @@ sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/skills/code-review/scr
 
 Prints `{"maxParallel": N, "waves": [[...], [...]]}` — `maxParallel` defaults to **10**, overridable with `DEV_TEAM_MAX_PARALLEL_REVIEW_AGENTS` (see the script's own docstring for the exact fallback rule; don't re-derive it here). Dispatch **exactly the waves the script printed, in that order** as parallel subagents in a single message per wave using the Agent tool — exactly as before, just bounded per message — waiting for each wave to fully return before dispatching the next, and for the last wave before aggregating. A roster no larger than `maxParallel` is always a single wave; nothing changes from today's behavior in that case.
 
+**Build the shared context pack first (#2006).** Before dispatching wave 1, prepare the panel's file context **once** rather than letting every lens read the same files itself:
+
+```bash
+git -c core.quotePath=false diff --name-status <base> \
+  | sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/review_context_pack.py" \
+      --name-status-from - --base <base>
+```
+
+Prints a manifest naming the pack path, its byte size, and `files_omitted`. Pass the **pack path** to every dispatched agent and tell it to read that file instead of opening the changed files individually.
+
+Why this exists: across 148 panels of >= 8 agents, 180 MB of Read volume covered 41.8 MB of unique content — a **4.31x re-read multiplier**, one file opened by 38 agents at worst, and those panels are 73% of all review spend. Of the 18 review lenses that declare a `Context needs` value, **17 need the full bodies of the changed files**, so one pack serves nearly the whole roster: `full-file` lenses read its **File bodies** section, `project-structure` lenses read that plus **Changed files**, `diff-only` lenses read **Diff**.
+
+Two rules when passing it:
+
+- **The pack narrows repeated reads, not the review.** A lens may still open anything not in the pack — a caller in an unchanged file, a sibling module. Never instruct an agent to treat the pack as the complete world.
+- **`files_omitted` is not optional to relay.** When the manifest reports omissions (a file over the per-file cap, a binary, a body that would exhaust the budget), name those paths in each agent's prompt and tell it to open them directly. The pack body says so too, but a silently skipped file is a coverage hole that reads as a clean review.
+
 - **File scope**: pass only files matching each agent's declared scope. Skip the agent if no files match.
-- **Context payload** (controlled by the agent's `Context needs`):
+- **Context payload** (controlled by the agent's `Context needs`) — served from the pack's sections above; fall back to inlining the content directly if the pack could not be built:
   - `diff-only` → diff output only (for auto-scope or `--since` only)
   - `full-file` → complete files
   - `project-structure` → full files + directory tree + the changed-file list (path + change type — `A`/`M`/`D`/`R`/`C`) computed in step 3 via `changed_file_list.py`, for diff-scoped runs (auto-scope or `--since`). Omit the changed-file list for `--path`/`--all`/full-repository scope — there is no diff to describe. Every `project-structure` agent (`arch-review`, `doc-review`, `domain-review`) has no Bash grant and must never invoke `git` itself to "see what changed" — that call is denied and surfaces as a spurious error (#1734); this payload is what makes that unnecessary.

--- a/plugins/dev-team/skills/code-review/scripts/review_context_pack.py
+++ b/plugins/dev-team/skills/code-review/scripts/review_context_pack.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""One shared context pack for a review panel (#2006).
+
+Every lens in a `/code-review` panel is handed the same changed files and then
+reads them itself. Measured across 148 panels of >= 8 agents: **180 MB of Read
+volume covering 41.8 MB of unique content — a 4.31x re-read multiplier**, with
+one file opened by 38 agents in the worst case. Those panels are 73% of all
+review spend.
+
+The multiplier is not only cross-agent duplication. A lens that opens a file,
+greps around it, and opens it again pays for it each time, and the panel pays
+that per lens. What removes it is giving every lens the same prepared bytes
+once, so reading is a single addressed fetch instead of an exploration.
+
+## Why one pack serves nearly the whole panel
+
+Of the 18 review lenses that declare a `Context needs` value, **17 need the
+full bodies of the changed files** (13 `full-file`, 4 `project-structure`);
+one needs the diff alone. So the union of what the panel needs is: the changed
+file list, the diff, and the full bodies — which is exactly this pack. Each
+lens reads the section its declaration calls for.
+
+## What this deliberately does NOT do
+
+It does not stop a lens from reading anything else. A lens tracing a caller
+into an unchanged file still should, and still can. The pack removes the
+*repeated* read of the *same* changed files, which is the measured cost; it is
+not a sandbox.
+
+## Truncation is always visible
+
+A pack over its byte cap omits **whole files**, names every one of them in the
+pack body and in the manifest, and tells the reader to open those directly.
+Silently truncating would hand a lens a file that looks complete and is not —
+a finding-shaped hole that reads as "reviewed". Per this repo's rule, a bound
+that drops coverage says so out loud.
+
+Stdlib-only. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+_HOOKS_LIB_DIR = _PLUGIN_ROOT / "hooks" / "lib"
+if str(_HOOKS_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_LIB_DIR))
+
+try:
+    import artifact_paths  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - degraded fallback, hooks/lib unreachable
+    # Same guarded-import shape as the sibling scripts in this directory, which
+    # is not in ruff.toml's E402 per-file-ignore list.
+    artifact_paths = None
+
+#: Default ceiling on the pack body. A pack is read by every lens in the panel,
+#: so bytes here are multiplied by the roster size — the cap is what keeps a
+#: large diff from costing more shared than it saved duplicated.
+DEFAULT_MAX_BYTES = 400_000
+
+#: Files above this size are omitted individually rather than crowding out the
+#: rest of the pack. A single generated or vendored file can exceed the whole
+#: budget on its own.
+DEFAULT_MAX_FILE_BYTES = 60_000
+
+_CATEGORY = "review-context"
+
+
+def _git(args, cwd: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-c", "core.quotePath=false", *args],
+            cwd=str(cwd), capture_output=True, text=True, timeout=60, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def read_file_text(path: Path) -> tuple[str | None, str]:
+    """Return (text, reason). `text` is None when the body cannot be included."""
+    try:
+        if not path.exists():
+            return None, "not present in the working tree (deleted or renamed)"
+        if path.is_dir():
+            return None, "directory"
+        raw = path.read_bytes()
+    except OSError as exc:
+        return None, f"unreadable ({exc.__class__.__name__})"
+    if b"\x00" in raw[:8192]:
+        return None, "binary"
+    try:
+        return raw.decode("utf-8"), ""
+    except UnicodeDecodeError:
+        return None, "not valid UTF-8"
+
+
+def number_lines(text: str) -> str:
+    """Line-numbered body, matching how the Read tool presents a file so a lens
+    can cite `file:line` from the pack without re-opening the file to count."""
+    lines = text.splitlines()
+    width = len(str(len(lines))) if lines else 1
+    return "\n".join(f"{str(i).rjust(width)}\t{line}" for i, line in enumerate(lines, 1))
+
+
+def select_bodies(files, cwd: Path, max_bytes: int, max_file_bytes: int):
+    """Include file bodies in the given order until the budget is spent.
+
+    Returns (included, omitted) where each entry is a dict. Selection walks the
+    caller's order and skips anything that does not fit, rather than stopping
+    at the first oversized file — one huge file must not hide every smaller one
+    behind it.
+    """
+    included, omitted = [], []
+    used = 0
+    for rel in files:
+        text, reason = read_file_text(cwd / rel)
+        if text is None:
+            omitted.append({"file": rel, "reason": reason})
+            continue
+        body = number_lines(text)
+        size = len(body.encode("utf-8"))
+        if size > max_file_bytes:
+            omitted.append({"file": rel, "reason": f"exceeds per-file cap ({size} bytes)"})
+            continue
+        if used + size > max_bytes:
+            omitted.append({"file": rel, "reason": "pack byte budget exhausted"})
+            continue
+        included.append({"file": rel, "body": body, "bytes": size})
+        used += size
+    return included, omitted
+
+
+def render_pack(*, changed, diff_text, included, omitted, base_ref) -> str:
+    parts = [
+        "# Review context pack",
+        "",
+        (
+            "Prepared once for this panel. Read the section your `Context needs` "
+            "declaration calls for instead of opening these files individually — "
+            "the bodies below are complete and line-numbered, so `file:line` "
+            "citations from this pack are accurate."
+        ),
+        "",
+        (
+            "You may still open anything NOT listed here (a caller in an unchanged "
+            "file, a sibling module). This pack removes the repeated read of the "
+            "changed set; it does not limit what you may consult."
+        ),
+        "",
+        "## Changed files",
+        "",
+    ]
+    if changed:
+        # A status is optional: the caller may know the paths without knowing
+        # how each changed. Claiming "full-repository scope" in that case (the
+        # original behavior) tells a lens the diff is empty when it is not.
+        parts += [
+            f"- `{status}` {path}" if status else f"- {path}"
+            for path, status in changed
+        ]
+    else:
+        parts.append("_(no change list — full-repository scope)_")
+    parts += ["", "## Diff", ""]
+    parts += [f"_(vs `{base_ref}`)_", "", "```diff", diff_text.rstrip("\n") or "(empty)", "```"] \
+        if diff_text.strip() else ["_(no diff — full-repository scope)_"]
+
+    parts += ["", "## File bodies", ""]
+    if not included:
+        parts.append("_(none included — see omissions below)_")
+    for entry in included:
+        parts += [f"### {entry['file']}", "", "```", entry["body"], "```", ""]
+
+    if omitted:
+        parts += [
+            "## NOT included in this pack",
+            "",
+            (
+                "These files are part of the change but their bodies are not "
+                "above. **Open them directly** — do not treat their absence as "
+                "'nothing to review here'."
+            ),
+            "",
+        ]
+        parts += [f"- {o['file']} — {o['reason']}" for o in omitted]
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
+def _pack_dir(cwd: Path) -> Path:
+    if artifact_paths is not None:
+        return artifact_paths.category_dir(_CATEGORY, cwd)
+    return cwd / ".claude" / _CATEGORY
+
+
+def build(
+    *, files, cwd: Path, base_ref: str, max_bytes: int, max_file_bytes: int,
+    diff_text: str | None = None, changed=None,
+) -> dict:
+    ordered = sorted(dict.fromkeys(files))
+    if changed is None:
+        changed = [(path, "") for path in ordered]
+    if diff_text is None:
+        diff_text = _git(["-c", "diff.relative=false", "diff", base_ref, "--", *ordered], cwd) \
+            if ordered else ""
+    included, omitted = select_bodies(ordered, cwd, max_bytes, max_file_bytes)
+    text = render_pack(
+        changed=changed or [], diff_text=diff_text, included=included,
+        omitted=omitted, base_ref=base_ref,
+    )
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    out_dir = _pack_dir(cwd)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"pack-{digest}.md"
+    out_path.write_text(text, encoding="utf-8")
+
+    unique_bytes = sum(e["bytes"] for e in included)
+    return {
+        "path": str(out_path),
+        "pack_bytes": len(text.encode("utf-8")),
+        "unique_body_bytes": unique_bytes,
+        "files_requested": len(ordered),
+        "files_included": [e["file"] for e in included],
+        "files_omitted": omitted,
+        "complete": not omitted,
+        "base_ref": base_ref,
+    }
+
+
+def parse_name_status(lines) -> list[tuple[str, str]]:
+    """Parse `git diff --name-status` rows into (path, status) pairs.
+
+    Rename and copy rows carry two paths (`R100\told\tnew`); the NEW path is
+    the one that exists on disk and the one findings are cited against, so it
+    is the one kept.
+    """
+    out: list[tuple[str, str]] = []
+    for line in lines:
+        parts = line.split("\t")
+        if len(parts) < 2 or not parts[0].strip():
+            continue
+        status = parts[0].strip()[0].upper()
+        path = parts[-1].strip() if status in {"R", "C"} else parts[1].strip()
+        if path:
+            out.append((path, status))
+    return out
+
+
+def _read_file_list(source: str | None) -> list[str]:
+    if not source:
+        return []
+    text = sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build one shared context pack for a review panel (#2006)."
+    )
+    parser.add_argument("--files-from", default="-",
+                        help="file with one changed path per line, or '-' for stdin")
+    parser.add_argument("--name-status-from", default=None,
+                        help="file of `git diff --name-status` lines (or '-'), "
+                             "so the pack can label each path A/M/D/R/C")
+    parser.add_argument("--base", default="HEAD", dest="base_ref")
+    parser.add_argument("--cwd", default=None)
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    parser.add_argument("--max-file-bytes", type=int, default=DEFAULT_MAX_FILE_BYTES)
+    args = parser.parse_args(argv)
+
+    cwd = Path(args.cwd) if args.cwd else Path.cwd()
+    changed = parse_name_status(_read_file_list(args.name_status_from)) \
+        if args.name_status_from else None
+    files = [p for p, _ in changed] if changed else _read_file_list(args.files_from)
+    if not files:
+        print(json.dumps({"error": "no files given", "path": None}))
+        return 1
+    manifest = build(
+        files=files, cwd=cwd, base_ref=args.base_ref, changed=changed,
+        max_bytes=args.max_bytes, max_file_bytes=args.max_file_bytes,
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dev-team/tests/scripts/test_review_context_pack.py
+++ b/plugins/dev-team/tests/scripts/test_review_context_pack.py
@@ -1,0 +1,216 @@
+"""Unit tests for skills/code-review/scripts/review_context_pack.py (#2006).
+
+The pack exists to cut a measured 4.31x re-read multiplier across review
+panels. What these tests defend is not the saving — it is that the saving
+never costs coverage. A pack that quietly drops a file hands every lens in the
+panel a change that looks fully reviewed and is not, and the panel's silence
+then reads as "no findings here." So every omission path is pinned to be both
+*visible in the pack body* and *reported in the manifest*, and the honesty of
+the rendered header is pinned too.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_SCRIPTS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "skills" / "code-review" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import review_context_pack as rcp
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "src" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    return tmp_path
+
+
+class TestLineNumbering:
+    def test_bodies_are_numbered_so_findings_can_cite_line_numbers(self):
+        assert rcp.number_lines("x\ny\n") == "1\tx\n2\ty"
+
+    def test_numbering_pads_to_a_consistent_width(self):
+        """Ragged columns make a body harder to scan, and a lens counting lines
+        by eye is exactly what the pack removes the need for."""
+        out = rcp.number_lines("\n".join(str(i) for i in range(1, 11)))
+        assert out.startswith(" 1\t1")
+        assert "10\t10" in out
+
+    def test_empty_file_does_not_raise(self):
+        assert rcp.number_lines("") == ""
+
+
+class TestUnreadableBodiesAreNamedNotDropped:
+    def test_missing_file_reports_a_reason(self, repo):
+        text, reason = rcp.read_file_text(repo / "src" / "gone.py")
+        assert text is None
+        assert "deleted" in reason
+
+    def test_binary_file_is_detected(self, repo):
+        (repo / "blob.bin").write_bytes(b"\x00\x01\x02")
+        text, reason = rcp.read_file_text(repo / "blob.bin")
+        assert text is None and reason == "binary"
+
+    def test_invalid_utf8_is_detected_without_raising(self, repo):
+        (repo / "bad.txt").write_bytes(b"\xff\xfe latin \xe9")
+        text, reason = rcp.read_file_text(repo / "bad.txt")
+        assert text is None and "UTF-8" in reason
+
+    def test_directory_is_not_treated_as_a_body(self, repo):
+        text, reason = rcp.read_file_text(repo / "src")
+        assert text is None and reason == "directory"
+
+
+class TestBudgetNeverTruncatesAFileSilently:
+    def test_an_oversized_file_is_omitted_whole_and_named(self, repo):
+        (repo / "huge.py").write_text("x = 1\n" * 5000, encoding="utf-8")
+        included, omitted = rcp.select_bodies(
+            ["huge.py", "src/a.py"], repo, max_bytes=10_000, max_file_bytes=1_000
+        )
+        assert [e["file"] for e in included] == ["src/a.py"]
+        assert omitted[0]["file"] == "huge.py"
+        assert "per-file cap" in omitted[0]["reason"]
+
+    def test_one_huge_file_does_not_hide_the_smaller_ones_behind_it(self, repo):
+        """Selection must keep walking past something that does not fit.
+        Stopping at the first oversized file would drop every later file for a
+        reason that has nothing to do with them — and the panel would never
+        know which behavior it got, since both report 'omitted'."""
+        (repo / "huge.py").write_text("x = 1\n" * 5000, encoding="utf-8")
+        included, _ = rcp.select_bodies(
+            ["huge.py", "src/a.py", "src/b.py"], repo, max_bytes=10_000, max_file_bytes=1_000
+        )
+        assert [e["file"] for e in included] == ["src/a.py", "src/b.py"]
+
+    def test_budget_exhaustion_is_reported_distinctly_from_the_per_file_cap(self, repo):
+        included, omitted = rcp.select_bodies(
+            ["src/a.py", "src/b.py"], repo, max_bytes=25, max_file_bytes=10_000
+        )
+        assert len(included) == 1
+        assert omitted[0]["reason"] == "pack byte budget exhausted"
+
+    def test_included_bodies_are_never_partial(self, repo):
+        """The whole point: a body in the pack is the complete file. A lens
+        citing line 40 of a body that stops at line 30 reports a phantom."""
+        included, _ = rcp.select_bodies(["src/a.py"], repo, 10_000, 10_000)
+        assert included[0]["body"].endswith("return 1")
+
+
+class TestRenderedPackIsHonest:
+    def test_omitted_files_are_listed_in_the_body_not_only_the_manifest(self, repo):
+        (repo / "huge.py").write_text("x = 1\n" * 5000, encoding="utf-8")
+        manifest = rcp.build(
+            files=["huge.py", "src/a.py"], cwd=repo, base_ref="HEAD",
+            max_bytes=10_000, max_file_bytes=1_000, diff_text="",
+        )
+        body = (repo / ".claude" / "review-context").glob("pack-*.md")
+        text = next(body).read_text(encoding="utf-8")
+        assert "## NOT included in this pack" in text
+        assert "huge.py" in text.split("## NOT included in this pack")[1]
+        assert "Open them directly" in text
+        assert manifest["complete"] is False
+
+    def test_a_complete_pack_has_no_omission_section(self, repo):
+        manifest = rcp.build(
+            files=["src/a.py"], cwd=repo, base_ref="HEAD",
+            max_bytes=10_000, max_file_bytes=10_000, diff_text="",
+        )
+        text = Path(manifest["path"]).read_text(encoding="utf-8")
+        assert "## NOT included" not in text
+        assert manifest["complete"] is True
+
+    def test_paths_without_a_status_are_not_labelled_full_repository_scope(self, repo):
+        """Regression: when the caller supplied paths but no change types, the
+        header read '(no change list — full-repository scope)', telling a lens
+        there was no diff when there was one. Absence of a *status* is not
+        absence of a *change*."""
+        manifest = rcp.build(
+            files=["src/a.py"], cwd=repo, base_ref="HEAD",
+            max_bytes=10_000, max_file_bytes=10_000, diff_text="",
+        )
+        text = Path(manifest["path"]).read_text(encoding="utf-8")
+        section = text.split("## Changed files")[1].split("## Diff")[0]
+        assert "full-repository scope" not in section
+        assert "src/a.py" in section
+
+    def test_statuses_are_rendered_when_supplied(self, repo):
+        manifest = rcp.build(
+            files=["src/a.py"], cwd=repo, base_ref="HEAD", changed=[("src/a.py", "A")],
+            max_bytes=10_000, max_file_bytes=10_000, diff_text="",
+        )
+        text = Path(manifest["path"]).read_text(encoding="utf-8")
+        assert "`A` src/a.py" in text
+
+    def test_pack_tells_lenses_they_may_still_read_other_files(self, repo):
+        """The pack narrows repeated reads, not the review. A lens that reads
+        it as a closed world stops tracing callers into unchanged files."""
+        manifest = rcp.build(
+            files=["src/a.py"], cwd=repo, base_ref="HEAD",
+            max_bytes=10_000, max_file_bytes=10_000, diff_text="",
+        )
+        text = Path(manifest["path"]).read_text(encoding="utf-8")
+        assert "NOT listed here" in text
+
+
+class TestNameStatusParsing:
+    def test_plain_rows(self):
+        assert rcp.parse_name_status(["M\tsrc/a.py", "A\tsrc/b.py"]) == [
+            ("src/a.py", "M"), ("src/b.py", "A")
+        ]
+
+    def test_rename_keeps_the_new_path(self):
+        """`R100\told\tnew` — the new path is what exists on disk and what a
+        finding cites. Keeping the old one would make every body read fail."""
+        assert rcp.parse_name_status(["R100\tsrc/old.py\tsrc/new.py"]) == [
+            ("src/new.py", "R")
+        ]
+
+    def test_copy_keeps_the_new_path(self):
+        assert rcp.parse_name_status(["C75\tsrc/a.py\tsrc/c.py"]) == [("src/c.py", "C")]
+
+    def test_malformed_rows_are_skipped(self):
+        assert rcp.parse_name_status(["", "junk", "\tno-status"]) == []
+
+
+class TestDeterminism:
+    def test_same_input_yields_the_same_pack_path(self, repo):
+        a = rcp.build(files=["src/b.py", "src/a.py"], cwd=repo, base_ref="HEAD",
+                      max_bytes=10_000, max_file_bytes=10_000, diff_text="")
+        b = rcp.build(files=["src/a.py", "src/b.py"], cwd=repo, base_ref="HEAD",
+                      max_bytes=10_000, max_file_bytes=10_000, diff_text="")
+        assert a["path"] == b["path"], "input order must not change the pack"
+
+    def test_duplicate_paths_are_collapsed(self, repo):
+        m = rcp.build(files=["src/a.py", "src/a.py"], cwd=repo, base_ref="HEAD",
+                      max_bytes=10_000, max_file_bytes=10_000, diff_text="")
+        assert m["files_requested"] == 1
+
+
+class TestCli:
+    def _run(self, cwd, *args, stdin=""):
+        return subprocess.run(
+            [sys.executable, str(_SCRIPTS_DIR / "review_context_pack.py"),
+             "--cwd", str(cwd), *args],
+            capture_output=True, text=True, timeout=60, check=False, input=stdin,
+        )
+
+    def test_no_files_exits_nonzero_rather_than_writing_an_empty_pack(self, repo):
+        result = self._run(repo, "--files-from", "-", stdin="")
+        assert result.returncode == 1
+        assert json.loads(result.stdout)["path"] is None
+
+    def test_manifest_is_parseable_and_names_the_pack(self, repo):
+        result = self._run(repo, "--files-from", "-", stdin="src/a.py\n")
+        assert result.returncode == 0, result.stderr
+        manifest = json.loads(result.stdout)
+        assert manifest["files_included"] == ["src/a.py"]
+        assert manifest["pack_bytes"] > 0


### PR DESCRIPTION
## Summary

- **The panel pays for the same bytes over and over.** Across 148 panels of ≥ 8 agents, 180 MB of Read volume covered 41.8 MB of unique content — a **4.31× re-read multiplier**, with one file opened by 38 agents at worst. Those panels are median $14.14 and **73% of all review spend**.
- **The cause is structural, not incidental.** Of the 18 review lenses that declare a `Context needs` value, **17 need the full bodies of the changed files** (13 `full-file`, 4 `project-structure`). Every one of them currently reads those files itself.
- **`review_context_pack.py` prepares that context once** — changed-file list with `A`/`M`/`D`/`R`/`C` statuses, the unified diff, and complete line-numbered file bodies — and Step 4 passes the pack to every dispatched agent. Each lens reads the section its declaration calls for instead of re-opening the same files.

Bodies are line-numbered to match how `Read` presents a file, so `file:line` citations taken from the pack are accurate without re-opening anything to count.

Epic #1973's p1 work narrowed the roster (13.79 → 12.12 lenses, −12.1%). This attacks the other axis: what each of those dispatches *carries*.

## Coverage is never traded for the saving

This is the part I'd want reviewed hardest. A pack that quietly drops a file hands every lens a change that looks fully reviewed and isn't, and the panel's resulting silence reads as "no findings here."

- Over the byte cap, the pack omits **whole files, never partial ones**, and names each omission in **both** the pack body and the manifest with an instruction to open them directly.
- Selection keeps walking past a file that doesn't fit, so one huge file can't hide every smaller one behind it.
- The pack states explicitly that lenses may still open anything not listed — it narrows *repeated reads*, not the review.
- Step 4 requires relaying `files_omitted` into each agent's prompt.

## Test Plan

- [x] 24 new unit tests covering every omission path (binary, missing, non-UTF-8, directory, per-file cap, budget exhaustion), rename/copy `--name-status` parsing, determinism, and the CLI
- [x] **Exercised on a real commit in this repo**, not just fixtures: the 313 KB generated `knowledge/index.json` is correctly omitted by the per-file cap and named, rather than swallowing the whole budget
- [x] Self-review caught a real defect before commit: with paths but no change types the header rendered *"(no change list — full-repository scope)"* — telling a lens there was no diff when there was one. Fixed and pinned by a regression test; `--name-status-from` added so statuses survive
- [x] Pack output byte-identical (90,889) before and after the lint refactor, confirming that pass was cosmetic
- [x] Full pre-push directory list: **9,301 passed, 47 skipped**
- [x] `ruff`, `check_md_references.py`, `build_knowledge_index.py` clean
- [x] `.claude/review-context/` gitignored

## Scope and what's deferred

Four files. The pack is written to disk and passed by path — the **inline-vs-file** question #2006 raises is deliberately left open, because answering it honestly needs the per-dispatch context instrumentation from #2010, which hasn't landed. The manifest reports `pack_bytes` and `unique_body_bytes` so that comparison is computable the moment it does.

Part of #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85)_