### PR TITLE
fix(hooks): stop measuring subagent turns as main-thread context occupancy

### DIFF
--- a/docs/adr/0037-block-by-default-at-the-context-ceiling-2000.md
+++ b/docs/adr/0037-block-by-default-at-the-context-ceiling-2000.md
@@ -112,3 +112,53 @@ Issue #2000. The change is small — one conditional and a footer — but the
 deliberate-failure test is the substance of it: this repo's rule is *when you
 add a gate, make it fail on purpose once before you trust it*, and a flip that
 left the guard still warning would report as fixed while changing nothing.
+
+## Amendment (2026-08-26)
+
+Two of this ADR's safety properties were asserted rather than implemented.
+Both are now closed in code with deliberate-failure tests; the decision
+itself — blocking by default — is unchanged.
+
+**"A window it cannot resolve does not produce a verdict at all" was not
+true.** The Context section above justified the flip partly on that claim.
+`_resolve_window` does not decline to produce a verdict for an unresolvable
+window: it returns the conservative 200K fallback tagged `default`, and the
+guard went on to a full blocking verdict against it. Provenance reached the
+message text and nothing else. So an unrecognized model id — on a model
+whose real window may be 1M — hard-blocked every capability load from 80,000
+tokens onward, at 8% of the real window. `_LARGE_WINDOW_RE` is version-pinned
+by deliberate design ([ADR 0011](0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md)'s
+amendment), which means *every model released after it was last edited* lands
+in that case until someone edits the pattern.
+
+The fallback's original rationale is explicit that it was written for a
+different posture: "over-nudging a 1M session is a minor false alarm." Under
+warn-by-default it was. Under this ADR it is a session that cannot dispatch
+an agent or invoke a skill. The asymmetry argument survives — an unknown
+model is still never assumed large, so the guard still *reports* — but its
+consequence is now downgraded: a `default`-provenance verdict warns with a
+`[not blocked: window unverified]` footer naming `DEV_TEAM_CONTEXT_WINDOW`.
+`override` and `detected` provenance block exactly as this ADR specifies.
+This is the same principle as consequence 2 above, applied one layer out: the
+guard blocks on what it knows, and it does not know an unrecognized model's
+window.
+
+**Occupancy could be measured from the wrong context.** `_measure_occupancy`
+took the most recent usage-bearing transcript row unconditionally, including
+rows marked `isSidechain` — subagent turns, whose usage describes the
+subagent's context rather than the main thread's. Under the harness layout
+that records sidechain turns inline, a 5K subagent turn recorded after a 190K
+main turn made the guard measure 5K and allow the load: silent
+non-enforcement, the exact failure this ADR exists to remove, arriving
+through the measurement instead of the posture. The reverse also held — a
+large subagent turn blocked a main thread at 10% of its window.
+`scripts/session_extract.py` and `scripts/measure_full_file_duplication.py`
+both already filtered on `isSidechain`; this hook was the transcript consumer
+that did not. Both scans now skip sidechain rows.
+
+Neither gap was caught by the #2000 test suite because every window-detection
+test runs under `_base_env`, which pins `DEV_TEAM_CONTEXT_STRICT=off`. The
+existing `test_unrecognized_model_falls_back_to_200000` asserts
+`returncode == 0` — correct for warn mode, and silent about the shipped
+default. The new cases run under `_posture_env`, which sets no posture
+variable at all, and each was confirmed to fail with its fix reverted.

--- a/plugins/dev-team/docs/context-management.md
+++ b/plugins/dev-team/docs/context-management.md
@@ -50,7 +50,7 @@ The warning follows one pinned template, field by field:
 | `{window}` | The resolved context window in tokens. |
 | `{eff}` | The effective ceiling: `min(ceiling_pct% of window, abs_ceiling)`. |
 | `{bound}` | Which threshold is binding — `percentage` or `absolute`. The two framings never co-occur; exactly one is reported. |
