### PR TITLE
feat(context-ceiling): stop blocking agent dispatches, add the session-economy playbook

### DIFF
--- a/docs/adr/0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md
+++ b/docs/adr/0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md
@@ -1,0 +1,116 @@
+# 39. Only Skill loads are worth blocking at the context ceiling
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+Amends [11. Enforce the context ceiling with a transcript-measured PreToolUse
+hook](0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md),
+which grouped `Agent` and `Skill` as a single class of "capability loads".
+[ADR 0037](0037-block-by-default-at-the-context-ceiling-2000.md)'s blocking
+default and [ADR 0038](0038-raise-the-absolute-context-ceiling-to-350k.md)'s
+350K threshold are both unchanged.
+
+## Context
+
+ADR 0011 chose what to gate before there was anything to block. Its reasoning:
+
+> **Capability loads (`Agent` + `Skill`).** Chosen: these are exactly the
+> "don't load speculatively" operations the protocol governs, far less
+> frequent than Read, and safe to block because recovery never needs a fresh
+> agent.
+
+Grouping them was reasonable while the guard only warned — a warning on either
+one says the same useful thing, and "capability load" is a fair description of
+both. Under ADR 0037's blocking default the grouping stopped being harmless,
+because the two tools do **opposite things to the quantity this guard
+measures**:
+
+- A **`Skill` invocation** loads `SKILL.md` into the main thread. It grows
+  main-thread occupancy directly, and declining it prevents that growth. A
+  block does what it says.
+- An **`Agent`/`Task` dispatch** runs in a *separate* context and returns only
+  its result. It is the cheapest available way to do a unit of work without
+  growing this context. Blocking it does not stop the work — the orchestrator
+  still has `Read`, `Edit`, `Bash`, and the task still needs doing, so the work
+  happens **inline instead**, growing occupancy by more than the delegation
+  would have.
+
+So on a 1M-window session sitting at 400K, the guard's block on a review
+dispatch does not save 400K from growing; it converts a ~2K result summary into
+tens of thousands of tokens of inline file reading. The guard makes the number
+it is protecting worse.
+
+This repo already settled the underlying question, on the other side of the
+same hook. #2054 excluded sidechain rows from `_measure_occupancy` because *a
+subagent's context is not this thread's context* — that is why a subagent turn
+recorded inline must not be read as main-thread occupancy. The gating side was
+never updated to match. If a subagent's tokens are not main-thread occupancy,
+then blocking a subagent dispatch to protect main-thread occupancy is
+incoherent.
+
+**The honest cost of this change.** Blocking `Agent` did do one useful thing
+incidentally: it was a second chokepoint that could force a session to stop and
+run `/handoff`, and dropping it means an over-budget session has one fewer place
+where it must confront the ceiling. That is a real reduction in pressure, and it
+is accepted deliberately, for two reasons. First, the pressure was bought by
+making the session more expensive, which is the opposite of what ADR 0037 set
+out to achieve. Second, using an occupancy ceiling as a proxy for session-total
+cost conflates two different quantities with two different correct thresholds —
+the same category error [ADR 0038](0038-raise-the-absolute-context-ceiling-to-350k.md)
+corrected when it found 150K had been borrowed from a system measuring something
+else. If session-total cost needs a control, it needs its own instrument
+(`hooks/lib/cost_meter.py` already measures the right quantity), not a
+side effect smuggled into a guard on a different number.
+
+## Decision
+
+Of the gated tools, only `Skill` blocks. `Agent` and `Task` still fire the
+guard — the occupancy diagnostic and the escalating action bands are unchanged
+— but they warn and proceed, carrying a `[not blocked: delegation]` footer
+explaining why, so the non-block does not read as the guard failing to fire.
+
+`DEV_TEAM_CONTEXT_GATE_AGENT=block` restores the previous behavior.
+
+That opt-in is deliberately **not** spelled the way `DEV_TEAM_CONTEXT_STRICT`
+is. `STRICT` treats every unrecognized value as "block", because its expensive
+direction of failure is silently not enforcing. Here the expensive direction is
+the reverse — blocking a dispatch that should not be blocked — so only the
+literal `block` opts in and anything else resolves toward the new default. The
+two variables point opposite ways on purpose.
+
+`scripts/context_ceiling_report.py` follows the same split, reading
+`_BLOCKING_TOOLS` from the guard rather than restating it: its block columns
+count `Skill` invocations only, agent dispatches are reported as advisory
+fires, and a session whose only gated calls are dispatches is excluded from the
+block-rate denominator entirely, since it can never be blocked at any ceiling.
+Leaving the report counting both would have overstated every candidate's block
+rate and argued for a higher ceiling than the evidence supports.
+
+## Consequences
+
+**What gets better.** The guard stops making main-thread occupancy worse in the
+one case where it had that effect, and delegation — the behavior the Context
+Loading Protocol actually wants from an over-budget orchestrator — is no longer
+penalized at exactly the moment it is most valuable.
+
+**What gets worse.** One chokepoint fewer for forcing a handoff, as above. An
+operator who wants it back sets `DEV_TEAM_CONTEXT_GATE_AGENT=block`.
+
+**What this does not change.** Blocking remains the default posture for
+`Skill`, only `off` opts out of it, recovery skills remain ungated, fail-open
+is unchanged, and the 350K threshold is untouched.
+
+**Revisit trigger.** If measurement shows sessions routinely running far past
+the ceiling *by dispatching agents* — visible as a high `advisory_fires` count
+against a low block rate in the ceiling report — then delegation is being used
+to evade the ceiling rather than to economize, and the right answer is a
+session-total cost control, not re-blocking dispatches.
+
+## Notes
+
+Issue #2062. Found during the context-guard review that also produced #2054,
+#2056, and #2060; held back from each of those because it changes *what* the
+guard gates rather than what it measures or where its threshold sits.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@
 * [36. The two session extractors stay forked, for now (#1994)](0036-the-two-session-extractors-stay-forked-1994.md)
 * [37. Block by default at the context ceiling (#2000)](0037-block-by-default-at-the-context-ceiling-2000.md)
 * [38. Raise the absolute context ceiling from 150K to 350K](0038-raise-the-absolute-context-ceiling-to-350k.md)
+* [39. Only Skill loads are worth blocking at the context ceiling](0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md)

--- a/docs/context-and-session-economy-playbook.md
+++ b/docs/context-and-session-economy-playbook.md
@@ -1,0 +1,152 @@
+# Session economy playbook
+
+A recurring procedure for reading session logs and context-ceiling data
+*over time*, so the plugin keeps getting cheaper to run and re-does less work.
+
+Every instrument this playbook uses already existed as a one-shot command.
+What was missing was the loop: a cadence, a fixed order, a decision rule per
+signal, and two append-only streams that make one round comparable to the
+last. Without those, each review re-derived its own baseline and the question
+"did anything we changed actually help?" had no mechanical answer.
+
+This is maintainer tooling for developing *this* plugin. It is not shipped, and
+it is not a workflow imposed on people who install dev-team on their own
+projects.
+
+## What this is not
+
+Do not reach for this playbook to answer a question one instrument already
+answers on its own:
+
+| Question | Use |
+| --- | --- |
+| How much did *that run* cost? | [`/cost-report`](../plugins/dev-team/skills/cost-report/SKILL.md) |
+| How did *that run* go, step by step? | [`/run-report`](../plugins/dev-team/skills/run-report/SKILL.md) |
+| What should we change, based on recent sessions? | [`/session-review`](../plugins/dev-team/skills/session-review/SKILL.md) |
+| Which agents/routing have gone stale? | [`/harness-audit`](../plugins/dev-team/skills/harness-audit/SKILL.md) |
+| Which skills and agents are unused? | [`/artifact-lifecycle`](../plugins/dev-team/skills/artifact-lifecycle/SKILL.md) |
+| Is the context ceiling in the right place *right now*? | [`context_ceiling_report.py`](context-ceiling-validation.md) |
+
+This playbook is the **longitudinal** layer over those: run them in a fixed
+order on a fixed cadence, persist the comparable subset, and act on the deltas
+rather than on any single round's absolute numbers.
+
+## Cadence
+
+**Monthly**, and additionally whenever one of these lands:
+
+- a change to the context ceiling, the guard, or what it gates;
+- a model change (a new default model resizes every window, and an
+  unrecognized id silently falls back to 200K — see [ADR 0011's
+  amendment](adr/0011-enforce-context-ceiling-with-transcript-measured-pretooluse-hook.md));
+- a batch of agent, skill, or hook changes large enough that you would not be
+  able to attribute a later regression to it.
+
+Monthly is deliberate rather than weekly. Both streams are per-session
+aggregates, and a week of one maintainer's work is too few sessions for a
+percentage to mean anything — a 2-of-9 blocked rate reads as 22% and is noise.
+A round that cannot distinguish signal from sample size is worse than no round,
+because it invites action on both.
+
+## The rounds
+
+Run in this order. Each step's output is input to the next.
+
+### 1. Refresh the session stream
+
+```bash
+python3 scripts/session_extract.py --plugin-root plugins/dev-team \
+  --append .claude/metrics/session-digest.jsonl
+```
+
+This is the same append `/session-review` performs at its step 5, extracted so
+a round can refresh the stream without also producing a suggestions report.
+Aggregate counts only — no file names, prompts, or code.
+
+What it captures, and what each field is for:
+
+| Group | Fields | Reads as |
+| --- | --- | --- |
+| `rework` | `repeated_file_edits`, `repeated_verify_runs`, `retried_bash_commands`, `failed_edits`, `permission_denials`, `compaction_events` | work done more than once — the thing to drive down |
+| `token` | per-model input/output/cache totals | what it cost |
+| `accuracy` | `tool_error_rate`, `user_correction_turns` | how often the loop went wrong |
+| `gate` | `commit_attempts`, `commit_bypasses`, `bypass_rate` | whether the gates are being obeyed or routed around |
+| `utilization` | `agents_invoked`, `skills_invoked`, `never_observed_*` | what is actually used |
+
+### 2. Refresh the ceiling stream
+
+```bash
+python3 scripts/context_ceiling_report.py \
+  --append .claude/metrics/context-ceiling.jsonl
+```
+
+Read the printed sweep now; the appended record is for next round. Full
+column-by-column guide: [Validating the context
+ceiling](context-ceiling-validation.md).
+
+**If the verdict says `inconclusive`, stop treating the ceiling as reviewed
+this round.** It means no session reached the ceiling at a blockable call, so
+the corpus contains no evidence either way. Widen `--transcripts` across more
+projects before concluding anything.
+
+### 3. Read the deltas, not the levels
+
+```bash
+python3 -c "
+import json, pathlib
+for stream in ('session-digest', 'context-ceiling'):
+    p = pathlib.Path('.claude/metrics') / f'{stream}.jsonl'
+    rows = [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+    print(f'== {stream}: {len(rows)} rounds ==')
+    for r in rows[-2:]:
+        print(' ', r.get('recorded_at'), json.dumps(r)[:160])
+"
+```
+
+A single round's absolute numbers are close to meaningless — the corpus
+changes shape every month. What carries information is the *direction* of a
+metric across rounds against a change you can name.
+
+### 4. Decide
+
+One rule per signal. Each names the action and, where one exists, the ADR
+whose revisit trigger it discharges.
+
+| Signal | Direction | Action |
+| --- | --- | --- |
+| `rework.repeated_file_edits` / `repeated_verify_runs` rising | worse | Run `/session-review` for the *why*; this stream says only that it happened. |
+| `gate.bypass_rate` rising | worse | A gate is being routed around. Fix the gate's cost or its correctness — never its enforcement. |
+| `accuracy.user_correction_turns` rising | worse | Instructions are being misread. Candidate for a CLAUDE.md or skill-prose fix, not a code fix. |
+| `utilization.never_observed_*` growing | drift | Feed to `/artifact-lifecycle`; a never-invoked artifact still costs registry tokens. |
+| ceiling `near-done` high at the shipped row | ceiling too low | Raise `DEV_TEAM_CONTEXT_ABS_CEILING` — [ADR 0037](adr/0037-block-by-default-at-the-context-ceiling-2000.md) is explicit that the answer is not a return to warn-by-default. |
+| ceiling `tokens over` high at every candidate | ceiling too high, or wrong lever | Re-derive per [ADR 0038](adr/0038-raise-the-absolute-context-ceiling-to-350k.md), and amend it with what the corpus says. |
+| ceiling `advisory_fires` high against a low block rate | delegation used to evade the ceiling | [ADR 0039](adr/0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md)'s revisit trigger: the answer is a session-total cost control, not re-blocking dispatches. |
+| `unrecognized_model_sessions` non-zero | guard is guessing | A model id has outrun `_LARGE_WINDOW_RE`. Its verdicts warn instead of blocking, so the ceiling is unenforced for those sessions until the pattern is taught the new id. |
+
+**Change one thing per round.** Two changes between rounds and the next delta
+attributes to neither. This is the whole reason the streams are append-only:
+a round is only evidence if it can be pinned to a known before-state.
+
+### 5. Write down what changed
+
+Append a one-line note to the round's PR or the relevant ADR: the date, the
+one change made, and the metric it was meant to move. Next round's step 3 is
+reading for exactly that.
+
+## What this playbook cannot tell you
+
+Stated plainly, because a review procedure that implies more coverage than it
+has is the same failure as a gate that cannot fail:
+
+- **Causation.** Both streams are observational. A metric that moves after a
+  change is consistent with that change, not proof of it.
+- **Sample size.** Neither stream records confidence intervals, and a
+  maintainer's month is a small n. Treat a single round's percentage move as a
+  hypothesis, not a finding.
+- **Anything outside a gated call.** The ceiling stream is blind to occupancy
+  that never met a blockable call, by construction. See [Validating the
+  context ceiling](context-ceiling-validation.md).
+- **Session-total cost.** No instrument here bounds what a session spends in
+  total; the ceiling bounds main-thread *occupancy*, which is a different
+  quantity. ADR 0039 records why the two must not be conflated, and
+  `hooks/lib/cost_meter.py` is the instrument that measures the other one.

--- a/docs/context-ceiling-validation.md
+++ b/docs/context-ceiling-validation.md
@@ -69,7 +69,16 @@ Sample output, against a synthetic corpus:
   450,000 |         6 |      50% |      72 |     467,499 |      33.3% |        66.6%†
 ```
 
-## Three properties worth knowing before acting on its output
+## Four properties worth knowing before acting on its output
+
+**It counts blocks, and only `Skill` blocks.** Per [ADR
+0039](adr/0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md),
+an `Agent`/`Task` dispatch over the ceiling warns and proceeds, so the sweep's
+block columns count skill invocations only; dispatches appear as
+`advisory_fires`, and a session whose only gated calls are dispatches is left
+out of the block-rate denominator entirely, since no ceiling could ever block
+it. The split is read from the guard's `_BLOCKING_TOOLS` rather than restated,
+so it cannot drift.
 
 **It conditions on gated calls, not on occupancy.** The ceiling only binds at
 an `Agent`/`Skill` call, so a session can sit far above any candidate and

--- a/plugins/dev-team/docs/context-management.md
+++ b/plugins/dev-team/docs/context-management.md
@@ -12,7 +12,8 @@ compression procedure it nudges toward, see
 
 A `PreToolUse` hook registered on `Agent` and `Skill` — every capability
 load (dispatching a sub-agent, invoking a skill) is a choke point where the
-hook can measure real context occupancy before the call proceeds. It reads
+hook can measure real context occupancy before the call proceeds. Both are
+measured and reported; only `Skill` is blocked (ADR 0039 — see Expectations). It reads
 `utilization = (input + cache_read + cache_creation) / model_context_window`
 from the session transcript's most recent assistant-message usage — ground
 truth from the harness, not a model self-estimate (a model has no reliable
@@ -95,10 +96,18 @@ load-bearing on a 200K window or if the cap is raised past 400K.
 
 ## Expectations
 
-- **Blocking is the default (#2000).** At or above the ceiling the hook
-  writes to stderr and exits 2 — the tool call is blocked — with a
-  `[blocked: context ceiling]` footer naming `/handoff` as the way out.
-  Nothing is written to stdout.
+- **Blocking is the default (#2000) — for `Skill`.** At or above the ceiling
+  a skill invocation writes to stderr and exits 2 — the call is blocked —
+  with a `[blocked: context ceiling]` footer naming `/handoff` as the way
+  out. Nothing is written to stdout.
+- **Agent/Task dispatches warn but proceed (ADR 0039).** The two gated tools
+  do opposite things to the measured quantity: a skill loads `SKILL.md` into
+  *this* context, while a subagent runs in its own and returns only a result.
+  Blocking a dispatch does not stop the work — it pushes the work inline,
+  growing occupancy by more than delegating would have, so the guard would be
+  making the number it protects worse. Dispatches still fire the full
+  diagnostic and action bands, carrying a `[not blocked: delegation]` footer.
+  `DEV_TEAM_CONTEXT_GATE_AGENT=block` restores blocking for them.
 - **Warn mode is opt-out.** `DEV_TEAM_CONTEXT_STRICT=off` downgrades the
   block to a stderr warning with `exit 0`, the pre-#2000 behavior. Only the
   literal value `off` (case- and whitespace-insensitive) does this; every
@@ -144,6 +153,7 @@ load-bearing on a 200K window or if the cap is raised past 400K.
 | --- | --- | --- |
 | `DEV_TEAM_CONTEXT_CEILING` | (unset = on) | `off` disables the guard entirely. |
 | `DEV_TEAM_CONTEXT_STRICT` | (unset = block) | `off` warns (`exit 0`) at or above the ceiling instead of blocking. Any other value blocks. |
+| `DEV_TEAM_CONTEXT_GATE_AGENT` | (unset = warn) | `block` also blocks `Agent`/`Task` dispatches over the ceiling. Only the literal `block` opts in — the opposite convention to `STRICT`, because here the expensive direction of failure is blocking a dispatch that should not be blocked. |
 | `DEV_TEAM_CONTEXT_CEILING_PCT` | `40` | Percentage-of-window threshold before the absolute cap is applied. |
 | `DEV_TEAM_CONTEXT_WINDOW` | (unset = auto-detect) | Overrides window auto-detection explicitly; always wins over detection. |
 | `DEV_TEAM_CONTEXT_ABS_CEILING` | `350000` | Absolute token cap on the effective threshold — `min(ceiling_pct% of window, this)`. Binding on every 1M-window model; a no-op on a 200K one. |

--- a/plugins/dev-team/hooks/context_ceiling_guard.py
+++ b/plugins/dev-team/hooks/context_ceiling_guard.py
@@ -33,6 +33,13 @@ none, so it now blocks and the operator opts out explicitly.
 Recovery skills are never gated: blocking /handoff (the way
 back under budget) would deadlock the session.
 
+What blocks vs what warns (ADR 0039): a `Skill` invocation loads SKILL.md
+into THIS context, so it grows the measured quantity and a block helps. An
+`Agent`/`Task` dispatch runs in a separate context and returns only a
+result, so blocking it does not stop the work — it pushes the work inline
+and grows occupancy by more than the delegation would have. Agent dispatches
+therefore warn (bands and all) but do not block. See `_BLOCKING_TOOLS`.
+
 Two properties keep the blocking default honest, and both are pinned by
 tests rather than left as prose:
 
@@ -48,6 +55,14 @@ Env:
                                      ceiling (default: block, #2000).
                                      Any other value, including the
                                      historical `on`, blocks.
+    DEV_TEAM_CONTEXT_GATE_AGENT=block
+                                     also BLOCK Agent/Task dispatches over
+                                     the ceiling (default: warn only, ADR
+                                     0039 — delegation reduces main-thread
+                                     growth, so blocking it costs more than
+                                     it saves). Skill invocations block
+                                     regardless. Only the literal `block`
+                                     opts in.
     DEV_TEAM_CONTEXT_CEILING_PCT=N   ceiling percent (default 40)
     DEV_TEAM_CONTEXT_WINDOW=N        context window in tokens; an explicit
                                      override that always wins over
@@ -133,6 +148,32 @@ _RECOVERY_SKILLS = frozenset(
 # (renamed Task → Agent in Claude Code 2.1.63; both live on as payload
 # tool_names, #1178).
 _GATED_TOOLS = frozenset({"Agent", "Task", "Skill"})
+
+#: Of the gated tools, the ones a block actually helps. Only `Skill` — see
+#: ADR 0039.
+#:
+#: The two gated tools do OPPOSITE things to the quantity this guard
+#: measures. A `Skill` invocation loads SKILL.md into the main thread, so it
+#: grows main-thread occupancy directly. An `Agent`/`Task` dispatch runs the
+#: work in a SEPARATE context and returns only its result, so it is the
+#: cheapest available way to do work without growing this context — and
+#: blocking it does not stop the work, it pushes the orchestrator to do that
+#: work inline, which grows occupancy by more than the delegation would have.
+#: A guard on main-thread occupancy that blocks the action which *reduces*
+#: main-thread growth is working against its own measurement.
+#:
+#: #2054 settled the same question on the measurement side: subagent turns
+#: are excluded from occupancy because a subagent's context is not this
+#: thread's (see `_is_sidechain`). This is that finding applied to the
+#: gating side — if a subagent's tokens are not main-thread occupancy, then
+#: blocking a subagent dispatch to protect main-thread occupancy is
+#: incoherent.
+#:
+#: Agent dispatches still WARN at the ceiling: the diagnostic and the
+#: escalating action bands are the point, and they survive. Only the block
+#: is dropped. `DEV_TEAM_CONTEXT_GATE_AGENT=block` restores the pre-#2062
+#: behavior for operators who want it.
+_BLOCKING_TOOLS = frozenset({"Skill"})
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +533,19 @@ _UNVERIFIED_WINDOW_FOOTER = (
     "to restore blocking."
 )
 
+#: Appended when an Agent/Task dispatch is over the ceiling and therefore
+#: warned rather than blocked (ADR 0039). Without this the operator sees a
+#: full ceiling diagnostic with no block and reasonably reads it as the guard
+#: failing to fire, rather than as the guard deliberately declining to make
+#: the session more expensive.
+_DELEGATION_NOT_BLOCKED_FOOTER = (
+    "[not blocked: delegation] A subagent runs in its own context and returns "
+    "only its result, so dispatching one is the cheapest way to do this work "
+    "without growing THIS context — blocking it would push the work inline "
+    "and cost more. Run /handoff to actually get back under the ceiling. "
+    "Set DEV_TEAM_CONTEXT_GATE_AGENT=block to block these too."
+)
+
 _BAND_ACTIONS = {
     _BAND_NUDGE: (
         "nudge",
@@ -653,11 +707,25 @@ def _resolve_verdict(payload: dict) -> tuple[int, str | None, bool]:
     # blocks on what it *knows*, and an unrecognized model id means it does
     # not know the window. An explicit `DEV_TEAM_CONTEXT_WINDOW` override
     # ("override") or a recognized model ("detected") both block as before.
-    if strict and provenance != "default":
+    # Which tools a block helps is a separate question from whether the
+    # posture is blocking at all — see `_BLOCKING_TOOLS` and ADR 0039.
+    # `DEV_TEAM_CONTEXT_GATE_AGENT=block` opts Agent/Task back in.
+    blocks_this_tool = tool_name in _BLOCKING_TOOLS or (
+        os.environ.get("DEV_TEAM_CONTEXT_GATE_AGENT", "").strip().lower() == "block"
+    )
+
+    if strict and provenance != "default" and blocks_this_tool:
         return 2, f"{msg}\n{_BLOCK_FOOTER}", False
 
-    if strict:
+    # Exactly one "why this did not block" footer is ever appended. An
+    # unverified window is reported ahead of delegation because it is the
+    # more surprising of the two: it says the threshold above may be wrong,
+    # whereas the delegation footer says the threshold was right and the
+    # block was declined on purpose.
+    if strict and provenance == "default":
         msg = f"{msg}\n{_UNVERIFIED_WINDOW_FOOTER}"
+    elif strict and not blocks_this_tool:
+        msg = f"{msg}\n{_DELEGATION_NOT_BLOCKED_FOOTER}"
 
     # Warn mode dedupe, re-keyed on band identity (#781): the dedupe key is
     # max(band_index_scaled, pct_bucket). _BAND_SCALE (100) makes any band

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -114,7 +114,7 @@ Skills are reusable knowledge modules in `.claude/skills/` that agents reference
 | CI Debugging | `skills/ci-debugging/SKILL.md` | 1,368 | Platform Engineer, Software Engineer, QA Engineer |
 | Claude Setup Review | `skills/claude-setup-review/SKILL.md` | ~1,296 | `/claude-setup-review` command, claude-setup-review |
 | Competitive Analysis | `skills/competitive-analysis/SKILL.md` | 2,034 | Orchestrator, Product Manager |
-| Context Loading Protocol | `skills/context-loading-protocol/SKILL.md` | 2,331 | Orchestrator |
+| Context Loading Protocol | `skills/context-loading-protocol/SKILL.md` | 2,628 | Orchestrator |
 | Coverage Baseline | `skills/coverage-baseline/SKILL.md` | ~5,115 | `/test-improve` (Phase 2), QA Engineer, Platform Engineer |
 | Coverage Delta | `skills/coverage-delta/SKILL.md` | ~3,852 | `/test-improve` (Phase 5), QA Engineer |
 | Design Doc | `skills/design-doc/SKILL.md` | 1,118 | Architect, Product Manager, Orchestrator |

--- a/plugins/dev-team/skills/context-loading-protocol/SKILL.md
+++ b/plugins/dev-team/skills/context-loading-protocol/SKILL.md
@@ -57,12 +57,11 @@ Summarize](../handoff/SKILL.md#when-to-summarize)) — before
 **blocking the load** at/above the ceiling (the default since
 #2000; `DEV_TEAM_CONTEXT_STRICT=off` downgrades it to a warning).
 
-Only **skill** invocations are blocked. An `Agent`/`Task` dispatch warns and
-proceeds (ADR 0039): a skill loads `SKILL.md` into this context, while a
-subagent runs in its own and returns only a result, so blocking a dispatch
-would push the work inline and grow occupancy by more than delegating would.
-Delegating is the right move for an over-budget orchestrator, and the guard no
-longer penalizes it. `DEV_TEAM_CONTEXT_GATE_AGENT=block` restores blocking.
+Only **skill** invocations block; an `Agent`/`Task` dispatch warns and proceeds
+(ADR 0039). A skill loads `SKILL.md` into this context; a subagent runs in its
+own and returns only a result, so blocking a dispatch would push the work
+inline and grow occupancy by more than delegating would.
+`DEV_TEAM_CONTEXT_GATE_AGENT=block` restores blocking.
 Recovery skills
 (`/handoff`, `/context-loading-protocol`, `/continue`,
 `/review-summary`, `/session-review`) are never gated — blocking the path

--- a/plugins/dev-team/skills/context-loading-protocol/SKILL.md
+++ b/plugins/dev-team/skills/context-loading-protocol/SKILL.md
@@ -56,6 +56,13 @@ summary + fresh conversation (see [Handoff → When to
 Summarize](../handoff/SKILL.md#when-to-summarize)) — before
 **blocking the load** at/above the ceiling (the default since
 #2000; `DEV_TEAM_CONTEXT_STRICT=off` downgrades it to a warning).
+
+Only **skill** invocations are blocked. An `Agent`/`Task` dispatch warns and
+proceeds (ADR 0039): a skill loads `SKILL.md` into this context, while a
+subagent runs in its own and returns only a result, so blocking a dispatch
+would push the work inline and grow occupancy by more than delegating would.
+Delegating is the right move for an over-budget orchestrator, and the guard no
+longer penalizes it. `DEV_TEAM_CONTEXT_GATE_AGENT=block` restores blocking.
 Recovery skills
 (`/handoff`, `/context-loading-protocol`, `/continue`,
 `/review-summary`, `/session-review`) are never gated — blocking the path
@@ -63,6 +70,7 @@ back under budget would deadlock the session.
 
 Knobs: `DEV_TEAM_CONTEXT_CEILING_PCT` (default 40), `DEV_TEAM_CONTEXT_ABS_CEILING`
 (default 350000), `DEV_TEAM_CONTEXT_WINDOW` (overrides auto-detection),
+`DEV_TEAM_CONTEXT_GATE_AGENT=block` (also block agent dispatches),
 `DEV_TEAM_CONTEXT_CEILING=off` (disables entirely).
 The hook is a backstop measured from real usage; the budget estimate below is still
 the planning tool you apply *before* loading.

--- a/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
+++ b/plugins/dev-team/tests/hooks/test_context_ceiling_guard.py
@@ -1578,3 +1578,164 @@ class TestUnverifiedWindowWarnsButDoesNotBlock:
         second = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
         assert first.stderr != b""
         assert second.stderr == b""
+
+
+# ---------------------------------------------------------------------------
+# #2062 / ADR 0039 — a block helps for Skill, not for Agent
+# ---------------------------------------------------------------------------
+
+
+class TestOnlySkillLoadsAreWorthBlocking:
+    """The two gated tools do opposite things to the measured quantity.
+
+    A `Skill` invocation loads SKILL.md into this context, so it grows
+    main-thread occupancy and a block helps. An `Agent`/`Task` dispatch runs
+    in a separate context and returns only its result, so blocking it does
+    not stop the work — it pushes that work inline, growing occupancy by
+    more than the delegation would have. #2054 already settled the same
+    question on the measurement side by excluding sidechain turns from
+    occupancy; this is that finding applied to gating.
+    """
+
+    def test_an_agent_dispatch_over_the_ceiling_warns_instead_of_blocking(
+        self, tmp_path: Path
+    ) -> None:
+        """The deliberate-failure case: this returned 2 before the change."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Agent", {"subagent_type": "test-review"}, tr), env)
+        assert result.returncode == 0, (
+            "blocking a subagent dispatch pushes the work inline and grows "
+            "the very number this guard measures"
+        )
+        assert b"not blocked: delegation" in result.stderr
+        assert b"blocked: context ceiling" not in result.stderr
+
+    def test_the_task_alias_is_treated_exactly_like_agent(
+        self, tmp_path: Path
+    ) -> None:
+        """`Task` and `Agent` are the same subagent-dispatch tool (#1178); a
+        split that covered only one spelling would block half of them."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Task", {"subagent_type": "test-review"}, tr), env)
+        assert result.returncode == 0
+        assert b"not blocked: delegation" in result.stderr
+
+    def test_a_skill_invocation_over_the_ceiling_still_blocks(
+        self, tmp_path: Path
+    ) -> None:
+        """The scope guard. Skill loads text into THIS context, so #2000's
+        blocking default is unchanged there — without this assertion the
+        change could quietly become "nothing blocks any more"."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Skill", {"skill": "plan"}, tr), env)
+        assert result.returncode == 2
+        assert b"blocked: context ceiling" in result.stderr
+        assert b"not blocked: delegation" not in result.stderr
+
+    def test_the_agent_warning_still_carries_the_diagnostic_and_band(
+        self, tmp_path: Path
+    ) -> None:
+        """Only the block is dropped. The occupancy diagnostic and the
+        escalating action band are the part that was doing useful work, and
+        they survive — otherwise this would be a silent un-gating."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)  # 95% — top band
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert b"190000 of 200000 tokens" in result.stderr
+        assert b"[full-summary]" in result.stderr
+        assert b"/handoff" in result.stderr
+
+    def test_gate_agent_block_restores_the_previous_behavior(
+        self, tmp_path: Path
+    ) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        env["DEV_TEAM_CONTEXT_GATE_AGENT"] = "block"
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert result.returncode == 2
+        assert b"blocked: context ceiling" in result.stderr
+
+    @pytest.mark.parametrize("value", ["BLOCK", "Block", " block ", "block\n"])
+    def test_gate_agent_block_is_matched_case_and_whitespace_insensitively(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        env["DEV_TEAM_CONTEXT_GATE_AGENT"] = value
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert result.returncode == 2
+
+    @pytest.mark.parametrize("value", ["", "on", "1", "true", "yes", "warn"])
+    def test_only_the_literal_block_opts_in(self, tmp_path: Path, value: str) -> None:
+        """Unlike DEV_TEAM_CONTEXT_STRICT, this variable resolves toward the
+        NEW default when it is not understood. That asymmetry is deliberate:
+        the expensive direction of failure for STRICT is silently not
+        enforcing, but here it is blocking a dispatch that should not be
+        blocked, so an unrecognized value must not opt in."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        env["DEV_TEAM_CONTEXT_GATE_AGENT"] = value
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert result.returncode == 0
+
+    def test_below_the_ceiling_an_agent_dispatch_is_still_silent(
+        self, tmp_path: Path
+    ) -> None:
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 50_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert result.returncode == 0
+        assert result.stderr == b""
+
+    def test_an_unverified_window_reports_that_reason_not_delegation(
+        self, tmp_path: Path
+    ) -> None:
+        """Both non-blocking reasons can apply to one Agent dispatch. Exactly
+        one footer is emitted, and it is the unverified-window one: that
+        footer says the threshold above may be wrong, which is strictly more
+        surprising than "the threshold was right and the block was declined
+        on purpose"."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 100_000, model="claude-opus-6")  # unrecognized
+        result = _run(
+            _mkinput("Agent", {"subagent_type": "x"}, tr), _posture_env(tmp_path)
+        )
+        assert result.returncode == 0
+        assert b"not blocked: window unverified" in result.stderr
+        assert b"not blocked: delegation" not in result.stderr
+
+    def test_warn_mode_gains_no_delegation_footer(self, tmp_path: Path) -> None:
+        """Under STRICT=off nothing was going to block anyway, so the footer
+        would be explaining a restriction that does not exist."""
+        tr = tmp_path / "t.jsonl"
+        _write_transcript(tr, 190_000)
+        env = _posture_env(tmp_path)
+        env["DEV_TEAM_CONTEXT_WINDOW"] = "200000"
+        env["DEV_TEAM_CONTEXT_STRICT"] = "off"
+        result = _run(_mkinput("Agent", {"subagent_type": "x"}, tr), env)
+        assert result.returncode == 0
+        assert b"not blocked: delegation" not in result.stderr
+
+    def test_blocking_tools_is_a_strict_subset_of_gated_tools(self) -> None:
+        """A tool that blocks but is never evaluated would be dead policy."""
+        assert hook._BLOCKING_TOOLS < hook._GATED_TOOLS
+        assert hook._BLOCKING_TOOLS == {"Skill"}

--- a/scripts/context_ceiling_report.py
+++ b/scripts/context_ceiling_report.py
@@ -23,6 +23,14 @@ session" systematically OVERSTATES how often the ceiling bites, and any
 threshold derived from occupancy alone is derived from the wrong distribution.
 This tool conditions on gated calls, which is where the guard actually lives.
 
+Narrower still since ADR 0039: of the gated tools, only `Skill` BLOCKS. An
+`Agent`/`Task` dispatch warns but proceeds, because it runs in its own context
+and blocking it would push the work inline and grow occupancy further. So the
+sweep's block columns count Skill invocations only; agent dispatches are
+reported separately as advisory fires. Counting them as blocks would overstate
+every candidate's block rate and argue for a higher ceiling than the evidence
+supports.
+
 The two failure directions, and the metric for each
 ---------------------------------------------------
 A ceiling can be wrong in two directions, and a single "block rate" number
@@ -116,7 +124,7 @@ def _occupancy_of(usage: dict) -> int | None:
 
 
 def _gated_calls_in(record: dict) -> list[tuple[str, str]]:
-    """Every gated capability load in one record, as (tool_name, label).
+    """Every gated capability load in one record, as (tool, label, blocks).
 
     Recovery skills are dropped here rather than counted and filtered later:
     they are never gated at any occupancy, so counting them would inflate
@@ -128,7 +136,7 @@ def _gated_calls_in(record: dict) -> list[tuple[str, str]]:
     content = message.get("content")
     if not isinstance(content, list):
         return []
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
     for block in content:
         if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
@@ -142,10 +150,16 @@ def _gated_calls_in(record: dict) -> list[tuple[str, str]]:
             skill = guard._extract_skill_name(tool_input)
             if skill in guard._RECOVERY_SKILLS:
                 continue
-            calls.append((name, skill or "?"))
+            calls.append((name, skill or "?", name in guard._BLOCKING_TOOLS))
         else:
             agent = tool_input.get("subagent_type")
-            calls.append((name, agent if isinstance(agent, str) and agent else "?"))
+            calls.append(
+                (
+                    name,
+                    agent if isinstance(agent, str) and agent else "?",
+                    name in guard._BLOCKING_TOOLS,
+                )
+            )
     return calls
 
 
@@ -157,6 +171,10 @@ class GateEvent:
     tool: str
     label: str
     turn_index: int
+    #: Whether the guard would BLOCK this call over the ceiling, as opposed
+    #: to warning and proceeding. Derived from `guard._BLOCKING_TOOLS` rather
+    #: than restated, so the split cannot drift from the shipped policy.
+    blocks: bool
 
 
 @dataclass
@@ -238,13 +256,14 @@ def replay_transcript(path: Path) -> SessionReplay | None:
             replay.turn_prompt_tokens.append(usage_occ)
             replay.peak_occupancy = max(replay.peak_occupancy, usage_occ)
             replay.final_occupancy = usage_occ
-        for tool, label in _gated_calls_in(record):
+        for tool, label, blocks in _gated_calls_in(record):
             replay.gates.append(
                 GateEvent(
                     occupancy=occupancy,
                     tool=tool,
                     label=label,
                     turn_index=max(0, replay.assistant_turns - 1),
+                    blocks=blocks,
                 )
             )
     return replay
@@ -268,6 +287,7 @@ def evaluate_ceiling(
     tokens_after_first_block = 0
     total_blocks = 0
     clamped_sessions = 0
+    advisory_fires = 0
 
     for replay in replays:
         threshold = effective_threshold(replay.window, ceiling_pct, abs_ceiling)
@@ -279,6 +299,12 @@ def evaluate_ceiling(
         if threshold < abs_ceiling:
             clamped_sessions += 1
         over = [g for g in replay.gates if g.occupancy >= threshold]
+        # ADR 0039: an Agent/Task dispatch over the ceiling warns and
+        # proceeds. Counting it as a block would overstate every candidate's
+        # block rate and argue for a higher ceiling than the evidence
+        # supports.
+        advisory_fires += sum(1 for g in over if not g.blocks)
+        over = [g for g in over if g.blocks]
         total_blocks += len(over)
         if not over:
             continue
@@ -290,10 +316,14 @@ def evaluate_ceiling(
             near_done_blocked += 1
         tokens_after_first_block += sum(replay.turn_prompt_tokens[first.turn_index + 1 :])
 
-    sessions_with_gates = sum(1 for r in replays if r.gates)
+    # Denominator is sessions that could have been blocked at all — one with
+    # only agent dispatches never can be, and including it would dilute every
+    # block rate toward zero.
+    sessions_with_gates = sum(1 for r in replays if any(g.blocks for g in r.gates))
     corpus_prompt_tokens = sum(r.prompt_tokens_total for r in replays)
     return {
         "abs_ceiling": abs_ceiling,
+        "advisory_fires": advisory_fires,
         "clamped_sessions": clamped_sessions,
         "clamped_pct": _pct(clamped_sessions, len(replays)),
         "sessions_blocked": blocked_sessions,
@@ -345,15 +375,22 @@ def _fmt(value) -> str:
 
 def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
     lines: list[str] = []
-    sessions_with_gates = sum(1 for r in replays if r.gates)
+    sessions_with_gates = sum(
+        1 for r in replays if any(g.blocks for g in r.gates)
+    )
     total_gates = sum(len(r.gates) for r in replays)
+    blocking_gates = sum(1 for r in replays for g in r.gates if g.blocks)
     peaks = sorted(r.peak_occupancy for r in replays)
 
     lines.append("Context ceiling validation")
     lines.append("=" * 74)
     lines.append(f"transcripts replayed      : {len(replays):,}")
-    lines.append(f"  with >=1 gated call     : {sessions_with_gates:,}")
+    lines.append(f"  with >=1 blockable call : {sessions_with_gates:,}")
     lines.append(f"  gated calls total       : {total_gates:,}")
+    lines.append(
+        f"    of which blockable    : {blocking_gates:,} "
+        f"(Skill; ADR 0039 — Agent/Task warns, never blocks)"
+    )
     lines.append(f"  unrecognized model      : {sum(1 for r in replays if not r.window_matched):,}")
     if peaks:
         lines.append("")
@@ -410,7 +447,8 @@ def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
             "      changes nothing there. To test a higher ceiling on those sessions,"
         )
         lines.append("      raise --ceiling-pct as well.")
-    lines.append("  blocked     : share of gated sessions the ceiling would stop")
+    lines.append("  blocked     : share of blockable sessions the ceiling would stop")
+    lines.append("                (Skill invocations only — agent dispatches warn)")
     lines.append("  near-done   : share of BLOCKED sessions that were nearly finished")
     lines.append("                — the over-blocking signal; drive toward 0")
     lines.append("  tokens over : share of corpus prompt tokens spent past the first")

--- a/scripts/context_ceiling_report.py
+++ b/scripts/context_ceiling_report.py
@@ -91,6 +91,8 @@ if str(_HOOKS_DIR) not in sys.path:
 
 # The guard is the source of truth for every policy constant below. See the
 # "Anti-drift" note in the module docstring.
+from datetime import UTC
+
 import context_ceiling_guard as guard  # type: ignore[import-not-found]
 
 #: Candidate ceilings swept when `--ceilings` is not given. Brackets the
@@ -355,6 +357,74 @@ def _pct(numerator: int, denominator: int) -> float | None:
     return round(numerator / denominator * 100, 1)
 
 
+def trend_record(replays: list[SessionReplay], sweep: list[dict], args) -> dict:
+    """A compact, AGGREGATE-COUNTS-ONLY record for the ceiling trend stream.
+
+    Mirrors `scripts/session_extract.py`'s `slim_record` convention (#129):
+    the trend stream carries metrics only — no transcript paths, no session
+    ids, no prompt or code content — because it is the artifact that
+    accumulates across rounds and outlives any single review. `recorded_at`
+    is the only wall-clock field and lives on the trend log, never in the
+    deterministic report output, so two runs over the same corpus produce
+    identical reports.
+    """
+    from datetime import datetime
+
+    peaks = sorted(r.peak_occupancy for r in replays)
+
+    def _pctile(fraction: float) -> int | None:
+        if not peaks:
+            return None
+        return peaks[min(len(peaks) - 1, int(len(peaks) * fraction))]
+
+    return {
+        "schema": "context-ceiling-trend/v1",
+        # `%Y-%m-%dT%H:%M:%SZ`, matching `session_extract.py` and the rest of
+        # the repo's metrics streams — the playbook reads both streams'
+        # timestamps side by side, so two spellings of UTC would be a
+        # gratuitous difference at exactly the point of comparison.
+        "recorded_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ceiling_pct": args.ceiling_pct,
+        "shipped_ceiling": args.shipped,
+        "near_done_turns": args.near_done_turns,
+        "sessions": len(replays),
+        "sessions_with_blockable_calls": sum(
+            1 for r in replays if any(g.blocks for g in r.gates)
+        ),
+        "gated_calls": sum(len(r.gates) for r in replays),
+        "blocking_calls": sum(1 for r in replays for g in r.gates if g.blocks),
+        "unrecognized_model_sessions": sum(1 for r in replays if not r.window_matched),
+        "peak_occupancy": {
+            "p50": _pctile(0.5),
+            "p90": _pctile(0.9),
+            "max": peaks[-1] if peaks else None,
+        },
+        "sweep": [
+            {
+                k: row[k]
+                for k in (
+                    "abs_ceiling",
+                    "sessions_blocked",
+                    "sessions_blocked_pct",
+                    "blocks_total",
+                    "advisory_fires",
+                    "median_occupancy_at_first_block",
+                    "near_done_blocked_pct",
+                    "prompt_tokens_after_first_block_pct",
+                )
+            }
+            for row in sweep
+        ],
+    }
+
+
+def append_trend(path: Path, record: dict) -> None:
+    """Append one record to the append-only trend stream, creating it if new."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
 def discover_transcripts(roots: list[Path]) -> list[Path]:
     found: list[Path] = []
     for root in roots:
@@ -537,6 +607,13 @@ def main(argv: list[str] | None = None) -> int:
         help="the shipped default, marked and summarized in the report",
     )
     parser.add_argument("--json", type=Path, help="also write the full result as JSON")
+    parser.add_argument(
+        "--append",
+        type=Path,
+        metavar="LOG",
+        help="append one metrics-only summary record to a trend stream "
+        "(append-only JSONL), so successive rounds are comparable",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -593,6 +670,10 @@ def main(argv: list[str] | None = None) -> int:
         }
         args.json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         print(f"\nwrote {args.json}")
+
+    if args.append:
+        append_trend(args.append, trend_record(replays, sweep, args))
+        print(f"appended a trend record to {args.append}")
     return 0
 
 

--- a/tests/scripts/test_context_ceiling_report.py
+++ b/tests/scripts/test_context_ceiling_report.py
@@ -524,3 +524,112 @@ def test_the_report_names_the_blockable_subset(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert b"of which blockable" in result.stdout.encode()
     assert b"Agent/Task warns, never blocks" in result.stdout.encode()
+
+
+# ---------------------------------------------------------------------------
+# the trend stream — what makes "over time" possible
+# ---------------------------------------------------------------------------
+
+
+def _trend_args(**over):
+    class _A:
+        ceiling_pct = 40
+        shipped = 350_000
+        near_done_turns = 5
+
+    a = _A()
+    for k, v in over.items():
+        setattr(a, k, v)
+    return a
+
+
+def test_the_trend_record_carries_metrics_only(tmp_path: Path) -> None:
+    """The trend stream accumulates across rounds and outlives any single
+    review, so it must carry no transcript paths, session ids, prompts or
+    code — the same constraint `session_extract.py`'s `slim_record` accepts
+    (#129). A leak here is permanent in a way a one-off report is not.
+    """
+    replays = _one_session(
+        tmp_path, _assistant(400_000, tool_uses=[_skill("build")])
+    )
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    blob = json.dumps(report.trend_record(replays, sweep, _trend_args()))
+
+    assert str(tmp_path) not in blob
+    assert ".jsonl" not in blob
+    for key in ("path", "session_id", "label"):
+        assert f'"{key}"' not in blob
+
+
+def test_the_trend_record_pins_the_settings_it_was_measured_under(
+    tmp_path: Path,
+) -> None:
+    """A row that does not say which ceiling_pct and near-done window
+    produced it cannot be compared against the next round — the whole point
+    of persisting it."""
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("x")]))
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    rec = report.trend_record(replays, sweep, _trend_args())
+    assert rec["schema"] == "context-ceiling-trend/v1"
+    assert (rec["ceiling_pct"], rec["shipped_ceiling"], rec["near_done_turns"]) == (
+        40,
+        350_000,
+        5,
+    )
+
+
+def test_recorded_at_is_the_only_wall_clock_field(tmp_path: Path) -> None:
+    """Two runs over the same corpus must produce identical reports; the
+    timestamp lives on the trend log, never in the deterministic output."""
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("x")]))
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    rec = report.trend_record(replays, sweep, _trend_args())
+    assert "recorded_at" in rec
+    assert "recorded_at" not in json.dumps(sweep)
+
+
+def test_append_creates_the_stream_and_never_rewrites_it(tmp_path: Path) -> None:
+    """Append-only: an earlier round is evidence, and a round that could
+    overwrite its predecessors would destroy the comparison it exists for."""
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("x")]))
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    log = tmp_path / "nested" / "trend.jsonl"
+
+    report.append_trend(log, report.trend_record(replays, sweep, _trend_args()))
+    report.append_trend(log, report.trend_record(replays, sweep, _trend_args()))
+
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 2
+    assert all(json.loads(ln)["schema"] == "context-ceiling-trend/v1" for ln in lines)
+
+
+def test_cli_append_writes_one_record_per_run(tmp_path: Path) -> None:
+    _write(tmp_path / "t.jsonl", _assistant(400_000, tool_uses=[_skill("build")]))
+    log = tmp_path / "trend.jsonl"
+    for _ in range(2):
+        result = _run_cli(
+            "--transcripts", str(tmp_path), "--ceilings", "350000",
+            "--append", str(log),
+        )
+        assert result.returncode == 0, result.stderr
+    assert len(log.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+def test_recorded_at_matches_the_repos_metrics_timestamp_format(
+    tmp_path: Path,
+) -> None:
+    """`session_extract.py` and the other metrics writers all emit
+    `%Y-%m-%dT%H:%M:%SZ`. The playbook reads both streams' timestamps side by
+    side, so a second spelling of UTC would be a gratuitous difference at
+    exactly the point of comparison."""
+    import datetime as _dt
+
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("x")]))
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    stamp = report.trend_record(replays, sweep, _trend_args())["recorded_at"]
+
+    assert stamp.endswith("Z") and "+00:00" not in stamp
+    parsed = _dt.datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=_dt.timezone.utc
+    )
+    assert parsed.tzinfo is _dt.timezone.utc

--- a/tests/scripts/test_context_ceiling_report.py
+++ b/tests/scripts/test_context_ceiling_report.py
@@ -436,3 +436,91 @@ def test_the_verdict_says_inconclusive_rather_than_endorsing_the_default(
     result = _run_cli("--transcripts", str(tmp_path))
     assert result.returncode == 0
     assert "inconclusive" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# ADR 0039 — the sweep counts blocks, and only Skill blocks
+# ---------------------------------------------------------------------------
+
+
+def test_an_agent_dispatch_over_the_ceiling_is_not_counted_as_a_block(
+    tmp_path: Path,
+) -> None:
+    """The deliberate-failure case for the report side. Counting agent
+    dispatches as blocks would overstate every candidate's block rate and
+    argue for a higher ceiling than the evidence supports."""
+    replays = _one_session(
+        tmp_path, _assistant(400_000, tool_uses=[_agent("test-review")])
+    )
+    result = report.evaluate_ceiling(replays, 350_000, 40, 5)
+    assert result["sessions_blocked"] == 0
+    assert result["blocks_total"] == 0
+    assert result["advisory_fires"] == 1, (
+        "the dispatch still fired the guard — it warned, and the report must "
+        "say so rather than dropping it silently"
+    )
+
+
+def test_a_skill_invocation_over_the_ceiling_is_counted_as_a_block(
+    tmp_path: Path,
+) -> None:
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("build")]))
+    result = report.evaluate_ceiling(replays, 350_000, 40, 5)
+    assert result["sessions_blocked"] == 1
+    assert result["blocks_total"] == 1
+    assert result["advisory_fires"] == 0
+
+
+def test_the_blocking_split_is_read_from_the_guard_not_restated(
+    tmp_path: Path,
+) -> None:
+    """Anti-drift for the split itself: if the guard ever changes which
+    tools block, the report must follow without being edited."""
+    replays = _one_session(
+        tmp_path,
+        _assistant(400_000, tool_uses=[_skill("build"), _agent("x")]),
+    )
+    by_tool = {g.tool: g.blocks for g in replays[0].gates}
+    assert by_tool == {
+        tool: tool in guard._BLOCKING_TOOLS for tool in ("Skill", "Agent")
+    }
+
+
+def test_a_session_with_only_agent_dispatches_is_not_in_the_denominator(
+    tmp_path: Path,
+) -> None:
+    """It can never be blocked at any ceiling, so including it would dilute
+    every block rate toward zero and make a too-low ceiling look fine."""
+    replays = _one_session(tmp_path, _assistant(900_000, tool_uses=[_agent("x")]))
+    result = report.evaluate_ceiling(replays, 150_000, 40, 5)
+    assert result["sessions_blocked"] == 0
+    assert result["sessions_blocked_pct"] is None, (
+        "no blockable session means there is nothing to take a percentage of"
+    )
+
+
+def test_tokens_after_first_block_ignores_a_preceding_agent_dispatch(
+    tmp_path: Path,
+) -> None:
+    """"First block" means the first BLOCKING gate. An earlier agent
+    dispatch over the ceiling is not where enforcement would have cut in."""
+    replays = _one_session(
+        tmp_path,
+        _assistant(400_000, tool_uses=[_agent("x")]),  # warns, does not block
+        _assistant(500_000, tool_uses=[_skill("build")]),  # this is the block
+        _assistant(600_000),
+    )
+    result = report.evaluate_ceiling(replays, 350_000, 40, 0)
+    assert result["median_occupancy_at_first_block"] == 500_000
+    assert result["prompt_tokens_after_first_block"] == 600_000
+
+
+def test_the_report_names_the_blockable_subset(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "t.jsonl",
+        _assistant(400_000, tool_uses=[_skill("build"), _agent("x")]),
+    )
+    result = _run_cli("--transcripts", str(tmp_path), "--ceilings", "350000")
+    assert result.returncode == 0
+    assert b"of which blockable" in result.stdout.encode()
+    assert b"Agent/Task warns, never blocks" in result.stdout.encode()


### PR DESCRIPTION
Two changes, retitled `feat` because this repo squash-merges and a `fix(hooks)` title would drop the playbook from the changelog. Happy to split into two PRs if you'd rather — say the word.

---

## 1. Stop blocking agent dispatches at the ceiling (`fix`)

The last of the four findings from the context-guard review (after #2054, #2056, #2060). ADR 0011 grouped `Agent` and `Skill` as one class of "capability loads" and gated both — harmless while the guard only warned, not harmless under #2000's blocking default, because **the two tools do opposite things to the quantity this guard measures**.

- A **`Skill` invocation** loads `SKILL.md` into the main thread. It grows main-thread occupancy, and declining it prevents that growth. A block does what it says.
- An **`Agent`/`Task` dispatch** runs in a *separate* context and returns only its result. Blocking it doesn't stop the work — the orchestrator still has `Read`/`Edit`/`Bash` and the task still needs doing, so the work happens **inline instead**, growing occupancy by *more* than the delegation would have. On a 1M-window session at 400K, blocking a review dispatch converts a ~2K result summary into tens of thousands of tokens of inline file reading. The guard makes the number it protects worse.

This repo already settled the underlying question on the other side of the same hook: **#2054 excluded sidechain rows from `_measure_occupancy` because a subagent's context is not this thread's context.** If a subagent's tokens aren't main-thread occupancy, blocking a subagent dispatch to protect main-thread occupancy is incoherent. The gating side was never updated to match the measurement side.

`Agent`/`Task` now warn and proceed with a `[not blocked: delegation]` footer — the diagnostic and escalating action bands are unchanged, since those were the part doing useful work. `Skill` blocks exactly as before. `DEV_TEAM_CONTEXT_GATE_AGENT=block` restores the old behavior, and **only the literal `block` opts in** — the opposite convention to `DEV_TEAM_CONTEXT_STRICT`, because the expensive direction of failure here is the reverse.

**The honest cost**, recorded in ADR 0039: blocking `Agent` was a second chokepoint that could force a handoff, and dropping it leaves one fewer place where an over-budget session must confront the ceiling. That pressure was bought by making the session more expensive, and using an occupancy ceiling as a proxy for session-total cost conflates two quantities with two different correct thresholds — the same category error ADR 0038 corrected. Session-total cost needs its own instrument (`cost_meter.py` already measures it), not a side effect smuggled into this guard.

`context_ceiling_report.py` follows the split, reading `_BLOCKING_TOOLS` from the guard rather than restating it: block columns count `Skill` only, dispatches become `advisory_fires`, and a session whose only gated calls are dispatches leaves the block-rate denominator entirely.

## 2. Session economy playbook (`feat`)

Every instrument for this already existed as a one-shot command — `/session-review`, `/harness-audit`, `/cost-report`, `/run-report`, `/artifact-lifecycle`, `context_ceiling_report.py`. What was missing was **the loop**: a cadence, a fixed order, a decision rule per signal, and streams that make one round comparable to the last. Without those, each review re-derived its own baseline and *"did the thing we changed actually help?"* had no mechanical answer.

`docs/context-and-session-economy-playbook.md` is the longitudinal layer over those instruments, not a replacement for any — it opens with a routing table sending single-question asks back to the one command that answers them, so it doesn't become the default entry point for work that doesn't need a round.

- **`context_ceiling_report.py --append`** mirrors `session_extract.py`'s metrics-only trend convention (#129): aggregate counts, no transcript paths, session ids, prompts or code, because the trend stream outlives any single review. `recorded_at` is the only wall-clock field and lives on the trend log, never in the report output, so two runs over one corpus still produce identical reports — and its format matches `session_extract.py`'s `%Y-%m-%dT%H:%M:%SZ`, since the playbook reads both streams' timestamps side by side.
- **Monthly, not weekly**, deliberately: both streams are per-session aggregates, and a week of one maintainer's work is too few sessions for a percentage to carry information. A round that can't separate signal from sample size invites action on both.
- **Each decision rule names the ADR revisit trigger it discharges** — 0037 for a ceiling set too low, 0038 for one set too high, 0039 for delegation used to evade it. Those triggers were written as conditions with no scheduled place to check them; this is that place.
- **Change one thing per round**, because two changes between rounds attribute to neither.

## Test Plan

- [x] `TestOnlySkillLoadsAreWorthBlocking` — 11 cases under `_posture_env` (shipped posture, no env set)
- [x] **Deliberate-failure checks on both new gates**: guard split reverted → 8 fail / 11 pass; report split reverted → 3 fail; both restored → all pass
- [x] Scope guards so the change can't become "nothing blocks any more": skill still blocks, agent warning keeps its diagnostic and band, `_BLOCKING_TOOLS` is a strict subset of `_GATED_TOOLS`
- [x] Both non-block reasons can apply at once — exactly one footer emitted, pinned
- [x] `DEV_TEAM_CONTEXT_GATE_AGENT`: case/whitespace-insensitive `block`; `on`/`1`/`true`/`yes`/`warn`/empty all resolve to the new default
- [x] Trend stream: metrics-only (asserts no paths, session ids, or `.jsonl` in the record), settings pinned in the record, `recorded_at` absent from the deterministic output, append-only across runs, timestamp format matches the repo convention
- [x] Live probe of the shipped hook across 6 shapes — agent/task warn at 400K, skill blocks, opt-in blocks, under-ceiling silent, recovery skill ungated
- [x] **Every command in the playbook was run end to end before it was written down** — including the step-3 delta reader against both live streams
- [x] Full affected suites → 9,750 then 7,483 passed; full local CI mirror on push → passed
- [x] `ruff` clean, `check_md_references.py` exit 0, `measure_tokens.py --verify` clean

## Notes

The `agent-registry` token-drift gate failed on the first push and is worth flagging: `context-loading-protocol/SKILL.md` was declared at 2,331 tokens against a measured **2,525 on clean `main`** — already 7.7% stale, under tolerance and therefore invisible. My doc addition pushed it past tolerance, which is the only reason it surfaced. I trimmed the addition and refreshed the declared value to the measured 2,628, resetting drift to zero rather than nudging it back under the wire.