### PR TITLE
feat(scripts): instrument the context ceiling instead of inferring it

### DIFF
--- a/docs/adr/0038-raise-the-absolute-context-ceiling-to-350k.md
+++ b/docs/adr/0038-raise-the-absolute-context-ceiling-to-350k.md
@@ -132,3 +132,34 @@ defects fixed separately — sidechain rows counted as main-thread occupancy,
 and an unverified fallback window producing a full blocking verdict. Those
 are correctness bugs in what the guard measures; this is a judgement call
 about where the line goes, which is why it is a separate decision.
+
+## Amendment (2026-08-26)
+
+The revisit trigger above asked for per-session peak occupancy to be
+instrumented directly, so the threshold could be re-derived from a recorded
+distribution instead of a token-ratio inference. That instrument now exists:
+`scripts/context_ceiling_report.py`, with
+`tests/scripts/test_context_ceiling_report.py` pinning its measurement to the
+guard's own.
+
+Building it surfaced a flaw in the reasoning this ADR used, which does not
+change the decision but does change how the next one should be argued. The
+occupancy figures in the Context section are **per-turn averages**, and the
+ceiling does not fire per turn — it fires only at a capability load. A session
+can sit at 600K indefinitely without ever tripping the guard, if it never
+dispatches an agent or invokes a skill while up there. So an
+occupancy-derived threshold is derived from the wrong distribution: it
+overstates how often any given ceiling actually binds. The tool therefore
+conditions on gated calls rather than on occupancy, and its peak-occupancy
+table carries an explicit warning against reading it as a block rate.
+
+The direction of that error favors the decision this ADR made — the real
+block rate at 150K is *lower* than the per-turn average implied, so the
+over-correction argument is weaker than stated, while the evidence that 150K
+was a borrowed rather than measured number is untouched. Treat the 350K value
+as still resting mainly on the second argument until the report has been run
+over a corpus large enough to return a verdict other than "inconclusive".
+
+Re-deriving the threshold is now a command, not a project. Run it, read the
+`near-done` and `tokens over` columns together, and amend this ADR with what
+the corpus says.

