### PR TITLE
fix(scripts): measure how much work a block interrupts, not just whether it was last

### DIFF
--- a/docs/adr/0038-raise-the-absolute-context-ceiling-to-350k.md
+++ b/docs/adr/0038-raise-the-absolute-context-ceiling-to-350k.md
@@ -163,3 +163,93 @@ over a corpus large enough to return a verdict other than "inconclusive".
 Re-deriving the threshold is now a command, not a project. Run it, read the
 `near-done` and `tokens over` columns together, and amend this ADR with what
 the corpus says.
+
+## Amendment (2026-08-26, second) — the first measured corpus
+
+`scripts/context_ceiling_report.py` has now been run over a real corpus: 306
+sessions, 79 of them making at least one blockable call, 3,055 gated calls.
+This is the measurement the revisit trigger above asked for, and it does not
+confirm this ADR's reasoning. It retires part of it.
+
+| candidate | sessions blocked | near-done (abs) | tokens past first block |
+|---|---|---|---|
+| 150,000 | 68.4% | 1 session | 71.3% |
+| 200,000 | 53.2% | 1 | 58.4% |
+| 250,000 | 41.8% | 2 | 51.0% |
+| 300,000 | 34.2% | 1 | 47.5% |
+| **350,000 (shipped)** | **26.6%** | **0** | **35.8%** |
+| 450,000 / 600,000 | 21.5% | 0 | 31.3% |
+
+(The last two rows are one candidate, not two: both clamp to 40% of a 1M
+window. The trend record was dropping the field that says so; fixed alongside
+this amendment.)
+
+**The occupancy estimate this ADR rests on was wrong by 3-5x.** It reasoned
+from a 316:1 prompt:output ratio to "200-370K average per-turn occupancy" and
+concluded 150K sat below the median working point. Measured, the median
+session's *peak* occupancy is **74,950** — half of all sessions never reach
+half of the old ceiling, let alone the new one. The distribution is not
+centered anywhere near either value; it is sharply skewed, p90 at 618K against
+that 75K median, and only 26% of sessions make a blockable call at all. The
+ceiling is simply irrelevant to three quarters of sessions.
+
+**The over-blocking case for raising to 350K is not in the data.** This ADR
+argued 150K would stop ordinary work. At 150K exactly **one** blocked session
+was near done. At every candidate the near-done count is 0-2 sessions. Whatever
+150K was doing wrong, it was not blocking sessions at the finish line.
+
+**But the data cannot justify lowering it either, and that is a defect in the
+instrument, not a finding.** `near_done_blocked_pct` is a *threshold* — it
+detects one failure shape, "blocked at the finish line", and collapses
+everything else into "fine". Read naively, a metric that sits at 0-6% across
+every candidate from 150K to 600K argues for lowering the ceiling without
+limit, which is plainly wrong: a session blocked at 20% done is not near-done,
+yet blocking it still costs a handoff and the re-establishment of everything
+it had loaded. The report now also emits
+`median_remaining_turns_at_first_block`, which measures how much work a block
+actually interrupts, precisely because the threshold alone could not adjudicate
+this question.
+
+**Decision: 350K stands, and the next move waits for the better metric.** Not
+because the data endorses it — it does not — but because the two arguments that
+could move it are both currently unsound. The argument that raised it is
+retired. The argument for lowering it rests on a metric now known to be
+insufficient for the purpose. Moving a threshold on a measure known to be the
+wrong shape is exactly how 150K was arrived at, and repeating that with a
+different number would not be progress.
+
+What survives of this ADR unchanged is the narrower claim: 150K was borrowed
+from the Claude API's managed-compaction default rather than derived from this
+plugin's behavior, and a threshold nobody measured should not be treated as
+one somebody chose. That remains true and remains the reason not to go back.
+
+**Next round.** Re-run after the corpus has accumulated
+`median_remaining_turns_at_first_block` at each candidate, per
+[the session economy playbook](../context-and-session-economy-playbook.md). A
+ceiling whose blocks land with few turns remaining is doing its job; one whose
+blocks land mid-flight, however low its near-done rate, is not.
+
+## Amendment (2026-08-26, third) — ADR 0039's revisit trigger has already fired
+
+The same corpus fires the trigger
+[ADR 0039](0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md)
+set for itself — "a high `advisory_fires` count against a low block rate". At
+the shipped 350K the ratio is **24:1**: 1,562 agent dispatches over the ceiling
+against 65 blocks. Corpus-wide, **93% of all gated calls are delegations**
+(2,841 of 3,055), not skill loads.
+
+Read carefully, that number cuts both ways and only one reading is supported.
+
+It is decisive validation of ADR 0039 itself: under the previous behavior every
+one of those 1,562 dispatches would have been a hard block, on sessions that in
+most cases had already passed the ceiling. The change did not soften a rare
+edge case; it removed the guard's most frequent action by a factor of 24.
+
+Whether it is *also* evasion — delegation used to keep working past a ceiling
+rather than to economize — this corpus cannot say, because nothing here
+distinguishes a dispatch that saved main-thread tokens from one that merely
+deferred a handoff. ADR 0039 already names the answer if it turns out to be
+evasion, and that answer is unchanged by this measurement: a session-total cost
+control, measured by `hooks/lib/cost_meter.py`, not re-blocking dispatches.
+Re-blocking would restore 1,562 blocks to buy a signal the occupancy guard was
+never measuring.