-| `{provenance}` | Where `{window}` came from — `override` (`DEV_TEAM_CONTEXT_WINDOW` set), `detected` (matched a pinned model family/version), or `default` (unrecognized model, or no model info — falls back to 200K). |
+| `{provenance}` | Where `{window}` came from — `override` (`DEV_TEAM_CONTEXT_WINDOW` set), `detected` (matched a pinned model family/version), or `default` (unrecognized model, or no model info — falls back to 200K). **`default` warns but never blocks** — see Expectations. |
 | `{label}` | What triggered the check — `loading agent '<name>'` or `invoking skill '<name>'`. |
 
 A second line follows, naming the Handoff action band for
@@ -93,6 +93,21 @@ Concrete fire-points at default settings (`DEV_TEAM_CONTEXT_CEILING_PCT=40`,
   alone accounting for 29% of main-thread spend at roughly 3x the per-turn
   cost of a sub-100K session. Recovery was invoked 3 times. An advisory
   ceiling reads as a guarantee and delivers none.
+- **An unverified window warns, it does not block.** When the window's
+  provenance is `default` — the model id is one the guard does not
+  recognize — the threshold above it is a guess, so the verdict is
+  downgraded to a warning carrying a `[not blocked: window unverified]`
+  footer. Blocking there would stop every capability load from 80,000
+  tokens onward on a model whose real window may be 1M, and every model
+  released after the detection pattern was last edited lands in this case.
+  Set `DEV_TEAM_CONTEXT_WINDOW` to the model's real window to restore
+  blocking; `override` and `detected` provenance block as normal.
+- **Subagent turns are not main-thread occupancy.** Transcript rows marked
+  `isSidechain` are excluded from both the occupancy scan and window
+  detection. Their usage describes the subagent's own context, so counting
+  them measures the wrong window in both directions — a small subagent turn
+  recorded after a large main turn would hide a full context, and a large
+  one would block a main thread nowhere near the ceiling.
 - **Fail-open guarantees.** The hook never blocks a session because of its
   own failure: missing or unreadable transcript, malformed or empty stdin,
   unmeasurable usage, a malformed env var, or any internal parse error all

--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -33,6 +33,15 @@ none, so it now blocks and the operator opts out explicitly.
 Recovery skills are never gated: blocking /handoff (the way
 back under budget) would deadlock the session.
 
+Two properties keep the blocking default honest, and both are pinned by
+tests rather than left as prose:
+
+* Sidechain (subagent) transcript rows are excluded from the scan — their
+  usage describes the subagent's context, not the main thread's. See
+  `_is_sidechain`.
+* A ceiling computed against the unverified 200K fallback window warns
+  instead of blocking. See `_UNVERIFIED_WINDOW_FOOTER`.
+
 Env:
     DEV_TEAM_CONTEXT_CEILING=off     disable entirely (default on)
     DEV_TEAM_CONTEXT_STRICT=off      warn instead of blocking over the
@@ -52,7 +61,11 @@ Env:
                                      model -> 200000 (conservative fallback —
                                      window is a fixed per-model property, and
                                      an unrecognized model is never assumed to
-                                     be a large-window one).
+                                     be a large-window one). A ceiling computed
+                                     against that fallback WARNS but never
+                                     blocks: the guard blocks on what it knows,
+                                     and an unrecognized model id means it does
+                                     not know the window.
     DEV_TEAM_CONTEXT_ABS_CEILING=N   absolute token cap on the threshold;
                                      defaults to 150000 (Anthropic's
                                      server-side compaction default). The
@@ -151,10 +164,16 @@ def _positive_int_env(name: str, default: int) -> int:
 # model that merely shares a family name (e.g. a hypothetical small-window
 # "sonnet-6") must NOT be assumed 1M just because "sonnet" matches — that is
 # why this list is version-pinned rather than a bare family regex. Unknown