--- a/docs/context-ceiling-validation.md
+++ b/docs/context-ceiling-validation.md
@@ -1,0 +1,122 @@
+# Validating the context ceiling
+
+The context ceiling enforced by `hooks/context_ceiling_guard.py` is a
+judgement call, and [ADR 0038](adr/0038-raise-the-absolute-context-ceiling-to-350k.md)
+named the weakest part of the reasoning behind its current 350K value:
+
+> The turn-count estimate above is the weakest link in this reasoning — it is
+> an inference from a token ratio, not a recorded count. If per-session peak
+> occupancy is ever instrumented directly, re-derive the threshold from the
+> actual distribution.
+
+`scripts/context_ceiling_report.py` is the instrument that replaces that
+inference. It replays real session transcripts, reconstructs the occupancy the
+guard *would have measured* at every capability load, and reports what each
+candidate ceiling would have done.
+
+This is maintainer tooling. It lives at the repo root and is **not shipped**
+with the plugin — see [ADR 0014](adr/0014-python-for-cross-os-scripts.md) on
+the scope split. For the shipped guard's own user-facing guide (what it
+measures, how to read its warning, which knobs exist), see
+[`plugins/dev-team/docs/context-management.md`](../plugins/dev-team/docs/context-management.md).
+
+## Running it
+
+```bash
+# default corpus: ~/.claude/projects/**/*.jsonl
+python3 scripts/context_ceiling_report.py
+
+# narrower corpus, custom sweep, machine-readable output
+python3 scripts/context_ceiling_report.py \
+  --transcripts ~/.claude/projects/-home-me-myproject \
+  --ceilings 150000,250000,350000,450000 \
+  --json /tmp/ceiling-report.json
+```
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--transcripts` | `~/.claude/projects` | Files or directories to replay; directories are searched recursively for `*.jsonl`. |
+| `--ceilings` | `150000,…,600000` | Comma-separated candidate absolute ceilings to sweep. |
+| `--ceiling-pct` | `40` | The percentage-of-window bound, matching `DEV_TEAM_CONTEXT_CEILING_PCT`. |
+| `--near-done-turns` | `5` | Assistant turns remaining at or below which a blocked session counts as "near done". |
+| `--shipped` | `350000` | Which row to mark and summarize in the verdict. |
+| `--json` | — | Also write the full per-session result for scripting. |
+
+## Reading the sweep
+
+A single "N% of sessions blocked" number cannot tell the two failure
+directions apart, so the report prints a column for each:
+
+| Column | Direction it detects | What a bad number looks like |
+| --- | --- | --- |
+| `near-done` | ceiling too **low** | a high share of blocked sessions were within a few turns of finishing — [ADR 0037](adr/0037-block-by-default-at-the-context-ceiling-2000.md)'s revisit trigger, verbatim |
+| `tokens over` | ceiling too **high** | a large share of corpus prompt tokens was spent past the first block, i.e. the expensive tail ran anyway |
+
+A better ceiling lowers `near-done` without letting `tokens over` climb. The
+report deliberately does not collapse these into a score or pick a number for
+you — the cost of a wrong ceiling is asymmetric in a way no single statistic
+captures, and the 150K→350K move happened precisely because a number got
+adopted without that trade-off being visible.
+
+Sample output, against a synthetic corpus:
+
+```text
+  ceiling |  sessions |  blocked |  blocks |  median@1st |  near-done |  tokens over
+------------------------------------------------------------------------------------
+  150,000 |        12 |     100% |     100 |     181,249 |      16.7% |        89.7%
+  250,000 |        10 |    83.3% |      85 |     291,246 |        50% |        78.8%
+  350,000 |         7 |    58.3% |      75 |     420,000 |      42.9% |        69.8% *
+  450,000 |         6 |      50% |      72 |     467,499 |      33.3% |        66.6%†
+```
+
+## Three properties worth knowing before acting on its output
+
+**It conditions on gated calls, not on occupancy.** The ceiling only binds at
+an `Agent`/`Skill` call, so a session can sit far above any candidate and
+never trip it. This is not a detail — it is the flaw the tool was built to
+correct. ADR 0038's own occupancy figures are per-turn averages, and the guard
+does not fire per turn, so reasoning from occupancy alone systematically
+*overstates* how often a given ceiling binds. The report's peak-occupancy
+table carries an explicit warning against reading it as a block rate.
+
+**A candidate above `ceiling_pct` of the window does nothing.** The effective
+threshold is `min(pct% of window, cap)`, so on a 1M window at the default 40%,
+no cap above 400K changes anything. Those rows are marked `†` rather than
+being left to look like genuine data points — a sweep row that silently equals
+its neighbour reads as "the ceiling made no difference" when the truth is
+"this candidate was never applied". Raise `--ceiling-pct` too if you want to
+test past that point.
+
+**An empty result is reported as inconclusive, never as confirmation.** If no
+session in the corpus reached the ceiling at a gated call, the verdict says so
+and asks for a larger corpus. "0 blocked" on data containing no evidence is
+not evidence the ceiling is right — that is this repo's *a gate that cannot
+fail is worse than no gate* rule applied to the measurement itself.
+
+## Why it cannot drift from the guard
+
+Every policy decision — which tools are gated, which skills are exempt, how a
+model maps to a window, how occupancy is summed, what counts as a sidechain
+row — is **imported** from
+[`plugins/dev-team/hooks/context_ceiling_guard.py`](../plugins/dev-team/hooks/context_ceiling_guard.py)
+rather than restated. A validator that measured the ceiling even slightly
+differently from the guard would be validating a threshold nobody ships.
+
+[`tests/scripts/test_context_ceiling_report.py`](../tests/scripts/test_context_ceiling_report.py)
+additionally pins the report's occupancy walk against the hook's own
+`_measure_occupancy` on shared fixtures, in the same spirit as the hook
+suite's utilization-formula equality test.
+
+## Acting on the result
+
+When the corpus is large enough to return a verdict other than "inconclusive",
+amend [ADR 0038](adr/0038-raise-the-absolute-context-ceiling-to-350k.md) with
+what it says. Both of that ADR's revisit triggers are now measurable rather
+than hypothetical:
+
+- `near-done` dominating the blocked population → the ceiling is too low; raise
+  `DEV_TEAM_CONTEXT_ABS_CEILING`, per ADR 0037's explicit instruction not to
+  return to warn-by-default instead.
+- sessions again running far past the ceiling, with `tokens over` high at every
+  candidate → the ceiling is too high, or the guard is not binding where the
+  spend happens.

--- a/scripts/context_ceiling_report.py
+++ b/scripts/context_ceiling_report.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Measure whether the context ceiling is set where it should be (#2056 follow-up).
+
+ADR 0038 raised `DEV_TEAM_CONTEXT_ABS_CEILING` from 150K to 350K, and named
+its own weakest link in the revisit trigger:
+
+    The turn-count estimate above is the weakest link in this reasoning — it
+    is an inference from a token ratio, not a recorded count. If per-session
+    peak occupancy is ever instrumented directly, re-derive the threshold
+    from the actual distribution.
+
+This is that instrument. It replays real session transcripts, reconstructs the
+occupancy the guard *would have measured* at every capability load, and sweeps
+candidate ceilings to show what each one would have done. It answers "should
+the ceiling move, and which way" from recorded data rather than from a ratio.
+
+Why replay rather than sample occupancy
+---------------------------------------
+The ceiling only binds at a gated call — an `Agent`/`Task` dispatch or a
+`Skill` invocation. A session can sit at 600K forever without the guard ever
+firing, if it never loads a capability while up there. So "peak occupancy per
+session" systematically OVERSTATES how often the ceiling bites, and any
+threshold derived from occupancy alone is derived from the wrong distribution.
+This tool conditions on gated calls, which is where the guard actually lives.
+
+The two failure directions, and the metric for each
+---------------------------------------------------
+A ceiling can be wrong in two directions, and a single "block rate" number
+cannot tell them apart. Each gets its own signal:
+
+* **Too low** — it blocks sessions that were essentially finished. ADR 0037's
+  revisit trigger names this case exactly ("blocked at 150K on work that would
+  have finished in another two turns"). Signal: `near_done_blocked_pct`, the
+  share of blocked sessions whose first block landed within
+  `--near-done-turns` assistant turns of the end.
+* **Too high** — it lets the expensive tail run. This is the case that
+  justified #2000 in the first place. Signal: `prompt_tokens_after_first_block`
+  as a share of the corpus total: the tokens spent while over the ceiling,
+  which is what enforcement would have cut into.
+
+A good ceiling drives the first toward zero without letting the second grow.
+Neither number is a verdict on its own; the report prints both per candidate
+and leaves the trade-off visible rather than collapsing it into a score.
+
+Anti-drift
+----------
+Every policy decision — which tools are gated, which skills are exempt, how a
+model maps to a window, how occupancy is summed, what counts as a sidechain
+row — is IMPORTED from `plugins/dev-team/hooks/context_ceiling_guard.py`
+rather than restated here. A validator that measured the ceiling slightly
+differently from the guard would validate a threshold nobody ships.
+`tests/scripts/test_context_ceiling_report.py` additionally pins this module's
+occupancy walk against the hook's own `_measure_occupancy` on shared fixtures,
+so the two cannot diverge silently.
+
+Usage
+-----
+    # default corpus: ~/.claude/projects/**/*.jsonl
+    python3 scripts/context_ceiling_report.py
+
+    # explicit paths, custom sweep, machine-readable output
+    python3 scripts/context_ceiling_report.py \
+        --transcripts ~/.claude/projects \
+        --ceilings 150000,250000,350000,450000 \
+        --json /tmp/ceiling-report.json
+
+Stdlib-only. Repo-root dev tooling — not shipped with the plugin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HOOKS_DIR = _REPO_ROOT / "plugins" / "dev-team" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+# The guard is the source of truth for every policy constant below. See the
+# "Anti-drift" note in the module docstring.
+import context_ceiling_guard as guard  # type: ignore[import-not-found]
+
+#: Candidate ceilings swept when `--ceilings` is not given. Brackets the
+#: shipped 350K default on both sides so the report can argue for moving it in
+#: either direction rather than only confirming it.
+DEFAULT_CEILINGS = (150_000, 200_000, 250_000, 300_000, 350_000, 450_000, 600_000)
+
+#: An assistant turn count at or below which a blocked session counts as
+#: "near done" — the over-blocking signal. Deliberately generous: the argument
+#: against a ceiling is strongest when it stopped work that was visibly
+#: finishing, and a loose threshold makes that case harder to overstate.
+DEFAULT_NEAR_DONE_TURNS = 5
+
+
+def _occupancy_of(usage: dict) -> int | None:
+    """Prompt-side token total for one usage block, or None if unusable.
+
+    Mirrors the guard's own summation (input + cache_read + cache_creation)
+    including its non-integer rejection. Kept as a function rather than
+    inlined so the equality test has something to pin.
+    """
+    if not isinstance(usage, dict):
+        return None
+    input_t = usage.get("input_tokens") or 0
+    cache_read = usage.get("cache_read_input_tokens") or 0
+    cache_creation = usage.get("cache_creation_input_tokens") or 0
+    if not all(isinstance(x, int) for x in (input_t, cache_read, cache_creation)):
+        return None
+    total = int(input_t) + int(cache_read) + int(cache_creation)
+    return total if total > 0 else None
+
+
+def _gated_calls_in(record: dict) -> list[tuple[str, str]]:
+    """Every gated capability load in one record, as (tool_name, label).
+
+    Recovery skills are dropped here rather than counted and filtered later:
+    they are never gated at any occupancy, so counting them would inflate
+    every block rate in the sweep.
+    """
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    calls: list[tuple[str, str]] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        name = block.get("name")
+        if name not in guard._GATED_TOOLS:
+            continue
+        tool_input = block.get("input")
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        if name == "Skill":
+            skill = guard._extract_skill_name(tool_input)
+            if skill in guard._RECOVERY_SKILLS:
+                continue
+            calls.append((name, skill or "?"))
+        else:
+            agent = tool_input.get("subagent_type")
+            calls.append((name, agent if isinstance(agent, str) and agent else "?"))
+    return calls
+
+
+@dataclass
+class GateEvent:
+    """One capability load, with the occupancy the guard would have seen."""
+
+    occupancy: int
+    tool: str
+    label: str
+    turn_index: int
+
+
+@dataclass
+class SessionReplay:
+    """One transcript, replayed."""
+
+    path: Path
+    window: int
+    window_matched: bool
+    peak_occupancy: int = 0
+    final_occupancy: int = 0
+    assistant_turns: int = 0
+    prompt_tokens_total: int = 0
+    #: Prompt tokens per assistant turn, in order — used to compute how much
+    #: was spent after a candidate ceiling's first block.
+    turn_prompt_tokens: list[int] = field(default_factory=list)
+    gates: list[GateEvent] = field(default_factory=list)
+
+    @property
+    def session_id(self) -> str:
+        return self.path.stem
+
+
+def replay_transcript(path: Path) -> SessionReplay | None:
+    """Reconstruct occupancy over one transcript. None if it carries no usage.
+
+    Sidechain rows are skipped exactly as the guard skips them: a subagent
+    turn's usage describes the subagent's context, not the main thread's
+    (see `guard._is_sidechain`).
+    """
+    try:
+        raw_lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+
+    last_model: str | None = None
+    current_occupancy = 0
+    replay: SessionReplay | None = None
+    records: list[tuple[int, dict]] = []
+
+    for line in raw_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(record, dict) or guard._is_sidechain(record):
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        model = message.get("model")
+        if isinstance(model, str) and model:
+            last_model = model
+        occupancy = _occupancy_of(message.get("usage"))
+        if occupancy is not None:
+            current_occupancy = occupancy
+        records.append((current_occupancy, record))
+
+    if not records or all(occ == 0 for occ, _ in records):
+        return None
+
+    window = guard._window_for_model(last_model or "")
+    matched = bool(
+        last_model
+        and (guard._HAIKU_RE.search(last_model) or guard._LARGE_WINDOW_RE.search(last_model))
+    )
+    replay = SessionReplay(path=path, window=window, window_matched=matched)
+
+    for occupancy, record in records:
+        usage_occ = _occupancy_of(
+            record.get("message", {}).get("usage")  # type: ignore[union-attr]
+        )
+        if usage_occ is not None:
+            replay.assistant_turns += 1
+            replay.prompt_tokens_total += usage_occ
+            replay.turn_prompt_tokens.append(usage_occ)
+            replay.peak_occupancy = max(replay.peak_occupancy, usage_occ)
+            replay.final_occupancy = usage_occ
+        for tool, label in _gated_calls_in(record):
+            replay.gates.append(
+                GateEvent(
+                    occupancy=occupancy,
+                    tool=tool,
+                    label=label,
+                    turn_index=max(0, replay.assistant_turns - 1),
+                )
+            )
+    return replay
+
+
+def effective_threshold(window: int, ceiling_pct: int, abs_ceiling: int) -> int:
+    """`min(pct% of window, abs_ceiling)` — the guard's own formula."""
+    return min((ceiling_pct * window) // 100, abs_ceiling)
+
+
+def evaluate_ceiling(
+    replays: list[SessionReplay],
+    abs_ceiling: int,
+    ceiling_pct: int,
+    near_done_turns: int,
+) -> dict:
+    """What one candidate ceiling would have done to this corpus."""
+    blocked_sessions = 0
+    near_done_blocked = 0
+    first_block_occupancies: list[int] = []
+    tokens_after_first_block = 0
+    total_blocks = 0
+    clamped_sessions = 0
+
+    for replay in replays:
+        threshold = effective_threshold(replay.window, ceiling_pct, abs_ceiling)
+        # The candidate never took effect here: `ceiling_pct` of this window is
+        # lower, so raising the absolute cap changed nothing. Tracked because a
+        # sweep row that silently equals its neighbour is worse than no row —
+        # it reads as "the ceiling made no difference" when the truth is "this
+        # candidate was never applied".
+        if threshold < abs_ceiling:
+            clamped_sessions += 1
+        over = [g for g in replay.gates if g.occupancy >= threshold]
+        total_blocks += len(over)
+        if not over:
+            continue
+        blocked_sessions += 1
+        first = over[0]
+        first_block_occupancies.append(first.occupancy)
+        remaining_turns = replay.assistant_turns - 1 - first.turn_index
+        if remaining_turns <= near_done_turns:
+            near_done_blocked += 1
+        tokens_after_first_block += sum(replay.turn_prompt_tokens[first.turn_index + 1 :])
+
+    sessions_with_gates = sum(1 for r in replays if r.gates)
+    corpus_prompt_tokens = sum(r.prompt_tokens_total for r in replays)
+    return {
+        "abs_ceiling": abs_ceiling,
+        "clamped_sessions": clamped_sessions,
+        "clamped_pct": _pct(clamped_sessions, len(replays)),
+        "sessions_blocked": blocked_sessions,
+        "sessions_blocked_pct": _pct(blocked_sessions, sessions_with_gates),
+        "blocks_total": total_blocks,
+        "median_occupancy_at_first_block": (
+            int(statistics.median(first_block_occupancies))
+            if first_block_occupancies
+            else None
+        ),
+        "near_done_blocked": near_done_blocked,
+        "near_done_blocked_pct": _pct(near_done_blocked, blocked_sessions),
+        "prompt_tokens_after_first_block": tokens_after_first_block,
+        "prompt_tokens_after_first_block_pct": _pct(
+            tokens_after_first_block, corpus_prompt_tokens
+        ),
+    }
+
+
+def _pct(numerator: int, denominator: int) -> float | None:
+    """Percentage, or None when the denominator is zero.
+
+    None rather than 0.0 deliberately: "no sessions to divide by" and "0% of
+    sessions" are different findings, and rendering the first as the second
+    would read as evidence the ceiling is fine.
+    """
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator * 100, 1)
+
+
+def discover_transcripts(roots: list[Path]) -> list[Path]:
+    found: list[Path] = []
+    for root in roots:
+        if root.is_file() and root.suffix == ".jsonl":
+            found.append(root)
+        elif root.is_dir():
+            found.extend(sorted(root.rglob("*.jsonl")))
+    return found
+
+
+def _fmt(value) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:g}%"
+    return f"{value:,}"
+
+
+def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
+    lines: list[str] = []
+    sessions_with_gates = sum(1 for r in replays if r.gates)
+    total_gates = sum(len(r.gates) for r in replays)
+    peaks = sorted(r.peak_occupancy for r in replays)
+
+    lines.append("Context ceiling validation")
+    lines.append("=" * 74)
+    lines.append(f"transcripts replayed      : {len(replays):,}")
+    lines.append(f"  with >=1 gated call     : {sessions_with_gates:,}")
+    lines.append(f"  gated calls total       : {total_gates:,}")
+    lines.append(f"  unrecognized model      : {sum(1 for r in replays if not r.window_matched):,}")
+    if peaks:
+        lines.append("")
+        lines.append("Peak main-thread occupancy per session:")
+        for label, value in (
+            ("min", peaks[0]),
+            ("p50", int(statistics.median(peaks))),
+            ("p90", peaks[min(len(peaks) - 1, int(len(peaks) * 0.9))]),
+            ("max", peaks[-1]),
+        ):
+            lines.append(f"  {label:>5} : {value:>12,}")
+        lines.append(
+            "  (occupancy alone is NOT the block rate — the ceiling only binds"
+        )
+        lines.append("   at a gated call; see the sweep below.)")
+
+    lines.append("")
+    lines.append(
+        f"Candidate ceilings (ceiling_pct={args.ceiling_pct}, "
+        f"near-done <= {args.near_done_turns} turns remaining):"
+    )
+    header = (
+        f"{'ceiling':>9} | {'sessions':>9} | {'blocked':>8} | {'blocks':>7} | "
+        f"{'median@1st':>11} | {'near-done':>10} | {'tokens over':>12}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    any_clamped = False
+    for row in sweep:
+        marker = " *" if row["abs_ceiling"] == args.shipped else "  "
+        if row["clamped_sessions"]:
+            any_clamped = True
+            marker = marker.rstrip() + "†"
+        lines.append(
+            f"{row['abs_ceiling']:>9,} | "
+            f"{_fmt(row['sessions_blocked']):>9} | "
+            f"{_fmt(row['sessions_blocked_pct']):>8} | "
+            f"{_fmt(row['blocks_total']):>7} | "
+            f"{_fmt(row['median_occupancy_at_first_block']):>11} | "
+            f"{_fmt(row['near_done_blocked_pct']):>10} | "
+            f"{_fmt(row['prompt_tokens_after_first_block_pct']):>12}{marker}"
+        )
+    lines.append("")
+    lines.append("  * = the shipped default")
+    if any_clamped:
+        lines.append(
+            "  † = clamped for at least one session: ceiling_pct of that window is"
+        )
+        lines.append(
+            f"      lower than the candidate, so raising the cap past "
+            f"{args.ceiling_pct}% of the window"
+        )
+        lines.append(
+            "      changes nothing there. To test a higher ceiling on those sessions,"
+        )
+        lines.append("      raise --ceiling-pct as well.")
+    lines.append("  blocked     : share of gated sessions the ceiling would stop")
+    lines.append("  near-done   : share of BLOCKED sessions that were nearly finished")
+    lines.append("                — the over-blocking signal; drive toward 0")
+    lines.append("  tokens over : share of corpus prompt tokens spent past the first")
+    lines.append("                block — the under-blocking signal; what enforcement")
+    lines.append("                would have cut into")
+    lines.append("")
+    lines.append(_verdict(sweep, args))
+    return "\n".join(lines)
+
+
+def _verdict(sweep: list[dict], args) -> str:
+    """State what the numbers support, or say the corpus is too thin.
+
+    This deliberately does not pick a number: it reports which direction the
+    two signals point and leaves the decision to a human, because the cost of
+    a wrong ceiling is asymmetric in a way no single statistic captures.
+    """
+    shipped = next((r for r in sweep if r["abs_ceiling"] == args.shipped), None)
+    if shipped is None:
+        return "No shipped-default row in the sweep; nothing to compare against."
+    if shipped["sessions_blocked"] == 0:
+        return (
+            f"VERDICT: inconclusive at {args.shipped:,}. No session in this corpus "
+            "reached the ceiling at a gated call, so the data neither supports nor\n"
+            "         challenges the current value. Re-run against a larger corpus "
+            "(more projects, or a longer window of sessions)."
+        )
+    parts = [f"VERDICT at the shipped {args.shipped:,}:"]
+    near_done = shipped["near_done_blocked_pct"]
+    tokens_over = shipped["prompt_tokens_after_first_block_pct"]
+    if near_done is not None and near_done >= 50:
+        parts.append(
+            f"  - OVER-BLOCKING: {near_done:g}% of blocked sessions were near done. "
+            "ADR 0037's revisit\n    trigger names this case; the response is to raise "
+            "the ceiling, not to warn."
+        )
+    elif near_done is not None:
+        parts.append(
+            f"  - {near_done:g}% of blocked sessions were near done — not the dominant case."
+        )
+    if tokens_over is not None:
+        parts.append(
+            f"  - {tokens_over:g}% of corpus prompt tokens were spent past the first block "
+            "— what\n    enforcement reclaims."
+        )
+    parts.append(
+        "  Compare the rows above: a better ceiling lowers near-done without letting\n"
+        "  tokens-over climb. Both columns must be read together."
+    )
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the context ceiling against recorded session transcripts.",
+    )
+    parser.add_argument(
+        "--transcripts",
+        nargs="*",
+        type=Path,
+        default=[Path.home() / ".claude" / "projects"],
+        help="transcript files or directories (default: ~/.claude/projects)",
+    )
+    parser.add_argument(
+        "--ceilings",
+        type=str,
+        default=",".join(str(c) for c in DEFAULT_CEILINGS),
+        help="comma-separated candidate absolute ceilings to sweep",
+    )
+    parser.add_argument(
+        "--ceiling-pct",
+        type=int,
+        default=40,
+        help="percentage-of-window bound, matching DEV_TEAM_CONTEXT_CEILING_PCT",
+    )
+    parser.add_argument(
+        "--near-done-turns",
+        type=int,
+        default=DEFAULT_NEAR_DONE_TURNS,
+        help="assistant turns remaining at/below which a blocked session is 'near done'",
+    )
+    parser.add_argument(
+        "--shipped",
+        type=int,
+        default=350_000,
+        help="the shipped default, marked and summarized in the report",
+    )
+    parser.add_argument("--json", type=Path, help="also write the full result as JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        ceilings = sorted({int(c) for c in args.ceilings.split(",") if c.strip()})
+    except ValueError:
+        print(f"error: --ceilings must be comma-separated integers: {args.ceilings}", file=sys.stderr)
+        return 2
+    if not ceilings:
+        print("error: --ceilings resolved to an empty sweep", file=sys.stderr)
+        return 2
+
+    paths = discover_transcripts(list(args.transcripts))
+    if not paths:
+        print(
+            f"error: no .jsonl transcripts found under {[str(p) for p in args.transcripts]}",
+            file=sys.stderr,
+        )
+        return 2
+
+    replays = [r for r in (replay_transcript(p) for p in paths) if r is not None]
+    if not replays:
+        print(
+            f"error: {len(paths)} transcript(s) found, none carrying usable usage data",
+            file=sys.stderr,
+        )
+        return 2
+
+    sweep = [
+        evaluate_ceiling(replays, c, args.ceiling_pct, args.near_done_turns)
+        for c in ceilings
+    ]
+    print(render_report(replays, sweep, args))
+
+    if args.json:
+        payload = {
+            "schema": "context-ceiling-report/v1",
+            "ceiling_pct": args.ceiling_pct,
+            "near_done_turns": args.near_done_turns,
+            "sessions": [
+                {
+                    "session_id": r.session_id,
+                    "path": str(r.path),
+                    "window": r.window,
+                    "window_matched": r.window_matched,
+                    "peak_occupancy": r.peak_occupancy,
+                    "final_occupancy": r.final_occupancy,
+                    "assistant_turns": r.assistant_turns,
+                    "prompt_tokens_total": r.prompt_tokens_total,
+                    "gated_calls": len(r.gates),
+                }
+                for r in replays
+            ],
+            "sweep": sweep,
+        }
+        args.json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/scripts/test_context_ceiling_report.py
+++ b/tests/scripts/test_context_ceiling_report.py
@@ -1,0 +1,438 @@
+"""Tests for scripts/context_ceiling_report.py — the context-ceiling validator.
+
+The load-bearing test in this file is `test_final_occupancy_equals_the_guards_
+own_measurement`: a validator that measured occupancy even slightly differently
+from `hooks/context_ceiling_guard.py` would be validating a threshold nobody
+ships. That test pins the two together on shared fixtures, in the same spirit
+as the hook suite's utilization-formula equality test.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+_SCRIPTS = REPO_ROOT / "scripts"
+_HOOKS = REPO_ROOT / "plugins" / "dev-team" / "hooks"
+for _p in (_SCRIPTS, _HOOKS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import context_ceiling_guard as guard  # type: ignore[import-not-found]
+import context_ceiling_report as report  # type: ignore[import-not-found]
+
+_SCRIPT = _SCRIPTS / "context_ceiling_report.py"
+
+
+# ---------------------------------------------------------------------------
+# fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _assistant(
+    occupancy: int,
+    *,
+    model: str = "claude-opus-5",
+    sidechain: bool = False,
+    tool_uses: list[dict] | None = None,
+) -> dict:
+    content: list[dict] = [{"type": "text", "text": "..."}]
+    for tu in tool_uses or []:
+        content.append({"type": "tool_use", **tu})
+    return {
+        "isSidechain": sidechain,
+        "message": {
+            "model": model,
+            "content": content,
+            "usage": {
+                "input_tokens": 2,
+                "cache_read_input_tokens": occupancy - 2,
+                "cache_creation_input_tokens": 0,
+            },
+        },
+    }
+
+
+def _skill(name: str) -> dict:
+    return {"name": "Skill", "input": {"skill": name}}
+
+
+def _agent(name: str) -> dict:
+    return {"name": "Agent", "input": {"subagent_type": name}}
+
+
+def _write(path: Path, *records: dict) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# anti-drift: the validator must measure what the guard measures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        pytest.param([_assistant(120_000)], id="single-turn"),
+        pytest.param([_assistant(50_000), _assistant(400_000)], id="rising"),
+        pytest.param([_assistant(400_000), _assistant(50_000)], id="falling-after-compact"),
+        pytest.param(
+            [_assistant(400_000), _assistant(9_000, sidechain=True)],
+            id="trailing-sidechain",
+        ),
+        pytest.param(
+            [_assistant(80_000), {"message": {"model": "claude-opus-5"}}],
+            id="trailing-row-without-usage",
+        ),
+    ],
+)
+def test_final_occupancy_equals_the_guards_own_measurement(
+    tmp_path: Path, records: list[dict]
+) -> None:
+    """The validator and the guard must agree on occupancy, byte for byte.
+
+    If these ever diverge, the sweep is measuring a quantity the shipped guard
+    does not enforce on, and every threshold recommendation drawn from it is
+    unsound. Fixtures stay under the guard's 400-line tail window so the two
+    read the same rows.
+    """
+    tr = _write(tmp_path / "t.jsonl", *records)
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.final_occupancy == guard._measure_occupancy(tr)
+
+
+def test_effective_threshold_matches_the_guards_min_formula() -> None:
+    """`min(pct% of window, abs)` — restated here only to be pinned."""
+    assert report.effective_threshold(1_000_000, 40, 350_000) == 350_000
+    assert report.effective_threshold(200_000, 40, 350_000) == 80_000
+    assert report.effective_threshold(1_000_000, 40, 500_000) == 400_000
+
+
+def test_window_resolution_defers_to_the_guards_model_map(tmp_path: Path) -> None:
+    known = report.replay_transcript(
+        _write(tmp_path / "a.jsonl", _assistant(10_000, model="claude-opus-5"))
+    )
+    unknown = report.replay_transcript(
+        _write(tmp_path / "b.jsonl", _assistant(10_000, model="totally-unknown"))
+    )
+    assert known is not None and unknown is not None
+    assert (known.window, known.window_matched) == (1_000_000, True)
+    assert (unknown.window, unknown.window_matched) == (200_000, False)
+
+
+# ---------------------------------------------------------------------------
+# gate detection
+# ---------------------------------------------------------------------------
+
+
+def test_sidechain_turns_are_excluded_from_occupancy_and_gates(tmp_path: Path) -> None:
+    tr = _write(
+        tmp_path / "t.jsonl",
+        _assistant(100_000, tool_uses=[_skill("build")]),
+        _assistant(900_000, sidechain=True, tool_uses=[_agent("test-review")]),
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.peak_occupancy == 100_000
+    assert len(replay.gates) == 1, "a subagent's own gated call is not a main-thread gate"
+
+
+def test_recovery_skills_are_not_counted_as_gates(tmp_path: Path) -> None:
+    """They are never gated at any occupancy, so counting them would inflate
+    every block rate in the sweep."""
+    tr = _write(
+        tmp_path / "t.jsonl",
+        _assistant(900_000, tool_uses=[_skill(s) for s in sorted(guard._RECOVERY_SKILLS)]),
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.gates == []
+
+
+def test_plugin_qualified_recovery_skill_is_also_excluded(tmp_path: Path) -> None:
+    tr = _write(tmp_path / "t.jsonl", _assistant(900_000, tool_uses=[_skill("dev-team:handoff")]))
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.gates == []
+
+
+@pytest.mark.parametrize("tool", ["Agent", "Task", "Skill"])
+def test_every_gated_tool_the_guard_knows_is_detected(tmp_path: Path, tool: str) -> None:
+    tu = {"name": tool, "input": {"skill": "build"} if tool == "Skill" else {"subagent_type": "x"}}
+    replay = report.replay_transcript(
+        _write(tmp_path / "t.jsonl", _assistant(500_000, tool_uses=[tu]))
+    )
+    assert replay is not None
+    assert [g.tool for g in replay.gates] == [tool]
+
+
+def test_ungated_tools_are_ignored(tmp_path: Path) -> None:
+    tr = _write(
+        tmp_path / "t.jsonl",
+        _assistant(900_000, tool_uses=[{"name": "Bash", "input": {"command": "ls"}}]),
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.gates == []
+
+
+def test_gate_sees_the_occupancy_of_its_own_turn(tmp_path: Path) -> None:
+    """The assistant record carrying the tool_use also carries the usage the
+    guard reads at PreToolUse time — not the previous turn's."""
+    tr = _write(
+        tmp_path / "t.jsonl",
+        _assistant(100_000),
+        _assistant(400_000, tool_uses=[_skill("build")]),
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert [g.occupancy for g in replay.gates] == [400_000]
+
+
+def test_parallel_dispatch_records_one_gate_per_call(tmp_path: Path) -> None:
+    tr = _write(
+        tmp_path / "t.jsonl",
+        _assistant(400_000, tool_uses=[_agent("a"), _agent("b"), _agent("c")]),
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert len(replay.gates) == 3
+    assert {g.occupancy for g in replay.gates} == {400_000}
+
+
+# ---------------------------------------------------------------------------
+# the sweep
+# ---------------------------------------------------------------------------
+
+
+def _one_session(tmp_path: Path, *records: dict) -> list:
+    replay = report.replay_transcript(_write(tmp_path / "t.jsonl", *records))
+    assert replay is not None
+    return [replay]
+
+
+def test_a_ceiling_below_the_gate_blocks_and_one_above_does_not(tmp_path: Path) -> None:
+    """The central counterfactual: the same session, two candidate ceilings."""
+    replays = _one_session(tmp_path, _assistant(250_000, tool_uses=[_skill("build")]))
+    low = report.evaluate_ceiling(replays, 150_000, 40, 5)
+    high = report.evaluate_ceiling(replays, 350_000, 40, 5)
+    assert low["sessions_blocked"] == 1
+    assert low["median_occupancy_at_first_block"] == 250_000
+    assert high["sessions_blocked"] == 0
+
+
+def test_near_done_flags_a_session_blocked_at_the_finish_line(tmp_path: Path) -> None:
+    """ADR 0037's revisit trigger in a metric: blocked with almost no work
+    left is the signature of a ceiling set too low."""
+    replays = _one_session(
+        tmp_path,
+        _assistant(400_000, tool_uses=[_skill("build")]),
+        _assistant(410_000),
+    )
+    result = report.evaluate_ceiling(replays, 350_000, 40, near_done_turns=5)
+    assert result["near_done_blocked"] == 1
+    assert result["near_done_blocked_pct"] == 100.0
+
+
+def test_a_session_with_a_long_tail_after_the_block_is_not_near_done(
+    tmp_path: Path,
+) -> None:
+    records = [_assistant(400_000, tool_uses=[_skill("build")])]
+    records += [_assistant(410_000) for _ in range(20)]
+    replays = _one_session(tmp_path, *records)
+    result = report.evaluate_ceiling(replays, 350_000, 40, near_done_turns=5)
+    assert result["sessions_blocked"] == 1
+    assert result["near_done_blocked"] == 0
+
+
+def test_tokens_after_the_first_block_are_what_enforcement_reclaims(
+    tmp_path: Path,
+) -> None:
+    replays = _one_session(
+        tmp_path,
+        _assistant(300_000, tool_uses=[_skill("build")]),
+        _assistant(500_000),
+        _assistant(600_000),
+    )
+    # Blocked at the first gate; everything spent afterwards is what a ceiling
+    # here would have reclaimed.
+    result = report.evaluate_ceiling(replays, 250_000, 40, 0)
+    assert result["sessions_blocked"] == 1
+    assert result["prompt_tokens_after_first_block"] == 1_100_000
+
+    # Nothing is over a ceiling nothing reaches, so nothing is reclaimed.
+    none_blocked = report.evaluate_ceiling(replays, 350_000, 40, 0)
+    assert none_blocked["sessions_blocked"] == 0
+    assert none_blocked["prompt_tokens_after_first_block"] == 0
+
+
+def test_a_candidate_above_the_percentage_bound_is_reported_as_clamped(
+    tmp_path: Path,
+) -> None:
+    """Raising the absolute cap past `ceiling_pct` of the window does nothing:
+    `min()` picks the percentage. A sweep row that silently equals its
+    neighbour reads as "the ceiling made no difference" when the truth is
+    "this candidate was never applied" — so the clamp is reported."""
+    replays = _one_session(
+        tmp_path, _assistant(400_000, tool_uses=[_skill("build")])
+    )
+    # 40% of a 1M window is 400K, so a 900K candidate is clamped to 400K and
+    # the gate at exactly 400K still blocks.
+    clamped = report.evaluate_ceiling(replays, 900_000, 40, 0)
+    assert clamped["clamped_sessions"] == 1
+    assert clamped["clamped_pct"] == 100.0
+    assert clamped["sessions_blocked"] == 1, (
+        "the percentage bound still applies; the candidate never took effect"
+    )
+
+    # Lifting ceiling_pct too is what actually raises the ceiling here.
+    unclamped = report.evaluate_ceiling(replays, 900_000, 90, 0)
+    assert unclamped["clamped_sessions"] == 0
+    assert unclamped["sessions_blocked"] == 0
+
+
+def test_a_candidate_under_the_percentage_bound_is_not_clamped(
+    tmp_path: Path,
+) -> None:
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("build")]))
+    assert report.evaluate_ceiling(replays, 350_000, 40, 0)["clamped_sessions"] == 0
+
+
+def test_a_200k_window_session_is_bound_by_the_percentage_not_the_cap(
+    tmp_path: Path,
+) -> None:
+    """On a small window the absolute cap is a no-op — the sweep must reflect
+    that, or it would report 200K-window sessions as never blocked."""
+    replays = _one_session(
+        tmp_path,
+        _assistant(90_000, model="claude-haiku-4-5", tool_uses=[_skill("build")]),
+    )
+    for candidate in (150_000, 350_000, 600_000):
+        result = report.evaluate_ceiling(replays, candidate, 40, 5)
+        assert result["sessions_blocked"] == 1, (
+            f"90K on a 200K window is over the 80K percentage bound "
+            f"regardless of a {candidate} absolute cap"
+        )
+
+
+def test_occupancy_without_a_gated_call_never_blocks(tmp_path: Path) -> None:
+    """The finding that motivates conditioning on gated calls: a session can
+    sit far over any candidate ceiling and never trip it."""
+    replays = _one_session(tmp_path, _assistant(900_000), _assistant(950_000))
+    result = report.evaluate_ceiling(replays, 150_000, 40, 5)
+    assert replays[0].peak_occupancy == 950_000
+    assert result["sessions_blocked"] == 0
+    assert result["sessions_blocked_pct"] is None
+
+
+def test_percentages_are_none_not_zero_when_there_is_nothing_to_divide_by() -> None:
+    """"No sessions to divide by" and "0% of sessions" are different findings;
+    rendering the first as the second would read as evidence the ceiling is
+    fine."""
+    assert report._pct(0, 0) is None
+    assert report._pct(0, 10) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# robustness + CLI
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_and_empty_lines_are_skipped_not_fatal(tmp_path: Path) -> None:
+    tr = tmp_path / "t.jsonl"
+    tr.write_text(
+        "\n".join(
+            [
+                "",
+                "not json at all",
+                "[1, 2, 3]",
+                json.dumps({"message": "not-a-dict"}),
+                json.dumps(_assistant(120_000)),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    replay = report.replay_transcript(tr)
+    assert replay is not None
+    assert replay.final_occupancy == 120_000
+
+
+def test_a_transcript_with_no_usage_is_dropped(tmp_path: Path) -> None:
+    tr = _write(tmp_path / "t.jsonl", {"message": {"model": "claude-opus-5"}})
+    assert report.replay_transcript(tr) is None
+
+
+def test_an_unreadable_transcript_is_dropped_not_raised(tmp_path: Path) -> None:
+    assert report.replay_transcript(tmp_path / "absent.jsonl") is None
+
+
+def test_discover_transcripts_accepts_files_and_directories(tmp_path: Path) -> None:
+    nested = tmp_path / "proj" / "sub"
+    nested.mkdir(parents=True)
+    a = _write(nested / "a.jsonl", _assistant(1_000))
+    b = _write(tmp_path / "b.jsonl", _assistant(1_000))
+    (tmp_path / "ignored.txt").write_text("x", encoding="utf-8")
+    assert set(report.discover_transcripts([tmp_path])) == {a, b}
+    assert report.discover_transcripts([a]) == [a]
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args], capture_output=True, text=True, check=False
+    )
+
+
+def test_cli_exits_2_when_no_transcripts_are_found(tmp_path: Path) -> None:
+    result = _run_cli("--transcripts", str(tmp_path / "nope"))
+    assert result.returncode == 2
+    assert "no .jsonl transcripts found" in result.stderr
+
+
+def test_cli_exits_2_on_a_malformed_ceiling_list(tmp_path: Path) -> None:
+    _write(tmp_path / "t.jsonl", _assistant(120_000))
+    result = _run_cli("--transcripts", str(tmp_path), "--ceilings", "abc")
+    assert result.returncode == 2
+    assert "comma-separated integers" in result.stderr
+
+
+def test_cli_reports_and_writes_json(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "t.jsonl",
+        _assistant(250_000, tool_uses=[_skill("build")]),
+        _assistant(260_000),
+    )
+    out = tmp_path / "report.json"
+    result = _run_cli(
+        "--transcripts", str(tmp_path), "--ceilings", "150000,350000", "--json", str(out)
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Context ceiling validation" in result.stdout
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema"] == "context-ceiling-report/v1"
+    assert len(payload["sessions"]) == 1
+    assert payload["sessions"][0]["peak_occupancy"] == 260_000
+    by_ceiling = {row["abs_ceiling"]: row for row in payload["sweep"]}
+    assert by_ceiling[150_000]["sessions_blocked"] == 1
+    assert by_ceiling[350_000]["sessions_blocked"] == 0
+
+
+def test_the_verdict_says_inconclusive_rather_than_endorsing_the_default(
+    tmp_path: Path,
+) -> None:
+    """An empty corpus must never read as confirmation. A validator that
+    reported "0 blocked, looks fine" on data containing no evidence would be
+    exactly the gate-that-cannot-fail this repo warns about."""
+    _write(tmp_path / "t.jsonl", _assistant(120_000))
+    result = _run_cli("--transcripts", str(tmp_path))
+    assert result.returncode == 0
+    assert "inconclusive" in result.stdout


### PR DESCRIPTION
## Summary

Follow-up to #2056. That PR set the ceiling to 350K; this one builds the instrument to tell whether 350K is right — and to re-derive it from data whenever the question comes up again.

ADR 0038 named its own weakest link: the per-session occupancy behind 350K was *inferred* from a prompt:output token ratio, not counted. `scripts/context_ceiling_report.py` replaces that inference. It replays real transcripts, reconstructs the occupancy the guard **would have measured** at every capability load, and sweeps candidate ceilings.

**Building it surfaced a flaw in ADR 0038's own reasoning**, now recorded there as an amendment. Those occupancy figures are *per-turn averages*, and the ceiling doesn't fire per turn — it fires only at a gated call. A session can sit at 600K indefinitely without tripping the guard if it never dispatches an agent or invokes a skill while up there. So an occupancy-derived threshold is derived from the wrong distribution and **overstates how often any ceiling binds**. The error's direction favors the decision ADR 0038 made (the real block rate at 150K is *lower* than implied, so the over-correction argument is weaker than stated), and the borrowed-number argument is untouched — so the value stands, but it now rests mainly on that second argument until a real corpus is measured. The report conditions on gated calls, and its peak-occupancy table carries an explicit warning against reading it as a block rate.

**A ceiling can be wrong in two directions and a single block rate can't tell them apart**, so each gets a column:

| Column | Detects | Bad number looks like |
|---|---|---|
| `near-done` | ceiling too **low** | high share of blocked sessions were within N turns of finishing — ADR 0037's revisit trigger, verbatim |
| `tokens over` | ceiling too **high** | large share of corpus prompt tokens spent past the first block |

The report prints both and picks no number: the cost of a wrong ceiling is asymmetric in a way no single statistic captures, and 150K became the ceiling precisely because a number got adopted without that trade-off visible.

```text
  ceiling |  sessions |  blocked |  blocks |  median@1st |  near-done |  tokens over
  150,000 |        12 |     100% |     100 |     181,249 |      16.7% |        89.7%
  250,000 |        10 |    83.3% |      85 |     291,246 |        50% |        78.8%
  350,000 |         7 |    58.3% |      75 |     420,000 |      42.9% |        69.8% *
  450,000 |         6 |      50% |      72 |     467,499 |      33.3% |        66.6%†
