### PR TITLE
docs(adr): record no-go decision on splitting orchestrator.py

### DIFF
--- a/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
+++ b/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
@@ -1,0 +1,111 @@
+# 40. Evaluate splitting orchestrator.py: no-go
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+`plugins/dev-team/scripts/orchestrator.py` grew across three consecutive
+slices of the "Wire orchestrator.py to Real Agent Dispatch" effort (epic
+#1648, spec #1707):
+
+- Slice 2 (PR #1718, Research phase) flagged the file was already past this
+  project's rubric's 400-line god-object watch line (533 lines pre-Slice-3).
+- Slice 3 (PR #1721, Plan phase) explicitly deferred a concrete commitment —
+  evaluate splitting the file into a dispatch-primitives module and a
+  phase-functions module before or during Slice 4, rather than letting the
+  file grow past that point unexamined.
+- Slice 4 (PR #1724, Implement phase) walked that commitment back again with
+  weaker language and preserved the split proposal and deferral history in
+  issue #1723, since `plans/*.md` files are transient and the decision's
+  context was at real risk of being lost permanently.
+
+By the time #1723 was evaluated, the file had reached **820 lines** — past
+the watch line by roughly 2x, having deferred the split question three times
+with no new information changing the calculus each time.
+
+Issue #1723 proposed a lightweight go/no-go, with candidate module
+boundaries already specified: a `dispatch-primitives` module
+(`dispatch_persona`, `dispatch_personas`, `_parse_dispatch_envelope`,
+`_failed_result`, `reconcile`, `WaveError`, timeout constants,
+`JSON_CONTRACT_PERSONAS`) and a `phase-functions` module
+(`_default_phase_research`, `_default_phase_plan`, `_default_phase_implement`,
+`_run_phase`, `_resolve_default`, `_warn_on_failed_personas`,
+`_print_wave_failure`, the persona-roster constants), with `run_pipeline`,
+`classify`, the CLI entry point, and the phase-state helpers staying in
+`orchestrator.py` as the composition root.
+
+**What the evaluation found.** `tests/scripts/test_orchestrator.py` contains
+**46 call sites** using `patch.object(orch, "dispatch_persona", ...)` or
+`patch.object(orch, "dispatch_personas", ...)` to intercept the dispatch
+calls made from inside the phase functions that the proposal moves to
+`phase-functions.py`. If those phase functions import `dispatch_persona`/
+`dispatch_personas` as bare names from a new `dispatch-primitives.py`
+module, patching `orch.dispatch_persona` — even with `orchestrator.py`
+re-exporting the name for backward compatibility — no longer intercepts the
+call: Python binds the imported name into `phase-functions.py`'s own module
+namespace at import time, and patching a different module's attribute of
+the same name does not affect that binding. Every one of the 46 sites would
+silently start exercising the *real* dispatch function instead of the test
+double, which performs real subprocess/Claude CLI dispatch — a failure mode
+that would not read as a test failure so much as a hang, an external call
+during CI, or a flaky timeout, depending on environment.
+
+This is not a novel or unusual pattern; it's the standard "patch where a
+name is *used*, not where it's *defined*" hazard, applied to two functions
+against 46 existing call sites in a single file. It is precisely fixable —
+retarget every site to patch the new module directly, or route calls through
+qualified module access rather than a bare imported name — but it is real,
+precise work with a real, silent-failure-mode risk of getting a subset of
+the 46 sites wrong, not a mechanical rename with no behavioral surface.
+
+## Decision
+
+**No-go, for now.** The 820-line size and the file's history of deferred
+splits are real signals of God-object growth, but they do not by themselves
+outweigh the concrete, verified risk in the 46-site test-patch coupling: a
+split done today either (a) requires touching and correctly re-verifying 46
+patch targets against a mocking pitfall with a silent, hard-to-notice
+failure mode, or (b) is scoped down to avoid moving `dispatch_persona`/
+`dispatch_personas` at all — which defeats the module boundary the proposal
+itself specifies, since those two functions are exactly what makes
+`dispatch-primitives.py` a coherent module.
+
+`orchestrator.py` stays a single file. No module split lands as part of
+this decision.
+
+**Revisit trigger.** Reopen this evaluation if either candidate module
+accumulates independent growth that would benefit from isolated testing —
+e.g., new dispatch-primitive functions with their own test suite, or new
+phase functions that don't touch `dispatch_persona`/`dispatch_personas`
+directly. A future split attempt should retarget the 46 (or by-then-more)
+`patch.object(orch, "dispatch_persona"/"dispatch_personas", ...)` sites as
+an explicit, verified step of that change — not an afterthought — and should
+consider whether the phase functions should call dispatch primitives via a
+qualified module reference (`dispatch_primitives.dispatch_persona(...)`)
+specifically so that test doubles can patch the primitives module directly
+rather than depending on re-export forwarding.
+
+## Consequences
+
+**What gets better.** No mechanical refactor risk is taken on right now; the
+existing 46 test-patch sites, and the passing test suite they protect,
+are untouched. The deferred-three-times decision finally has a durable,
+findable record instead of evaporating with another transient plan file.
+
+**What gets worse.** `orchestrator.py` remains an 820-line file, past this
+project's own 400-line watch line by a wide margin, and will keep growing as
+future phases or dispatch behavior are added to it.
+
+**What this does not change.** The candidate module boundaries proposed in
+issue #1723 remain valid as a design if a future split is attempted — this
+decision does not invalidate them, it defers acting on them until the
+test-patch coupling risk above is specifically addressed.
+
+## Notes
+
+Issue #1723, part of epic #1648 / spec #1707. Evaluated as a go/no-go per
+the issue's own framing ("a lightweight go/no-go, not a mandate to split").

--- a/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
+++ b/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
@@ -15,8 +15,8 @@ slices of the "Wire orchestrator.py to Real Agent Dispatch" effort (epic
 - Slice 2 (PR #1718, Research phase) flagged the file was already past this
   project's rubric's 400-line god-object watch line (533 lines pre-Slice-3).
 - Slice 3 (PR #1721, Plan phase) explicitly deferred a concrete commitment —
-  evaluate splitting the file into a dispatch-primitives module and a
-  phase-functions module before or during Slice 4, rather than letting the
+  evaluate splitting the file into a dispatch_primitives module and a
+  phase_functions module before or during Slice 4, rather than letting the
   file grow past that point unexamined.
 - Slice 4 (PR #1724, Implement phase) walked that commitment back again with
   weaker language and preserved the split proposal and deferral history in
@@ -28,10 +28,10 @@ the watch line by roughly 2x, having deferred the split question three times
 with no new information changing the calculus each time.
 
 Issue #1723 proposed a lightweight go/no-go, with candidate module
-boundaries already specified: a `dispatch-primitives` module
+boundaries already specified: a `dispatch_primitives` module
 (`dispatch_persona`, `dispatch_personas`, `_parse_dispatch_envelope`,
 `_failed_result`, `reconcile`, `WaveError`, timeout constants,
-`JSON_CONTRACT_PERSONAS`) and a `phase-functions` module
+`JSON_CONTRACT_PERSONAS`) and a `phase_functions` module
 (`_default_phase_research`, `_default_phase_plan`, `_default_phase_implement`,
 `_run_phase`, `_resolve_default`, `_warn_on_failed_personas`,
 `_print_wave_failure`, the persona-roster constants), with `run_pipeline`,
@@ -39,40 +39,56 @@ boundaries already specified: a `dispatch-primitives` module
 `orchestrator.py` as the composition root.
 
 **What the evaluation found.** `tests/scripts/test_orchestrator.py` contains
-**46 call sites** using `patch.object(orch, "dispatch_persona", ...)` or
+**58 call sites** using `patch.object(orch, "dispatch_persona", ...)` or
 `patch.object(orch, "dispatch_personas", ...)` to intercept the dispatch
 calls made from inside the phase functions that the proposal moves to
-`phase-functions.py`. If those phase functions import `dispatch_persona`/
-`dispatch_personas` as bare names from a new `dispatch-primitives.py`
-module, patching `orch.dispatch_persona` — even with `orchestrator.py`
-re-exporting the name for backward compatibility — no longer intercepts the
-call: Python binds the imported name into `phase-functions.py`'s own module
-namespace at import time, and patching a different module's attribute of
-the same name does not affect that binding. Every one of the 46 sites would
-silently start exercising the *real* dispatch function instead of the test
-double, which performs real subprocess/Claude CLI dispatch — a failure mode
-that would not read as a test failure so much as a hang, an external call
-during CI, or a flaky timeout, depending on environment.
+`phase_functions.py` — verified with a multiline-aware search; a naive
+single-line grep undercounts to 45, missing 13 sites where the
+`patch.object(` opener and its `orch, "dispatch_persona(s)"` arguments are
+split across lines (e.g. `test_orchestrator.py` lines 938-939, 1786-1789).
+If those phase functions import `dispatch_persona`/`dispatch_personas` as
+bare names from a new `dispatch_primitives.py` module, patching
+`orch.dispatch_persona` — even with `orchestrator.py` re-exporting the name
+for backward compatibility — no longer intercepts the call: Python binds the
+imported name into `phase_functions.py`'s own module namespace at import
+time, and patching a different module's attribute of the same name does not
+affect that binding.
 
 This is not a novel or unusual pattern; it's the standard "patch where a
 name is *used*, not where it's *defined*" hazard, applied to two functions
-against 46 existing call sites in a single file. It is precisely fixable —
-retarget every site to patch the new module directly, or route calls through
-qualified module access rather than a bare imported name — but it is real,
-precise work with a real, silent-failure-mode risk of getting a subset of
-the 46 sites wrong, not a mechanical rename with no behavioral surface.
+against 58 existing call sites in a single file. The practical severity of a
+missed site is narrower than it might first appear, though, and is stated
+precisely rather than worst-cased: `dispatch_persona` returns a stub result
+immediately when `skip_llm=True` (`orchestrator.py:546-547`), before any
+subprocess call — 72 of the 58+ call sites in the test file pass
+`skip_llm=True`. For the remaining `skip_llm=False` sites, the real
+subprocess call is bounded by `PERSONA_DISPATCH_TIMEOUT_S` (60s), and
+`FileNotFoundError`/`TimeoutExpired`/`OSError` are caught and converted to
+`_failed_result(persona, error="llm_unavailable")` rather than propagating —
+so a missed patch site cannot hang the suite indefinitely, and on a machine
+without the `claude` binary it makes no external call at all. Most sites
+also patch specifically to *capture* the call and assert on what was
+captured; bypassing the patch there surfaces as a loud assertion failure on
+an empty/wrong capture, not silence. The residual, real risk is narrower
+than "silent hang": a `skip_llm=False` site whose assertions don't depend on
+call capture could pass while quietly making a bounded (<=60s) real
+dispatch call on a machine that has the `claude` CLI installed — real, but
+neither silent nor unbounded, and precisely fixable by retargeting every
+site to patch the new module directly (or routing calls through qualified
+module access rather than a bare imported name), not a mechanical rename
+with no behavioral surface.
 
 ## Decision
 
 **No-go, for now.** The 820-line size and the file's history of deferred
 splits are real signals of God-object growth, but they do not by themselves
-outweigh the concrete, verified risk in the 46-site test-patch coupling: a
-split done today either (a) requires touching and correctly re-verifying 46
-patch targets against a mocking pitfall with a silent, hard-to-notice
-failure mode, or (b) is scoped down to avoid moving `dispatch_persona`/
-`dispatch_personas` at all — which defeats the module boundary the proposal
-itself specifies, since those two functions are exactly what makes
-`dispatch-primitives.py` a coherent module.
+outweigh the concrete, verified risk in the 58-site test-patch coupling: a
+split done today either (a) requires touching and correctly re-verifying 58
+patch targets against a mocking pitfall with a real, non-silent-but-still
+easy-to-miss failure mode, or (b) is scoped down to avoid moving
+`dispatch_persona`/`dispatch_personas` at all — which defeats the module
+boundary the proposal itself specifies, since those two functions are
+exactly what makes `dispatch_primitives.py` a coherent module.
 
 `orchestrator.py` stays a single file. No module split lands as part of
 this decision.
@@ -81,24 +97,43 @@ this decision.
 accumulates independent growth that would benefit from isolated testing —
 e.g., new dispatch-primitive functions with their own test suite, or new
 phase functions that don't touch `dispatch_persona`/`dispatch_personas`
-directly. A future split attempt should retarget the 46 (or by-then-more)
+directly. A future split attempt should retarget the 58 (or by-then-more)
 `patch.object(orch, "dispatch_persona"/"dispatch_personas", ...)` sites as
-an explicit, verified step of that change — not an afterthought — and should
-consider whether the phase functions should call dispatch primitives via a
-qualified module reference (`dispatch_primitives.dispatch_persona(...)`)
-specifically so that test doubles can patch the primitives module directly
-rather than depending on re-export forwarding.
+an explicit, verified step of that change — counted with a multiline-aware
+search, not a single-line grep, which is exactly the blind spot this
+evaluation found — and should consider one of two mitigations:
+
+1. Route calls through a qualified module reference
+   (`dispatch_primitives.dispatch_persona(...)`) rather than a bare imported
+   name, so test doubles can patch the primitives module directly instead of
+   depending on re-export forwarding.
+2. Extend `orchestrator.py`'s own existing dependency-injection pattern —
+   `run_pipeline` already takes `classify_fn`/`phase_research_fn`/
+   `phase_plan_fn`/`phase_implement_fn`, resolved at call time via
+   `_resolve_default` (`orchestrator.py:637`, under the "Resolve
+   inject-able dependencies" comment at line 685) — to the dispatch
+   primitives, e.g. a `dispatch_fn=None` parameter on each phase function
+   resolved the same way. This would make a split test-transparent by
+   construction rather than by patch-target bookkeeping, and is consistent
+   with a pattern this module already uses for the same class of problem.
 
 ## Consequences
 
 **What gets better.** No mechanical refactor risk is taken on right now; the
-existing 46 test-patch sites, and the passing test suite they protect,
+existing 58 test-patch sites, and the passing test suite they protect,
 are untouched. The deferred-three-times decision finally has a durable,
 findable record instead of evaporating with another transient plan file.
 
 **What gets worse.** `orchestrator.py` remains an 820-line file, past this
 project's own 400-line watch line by a wide margin, and will keep growing as
-future phases or dispatch behavior are added to it.
+future phases or dispatch behavior are added to it. Every future plan that
+touches this file will re-trigger `plan-review-design`'s "God object growing
+beyond 400 lines with mixed responsibilities" blocker
+(`plugins/dev-team/agents/plan-review-design.md:83`) — that rubric governs
+plans that add logic to the file, a distinct concern from this ADR's split
+decision, so the two do not contradict each other, but a future plan should
+cite this ADR (rather than re-litigating the split question from zero) up to
+the point this ADR's own revisit trigger fires.
 
 **What this does not change.** The candidate module boundaries proposed in
 issue #1723 remain valid as a design if a future split is attempted — this

--- a/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
+++ b/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
@@ -61,9 +61,13 @@ missed site is narrower than it might first appear, though: `dispatch_persona`
 returns a stub result immediately when `skip_llm=True`, before any subprocess
 call. Separately (this is not a claim that the two counts overlap — they are
 two independent facts about the test file, not a subset relationship):
-`tests/scripts/test_orchestrator.py` passes the literal `skip_llm=True` 72
-times and `skip_llm=False` 63 times across all of its calls, so the test
-suite's default posture already favors the short-circuited path. For a
+`tests/scripts/test_orchestrator.py` calls into the dispatch path with the
+literal `skip_llm=True` argument 72 times, versus 23 real
+`skip_llm=False` call sites (the literal string `skip_llm=False` appears 63
+times total, but 40 of those are default parameter values on locally-defined
+dispatch stubs, e.g. `async def counting_dispatch(persona, plan,
+skip_llm=False):`, not call arguments) — so the test suite's default posture
+already favors the short-circuited path by a wide margin. For a
 `skip_llm=False` call whose patch is bypassed, the real
 subprocess call is bounded by `PERSONA_DISPATCH_TIMEOUT_S` (60s), and
 `FileNotFoundError`/`TimeoutExpired`/`OSError` are caught and converted to

--- a/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
+++ b/docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md
@@ -57,11 +57,14 @@ affect that binding.
 This is not a novel or unusual pattern; it's the standard "patch where a
 name is *used*, not where it's *defined*" hazard, applied to two functions
 against 58 existing call sites in a single file. The practical severity of a
-missed site is narrower than it might first appear, though, and is stated
-precisely rather than worst-cased: `dispatch_persona` returns a stub result
-immediately when `skip_llm=True` (`orchestrator.py:546-547`), before any
-subprocess call — 72 of the 58+ call sites in the test file pass
-`skip_llm=True`. For the remaining `skip_llm=False` sites, the real
+missed site is narrower than it might first appear, though: `dispatch_persona`
+returns a stub result immediately when `skip_llm=True`, before any subprocess
+call. Separately (this is not a claim that the two counts overlap — they are
+two independent facts about the test file, not a subset relationship):
+`tests/scripts/test_orchestrator.py` passes the literal `skip_llm=True` 72
+times and `skip_llm=False` 63 times across all of its calls, so the test
+suite's default posture already favors the short-circuited path. For a
+`skip_llm=False` call whose patch is bypassed, the real
 subprocess call is bounded by `PERSONA_DISPATCH_TIMEOUT_S` (60s), and
 `FileNotFoundError`/`TimeoutExpired`/`OSError` are caught and converted to
 `_failed_result(persona, error="llm_unavailable")` rather than propagating —
@@ -80,8 +83,10 @@ with no behavioral surface.
 
 ## Decision
 
-**No-go, for now.** The 820-line size and the file's history of deferred
-splits are real signals of God-object growth, but they do not by themselves
+**No-go, for now.** The file's size (820 lines when this evaluation started,
+and growing — see Notes on why an ADR should not pin an exact present-tense
+line count) and its history of deferred splits are real signals of
+God-object growth, but they do not by themselves
 outweigh the concrete, verified risk in the 58-site test-patch coupling: a
 split done today either (a) requires touching and correctly re-verifying 58
 patch targets against a mocking pitfall with a real, non-silent-but-still
@@ -108,14 +113,17 @@ evaluation found — and should consider one of two mitigations:
    name, so test doubles can patch the primitives module directly instead of
    depending on re-export forwarding.
 2. Extend `orchestrator.py`'s own existing dependency-injection pattern —
-   `run_pipeline` already takes `classify_fn`/`phase_research_fn`/
-   `phase_plan_fn`/`phase_implement_fn`, resolved at call time via
-   `_resolve_default` (`orchestrator.py:637`, under the "Resolve
-   inject-able dependencies" comment at line 685) — to the dispatch
-   primitives, e.g. a `dispatch_fn=None` parameter on each phase function
-   resolved the same way. This would make a split test-transparent by
-   construction rather than by patch-target bookkeeping, and is consistent
-   with a pattern this module already uses for the same class of problem.
+   `run_pipeline` already takes `phase_research_fn`/`phase_plan_fn`/
+   `phase_implement_fn` parameters, each resolved at call time via the
+   `_resolve_default` helper under its "Resolve inject-able dependencies"
+   comment (`classify_fn` is a separate case, resolved by its own
+   hand-written branch rather than `_resolve_default` — the ad-hoc
+   alternative `_resolve_default` was introduced to replace for the other
+   three) — to the dispatch primitives, e.g. a `dispatch_fn=None` parameter
+   on each phase function resolved the same way. This would make a split
+   test-transparent by construction rather than by patch-target bookkeeping,
+   and is consistent with a pattern this module already uses for the same
+   class of problem.
 
 ## Consequences
 
@@ -124,8 +132,10 @@ existing 58 test-patch sites, and the passing test suite they protect,
 are untouched. The deferred-three-times decision finally has a durable,
 findable record instead of evaporating with another transient plan file.
 
-**What gets worse.** `orchestrator.py` remains an 820-line file, past this
-project's own 400-line watch line by a wide margin, and will keep growing as
+**What gets worse.** `orchestrator.py` remains a large single file, past this
+project's own 400-line watch line by a wide margin (already true at the
+820-line count this ADR was evaluated against, and only more so as it grows),
+and will keep growing as
 future phases or dispatch behavior are added to it. Every future plan that
 touches this file will re-trigger `plan-review-design`'s "God object growing
 beyond 400 lines with mixed responsibilities" blocker
@@ -144,3 +154,12 @@ test-patch coupling risk above is specifically addressed.
 
 Issue #1723, part of epic #1648 / spec #1707. Evaluated as a go/no-go per
 the issue's own framing ("a lightweight go/no-go, not a mandate to split").
+
+This ADR deliberately cites `orchestrator.py` symbols by name rather than by
+line number wherever practical, and avoids restating an exact present-tense
+line count for the file — an earlier draft of this ADR cited specific line
+numbers for `dispatch_persona`'s `skip_llm` check and for `_resolve_default`,
+and its own comment-block edit (adding the pointer this ADR describes)
+immediately shifted every one of them by 3, which review caught before merge.
+A durable record should not cite line numbers that the record's own existence
+can invalidate.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@
 * [37. Block by default at the context ceiling (#2000)](0037-block-by-default-at-the-context-ceiling-2000.md)
 * [38. Raise the absolute context ceiling from 150K to 350K](0038-raise-the-absolute-context-ceiling-to-350k.md)
 * [39. Only Skill loads are worth blocking at the context ceiling](0039-only-skill-loads-are-worth-blocking-at-the-context-ceiling.md)
+* [40. Evaluate splitting orchestrator.py: no-go](0040-evaluate-splitting-orchestrator-py-no-go.md)

--- a/plugins/dev-team/scripts/orchestrator.py
+++ b/plugins/dev-team/scripts/orchestrator.py
@@ -17,14 +17,17 @@ Exit codes:
   0 = success
   1 = error (no prior state with --resume, wave barrier failure, etc.)
 
-Module split: evaluated and declined for now — see ADR 0040
-(docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md, issue #1723).
-The blocker is 46 `patch.object(orch, "dispatch_persona"/"dispatch_personas",
-...)` sites in tests/scripts/test_orchestrator.py that would silently stop
-intercepting dispatch calls if the phase functions imported those names from
-a separate module. Revisit if dispatch-primitives or phase-functions grows
-independently.
+Module split: see ADR 0040.
 """
+
+# Module split (dispatch_primitives / phase_functions): evaluated and
+# declined for now — see ADR 0040
+# (docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md, issue #1723).
+# The blocker is 58 `patch.object(orch, "dispatch_persona"/"dispatch_personas",
+# ...)` sites in tests/scripts/test_orchestrator.py (multiline-aware count —
+# a single-line grep undercounts to 45) that would stop intercepting dispatch
+# calls if the phase functions imported those names from a separate module.
+# Revisit if dispatch_primitives or phase_functions grows independently.
 
 from __future__ import annotations
 

--- a/plugins/dev-team/scripts/orchestrator.py
+++ b/plugins/dev-team/scripts/orchestrator.py
@@ -16,6 +16,14 @@ Flags:
 Exit codes:
   0 = success
   1 = error (no prior state with --resume, wave barrier failure, etc.)
+
+Module split: evaluated and declined for now — see ADR 0040
+(docs/adr/0040-evaluate-splitting-orchestrator-py-no-go.md, issue #1723).
+The blocker is 46 `patch.object(orch, "dispatch_persona"/"dispatch_personas",
+...)` sites in tests/scripts/test_orchestrator.py that would silently stop
+intercepting dispatch calls if the phase functions imported those names from
+a separate module. Revisit if dispatch-primitives or phase-functions grows
+independently.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Evaluated splitting `orchestrator.py` (820 lines when evaluated) into `dispatch_primitives` and `phase_functions` modules per issue #1723's proposal (itself the durable record of a split decision deferred across Slices 2-4 of epic #1648 / spec #1707).

Found a concrete blocker: `tests/scripts/test_orchestrator.py` has 58 call sites (verified with a multiline-aware search — a naive single-line grep undercounts to 45) using `patch.object(orch, "dispatch_persona"/"dispatch_personas", ...)` to intercept dispatch calls made from inside the phase functions the split would relocate to `phase_functions.py`. If those phase functions imported `dispatch_persona`/`dispatch_personas` as bare names from a new `dispatch_primitives.py`, patching `orch.dispatch_persona` — even with a backward-compat re-export — would no longer intercept the call: Python binds an imported name into the importing module's own namespace at import time, so patching a different module's attribute of the same name doesn't reach it.

Decision: **no-go for now** — recorded as ADR 0040, with a one-line pointer comment in `orchestrator.py` (the detailed rationale lives in a plain `#` comment block, not inside the module docstring, since that docstring is also the script's `--help` text via `argparse.ArgumentParser(description=__doc__)`). The proposed module boundaries remain valid for a future attempt; this decision defers acting on them until the test-patch coupling above is specifically addressed — the ADR names two concrete mitigation options (qualified module reference, or extending the module's existing `_resolve_default` dependency-injection pattern to the dispatch primitives).

No behavior change — docs and one comment/docstring restructuring only.

**Review history disclosed for transparency:** this PR went through 4 rounds of the code-review skill's dispatch panel (9 agents round 1, then targeted re-verification rounds). Each round after the first found a real defect *in the previous round's own fix* — mostly numeric/citation precision issues in the ADR's prose, not in the underlying technical claim (which held up across every round: 58 sites, the name-binding hazard, the `--help` leak). The review hit its round cap; one suggestion-tier item remains open by design (a ~1/20th-scale prose imprecision in a skip_llm call-count aside — the reviewing agent explicitly recommended not re-opening a round for it, since the ADR's actual conclusion is unaffected either way). A final corroboration pass (doc-review) confirmed no drift or stale cross-references in the final content.

## Test Plan

- [x] `pytest tests/repo/test_adr_readme_toc_complete.py -q` — passes (README TOC includes ADR 0040)
- [x] `pytest tests/scripts/test_orchestrator.py tests/scripts/test_orchestrator_cli.py -q` — 146 passed, 1 skipped (no behavior change)
- [x] `ruff check plugins/dev-team/scripts/orchestrator.py` — clean
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Full local CI gate (`scripts/ci-local.sh`) — all checks pass (run twice, after each push)
- [x] gitleaks secret scan on the branch diff — no leaks
- [x] 9-agent code-review panel (round 1) + 3 rounds of targeted re-verification + 1 corroboration pass — converged with only a suggestion-tier item remaining

## Decisions & Assumptions

- Round-cap discipline: per this repo's own code-review skill, a review that keeps finding new (if smaller) defects round over round escalates to human at round 4 rather than continuing indefinitely. That threshold was reached here; the residual suggestion-tier finding is disclosed above rather than silently dropped.

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)