### PR TITLE
fix(code-review): make the shared context pack opt-in

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -427,7 +427,13 @@ sh "$CLAUDE_PLUGIN_ROOT/hooks/py.sh" "$CLAUDE_PLUGIN_ROOT/skills/code-review/scr
 
 Prints `{"maxParallel": N, "waves": [[...], [...]]}` — `maxParallel` defaults to **10**, overridable with `DEV_TEAM_MAX_PARALLEL_REVIEW_AGENTS` (see the script's own docstring for the exact fallback rule; don't re-derive it here). Dispatch **exactly the waves the script printed, in that order** as parallel subagents in a single message per wave using the Agent tool — exactly as before, just bounded per message — waiting for each wave to fully return before dispatching the next, and for the last wave before aggregating. A roster no larger than `maxParallel` is always a single wave; nothing changes from today's behavior in that case.
 
-**Build the shared context pack first (#2006).** Before dispatching wave 1, prepare the panel's file context **once** rather than letting every lens read the same files itself:
+**Optional: shared context pack (#2006, opt-in — off by default).** `scripts/review_context_pack.py` can prepare the panel's file context **once** — changed-file list, diff, and complete line-numbered file bodies — so each lens reads one prepared artifact instead of opening the same changed files itself.
+
+**Do not use it unless the caller explicitly opts in** (`DEV_TEAM_REVIEW_CONTEXT_PACK=on`). The default dispatch path is the per-agent context payload described below, unchanged.
+
+Why it is off by default: [ADR 0034](../../../../docs/adr/0034-do-not-build-shared-context-pre-pass-for-duplicate-full-file-reads-1611.md) declined exactly this pre-pass after measuring duplicate full-file reads at **0.38%–4.86% of a round's total input spend, median 0.8%** (#1618). A later re-measurement with the same tool (`scripts/measure_full_file_duplication.py`) put it at **0.22%**. The 4.31x figure sometimes quoted for this is a *read-volume ratio*, not a share of spend — a different denominator, and not the one this decision turns on. The pack ships full file bodies rather than the structural skeleton ADR 0034 warned would degrade line-level lenses, so it carries no known quality risk; it simply has not been shown to pay for itself. #2024 tracks measuring panels of >= 8 agents, which is the shape that could change the answer.
+
+When opted in:
 
 ```bash
 git -c core.quotePath=false diff --name-status <base> \
@@ -435,17 +441,13 @@ git -c core.quotePath=false diff --name-status <base> \
       --name-status-from - --base <base>
 ```
 
-Prints a manifest naming the pack path, its byte size, and `files_omitted`. Pass the **pack path** to every dispatched agent and tell it to read that file instead of opening the changed files individually.
-
-Why this exists: across 148 panels of >= 8 agents, 180 MB of Read volume covered 41.8 MB of unique content — a **4.31x re-read multiplier**, one file opened by 38 agents at worst, and those panels are 73% of all review spend. Of the 18 review lenses that declare a `Context needs` value, **17 need the full bodies of the changed files**, so one pack serves nearly the whole roster: `full-file` lenses read its **File bodies** section, `project-structure` lenses read that plus **Changed files**, `diff-only` lenses read **Diff**.
-
-Two rules when passing it:
+Prints a manifest naming the pack path, its byte size, and `files_omitted`. Pass the pack path to each dispatched agent, and observe both rules:
 
 - **The pack narrows repeated reads, not the review.** A lens may still open anything not in the pack — a caller in an unchanged file, a sibling module. Never instruct an agent to treat the pack as the complete world.
 - **`files_omitted` is not optional to relay.** When the manifest reports omissions (a file over the per-file cap, a binary, a body that would exhaust the budget), name those paths in each agent's prompt and tell it to open them directly. The pack body says so too, but a silently skipped file is a coverage hole that reads as a clean review.
 
 - **File scope**: pass only files matching each agent's declared scope. Skip the agent if no files match.
-- **Context payload** (controlled by the agent's `Context needs`) — served from the pack's sections above; fall back to inlining the content directly if the pack could not be built:
+- **Context payload** (controlled by the agent's `Context needs`):
   - `diff-only` → diff output only (for auto-scope or `--since` only)
   - `full-file` → complete files
   - `project-structure` → full files + directory tree + the changed-file list (path + change type — `A`/`M`/`D`/`R`/`C`) computed in step 3 via `changed_file_list.py`, for diff-scoped runs (auto-scope or `--since`). Omit the changed-file list for `--path`/`--all`/full-repository scope — there is no diff to describe. Every `project-structure` agent (`arch-review`, `doc-review`, `domain-review`) has no Bash grant and must never invoke `git` itself to "see what changed" — that call is denied and surfaces as a spurious error (#1734); this payload is what makes that unnecessary.

--- a/plugins/dev-team/skills/code-review/scripts/review_context_pack.py
+++ b/plugins/dev-team/skills/code-review/scripts/review_context_pack.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""One shared context pack for a review panel (#2006).
+"""One shared context pack for a review panel (#2006). OPT-IN, off by default.
+
+**This is not the default dispatch path.** `code-review/SKILL.md` step 4 uses
+the per-agent context payload unless the caller sets
+`DEV_TEAM_REVIEW_CONTEXT_PACK=on`. ADR 0034 declined a shared-context pre-pass
+after measuring duplicate full-file reads at 0.38%-4.86% of a round's total
+input spend (median 0.8%); a later re-measurement with the same tool put it at
+0.22%. The 4.31x multiplier quoted for this problem is a read-volume ratio, a
+different denominator from the one that decision turns on. #2024 tracks
+measuring panels of >= 8 agents, the shape that could change the answer.
+
+The pack ships complete file bodies, not the structural skeleton ADR 0034
+warned would starve line-level lenses, so it carries no known quality risk —
+it simply has not been shown to pay for its complexity.
 
 Every lens in a `/code-review` panel is handed the same changed files and then
 reads them itself. Measured across 148 panels of >= 8 agents: **180 MB of Read

--- a/tests/skills/test_review_context_pack_is_opt_in.py
+++ b/tests/skills/test_review_context_pack_is_opt_in.py
@@ -1,0 +1,122 @@
+"""The shared context pack stays opt-in (#2023).
+
+`review_context_pack.py` was built and wired into `/code-review` step 4 as the
+default dispatch path, contradicting [ADR 0034], which had already declined a
+shared-context pre-pass after measuring duplicate full-file reads at
+0.38%-4.86% of a round's total input spend (median 0.8%). The justification
+used a *read-volume ratio* (4.31x) — a different denominator from the one that
+decision turns on. Re-measured with the repo's own
+`scripts/measure_full_file_duplication.py`, the figure was 0.22%.
+
+Nothing mechanical caught that. The ADR said in prose "a future session should
+not re-open or re-attempt this fix without first reading why it was declined
+here", and a future session did exactly that. This file is the mechanism that
+prose wasn't: it fails if the pack drifts back to being the default, and it
+fails if the reason stops being stated where someone would read it.
+
+The pack is not being removed. It carries no known quality risk — it ships
+complete file bodies, not the structural skeleton ADR 0034 warned would starve
+line-level lenses. It simply has not been shown to pay for its complexity, and
+#2024 tracks the >= 8-agent measurement that could change that. When it does,
+this file is the thing to update — deliberately, with the number in hand.
+
+[ADR 0034]: docs/adr/0034-do-not-build-shared-context-pre-pass-for-duplicate-full-file-reads-1611.md
+"""
+
+from __future__ import annotations
+
+import re
+
+from _repo_root import REPO_ROOT
+
+SKILL = REPO_ROOT / "plugins/dev-team/skills/code-review/SKILL.md"
+SCRIPT = (
+    REPO_ROOT
+    / "plugins/dev-team/skills/code-review/scripts/review_context_pack.py"
+)
+ADR_0034 = (
+    REPO_ROOT
+    / "docs/adr"
+    / "0034-do-not-build-shared-context-pre-pass-for-duplicate-full-file-reads-1611.md"
+)
+
+#: The env var a caller sets to turn the pack on. Named here so a rename has to
+#: come through this test rather than silently orphaning the opt-in.
+OPT_IN_VAR = "DEV_TEAM_REVIEW_CONTEXT_PACK"
+
+
+def _skill() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def test_the_pack_is_declared_opt_in_and_off_by_default() -> None:
+    text = _skill()
+    assert "opt-in" in text and OPT_IN_VAR in text, (
+        "step 4 must name the opt-in switch; without it the pack reads as "
+        "standard procedure"
+    )
+    assert re.search(r"off by default", text), (
+        "the default posture must be stated explicitly, not left to be "
+        "inferred from the absence of an instruction"
+    )
+
+
+def test_step_4_does_not_instruct_building_the_pack_unconditionally() -> None:
+    """The original wiring opened with 'Build the shared context pack first'.
+    Any imperative of that shape makes the pack the default again regardless
+    of what the surrounding prose says about opting in."""
+    text = _skill()
+    for forbidden in (
+        "Build the shared context pack first",
+        "prepare the panel's file context **once** rather than",
+    ):
+        assert forbidden not in text, f"step 4 reverted to default-on: {forbidden!r}"
+
+
+def test_the_default_context_payload_is_not_described_as_pack_served() -> None:
+    """The `Context needs` bullet must describe the per-agent payload on its
+    own terms. Phrasing it as 'served from the pack' makes the pack load-
+    bearing for the default path even while the prose above calls it optional."""
+    text = _skill()
+    assert "served from the pack" not in text
+    assert "**Context payload** (controlled by the agent's `Context needs`):" in text
+
+
+def test_the_reason_travels_with_the_instruction() -> None:
+    """A bare 'off by default' invites someone to flip it as a tidy-up. The
+    ADR, the measured share-of-spend, and the denominator mistake have to be
+    readable at the point of use."""
+    text = _skill()
+    assert "0034" in text, "step 4 must cite the ADR that declined this"
+    assert "0.22%" in text or "0.8%" in text, (
+        "step 4 must carry the measured share of round spend"
+    )
+    assert "denominator" in text or "read-volume ratio" in text, (
+        "the 4.31x figure must be marked as a different measurement, or it "
+        "will be cited again as justification"
+    )
+
+
+def test_the_script_itself_records_that_it_is_not_the_default() -> None:
+    """Someone reading the module cold — a maintainer, or a future session
+    grepping for the pack — must learn its status from the file, not only from
+    a skill doc they may never open."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    head = source[:2000]
+    assert "OPT-IN" in head or "opt-in" in head
+    assert "0034" in head, "the script must name the ADR that governs it"
+
+
+def test_adr_0034_still_stands_and_is_not_silently_superseded() -> None:
+    """If the >= 8-agent measurement in #2024 justifies making the pack the
+    default, that is a decision reversal and needs its own ADR — the way ADR
+    0037 superseded 0011's warn-default. Editing this test to pass while ADR
+    0034 still reads 'Accepted' with no superseding record would be exactly
+    the silent divergence #2023 is about."""
+    text = ADR_0034.read_text(encoding="utf-8")
+    status = text.split("## Status", 1)[1].split("##", 1)[0]
+    assert "Accepted" in status
+    assert "Superseded" not in status, (
+        "ADR 0034 is marked superseded — update this test deliberately, "
+        "citing the ADR that replaced it and the measurement behind it"
+    )


### PR DESCRIPTION
## Summary

- **Returns `/code-review` step 4 to the ADR-sanctioned default.** #2021 wired `review_context_pack.py` in as the default dispatch path; [ADR 0034](docs/adr/0034-do-not-build-shared-context-pre-pass-for-duplicate-full-file-reads-1611.md) had already declined exactly that pre-pass. The per-agent `Context needs` payload is the default again, and the pack lives behind `DEV_TEAM_REVIEW_CONTEXT_PACK`.
- **The script stays.** It ships complete file bodies, not the structural skeleton ADR 0034 warned would starve line-level lenses, so it carries no known quality risk — it simply has not been shown to pay for its complexity.
- **`tests/skills/test_review_context_pack_is_opt_in.py`** is the mechanism that prose wasn't.

## The measurements never actually disagreed

| source | metric | value |
|---|---|---|
| ADR 0034 / #1618 | avoidable duplicate reads ÷ round **total input spend** | 0.38%–4.86%, median 0.8% |
| re-measurement, same tool | same metric | **0.22%** |
| #2021's justification | read volume ÷ **unique** read volume | 4.31× |

The last row is a different denominator. A 4.31× multiplier on reads is entirely consistent with reads being ~1% of a round's input tokens — it neither confirms nor contradicts ADR 0034, it just doesn't speak to the question. Re-run with the repo's own `scripts/measure_full_file_duplication.py`, the governing metric came out at **0.22%**, inside ADR 0034's band and below its minimum.

## Why a test and not just a doc edit

ADR 0034 already said, in prose:

> a future session should not re-open or re-attempt this fix without first reading why it was declined here

A future session did exactly that. Prose was the control and it failed — the same shape as #2000 (a ceiling that only warned), #1998 (silently dropped review outputs), and #2009 (a bypassed commit gate). So the guard is mechanical, and it fails on four distinct regressions:

| the test fails if… | why that matters |
|---|---|
| step 4 reverts to an imperative "build the pack first" | makes it the default again regardless of surrounding prose |
| the `Context needs` bullet is described as "served from the pack" | makes the pack load-bearing for the default path while calling it optional |
| the ADR, the measured share of spend, or the denominator note stops being stated at the point of use | a bare "off by default" invites a tidy-up flip |
| ADR 0034 is marked superseded without this test being updated | a reversal must be a deliberate ADR, per ADR 0037's precedent |

**Verified by restoring the default-on wiring in place and watching it fail** — 1 failed, 5 passed. Mechanically confirmed, not asserted.

## Test Plan

- [x] 6 new content-guard tests, each pinning a distinct drift path
- [x] Deliberate-failure check: default-on wiring restored → guard fails
- [x] Rationale carried in **both** step 4 and the module docstring, so a reader who never opens the skill doc still learns the pack's status from the file
- [x] Full pre-push directory list: **9,331 passed, 47 skipped**
- [x] `ruff`, `check_md_references.py` (including the new relative ADR link), `build_knowledge_index.py` clean

## What's deferred, and to where

[#2024](https://github.com/bdfinst/agentic-dev-team/issues/2024) tracks measuring panels of **≥ 8 agents** — the shape neither prior measurement covered. ADR 0034's band came from 2-agent-scale rounds in one transcript and it explicitly warns against quoting it beyond that shape; the 0.22% re-measurement has the same limit. That issue sets its decision rule *before* the data arrives (<2% → stays opt-in; ≥5% → grounds for a superseding ADR; between → decide explicitly), so the number decides rather than the narrative.

Part of #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85)_