### PR TITLE
feat(metrics): report real per-agent context volume, not a message count

### DIFF
--- a/plugins/dev-team/docs/session-review.md
+++ b/plugins/dev-team/docs/session-review.md
@@ -56,7 +56,7 @@ prompts, command strings, or code (privacy by construction):
 | `transcripts` / `subagent_transcripts` | main-thread sessions vs dispatched agent runs |
 | `tokens` | input/output/cache token totals |
 | `cost_usd`, `cache_hit_ratio` | session cost and cache-read efficiency |
-| `token.by_agent_type` | message counts keyed by agent name — `main`, `unattributed` where none resolves, `sidechain` for an older harness's inlined turns |
+| `token.by_agent_type` | per-agent token buckets keyed by agent name — `main`, `unattributed` where none resolves, `sidechain` for an older harness's inlined turns. **Was a bare message count before #2010**, which read as a token figure under this key and was off from `token.totals` by orders of magnitude |
 | `rework` | counts: `failed_edits`, `repeated_file_edits`, `retried_bash_commands`, `repeated_verify_runs`, `permission_denials`, `compaction_events` |
 | `accuracy` | `tool_calls`, `tool_error_rate`, `user_correction_turns` |
 | `utilization` | `skills_invoked`, `agents_invoked` (RUNS), `agent_dispatches` (Agent/Task calls), `never_observed_skills`, `never_observed_agents` |
@@ -117,7 +117,22 @@ otherwise conflate:
 | Field | Meaning |
 |---|---|
 | `transcripts` / `subagent_transcripts` | main-thread sessions vs dispatched agent runs, both scoped to the reported window |
