### PR TITLE
fix(mutation-kill): four shard-pipeline and retry defects, plus yield steering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,47 @@ The local gates (`scripts/ci-local.sh`, run by the `pre-push` hook) need these t
 
 **The pre-push pytest gate spans more than `plugins/dev-team/tests`.** `ci-local.sh`'s unit-test step runs pytest over `plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks` (with `-n auto --dist loadgroup`; two csharp-stryker files `--ignore`d). Editing agent/skill markdown can break repo-level content-guards that live **outside** `plugins/dev-team/tests` — e.g. `tests/skills/test_code_review_frontend_dispatch.py` asserts specific agent names appear verbatim in `code-review/SKILL.md`, and `tests/repo` runs `check_md_references.py` (a backticked cross-skill path must be file-relative, e.g. `../code-review/SKILL.md`). `tests/hooks/` (repo-root, distinct from `plugins/dev-team/tests/hooks/`) joined this list in #1475 after two of its tests — pinning `hooks.json`'s dispatch-matcher registration — went silently red for a full ADR migration (ADR 0026) because this directory wasn't in the gate; the stryker/pitest/mutmut *adapter* tests that actually shell out to those tools live in `plugins/dev-team/tests/hooks/` (already covered by `plugins/dev-team/tests` above) — this directory only hosts the static fixture files those adapter tests read (`tests/hooks/fixtures/`, `tests/hooks/fake-bin/`), so `tests/hooks/` itself is fast and portable. Before pushing plugin-content changes, run that **full dir list** — not just the plugin subdir — plus `python3 scripts/check_md_references.py` and `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py`, or the `pre-push` hook / CI will catch what a plugin-only run missed.
 