-# models fall back to the 200K default: over-nudging a 1M session is a minor
-# false-alarm; under-nudging a 200K session risks running well past the real
-# ceiling. See ADR 0011's dated amendment for the rationale change from a
-# pure env-var default to this per-model map.
+# models fall back to the 200K default so the guard still *reports* rather
+# than going silent, but that fallback no longer produces a block — see
+# `_UNVERIFIED_WINDOW_FOOTER`. The original asymmetry argument ("over-nudging
+# a 1M session is a minor false alarm; under-nudging a 200K session risks
+# running well past the real ceiling") was written when the default posture
+# was warn, where a false alarm really did cost only a nudge. Under the #2000
+# blocking default it would have cost every capability load from 80K onward
+# on any model this regex has not been taught, so the fallback's consequence
+# was downgraded rather than its value. See ADR 0011's dated amendment for
+# the rationale change from a pure env-var default to this per-model map.
 #
 # Family match order matters: Haiku is checked first so a hypothetical
 # "haiku-opus" alias (or similar) can't fall through to the 1M branch.
@@ -184,12 +203,40 @@ def _window_for_model(model: str) -> int:
     model fails safe toward the conservative 200K default, so leaving Opus 5
     out of the pattern was an under-nudging gap for what is currently this
     repo's default model, not a safe omission.