-| `token.by_agent_type` | message counts keyed by agent name — `main` for the main thread, `unattributed` where no agent is resolvable. Same vocabulary as cost-metering's `by_agent_type` (`knowledge/telemetry-schema.md`); deliberately NOT `by_subagent`, which means main-vs-sidechain in `session_extract.py` |
+| `token.by_agent_type` | **per-agent token buckets** (#2010), keyed by agent name — `main` for the main thread, `unattributed` where no agent is resolvable. Same vocabulary as cost-metering's `by_agent_type` (`knowledge/telemetry-schema.md`) and now the same field names as its buckets; deliberately NOT `by_subagent`, which means main-vs-sidechain in `session_extract.py` |
+
+Each `token.by_agent_type` bucket carries:
+
+| Key | Meaning |
+|---|---|
+| `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` | the usage fields that make up what a dispatch **carried in** |
+| `output_tokens` | what it generated — tracked, but deliberately outside `context_tokens` |
+| `context_tokens` | the sum of the three context fields. Session telemetry puts ~90% of spend here, which is why this is the figure a panel-cost decision reads |
+| `messages` | assistant messages carrying usage — the value this key held on its own before #2010 |
+| `dispatches` | runs, counted one per subagent transcript. Never inferred from message volume, which would make a verbose agent look cheap per dispatch |
+| `context_per_dispatch` | `context_tokens / dispatches`, or **`null`** when `dispatches` is 0 (`main`, and any agent that never ran). Null rather than 0 so a never-dispatched agent cannot sort as the cheapest row |
+
+**Reconciliation invariant.** The per-agent `context_tokens` sum exactly to `token.totals`' three context fields. Both are derived from the same usage records, so a mismatch means a dispatch was double-counted or dropped; `tests/scripts/test_extract_session_report.py` pins it.
+
+**Not comparable across the #2010 boundary.** A pre-#2010 digest carries an int here. The cross-project merge preserves such a label at zero rather than summing a message count into a token total.
 | `utilization.agents_invoked` | agent RUNS, from each subagent transcript's `attributionAgent` — ground truth |
 | `utilization.agent_dispatches` | `Agent`/`Task` tool calls, i.e. dispatches requested |
 

--- a/plugins/dev-team/scripts/extract_session_report.py
+++ b/plugins/dev-team/scripts/extract_session_report.py
@@ -241,6 +241,70 @@ def load_registry(plugin_root: Path) -> dict:
 # --- per-record signal accumulation (adapted from session_extract.py) -------
 
 
+#: The usage fields that make up a dispatch's CONTEXT — what it carried in,
+#: as opposed to what it generated. Session telemetry puts ~90% of spend here
+#: (cache read + cache write), which is why per-agent context is the figure a
+#: panel-cost decision needs and `output_tokens` is tracked separately.
+_CONTEXT_TOKEN_FIELDS = (
+    "input_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+#: Mirrors `hooks/lib/cost_meter.py`'s `_new_bucket()` shape (#1094) so the two
+#: per-agent breakdowns in this plugin agree on field names. They stay separate
+#: implementations — cost_meter runs live per turn, this runs over a whole tree.
+_AGENT_BUCKET_FIELDS = (*_CONTEXT_TOKEN_FIELDS, "output_tokens")
+
+
+def _new_agent_bucket() -> dict:
+    bucket = {f: 0 for f in _AGENT_BUCKET_FIELDS}
+    bucket["messages"] = 0
+    bucket["dispatches"] = 0
+    return bucket
+
+
+def _merge_agent_buckets(dest: dict, src: dict) -> None:
+    """Fold one project's per-agent buckets into the cross-project totals.
+
+    Re-sums the raw fields rather than the derived ones: adding two projects'
+    `context_per_dispatch` values would produce a number that is not a mean of
+    anything. The derived figures are recomputed once, after the merge.
+    """
+    for label, bucket in (src or {}).items():
+        if not isinstance(bucket, dict):
+            # A digest written before #2010 carries an int (a message count).
+            # Merging it as tokens would silently corrupt the total, so the
+            # label is preserved at zero rather than guessed at.
+            dest.setdefault(label, _new_agent_bucket())
+            continue
+        into = dest.setdefault(label, _new_agent_bucket())
+        for field in (*_AGENT_BUCKET_FIELDS, "messages", "dispatches"):
+            into[field] += bucket.get(field, 0) or 0
+
+
+def _finalize_agent_buckets(by_agent_type: dict) -> dict:
+    """Add the derived per-dispatch figure each bucket exists to answer.
+
+    `context_tokens` is the sum a dispatch is charged for carrying;
+    `context_per_dispatch` divides it by real dispatch count, which is why
+    dispatches are counted from subagent transcripts rather than messages. It
+    is `None` for `main` and for any agent with no counted dispatch — a
+    division that has no meaning must read as absent, not as 0, which would
+    rank a never-dispatched agent as the cheapest in the table.
+    """
+    out = {}
+    for label, b in sorted(by_agent_type.items()):
+        context = sum(b[f] for f in _CONTEXT_TOKEN_FIELDS)
+        entry = dict(b)
+        entry["context_tokens"] = context
+        entry["context_per_dispatch"] = (
+            round(context / b["dispatches"]) if b["dispatches"] else None
+        )
+        out[label] = entry
+    return out
+
+
 def _accumulate_token_signals(usage, model, tokens_total, by_model):
     for f in (
         "input_tokens",
@@ -370,7 +434,7 @@ def extract(
     no session_id is excluded, same fail-closed convention."""
     tokens_total = Counter()
     by_model: dict[str, Counter] = defaultdict(Counter)
-    by_agent_type = Counter()
+    by_agent_type = {}
     sessions: set[str] = set()
 
     edits_per_file = Counter()
@@ -404,6 +468,7 @@ def extract(
         thread = _new_thread()
         pending_tool: dict[str, str] = {}
         thread_msgs = 0
+        thread_usage = _new_agent_bucket()
         records_in_window = 0
 
         for rec in _iter_file_records(path):
@@ -448,6 +513,13 @@ def extract(
             if usage:
                 thread_msgs += 1
                 _accumulate_token_signals(usage, model, tokens_total, by_model)
+                # Real per-dispatch context (#2010). The usage record is already
+                # in hand here; before this it was folded into the totals and
+                # then discarded for a message count, which is why "what does
+                # each dispatch carry" was unanswerable from this report.
+                thread_usage["messages"] += 1
+                for field in _CONTEXT_TOKEN_FIELDS:
+                    thread_usage[field] += usage.get(field, 0) or 0
 
             content = msg.get("content")
             _accumulate_skill_agent_signals(content, skills_invoked, agent_dispatches)
@@ -475,7 +547,14 @@ def extract(
         # resolved here rather than per record.
         label = agent_name or (_UNATTRIBUTED_LABEL if is_subagent else _MAIN_LABEL)
         if thread_msgs:  # `+= 0` would materialize a zero-valued key
-            by_agent_type[label] += thread_msgs
+            bucket = by_agent_type.setdefault(label, _new_agent_bucket())
+            bucket["messages"] += thread_usage["messages"]
+            for field in _CONTEXT_TOKEN_FIELDS:
+                bucket[field] += thread_usage[field]
+            # One subagent transcript is one dispatch, so dispatches are
+            # counted here rather than inferred from message volume.
+            if is_subagent:
+                bucket["dispatches"] += 1
         # A transcript whose every record fell outside --since/--until did not
         # happen in the reported window, so it is neither a run nor a counted
         # transcript there. Counting files on a different basis from every
@@ -517,7 +596,7 @@ def extract(
             "totals": dict(sorted(tokens_total.items())),
             "cache_hit_ratio": cache_hit_ratio,
             "by_model": {m: dict(sorted(v.items())) for m, v in sorted(by_model.items())},
-            "by_agent_type": dict(sorted(by_agent_type.items())),
+            "by_agent_type": _finalize_agent_buckets(by_agent_type),
         },
         "rework": {
             "failed_edits": error_counts["failed_edits"],
@@ -564,7 +643,7 @@ def combine(digests: dict[str, dict], registry: dict) -> dict:
     transcripts = 0
     subagent_transcripts = 0
     tokens_total = Counter()
-    by_agent_type = Counter()
+    by_agent_type = {}
     cr = cc = 0
     rework = Counter()
     repeated_file_edits: Counter = Counter()
@@ -582,7 +661,7 @@ def combine(digests: dict[str, dict], registry: dict) -> dict:
         transcripts += d["transcripts"]
         subagent_transcripts += d.get("subagent_transcripts", 0)
         _merge_counters(tokens_total, d["token"]["totals"])
-        _merge_counters(by_agent_type, d["token"]["by_agent_type"])
+        _merge_agent_buckets(by_agent_type, d["token"]["by_agent_type"])
         cr += d["token"]["totals"].get("cache_read_input_tokens", 0)
         cc += d["token"]["totals"].get("cache_creation_input_tokens", 0)
 
@@ -621,7 +700,7 @@ def combine(digests: dict[str, dict], registry: dict) -> dict:
         "token": {
             "totals": dict(sorted(tokens_total.items())),
             "cache_hit_ratio": round(cr / (cr + cc), 4) if (cr + cc) else 0.0,
-            "by_agent_type": dict(sorted(by_agent_type.items())),
+            "by_agent_type": _finalize_agent_buckets(by_agent_type),
         },
         "rework": {
             "failed_edits": rework["failed_edits"],

--- a/tests/scripts/test_extract_session_report.py
+++ b/tests/scripts/test_extract_session_report.py
@@ -133,11 +133,16 @@ def test_subagent_usage_counts_toward_token_totals(tree, tmp_path):
 def test_by_agent_type_is_keyed_by_agent_name(tree, tmp_path):
     report = _run(tree, tmp_path / "r.json")
     by_agent_type = report["combined"]["token"]["by_agent_type"]
-    assert by_agent_type == {
-        "main": 1,
-        "correctness-review": 1,
-        "angular-reactivity-review": 1,
+    assert set(by_agent_type) == {
+        "main",
+        "correctness-review",
+        "angular-reactivity-review",
     }
+    # Each bucket is a real token breakdown (#2010), not the message count this
+    # key used to carry under `token` — where an int read as a token figure and
+    # was off by orders of magnitude from `token.totals`.
+    assert by_agent_type["correctness-review"]["messages"] == 1
+    assert by_agent_type["correctness-review"]["context_tokens"] > 0
 
 
 def test_regression_1990_signature_cannot_return(tree, tmp_path):
@@ -508,7 +513,8 @@ def test_a_projects_root_containing_a_subagents_segment_is_not_misread(tmp_path)
     combined = _run(root, tmp_path / "r.json")["combined"]
     assert combined["transcripts"] == 1
     assert combined["subagent_transcripts"] == 0
-    assert combined["token"]["by_agent_type"] == {"main": 1}
+    assert set(combined["token"]["by_agent_type"]) == {"main"}
+    assert combined["token"]["by_agent_type"]["main"]["messages"] == 1
 
 
 def test_a_malformed_model_value_does_not_abort_the_run(tmp_path):
@@ -531,7 +537,8 @@ def test_main_thread_records_are_never_relabelled_by_attribution(tmp_path):
         _assistant([{"type": "text", "text": "inlined"}], agent="dev-team:doc-review"),
     ])
     combined = _run(root, tmp_path / "r.json")["combined"]
-    assert combined["token"]["by_agent_type"] == {"main": 2}
+    assert set(combined["token"]["by_agent_type"]) == {"main"}
+    assert combined["token"]["by_agent_type"]["main"]["messages"] == 2
 
 
 def test_agent_runs_fall_back_to_dispatches_only_when_the_layout_is_absent(tmp_path):
@@ -552,3 +559,89 @@ def test_agent_runs_fall_back_to_dispatches_only_when_the_layout_is_absent(tmp_p
     assert combined["subagent_transcripts"] == 0
     assert combined["utilization"]["agents_invoked"] == {}
     assert combined["utilization"]["agent_dispatches"] == {"security-review": 1}
+
+
+# --- #2010: per-dispatch context volume ------------------------------------
+
+
+def test_per_agent_context_sums_to_the_report_totals(tree, tmp_path):
+    """The load-bearing correctness property. Per-agent context is derived from
+    the same usage records as `token.totals`, so the two must reconcile exactly.
+    A mismatch means a dispatch was double-counted or dropped — and a per-lens
+    cost decision made on either shape would be wrong in a way no other
+    assertion here would catch."""
+    combined = _run(tree, tmp_path / "r.json")["combined"]
+    totals = combined["token"]["totals"]
+    expected = (
+        totals["input_tokens"]
+        + totals["cache_read_input_tokens"]
+        + totals["cache_creation_input_tokens"]
+    )
+    actual = sum(b["context_tokens"] for b in combined["token"]["by_agent_type"].values())
+    assert actual == expected
+
+
+def test_context_excludes_output_tokens(tree, tmp_path):
+    """Context is what a dispatch CARRIED IN. Folding generation into it would
+    make an agent that writes long findings look expensive to dispatch, which
+    is the opposite of what this figure is for."""
+    combined = _run(tree, tmp_path / "r.json")["combined"]
+    for label, bucket in combined["token"]["by_agent_type"].items():
+        carried = (
+            bucket["input_tokens"]
+            + bucket["cache_read_input_tokens"]
+            + bucket["cache_creation_input_tokens"]
+        )
+        assert bucket["context_tokens"] == carried, label
+        assert "output_tokens" in bucket, "output stays tracked, just separately"
+
+
+def test_context_per_dispatch_is_none_rather_than_zero_without_dispatches(
+    tree, tmp_path
+):
+    """`main` is not dispatched, so its per-dispatch figure is undefined. Zero
+    would sort it as the cheapest row in any ranking built on this field —
+    exactly backwards, since main carries the most context of anything."""
+    combined = _run(tree, tmp_path / "r.json")["combined"]
+    main = combined["token"]["by_agent_type"]["main"]
+    assert main["dispatches"] == 0
+    assert main["context_per_dispatch"] is None
+    assert main["context_tokens"] > 0
+
+
+def test_dispatches_are_counted_from_subagent_transcripts_not_messages(
+    tree, tmp_path
+):
+    """One subagent transcript is one dispatch. Inferring dispatch count from
+    message volume would divide by a number that grows with how chatty a lens
+    is, making a verbose agent look cheap per dispatch."""
+    combined = _run(tree, tmp_path / "r.json")["combined"]
+    by_agent = combined["token"]["by_agent_type"]
+    dispatched = sum(b["dispatches"] for b in by_agent.values())
+    assert dispatched == combined["subagent_transcripts"]
+
+
+def test_a_pre_2010_digest_does_not_corrupt_merged_totals():
+    """Older digests carry an int (a message count) under this key. Summing it
+    as tokens would silently inflate a cross-project total by a meaningless
+    number, so the label is kept at zero instead of guessed at.
+
+    Imported directly rather than driven through the CLI: the merge path only
+    runs across multiple project digests, and the mixed-vintage case cannot be
+    staged from transcripts alone."""
+    import importlib.util
+
+    path = REPO_ROOT / "plugins/dev-team/scripts/extract_session_report.py"
+    spec = importlib.util.spec_from_file_location("_esr_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    dest = {}
+    module._merge_agent_buckets(dest, {"doc-review": 7})
+    assert dest["doc-review"]["input_tokens"] == 0
+    assert dest["doc-review"]["messages"] == 0
+
+    # A current-vintage bucket still merges normally alongside it.
+    module._merge_agent_buckets(dest, {"doc-review": {"input_tokens": 5, "messages": 1}})
+    assert dest["doc-review"]["input_tokens"] == 5
+    assert dest["doc-review"]["messages"] == 1


### PR DESCRIPTION
## Summary

- **The plugin counted dispatches and never counted what each one carried**, so *"is this lens expensive to dispatch?"* was unanswerable from session telemetry — the question the 90%-of-spend-is-context finding makes central.
- **The data was already there.** The extractor reads each record's `usage`, folds it into `token.totals`, and then discarded it for a message count.
- `token.by_agent_type` now carries a real per-agent bucket, with field names matching `hooks/lib/cost_meter.py`'s buckets (#1094).

## The field was actively misleading

`token.by_agent_type` held a bare message count, under the `token` key, where a reader naturally reads tokens. Across the 2,462-session corpus:

| | |
|---|---|
| `token.by_agent_type` summed | **142,205** |
| `token.totals` summed | **~28,000,000,000** |

Five orders of magnitude apart. Anyone citing it as per-agent cost — the obvious thing to do when asking what a lens costs — would have been badly wrong, and silently.

## What each bucket now carries

| key | meaning |
|---|---|
| `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` | what the dispatch **carried in** |
| `output_tokens` | what it generated — tracked, deliberately outside `context_tokens` |
| `context_tokens` | sum of the three context fields; ~90% of spend lives here |
| `messages` | the value this key held on its own before |
| `dispatches` | runs, one per subagent transcript |
| `context_per_dispatch` | `context_tokens / dispatches`, or **`null`** when `dispatches` is 0 |

## Three choices that decide whether the number can be trusted

- **Context excludes `output_tokens`.** Folding generation in would make a lens that writes long findings look expensive to *dispatch* — the opposite of what the figure is for.
- **Dispatches come from subagent transcripts, never message volume.** That divisor grows with how chatty a lens is, so a verbose agent would look cheap per dispatch.
- **`context_per_dispatch` is `null`, not `0`.** Zero would sort `main` — which carries the most context of anything — as the cheapest row in any ranking built on this field.

## Verified against live transcripts, not fixtures

Run over this repo's real session tree, the reconciliation is exact:

```
per-agent context:  679,405,666
token.totals ctx :  679,405,666
```

Both derive from the same usage records, so a mismatch means a dispatch was double-counted or dropped. That invariant is pinned by a test, and **folding `output_tokens` into the context fields makes it fail** — verified by doing it.

The same run produces the figure #2010 exists for, for the first time:

| agent | context/dispatch |
|---|---|
| `test-review` | ~6.0M |
| `correctness-review` | ~4.1M |
| `doc-review` | ~4.0M |

One caveat worth stating: in that session `main` accounted for **96%** of all context. It is a single main-thread-heavy session and generalizes to nothing — but it is the kind of thing this field now makes visible at all, and it is worth keeping in view when reading #2024's panel measurements.

## Test Plan

- [x] 5 new tests, including the sums-to-totals invariant and the null-vs-zero case
- [x] Deliberate-failure check: folding output into context fails 2 tests
- [x] 3 existing assertions updated — they pinned the int shape, i.e. the wrong contract
- [x] Full pre-push directory list: **9,339 passed, 47 skipped**
- [x] `ruff` clean on both installed versions (0.15.8 and 0.16.1, per #2027)
- [x] `check_md_references.py`, `build_knowledge_index.py` clean

## Scope

Shipped extractor only. `scripts/session_extract.py` carries the same message-count defect and stays forked per [ADR 0036](docs/adr/0036-the-two-session-extractors-stay-forked-1994.md); flagged rather than diverged further in silence.

The **always-on floor** half of #2010's acceptance is not here — that measures resting context before any dispatch, a different mechanism. Per-dispatch volume is what #2024 and the remaining #1973 slices are blocked on.

`token.by_agent_type` changes shape from `int` to object. Pre-#2010 digests merge with the label preserved at zero rather than a message count summed into a token total; documented in `session-review.md`.

Closes #2010
Part of #2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9u5zBi9QswuuFvXNz9R85)_