```

**Two honesty properties, both pinned by tests.** A candidate above `ceiling_pct` of the window never takes effect (`min()` picks the percentage), so those rows are marked `†` rather than left looking like data — a row that silently equals its neighbour reads as "made no difference" when the truth is "never applied". And an empty result reports as **inconclusive, never as confirmation**: "0 blocked" on data containing no evidence is not evidence the ceiling is right.

**It cannot drift from the guard.** Every policy decision — gated tools, recovery-skill exemptions, the model→window map, the occupancy sum, sidechain filtering — is *imported* from `context_ceiling_guard.py` rather than restated, and `test_final_occupancy_equals_the_guards_own_measurement` pins the report's occupancy walk against the hook's own `_measure_occupancy` on shared fixtures. A validator measuring the ceiling differently from the guard would be validating a threshold nobody ships.

Documented at repo level (`docs/context-ceiling-validation.md`), not in the plugin's shipped docs — this is maintainer tooling that isn't distributed, so a shipped doc must not tell plugin users to run it. The repo's own `test_bare_invocation_wide_scan` gate caught my first attempt at putting it in the wrong place.

## Test Plan

- [x] 33 new tests in `tests/scripts/test_context_ceiling_report.py` (already in the pre-push gate's directory list)
- [x] **Anti-drift**: `test_final_occupancy_equals_the_guards_own_measurement`, parametrized over 5 transcript shapes including trailing-sidechain and trailing-row-without-usage
- [x] Gate detection: all three gated tools, recovery skills (plain and plugin-qualified) excluded, ungated tools ignored, parallel dispatch counted per call, gate sees its own turn's occupancy
- [x] Sweep: blocked-below/clear-above counterfactual, near-done flagging, long-tail non-flagging, tokens-reclaimed arithmetic, 200K-window percentage bound, clamping in both directions
- [x] Honesty properties: `_pct` returns `None` not `0.0` on a zero denominator; the verdict says "inconclusive" rather than endorsing the default on an empty corpus
- [x] Robustness: malformed/empty lines, no-usage transcript, unreadable path, CLI exit 2 on no transcripts and on a malformed `--ceilings`
- [x] Ran against this container's real transcript (1 session, peak 290K, zero gated calls) — correctly reports **inconclusive**, which is itself the tool's central point demonstrated
- [x] Ran against a 12-session synthetic corpus to exercise the full render (output above)
- [x] `tests/scripts tests/repo tests/docs tests/knowledge plugins/dev-team/tests/hooks` → 5,694 passed, 46 skipped
- [x] `ruff check` clean; `check_md_references.py` exit 0

## Notes

Not a spec/plan slice — no issue to close. If you'd like this tracked, happy to open one retroactively.

---
_Generated by [Claude Code](https://claude.ai/code/session_015No9ngckCVJ7dQ7ijidkZ7)_