--- a/docs/context-ceiling-validation.md
+++ b/docs/context-ceiling-validation.md
@@ -39,6 +39,7 @@ python3 scripts/context_ceiling_report.py \
 | `--ceilings` | `150000,…,600000` | Comma-separated candidate absolute ceilings to sweep. |
 | `--ceiling-pct` | `40` | The percentage-of-window bound, matching `DEV_TEAM_CONTEXT_CEILING_PCT`. |
 | `--near-done-turns` | `5` | Assistant turns remaining at or below which a blocked session counts as "near done". |
+| `--append` | — | Append one metrics-only record to a trend stream, so rounds are comparable. |
 | `--shipped` | `350000` | Which row to mark and summarize in the verdict. |
 | `--json` | — | Also write the full per-session result for scripting. |
 
@@ -50,7 +51,19 @@ directions apart, so the report prints a column for each:
 | Column | Direction it detects | What a bad number looks like |
 | --- | --- | --- |
 | `near-done` | ceiling too **low** | a high share of blocked sessions were within a few turns of finishing — [ADR 0037](adr/0037-block-by-default-at-the-context-ceiling-2000.md)'s revisit trigger, verbatim |
+| `turns left` | ceiling too **low** | blocks landing with a lot of work still to come, i.e. mid-flight rather than at the end |
 | `tokens over` | ceiling too **high** | a large share of corpus prompt tokens was spent past the first block, i.e. the expensive tail ran anyway |
+
+**Read `near-done` and `turns left` together — the first is a threshold and
+cannot stand alone.** The first real corpus (306 sessions) made this concrete:
+`near-done` sat at 0-6% across *every* candidate from 150K to 600K. Taken by
+itself that reads as "no ceiling over-blocks anywhere", which would argue for
+lowering the ceiling without limit. It only ever detected one shape — blocked
+*at* the finish line. A session blocked at 20% done is not near-done, and
+blocking it still costs a handoff and the re-establishment of everything it had
+loaded. `turns left` is the median work remaining when the block landed, which
+is the quantity `near-done` was standing in for. A near-done of 0 beside a
+large turns-left means blocks are landing mid-flight.
 
 A better ceiling lowers `near-done` without letting `tokens over` climb. The
 report deliberately does not collapse these into a score or pick a number for
@@ -60,14 +73,24 @@ adopted without that trade-off being visible.
 
 Sample output, against a synthetic corpus:
 
+The first real corpus — 306 sessions, 79 with a blockable call:
+
 ```text
   ceiling |  sessions |  blocked |  blocks |  median@1st |  near-done |  tokens over
 ------------------------------------------------------------------------------------
-  150,000 |        12 |     100% |     100 |     181,249 |      16.7% |        89.7%
-  250,000 |        10 |    83.3% |      85 |     291,246 |        50% |        78.8%
-  350,000 |         7 |    58.3% |      75 |     420,000 |      42.9% |        69.8% *
-  450,000 |         6 |      50% |      72 |     467,499 |      33.3% |        66.6%†
+  150,000 |        79 |    68.4% |     145 |     188,662 |       1.9% |        71.3%
+  250,000 |        79 |    41.8% |      92 |     333,142 |       6.1% |        51.0%
+  350,000 |        79 |    26.6% |      65 |     399,708 |       0.0% |        35.8% *
+  450,000 |        79 |    21.5% |      51 |     444,816 |       0.0% |        31.3%†
+  600,000 |        79 |    21.5% |      51 |     444,816 |       0.0% |        31.3%†
 ```