+
+    "Fails safe" is doing less work here than it looks: the 200K fallback
+    sizes the threshold, and a threshold is only as good as the window under
+    it. That is why a fallback-derived verdict warns instead of blocking —
+    every model released after this pattern was last edited lands here.
     """
     if _HAIKU_RE.search(model):
         return _HAIKU_WINDOW
     if _LARGE_WINDOW_RE.search(model):
         return _LARGE_WINDOW
     return _DEFAULT_WINDOW
+
+
+def _is_sidechain(row: dict) -> bool:
+    """True for a subagent (sidechain) transcript record.
+
+    Older harness layouts record subagent turns inline in the main
+    transcript with `isSidechain: true`; newer ones write them to sibling
+    per-subagent files (see `hooks/lib/cost_meter.py`). Under the inline
+    layout the most recent usage-bearing row is frequently a subagent's, and
+    its usage describes the subagent's own context rather than the main
+    thread's — so counting it measures the wrong window, in both directions:
+
+    * a small subagent turn recorded after a large main turn UNDER-reports
+      occupancy, and the guard silently stops enforcing — the exact
+      failure mode ADR 0037 exists to remove;
+    * a large subagent turn recorded after a small main turn OVER-reports
+      it, and the guard blocks a main thread nowhere near the ceiling.
+
+    `isSidechain` is the same signal `scripts/session_extract.py` and
+    `scripts/measure_full_file_duplication.py` already key off for the
+    inline layout; this hook was the one transcript consumer that did not.
+    """
+    return bool(row.get("isSidechain"))
 
 
 def _detect_window(transcript_path: Path) -> tuple[int, bool]:
@@ -220,6 +267,8 @@ def _detect_window(transcript_path: Path) -> tuple[int, bool]:
         except (json.JSONDecodeError, ValueError):
             continue
         if not isinstance(row, dict):
+            continue
+        if _is_sidechain(row):
             continue
         message = row.get("message")
         if not isinstance(message, dict):
@@ -303,6 +352,8 @@ def _measure_occupancy(transcript_path: Path) -> int | None:
         except (json.JSONDecodeError, ValueError):
             continue
         if not isinstance(row, dict):
+            continue
+        if _is_sidechain(row):
             continue
         message = row.get("message")
         if not isinstance(message, dict):
@@ -419,6 +470,27 @@ _BLOCK_FOOTER = (
     "[blocked: context ceiling] Run /handoff to summarize and continue in a "
     "fresh context — recovery skills are never gated, so it will run. "
     "Set DEV_TEAM_CONTEXT_STRICT=off to warn instead of blocking."
+)
+
+#: Appended instead of `_BLOCK_FOOTER` when the guard is over the ceiling but
+#: the window it measured against is the unverified 200K fallback (provenance
+#: "default"). ADR 0037 justified the blocking default partly on the claim
+#: that "a wrong window can no longer brick a session, because a window it
+#: cannot resolve does not produce a verdict at all" — which was not what the
+#: code did: `_resolve_window` returns the 200K fallback and the guard went on
+#: to a full blocking verdict against it. On a model whose real window is 1M
+#: that blocks every capability load from 80K onward, i.e. at 8% of the real
+#: window, and it does so for every model released after `_LARGE_WINDOW_RE`
+#: was last edited. The conservative fallback's own rationale ("over-nudging a
+#: 1M session is a minor false alarm") was written for the warn-by-default era
+#: and does not survive the flip: an unverified window now warns, and only a
+#: verified one — an explicit override or a recognized model — blocks.
+_UNVERIFIED_WINDOW_FOOTER = (
+    "[not blocked: window unverified] This transcript's model id is not one "
+    "this guard recognizes, so the ceiling above was computed against the "
+    "conservative 200000-token fallback, which may be a small fraction of "
+    "the real window. Set DEV_TEAM_CONTEXT_WINDOW to the model's real window "
+    "to restore blocking."
 )
 
 _BAND_ACTIONS = {
@@ -573,8 +645,19 @@ def _resolve_verdict(payload: dict) -> tuple[int, str | None, bool]:
     # warning. Every other value — including the historical `on`, which many
     # environments already set — blocks, so opting IN never silently becomes
     # opting out.
-    if os.environ.get("DEV_TEAM_CONTEXT_STRICT", "").strip().lower() != "off":
+    strict = os.environ.get("DEV_TEAM_CONTEXT_STRICT", "").strip().lower() != "off"
+
+    # A verdict computed against the unverified 200K fallback window warns but
+    # never blocks — see `_UNVERIFIED_WINDOW_FOOTER`. This is the same
+    # fail-open principle the rest of the hook already follows: the guard
+    # blocks on what it *knows*, and an unrecognized model id means it does
+    # not know the window. An explicit `DEV_TEAM_CONTEXT_WINDOW` override
+    # ("override") or a recognized model ("detected") both block as before.
+    if strict and provenance != "default":
         return 2, f"{msg}\n{_BLOCK_FOOTER}", False
+
+    if strict:
+        msg = f"{msg}\n{_UNVERIFIED_WINDOW_FOOTER}"
 
     # Warn mode dedupe, re-keyed on band identity (#781): the dedupe key is
     # max(band_index_scaled, pct_bucket). _BAND_SCALE (100) makes any band

--- a/plugins/dev-team/skills/context-loading-protocol/SKILL.md
+++ b/plugins/dev-team/skills/context-loading-protocol/SKILL.md
@@ -27,9 +27,16 @@ window, which the hook auto-detects from the session's most recent
 1M-window models -> 1M (Fable, Mythos, Opus 4.6/4.7/4.8, Sonnet 5, Sonnet 4.6);
 unrecognized model, or a same-family model outside those pinned versions ->
 200K conservative fallback (window is a fixed per-model property, so an
-unrecognized model is never assumed large — over-nudging is a minor false
-alarm, under-nudging risks running well past the real ceiling). Set
-`DEV_TEAM_CONTEXT_WINDOW` to override detection explicitly.
+unrecognized model is never assumed large). A ceiling computed against that
+fallback **warns but never blocks** — the guard blocks on windows it knows,
+and an unrecognized model id means it does not know this one. Set
+`DEV_TEAM_CONTEXT_WINDOW` to override detection explicitly, which also
+restores blocking.
+
+Occupancy is measured from main-thread turns only: transcript rows marked
+`isSidechain` are subagent turns whose usage describes the subagent's
+context, not this one's, and are skipped by both the occupancy scan and
+window detection.
 
 The effective ceiling is `min(ceiling_pct% of window, 150K tokens)` — an
 absolute-token cap (`DEV_TEAM_CONTEXT_ABS_CEILING`, default 150000, matching

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -1329,3 +1329,217 @@ class TestBlockingIsTheDefault:
         env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
         result = _run(_mkinput("Bash", {"command": "ls"}, tr), env)
         assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Sidechain (subagent) rows must not be measured as main-thread occupancy
+# ---------------------------------------------------------------------------
+
+
+def _usage_row(total: int, *, model: str = "claude-haiku-4-5",
+               sidechain: bool = False) -> str:
+    return json.dumps(
+        {
+            "isSidechain": sidechain,
+            "message": {
+                "model": model,
+                "usage": {
+                    "input_tokens": 2,
+                    "cache_read_input_tokens": total - 2,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+        }
+    )
+
+
+def _write_rows(path: Path, *rows: str) -> None:
+    path.write_text("\n".join(rows) + "\n")
+
+
+class TestSidechainRowsAreNotMainThreadOccupancy:
+    """A subagent turn's usage describes the subagent's context, not the main
+    thread's. The hook took the last usage-bearing row unconditionally, so
+    under the harness layout that records sidechain turns inline the measured
+    number could belong to a different context entirely — in either
+    direction. `scripts/session_extract.py` and
+    `scripts/measure_full_file_duplication.py` both already filter on
+    `isSidechain`; this hook was the transcript consumer that did not.
+    """
+
+    def test_a_trailing_sidechain_row_does_not_hide_a_full_main_thread(
+        self, tmp_path: Path
+    ) -> None:
+        """The deliberate-failure case. Main thread at 190K on a 200K window
+        is far past the ceiling; a 5K subagent turn recorded after it made the
+        guard measure 5K and allow the load. That is silent non-enforcement —
+        precisely the failure ADR 0037 exists to remove, arriving through the
+        measurement rather than the posture.
+        """
+        tr = tmp_path / "t.jsonl"
+        _write_rows(tr, _usage_row(190_000), _usage_row(5_000, sidechain=True))
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert result.returncode == 2, (
+            "a subagent turn recorded after the main turn must not mask "
+            "main-thread occupancy"
+        )
+        assert b"190000 of 200000" in result.stderr
+
+    def test_a_trailing_sidechain_row_does_not_invent_occupancy(
+        self, tmp_path: Path
+    ) -> None:
+        """The other direction: a 300K subagent turn after a 20K main turn
+        blocked a main thread at 10% of its window."""
+        tr = tmp_path / "t.jsonl"
+        _write_rows(tr, _usage_row(20_000), _usage_row(300_000, sidechain=True))
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert result.returncode == 0
+        assert result.stderr == b""
+
+    def test_measure_occupancy_skips_sidechain_rows(self, tmp_path: Path) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_rows(tr, _usage_row(1_000), _usage_row(9_000, sidechain=True))
+        assert hook._measure_occupancy(tr) == 1_000
+
+    def test_measure_occupancy_is_none_when_every_row_is_sidechain(
+        self, tmp_path: Path
+    ) -> None:
+        """All-sidechain means nothing is known about the main thread, which
+        is a measurement failure — and measurement failures fail open."""
+        tr = tmp_path / "t.jsonl"
+        _write_rows(tr, _usage_row(9_000, sidechain=True))
+        assert hook._measure_occupancy(tr) is None
+
+    def test_detect_window_skips_sidechain_rows(self, tmp_path: Path) -> None:
+        """Window detection reads the same rows, so it needs the same filter:
+        a subagent running on a different model must not resize the main
+        thread's ceiling."""
+        tr = tmp_path / "t.jsonl"
+        _write_rows(
+            tr,
+            _usage_row(1_000, model="claude-opus-5"),
+            _usage_row(9_000, model="claude-haiku-4-5", sidechain=True),
+        )
+        assert hook._detect_window(tr) == (1_000_000, True)
+
+    @pytest.mark.parametrize("flag", [False, None, 0, ""])
+    def test_falsy_sidechain_flags_are_main_thread(self, flag) -> None:
+        assert hook._is_sidechain({"isSidechain": flag}) is False
+
+    def test_a_row_with_no_sidechain_key_is_main_thread(self) -> None:
+        """The overwhelmingly common shape — the key is absent on main-loop
+        records. Treating absence as sidechain would filter the whole
+        transcript and silently disable the guard."""
+        assert hook._is_sidechain({"message": {}}) is False
+
+
+# ---------------------------------------------------------------------------
+# A ceiling computed against the unverified fallback window must not block
+# ---------------------------------------------------------------------------
+
+
+class TestUnverifiedWindowWarnsButDoesNotBlock:
+    """ADR 0037 justified the blocking default partly on the claim that "a
+    wrong window can no longer brick a session, because a window it cannot
+    resolve does not produce a verdict at all." That was not what the code
+    did: an unrecognized model id resolved to the 200K fallback and went on
+    to a full blocking verdict against it. On a model whose real window is
+    1M that blocks every capability load from 80K — 8% of the real window —
+    and every model released after `_LARGE_WINDOW_RE` was last edited lands
+    there. These tests make the ADR's claim true.
+    """
+
+    def test_an_unrecognized_model_over_the_fallback_ceiling_warns(
+        self, tmp_path: Path
+    ) -> None:
+        """The deliberate-failure case: this returned 2 before the fix."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")
+        result = _run(
+            _mkinput("Skill", {"skill": "plan"}, tr), _posture_env(tmp_path)
+        )
+        assert result.returncode == 0, (
+            "a threshold computed against a window the guard could not "
+            "verify must not block"
+        )
+        assert b"window default" in result.stderr
+        assert b"not blocked: window unverified" in result.stderr
+        assert b"blocked: context ceiling" not in result.stderr
+
+    def test_the_warning_names_the_knob_that_restores_blocking(
+        self, tmp_path: Path
+    ) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")
+        result = _run(
+            _mkinput("Agent", {"subagent_type": "x"}, tr), _posture_env(tmp_path)
+        )
+        assert b"DEV_TEAM_CONTEXT_WINDOW" in result.stderr
+
+    def test_a_detected_window_still_blocks(self, tmp_path: Path) -> None:
+        """The downgrade is scoped to `default` provenance only. A recognized
+        model is a window the guard knows, so #2000's default is unchanged
+        there — this is the assertion that keeps the fix from quietly
+        becoming a return to warn-by-default."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 200_000, model="claude-opus-5")  # 1M window
+        result = _run(
+            _mkinput("Skill", {"skill": "plan"}, tr), _posture_env(tmp_path)
+        )
+        assert result.returncode == 2
+        assert b"window detected" in result.stderr
+
+    def test_an_explicit_override_still_blocks_even_on_an_unknown_model(
+        self, tmp_path: Path
+    ) -> None:
+        """`DEV_TEAM_CONTEXT_WINDOW` is the operator stating the window, so
+        the guard is no longer guessing and blocking resumes."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert result.returncode == 2
+        assert b"window override" in result.stderr
+
+    def test_below_the_fallback_ceiling_is_still_silent(
+        self, tmp_path: Path
+    ) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 50_000, model="claude-opus-6")
+        result = _run(
+            _mkinput("Skill", {"skill": "plan"}, tr), _posture_env(tmp_path)
+        )
+        assert result.returncode == 0
+        assert result.stderr == b""
+
+    def test_explicit_warn_mode_does_not_gain_the_unverified_footer(
+        self, tmp_path: Path
+    ) -> None:
+        """Under `STRICT=off` nothing was going to block anyway, so the
+        footer would be explaining a restriction that does not exist."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_STRICT"] = "off"
+        result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert result.returncode == 0
+        assert b"not blocked: window unverified" not in result.stderr
+
+    def test_unverified_warnings_are_deduped_like_any_other_warning(
+        self, tmp_path: Path
+    ) -> None:
+        """Downgrading to a warning routes through the existing per-session
+        dedupe; without that, an unrecognized model would print the footer on
+        every single capability load."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")
+        env = _posture_env(tmp_path)
+        first = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        second = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert first.stderr != b""
+        assert second.stderr == b""


### PR DESCRIPTION
## Summary

Two defects in `hooks/context_ceiling_guard.py` that were harmless while the default posture was warn, and became load-bearing when #2000 made blocking the default. Found while reviewing the guard's size limit; both are measurement/scope bugs, not threshold changes — the ceiling stays exactly where it is.

- **Sidechain rows were measured as main-thread occupancy.** `_measure_occupancy` took the most recent usage-bearing transcript row unconditionally, including rows marked `isSidechain` — subagent turns, whose usage describes the subagent's context rather than the main thread's. Under the harness layout that records sidechain turns inline, a 5K subagent turn recorded after a 190K main turn made the guard measure 5K and **allow** the load: silent non-enforcement, the exact failure ADR 0037 exists to remove, arriving through the measurement instead of the posture. The reverse held too — a 300K subagent turn **blocked** a main thread at 10% of its window. `scripts/session_extract.py` and `scripts/measure_full_file_duplication.py` both already filter on `isSidechain`; this hook was the one transcript consumer that did not. Both the occupancy scan and window detection now skip them.
- **An unverified window produced a full blocking verdict.** ADR 0037 justified the blocking default partly on the claim that *"a wrong window can no longer brick a session, because a window it cannot resolve does not produce a verdict at all."* That is not what the code did: `_resolve_window` returns the conservative 200K fallback tagged `default`, and the guard blocked against it — provenance reached the message text and nothing else. On a model whose real window is 1M that blocks every capability load from 80,000 tokens onward (8% of the real window), and because `_LARGE_WINDOW_RE` is version-pinned by deliberate design (ADR 0011's amendment), **every model released after it was last edited lands there**. A `default`-provenance verdict now warns with a `[not blocked: window unverified]` footer naming `DEV_TEAM_CONTEXT_WINDOW`; `override` and `detected` provenance block exactly as before.
- Docs (`docs/context-management.md`, `context-loading-protocol/SKILL.md`) and an ADR 0037 amendment record both, including the stale warn-era rationale comment (*"over-nudging a 1M session is a minor false alarm"*) that no longer held after the flip.

Neither gap was covered by the #2000 suite because every window-detection test runs under `_base_env`, which pins `DEV_TEAM_CONTEXT_STRICT=off`. `test_unrecognized_model_falls_back_to_200000` asserts `returncode == 0` — correct for warn mode, and silent about the shipped default.

## Test Plan

- [x] 15 new tests in two classes, all under `_posture_env` (no posture variable set, so the shipped default is what runs) — `TestSidechainRowsAreNotMainThreadOccupancy` and `TestUnverifiedWindowWarnsButDoesNotBlock`
- [x] **Deliberate-failure check, per this repo's "make a gate fail on purpose once before you trust it" rule** — with the sidechain filter reverted: 5 failed / 5 passed; with the unverified-window downgrade reverted: 2 failed / 5 passed; both restored: 183 passed
- [x] Scope guard: `test_a_detected_window_still_blocks` and `test_an_explicit_override_still_blocks_even_on_an_unknown_model` pin that this does not quietly become a return to warn-by-default
- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_context_ceiling_guard.py -q` → 183 passed
- [x] Full local CI mirror on push (`scripts/ci-local.sh` via `pre-push`) → **All local CI checks passed**, 9,530 passed / 47 skipped
- [x] `ruff check` clean; `scripts/check_md_references.py` exit 0; `build_knowledge_index.py` produced no drift

<sub>Note for reviewers: this container was missing `jsonschema`, `semgrep`, and `pytest-asyncio`; the 3 adapter and 92 orchestrator failures those caused were confirmed identical on clean `origin/main` before being resolved by installing them. No pre-existing failures are attributable to this branch.</sub>

Follow-up PR raising the `DEV_TEAM_CONTEXT_ABS_CEILING` default is stacked on this branch and will be opened separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_015No9ngckCVJ7dQ7ijidkZ7)_