+### The inner loop — three speeds, not two
+
+Before #2002/#2005 the loop had two speeds: run one file, or run the whole
+9,469-test directory list. "What does this change affect?" was answered by a
+guess, and per the deterministic-tools rule that is a mechanical question a
+program should compute.
+
+1. **`--lf` / `--ff`** — free, built into pytest, no map and no dependency.
+   `--lf` re-runs only last run's failures; `--ff` runs them first, then the
+   rest. This is the right tool for the tight red→green loop and costs nothing
+   to adopt.
+2. **Impact selection** — `scripts/impact_tests.py` answers "given that
+   something changed, which tests reach it" from a per-test coverage map:
+
+   ```bash
+   python3 scripts/impact_tests.py build --out .cache/impact-map.json -- \
+     plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs \
+     tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks
+   python3 scripts/impact_tests.py select --map .cache/impact-map.json \
+     --changed-from-git | xargs python3 -m pytest -q
+   ```
+
+   Built on `pytest-cov`'s `--cov-context=test` — already a dev dependency —
+   rather than adding `pytest-testmon`. Measured on this checkout: a
+   `hooks/telemetry.py` edit selects **28 tests in 0.6s** against 9,493 in
+   ~80s. Building the map costs one full instrumented run (~4 min).
+
+   **It never narrows on a guess.** `select` exits **2** — meaning *run the
+   full suite* — when the map is missing or malformed, when a changed file is
+   absent from the map (a new or uncovered file has unknown reach), or when a
+   changed file is itself a test. Treat any non-zero exit as the full suite,
+   never as an empty selection. The map is a snapshot: rebuild it after adding
+   tests or source files.
+3. **The full directory list** — still what `pre-push` and CI run, and still
+   the answer whenever selection refuses.
+
+`scripts/ci_tree_cache.py` (#2002) sits underneath all three and answers a
+different question — "has anything changed at all" — skipping `chk_hook_units`
+outright when the working tree is byte-identical to the one it last passed on.
+`CI_LOCAL_NO_TREE_CACHE=1` forces a run.
+
 ### Worktrees — run `npm ci` first
 
 Run `npm ci` as the first step in any new worktree, before committing. An unprovisioned worktree has no `.husky/_`/`node_modules`, so git hooks silently don't run; `scripts/ci-local.sh` and CI backstop what the hooks would have caught.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --fix",
-    "*.py": "ruff check --fix"
+    "*.py": "python3 -m ruff check --fix"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",

--- a/plugins/dev-team/docs/test-improve.md
+++ b/plugins/dev-team/docs/test-improve.md
@@ -84,9 +84,14 @@ is `none`, +1 once Phase 6 enters Phase 7) rather than a hardcoded 9 or 10.
   (no-refactor) → `/coverage-delta --workflow test-improve --story <id>` →
   `scripts/coverage_delta_steering.py` (three consecutive near-zero-delta
   Stories exit 3 and prompt `[t] re-check Phase-1 targeting / [c] continue`
-  mid-phase, #1790) → `mutation-kill` agent (`--file <story-file>
-  --max-rounds 3`, `[c/r/w/q]` on
-  residuals). End-of-phase review loop runs `/test-design --since` and
+  mid-phase, #1790) → `mutation-kill` agent, dispatched once per module batch
+  (`--file <every story file in the batch> --max-rounds 3
+  --target-honest-score <Phase-0 mutation target>`, #2030; `[c/r/w/q]` on
+  residuals) → `scripts/mutation_yield_steering.py` at the batch boundary
+  (two consecutive batches killing fewer than the minimum net survivors exit
+  3 and prompt the same `[t] re-check Phase-1 targeting / [c] continue`,
+  #2033 — the #1790 mechanism ported to the more expensive lane, sharing its
+  status vocabulary and exit-code contract). End-of-phase review loop runs `/test-design --since` and
   `/code-review --since` in parallel, `/apply-fixes` then re-run, cap 2
   iterations, `[r/w/q]` escalation. Evidence in `phase-5-review.json`.
 - **Phase 6 — Refactor decision prompt.** `[y] enter Phase 7 / [b] backlog

--- a/plugins/dev-team/scripts/mutation_yield_steering.py
+++ b/plugins/dev-team/scripts/mutation_yield_steering.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""mutation_yield_steering.py — turn per-batch mutation yield into a live
+Phase-5 steering signal (issue #2033).
+
+Why this exists. Phase 5 has a mid-phase steering check for coverage (#1790,
+``coverage_delta_steering.py``) and none for mutation. `mutation-kill` is
+dispatched once per module batch (#1963) with ``--max-rounds 3``, and a batch
+that yields near-zero net kills does not inform the next batch — the lane runs
+to the end of the Story set regardless of what the earlier batches showed.
+That is exactly the failure #1790 was written to stop, in the more expensive of
+the two lanes: `mutation-kill` is 34.4% of thread messages in the 11-25 Aug
+2026 corpus against 5.1% for every review lens combined.
+
+This is a **port of #1790's mechanism, not a new one**. It shares that
+script's status vocabulary and exit-code contract deliberately, so an operator
+reading one already knows how to read the other, and so `/test-improve` can
+branch on both identically.
+
+The unit is the **batch**, not the Story. `mutation-kill` now runs per batch,
+so a per-Story mutation check would have no observation to make on most
+Stories — the signal only exists at a batch boundary.
+
+Yield, per batch, is ``starting_survivors - ending_survivors``: the net
+survivors killed. A **negative** yield counts as flat — a batch that ended
+with more survivors than it started is certainly not progress. A batch whose
+yield cannot be measured (either count missing or non-numeric) has yield
+``None`` and **breaks** the streak rather than extending it: absence of
+measurement is not evidence of flatness.
+
+Honest score before/after is reported alongside but does **not** drive the
+verdict. Score movement depends on the size of the file's mutant set, so a
+batch over a large module can kill real survivors while barely moving the
+percentage; keying the gate on it would make the check silently
+module-size-dependent. This mirrors #1790's reason for not keying on branch
+coverage.
+
+Statuses (and exit codes):
+
+- ``flat_streak`` (3) — ``--consecutive`` or more trailing batches each yielded
+  fewer than ``--min-kills``. The caller prompts; this script does not decide
+  policy.
+- ``flat_streak_forming`` (0) — the trailing batch yielded less than the
+  minimum but the streak is still shorter than ``--consecutive``. A distinct
+  status rather than ``ok``, because "not yet a streak" is not "mutation-kill
+  is producing kills".
+- ``insufficient_history`` (0) — fewer measurable batches than
+  ``--consecutive``, or a trailing batch whose yield could not be measured at
+  all, so no streak verdict is possible yet.
+- ``ok`` (0) — the trailing batch yielded at least the minimum.
+- exit ``2`` — the history file is missing, unreadable, not JSON, not a JSON
+  array, or carries a non-record element; also an out-of-range
+  ``--consecutive``/``--min-kills``. **Never** reported as an all-clear — the
+  same trap #1790 calls out.
+
+Stdlib-only (ADR 0014/0015), Python 3.10+ floor (ADR 0031).
+
+Usage:
+    python3 mutation_yield_steering.py \\
+      --history .dev-team-reports/test-improve/<slug>/data/mutation-history.json
+    python3 mutation_yield_steering.py --history <path> \\
+      --min-kills 1 --consecutive 2 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_MIN_KILLS = 1
+DEFAULT_CONSECUTIVE = 2
+
+STATUS_FLAT = "flat_streak"
+STATUS_FORMING = "flat_streak_forming"
+STATUS_OK = "ok"
+STATUS_INSUFFICIENT = "insufficient_history"
+
+# Score movements are rounded only to kill binary-float artifacts
+# (72.4 - 72.0 = 0.40000000000000568). Yield itself is an integer count and is
+# never rounded. Score never decides the verdict — see the module docstring.
+_SCORE_PRECISION = 10
+
+
+class HistoryError(ValueError):
+    """The mutation history could not be read or is not a record array."""
+
+
+def load_history(path: Path) -> list[dict]:
+    """Read ``mutation-history.json``, raising HistoryError on anything that is
+    not a readable JSON array of batch-record objects."""
+    if not path.is_file():
+        raise HistoryError(f"mutation history not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HistoryError(f"{path}: unreadable mutation history ({exc})") from exc
+    if not isinstance(payload, list):
+        raise HistoryError(
+            f"{path}: mutation history must be a JSON array of batch records, "
+            f"got {type(payload).__name__}"
+        )
+    # A non-dict element means the file is corrupt or half-rewritten. Dropping
+    # it silently would leave a corrupt history indistinguishable from a phase
+    # that simply hasn't closed enough batches yet — a clean verdict from
+    # unusable evidence, which is the one thing this gate must never produce.
+    for index, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            raise HistoryError(
+                f"{path}: mutation history entry at index {index} is a "
+                f"{type(entry).__name__}, not a batch record"
+            )
+    return list(payload)
+
+
+def batch_records(history: list[dict]) -> list[dict]:
+    """Keep only batch-attributed records — the per-batch Phase-5 dispatches.
+
+    A record with no ``batch`` is not a batch boundary (e.g. a whole-suite
+    Phase-8 measurement written into the same stream) and must not enter the
+    streak. Mirrors #1790's ``story_snapshots``.
+    """
+    return [entry for entry in history if entry.get("batch")]
+
+
+def _as_number(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _yield_of(record: dict) -> int | None:
+    """Net survivors killed by this batch, or ``None`` when unmeasurable."""
+    start = _as_number(record.get("starting_survivors"))
+    end = _as_number(record.get("ending_survivors"))
+    if start is None or end is None:
+        return None
+    return int(start - end)
+
+
+def _score_movement(record: dict) -> float | None:
+    before = _as_number(record.get("honest_score_before"))
+    after = _as_number(record.get("honest_score_after"))
+    if before is None or after is None:
+        return None
+    return round(after - before, _SCORE_PRECISION)
+
+
+def _batch_rows(records: list[dict]) -> list[dict]:
+    return [
+        {
+            "batch": record.get("batch"),
+            "module": record.get("module"),
+            "captured_at": record.get("captured_at"),
+            "starting_survivors": record.get("starting_survivors"),
+            "ending_survivors": record.get("ending_survivors"),
+            "rounds_spent": record.get("rounds_spent"),
+            "kills": _yield_of(record),
+            "score_movement": _score_movement(record),
+        }
+        for record in records
+    ]
+
+
+def _trailing_flat_streak(rows: list[dict], min_kills: int) -> list[dict]:
+    """The trailing run of batches whose measured yield is below the minimum.
+
+    Stops at the first batch that yielded enough OR whose yield is
+    unmeasurable — an unmeasured batch breaks the streak rather than
+    extending it.
+    """
+    streak: list[dict] = []
+    for row in reversed(rows):
+        kills = row["kills"]
+        if kills is None or kills >= min_kills:
+            break
+        streak.append(row)
+    streak.reverse()
+    return streak
+
+
+def evaluate(
+    records: list[dict],
+    min_kills: int = DEFAULT_MIN_KILLS,
+    consecutive: int = DEFAULT_CONSECUTIVE,
+) -> dict:
+    """Evaluate batch-attributed ``records`` for a flat mutation-yield streak."""
+    rows = _batch_rows(records)
+    measured = [r for r in rows if r["kills"] is not None]
+    streak = _trailing_flat_streak(rows, min_kills)
+
+    if len(streak) >= consecutive:
+        status = STATUS_FLAT
+        message = (
+            f"{len(streak)} consecutive batches killed fewer than {min_kills} "
+            "survivor(s) ("
+            + ", ".join(f"{r['batch']}: {r['kills']:+}" for r in streak)
+            + "). Re-read coverage-gap-ranking.json and re-order the remaining "
+            "batches before spending another mutation-kill dispatch — further "
+            "rounds on this module are not converting into kills."
+        )
+    elif len(measured) < consecutive:
+        status = STATUS_INSUFFICIENT
+        message = (
+            f"{len(measured)} batch yield(s) measured; {consecutive} are needed "
+            "before a flat-yield streak can be judged."
+        )
+    elif rows[-1]["kills"] is None:
+        # The trailing batch carries no usable survivor counts, so its yield
+        # could not be measured. Neither `ok` nor `flat_streak` is honest here.
+        status = STATUS_INSUFFICIENT
+        message = (
+            f"The latest batch ({rows[-1]['batch']}) could not be measured — "
+            "its record carries no comparable survivor counts, so no yield "
+            "verdict is possible for it."
+        )
+    elif streak:
+        # Below the streak threshold but still not killing: reporting this as
+        # `ok` would claim "mutation-kill is producing kills" about a batch
+        # that killed less than the minimum — the false all-clear this gate
+        # exists to prevent. Exit code stays 0; only the wording and status
+        # carry the warning.
+        status = STATUS_FORMING
+        message = (
+            f"The latest {len(streak)} batch/batches killed fewer than "
+            f"{min_kills} survivor(s) ({len(streak)} of {consecutive} needed "
+            "for a flat-yield streak). Watch the next batch's yield before "
+            "spending more of the phase on this module."
+        )
+    else:
+        status = STATUS_OK
+        message = (
+            f"Latest batch killed {rows[-1]['kills']} survivor(s) — "
+            "mutation-kill is converting rounds into kills."
+        )
+
+    average = (
+        round(sum(r["kills"] for r in measured) / len(measured), 2) if measured else None
+    )
+    return {
+        "status": status,
+        "batches_evaluated": len(rows),
+        "batches_measured": len(measured),
+        "min_kills": min_kills,
+        "consecutive_threshold": consecutive,
+        "streak": len(streak),
+        "flat_batches": streak,
+        "running_average_kills": average,
+        "batches": rows,
+        "message": message,
+    }
+
+
+def render_text(result: dict) -> str:
+    lines = [
+        f"Mutation-yield steering: {result['status']}",
+        result["message"],
+        "",
+        (
+            f"{'batch':<24}  {'start':>6}  {'end':>6}  {'kills':>6}  "
+            f"{'rounds':>6}  {'Δ score':>8}"
+        ),
+    ]
+    for row in result["batches"]:
+        kills = row["kills"]
+        move = row["score_movement"]
+        lines.append(
+            f"{row['batch']!s:<24}  "
+            f"{row['starting_survivors'] if row['starting_survivors'] is not None else '-':>6}  "
+            f"{row['ending_survivors'] if row['ending_survivors'] is not None else '-':>6}  "
+            f"{kills if kills is not None else '-':>6}  "
+            f"{row['rounds_spent'] if row['rounds_spent'] is not None else '-':>6}  "
+            f"{move if move is not None else '-':>8}"
+        )
+    lines.append("")
+    lines.append(f"running average kills per batch: {result['running_average_kills']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="mutation_yield_steering.py",
+        description=(
+            "Flag several consecutive mutation-kill batches whose net yield is "
+            "near zero, so Phase-1 targeting can be re-checked mid-phase."
+        ),
+    )
+    parser.add_argument(
+        "--history",
+        type=Path,
+        required=True,
+        help="Path to mutation-history.json.",
+    )
+    parser.add_argument(
+        "--min-kills",
+        type=int,
+        default=DEFAULT_MIN_KILLS,
+        help=(
+            "Minimum expected net survivors killed per batch "
+            f"(default: {DEFAULT_MIN_KILLS})."
+        ),
+    )
+    parser.add_argument(
+        "--consecutive",
+        type=int,
+        default=DEFAULT_CONSECUTIVE,
+        help=(
+            "How many consecutive below-minimum batches constitute a flat "
+            f"streak (default: {DEFAULT_CONSECUTIVE})."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    # An out-of-range threshold must fail loudly rather than produce a nonsense
+    # verdict: `--consecutive 0` makes `len(streak) >= consecutive` trivially
+    # true for any history (including an empty one), and `--min-kills 0` makes
+    # every batch — including one that ADDED survivors — count as progress.
+    if args.consecutive < 1:
+        parser.error("--consecutive must be >= 1")
+    if args.min_kills < 1:
+        parser.error("--min-kills must be >= 1")
+
+    try:
+        history = load_history(args.history)
+    except HistoryError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    result = evaluate(
+        batch_records(history),
+        min_kills=args.min_kills,
+        consecutive=args.consecutive,
+    )
+    print(json.dumps(result, indent=2) if args.json else render_text(result))
+    return 3 if result["status"] == STATUS_FLAT else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -220,6 +220,53 @@ def make_scoped_config(config: LoopConfig, source_file: str) -> dict:
     return {"stryker-config": scoped}
 
 
+def make_confirm_scoped_config(
+    config: LoopConfig, source_file: str, lines: Sequence[int]
+) -> dict:
+    """Build a Stryker config scoped to specific SOURCE LINES of one file.
+
+    #2031: every file that converges pays one full scoped mutation run to
+    learn it has converged, and that run generates nothing. The terminal
+    round only needs to re-test the handful of mutants that survived the
+    previous round, whose lines ``mutation_report.survivor_lines`` already
+    computes.
+
+    **The line-span syntax below is NOT yet verified against a real Stryker.**
+    Today ``mutate`` is only ever set at file-glob granularity here
+    (``make_scoped_config``), and every reference example in
+    ``csharp-stryker-net.md`` is a glob; narrowing below that is the new part.
+    This function is therefore **not wired into the default loop path** — see
+    #2031. Until someone exercises it against a real Stryker.NET and records
+    the result, treat the emitted span form as a proposal, not a contract.
+
+    The specific hazard, and why it must not be defaulted on blind: if Stryker
+    does not recognize the span suffix and matches nothing, the confirm run
+    reports **zero mutants**, and ``_score_round``'s existing ``total_mutants
+    == 0`` guard reads that as "NOT convergence" and stops the file (#1606).
+    A wrong guess here would silently truncate every file's loop while looking
+    like a saving. Any caller must therefore treat a zero-mutant confirm
+    result as "confirm scope produced nothing — fall back to a full scoped
+    run", never as a verdict.
+
+    Empty ``lines`` returns the ordinary whole-file scoped config, so a caller
+    that finds no clustered survivors degrades to today's behavior rather than
+    emitting a config that matches nothing.
+    """
+    if not lines:
+        return make_scoped_config(config, source_file)
+    spans = [f"**/{source_file}{{{line}..{line}}}" for line in sorted(set(lines))]
+    scoped = {
+        "solution": config.solution,
+        "project": config.project,
+        "test-projects": config.test_projects,
+        "mutate": spans,
+        "coverage-analysis": "perTest",
+        "reporters": ["json"],
+    }
+    scoped = {k: v for k, v in scoped.items() if v is not None}
+    return {"stryker-config": scoped}
+
+
 def _write_scoped_config(config: LoopConfig, source_file: str) -> Path:
     with tempfile.NamedTemporaryFile(
         suffix=".json", delete=False, mode="w", prefix="stryker-scoped-"

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_retry.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_retry.py
@@ -65,13 +65,61 @@ _GATEWAY_CLASS_MARKERS = (
     "connection reset",
 )
 
-# Anchored numeral markers (#1938): a bare "502"/"503"/"504" substring
-# false-positives on unrelated numbers (a request id, a byte count). Requires
-# a status-context word (status/http/code) within 12 non-digit characters
-# before the digits, so "HTTP 502", "status: 503", and "error code 504" all
-# match but "request id 502391" does not. Case-insensitive to match the six
-# non-numeric markers above.
-_GATEWAY_STATUS_RE = re.compile(r"\b(?:status|http|code)[^0-9]{0,12}50[234]\b", re.IGNORECASE)
+# Anchored numeral markers (#1938, widened by #1950): a bare "502"/"503"/"504"
+# substring false-positives on unrelated numbers (a request id, a byte count).
+# Requires a status-context word (status/http/code) close before the digits, so
+# "HTTP 502", "status: 503", and "error code 504" all match but
+# "request id 502391" does not.
+#
+# Three #1950 corrections to the original `\b(?:status|http|code)[^0-9]{0,12}50[234]\b`:
+#
+# 1. `\b` REJECTED UNDERSCORE-JOINED KEYS. `_` is a `\w` character, so `\b`
+#    requires a NON-word character immediately before status/http/code — and
+#    the `_c` in `error_code: 503` and the `rC` in `errorCode=504` are both
+#    word-to-word transitions. Underscore- and camel-joined status keys are
+#    routine in real provider payloads. The lookbehind is now
+#    `(?<![A-Za-z0-9])`, which treats `_` (and a camel boundary) as a
+#    separator while still refusing to match inside a longer alphanumeric run.
+# 2. `HTTP/1.1 502` FAILED because the version token puts digits in the gap,
+#    which `[^0-9]{0,12}` forbids. An optional `/<major>[.<minor>]` is now
+#    consumed explicitly rather than by widening the gap to allow digits —
+#    widening would have re-admitted exactly the "request id 502391" class
+#    #1938 anchored the pattern to exclude.
+# 3. STATUS 529 (Anthropic's own overload code) was absent from the numeral
+#    alternation. The downgrade ladder this policy drives is Anthropic-specific,
+#    so 529 is plausibly the most common real "retry me" signal this classifier
+#    will ever see. It was covered only via the `overloaded_error` marker
+#    string, which a rendered `API Error: 529 Overloaded` does not contain
+#    verbatim.
+#
+# The trailing `(?![0-9])` replaces `\b` for the same reason as the lookbehind,
+# and still rejects "502391" (the `2` is followed by `3`).
+#
+# 4. A CAMEL-JOINED key (`errorCode=504`) still fails a plain lookbehind: the
+#    `rC` transition is letter-to-letter, and the pattern is IGNORECASE so the
+#    lookbehind cannot itself distinguish case. Rather than relaxing the
+#    lookbehind to allow any preceding letter — which would admit "barcode 502"
+#    and "decode 503" — camel humps are split to `_` first, reducing the camel
+#    case to the underscore case already handled.
+# 5. `error` joins the context words so a rendered `API Error: 529 Overloaded`
+#    anchors at all; it carries none of status/http/code. The trailing
+#    `(?![0-9])` keeps this from admitting "error after 5024 ms".
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+_GATEWAY_STATUS_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:status|http|code|error)(?:/\d+(?:\.\d+)?)?"
+    r"[^0-9]{0,12}(?:50[234]|529)(?![0-9])",
+    re.IGNORECASE,
+)
+
+
+def _anchorable(text: str) -> str:
+    """Normalize camel humps to `_` so a camel-joined status key anchors.
+
+    Pure and deterministic: `errorCode=504` -> `error_Code=504`, which the
+    pattern's `(?<![A-Za-z0-9])` lookbehind then accepts.
+    """
+    return _CAMEL_SPLIT_RE.sub("_", text)
 
 # 3 consecutive gateway-class failures on the same model earn exactly one
 # same-model retry before a downgrade is considered (#1908).
@@ -98,9 +146,16 @@ def is_gateway_class_error(exc: BaseException) -> bool:
     """
     if not isinstance(exc, mutation_kill_shared.HeadlessCallFailed):
         return False
-    lowered = exc.stderr.lower()
+    # #1950: classify over stderr AND stdout. The claude CLI renders some
+    # upstream failures to stdout while stderr carries only a generic
+    # non-zero-exit line; a stderr-only classifier calls those non-gateway-class
+    # and spends the file's whole budget on a genuinely retryable overload.
+    # `getattr` rather than attribute access so a HeadlessCallFailed built by
+    # an older two-argument call site (or a test fake) still classifies.
+    combined = f"{exc.stderr}\n{getattr(exc, 'stdout', '') or ''}"
+    lowered = combined.lower()
     return any(marker in lowered for marker in _GATEWAY_CLASS_MARKERS) or bool(
-        _GATEWAY_STATUS_RE.search(exc.stderr)
+        _GATEWAY_STATUS_RE.search(_anchorable(combined))
     )
 
 
@@ -154,6 +209,15 @@ class DowngradeEvent:
     from_model: str | None
     to_model: str | None
     error_class: str
+    #: Whether this file had ALREADY spent its one downgrade before this
+    #: failure. #1952: on an exhausted event this is the actual reason the
+    #: caller computed and then discarded, forcing
+    #: :func:`_format_downgrade_message` to re-infer it from a proxy (is
+    #: ``from_model`` a known ladder model?) that a valid non-ladder
+    #: ``--model``/``DEV_TEAM_MUTATION_FALLBACK_MODEL`` override defeats.
+    #: Defaulted so every existing construction keeps working; the one
+    #: internal call site sets it explicitly.
+    already_downgraded: bool = False
 
     @property
     def exhausted(self) -> bool:
@@ -163,23 +227,18 @@ class DowngradeEvent:
         return self.to_model is None
 
 
-# Models with a defined ladder position — a downgrade that exhausts starting
-# from one of these (haiku, the floor; or opus/sonnet, only reachable here
-# after this file already spent its one downgrade) genuinely considered a
-# downgrade and ran out of ladder, so the "no further downgrade" wording is
-# accurate. ``None`` (unresolved) or any other model string (an operator
-# override outside the ladder, e.g. an unrecognized --model value) never had
-# a ladder position to begin with — a distinct, more honest message (#1908
-# review).
-_KNOWN_LADDER_MODELS = frozenset({"opus", "sonnet", "haiku"})
-
-
 def _format_downgrade_message(event: DowngradeEvent) -> str:
     source_file = " ".join(str(event.source_file).split())
     if event.exhausted:
-        normalized_from = event.from_model.strip().lower() if event.from_model else None
         model_label = event.from_model if event.from_model is not None else "unspecified"
-        if normalized_from in _KNOWN_LADDER_MODELS:
+        # #1952: branch on the reason the caller actually computed, not on
+        # whether from_model happens to be a ladder name. `fable` is a VALID
+        # --model / DEV_TEAM_MUTATION_FALLBACK_MODEL override that deliberately
+        # has no _MODEL_DOWNGRADE_LADDER entry, so a file that started on opus,
+        # downgraded once to fable, and then exhausted was reported as "no
+        # downgrade ladder position available for this model" when the true
+        # cause was "this file already spent its one downgrade".
+        if event.already_downgraded:
             return (
                 f"generation for {source_file} (round {event.round_num}) "
                 f"exhausted its retry budget on model {model_label!r} after "
@@ -321,6 +380,7 @@ def _retry_once_then_maybe_downgrade(
             from_model=from_model,
             to_model=to_model,
             error_class=error_class,
+            already_downgraded=already_downgraded,
         )
         ctx.log(_format_downgrade_message(event))
         if ctx.on_downgrade is not None:

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_shared.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_shared.py
@@ -509,9 +509,17 @@ class HeadlessCallFailed(RuntimeError):
     before.
     """
 
-    def __init__(self, returncode: int, stderr: str) -> None:
+    def __init__(self, returncode: int, stderr: str, stdout: str = "") -> None:
         self.returncode = returncode
         self.stderr = stderr
+        # #1950: the classifier was structurally blind to stdout. The claude
+        # CLI renders some upstream failures to stdout (a rendered
+        # "API Error: 529 Overloaded" body) while stderr carries only a
+        # generic non-zero-exit line, so a stderr-only classifier calls a
+        # genuinely retryable overload non-gateway-class and burns the file's
+        # whole budget on it. Defaulted so every existing two-argument
+        # construction — including test fakes — keeps working unchanged.
+        self.stdout = stdout
         super().__init__(str(self))
 
     def __str__(self) -> str:
@@ -569,7 +577,7 @@ def run_claude_headless(prompt: str, *, model: str | None, cwd: Path | None = No
             "DEV_TEAM_MUTATION_GENERATION_TIMEOUT_S to raise it)"
         ) from exc
     if result.returncode != 0:
-        raise HeadlessCallFailed(result.returncode, result.stderr)
+        raise HeadlessCallFailed(result.returncode, result.stderr, result.stdout or "")
     return strip_code_fences(result.stdout)
 
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_report.py
@@ -415,6 +415,94 @@ def survivors_by_line(report_path: Path, file_path: str) -> dict:
     return _survivors_by_line_from_data(load_report(report_path), file_path)
 
 
+def survivor_lines(report_path: Path, file_path: str) -> list[int]:
+    """Return the sorted, de-duplicated source lines carrying a Survived
+    mutant for one file — the set a #2031 confirm run needs to re-test.
+
+    Built on :func:`survivors_by_line` rather than re-deriving the clustering,
+    so the confirm scope and the generation targets can never disagree about
+    which lines had survivors. ``unclustered`` survivors (no resolvable line)
+    are deliberately excluded: they cannot be expressed as a line-scoped
+    mutate span, and a caller that cannot scope them must fall back to a full
+    scoped run rather than silently dropping them — see
+    :func:`confirm_scope_is_complete`.
+    """
+    clustered = survivors_by_line(report_path, file_path)
+    return sorted({c["line"] for c in clustered.get("clusters", [])})
+
+
+def confirm_scope_is_complete(report_path: Path, file_path: str) -> bool:
+    """Whether every Survived mutant for ``file_path`` has a resolvable line.
+
+    A confirm run narrowed to line spans can only re-test mutants whose line
+    is known. If any survivor is ``unclustered``, narrowing would silently
+    stop re-testing it, and its absence from the confirm result would read as
+    "killed" once spliced. Callers must run the ordinary full scoped round in
+    that case: correctness first, saving second.
+    """
+    clustered = survivors_by_line(report_path, file_path)
+    return not clustered.get("unclustered")
+
+
+def splice_confirm_over_prior(prior: dict, confirm: dict, file_path: str) -> dict:
+    """Overlay a survivor-scoped confirm result onto the prior round's report.
+
+    A confirm run mutates only the lines that had survivors last round, so its
+    report is a strict subset of the file's mutant set. Reporting it alone
+    would understate the file (every mutant outside the confirm scope would
+    vanish, inflating or deflating the score depending on their status). This
+    splices instead — the same pattern Phase 8 (``/quality-targets-converge``,
+    #1208) uses to report a whole-repo score from freshly-measured changed
+    files over a persisted baseline.
+
+    Mutants are matched by ``id`` where both sides carry one, falling back to
+    ``(line, mutatorName, replacement)`` — Stryker ids are stable within a run
+    but not guaranteed across runs. A confirm mutant replaces its prior
+    counterpart; a prior mutant the confirm run did not cover is carried
+    forward unchanged; a confirm mutant with no prior counterpart is added.
+
+    Never raises on malformed input, matching this module's standing posture:
+    an unusable side is treated as absent rather than fatal.
+    """
+
+    def _key(mutant: dict) -> tuple:
+        if not isinstance(mutant, dict):
+            return ("", "", "", "")
+        mid = mutant.get("id")
+        if isinstance(mid, (str, int)) and not isinstance(mid, bool):
+            return ("id", str(mid))
+        return (
+            "shape",
+            str(_resolve_survivor_line(mutant)),
+            str(mutant.get("mutatorName")),
+            str(mutant.get("replacement")),
+        )
+
+    prior_info = _find_file_info(prior if isinstance(prior, dict) else {}, file_path)
+    confirm_info = _find_file_info(
+        confirm if isinstance(confirm, dict) else {}, file_path
+    )
+    if not isinstance(prior_info, dict):
+        return confirm if isinstance(confirm, dict) else {}
+    prior_mutants = prior_info.get("mutants")
+    prior_mutants = prior_mutants if isinstance(prior_mutants, list) else []
+    confirm_mutants = (
+        confirm_info.get("mutants") if isinstance(confirm_info, dict) else None
+    )
+    confirm_mutants = confirm_mutants if isinstance(confirm_mutants, list) else []
+
+    merged = {_key(m): m for m in prior_mutants if isinstance(m, dict)}
+    for mutant in confirm_mutants:
+        if isinstance(mutant, dict):
+            merged[_key(mutant)] = mutant
+
+    spliced = json.loads(json.dumps(prior))
+    spliced_info = _find_file_info(spliced, file_path)
+    if isinstance(spliced_info, dict):
+        spliced_info["mutants"] = list(merged.values())
+    return spliced
+
+
 def _accepted_static_survivors_from_data(
     data: dict, file_path: str, *, skip_static_active: bool
 ) -> list[dict]:

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -150,7 +150,22 @@ def make_timeout_callback(
 # ── git worktree management ─────────────────────────────────────────────────────
 
 
-def _git(cmd: Sequence[str], repo_root: Path, *, check: bool) -> subprocess.CompletedProcess:
+def _git(cmd: Sequence[str], repo_root: Path, check: bool) -> subprocess.CompletedProcess:
+    """Run a git command in ``repo_root``.
+
+    ``check`` is deliberately POSITIONAL, not keyword-only. This is the default
+    ``GitRunner``, and that alias — ``Callable[[Sequence[str], Path, bool],
+    object]`` — is the contract every call site and every test fake already
+    implements positionally. Declaring it ``*, check`` here made the production
+    default the only implementation that did not satisfy its own alias, so
+    every real invocation (any path that does not inject a fake, which is all
+    of them: ``main()`` calls ``run_all(...)`` with no ``git_run``) raised
+    ``TypeError: _git() takes 2 positional arguments but 3 were given`` (#1953).
+
+    The bug was invisible to the suite precisely because every test injects a
+    fake, so the default was never exercised — which is why the regression
+    test below calls the real default rather than a fake.
+    """
     return subprocess.run(
         list(cmd), cwd=str(repo_root), capture_output=True, check=check
     )

--- a/plugins/dev-team/skills/test-improve/references/phase-5-improve.md
+++ b/plugins/dev-team/skills/test-improve/references/phase-5-improve.md
@@ -129,6 +129,49 @@ assignment alone is not a substitute for worktree isolation here.
    **Name the batches when the phase starts**, so the operator sees the
    grouping rather than inferring it from dispatch counts: print one line per
    batch — `Mutation-kill batch <n>: module <module>, Stories <ids>.`
+
+   **Mutation-yield steering check at the batch boundary (issue #2033).**
+   After each batch's `mutation-kill` dispatch returns, append one record to
+   `.dev-team-reports/test-improve/<slug>/data/mutation-history.json` — the
+   git-tracked `data/` sibling of `coverage-history.json`, written atomically
+   the way the baselines are — carrying `batch`, `module`, `captured_at`,
+   `starting_survivors`, `ending_survivors`, `honest_score_before`,
+   `honest_score_after`, and `rounds_spent`. Then run the trailing-streak
+   check. Do not eyeball the history:
+
+   ```
+   sh "${CLAUDE_PLUGIN_ROOT}/hooks/py.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/mutation_yield_steering.py" \
+     --history .dev-team-reports/test-improve/<slug>/data/mutation-history.json \
+     --json
+   ```
+
+   This is the #1790 mechanism ported to the more expensive lane, and it
+   shares that script's status vocabulary and exit-code contract exactly, so
+   read the exit codes the same way:
+
+   - **Exit 0** — continue to the next batch, but read *which* exit-0 status
+     came back: `ok` means the last batch actually killed survivors;
+     `insufficient_history` means too few batches have closed (or the latest
+     batch's yield could not be measured) to judge a streak;
+     `flat_streak_forming` means the latest batch did **not** clear the
+     minimum but the streak is still short of the threshold — echo that one
+     to the operator as a watch signal rather than silently treating it as
+     `ok`.
+   - **Exit 2** — the history is missing, unreadable, or corrupt. **Never
+     read this as `ok`** — it is the same trap #1790 calls out. Fix the
+     history before continuing.
+   - **Exit 3** (`flat_streak`) — two or more consecutive batches (the
+     default; `--consecutive` and `--min-kills` tune it) killed fewer than
+     the minimum net survivors. **Surface it now, at the batch boundary** —
+     per-Story would be meaningless because `mutation-kill` runs per batch.
+     Print the script's flat-batch list and running average, then prompt
+     **`[t] re-check Phase-1 targeting / [c] continue`** — the same `[t/c]`
+     shape the coverage check uses:
+     - **`[t]`** — re-read `coverage-gap-ranking.json` and re-order the
+       remaining batches into its rank order before the next dispatch.
+     - **`[c]`** — continue, recording
+       `mutation_flat_streak: <n> batches` in the phase's progress file so
+       the Phase-9 report carries the accepted signal rather than losing it.
 6. **Go mutation-kill is advisory.** On Go stacks, `mutation-kill` logs
    survivors but makes **no commit** — the operator is instructed to apply
    changes manually. Advisory-only handling matches the Phase-0 Go advisory,

--- a/plugins/dev-team/tests/scripts/test_mutation_yield_steering.py
+++ b/plugins/dev-team/tests/scripts/test_mutation_yield_steering.py
@@ -1,0 +1,266 @@
+"""Tests for scripts/mutation_yield_steering.py — flag several consecutive
+near-zero-yield mutation-kill batches mid-Phase-5 (issue #2033).
+
+The defect these tests pin: Phase 5 had a mid-phase steering check for
+coverage (#1790) and none for mutation, so a batch yielding near-zero net
+kills did not inform the next batch — the lane ran to the end of the Story
+set regardless of what earlier batches showed. This is the more expensive of
+the two lanes.
+
+Deliberately mirrors test_coverage_delta_steering.py: #2033 ports #1790's
+mechanism rather than inventing one, so the two suites should stay legible
+side by side.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+SCRIPT = SCRIPTS_DIR / "mutation_yield_steering.py"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from mutation_yield_steering import (
+    DEFAULT_CONSECUTIVE,
+    DEFAULT_MIN_KILLS,
+    batch_records,
+    evaluate,
+    main,
+)
+
+
+def _record(
+    batch: str | None,
+    starting: object = 10,
+    ending: object = 5,
+    *,
+    before: float = 60.0,
+    after: float = 70.0,
+    rounds: int = 3,
+) -> dict:
+    return {
+        "phase": 5,
+        "captured_at": "2026-08-26T00:00:00Z",
+        "batch": batch,
+        "module": "payments",
+        "starting_survivors": starting,
+        "ending_survivors": ending,
+        "honest_score_before": before,
+        "honest_score_after": after,
+        "rounds_spent": rounds,
+    }
+
+
+def _write(tmp_path: Path, records: list[dict]) -> Path:
+    path = tmp_path / "mutation-history.json"
+    path.write_text(json.dumps(records), encoding="utf-8")
+    return path
+
+
+# --- yield measurement ------------------------------------------------------
+
+
+def test_yield_is_net_survivors_killed():
+    result = evaluate([_record("b1", starting=10, ending=4)])
+    assert result["batches"][0]["kills"] == 6
+
+
+def test_a_batch_that_added_survivors_counts_as_flat():
+    """Negative yield is not progress — it must not clear the minimum."""
+    result = evaluate([_record("b1", starting=4, ending=10)], consecutive=1)
+    assert result["batches"][0]["kills"] == -6
+    assert result["status"] == "flat_streak"
+
+
+def test_unmeasurable_yield_breaks_the_streak_rather_than_extending_it():
+    """Absence of measurement is not evidence of flatness — the same rule
+    #1790 applies to an unmeasurable Story."""
+    records = [
+        _record("b1", starting=10, ending=10),
+        _record("b2", starting=None, ending=None),
+        _record("b3", starting=10, ending=10),
+    ]
+    result = evaluate(records, consecutive=2)
+    # b3 is flat, b2 breaks the streak, so the streak is 1 — not 2.
+    assert result["streak"] == 1
+    assert result["status"] != "flat_streak"
+
+
+def test_booleans_are_not_accepted_as_survivor_counts():
+    """bool is an int subclass in Python but is never a survivor count."""
+    result = evaluate([_record("b1", starting=True, ending=False)])
+    assert result["batches"][0]["kills"] is None
+
+
+# --- statuses ---------------------------------------------------------------
+
+
+def test_flat_streak_at_the_threshold(tmp_path):
+    records = [_record("b1", 10, 10), _record("b2", 10, 10)]
+    result = evaluate(records, consecutive=2)
+    assert result["status"] == "flat_streak"
+    assert result["streak"] == 2
+
+
+def test_flat_streak_forming_is_distinct_from_ok():
+    """"Not yet a streak" is not "mutation-kill is producing kills" — the
+    false all-clear this gate exists to prevent."""
+    # Three measured batches so `insufficient_history` does not outrank the
+    # verdict under test, with only the trailing one flat.
+    records = [_record("b1", 10, 2), _record("b2", 10, 2), _record("b3", 10, 10)]
+    result = evaluate(records, consecutive=3)
+    assert result["status"] == "flat_streak_forming"
+    assert result["streak"] == 1
+
+
+def test_insufficient_history_is_not_ok():
+    result = evaluate([_record("b1", 10, 2)], consecutive=2)
+    assert result["status"] == "insufficient_history"
+
+
+def test_insufficient_history_when_the_trailing_batch_is_unmeasurable():
+    records = [
+        _record("b1", 10, 2),
+        _record("b2", 10, 2),
+        _record("b3", starting=None, ending=None),
+    ]
+    result = evaluate(records, consecutive=2)
+    assert result["status"] == "insufficient_history"
+
+
+def test_ok_when_the_latest_batch_met_the_minimum():
+    records = [_record("b1", 10, 10), _record("b2", 10, 2)]
+    result = evaluate(records, consecutive=2)
+    assert result["status"] == "ok"
+
+
+# --- score movement is reported but never decides ---------------------------
+
+
+def test_score_movement_is_reported():
+    result = evaluate([_record("b1", before=60.0, after=72.5)])
+    assert result["batches"][0]["score_movement"] == 12.5
+
+
+def test_score_movement_does_not_rescue_a_flat_yield():
+    """A batch can move the percentage without killing survivors on a large
+    module; keying the gate on score would make it module-size-dependent."""
+    records = [
+        _record("b1", 10, 10, before=60.0, after=90.0),
+        _record("b2", 10, 10, before=90.0, after=99.0),
+    ]
+    assert evaluate(records, consecutive=2)["status"] == "flat_streak"
+
+
+# --- record filtering -------------------------------------------------------
+
+
+def test_records_without_a_batch_are_excluded():
+    """A whole-suite measurement written into the same stream is not a batch
+    boundary and must not enter the streak."""
+    records = [_record("b1"), _record(None), {"phase": 8, "honest_score_after": 80.0}]
+    assert [r["batch"] for r in batch_records(records)] == ["b1"]
+
+
+# --- CLI contract: exit codes and loud failure ------------------------------
+
+
+def test_flat_streak_exits_3(tmp_path, capsys):
+    history = _write(tmp_path, [_record("b1", 10, 10), _record("b2", 10, 10)])
+    assert main(["--history", str(history), "--consecutive", "2"]) == 3
+
+
+def test_ok_exits_0(tmp_path, capsys):
+    history = _write(tmp_path, [_record("b1", 10, 2), _record("b2", 10, 2)])
+    assert main(["--history", str(history), "--consecutive", "2"]) == 0
+
+
+def test_missing_history_exits_2_never_ok(tmp_path, capsys):
+    """#1790's trap, ported: an unreadable history must never read as ok."""
+    rc = main(["--history", str(tmp_path / "nope.json")])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_non_array_history_exits_2(tmp_path, capsys):
+    path = tmp_path / "mutation-history.json"
+    path.write_text(json.dumps({"batch": "b1"}), encoding="utf-8")
+    assert main(["--history", str(path)]) == 2
+
+
+def test_corrupt_element_exits_2_rather_than_being_dropped(tmp_path, capsys):
+    """A half-rewritten history must not be indistinguishable from a phase
+    that simply hasn't closed enough batches yet."""
+    path = tmp_path / "mutation-history.json"
+    path.write_text(json.dumps([_record("b1"), "garbage"]), encoding="utf-8")
+    assert main(["--history", str(path)]) == 2
+
+
+def test_unparseable_json_exits_2(tmp_path, capsys):
+    path = tmp_path / "mutation-history.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert main(["--history", str(path)]) == 2
+
+
+def test_consecutive_below_one_is_rejected(tmp_path):
+    """--consecutive 0 makes the streak check trivially true for any history,
+    including an empty one."""
+    history = _write(tmp_path, [_record("b1")])
+    with __import__("pytest").raises(SystemExit):
+        main(["--history", str(history), "--consecutive", "0"])
+
+
+def test_min_kills_below_one_is_rejected(tmp_path):
+    """--min-kills 0 makes every batch — including one that ADDED survivors —
+    count as progress."""
+    history = _write(tmp_path, [_record("b1")])
+    with __import__("pytest").raises(SystemExit):
+        main(["--history", str(history), "--min-kills", "0"])
+
+
+def test_json_output_is_machine_readable(tmp_path, capsys):
+    history = _write(tmp_path, [_record("b1", 10, 10), _record("b2", 10, 10)])
+    main(["--history", str(history), "--consecutive", "2", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "flat_streak"
+    assert payload["streak"] == 2
+
+
+# --- shared contract with #1790 --------------------------------------------
+
+
+def test_status_vocabulary_matches_the_coverage_sibling():
+    """#2033 ports #1790's mechanism; an operator reading one must already
+    know how to read the other, and /test-improve branches on both."""
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    import coverage_delta_steering as coverage
+    import mutation_yield_steering as mutation
+
+    assert mutation.STATUS_FLAT == coverage.STATUS_FLAT
+    assert mutation.STATUS_FORMING == coverage.STATUS_FORMING
+    assert mutation.STATUS_OK == coverage.STATUS_OK
+    assert mutation.STATUS_INSUFFICIENT == coverage.STATUS_INSUFFICIENT
+
+
+def test_runs_as_a_subprocess_under_the_shipped_interpreter(tmp_path):
+    """Shipped script: must run standalone, stdlib-only, no import shims."""
+    history = _write(tmp_path, [_record("b1", 10, 10), _record("b2", 10, 10)])
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--history", str(history), "--consecutive", "2"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 3
+    assert "flat_streak" in proc.stdout
+
+
+def test_defaults_are_batch_shaped():
+    """mutation-kill runs per batch with --max-rounds 3, so two consecutive
+    dead batches is the point at which re-targeting is cheaper than another
+    dispatch."""
+    assert DEFAULT_MIN_KILLS == 1
+    assert DEFAULT_CONSECUTIVE == 2

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -574,6 +574,25 @@ chk_hook_units() {
     printf '%s∼ skipped (pytest not installed — see requirements-dev.txt)%s\n' "$yellow" "$reset"
     return 0
   fi
+  # Tree-hash cache (#2002). This suite ran 1,029 times in 30 days (27% of all
+  # pytest invocations), including 35 sessions that re-ran the identical
+  # command >= 8 times and one that ran it 34 times. The waste is re-running an
+  # UNCHANGED tree, which a content hash detects exactly.
+  #
+  # The key covers the whole working tree, not a per-check subset: hashing
+  # everything costs ~0.1s against a ~90s suite, so a subset buys nothing and
+  # would reintroduce the superset problem #2003 documents (a path the suite
+  # reads but the hash forgot = a silent false skip). ci_tree_cache.py answers
+  # "not fresh" on every failure path, so an unreadable cache or a git error
+  # runs the suite rather than skipping it.
+  #
+  # Opt out with CI_LOCAL_NO_TREE_CACHE=1.
+  if [ "${CI_LOCAL_NO_TREE_CACHE:-0}" != "1" ] \
+    && python3 scripts/ci_tree_cache.py is-fresh chk_hook_units >/dev/null 2>&1; then
+    printf '%s∼ skipped (tree unchanged since this suite last passed; CI_LOCAL_NO_TREE_CACHE=1 to force)%s\n' \
+      "$yellow" "$reset"
+    return 0
+  fi
   # tests/agents/, tests/commands/, tests/docs/, tests/knowledge/, and
   # tests/stack_aware/ (formerly tests/bats/) were ported from bats to pytest under issue #675 (epic
   # #668). tests/repo/'s eval/cost/telemetry/workflow-audit suites were
@@ -639,6 +658,13 @@ chk_hook_units() {
     --ignore=tests/scripts/test_csharp_stryker_net_wrapper.py \
     --ignore=tests/scripts/test_csharp_stryker_net_status_loop.py \
     ${parallel[@]+"${parallel[@]}"}
+  local rc=$?
+  # Record ONLY on green (#2002): a red run must never poison the cache into
+  # skipping the very failure it just found.
+  if [ "$rc" -eq 0 ] && [ "${CI_LOCAL_NO_TREE_CACHE:-0}" != "1" ]; then
+    python3 scripts/ci_tree_cache.py record chk_hook_units >/dev/null 2>&1 || true
+  fi
+  return "$rc"
 }
 # Informational coverage report over the plugin's own source (.coveragerc) —
 # a SEPARATE, SERIAL run, deliberately not folded into chk_hook_units above.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -765,6 +765,17 @@ for entry in "${CHECKS[@]}"; do
     idx=$((idx + 1))
     continue
   fi
+  # Second, independent skip lever (#2003): every changed file is provably
+  # inert for this check. Universal quantifier, unlike the existential test
+  # above — see the rationale in scripts/lib/ci-changed-only.sh. Reported with
+  # its own wording so a reader can tell the two levers apart in the summary.
+  if [ "$CHANGED_ONLY" = "1" ] && ci_suite_is_all_inert "$fn" "$CHANGED_LIST"; then
+    printf '%s∼ skipped (every changed file is inert for this check)%s\n' \
+      "$yellow" "$reset" >"$RUNDIR/$idx.out"
+    echo 0 >"$RUNDIR/$idx.rc"
+    idx=$((idx + 1))
+    continue
+  fi
   # Time each check with the `time` keyword (TIMEFORMAT='%R' -> bare real
   # seconds) inside its own subshell, writing the real time to a per-index file
   # alongside .out/.rc. One subshell owns each index, so concurrent checks cannot

--- a/scripts/ci_tree_cache.py
+++ b/scripts/ci_tree_cache.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""ci_tree_cache.py — skip a gate whose tree has not changed since it last
+passed (issue #2002).
+
+Why this exists. `chk_hook_units` collects 9,469 tests and is the gate's
+wall-clock long pole. Session-report data shows **1,029 runs of that exact
+directory list in 30 days (27% of all pytest invocations)**, plus 35 cases of
+an identical pytest command repeated >= 8x within a single session, worst case
+**34x**. The waste is re-running an unchanged tree, and a content hash detects
+exactly that: the 34x case collapses to one run.
+
+Why the key covers the WHOLE tracked tree, not a per-check subset
+-----------------------------------------------------------------
+This is a gate-skipping mechanism, so a false skip is silent and CI-only —
+the same danger #2003 analyses for the watched-path lever. A per-check hash
+set would have to be a permanent SUPERSET of everything the suite reads, and
+for `chk_hook_units` that is already `.claude/`, `docs/`, `evals/`, `.husky/`,
+`.github/`, `README.md`, `package.json`, `package-lock.json`,
+`.claude-plugin/`, `ruff.toml`, `plugins/`, `scripts/`, `tests/` — open-ended
+and growing with every content-guard. A forgotten path there is a false skip.
+
+Hashing the entire tracked tree costs ~64ms against a ~90s suite, so the
+subset buys nothing and risks correctness. Everything is hashed; any change
+anywhere invalidates every cached entry. The superset problem does not arise
+because there is no subset.
+
+Safety posture — every failure path answers "not fresh"
+------------------------------------------------------
+`is-fresh` exits non-zero (run the suite) on: an unknown check, a missing or
+unreadable cache, a cache written by a different repo root, a git failure, or
+any unexpected exception. A gate that cannot fail is worse than no gate; a
+cache that skips on error is that gate. The only exit-0 path is a recorded key
+that byte-equals a freshly computed one.
+
+`record` is called ONLY after a green run, so a red run never poisons the
+cache into skipping.
+
+Stdlib-only, Python 3.10+ floor. Not shipped with the plugin — this is
+repo-root developer tooling (see CLAUDE.md's scope note for `scripts/*`).
+
+Usage:
+    python3 scripts/ci_tree_cache.py key
+    python3 scripts/ci_tree_cache.py is-fresh chk_hook_units && echo skip
+    python3 scripts/ci_tree_cache.py record chk_hook_units
+    python3 scripts/ci_tree_cache.py clear
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+#: Checks that may consult the cache. Deliberately an allowlist: a check not
+#: named here can never be skipped by this mechanism, mirroring the safe
+#: default the --changed-only levers use for unmapped checks.
+CACHEABLE_CHECKS = frozenset({"chk_hook_units"})
+
+#: Cache version. Bump to invalidate every stored entry when the key
+#: computation itself changes — otherwise a stale key from an older algorithm
+#: could compare equal by coincidence of format.
+CACHE_VERSION = 1
+
+_GIT_TIMEOUT_S = 60
+
+
+def cache_path() -> Path:
+    """Per-user cache file, alongside the pinned-shellcheck download."""
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "agentic-dev-team" / "tree-cache.json"
+
+
+def _git(args: list[str], repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=_GIT_TIMEOUT_S,
+    )
+    return result.stdout
+
+
+def repo_root() -> Path:
+    return Path(
+        _git(["rev-parse", "--show-toplevel"], Path.cwd()).strip()
+    ).resolve()
+
+
+def _tracked_and_untracked(root: Path) -> list[str]:
+    """Every file git considers part of the working tree.
+
+    Tracked files plus untracked-but-not-ignored ones — the latter matter
+    because a brand-new test file that nobody has `git add`ed yet still
+    changes what the suite collects. Ignored files are excluded: build output
+    and caches are not inputs.
+    """
+    tracked = _git(["ls-files", "-z"], root).split("\0")
+    untracked = _git(
+        ["ls-files", "-z", "--others", "--exclude-standard"], root
+    ).split("\0")
+    return sorted({f for f in (*tracked, *untracked) if f})
+
+
+def compute_key(root: Path) -> str:
+    """A content hash over the whole working tree.
+
+    Path, size, and bytes all feed the digest, with an explicit length prefix
+    so two files cannot be confused by concatenation (a rename that shifts
+    content across a boundary must change the key).
+    """
+    digest = hashlib.sha256()
+    digest.update(f"v{CACHE_VERSION}\0".encode())
+    for rel in _tracked_and_untracked(root):
+        path = root / rel
+        try:
+            payload = path.read_bytes()
+        except (OSError, ValueError):
+            # A path git lists but we cannot read (a broken symlink, a race
+            # with a concurrent write). Fold the failure into the key rather
+            # than ignoring it, so the tree is never treated as equal to one
+            # where the file read cleanly.
+            digest.update(b"UNREADABLE\0")
+            digest.update(rel.encode())
+            continue
+        digest.update(rel.encode())
+        digest.update(b"\0")
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _load_cache() -> dict:
+    try:
+        payload = json.loads(cache_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _entry_key(root: Path, check: str) -> str:
+    """Namespace entries by repo root so sibling worktrees never share a
+    verdict — two worktrees of this repo have different trees at the same
+    check name."""
+    return f"{root}::{check}"
+
+
+def is_fresh(root: Path, check: str) -> bool:
+    if check not in CACHEABLE_CHECKS:
+        return False
+    cache = _load_cache()
+    if cache.get("version") != CACHE_VERSION:
+        return False
+    recorded = cache.get("entries", {})
+    if not isinstance(recorded, dict):
+        return False
+    stored = recorded.get(_entry_key(root, check))
+    if not isinstance(stored, str) or not stored:
+        return False
+    return stored == compute_key(root)
+
+
+def record(root: Path, check: str) -> None:
+    if check not in CACHEABLE_CHECKS:
+        return
+    cache = _load_cache()
+    entries = cache.get("entries")
+    if not isinstance(entries, dict) or cache.get("version") != CACHE_VERSION:
+        entries = {}
+    entries[_entry_key(root, check)] = compute_key(root)
+    path = cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Write-then-rename so a crash mid-write cannot leave a truncated cache
+    # that later parses as a valid-but-wrong entry.
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps({"version": CACHE_VERSION, "entries": entries}, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci_tree_cache.py",
+        description=(
+            "Skip a gate whose working tree is byte-identical to the one it "
+            "last passed on."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("key", help="print the current tree key")
+    fresh = sub.add_parser(
+        "is-fresh", help="exit 0 iff <check> already passed on this exact tree"
+    )
+    fresh.add_argument("check")
+    rec = sub.add_parser("record", help="record <check> as passing on this tree")
+    rec.add_argument("check")
+    sub.add_parser("clear", help="delete the cache")
+    args = parser.parse_args(argv)
+
+    # Every unexpected failure resolves to "not fresh" / no-op, never a skip.
+    try:
+        root = repo_root()
+        if args.command == "key":
+            print(compute_key(root))
+            return 0
+        if args.command == "is-fresh":
+            return 0 if is_fresh(root, args.check) else 1
+        if args.command == "record":
+            record(root, args.check)
+            return 0
+        if args.command == "clear":
+            cache_path().unlink(missing_ok=True)
+            return 0
+    except (subprocess.SubprocessError, OSError, ValueError) as exc:
+        print(f"ci_tree_cache: {exc}", file=sys.stderr)
+        return 1
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/impact_tests.py
+++ b/scripts/impact_tests.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""impact_tests.py — select the tests a change can actually affect (issue #2005).
+
+The inner loop had two speeds: run one file (46% of observed invocations) or
+run the full 9,469-test directory list (27%). Nothing in between, so "I changed
+something, what does it affect?" was answered by a developer's guess. Per
+CLAUDE.md, that is a mechanical question and inference fails it in the
+expensive direction twice over: guess narrow and miss a regression, guess wide
+and pay for the whole suite.
+
+Why coverage contexts, not pytest-testmon
+-----------------------------------------
+#2005 lists testmon as option 2 and, as option 3, asks whether an existing
+per-test map can be built on instead of adding a dependency. It can.
+`pytest-cov` is ALREADY in requirements-dev.txt and already runs under
+`chk_coverage_report`, and `--cov-context=test` records which test executed
+which line. That is the exact per-test map testmon would install a new
+dependency to provide, so this adds none.
+
+Relationship to the tree-hash cache (#2002)
+-------------------------------------------
+They answer different questions and compose. #2002 answers "has anything
+changed at all" and skips the suite outright when nothing has. This answers
+"given that something changed, what does it reach". Neither subsumes the other.
+
+Safety posture — never silently narrow
+--------------------------------------
+Selecting a subset is only sound when the map can account for the change.
+`select` REFUSES (exit 2, empty selection) rather than guessing when:
+
+  - the map is missing, unreadable, or malformed
+  - a changed file is absent from the map entirely — a new or previously
+    uncovered source file has unknown reach, and "no test covers it" is
+    indistinguishable from "the map predates it"
+  - a changed file is itself a test file — it must run regardless, and a test
+    added since the map was built has no entry at all
+  - the map is older than the current tree in a way it cannot reconcile
+
+Exit 2 means "run the full suite". A caller must treat any non-zero exit as
+the full suite, never as an empty selection.
+
+Stdlib-only at read time (the build step shells out to pytest). Python 3.10+
+floor. Repo-root developer tooling, not shipped with the plugin.
+
+Usage:
+    python3 scripts/impact_tests.py build --out .cache/impact-map.json
+    python3 scripts/impact_tests.py select --map .cache/impact-map.json \\
+        --changed plugins/dev-team/hooks/telemetry.py
+    python3 scripts/impact_tests.py select --map <path> --changed-from-git
+
+Feeding the result to pytest (file granularity, the default):
+
+    python3 scripts/impact_tests.py select --map <path> --changed-from-git \
+      | xargs python3 -m pytest -q
+
+Exact node ids need NUL separation — a parametrized id can contain spaces:
+
+    python3 scripts/impact_tests.py select --map <path> --changed-from-git \
+      --granularity test --null | xargs -0 python3 -m pytest -q
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+MAP_VERSION = 1
+
+#: Suffixes that mark a path as a test file. A changed test file always runs,
+#: and a test added since the map was built has no entry, so the map can never
+#: prove its reach.
+_TEST_MARKERS = ("test_", "_test.")
+
+EXIT_OK = 0
+EXIT_RUN_EVERYTHING = 2
+
+
+def _repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return Path(out.stdout.strip()).resolve()
+
+
+def is_test_path(rel: str) -> bool:
+    name = Path(rel).name
+    return name.startswith(_TEST_MARKERS[0]) or _TEST_MARKERS[1] in name
+
+
+def _table_exists(connection: sqlite3.Connection, name: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def read_contexts(coverage_db: Path, root: Path) -> dict[str, list[str]]:
+    """Map source file -> the test node ids that executed it.
+
+    Reads coverage.py's own SQLite schema. Contexts are recorded as
+    ``path::test_name|run``; the ``|run`` suffix is coverage's phase marker and
+    is stripped so the result is a pytest-runnable node id.
+    """
+    mapping: dict[str, set[str]] = {}
+    connection = sqlite3.connect(f"file:{coverage_db}?mode=ro", uri=True)
+    try:
+        rows: list[tuple] = []
+        # Coverage stores measurements in `line_bits` under line coverage and
+        # in `arc` under BRANCH coverage — never both. This repo's .coveragerc
+        # sets `branch = True`, so a `line_bits`-only query returns zero rows
+        # and yields a silently empty map: measured, not assumed (files: 135,
+        # contexts: 23, line_bits: 0). Both tables are read and unioned so the
+        # map does not depend on which mode the caller's config selected.
+        for table in ("line_bits", "arc"):
+            if not _table_exists(connection, table):
+                continue
+            rows.extend(
+                connection.execute(
+                    f"SELECT DISTINCT c.context, f.path "
+                    f"FROM {table} t "
+                    "JOIN context c ON c.id = t.context_id "
+                    "JOIN file f ON f.id = t.file_id"
+                ).fetchall()
+            )
+    finally:
+        connection.close()
+
+    for context, path in rows:
+        if not context:
+            # The empty context is coverage recorded outside any test (import
+            # time). It names no test, so it cannot select one.
+            continue
+        node = context.split("|", 1)[0]
+        try:
+            rel = str(Path(path).resolve().relative_to(root))
+        except ValueError:
+            # Outside the repo (site-packages). Not a change we can be asked
+            # about, so it cannot affect selection.
+            continue
+        mapping.setdefault(rel, set()).add(node)
+    return {path: sorted(nodes) for path, nodes in sorted(mapping.items())}
+
+
+#: Source trees the map measures. Deliberately NOT `.coveragerc`'s `source`
+#: list, which scopes to `plugins/dev-team/hooks` and `scripts` for the
+#: informational coverage report. That list omits `plugins/dev-team/scripts`
+#: and `plugins/dev-team/skills`, so a bare `--cov` yields a map with zero
+#: contexts for anything living there — measured, not assumed: the first build
+#: against `.coveragerc` mapped 0 files. A map that silently covers less than
+#: the caller believes is the false-narrow failure this tool must never have,
+#: so the targets are named here explicitly.
+DEFAULT_COV_TARGETS = (
+    "plugins/dev-team/hooks",
+    "plugins/dev-team/scripts",
+    "plugins/dev-team/skills",
+    "scripts",
+)
+
+
+def build(
+    out: Path, pytest_args: list[str], root: Path, cov_targets: list[str]
+) -> int:
+    """Run the suite once under per-test coverage contexts and store the map."""
+    env = dict(os.environ)
+    data_file = out.parent / ".impact-coverage"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    env["COVERAGE_FILE"] = str(data_file)
+
+    cov_flags = [f"--cov={target}" for target in cov_targets]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *cov_flags,
+            "--cov-context=test",
+            "--cov-report=",
+            "-q",
+            *pytest_args,
+        ],
+        cwd=str(root),
+        env=env,
+        check=False,
+    )
+    if not data_file.exists():
+        print(
+            "impact_tests: no coverage data produced — is pytest-cov installed?",
+            file=sys.stderr,
+        )
+        return EXIT_RUN_EVERYTHING
+
+    mapping = read_contexts(data_file, root)
+    if not mapping:
+        # An empty map is never usable, and writing one would let `select`
+        # refuse on every file forever while looking configured. Fail loudly.
+        print(
+            "impact_tests: the run produced no per-test contexts — nothing was "
+            "measured under --cov, so no map was written",
+            file=sys.stderr,
+        )
+        return EXIT_RUN_EVERYTHING
+    out.write_text(
+        json.dumps(
+            {
+                "version": MAP_VERSION,
+                "pytest_returncode": result.returncode,
+                "files": mapping,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"impact_tests: mapped {len(mapping)} source file(s) -> tests", file=sys.stderr)
+    return EXIT_OK
+
+
+def load_map(path: Path) -> dict[str, list[str]] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("version") != MAP_VERSION:
+        return None
+    files = payload.get("files")
+    if not isinstance(files, dict):
+        return None
+    return {k: v for k, v in files.items() if isinstance(v, list)}
+
+
+def select(mapping: dict[str, list[str]], changed: list[str]) -> tuple[list[str], str]:
+    """Return (test node ids, reason-if-refused).
+
+    A non-empty reason means the caller must run the full suite: the selection
+    is not trustworthy, and an empty list must never be read as "nothing to
+    run".
+    """
+    if not changed:
+        return [], "no changed files supplied"
+
+    selected: set[str] = set()
+    for rel in changed:
+        if is_test_path(rel):
+            return [], (
+                f"{rel} is a test file — a changed or newly added test must run "
+                "regardless, and the map cannot prove the reach of a test it "
+                "was built before"
+            )
+        if rel not in mapping:
+            return [], (
+                f"{rel} is absent from the impact map — a new or uncovered "
+                "source file has unknown reach, and that is indistinguishable "
+                "from a map built before it existed"
+            )
+        selected.update(mapping[rel])
+
+    if not selected:
+        return [], (
+            "every changed file is in the map but no test covers any of them — "
+            "refusing to select nothing"
+        )
+    return sorted(selected), ""
+
+
+def _changed_from_git(root: Path) -> list[str]:
+    tracked = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD", "--"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    ).stdout.split()
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    ).stdout.split()
+    return sorted({*tracked, *untracked})
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="impact_tests.py",
+        description="Select the tests a change can actually affect.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    b = sub.add_parser("build", help="build the per-test impact map")
+    b.add_argument("--out", type=Path, required=True)
+    b.add_argument(
+        "--cov",
+        dest="cov_targets",
+        action="append",
+        default=None,
+        help=(
+            "source tree to measure (repeatable). Defaults to "
+            f"{', '.join(DEFAULT_COV_TARGETS)} — NOT .coveragerc's narrower list."
+        ),
+    )
+    b.add_argument("pytest_args", nargs="*", help="paths/args passed to pytest")
+
+    s = sub.add_parser("select", help="print the tests a change can affect")
+    s.add_argument("--map", dest="map_path", type=Path, required=True)
+    s.add_argument("--changed", nargs="*", default=[])
+    s.add_argument(
+        "--changed-from-git",
+        action="store_true",
+        help="derive the changed set from the working tree",
+    )
+    s.add_argument(
+        "--granularity",
+        choices=("file", "test"),
+        default="file",
+        help=(
+            "file (default): emit test FILE paths. test: emit exact node ids. "
+            "File is the default deliberately — a parametrized node id can "
+            "contain spaces and brackets, so a naive $(...) split corrupts it, "
+            "and ids churn whenever a parametrize list changes while the file "
+            "path does not. File granularity is nearly as selective and far "
+            "more robust."
+        ),
+    )
+    s.add_argument(
+        "--null",
+        action="store_true",
+        help=(
+            "NUL-separate the output for `xargs -0`. Required for safe "
+            "--granularity test consumption, since node ids may contain spaces."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        root = _repo_root()
+    except (subprocess.SubprocessError, OSError) as exc:
+        print(f"impact_tests: {exc}", file=sys.stderr)
+        return EXIT_RUN_EVERYTHING
+
+    if args.command == "build":
+        targets = args.cov_targets or list(DEFAULT_COV_TARGETS)
+        return build(args.out, args.pytest_args, root, targets)
+
+    mapping = load_map(args.map_path)
+    if mapping is None:
+        print(
+            "impact_tests: no usable impact map — run the full suite",
+            file=sys.stderr,
+        )
+        return EXIT_RUN_EVERYTHING
+
+    changed = list(args.changed)
+    if args.changed_from_git:
+        try:
+            changed.extend(_changed_from_git(root))
+        except (subprocess.SubprocessError, OSError) as exc:
+            print(f"impact_tests: {exc} — run the full suite", file=sys.stderr)
+            return EXIT_RUN_EVERYTHING
+
+    selected, refusal = select(mapping, sorted(set(changed)))
+    if refusal:
+        print(f"impact_tests: {refusal} — run the full suite", file=sys.stderr)
+        return EXIT_RUN_EVERYTHING
+
+    if args.granularity == "file":
+        selected = sorted({node.split("::", 1)[0] for node in selected})
+
+    terminator = "\0" if args.null else "\n"
+    sys.stdout.write(terminator.join(selected) + terminator)
+    return EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -4,7 +4,7 @@
 #
 # The git interaction (resolving the changed-file set) stays in ci-local.sh; this
 # file holds only the pure mapping + matching logic so it is unit-testable
-# (tests/scripts/ci_changed_only_tests.bats) without a contrived git history.
+# (tests/scripts/test_ci_changed_only.py) without a contrived git history.
 #
 # bash 3.2 safe: the mapping is a case statement, not an associative array.
 
@@ -68,4 +68,96 @@ ci_suite_has_changes() {
 
   [ "$had_noglob" -eq 1 ] || set +f
   return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Inert-path lever (#2003) — a SECOND, independent skip mechanism.
+#
+# ci_watched_paths/ci_suite_has_changes above are EXISTENTIAL: run if ANY
+# changed file matches a watched path. Skipping under that form requires the
+# mapping to be a permanent SUPERSET of everything a suite observes, and a
+# forgotten path produces a FALSE SKIP — silent, CI-only. For chk_hook_units
+# that superset is already 13+ open-ended top-level paths (.claude/, docs/,
+# evals/, .husky/, .github/, README.md, package.json, package-lock.json,
+# .claude-plugin/, ruff.toml, plugins/, scripts/, tests/) and grows with every
+# new content-guard. That is the hand-maintained-denylist shape CLAUDE.md
+# documents for the Python floor.
+#
+# This lever inverts the quantifier. It is UNIVERSAL: skip only when EVERY
+# changed file is provably inert. A path nobody has classified simply is not in
+# the set, so the omission costs a wasted run and never correctness.
+#
+#   Watched-path  : forget a path -> false SKIP  -> silent, CI-only
+#   Inert-allowlist: forget a path -> false RUN  -> wasted minutes
+#
+# ci_inert_paths <check-fn-name>
+# Echoes the space-separated paths a check PROVABLY CANNOT OBSERVE. Entry
+# shapes match ci_watched_paths. An unmapped check echoes nothing, and an empty
+# set can never satisfy the universal test below, so unmapped means never
+# skipped by this lever — the same safe default the existential form uses.
+#
+# Grow a set ONLY with a test proving the added path is unobserved
+# (tests/scripts/test_ci_changed_only.py). Deliberately NOT inert for
+# chk_hook_units: docs/**, *.md, and docs/adr/** — tests/repo reads all three.
+# test_adr_readme_toc_complete.py exists because ADRs 0013/0014/0015 landed
+# without README entries (#732); making docs/adr/ inert would let that recur.
+ci_inert_paths() {
+  case "$1" in
+    # Non-shipping repo metadata that no test under the chk_hook_units
+    # directory list ever READS from disk; pinned by test_ci_changed_only.py.
+    #
+    # `.gitignore` is deliberately NOT here, though #2003 proposed it: the
+    # suite reads the root .gitignore in at least three places
+    # (tests/repo/test_gitignore_overrides.py,
+    # test_gitignore_gate_bypass_audit.py, tests/skills/
+    # test_setup_gitignore_hygiene.py). The guard test caught that seed being
+    # wrong, which is the lever working as designed.
+    chk_hook_units) printf '%s' "LICENSE .gitattributes" ;;
+    *)              printf '%s' "" ;;
+  esac
+}
+
+# ci_path_is_inert <path> <inert-paths>
+# Returns 0 when <path> matches one of the inert entries. Shared matcher so the
+# entry shapes cannot drift from ci_suite_has_changes's.
+ci_path_is_inert() {
+  local f="$1"
+  local paths="$2"
+  local had_noglob=0
+  case "$-" in *f*) had_noglob=1 ;; *) set -f ;; esac
+
+  local rc=1 p
+  for p in $paths; do
+    # $p is intentionally used as a glob pattern in the case below.
+    # shellcheck disable=SC2254
+    case "$p" in
+      */)    case "$f" in "$p"*) rc=0 ;; esac ;;
+      *'*'*) case "$f" in $p) rc=0 ;; esac ;;
+      *)     [ "$f" = "$p" ] && rc=0 ;;
+    esac
+    [ "$rc" -eq 0 ] && break
+  done
+
+  [ "$had_noglob" -eq 1 ] || set +f
+  return "$rc"
+}
+
+# ci_suite_is_all_inert <check-fn-name> <changed-files>
+# Returns 0 (skippable) only when the changed set is NON-EMPTY and EVERY file
+# in it is inert for this check. Returns 1 (run) otherwise — including an
+# unmapped check, an empty inert set, and an empty changed set, each of which
+# preserves today's behavior exactly.
+ci_suite_is_all_inert() {
+  local fn="$1"
+  local changed="$2"
+  local paths
+  paths="$(ci_inert_paths "$fn")"
+  [ -z "$paths" ] && return 1
+  [ -z "$changed" ] && return 1
+
+  local f
+  for f in $changed; do
+    ci_path_is_inert "$f" "$paths" || return 1
+  done
+  return 0
 }

--- a/scripts/lib/ci-changed-only.sh
+++ b/scripts/lib/ci-changed-only.sh
@@ -112,7 +112,13 @@ ci_inert_paths() {
     # test_gitignore_gate_bypass_audit.py, tests/skills/
     # test_setup_gitignore_hygiene.py). The guard test caught that seed being
     # wrong, which is the lever working as designed.
-    chk_hook_units) printf '%s' "LICENSE .gitattributes" ;;
+    #
+    # `.gitattributes` was also here briefly and is NOT: this repo does not
+    # track one. A machine-local, gitignored `.gitattributes` that graphify's
+    # hook install writes made a "does it exist" probe answer yes locally and
+    # no in CI. An inert entry for a file the repo does not have is dead
+    # weight anyway -- the lever can never fire on it.
+    chk_hook_units) printf '%s' "LICENSE" ;;
     *)              printf '%s' "" ;;
   esac
 }

--- a/tests/repo/test_python_floor.py
+++ b/tests/repo/test_python_floor.py
@@ -180,6 +180,11 @@ SLICE_EXCLUSIONS = {
         "stdlib argparse/json/pathlib only; no floor-sensitive runtime API"
     ),
     "coverage_delta_steering.py": "stdlib argparse/json/pathlib only; no floor-sensitive runtime API",
+    "mutation_yield_steering.py": (
+        "stdlib argparse/json/sys/pathlib only; no floor-sensitive runtime API "
+        "— same import set and same classification as its coverage sibling "
+        "coverage_delta_steering.py, which #2033 ports"
+    ),
     "coverage_discovery_java.py": (
         "stdlib re/sys/xml.etree/pathlib only; no floor-sensitive body of its "
         "own — the fromisoformat shim it could exercise lives in "

--- a/tests/repo/test_ruff_is_invoked_as_a_module.py
+++ b/tests/repo/test_ruff_is_invoked_as_a_module.py
@@ -1,0 +1,107 @@
+"""Every ruff invocation in this repo runs the PINNED module, never the bare
+PATH binary (#1676, #2027).
+
+#1676 established the rule and `scripts/ci-local.sh` states it at the call
+site: both a PATH `ruff` and the `requirements-dev.txt`-pinned one can be
+present at once and disagree on real findings. `python3 -m ruff` resolves to
+the version this repo pins, so the gate means the same thing locally, in CI,
+and on every contributor machine.
+
+#2027 is the recurrence that motivated this file. `package.json`'s
+`lint-staged` config was the one invocation site that never got the fix, so
+the protection held for `ci-local.sh` and CI and was absent from the path that
+runs on **every single commit**. Observed in this repo's own container, which
+carried both:
+
+    python3 -m ruff (pinned, what CI runs)  0.16.1  -> clean
+    ruff from PATH (what lint-staged ran)   0.15.8  -> E402, 1 error
+
+Note the direction is INVERTED from #1676's case: there the pinned version was
+stricter, here the PATH version is. That is the point — two versions disagree
+per-rule, so neither "newer is stricter" nor "older is stricter" is a safe
+assumption. The only stable property is *which version this repo pins*.
+
+The quiet failure runs the other way too: a contributor whose PATH ruff is
+more permissive gets a clean pre-commit hook and a red `Lint (ruff + eslint)`
+in CI, having done nothing wrong.
+
+Per the repo CLAUDE.md ratchet — a mechanically-checkable finding reported a
+second time becomes a check — this is that check.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from _repo_root import REPO_ROOT
+
+#: A bare-binary invocation: `ruff` at a command position, not preceded by
+#: `-m ` (the module form) and not part of a longer word (`ruff.toml`,
+#: `python3 -m ruff`).
+_BARE_RUFF = re.compile(r"(?<!-m )(?<![\w./-])ruff(?![\w.-])")
+
+
+def _shell_commands_from_package_json() -> dict[str, str]:
+    """Every shell command package.json can run: scripts + lint-staged globs."""
+    payload = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    commands: dict[str, str] = {}
+    for name, command in (payload.get("scripts") or {}).items():
+        commands[f"scripts.{name}"] = command
+    lint_staged = payload.get("lint-staged") or {}
+    for glob, command in lint_staged.items():
+        # lint-staged values may be a string or a list of strings.
+        entries = command if isinstance(command, list) else [command]
+        for index, entry in enumerate(entries):
+            commands[f"lint-staged[{glob}][{index}]"] = entry
+    return commands
+
+
+def test_package_json_never_invokes_the_bare_ruff_binary():
+    """#2027: lint-staged runs on every commit — the one path where a stray
+    PATH ruff does the most damage."""
+    offenders = {
+        where: command
+        for where, command in _shell_commands_from_package_json().items()
+        if _BARE_RUFF.search(command)
+    }
+    assert not offenders, (
+        "package.json invokes the bare `ruff` binary from PATH, which may be a "
+        "different version than requirements-dev.txt pins (#1676/#2027). Use "
+        f"`python3 -m ruff` instead. Offending entries: {offenders}"
+    )
+
+
+def test_lint_staged_lints_python_through_the_pinned_module():
+    """Positive assertion, so deleting the Python entry cannot pass this file
+    by making the negative check above vacuous."""
+    payload = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    lint_staged = payload.get("lint-staged") or {}
+    python_entries = [
+        command for glob, command in lint_staged.items() if glob.endswith(".py")
+    ]
+    assert python_entries, "lint-staged no longer lints *.py at all"
+    flat = " ".join(
+        " ".join(entry) if isinstance(entry, list) else entry for entry in python_entries
+    )
+    assert "-m ruff" in flat, f"lint-staged must run `python3 -m ruff`, got: {flat}"
+
+
+def test_ci_local_invokes_ruff_as_a_module():
+    """The rule's original site (#1676) — pinned here so the two cannot drift
+    apart again, which is precisely how #2027 happened."""
+    text = (REPO_ROOT / "scripts" / "ci-local.sh").read_text(encoding="utf-8")
+    chk = re.search(r"chk_ruff\(\)\s*\{([^}]*)\}", text)
+    assert chk is not None, "chk_ruff() not found in scripts/ci-local.sh"
+    body = chk.group(1)
+    assert "-m ruff" in body, f"chk_ruff must invoke `python3 -m ruff`, got: {body}"
+    assert not _BARE_RUFF.search(body), f"chk_ruff invokes a bare ruff: {body}"
+
+
+def test_the_bare_ruff_pattern_actually_matches_a_bare_invocation():
+    """A gate that cannot fail is worse than no gate — pin the regex itself."""
+    assert _BARE_RUFF.search("ruff check --fix")
+    assert _BARE_RUFF.search("npx foo && ruff check")
+    assert not _BARE_RUFF.search("python3 -m ruff check --fix")
+    assert not _BARE_RUFF.search("cat ruff.toml")
+    assert not _BARE_RUFF.search("path/to/ruff-config")

--- a/tests/scripts/test_ci_changed_only.py
+++ b/tests/scripts/test_ci_changed_only.py
@@ -222,8 +222,6 @@ def _is_all_inert(fn: str, changed: str) -> bool:
 def test_a_purely_inert_diff_skips_the_long_pole_suite():
     """#2003 AC: LICENSE / .gitignore-only diffs skip chk_hook_units."""
     assert _is_all_inert("chk_hook_units", "LICENSE")
-    assert _is_all_inert("chk_hook_units", ".gitattributes")
-    assert _is_all_inert("chk_hook_units", "LICENSE .gitattributes")
 
 
 def test_a_docs_adr_diff_still_runs_the_suite():
@@ -327,13 +325,35 @@ def test_every_inert_path_is_genuinely_unread_by_the_suite():
     )
 
 
-def test_every_inert_path_actually_exists_in_the_repo():
-    """An inert entry for a file this repo does not have is dead weight — the
+def test_every_inert_path_is_actually_TRACKED_by_the_repo():
+    """An inert entry for a file this repo does not track is dead weight — the
     lever can never fire on it, so it only makes the set look broader than it
-    is. (#2003's seed named .editorconfig and CODEOWNERS, neither present.)"""
+    is. (#2003's seed named .editorconfig and CODEOWNERS, neither present.)
+
+    Asks **git**, not the filesystem, and that distinction is load-bearing: a
+    first version of this test used `(REPO_ROOT / p).exists()` and passed
+    locally while failing in CI on `.gitattributes`. This repo tracks no
+    `.gitattributes`; graphify's hook install writes a gitignored,
+    machine-local one, so "exists on disk" answered yes on a developer machine
+    and no on a runner. A gate whose verdict depends on an untracked local
+    artifact means something different in the two places it runs.
+    """
     inert = _run_fn("ci_inert_paths", "chk_hook_units").stdout.split()
-    missing = [p for p in inert if not (REPO_ROOT / p).exists()]
-    assert not missing, f"inert paths that do not exist in this repo: {missing}"
+    assert inert, "chk_hook_units lost its inert set entirely"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", *inert],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+    ).stdout.split()
+    missing = [p for p in inert if p not in tracked]
+    assert not missing, (
+        f"inert paths this repo does not TRACK: {missing}. An untracked path "
+        "cannot be a real inert entry — and if it merely exists locally "
+        "(a gitignored tool artifact), the check would disagree between a "
+        "developer machine and CI."
+    )
 
 
 def test_gitignore_is_not_inert_because_the_suite_reads_it():

--- a/tests/scripts/test_ci_changed_only.py
+++ b/tests/scripts/test_ci_changed_only.py
@@ -193,3 +193,174 @@ def test_multi_file_changeset_no_matching_file_skips() -> None:
 def test_empty_changeset_skips_a_mapped_suite() -> None:
     r = _run_fn("ci_suite_has_changes", "chk_shellcheck_helpers", "")
     assert r.returncode == 1
+
+
+# ===========================================================================
+# #2003 — the inert-path lever. A SECOND, independent skip mechanism with the
+# opposite quantifier to ci_suite_has_changes: skip only when EVERY changed
+# file is provably inert, so a forgotten path costs a wasted run rather than
+# a silent false skip.
+# ===========================================================================
+CHK_HOOK_UNITS_DIRS = (
+    "plugins/dev-team/tests",
+    "tests/repo",
+    "tests/agents",
+    "tests/commands",
+    "tests/docs",
+    "tests/knowledge",
+    "tests/stack_aware",
+    "tests/skills",
+    "tests/scripts",
+    "tests/hooks",
+)
+
+
+def _is_all_inert(fn: str, changed: str) -> bool:
+    return _run_fn("ci_suite_is_all_inert", fn, changed).returncode == 0
+
+
+def test_a_purely_inert_diff_skips_the_long_pole_suite():
+    """#2003 AC: LICENSE / .gitignore-only diffs skip chk_hook_units."""
+    assert _is_all_inert("chk_hook_units", "LICENSE")
+    assert _is_all_inert("chk_hook_units", ".gitattributes")
+    assert _is_all_inert("chk_hook_units", "LICENSE .gitattributes")
+
+
+def test_a_docs_adr_diff_still_runs_the_suite():
+    """#2003 AC, and the correction the issue makes to its own original
+    framing: tests/repo/test_adr_readme_toc_complete.py exists because ADRs
+    0013/0014/0015 landed without README entries (#732). Making docs/adr/
+    inert would let exactly that recur, silently and CI-only."""
+    assert not _is_all_inert("chk_hook_units", "docs/adr/0039-something.md")
+    assert not _is_all_inert("chk_hook_units", "docs/adr/README.md")
+
+
+def test_markdown_and_docs_are_not_inert():
+    """Blanket docs/** and *.md are out for the same reason as docs/adr/**."""
+    assert not _is_all_inert("chk_hook_units", "README.md")
+    assert not _is_all_inert("chk_hook_units", "docs/cloud-setup.md")
+
+
+def test_a_mixed_diff_runs_the_suite():
+    """#2003 AC: the universal quantifier pinned in both directions — one
+    live file among inert ones is enough to run."""
+    assert not _is_all_inert("chk_hook_units", "LICENSE plugins/dev-team/hooks/x.py")
+    assert not _is_all_inert("chk_hook_units", "plugins/dev-team/hooks/x.py LICENSE")
+
+
+def test_an_unmapped_check_is_never_skipped_by_this_lever():
+    """#2003 AC: mirrors the existing safe default — unmapped means run."""
+    assert not _is_all_inert("chk_ruff", "LICENSE")
+    assert not _is_all_inert("chk_some_future_check", "LICENSE")
+    assert _run_fn("ci_inert_paths", "chk_ruff").stdout == ""
+
+
+def test_an_empty_changed_set_is_never_skipped_by_this_lever():
+    """Preserves today's behavior: ci-local.sh already disables --changed-only
+    on an empty diff, and this lever must not invent a skip there either."""
+    assert not _is_all_inert("chk_hook_units", "")
+
+
+def test_the_two_levers_are_independent():
+    """#2003 item 4: ci_watched_paths / ci_suite_has_changes are untouched.
+    chk_hook_units still has no watched-path mapping, so the existential lever
+    still always runs it — the inert lever is additive, not a replacement."""
+    assert _run_fn("ci_watched_paths", "chk_hook_units").stdout == ""
+    assert _run_fn("ci_suite_has_changes", "chk_hook_units", "LICENSE").returncode == 0
+
+
+#: A mention of a filename is not an observation of it — `"LICENSE"` sitting in
+#: a list of example filenames (tests/scripts/test_select_lenses.py) cannot
+#: change its verdict when the real LICENSE is edited. What makes a path
+#: observable is the suite READING it, so the discriminator is the path
+#: appearing on a line that also performs filesystem access.
+_FILESYSTEM_READ_IDIOMS = r"REPO_ROOT|read_text|open\(|Path\(|\.exists\(|is_file"
+
+
+def _lines_reading(path: str, dirs: list[str]) -> list[str]:
+    """Lines under `dirs` that name `path` AND touch the filesystem."""
+    grep = subprocess.run(
+        ["grep", "-rn", "--include=*.py", "-F", path, *dirs],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    if grep.returncode != 0:
+        return []
+    filtered = subprocess.run(
+        ["grep", "-E", _FILESYSTEM_READ_IDIOMS],
+        input=grep.stdout,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [line for line in filtered.stdout.splitlines() if line.strip()]
+
+
+def test_every_inert_path_is_genuinely_unread_by_the_suite():
+    """#2003 AC: the inert set cannot loosen unnoticed.
+
+    Sweeps the ENTIRE chk_hook_units directory list for each inert path used
+    as a filesystem target. If a test ever starts reading one, this fails and
+    the path must leave the set.
+
+    This guard already earned its keep: #2003 proposed seeding the set with
+    `.gitignore`, and this test caught that the suite reads the root
+    .gitignore in three places. A false skip there would have been silent and
+    CI-only — exactly the failure mode the inert lever exists to avoid.
+    """
+    inert = _run_fn("ci_inert_paths", "chk_hook_units").stdout.split()
+    assert inert, "chk_hook_units lost its inert set entirely"
+
+    existing_dirs = [d for d in CHK_HOOK_UNITS_DIRS if (REPO_ROOT / d).is_dir()]
+    assert existing_dirs, "none of the chk_hook_units directories exist"
+
+    offenders = {
+        path: lines
+        for path in inert
+        if (lines := _lines_reading(path, existing_dirs))
+    }
+    assert not offenders, (
+        "these paths are in chk_hook_units's inert set but ARE read by tests "
+        f"the suite runs, so the suite can observe them: {offenders}"
+    )
+
+
+def test_every_inert_path_actually_exists_in_the_repo():
+    """An inert entry for a file this repo does not have is dead weight — the
+    lever can never fire on it, so it only makes the set look broader than it
+    is. (#2003's seed named .editorconfig and CODEOWNERS, neither present.)"""
+    inert = _run_fn("ci_inert_paths", "chk_hook_units").stdout.split()
+    missing = [p for p in inert if not (REPO_ROOT / p).exists()]
+    assert not missing, f"inert paths that do not exist in this repo: {missing}"
+
+
+def test_gitignore_is_not_inert_because_the_suite_reads_it():
+    """Pinned as its own named case, not just an absence: #2003 proposed
+    `.gitignore` and it is genuinely observed."""
+    inert = _run_fn("ci_inert_paths", "chk_hook_units").stdout.split()
+    assert ".gitignore" not in inert
+    assert not _is_all_inert("chk_hook_units", ".gitignore")
+
+    existing_dirs = [d for d in CHK_HOOK_UNITS_DIRS if (REPO_ROOT / d).is_dir()]
+    assert _lines_reading(".gitignore", existing_dirs), (
+        "the suite no longer reads .gitignore — if that is real, this test and "
+        "the inert set can both be revisited"
+    )
+
+
+def test_inert_matcher_honours_the_directory_prefix_shape():
+    """Entry shapes must not drift from ci_suite_has_changes's."""
+    assert _run_fn("ci_path_is_inert", "vendor/x/y.py", "vendor/").returncode == 0
+    assert _run_fn("ci_path_is_inert", "src/x.py", "vendor/").returncode != 0
+
+
+def test_inert_matcher_honours_the_glob_shape():
+    assert _run_fn("ci_path_is_inert", "a.lock", "*.lock").returncode == 0
+    assert _run_fn("ci_path_is_inert", "a.py", "*.lock").returncode != 0
+
+
+def test_inert_matcher_honours_the_exact_file_shape():
+    assert _run_fn("ci_path_is_inert", "LICENSE", "LICENSE").returncode == 0
+    assert _run_fn("ci_path_is_inert", "LICENSE.md", "LICENSE").returncode != 0

--- a/tests/scripts/test_ci_tree_cache.py
+++ b/tests/scripts/test_ci_tree_cache.py
@@ -1,0 +1,247 @@
+"""Tests for scripts/ci_tree_cache.py — skip a gate whose tree has not changed
+since it last passed (issue #2002).
+
+`chk_hook_units` collects 9,469 tests and is the gate's wall-clock long pole:
+1,029 runs in 30 days (27% of all pytest invocations), including 35 sessions
+that re-ran the identical command >= 8 times and one that ran it 34 times.
+
+This is a gate-SKIPPING mechanism, so the tests below are weighted toward the
+dangerous direction: every failure path must answer "not fresh" (run the
+suite), and only a byte-identical tree may answer "fresh".
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import ci_tree_cache
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A throwaway git repo with its own cache file, so nothing here can read
+    or clobber the developer's real ~/.cache entry."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "t@e.st"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "t"], check=True)
+    (root / "a.py").write_text("print(1)\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+
+    cache = tmp_path / "cache" / "tree-cache.json"
+    monkeypatch.setattr(ci_tree_cache, "cache_path", lambda: cache)
+    return root
+
+
+CHECK = "chk_hook_units"
+
+
+# --- the core contract ------------------------------------------------------
+
+
+def test_cold_cache_is_not_fresh(repo):
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_recorded_tree_is_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    assert ci_tree_cache.is_fresh(repo, CHECK) is True
+
+
+def test_editing_a_tracked_file_invalidates(repo):
+    ci_tree_cache.record(repo, CHECK)
+    (repo / "a.py").write_text("print(2)\n", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_adding_an_untracked_file_invalidates(repo):
+    """A brand-new test file nobody has `git add`ed yet still changes what the
+    suite collects, so it must invalidate."""
+    ci_tree_cache.record(repo, CHECK)
+    (repo / "test_new.py").write_text("def test_x(): pass\n", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_deleting_a_file_invalidates(repo):
+    ci_tree_cache.record(repo, CHECK)
+    (repo / "a.py").unlink()
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_renaming_a_file_invalidates(repo):
+    """Path feeds the digest, so identical bytes at a new path is a new tree."""
+    ci_tree_cache.record(repo, CHECK)
+    (repo / "a.py").rename(repo / "b.py")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_an_ignored_file_does_not_invalidate(repo):
+    """Build output and caches are not inputs to the suite."""
+    (repo / ".gitignore").write_text("junk/\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "ignore"], check=True)
+    ci_tree_cache.record(repo, CHECK)
+    (repo / "junk").mkdir()
+    (repo / "junk" / "out.bin").write_text("x", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is True
+
+
+def test_reverting_an_edit_restores_freshness(repo):
+    """The key is content, not a timestamp — restoring the bytes restores the
+    verdict. This is what collapses the 34x-in-one-session case."""
+    ci_tree_cache.record(repo, CHECK)
+    original = (repo / "a.py").read_text(encoding="utf-8")
+    (repo / "a.py").write_text("print(2)\n", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+    (repo / "a.py").write_text(original, encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is True
+
+
+# --- every failure path answers "not fresh" ---------------------------------
+
+
+def test_an_uncacheable_check_is_never_fresh(repo):
+    """Allowlist, mirroring the safe default the --changed-only levers use for
+    unmapped checks."""
+    ci_tree_cache.record(repo, "chk_ruff")
+    assert ci_tree_cache.is_fresh(repo, "chk_ruff") is False
+
+
+def test_recording_an_uncacheable_check_writes_nothing(repo):
+    ci_tree_cache.record(repo, "chk_ruff")
+    assert not ci_tree_cache.cache_path().exists()
+
+
+def test_a_corrupt_cache_is_not_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    ci_tree_cache.cache_path().write_text("{not json", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_a_non_dict_cache_is_not_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    ci_tree_cache.cache_path().write_text("[]", encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_a_cache_from_an_older_version_is_not_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    payload = json.loads(ci_tree_cache.cache_path().read_text(encoding="utf-8"))
+    payload["version"] = ci_tree_cache.CACHE_VERSION - 1
+    ci_tree_cache.cache_path().write_text(json.dumps(payload), encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_a_non_string_stored_key_is_not_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    path = ci_tree_cache.cache_path()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["entries"] = dict.fromkeys(payload["entries"], 12345)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_an_empty_stored_key_is_not_fresh(repo):
+    ci_tree_cache.record(repo, CHECK)
+    path = ci_tree_cache.cache_path()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["entries"] = dict.fromkeys(payload["entries"], "")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert ci_tree_cache.is_fresh(repo, CHECK) is False
+
+
+def test_a_sibling_worktree_does_not_share_a_verdict(repo, tmp_path):
+    """Entries are namespaced by repo root: two worktrees have different trees
+    at the same check name, and one's green must never skip the other's run."""
+    other = tmp_path / "other"
+    other.mkdir()
+    subprocess.run(["git", "init", "-q", str(other)], check=True)
+    ci_tree_cache.record(repo, CHECK)
+    assert ci_tree_cache.is_fresh(repo, CHECK) is True
+    assert ci_tree_cache.is_fresh(other, CHECK) is False
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def _cli(*args, cwd) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "ci_tree_cache.py"), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(cwd),
+    )
+
+
+def test_cli_is_fresh_exits_nonzero_when_cold(repo, tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert _cli("is-fresh", CHECK, cwd=repo).returncode != 0
+
+
+def test_cli_record_then_is_fresh_exits_zero(repo, tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert _cli("record", CHECK, cwd=repo).returncode == 0
+    assert _cli("is-fresh", CHECK, cwd=repo).returncode == 0
+
+
+def test_cli_outside_a_git_repo_exits_nonzero(tmp_path, monkeypatch):
+    """A git failure must never present as a skip."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _cli("is-fresh", CHECK, cwd=plain).returncode != 0
+
+
+def test_cli_key_is_stable_across_invocations(repo, tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    first = _cli("key", cwd=repo)
+    second = _cli("key", cwd=repo)
+    assert first.returncode == 0
+    assert first.stdout.strip() == second.stdout.strip()
+    assert len(first.stdout.strip()) == 64
+
+
+def test_cli_clear_removes_the_cache(repo, tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    _cli("record", CHECK, cwd=repo)
+    assert _cli("is-fresh", CHECK, cwd=repo).returncode == 0
+    assert _cli("clear", cwd=repo).returncode == 0
+    assert _cli("is-fresh", CHECK, cwd=repo).returncode != 0
+
+
+# --- wiring in ci-local.sh --------------------------------------------------
+
+
+def test_ci_local_records_only_on_a_green_run():
+    """A red run must never poison the cache into skipping the very failure it
+    just found. Pinned against the script text because reproducing a red
+    9,469-test run in a unit test is not worth 80 seconds."""
+    text = (REPO_ROOT / "scripts" / "ci-local.sh").read_text(encoding="utf-8")
+    assert 'if [ "$rc" -eq 0 ]' in text
+    record_line = "ci_tree_cache.py record chk_hook_units"
+    assert record_line in text
+    guard_index = text.index('if [ "$rc" -eq 0 ]')
+    assert text.index(record_line) > guard_index
+
+
+def test_ci_local_exposes_an_opt_out():
+    text = (REPO_ROOT / "scripts" / "ci-local.sh").read_text(encoding="utf-8")
+    assert "CI_LOCAL_NO_TREE_CACHE" in text
+
+
+def test_ci_local_skip_message_says_skipped_not_a_fake_duration():
+    """Consistent with the existing --changed-only output contract — never a
+    0.00s masquerading as a run."""
+    text = (REPO_ROOT / "scripts" / "ci-local.sh").read_text(encoding="utf-8")
+    assert "skipped (tree unchanged since this suite last passed" in text

--- a/tests/scripts/test_impact_tests.py
+++ b/tests/scripts/test_impact_tests.py
@@ -1,0 +1,283 @@
+"""Tests for scripts/impact_tests.py — select the tests a change can actually
+affect (issue #2005).
+
+The inner loop had two speeds: one file (46% of invocations) or the full
+9,469-test list (27%). Nothing in between, so "what does this change affect"
+was answered by a guess, which fails expensively in both directions.
+
+This is a test-SELECTION tool, so the tests below weight the dangerous
+direction: narrowing is only sound when the map can account for the change,
+and every case where it cannot must refuse rather than silently emit a
+subset.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import impact_tests
+
+SCRIPT = REPO_ROOT / "scripts" / "impact_tests.py"
+
+
+@pytest.fixture
+def mapping():
+    return {
+        "plugins/dev-team/hooks/telemetry.py": [
+            "tests/hooks/test_telemetry.py::test_a",
+            "tests/hooks/test_telemetry.py::test_b",
+        ],
+        "scripts/thing.py": ["tests/scripts/test_thing.py::test_c"],
+    }
+
+
+# --- selection --------------------------------------------------------------
+
+
+def test_a_covered_file_selects_its_tests(mapping):
+    selected, refusal = impact_tests.select(
+        mapping, ["plugins/dev-team/hooks/telemetry.py"]
+    )
+    assert refusal == ""
+    assert selected == [
+        "tests/hooks/test_telemetry.py::test_a",
+        "tests/hooks/test_telemetry.py::test_b",
+    ]
+
+
+def test_multiple_changed_files_union_their_tests(mapping):
+    selected, refusal = impact_tests.select(
+        mapping, ["plugins/dev-team/hooks/telemetry.py", "scripts/thing.py"]
+    )
+    assert refusal == ""
+    assert len(selected) == 3
+
+
+# --- every unaccountable case refuses ---------------------------------------
+
+
+def test_an_unmapped_source_file_refuses(mapping):
+    """A new or previously uncovered file has unknown reach, and "no test
+    covers it" is indistinguishable from "the map predates it"."""
+    selected, refusal = impact_tests.select(mapping, ["plugins/dev-team/hooks/new.py"])
+    assert selected == []
+    assert "absent from the impact map" in refusal
+
+
+def test_a_changed_test_file_refuses(mapping):
+    """A changed test must run regardless, and a test added since the map was
+    built has no entry at all."""
+    selected, refusal = impact_tests.select(mapping, ["tests/hooks/test_telemetry.py"])
+    assert selected == []
+    assert "is a test file" in refusal
+
+
+def test_a_trailing_test_suffix_is_also_recognised(mapping):
+    selected, refusal = impact_tests.select(mapping, ["tests/some_test.py"])
+    assert selected == []
+    assert "is a test file" in refusal
+
+
+def test_an_empty_changed_set_refuses(mapping):
+    selected, refusal = impact_tests.select(mapping, [])
+    assert selected == []
+    assert refusal
+
+
+def test_a_mapped_file_with_no_tests_refuses():
+    """Refusing to select nothing: an empty selection must never be read as
+    "nothing to run"."""
+    selected, refusal = impact_tests.select({"a.py": []}, ["a.py"])
+    assert selected == []
+    assert "refusing to select nothing" in refusal
+
+
+def test_one_unaccountable_file_poisons_the_whole_selection(mapping):
+    """Mixed diffs take the safe branch — a subset that silently omits the
+    unaccountable file is the false-narrow failure this tool must not have."""
+    selected, refusal = impact_tests.select(
+        mapping, ["plugins/dev-team/hooks/telemetry.py", "brand/new/file.py"]
+    )
+    assert selected == []
+    assert refusal
+
+
+# --- map loading ------------------------------------------------------------
+
+
+def test_a_missing_map_loads_as_none(tmp_path):
+    assert impact_tests.load_map(tmp_path / "nope.json") is None
+
+
+def test_a_corrupt_map_loads_as_none(tmp_path):
+    path = tmp_path / "m.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert impact_tests.load_map(path) is None
+
+
+def test_a_wrong_version_map_loads_as_none(tmp_path):
+    path = tmp_path / "m.json"
+    path.write_text(
+        json.dumps({"version": impact_tests.MAP_VERSION + 1, "files": {}}),
+        encoding="utf-8",
+    )
+    assert impact_tests.load_map(path) is None
+
+
+# --- coverage schema: the branch-mode trap ----------------------------------
+
+
+def _coverage_db(path, table: str):
+    """Build a minimal coverage.py-shaped DB using `table` for measurements."""
+    db = sqlite3.connect(path)
+    db.execute("CREATE TABLE context (id INTEGER PRIMARY KEY, context TEXT)")
+    db.execute("CREATE TABLE file (id INTEGER PRIMARY KEY, path TEXT)")
+    db.execute(f"CREATE TABLE {table} (file_id INTEGER, context_id INTEGER)")
+    db.execute("INSERT INTO context VALUES (1, 'tests/test_x.py::test_y|run')")
+    db.execute("INSERT INTO file VALUES (1, ?)", (str(REPO_ROOT / "src" / "a.py"),))
+    db.execute(f"INSERT INTO {table} VALUES (1, 1)")
+    db.commit()
+    db.close()
+
+
+def test_read_contexts_handles_line_coverage(tmp_path):
+    db = tmp_path / "line.db"
+    _coverage_db(db, "line_bits")
+    assert impact_tests.read_contexts(db, REPO_ROOT) == {
+        "src/a.py": ["tests/test_x.py::test_y"]
+    }
+
+
+def test_read_contexts_handles_branch_coverage(tmp_path):
+    """The trap this tool actually hit: .coveragerc sets `branch = True`, so
+    coverage stores measurements in `arc`, not `line_bits`. A line_bits-only
+    query returned zero rows and produced a silently EMPTY map — measured on
+    this repo as files: 135, contexts: 23, line_bits: 0."""
+    db = tmp_path / "arc.db"
+    _coverage_db(db, "arc")
+    assert impact_tests.read_contexts(db, REPO_ROOT) == {
+        "src/a.py": ["tests/test_x.py::test_y"]
+    }
+
+
+def test_read_contexts_drops_the_empty_import_time_context(tmp_path):
+    db = tmp_path / "empty.db"
+    _coverage_db(db, "line_bits")
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO context VALUES (2, '')")
+    conn.execute("INSERT INTO line_bits VALUES (1, 2)")
+    conn.commit()
+    conn.close()
+    # Only the named test survives; the empty context names no test.
+    assert impact_tests.read_contexts(db, REPO_ROOT) == {
+        "src/a.py": ["tests/test_x.py::test_y"]
+    }
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def _cli(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+
+
+@pytest.fixture
+def map_file(tmp_path, mapping):
+    path = tmp_path / "map.json"
+    path.write_text(
+        json.dumps({"version": impact_tests.MAP_VERSION, "files": mapping}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_cli_refusals_exit_with_run_everything(map_file):
+    """Exit 2 is the contract: a caller must treat any non-zero exit as the
+    full suite, never as an empty selection."""
+    for changed in ("brand/new/file.py", "tests/hooks/test_telemetry.py"):
+        result = _cli("select", "--map", str(map_file), "--changed", changed)
+        assert result.returncode == impact_tests.EXIT_RUN_EVERYTHING, changed
+
+
+def test_cli_missing_map_exits_with_run_everything(tmp_path):
+    result = _cli(
+        "select", "--map", str(tmp_path / "nope.json"), "--changed", "a.py"
+    )
+    assert result.returncode == impact_tests.EXIT_RUN_EVERYTHING
+
+
+def test_cli_defaults_to_file_granularity(map_file):
+    """A parametrized node id can contain spaces and brackets, so a naive
+    $(...) split corrupts it — file paths cannot."""
+    result = _cli(
+        "select",
+        "--map",
+        str(map_file),
+        "--changed",
+        "plugins/dev-team/hooks/telemetry.py",
+    )
+    assert result.returncode == 0
+    assert result.stdout.split() == ["tests/hooks/test_telemetry.py"]
+
+
+def test_cli_test_granularity_emits_node_ids(map_file):
+    result = _cli(
+        "select",
+        "--map",
+        str(map_file),
+        "--changed",
+        "plugins/dev-team/hooks/telemetry.py",
+        "--granularity",
+        "test",
+    )
+    assert result.returncode == 0
+    assert "::test_a" in result.stdout
+
+
+def test_cli_null_separation_for_ids_containing_spaces(tmp_path):
+    path = tmp_path / "m.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": impact_tests.MAP_VERSION,
+                "files": {"src/a.py": ["tests/t.py::test_x[a b c]"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _cli(
+        "select",
+        "--map",
+        str(path),
+        "--changed",
+        "src/a.py",
+        "--granularity",
+        "test",
+        "--null",
+    )
+    assert result.returncode == 0
+    assert result.stdout.split("\0")[0] == "tests/t.py::test_x[a b c]"
+
+
+def test_default_cov_targets_are_wider_than_coveragerc(tmp_path):
+    """.coveragerc scopes `source` to the informational report's two trees, so
+    a bare --cov maps nothing under plugins/dev-team/scripts. Measured: the
+    first build against .coveragerc mapped 0 files."""
+    assert "plugins/dev-team/scripts" in impact_tests.DEFAULT_COV_TARGETS
+    coveragerc = (REPO_ROOT / ".coveragerc").read_text(encoding="utf-8")
+    assert "plugins/dev-team/scripts" not in coveragerc

--- a/tests/scripts/test_mutation_kill_loop.py
+++ b/tests/scripts/test_mutation_kill_loop.py
@@ -489,3 +489,59 @@ def test_make_scoped_config_carries_a_set_solution_through(tmp_path: Path):
 
     inner = scoped["stryker-config"]
     assert inner["solution"] == "App.sln"
+
+
+# =============================================================================
+# #2031 — make_confirm_scoped_config. NOT wired into the default loop path:
+# the line-span syntax is unverified against a real Stryker (no dotnet in the
+# gate), so these tests pin the emitted SHAPE only, never that Stryker honors
+# it. Wiring it live is gated on that verification — see #2031.
+# =============================================================================
+def _cfg():
+    return loop.LoopConfig(
+        project="Calc.csproj",
+        test_projects=["Calc.Tests.csproj"],
+        mutate=[],
+        solution="Calc.sln",
+    )
+
+
+def test_confirm_scoped_config_emits_one_span_per_survivor_line():
+    cfg = loop.make_confirm_scoped_config(_cfg(), "Calc.cs", [10, 99])
+    assert cfg["stryker-config"]["mutate"] == [
+        "**/Calc.cs{10..10}",
+        "**/Calc.cs{99..99}",
+    ]
+
+
+def test_confirm_scoped_config_sorts_and_deduplicates_lines():
+    cfg = loop.make_confirm_scoped_config(_cfg(), "Calc.cs", [99, 10, 10])
+    assert cfg["stryker-config"]["mutate"] == [
+        "**/Calc.cs{10..10}",
+        "**/Calc.cs{99..99}",
+    ]
+
+
+def test_confirm_scoped_config_degrades_to_the_whole_file_when_no_lines():
+    """No clustered survivors must yield today's behavior, never a config that
+    matches nothing — a zero-mutant result is read as 'not convergence' by
+    _score_round and would stop the file (#1606)."""
+    assert loop.make_confirm_scoped_config(
+        _cfg(), "Calc.cs", []
+    ) == loop.make_scoped_config(_cfg(), "Calc.cs")
+
+
+def test_confirm_scoped_config_inherits_solution_project_and_test_projects():
+    scoped = loop.make_confirm_scoped_config(_cfg(), "Calc.cs", [10])["stryker-config"]
+    assert scoped["solution"] == "Calc.sln"
+    assert scoped["project"] == "Calc.csproj"
+    assert scoped["test-projects"] == ["Calc.Tests.csproj"]
+
+
+def test_confirm_scoped_config_is_not_wired_into_the_default_loop_path():
+    """#2031 guard: the span syntax is unverified, and a wrong guess silently
+    truncates every file's loop. This fails the moment someone wires it in
+    without recording the verification."""
+    import inspect
+
+    assert "make_confirm_scoped_config" not in inspect.getsource(loop._score_round)

--- a/tests/scripts/test_mutation_kill_retry.py
+++ b/tests/scripts/test_mutation_kill_retry.py
@@ -834,3 +834,184 @@ def test_make_downgrade_audit_hook_wired_end_to_end_with_make_retrying_headless_
     assert label is not None
     assert "opus" in label and "sonnet" in label and "foo.py" in label
 
+
+
+# =============================================================================
+# #1950 — three real-world 5xx shapes the anchored pattern evaded. Each was
+# independently identified by domain-review and correctness-review during
+# #1938 Slice 1's checkpoint; none were bugs against #1938's own acceptance
+# criteria, which is why they were deferred rather than folded in.
+# =============================================================================
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        # 1. `\b` rejected underscore- and camel-joined status keys: `_` is a
+        #    `\w` char, so the `_c`/`rC` transitions are word-to-word.
+        "error_code: 503",
+        "errorCode=504",
+        "provider returned error_code=502",
+        # 2. `HTTP/1.1 502` — the version token puts digits in the gap, which
+        #    the `[^0-9]{0,12}` anchor forbade.
+        "HTTP/1.1 502 Bad Gateway",
+        "HTTP/2 503",
+        # 3. Status 529 — Anthropic's own overload code, absent from the
+        #    numeral alternation. Covered before only via the
+        #    `overloaded_error` marker, which a rendered message omits.
+        "API Error: 529 Overloaded",
+        "status: 529",
+    ],
+)
+def test_gateway_classifier_matches_the_1950_shapes(stderr):
+    assert retry.is_gateway_class_error(gateway_error(stderr)) is True
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        # #1938's anchoring must survive #1950's widening — these are the
+        # false positives the pattern exists to exclude.
+        "request id 502391",
+        "barcode 502391",
+        "error after 5024 ms",
+        "processed 5029 records",
+        "wrote 5030 bytes",
+        "generation succeeded",
+    ],
+)
+def test_gateway_classifier_still_rejects_unrelated_numbers(stderr):
+    assert retry.is_gateway_class_error(gateway_error(stderr)) is False
+
+
+def test_gateway_classifier_reads_stdout_not_only_stderr():
+    """#1950: the claude CLI renders some upstream failures to stdout while
+    stderr carries only a generic non-zero-exit line. A stderr-only classifier
+    calls a genuinely retryable overload non-gateway-class and burns the
+    file's whole budget on it."""
+    exc = shared.HeadlessCallFailed(
+        1, "claude CLI failed", "API Error: 529 Overloaded"
+    )
+    assert retry.is_gateway_class_error(exc) is True
+
+
+def test_gateway_classifier_tolerates_a_two_argument_construction():
+    """`stdout` is defaulted, so every pre-#1950 call site and test fake keeps
+    classifying rather than raising AttributeError."""
+    exc = shared.HeadlessCallFailed(1, "status 503")
+    assert retry.is_gateway_class_error(exc) is True
+
+
+def test_headless_call_failed_carries_stdout_from_the_raise_site():
+    exc = shared.HeadlessCallFailed(1, "err", "out")
+    assert exc.stdout == "out"
+    assert exc.stderr == "err"
+
+
+def test_headless_call_failed_str_is_unchanged_by_the_stdout_field():
+    """`__str__` is byte-for-byte the plain RuntimeError message this type
+    replaced; adding stdout must not leak into it."""
+    exc = shared.HeadlessCallFailed(1, "err", "SECRET-STDOUT")
+    assert "SECRET-STDOUT" not in str(exc)
+    assert str(exc) == "claude CLI failed (exit 1): err"
+
+
+def test_camel_split_is_a_pure_normalization():
+    assert retry._anchorable("errorCode=504") == "error_Code=504"
+    assert retry._anchorable("error_code=504") == "error_code=504"
+    assert retry._anchorable("plain text") == "plain text"
+
+
+# =============================================================================
+# #1952 — the exhaustion reason is the one the caller computed, not one
+# re-inferred from whether from_model looks like a ladder name.
+# =============================================================================
+def test_exhaustion_after_a_spent_downgrade_reports_the_spent_downgrade():
+    """The #1952 failure scenario: a file starts on opus, downgrades once to
+    `fable` (a VALID DEV_TEAM_MUTATION_FALLBACK_MODEL override that
+    deliberately has no ladder entry), then exhausts. The old proxy —
+    `from_model in {opus, sonnet, haiku}` — reported "no downgrade ladder
+    position available for this model" when the true cause was "this file
+    already spent its one downgrade"."""
+    event = retry.DowngradeEvent(
+        source_file="calc.py",
+        round_num=3,
+        from_model="fable",
+        to_model=None,
+        error_class="gateway-class",
+        already_downgraded=True,
+    )
+    message = retry._format_downgrade_message(event)
+    assert "no further downgrade will be attempted" in message
+    assert "no downgrade ladder position available" not in message
+
+
+def test_exhaustion_without_a_prior_downgrade_reports_the_absent_ladder_slot():
+    event = retry.DowngradeEvent(
+        source_file="calc.py",
+        round_num=1,
+        from_model="some-unrecognized-model",
+        to_model=None,
+        error_class="gateway-class",
+        already_downgraded=False,
+    )
+    message = retry._format_downgrade_message(event)
+    assert "no downgrade ladder position available" in message
+
+
+def test_exhaustion_reason_no_longer_depends_on_the_model_name():
+    """Same model, opposite reasons — the two messages must differ. Under the
+    old proxy both took the same branch, since the branch read only the name."""
+    def _event(already):
+        return retry.DowngradeEvent(
+            source_file="calc.py",
+            round_num=2,
+            from_model="fable",
+            to_model=None,
+            error_class="gateway-class",
+            already_downgraded=already,
+        )
+
+    assert retry._format_downgrade_message(
+        _event(True)
+    ) != retry._format_downgrade_message(_event(False))
+
+
+def test_a_ladder_model_that_never_downgraded_reports_the_absent_slot():
+    """The inverse of the #1952 case, and the one the old proxy also got
+    wrong in the other direction: haiku IS a ladder name, but a haiku file
+    that exhausted without ever downgrading ran out of ladder — it did not
+    spend a downgrade."""
+    event = retry.DowngradeEvent(
+        source_file="calc.py",
+        round_num=1,
+        from_model="haiku",
+        to_model=None,
+        error_class="gateway-class",
+        already_downgraded=False,
+    )
+    assert "no downgrade ladder position available" in retry._format_downgrade_message(
+        event
+    )
+
+
+def test_already_downgraded_defaults_false_for_existing_constructions():
+    event = retry.DowngradeEvent(
+        source_file="calc.py",
+        round_num=1,
+        from_model="opus",
+        to_model="sonnet",
+        error_class="gateway-class",
+    )
+    assert event.already_downgraded is False
+
+
+def test_non_exhausted_event_message_is_unchanged():
+    event = retry.DowngradeEvent(
+        source_file="calc.py",
+        round_num=1,
+        from_model="opus",
+        to_model="sonnet",
+        error_class="gateway-class",
+    )
+    message = retry._format_downgrade_message(event)
+    assert message.startswith("downgrading generation for calc.py")
+    assert "exhausted" not in message

--- a/tests/scripts/test_mutation_report.py
+++ b/tests/scripts/test_mutation_report.py
@@ -1074,3 +1074,167 @@ def test_module_source_carries_no_repo_specific_literal():
 
     present = [literal for literal in FORBIDDEN_LITERALS if literal in source]
     assert present == [], f"repo-specific literals leaked into module: {present}"
+
+
+# =============================================================================
+# #2031 — survivor-scoped confirm run: line extraction, scope completeness,
+# and the splice over the prior round's report.
+# =============================================================================
+def _cm(mid, line, status, mutator="Arithmetic", replacement="-"):
+    return {
+        "id": mid,
+        "status": status,
+        "mutatorName": mutator,
+        "replacement": replacement,
+        "location": {"start": {"line": line}},
+    }
+
+
+def _write(tmp_path, data):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_survivor_lines_are_sorted_and_deduplicated(tmp_path):
+    report = _write(
+        tmp_path,
+        {
+            "files": {
+                "Calc.cs": {
+                    "mutants": [
+                        _cm("1", 99, "Survived"),
+                        _cm("2", 10, "Survived"),
+                        _cm("3", 10, "Survived"),
+                        _cm("4", 50, "Killed"),
+                    ]
+                }
+            }
+        },
+    )
+    assert mutation_report.survivor_lines(report, "Calc.cs") == [10, 99]
+
+
+def test_survivor_lines_excludes_killed_lines(tmp_path):
+    """A Killed mutant's line must not enter the confirm scope — re-testing it
+    buys nothing, which is the whole point of narrowing."""
+    report = _write(
+        tmp_path, {"files": {"Calc.cs": {"mutants": [_cm("1", 7, "Killed")]}}}
+    )
+    assert mutation_report.survivor_lines(report, "Calc.cs") == []
+
+
+def test_confirm_scope_is_incomplete_when_a_survivor_has_no_resolvable_line(tmp_path):
+    """An unclustered survivor cannot be expressed as a line span. Narrowing
+    anyway would stop re-testing it, and its absence from the confirm result
+    would read as 'killed' once spliced — a silent false improvement."""
+    report = _write(
+        tmp_path,
+        {
+            "files": {
+                "Calc.cs": {
+                    "mutants": [
+                        _cm("1", 10, "Survived"),
+                        {"id": "2", "status": "Survived", "location": {}},
+                    ]
+                }
+            }
+        },
+    )
+    assert mutation_report.confirm_scope_is_complete(report, "Calc.cs") is False
+
+
+def test_confirm_scope_is_complete_when_every_survivor_has_a_line(tmp_path):
+    report = _write(
+        tmp_path, {"files": {"Calc.cs": {"mutants": [_cm("1", 10, "Survived")]}}}
+    )
+    assert mutation_report.confirm_scope_is_complete(report, "Calc.cs") is True
+
+
+def test_splice_carries_forward_mutants_outside_the_confirm_scope():
+    """The confirm report is a strict subset of the file's mutant set;
+    reporting it alone would drop every out-of-scope mutant."""
+    prior = {
+        "files": {
+            "Calc.cs": {
+                "mutants": [
+                    _cm("1", 10, "Survived"),
+                    _cm("2", 50, "Killed"),
+                    _cm("3", 99, "Survived"),
+                ]
+            }
+        }
+    }
+    confirm = {"files": {"Calc.cs": {"mutants": [_cm("1", 10, "Killed")]}}}
+
+    spliced = mutation_report.splice_confirm_over_prior(prior, confirm, "Calc.cs")
+    by_id = {m["id"]: m["status"] for m in spliced["files"]["Calc.cs"]["mutants"]}
+    assert by_id == {"1": "Killed", "2": "Killed", "3": "Survived"}
+
+
+def test_splice_does_not_mutate_the_prior_report():
+    prior = {"files": {"Calc.cs": {"mutants": [_cm("1", 10, "Survived")]}}}
+    confirm = {"files": {"Calc.cs": {"mutants": [_cm("1", 10, "Killed")]}}}
+
+    mutation_report.splice_confirm_over_prior(prior, confirm, "Calc.cs")
+    assert prior["files"]["Calc.cs"]["mutants"][0]["status"] == "Survived"
+
+
+def test_splice_matches_on_shape_when_ids_are_absent():
+    """Stryker ids are stable within a run but not guaranteed across runs, so
+    the fallback key must still overlay rather than duplicate."""
+    prior_mutant = _cm(None, 10, "Survived")
+    confirm_mutant = _cm(None, 10, "Killed")
+    del prior_mutant["id"]
+    del confirm_mutant["id"]
+    prior = {"files": {"Calc.cs": {"mutants": [prior_mutant]}}}
+    confirm = {"files": {"Calc.cs": {"mutants": [confirm_mutant]}}}
+
+    spliced = mutation_report.splice_confirm_over_prior(prior, confirm, "Calc.cs")
+    mutants = spliced["files"]["Calc.cs"]["mutants"]
+    assert len(mutants) == 1
+    assert mutants[0]["status"] == "Killed"
+
+
+def test_splice_survives_a_malformed_confirm_report():
+    """Never-raise posture: an unusable side is absent, not fatal."""
+    prior = {"files": {"Calc.cs": {"mutants": [_cm("1", 10, "Survived")]}}}
+    spliced = mutation_report.splice_confirm_over_prior(prior, {}, "Calc.cs")
+    assert spliced["files"]["Calc.cs"]["mutants"][0]["status"] == "Survived"
+
+
+def test_spliced_score_matches_a_full_run_that_saw_the_same_outcomes():
+    """The splice is only worth anything if the score it yields is the score a
+    full round would have produced — pinned here rather than assumed."""
+    full = {
+        "files": {
+            "Calc.cs": {
+                "mutants": [
+                    _cm("1", 10, "Killed"),
+                    _cm("2", 50, "Killed"),
+                    _cm("3", 99, "Survived"),
+                ]
+            }
+        }
+    }
+    prior = {
+        "files": {
+            "Calc.cs": {
+                "mutants": [
+                    _cm("1", 10, "Survived"),
+                    _cm("2", 50, "Killed"),
+                    _cm("3", 99, "Survived"),
+                ]
+            }
+        }
+    }
+    confirm = {
+        "files": {
+            "Calc.cs": {"mutants": [_cm("1", 10, "Killed"), _cm("3", 99, "Survived")]}
+        }
+    }
+
+    spliced = mutation_report.splice_confirm_over_prior(prior, confirm, "Calc.cs")
+    assert mutation_report._score_data_for_file(
+        spliced, "Calc.cs"
+    ) == mutation_report._score_data_for_file(full, "Calc.cs")

--- a/tests/scripts/test_stryker_shard_pipeline.py
+++ b/tests/scripts/test_stryker_shard_pipeline.py
@@ -880,3 +880,42 @@ def test_no_repo_specific_literal(module_name):
     source = (SCRIPTS_DIR / module_name).read_text(encoding="utf-8")
     for literal in FORBIDDEN_LITERALS:
         assert literal not in source, f"{literal} leaked into {module_name}"
+
+
+# =============================================================================
+# #1953 — the DEFAULT git_run path. Every other test in this file injects a
+# fake git_run, which is exactly why a broken default survived: the production
+# path (main() -> run_all(...) with no git_run) was never exercised. These
+# tests deliberately use the real default.
+# =============================================================================
+def test_default_git_runner_satisfies_the_GitRunner_alias_positionally(tmp_path):
+    """`GitRunner` is `Callable[[Sequence[str], Path, bool], object]` and every
+    call site passes `check` positionally. `_git` declaring it keyword-only
+    made the shipped default the one implementation that did not satisfy its
+    own alias — TypeError on every real invocation."""
+    import inspect
+
+    param = inspect.signature(pipeline._git).parameters["check"]
+    assert param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_worktree_remove_runs_with_the_default_git_runner(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    # Must not raise TypeError. check=False, so a missing worktree is fine.
+    pipeline.worktree_remove(tmp_path, tmp_path / "absent-worktree")
+
+
+def test_worktree_add_runs_with_the_default_git_runner(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@e.st"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "init"], check=True)
+
+    worktree = tmp_path / "wt"
+    pipeline.worktree_add(repo, worktree)
+    assert worktree.is_dir()
+    pipeline.worktree_remove(repo, worktree)


### PR DESCRIPTION
## Summary

Follow-on to the merged [#2052](https://github.com/bdfinst/agentic-dev-team/pull/2052), continuing the same priority sequence.

**Real bugs (cluster 2)**

- **#1953** — `stryker_shard_pipeline._git` declared `check` keyword-only while the `GitRunner` alias, all three call sites, and every test fake pass it positionally. The shipped default was the one implementation that didn't satisfy its own alias, so **every real invocation raised `TypeError`** — `main()` calls `run_all()` with no `git_run`, so that's all of them. Invisible to the suite because every existing test injects a fake; the new regression tests call the real default.
- **#2027** — `lint-staged` ran the bare `ruff` binary, bypassing #1676's pinned-module rule on the path that runs *every commit*. Measured in this container: pinned 0.16.1 clean, PATH 0.15.8 reporting E402 — and the direction is inverted from #1676's case, so only "which version this repo pins" is stable. Converted to a `tests/repo/` check per the CLAUDE.md ratchet.
- **#1950** — `is_gateway_class_error` missed underscore/camel-joined status keys, `HTTP/1.1 502` (version digits inside the anchor gap), and status **529** (Anthropic's own overload code). Also made the classifier read stdout, which it was structurally blind to.
- **#1952** — `_format_downgrade_message` inferred *why* generation exhausted from a model-name proxy instead of the reason the caller computed and discarded. `DowngradeEvent` now carries `already_downgraded`; the proxy constant is removed.

**Mutation-kill economics (cluster 1 remainder)**

- **#2033** — mid-phase mutation-yield steering at batch boundaries, porting #1790's mechanism (same status vocabulary, same exit-code contract, asserted equal by test) into the lane that is 34.4% of thread messages.
- **#2031** — *partial.* Lands the deterministic core (`survivor_lines`, `confirm_scope_is_complete`, `splice_confirm_over_prior`, `make_confirm_scoped_config`) but **deliberately does not wire it into the loop**.

## Test Plan

- [x] Full pre-push suite green — 9,529 passed, 49 skipped
- [x] `ruff check` clean; `check_md_references.py` clean
- [x] Every fix's tests confirmed **red** against the pre-change code before merge
- [x] #1950 verified against 13 cases including the false-positive guards #1938 anchored for (`request id 502391`, `error after 5024 ms`, `barcode 502391`)
- [x] `HeadlessCallFailed.__str__` asserted unchanged, so no consumer sees new text from the added `stdout` field
- [x] Two repo invariants caught this work and were satisfied properly, not worked around: the Python floor slice (`mutation_yield_steering.py` classified into `SLICE_EXCLUSIONS` with the same reason as its coverage sibling) and the repo-root resolution check
- [ ] #2031 is **not** closed — see below

### Why #2031 is only partial

Its core mechanism depends on Stryker's `mutate` **line-span syntax**, which I could not exercise: there is no dotnet or Stryker in this container, and the repo documents `mutate` only at file-glob granularity. Per CLAUDE.md's own rule, shipping it live would be a guess that looks like a result — and the failure is silent in the confident direction: an unrecognized span matches nothing, the confirm run reports zero mutants, and `_score_round`'s `total_mutants == 0` guard (#1606) reads that as *"NOT convergence"* and stops the file. A wrong guess would truncate every file's loop while looking like a saving.

A test asserts `make_confirm_scoped_config` does not appear in `_score_round`, so wiring it in without recording that verification fails the gate.

### Note on the local gate

`chk_semgrep_fixtures` remains red on this branch **and on `origin/main`** — semgrep crashes on import in this container (`pyo3_runtime.PanicException`, a debian-`cryptography`/pip-`PyJWT` conflict), so every rule reports NO-FIRE because semgrep never runs. Nothing here touches `plugins/security-assessment/`.

Closes #1953
Closes #2027
Closes #1950
Closes #1952
Closes #2033
Part of #2031
Part of #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY4SPke91uZSVZ3YxdumBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY4SPke91uZSVZ3YxdumBF)_