+
+Two things to notice, both of which drove changes to this tool. The last two
+rows are identical because they are **one** candidate — 40% of a 1M window
+clamps both to 400K, which is what `†` says. And `near-done` never rises above
+6%, which is the reading that showed a threshold alone cannot adjudicate a
+ceiling. See [ADR 0038's second
+amendment](adr/0038-raise-the-absolute-context-ceiling-to-350k.md).
 
 ## Four properties worth knowing before acting on its output
 

--- a/scripts/context_ceiling_report.py
+++ b/scripts/context_ceiling_report.py
@@ -286,6 +286,7 @@ def evaluate_ceiling(
     blocked_sessions = 0
     near_done_blocked = 0
     first_block_occupancies: list[int] = []
+    remaining_turns_at_block: list[int] = []
     tokens_after_first_block = 0
     total_blocks = 0
     clamped_sessions = 0
@@ -314,6 +315,7 @@ def evaluate_ceiling(
         first = over[0]
         first_block_occupancies.append(first.occupancy)
         remaining_turns = replay.assistant_turns - 1 - first.turn_index
+        remaining_turns_at_block.append(remaining_turns)
         if remaining_turns <= near_done_turns:
             near_done_blocked += 1
         tokens_after_first_block += sum(replay.turn_prompt_tokens[first.turn_index + 1 :])
@@ -338,6 +340,21 @@ def evaluate_ceiling(
         ),
         "near_done_blocked": near_done_blocked,
         "near_done_blocked_pct": _pct(near_done_blocked, blocked_sessions),
+        # `near_done_blocked_pct` is a THRESHOLD on this distribution, and the
+        # first real corpus showed the threshold alone cannot adjudicate a
+        # ceiling: it sat at 0-6% across every candidate from 150K to 600K,
+        # which reads as "no candidate over-blocks" and would argue for
+        # lowering the ceiling without limit. It only ever detected one
+        # failure shape — blocked AT the finish line. A session blocked at 20%
+        # done is not near-done, yet blocking it still costs a handoff and the
+        # re-establishment of everything it had loaded. The median says how
+        # much work was actually left, which is the quantity the threshold was
+        # standing in for.
+        "median_remaining_turns_at_first_block": (
+            int(statistics.median(remaining_turns_at_block))
+            if remaining_turns_at_block
+            else None
+        ),
         "prompt_tokens_after_first_block": tokens_after_first_block,
         "prompt_tokens_after_first_block_pct": _pct(
             tokens_after_first_block, corpus_prompt_tokens
@@ -404,12 +421,20 @@ def trend_record(replays: list[SessionReplay], sweep: list[dict], args) -> dict:
                 k: row[k]
                 for k in (
                     "abs_ceiling",
+                    # Without the clamp the persisted stream cannot explain why
+                    # two rows are identical — the first real corpus produced a
+                    # 450K row and a 600K row with every field equal, because
+                    # both clamp to 40% of a 1M window. The terminal report
+                    # marks that with a dagger; the trend record was dropping
+                    # the only field that carries it.
+                    "clamped_sessions",
                     "sessions_blocked",
                     "sessions_blocked_pct",
                     "blocks_total",
                     "advisory_fires",
                     "median_occupancy_at_first_block",
                     "near_done_blocked_pct",
+                    "median_remaining_turns_at_first_block",
                     "prompt_tokens_after_first_block_pct",
                 )
             }
@@ -484,7 +509,8 @@ def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
     )
     header = (
         f"{'ceiling':>9} | {'sessions':>9} | {'blocked':>8} | {'blocks':>7} | "
-        f"{'median@1st':>11} | {'near-done':>10} | {'tokens over':>12}"
+        f"{'median@1st':>11} | {'near-done':>10} | {'turns left':>10} | "
+        f"{'tokens over':>12}"
     )
     lines.append(header)
     lines.append("-" * len(header))
@@ -501,6 +527,7 @@ def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
             f"{_fmt(row['blocks_total']):>7} | "
             f"{_fmt(row['median_occupancy_at_first_block']):>11} | "
             f"{_fmt(row['near_done_blocked_pct']):>10} | "
+            f"{_fmt(row['median_remaining_turns_at_first_block']):>10} | "
             f"{_fmt(row['prompt_tokens_after_first_block_pct']):>12}{marker}"
         )
     lines.append("")
@@ -520,7 +547,11 @@ def render_report(replays: list[SessionReplay], sweep: list[dict], args) -> str:
     lines.append("  blocked     : share of blockable sessions the ceiling would stop")
     lines.append("                (Skill invocations only — agent dispatches warn)")
     lines.append("  near-done   : share of BLOCKED sessions that were nearly finished")
