### PR TITLE
feat(scripts): bridge recon artifact, cardinality tests, timeout pinning

### DIFF
--- a/plugins/dev-team/scripts/orchestrator.py
+++ b/plugins/dev-team/scripts/orchestrator.py
@@ -242,11 +242,13 @@ async def classify(request: str, skip_llm: bool = False) -> dict:
 def _derive_recon_slug(root: Path) -> str:
     """Kebab-safe, lowercase repo-root directory name.
 
-    Mirrors codebase_recon.py's own `_derive_slug` (same algorithm,
-    duplicated rather than imported — that module's function is
-    underscore-private to its own CLI). Keep the two in sync by hand until
-    a content-guard test exists, matching this file's existing convention
-    for SECURITY_KEYWORDS/PLAN_CORE_PERSONAS's prose-duplication notes.
+    Duplicates codebase_recon.py's own `_derive_slug` (same algorithm)
+    rather than importing it. Both are hand-kept in sync by
+    `test_derive_recon_slug_matches_codebase_recon_algorithm`, which already
+    exists (this is not a "keep in sync until a guard test exists" gap —
+    tracked instead as a cleanup: promote both to a shared `scripts/lib/`
+    module, matching codebase_recon.py's own existing `from lib import ...`
+    convention, and delete this copy — see follow-up #2068).
     """
     name = root.resolve().name.lower()
     name = re.sub(r"[^a-z0-9._-]", "-", name)
@@ -258,15 +260,49 @@ def _recon_artifact_path(root: Path) -> Path:
     """Path to codebase-recon's JSON artifact for the repo at `root`.
 
     Per agents/codebase-recon.md's Contract section: always
-    `.claude/memory/recon-<slug>.json`, independent of orchestrator.py's
-    own (configurable) --memory-dir — the recon agent's prompt hardcodes
-    this path relative to its own CWD, which is orchestrator.py's CWD
-    since dispatch_persona's subprocess.run inherits it. If --memory-dir
-    points elsewhere, this path and the phase-state directory diverge; that
-    divergence is inherent to the recon agent's contract, not something
-    this function can paper over.
+    `.claude/memory/recon-<slug>.json`. `root` is deliberately the caller's
+    own CWD, not a git-root resolution (e.g.
+    hooks/lib/artifact_paths.py::memory_dir, used by other scripts in this
+    directory for that purpose) — the recon *agent*'s prompt writes this
+    path relative to its own CWD, which is orchestrator.py's CWD since
+    dispatch_persona's subprocess.run inherits it unchanged. Resolving
+    against the git root instead would disagree with the recon agent's own
+    write location whenever they differ (e.g. orchestrator.py invoked from
+    a subdirectory), which is the opposite of this function's purpose.
+    Also independent of orchestrator.py's own (configurable) --memory-dir;
+    if that flag points elsewhere, this path and the phase-state directory
+    diverge — inherent to the recon agent's contract, not something this
+    function can paper over.
     """
     return root / ".claude" / "memory" / f"recon-{_derive_recon_slug(root)}.json"
+
+
+async def _resolve_recon_artifact(personas: list, results: list, cwd: Path) -> str | None:
+    """Link codebase-recon's own artifact (agents/codebase-recon.md's
+    Contract — .claude/memory/recon-<slug>.json) into Research state, so a
+    Plan-phase consumer doesn't need to independently know that naming
+    convention (follow-up #1716). Returns `None` when codebase-recon wasn't
+    dispatched, didn't succeed, or its artifact file isn't on disk (e.g.
+    --skip-llm, where no real agent ran).
+
+    `cwd` is captured by the caller before its own `await` rather than read
+    here via `Path.cwd()` directly — process-global state should not be
+    re-read across an await boundary in case a future concurrent coroutine
+    ever changes it.
+    """
+    if "codebase-recon" not in personas:
+        return None
+    recon_result = next((r for r in results if r.get("persona") == "codebase-recon"), None)
+    if recon_result is None or recon_result.get("status") != "success":
+        return None
+    candidate = _recon_artifact_path(cwd)
+    # Offload to a thread, matching classify()'s own run_in_executor use for
+    # its blocking call — the event loop shouldn't block on a filesystem
+    # stat any more than it should on subprocess.run.
+    loop = asyncio.get_running_loop()
+    if not await loop.run_in_executor(None, candidate.is_file):
+        return None
+    return str(candidate)
 
 
 async def _default_phase_research(request: str, task: dict, skip_llm: bool) -> dict:
@@ -279,6 +315,9 @@ async def _default_phase_research(request: str, task: dict, skip_llm: bool) -> d
     verbatim — reconcile()/WaveError are scoped to the Implement phase's
     wave loop, not Research.
     """
+    # Captured before the await below (see _resolve_recon_artifact's
+    # docstring) rather than read via Path.cwd() after it.
+    cwd = Path.cwd()
     # RESEARCH_PERSONAS is an immutable tuple; list() converts it into the
     # mutable working copy the conditional security-engineer append below
     # needs (see the constant's own definition for why it's a tuple).
@@ -296,24 +335,11 @@ async def _default_phase_research(request: str, task: dict, skip_llm: bool) -> d
     # on the console, to one that succeeded fully. Mirrors classify()'s own
     # degraded-but-non-fatal WARNING.
     _warn_on_failed_personas("Research", results)
-    # Bridge codebase-recon's own artifact (agents/codebase-recon.md's
-    # Contract — .claude/memory/recon-<slug>.json) into this state, so a
-    # Plan-phase consumer doesn't need to independently know that naming
-    # convention (follow-up #1716). Always present, `None` when
-    # codebase-recon wasn't dispatched, didn't succeed, or its artifact
-    # file isn't on disk (e.g. --skip-llm, where no real agent ran).
-    recon_artifact = None
-    if "codebase-recon" in personas:
-        recon_result = next((r for r in results if r.get("persona") == "codebase-recon"), None)
-        if recon_result is not None and recon_result.get("status") == "success":
-            candidate = _recon_artifact_path(Path.cwd())
-            if candidate.is_file():
-                recon_artifact = str(candidate)
     return {
         "personas": personas,
         "results": results,
         "skip_llm": skip_llm,
-        "recon_artifact": recon_artifact,
+        "recon_artifact": await _resolve_recon_artifact(personas, results, cwd),
     }
 
 

--- a/plugins/dev-team/scripts/orchestrator.py
+++ b/plugins/dev-team/scripts/orchestrator.py
@@ -24,6 +24,7 @@ import argparse
 import asyncio
 import functools
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -56,7 +57,7 @@ JSON_CONTRACT_PERSONAS = DEFAULT_PERSONAS + CODE_REVIEW_PANEL
 # restates the same seven keywords in prose for its own (agent-facing,
 # standalone) audience; that restatement is not mechanically bound to this
 # tuple today — keep the two in sync by hand until a content-guard test
-# exists (see follow-up #1716).
+# exists (see follow-up #2067).
 SECURITY_KEYWORDS = (
     "auth",
     "secret",
@@ -85,7 +86,7 @@ RESEARCH_PERSONAS = ("codebase-recon", "architect", "data-flow-tracer")
 # agents/orchestrator.md's "Plan persona roster" section restates this same
 # trio (and CRITICS_SKIPPED_ALL_CORE_FAILED's value) in prose; that
 # restatement is not mechanically bound to this tuple today — keep the two
-# in sync by hand until a content-guard test exists (see follow-up #1716).
+# in sync by hand until a content-guard test exists (see follow-up #2067).
 PLAN_CORE_PERSONAS = ("product-manager", "architect", "qa-engineer")
 
 # Persisted-state vocabulary for _default_phase_plan's all-core-failed guard
@@ -123,8 +124,10 @@ TECH_WRITER_PERSONA = "tech-writer"
 IMPLEMENT_WAVE_SLICES = ("implement-1",)
 
 # Timeouts (seconds) for the two `claude -p` subprocess dispatch sites below.
-# Unverified placeholders, not measured against a real dispatch — see
-# follow-up #1716.
+# Unverified placeholders, not measured against a real dispatch — pinned by
+# a direct test (test_orchestrator.py) per follow-up #1716 so an accidental
+# edit fails fast instead of surfacing only as a flaky/slow-CLI symptom;
+# the underlying values themselves remain unverified against real latency.
 CLASSIFY_TIMEOUT_S = 30
 PERSONA_DISPATCH_TIMEOUT_S = 60
 
@@ -236,6 +239,36 @@ async def classify(request: str, skip_llm: bool = False) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _derive_recon_slug(root: Path) -> str:
+    """Kebab-safe, lowercase repo-root directory name.
+
+    Mirrors codebase_recon.py's own `_derive_slug` (same algorithm,
+    duplicated rather than imported — that module's function is
+    underscore-private to its own CLI). Keep the two in sync by hand until
+    a content-guard test exists, matching this file's existing convention
+    for SECURITY_KEYWORDS/PLAN_CORE_PERSONAS's prose-duplication notes.
+    """
+    name = root.resolve().name.lower()
+    name = re.sub(r"[^a-z0-9._-]", "-", name)
+    name = re.sub(r"-{2,}", "-", name)
+    return name.strip("-") or "repo"
+
+
+def _recon_artifact_path(root: Path) -> Path:
+    """Path to codebase-recon's JSON artifact for the repo at `root`.
+
+    Per agents/codebase-recon.md's Contract section: always
+    `.claude/memory/recon-<slug>.json`, independent of orchestrator.py's
+    own (configurable) --memory-dir — the recon agent's prompt hardcodes
+    this path relative to its own CWD, which is orchestrator.py's CWD
+    since dispatch_persona's subprocess.run inherits it. If --memory-dir
+    points elsewhere, this path and the phase-state directory diverge; that
+    divergence is inherent to the recon agent's contract, not something
+    this function can paper over.
+    """
+    return root / ".claude" / "memory" / f"recon-{_derive_recon_slug(root)}.json"
+
+
 async def _default_phase_research(request: str, task: dict, skip_llm: bool) -> dict:
     """Dispatch the Research-phase personas and aggregate their results.
 