-    lines.append("                — the over-blocking signal; drive toward 0")
+    lines.append("                — one over-blocking shape, not the only one")
+    lines.append("  turns left  : median assistant turns still to come when the block")
+    lines.append("                landed — how much work a block actually interrupts.")
+    lines.append("                Read WITH near-done: a near-done of 0 next to a large")
+    lines.append("                turns-left means blocks land mid-flight, not at the end")
     lines.append("  tokens over : share of corpus prompt tokens spent past the first")
     lines.append("                block — the under-blocking signal; what enforcement")
     lines.append("                would have cut into")

--- a/tests/scripts/test_context_ceiling_report.py
+++ b/tests/scripts/test_context_ceiling_report.py
@@ -633,3 +633,85 @@ def test_recorded_at_matches_the_repos_metrics_timestamp_format(
         tzinfo=_dt.timezone.utc
     )
     assert parsed.tzinfo is _dt.timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# what the first real corpus (306 sessions) exposed about the instrument
+# ---------------------------------------------------------------------------
+
+
+def test_turns_left_distinguishes_two_blocks_near_done_cannot(
+    tmp_path: Path,
+) -> None:
+    """The gap the first real corpus exposed. `near_done_blocked_pct` sat at
+    0-6% across every candidate from 150K to 600K, which reads as "nothing
+    over-blocks anywhere" and would argue for lowering the ceiling without
+    limit. It only ever saw one shape — blocked AT the finish line. These two
+    sessions are identical to that metric and completely different in fact.
+    """
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    early = _one_session(
+        a,
+        _assistant(400_000, tool_uses=[_skill("build")]),
+        *[_assistant(410_000) for _ in range(40)],
+    )
+    late = _one_session(
+        b,
+        *[_assistant(100_000) for _ in range(40)],
+        _assistant(400_000, tool_uses=[_skill("build")]),
+        *[_assistant(410_000) for _ in range(8)],
+    )
+    early_r = report.evaluate_ceiling(early, 350_000, 40, 5)
+    late_r = report.evaluate_ceiling(late, 350_000, 40, 5)
+
+    # Both sit above the near-done threshold, so it reports them identically —
+    # "0% over-blocking", the reading the real corpus produced at every
+    # candidate.
+    assert early_r["near_done_blocked_pct"] == late_r["near_done_blocked_pct"] == 0.0
+    # They are not remotely the same block: one interrupts 40 turns of work,
+    # the other 8.
+    assert early_r["median_remaining_turns_at_first_block"] == 40
+    assert late_r["median_remaining_turns_at_first_block"] == 8
+
+
+def test_turns_left_is_none_when_nothing_was_blocked(tmp_path: Path) -> None:
+    replays = _one_session(tmp_path, _assistant(100_000, tool_uses=[_skill("x")]))
+    result = report.evaluate_ceiling(replays, 350_000, 40, 5)
+    assert result["sessions_blocked"] == 0
+    assert result["median_remaining_turns_at_first_block"] is None
+
+
+def test_the_trend_record_carries_the_clamp(tmp_path: Path) -> None:
+    """The first real corpus produced a 450K row and a 600K row with every
+    persisted field equal, because both clamp to 40% of a 1M window. Without
+    `clamped_sessions` the stream cannot say why, and a later reader compares
+    two rows that were never two candidates."""
+    replays = _one_session(tmp_path, _assistant(400_000, tool_uses=[_skill("x")]))
+    sweep = [
+        report.evaluate_ceiling(replays, c, 40, 5) for c in (350_000, 450_000, 600_000)
+    ]
+    rec = report.trend_record(replays, sweep, _trend_args())
+    by_ceiling = {row["abs_ceiling"]: row for row in rec["sweep"]}
+
+    assert by_ceiling[350_000]["clamped_sessions"] == 0
+    assert by_ceiling[450_000]["clamped_sessions"] == 1
+    assert by_ceiling[600_000]["clamped_sessions"] == 1
+    # The two clamped rows are otherwise identical — which is exactly why the
+    # clamp field has to be present to explain them.
+    assert {k: v for k, v in by_ceiling[450_000].items() if k != "abs_ceiling"} == {
+        k: v for k, v in by_ceiling[600_000].items() if k != "abs_ceiling"
+    }
+
+
+def test_the_trend_record_carries_turns_left(tmp_path: Path) -> None:
+    replays = _one_session(
+        tmp_path,
+        _assistant(400_000, tool_uses=[_skill("build")]),
+        _assistant(410_000),
+        _assistant(420_000),
+    )
+    sweep = [report.evaluate_ceiling(replays, 350_000, 40, 5)]
+    rec = report.trend_record(replays, sweep, _trend_args())
+    assert rec["sweep"][0]["median_remaining_turns_at_first_block"] == 2


### PR DESCRIPTION
## Summary

The ceiling report has now been run over a real corpus — **306 sessions, 79 with a blockable call, 3,055 gated calls**. This is the measurement ADR 0038's revisit trigger asked for. It exposed two defects in the instrument and retired part of that ADR's reasoning; all three are recorded in its second and third amendments.

| candidate | blocked | near-done (abs) | tokens past first block |
|---|---|---|---|
| 150,000 | 68.4% | 1 session | 71.3% |
| 250,000 | 41.8% | 2 | 51.0% |
| **350,000 (shipped)** | **26.6%** | **0** | **35.8%** |
| 450,000 / 600,000 | 21.5% | 0 | 31.3% |

### Defect 1 — `near-done` can't adjudicate a ceiling alone

It's a **threshold**, and on real data it sat at **0–6% across every candidate from 150K to 600K**. Read naively that says no ceiling over-blocks anywhere, which argues for lowering the ceiling without limit — plainly wrong, because it only ever detected one shape: blocked *at* the finish line. A session blocked at 20% done isn't near-done, yet blocking it still costs a handoff and the re-establishment of everything it had loaded.

`evaluate_ceiling` now also emits `median_remaining_turns_at_first_block` — the median work still to come when the block landed, which is the quantity the threshold was standing in for. The new test constructs two sessions **identical to `near-done` (both 0%)** that interrupt 40 turns and 8 turns of work respectively.

### Defect 2 — the trend record dropped `clamped_sessions`

The corpus produced a 450K row and a 600K row with *every persisted field equal*, because both clamp to 40% of a 1M window — they're **one** candidate, not two. The terminal report marks that with `†`; the trend stream was dropping the only field carrying it, so a later reader would compare two rows that were never two candidates.

### What the corpus says about 350K

**The occupancy estimate behind ADR 0038 was wrong by 3–5x.** It reasoned from a 316:1 prompt:output ratio to "200–370K average per-turn occupancy". Measured, the median session's *peak* is **74,950** — p90 at 618K, and only **26% of sessions make a blockable call at all**. The ceiling is irrelevant to three quarters of sessions.

**The over-blocking case for raising to 350K is absent.** At 150K exactly *one* blocked session was near done.

**350K stands anyway** — not because the data endorses it, but because the argument that raised it is retired and the argument for lowering it rests on the metric this PR just showed to be the wrong shape. Moving a threshold on a measure known to be wrong-shaped is how 150K happened. What survives is the narrower claim: 150K was borrowed from a different system's default, and that remains the reason not to go back.

### ADR 0039's revisit trigger has already fired

**24:1 advisory-to-block** at the shipped ceiling, and **93% of all gated calls are delegations** (2,841 of 3,055). That is decisive validation of #2063 — every one of those 1,562 dispatches would previously have been a hard block, on sessions that had mostly already passed the ceiling. Whether it's *also* evasion, this corpus can't say: nothing here distinguishes a dispatch that saved main-thread tokens from one that deferred a handoff. ADR 0039's prescribed answer is unchanged — a session-total cost control via `cost_meter.py`, not re-blocking dispatches.

## Test Plan

- [x] `test_turns_left_distinguishes_two_blocks_near_done_cannot` — two sessions identical to `near-done` (both 0.0%), turns-left 40 vs 8
- [x] `test_the_trend_record_carries_the_clamp` — 350K unclamped, 450K/600K clamped and otherwise byte-identical, which is why the field must be there
- [x] `test_turns_left_is_none_when_nothing_was_blocked`, `test_the_trend_record_carries_turns_left`
- [x] Rendered the new `turns left` column against the synthetic corpus and read the legend back
- [x] `tests/scripts tests/repo tests/docs tests/knowledge plugins/dev-team/tests/hooks` → 5,738 passed, 46 skipped
- [x] Full local CI mirror on push → passed; `ruff` clean; `check_md_references.py` exit 0

## Notes

My first test for the `turns left` metric was wrong and the suite caught it: I built a "late block" case with one turn remaining, which *is* near-done, so the two metrics agreed and the demonstration proved nothing. The committed version puts both cases above the near-done threshold, which is the only arrangement that shows what the threshold hides.

---
_Generated by [Claude Code](https://claude.ai/code/session_015No9ngckCVJ7dQ7ijidkZ7)_