@@ -263,7 +296,25 @@ async def _default_phase_research(request: str, task: dict, skip_llm: bool) -> d
     # on the console, to one that succeeded fully. Mirrors classify()'s own
     # degraded-but-non-fatal WARNING.
     _warn_on_failed_personas("Research", results)
-    return {"personas": personas, "results": results, "skip_llm": skip_llm}
+    # Bridge codebase-recon's own artifact (agents/codebase-recon.md's
+    # Contract — .claude/memory/recon-<slug>.json) into this state, so a
+    # Plan-phase consumer doesn't need to independently know that naming
+    # convention (follow-up #1716). Always present, `None` when
+    # codebase-recon wasn't dispatched, didn't succeed, or its artifact
+    # file isn't on disk (e.g. --skip-llm, where no real agent ran).
+    recon_artifact = None
+    if "codebase-recon" in personas:
+        recon_result = next((r for r in results if r.get("persona") == "codebase-recon"), None)
+        if recon_result is not None and recon_result.get("status") == "success":
+            candidate = _recon_artifact_path(Path.cwd())
+            if candidate.is_file():
+                recon_artifact = str(candidate)
+    return {
+        "personas": personas,
+        "results": results,
+        "skip_llm": skip_llm,
+        "recon_artifact": recon_artifact,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_orchestrator.py
+++ b/tests/scripts/test_orchestrator.py
@@ -1037,12 +1037,27 @@ def test_derive_recon_slug_matches_codebase_recon_algorithm(tmp_path):
     """orchestrator.py's slug derivation must stay byte-identical to
     codebase_recon.py's own _derive_slug (the recon agent's Contract section
     names the slug convention once; a drifted copy here would silently
-    compute the wrong artifact path)."""
+    compute the wrong artifact path). No mkdir needed: both functions only
+    call Path.resolve(strict=False) and do pure string transforms on
+    `.name` — the directory need not exist on disk for this comparison."""
     from codebase_recon import _derive_slug
 
     messy = tmp_path / "My Repo__Name!!"
-    messy.mkdir()
     assert orch._derive_recon_slug(messy) == _derive_slug(messy)
+
+
+def _seed_recon_artifact(tmp_path):
+    """Create a fake .claude/memory/recon-<slug>.json under tmp_path and
+    return its Path. Shared by the recon-artifact tests below that need an
+    existing-on-disk artifact, avoiding re-typing the same four-line setup
+    (test-smell finding, matching this file's existing
+    _capturing_dispatch_personas_stub extraction rationale)."""
+    recon_dir = tmp_path / ".claude" / "memory"
+    recon_dir.mkdir(parents=True)
+    slug = orch._derive_recon_slug(tmp_path)
+    artifact = recon_dir / f"recon-{slug}.json"
+    artifact.write_text("{}")
+    return artifact
 
 
 @pytest.mark.asyncio
@@ -1050,11 +1065,7 @@ async def test_default_phase_research_links_recon_artifact_when_present(tmp_path
     """When codebase-recon succeeds and its artifact file exists on disk,
     the Research state links to it (follow-up #1716)."""
     monkeypatch.chdir(tmp_path)
-    recon_dir = tmp_path / ".claude" / "memory"
-    recon_dir.mkdir(parents=True)
-    slug = orch._derive_recon_slug(tmp_path)
-    artifact = recon_dir / f"recon-{slug}.json"
-    artifact.write_text("{}")
+    artifact = _seed_recon_artifact(tmp_path)
 
     with patch.object(
         orch, "dispatch_personas", side_effect=_capturing_dispatch_personas_stub({})
@@ -1088,10 +1099,7 @@ async def test_default_phase_research_recon_artifact_none_when_recon_failed(tmp_
     """A failed codebase-recon dispatch never links its artifact, even if a
     stale file from a prior run happens to exist at that path."""
     monkeypatch.chdir(tmp_path)
-    recon_dir = tmp_path / ".claude" / "memory"
-    recon_dir.mkdir(parents=True)
-    slug = orch._derive_recon_slug(tmp_path)
-    (recon_dir / f"recon-{slug}.json").write_text("{}")
+    _seed_recon_artifact(tmp_path)
 
     async def fake_dispatch_personas(personas, plan, skip_llm=False):
         return [
@@ -1126,11 +1134,20 @@ async def test_default_phase_research_calls_dispatch_personas_with_task_and_requ
 
 
 @pytest.mark.asyncio
-async def test_run_pipeline_with_real_research_fn_writes_expected_json_shape():
+async def test_run_pipeline_with_real_research_fn_writes_expected_json_shape(tmp_path, monkeypatch):
     """orchestrator-research.json's contents after a full run_pipeline run
     with the real (non-stub) research function and skip_llm=True match the
     {personas, results, skip_llm, recon_artifact} shape, using set-equality
-    on personas."""
+    on personas.
+
+    Chdir's to an isolated tmp_path (rather than leaving CWD as whatever the
+    test runner's real invocation directory happens to be): recon_artifact
+    is resolved off Path.cwd(), so without this isolation the assertion
+    below would depend on whether a real .claude/memory/recon-<slug>.json
+    happens to exist wherever the suite is run from — a prior real
+    orchestrator run against this repo would silently flip this red with no
+    related code change (test-smell finding)."""
+    monkeypatch.chdir(tmp_path)
     with tempfile.TemporaryDirectory() as tmp:
         memory_dir = Path(tmp)
         exit_code = await orch.run_pipeline(

--- a/tests/scripts/test_orchestrator.py
+++ b/tests/scripts/test_orchestrator.py
@@ -135,6 +135,20 @@ def test_tech_writer_persona_is_exactly_tech_writer():
     assert orch.TECH_WRITER_PERSONA == "tech-writer"
 
 
+def test_classify_timeout_is_exactly_30_seconds():
+    """CLASSIFY_TIMEOUT_S must equal exactly 30 (follow-up #1716) — an
+    accidental edit to this constant should fail this test directly instead
+    of only surfacing as a flaky/slow-CLI symptom in classify()'s own
+    subprocess.run call."""
+    assert orch.CLASSIFY_TIMEOUT_S == 30
+
+
+def test_persona_dispatch_timeout_is_exactly_60_seconds():
+    """PERSONA_DISPATCH_TIMEOUT_S must equal exactly 60 (follow-up #1716),
+    matching CLASSIFY_TIMEOUT_S's own pinning test above."""
+    assert orch.PERSONA_DISPATCH_TIMEOUT_S == 60
+
+
 def test_implement_wave_slices_is_exactly_the_single_synthetic_slice():
     """IMPLEMENT_WAVE_SLICES must equal exactly ("implement-1",) — the one
     normative definition of this persisted, operator-facing slice name,
@@ -943,6 +957,9 @@ async def test_default_phase_research_standard_dispatches_three_always_on_person
         )
 
     assert set(captured["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(captured["personas"]) == len(RESEARCH_ALWAYS_ON)
     # Independent expected literal, not a self-comparison against `captured`
     # (result["personas"] is literally the same list _default_phase_research
     # built and dispatch_personas echoed back — comparing it to `captured`
@@ -950,6 +967,9 @@ async def test_default_phase_research_standard_dispatches_three_always_on_person
     # equality, not list equality: the approved plan's Step 1.2 explicitly
     # states dispatch order is not a contract.
     assert set(result["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(result["personas"]) == len(RESEARCH_ALWAYS_ON)
     # Negative case for the failed-persona WARNING: an all-success dispatch
     # must print nothing about failures.
     assert "WARNING: Research persona dispatch failed" not in capsys.readouterr().err
@@ -971,6 +991,9 @@ async def test_default_phase_research_complex_dispatches_same_always_on_personas
         )
 
     assert set(captured["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(captured["personas"]) == len(RESEARCH_ALWAYS_ON)
 
 
 @pytest.mark.asyncio
@@ -985,6 +1008,9 @@ async def test_default_phase_research_adds_security_engineer_when_request_touche
         )
 
     assert set(captured["personas"]) == RESEARCH_ALWAYS_ON | {orch.SECURITY_ENGINEER_PERSONA}
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(captured["personas"]) == len(RESEARCH_ALWAYS_ON) + 1
 
 
 @pytest.mark.asyncio
@@ -1002,6 +1028,83 @@ async def test_default_phase_research_omits_security_engineer_when_no_signal():
     # a regression that also dropped e.g. "architect" from the always-on
     # trio would still pass a bare `not in` check.
     assert set(captured["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(captured["personas"]) == len(RESEARCH_ALWAYS_ON)
+
+
+def test_derive_recon_slug_matches_codebase_recon_algorithm(tmp_path):
+    """orchestrator.py's slug derivation must stay byte-identical to
+    codebase_recon.py's own _derive_slug (the recon agent's Contract section
+    names the slug convention once; a drifted copy here would silently
+    compute the wrong artifact path)."""
+    from codebase_recon import _derive_slug
+
+    messy = tmp_path / "My Repo__Name!!"
+    messy.mkdir()
+    assert orch._derive_recon_slug(messy) == _derive_slug(messy)
+
+
+@pytest.mark.asyncio
+async def test_default_phase_research_links_recon_artifact_when_present(tmp_path, monkeypatch):
+    """When codebase-recon succeeds and its artifact file exists on disk,
+    the Research state links to it (follow-up #1716)."""
+    monkeypatch.chdir(tmp_path)
+    recon_dir = tmp_path / ".claude" / "memory"
+    recon_dir.mkdir(parents=True)
+    slug = orch._derive_recon_slug(tmp_path)
+    artifact = recon_dir / f"recon-{slug}.json"
+    artifact.write_text("{}")
+
+    with patch.object(
+        orch, "dispatch_personas", side_effect=_capturing_dispatch_personas_stub({})
+    ):
+        result = await orch._default_phase_research(
+            "add a login form", {"size": "standard"}, skip_llm=False
+        )
+
+    assert result["recon_artifact"] == str(artifact)
+
+
+@pytest.mark.asyncio
+async def test_default_phase_research_recon_artifact_none_when_file_missing(tmp_path, monkeypatch):
+    """codebase-recon reporting success doesn't guarantee its artifact
+    exists on disk (e.g. --skip-llm never runs the real agent) — the link
+    is None rather than a dangling path in that case."""
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(
+        orch, "dispatch_personas", side_effect=_capturing_dispatch_personas_stub({})
+    ):
+        result = await orch._default_phase_research(
+            "add a login form", {"size": "standard"}, skip_llm=True
+        )
+
+    assert result["recon_artifact"] is None
+
+
+@pytest.mark.asyncio
+async def test_default_phase_research_recon_artifact_none_when_recon_failed(tmp_path, monkeypatch):
+    """A failed codebase-recon dispatch never links its artifact, even if a
+    stale file from a prior run happens to exist at that path."""
+    monkeypatch.chdir(tmp_path)
+    recon_dir = tmp_path / ".claude" / "memory"
+    recon_dir.mkdir(parents=True)
+    slug = orch._derive_recon_slug(tmp_path)
+    (recon_dir / f"recon-{slug}.json").write_text("{}")
+
+    async def fake_dispatch_personas(personas, plan, skip_llm=False):
+        return [
+            {"persona": p, "status": "failed" if p == "codebase-recon" else "success"}
+            for p in personas
+        ]
+
+    with patch.object(orch, "dispatch_personas", side_effect=fake_dispatch_personas):
+        result = await orch._default_phase_research(
+            "add a login form", {"size": "standard"}, skip_llm=False
+        )
+
+    assert result["recon_artifact"] is None
 
 
 @pytest.mark.asyncio
@@ -1026,7 +1129,8 @@ async def test_default_phase_research_calls_dispatch_personas_with_task_and_requ
 async def test_run_pipeline_with_real_research_fn_writes_expected_json_shape():
     """orchestrator-research.json's contents after a full run_pipeline run
     with the real (non-stub) research function and skip_llm=True match the
-    {personas, results, skip_llm} shape, using set-equality on personas."""
+    {personas, results, skip_llm, recon_artifact} shape, using set-equality
+    on personas."""
     with tempfile.TemporaryDirectory() as tmp:
         memory_dir = Path(tmp)
         exit_code = await orch.run_pipeline(
@@ -1038,11 +1142,17 @@ async def test_run_pipeline_with_real_research_fn_writes_expected_json_shape():
         state = orch.read_progress("research", memory_dir)
 
     assert exit_code == 0
-    assert set(state.keys()) == {"personas", "results", "skip_llm"}
+    assert set(state.keys()) == {"personas", "results", "skip_llm", "recon_artifact"}
     assert set(state["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(state["personas"]) == len(RESEARCH_ALWAYS_ON)
     assert state["skip_llm"] is True
     assert {r["persona"] for r in state["results"]} == set(state["personas"])
     assert all(r["status"] == "success" for r in state["results"])
+    # skip_llm=True never runs the real codebase-recon agent, so no artifact
+    # file exists on disk regardless of dispatch success.
+    assert state["recon_artifact"] is None
     # skip_llm's stub contract (dispatch_persona) returns bare
     # {persona, status} — no "output"/"review_status" field. Asserting their
     # absence, not just status == "success", is what distinguishes a genuine
@@ -1070,6 +1180,9 @@ async def test_run_pipeline_with_real_research_fn_includes_security_engineer_in_
 
     assert exit_code == 0
     assert set(state["personas"]) == RESEARCH_ALWAYS_ON | {orch.SECURITY_ENGINEER_PERSONA}
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(state["personas"]) == len(RESEARCH_ALWAYS_ON) + 1
 
 
 @pytest.mark.asyncio
@@ -1089,6 +1202,9 @@ async def test_run_pipeline_with_real_research_fn_omits_security_engineer_in_wri
 
     assert exit_code == 0
     assert set(state["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(state["personas"]) == len(RESEARCH_ALWAYS_ON)
     assert orch.SECURITY_ENGINEER_PERSONA not in state["personas"]
 
 
@@ -1112,6 +1228,9 @@ async def test_run_pipeline_with_real_research_fn_complex_classification_writes_
 
     assert exit_code == 0
     assert set(state["personas"]) == RESEARCH_ALWAYS_ON
+    # Cardinality check (follow-up #1716): set-equality alone wouldn't
+    # catch a future accidental double-append to the persona list.
+    assert len(state["personas"]) == len(RESEARCH_ALWAYS_ON)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes 3 of #1716's 5 deferred follow-up findings from #1715's `/code-review` cycle (the other 2 were already resolved by an earlier slice, or are documented as an accepted, intentional no-op — see below):

1. **Bridge codebase-recon's own artifact into `orchestrator-research.json`.** Research's aggregation now links `codebase-recon`'s artifact (`.claude/memory/recon-<slug>.json`, per `agents/codebase-recon.md`'s Contract section) via a new `recon_artifact` key — `None` when codebase-recon wasn't dispatched, didn't succeed, or the file isn't on disk. A future Plan-phase consumer no longer needs to independently know that naming convention.
2. **Cardinality checks alongside existing set-equality assertions.** Added `len()` assertions at all 9 sites that assert `set(personas) == <expected>` on dispatched personas — guards against a future accidental double-append going unnoticed by set-equality alone.
3. **Pinning tests for the two dispatch timeout constants.** `CLASSIFY_TIMEOUT_S` (30) and `PERSONA_DISPATCH_TIMEOUT_S` (60) now have direct tests, so an accidental edit fails fast instead of only surfacing as a flaky/slow-CLI symptom.

Not addressed here (with reasons): the `--dispatch-personas` CLI keyword-argument convention was already fixed incidentally in an earlier slice (verified — `orchestrator.py`'s debug branch already uses the keyword-argument form). The `_touches_security` substring false-positive (e.g. "cryptocurrency" matching "crypto") is explicitly accepted as intentional in #1716's own text, not a defect to fix.

## Review history

Two "see follow-up #1716" comments unrelated to the 5 items above (a content-guard test to keep `SECURITY_KEYWORDS`/`PLAN_CORE_PERSONAS` in sync with `agents/orchestrator.md`'s prose) were repointed to new issue #2067 so they don't dangle once #1716 closes.

A 9-agent `/code-review` panel + one fix round + a bounded 2-agent closing pass found and fixed real issues in the initial implementation:
- A blocking filesystem stat inside the async Research phase, not offloaded to a thread (unlike this file's own `classify()` precedent) — fixed with `run_in_executor`.
- `Path.cwd()` read after an `await` rather than before it — fixed by capturing it at function entry.
- A 3-level-nested inline block — extracted to `_resolve_recon_artifact()`.
- A docstring making false claims about why duplicating `codebase_recon.py`'s slug algorithm was necessary — corrected; actually eliminating the duplication is filed as follow-up #2068 (it would also require touching `codebase_recon.py`, out of scope here).
- A real test correctness gap (Mystery Guest): a pre-existing test asserted `recon_artifact is None` without isolating CWD, which would have silently broken if a real recon artifact ever existed in the invocation directory — fixed with the same `monkeypatch.chdir` isolation its sibling tests already use.
- Duplicated test fixture-seeding code — extracted into a shared helper.

Incidentally discovered and filed separately (pre-existing, unrelated to this change): `codebase_recon.py`'s own CLI writes its artifact to a different, legacy path than the documented agent contract — #2069.

The closing pass converged with only suggestion-tier residue, disclosed rather than chased further (round-cap discipline): (1) `_derive_recon_slug`'s `root.resolve()` call isn't offloaded to a thread like the adjacent `is_file()` check now is — negligible cost since `Path.cwd()` is already resolved by the OS; (2) the new function's persona-membership guard is unreachable at its single current call site (documented pattern already used elsewhere in this file for exactly this shape, just not yet applied to the new docstring); (3) no test distinguishes the deliberate cwd-relative artifact resolution from the git-root-relative `artifact_paths.memory_dir()` resolver it declines to use; (4) codebase_recon.py's own path drift (see #2069) means a future shared-slug module (#2068) must not also assume a shared directory convention.

## Test Plan

- [x] `pytest tests/scripts/test_orchestrator.py tests/scripts/test_orchestrator_cli.py -q` — 150 passed, 1 skipped
- [x] `ruff check` on all changed files — clean
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Full local CI gate (`scripts/ci-local.sh`) — all checks pass
- [x] Full pre-push pytest suite (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks`) — 9768 passed, 47 skipped
- [x] gitleaks secret scan on the branch diff — no leaks
- [x] 13-agent code-review panel + 1 fix round + 1 bounded 2-agent closing pass — converged with only suggestion-tier residue (disclosed above)

Closes #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)