### PR TITLE
fix(scripts): Wave 1 of the open-issue consolidation plan

### DIFF
--- a/.claude/ensure_session_archive.py
+++ b/.claude/ensure_session_archive.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""SessionStart hook (registered in .claude/settings.json): archive this
+machine's new/changed sessions into a durable local file before Claude
+Code's default 30-day transcript retention (`cleanupPeriodDays`, unset here)
+ages them out from under the harness-measurement corpus (#2018).
+
+Why this matters: this repo's session-report analysis (feeding #1973, #1999,
+#2008) reads directly from live `~/.claude/projects/**/*.jsonl` transcripts.
+Those expire in 30 days. A prior durable archive
+(`digests/<host>/session-digest.jsonl` in a separate telemetry repo) existed
+and stopped being written on 2026-07-27 -- no workflow, hook, or job called
+it. This is the "small and urgent" half of #2018's fix: it stops today's
+bleeding by writing `session_extract.py --sync-out`'s incremental,
+metrics-only stream to a LOCAL file under `.claude/metrics/` (gitignored,
+`**/metrics/*` -- never committed), independent of whether/how a session's
+`plugin_version` gets fixed (#2018's second, larger half, tracked
+separately). It never pushes anywhere and never touches git.
+
+The cross-machine telemetry-sync mechanism (`scripts/telemetry-sync.sh`,
+which clones/commits/pushes to a *separate*, explicitly-configured
+`DEV_TEAM_TELEMETRY_REMOTE` repo) is deliberately NOT what this hook runs --
+that is a real, consequential network write an operator opts into by hand,
+not something a SessionStart hook should trigger silently.
+
+Fail-open and time-boxed -- never blocks session start. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+try:
+    from session_start_common import resolve_project_root, run_logged
+except ImportError:
+    # The shared module must be present for this hook to do anything useful;
+    # if it's missing (e.g. a partial checkout), fail open rather than raise.
+    sys.exit(0)
+
+_TIMEOUT_SECONDS = 120
+
+
+def _emit(message: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": message,
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        root = resolve_project_root()
+
+        # Only meaningful in THIS repo's own checkout(s) -- same in-repo
+        # detection /dev-team:setup uses (requirements-dev.txt +
+        # plugins/dev-team/.claude-plugin/plugin.json), so this hook is
+        # inert for a downstream project that merely has the plugin
+        # installed.
+        if not (root / "requirements-dev.txt").is_file():
+            return 0
+        if not (
+            root / "plugins" / "dev-team" / ".claude-plugin" / "plugin.json"
+        ).is_file():
+            return 0
+
+        script = root / "scripts" / "session_extract.py"
+        if not script.is_file():
+            return 0
+
+        metrics_dir = root / ".claude" / "metrics"
+        digest_out = metrics_dir / "session-digest.jsonl"
+        watermark = metrics_dir / "session-digest-watermark.json"
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+
+        host = socket.gethostname() or "unknown-host"
+        log_path = Path.home() / ".cache" / "session-archive-sessionstart.log"
+        ok = run_logged(
+            [
+                sys.executable,
+                str(script),
+                "--sync-out",
+                str(digest_out),
+                "--watermark",
+                str(watermark),
+                "--host",
+                host,
+                "--plugin-root",
+                str(root / "plugins" / "dev-team"),
+            ],
+            root,
+            log_path,
+            _TIMEOUT_SECONDS,
+        )
+
+        if not ok:
+            _emit(
+                "Session archival (session_extract.py --sync-out, #2018) failed "
+                f"or timed out this run -- transcripts still age out at 30 days "
+                f"until it succeeds. See {log_path}."
+            )
+        # Silent on success -- this runs every session start, and a
+        # steady-state "archived N sessions" line on every launch is exactly
+        # the noise a SessionStart hook should not add once it's working.
+        return 0
+    except Exception:  # noqa: BLE001 - never let this hook block or fail session start.
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,10 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/ensure_code_graph_tools.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/ensure_session_archive.py\""
           }
         ]
       }

--- a/plugins/dev-team/scripts/extract_session_report.py
+++ b/plugins/dev-team/scripts/extract_session_report.py
@@ -45,6 +45,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import socket
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta, timezone
@@ -62,8 +63,92 @@ _CORRECTION_RE = re.compile(
 _PERMISSION_RE = re.compile(r"permission|denied|not allowed|blocked by", re.IGNORECASE)
 _OLDSTRING_RE = re.compile(r"old_string|not found|no match|string to replace", re.IGNORECASE)
 _EDIT_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
-_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-_BYPASS_RE = re.compile(r"--no-verify|(^|\s)-n(\s|$)")
+# Gate signal (#111): a `git commit`, and whether it bypassed the pre-commit
+# review gate (--no-verify, or a bare -n). Detection is argv-shaped, not a
+# substring search over the whole command (#2036) — see
+# _bash_segments()/_is_git_commit_argv() below. A prior version searched
+# `\bgit\s+commit\b` and `--no-verify|(^|\s)-n(\s|$)` against the raw string,
+# which matched inside unrelated flags in a compound command (`grep -n`,
+# `ls -n`) and even inside an unrelated string (`echo "git commit"`). Kept in
+# agreement with the identical fix in scripts/session_extract.py — the two
+# extractors' sharing of this logic is scoped to happen properly in #2040,
+# not duplicated-by-hand again here.
+_GIT_GLOBAL_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
+_COMMIT_BYPASS_TOKENS = {"--no-verify", "-n"}
+
+
+def _statement_break_newlines(cmd: str) -> str:
+    """Replace a bare (unquoted) newline with ';' so a tokenizer sees a
+    statement boundary there — a newline embedded inside a quoted argument
+    (e.g. a multi-line commit message) is left untouched."""
+    out = []
+    in_single = in_double = False
+    i, n = 0, len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            out.append(ch)
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            out.append(ch)
+        elif ch == "\\" and in_double and i + 1 < n:
+            out.append(ch)
+            out.append(cmd[i + 1])
+            i += 1
+        elif ch == "\n" and not in_single and not in_double:
+            out.append(";")
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _bash_segments(cmd: str) -> list[list[str]]:
+    """Split `cmd` into argv-shaped segments at top-level shell operators
+    (&&, ||, ;, |, and bare newlines), respecting quoting throughout — a
+    quoted operator or newline inside a commit message never splits the
+    command, and a quoted flag never crosses a segment boundary."""
+    lex = shlex.shlex(_statement_break_newlines(cmd), posix=True, punctuation_chars="&|;")
+    lex.whitespace_split = True
+    try:
+        tokens = list(lex)
+    except ValueError:
+        # Malformed shell syntax (e.g. an unbalanced quote) — cannot be
+        # segmented reliably. Fall back to a single opaque whitespace-split
+        # segment rather than losing the signal outright.
+        return [cmd.split()]
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for tok in tokens:
+        if tok in ("&&", "||", ";", "|", "&"):
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(tok)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _is_git_commit_argv(tokens: list[str]) -> bool:
+    """True if `tokens` invokes `git ... commit ...` — walks past git's
+    global options (including ones taking a separate argument, e.g. `-C`)
+    to find the subcommand, so `git -C path commit` is recognized."""
+    if not tokens or tokens[0] != "git":
+        return False
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in _GIT_GLOBAL_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return tok == "commit"
+    return False
 _VERSION_RE = re.compile(r"^[0-9A-Za-z._+-]{1,32}$")
 # Agent transcripts are `agent-<id>.jsonl` (see _is_transcript_path).
 _AGENT_TRANSCRIPT_RE = re.compile(r"^agent-[0-9A-Za-z_-]{1,64}\.jsonl$")
@@ -389,10 +474,11 @@ def _track_bash(block, bash_signal_counts, thread):
             bash_signal_counts["repeated_verify_runs"] += 1
         thread["last_verify_norm"] = norm
         thread["edited_since_verify"] = False
-    if _COMMIT_RE.search(cmd):
-        bash_signal_counts["commit_attempts"] += 1
-        if _BYPASS_RE.search(cmd):
-            bash_signal_counts["commit_bypasses"] += 1
+    for segment in _bash_segments(cmd):
+        if _is_git_commit_argv(segment):
+            bash_signal_counts["commit_attempts"] += 1
+            if any(tok in _COMMIT_BYPASS_TOKENS for tok in segment[1:]):
+                bash_signal_counts["commit_bypasses"] += 1
 
 
 def _new_thread() -> dict:

--- a/plugins/dev-team/skills/long-eval/run_eval.py
+++ b/plugins/dev-team/skills/long-eval/run_eval.py
@@ -82,7 +82,11 @@ def _live_pid(out_dir):
     marker = str(Path(out_dir).resolve())
     try:
         ps = subprocess.run(
-            ["ps", "-eo", "pid,args"], capture_output=True, text=True, check=True
+            ["ps", "-eo", "pid,args"],
+            capture_output=True,
+            text=True,
+            errors="replace",
+            check=True,
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return None

--- a/plugins/dev-team/tests/scripts/test_durable_runner.py
+++ b/plugins/dev-team/tests/scripts/test_durable_runner.py
@@ -2,6 +2,7 @@
 import argparse
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -161,3 +162,37 @@ def test_ensure_alive_noops_when_done(tmp_path, capsys):
 def test_live_pid_none_when_no_driver(tmp_path):
     run_eval = _load("run_eval")
     assert run_eval._live_pid(tmp_path) is None
+
+
+def test_live_pid_survives_non_utf8_bytes_in_ps_output(tmp_path, monkeypatch):
+    """#2065 — a real process's `args` column can carry arbitrary bytes.
+
+    `subprocess.run(..., text=True)` decodes with strict UTF-8 by default, so
+    one non-UTF8 byte anywhere in the live process table raised
+    UnicodeDecodeError and crashed `_live_pid` outright — not on a code path
+    that failed, but on unrelated processes it never needed to interpret. This
+    installs a fake `ps` on PATH that emits an invalid UTF-8 byte, so the test
+    exercises the real subprocess decode rather than mocking it away.
+    """
+    run_eval = _load("run_eval")
+
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    fake_ps = fakebin / "ps"
+    # A shell heredoc's \xHH is not portably interpreted by /bin/sh's printf
+    # (dash emits the four literal characters, not the byte) — write the raw
+    # invalid byte directly so this test cannot silently stop exercising the
+    # decode path it exists to cover.
+    fake_ps.write_bytes(
+        b"#!/usr/bin/env python3\n"
+        b"import sys\n"
+        b"sys.stdout.buffer.write(b'  PID ARGS\\n')\n"
+        b"sys.stdout.buffer.write(b'  1234 some-proc \\xac garbled\\n')\n"
+    )
+    fake_ps.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{fakebin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    assert run_eval._live_pid(out_dir) is None

--- a/scripts/session_extract.py
+++ b/scripts/session_extract.py
@@ -57,6 +57,7 @@ import json
 import math
 import os
 import re
+import shlex
 from collections import Counter, defaultdict
 from datetime import UTC
 from pathlib import Path
@@ -74,10 +75,95 @@ _PERMISSION_RE = re.compile(r"permission|denied|not allowed|blocked by", re.IGNO
 _OLDSTRING_RE = re.compile(r"old_string|not found|no match|string to replace", re.IGNORECASE)
 _EDIT_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
 # Gate signal (#111): a `git commit`, and whether it bypassed the pre-commit
-# review gate (--no-verify, or a bare -n in any position) — mirrors the rule in
-# hooks/telemetry.sh so the two agree.
-_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-_BYPASS_RE = re.compile(r"--no-verify|(^|\s)-n(\s|$)")
+# review gate (--no-verify, or a bare -n). #2036: the review-corroboration
+# gate itself moved from `git commit` time to `gh pr create` time in #1886 —
+# `hooks/telemetry.py` now keys its bypass signal off `PR_GATE_BYPASS_REASON`
+# on a `gh pr create` invocation, an unrelated mechanism this no longer
+# mirrors. This signal stays commit-time on purpose: it measures how often a
+# commit itself skips local review, which is a real and different question
+# from whether a PR was opened without one.
+#
+# Detection is argv-shaped, not a substring search over the whole command —
+# see _bash_segments()/_is_git_commit_argv() below. A prior version searched
+# `\bgit\s+commit\b` and `--no-verify|(^|\s)-n(\s|$)` against the raw string,
+# which matched inside unrelated flags in a compound command (`grep -n`,
+# `ls -n`) and even inside an unrelated string (`echo "git commit"`).
+_GIT_GLOBAL_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
+_COMMIT_BYPASS_TOKENS = {"--no-verify", "-n"}
+
+
+def _statement_break_newlines(cmd: str) -> str:
+    """Replace a bare (unquoted) newline with ';' so a tokenizer sees a
+    statement boundary there — a newline embedded inside a quoted argument
+    (e.g. a multi-line commit message) is left untouched."""
+    out = []
+    in_single = in_double = False
+    i, n = 0, len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            out.append(ch)
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            out.append(ch)
+        elif ch == "\\" and in_double and i + 1 < n:
+            out.append(ch)
+            out.append(cmd[i + 1])
+            i += 1
+        elif ch == "\n" and not in_single and not in_double:
+            out.append(";")
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _bash_segments(cmd: str) -> list[list[str]]:
+    """Split `cmd` into argv-shaped segments at top-level shell operators
+    (&&, ||, ;, |, and bare newlines), respecting quoting throughout — a
+    quoted operator or newline inside a commit message never splits the
+    command, and a quoted flag never crosses a segment boundary."""
+    lex = shlex.shlex(_statement_break_newlines(cmd), posix=True, punctuation_chars="&|;")
+    lex.whitespace_split = True
+    try:
+        tokens = list(lex)
+    except ValueError:
+        # Malformed shell syntax (e.g. an unbalanced quote) — cannot be
+        # segmented reliably. Fall back to a single opaque whitespace-split
+        # segment rather than losing the signal outright.
+        return [cmd.split()]
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for tok in tokens:
+        if tok in ("&&", "||", ";", "|", "&"):
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(tok)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _is_git_commit_argv(tokens: list[str]) -> bool:
+    """True if `tokens` invokes `git ... commit ...` — walks past git's
+    global options (including ones taking a separate argument, e.g. `-C`)
+    to find the subcommand, so `git -C path commit` is recognized."""
+    if not tokens or tokens[0] != "git":
+        return False
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in _GIT_GLOBAL_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return tok == "commit"
+    return False
 
 
 # Agent transcripts are `agent-<id>.jsonl` (see _is_transcript_path).
@@ -333,16 +419,27 @@ def _accumulate_token_signals(
 ) -> float:
     """Token-accounting concern: usage/cost totals split by model and skill.
     Returns this record's cost (added to the running cost_total by the caller).
-    Thread attribution moved to the caller's `by_agent_type` bucketing (#1994)."""
+    Thread attribution moved to the caller's `by_agent_type` bucketing (#1994).
+
+    #2080: `usage` is read from a LOCAL transcript file — a different trust
+    domain from the peer-digest path `_safe_number` was written to guard, but
+    still "a transcript this script does not author" (per `_iter_records`'s
+    own comment): a corrupted or hand-edited file can carry an out-of-range
+    or negative token count. Read every field through `_safe_number` once,
+    here, so `_cost`'s `inp / 1e6 * ir` never sees a value whose magnitude
+    overflows the int-to-float conversion (raising OverflowError and
+    aborting the whole run before `round(cost * 1e6)` below is even reached)
+    and the running totals can never go negative from one bad record."""
     fields = (
         "input_tokens",
         "output_tokens",
         "cache_creation_input_tokens",
         "cache_read_input_tokens",
     )
-    cost = _cost(usage, _rate(pricing, raw_model or ""), pricing)
+    safe_usage = {f: _safe_number(usage.get(f, 0) or 0) for f in fields}
+    cost = _cost(safe_usage, _rate(pricing, raw_model or ""), pricing)
     for f in fields:
-        v = usage.get(f, 0) or 0
+        v = safe_usage[f]
         tokens_total[f] += v
         if model:
             by_model[model][f] += v
@@ -472,11 +569,13 @@ def _track_bash(
             bash_signal_counts["repeated_verify_runs"] += 1
         last_verify_norm[skey] = norm
         verify_edited_since[skey] = False
-    # gate signal (#111): commit + review-gate bypass
-    if _COMMIT_RE.search(cmd):
-        bash_signal_counts["commit_attempts"] += 1
-        if _BYPASS_RE.search(cmd):
-            bash_signal_counts["commit_bypasses"] += 1
+    # gate signal (#111): commit + review-gate bypass, scoped to the git-commit
+    # argv (#2036) — see _bash_segments()/_is_git_commit_argv() above.
+    for segment in _bash_segments(cmd):
+        if _is_git_commit_argv(segment):
+            bash_signal_counts["commit_attempts"] += 1
+            if any(tok in _COMMIT_BYPASS_TOKENS for tok in segment[1:]):
+                bash_signal_counts["commit_bypasses"] += 1
 
 
 def _detect_correction_turn(rec: dict, content) -> bool:
@@ -1082,6 +1181,14 @@ def _normalize_plugin_version(value) -> str | None:
 # small enough that no realistic downstream multiply-by-a-few-million or
 # cross-record accumulation can reach `inf`, and large enough for any
 # legitimate token count or cost figure.
+#
+# #2080: `_accumulate_token_signals` also routes the LOCAL-transcript token
+# fields through `_safe_number` before `_cost`'s `inp / 1e6 * ir` runs, for
+# the same reason in a different trust domain — an out-of-range int raises
+# `OverflowError` on the int-to-float conversion `/` performs, which aborts
+# `extract` before `round(cost * 1e6)` (below, at the peer-digest path) is
+# ever reached. Both `round(cost * 1e6)` call sites are protected by the
+# same bound now, not just the peer-ingestion one.
 _NUM_MAX = 2**53
 
 
@@ -1092,19 +1199,30 @@ def _safe_number(value) -> int | float:
     that isn't a plain `int`/`float` (a `bool` included: it's an `int`
     subclass in Python, so `True` would otherwise silently become `1`), for a
     non-finite `float` (`NaN`/`Infinity`, which would poison a running `+=`
-    aggregate for every OTHER host's data in the same run), and for anything
-    whose magnitude exceeds `_NUM_MAX` (see above). An `int` is never cast to
-    `float` to check finiteness or magnitude — `math.isfinite(float(v))`
-    raises `OverflowError` once `v`'s magnitude exceeds `sys.float_info.max`,
-    a legal JSON integer with no wire-size limit, so a hostile peer can
-    trivially send one and abort the run for every host. Comparing magnitude
-    directly instead is safe for arbitrary precision: Python's int/float rich
-    comparison never converts `value` through `float()`."""
+    aggregate for every OTHER host's data in the same run), for anything
+    whose magnitude exceeds `_NUM_MAX` (see above), and for anything
+    **negative** (#2079). Every field that ever reaches this function is a
+    count or a cost — skill/agent invocation counts, `cost_usd`, rework
+    counts — none of which is ever legitimately negative, so a negative
+    value is exactly as untrusted as a non-numeric one. Left unclamped, a
+    single hostile peer's `{"code-review": -999}` could drive a CROSS-HOST
+    Counter negative: combined with the `c > 0` gate `rollup()` uses for
+    `never_observed_skills`/`never_observed_agents`, that silently rewrites
+    another host's genuine invocation out of `invoked_skills`. An `int` is
+    never cast to `float` to check finiteness or magnitude —
+    `math.isfinite(float(v))` raises `OverflowError` once `v`'s magnitude
+    exceeds `sys.float_info.max`, a legal JSON integer with no wire-size
+    limit, so a hostile peer can trivially send one and abort the run for
+    every host. Comparing magnitude directly instead is safe for arbitrary
+    precision: Python's int/float rich comparison never converts `value`
+    through `float()`."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return 0
     if isinstance(value, float) and not math.isfinite(value):
         return 0
-    return 0 if abs(value) > _NUM_MAX else value
+    if value < 0 or abs(value) > _NUM_MAX:
+        return 0
+    return value
 
 
 def _normalize_name_dicts(container: dict, fields: tuple) -> None:

--- a/tests/repo/test_commit_bypass_gate_scoping.py
+++ b/tests/repo/test_commit_bypass_gate_scoping.py
@@ -1,0 +1,156 @@
+r"""#2036 — the commit-bypass gate signal must scope to the git-commit argv,
+not search the raw command string.
+
+Both session-report extractors independently carried the identical bug:
+`_COMMIT_RE = re.compile(r"\bgit\s+commit\b")` /
+`_BYPASS_RE = re.compile(r"--no-verify|(^|\s)-n(\s|$)")`, searched against the
+WHOLE command string. Neither pattern was anchored to an actual `git commit`
+invocation, so any `-n` anywhere in a compound Bash call counted as a
+review-gate bypass — `grep -n`, `rg -n`, `ls -n` are routine — and
+`_COMMIT_RE` matched the substring "git commit" even inside an unrelated
+string (`echo "git commit"`). #2036 found an unknown share of the reported
+13.5% bypass rate across 33 projects was this noise, not real bypasses.
+
+This module drives the table from the issue directly against both
+extractors' `_track_bash`, parametrized so a regression in either copy is
+caught — the two are deliberately still separate implementations (their
+unification is epic #2040's job, not this fix's), so nothing but an identical
+test run twice keeps them in agreement.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from _repo_root import REPO_ROOT
+
+# --- the table from #2036 (plus the three new argv-shaped cases) ----------
+# (command, expect_attempt, expect_bypass)
+CASES = [
+    pytest.param('git commit -m "fix"', True, False, id="plain-commit"),
+    pytest.param(
+        "git commit --no-verify -m x", True, True, id="explicit-no-verify"
+    ),
+    pytest.param(
+        'git commit -m "fix" && grep -n TODO src/',
+        True,
+        False,
+        id="compound-grep-n-not-a-bypass",
+    ),
+    pytest.param(
+        "git commit -m x; rg -n foo", True, False, id="compound-rg-n-not-a-bypass"
+    ),
+    pytest.param(
+        'echo "git commit" && ls -n',
+        False,
+        False,
+        id="commit-substring-inside-echo-is-not-an-attempt",
+    ),
+    pytest.param("git commit -n", True, True, id="bare-n-flag-is-a-bypass"),
+    pytest.param(
+        "git -C path commit -n",
+        True,
+        True,
+        id="global-option-with-arg-before-subcommand",
+    ),
+    pytest.param(
+        'git commit -m "pass -n to grep"',
+        True,
+        False,
+        id="quoted--n-inside-commit-message-is-not-a-bypass",
+    ),
+    pytest.param(
+        'git commit -m "line one\nline two"',
+        True,
+        False,
+        id="unquoted-vs-quoted-newline-embedded-message-not-split",
+    ),
+]
+
+
+def _session_extract(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
+    import session_extract
+
+    return session_extract
+
+
+def _extract_session_report(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.syspath_prepend(
+        str(REPO_ROOT / "plugins" / "dev-team" / "scripts")
+    )
+    import extract_session_report
+
+    return extract_session_report
+
+
+@pytest.mark.parametrize("cmd,expect_attempt,expect_bypass", CASES)
+def test_session_extract_commit_bypass_scoping(
+    cmd, expect_attempt, expect_bypass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mod = _session_extract(monkeypatch)
+    block = {"name": "Bash", "input": {"command": cmd}}
+    bash_commands = Counter()
+    signals = Counter()
+    mod._track_bash(block, "sid-1", bash_commands, signals, {}, {})
+    assert signals["commit_attempts"] == (1 if expect_attempt else 0)
+    assert signals["commit_bypasses"] == (1 if expect_bypass else 0)
+
+
+@pytest.mark.parametrize("cmd,expect_attempt,expect_bypass", CASES)
+def test_extract_session_report_commit_bypass_scoping(
+    cmd, expect_attempt, expect_bypass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mod = _extract_session_report(monkeypatch)
+    block = {"name": "Bash", "input": {"command": cmd}}
+    thread = mod._new_thread()
+    signals = Counter()
+    mod._track_bash(block, signals, thread)
+    assert signals["commit_attempts"] == (1 if expect_attempt else 0)
+    assert signals["commit_bypasses"] == (1 if expect_bypass else 0)
+
+
+# --- both extractors must agree on the same input, per #2036's acceptance --
+
+
+@pytest.mark.parametrize("cmd,expect_attempt,expect_bypass", CASES)
+def test_both_extractors_agree(
+    cmd, expect_attempt, expect_bypass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    se = _session_extract(monkeypatch)
+    esr = _extract_session_report(monkeypatch)
+
+    block = {"name": "Bash", "input": {"command": cmd}}
+
+    se_signals = Counter()
+    se._track_bash(block, "sid-1", Counter(), se_signals, {}, {})
+
+    esr_signals = Counter()
+    esr._track_bash(block, esr_signals, esr._new_thread())
+
+    assert se_signals["commit_attempts"] == esr_signals["commit_attempts"]
+    assert se_signals["commit_bypasses"] == esr_signals["commit_bypasses"]
+
+
+# --- a real invocation still counts once per real git-commit segment -------
+
+
+def test_two_real_commits_in_one_bash_call_count_as_two_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deliberate behavior change from the pre-#2036 whole-string search,
+    which could only ever detect one attempt per Bash call regardless of how
+    many `git commit`s it chained. Segmenting by shell operator means each
+    real invocation is counted — strictly more correct, and worth pinning
+    explicitly since it changes what the raw counter means."""
+    mod = _session_extract(monkeypatch)
+    block = {
+        "name": "Bash",
+        "input": {"command": 'git commit -m a && git commit -m b --no-verify'},
+    }
+    signals = Counter()
+    mod._track_bash(block, "sid-1", Counter(), signals, {}, {})
+    assert signals["commit_attempts"] == 2
+    assert signals["commit_bypasses"] == 1

--- a/tests/repo/test_ensure_session_archive.py
+++ b/tests/repo/test_ensure_session_archive.py
@@ -1,0 +1,176 @@
+"""Tests for .claude/ensure_session_archive.py — the SessionStart hook that
+archives new/changed sessions to a durable local file before Claude Code's
+30-day transcript retention ages them out (#2018, the "small and urgent"
+archival half — the per-session plugin-version attribution half is tracked
+separately and this hook does not touch it).
+
+Every test runs the real script as a subprocess against a throwaway
+``tmp_path`` standing in for both the project root and ``$HOME`` (so
+``~/.claude/projects`` and ``~/.cache/...`` never touch the real machine),
+using the REAL ``scripts/session_extract.py`` from this checkout — it is
+deterministic and stdlib-only, so running it for real against a tiny
+synthetic transcript is both faithful and safe.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from _repo_root import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".claude" / "ensure_session_archive.py"
+
+
+def _scaffold_repo(root: Path, *, in_repo: bool = True) -> None:
+    if in_repo:
+        (root / "requirements-dev.txt").write_text("")
+        plugin_dir = root / "plugins" / "dev-team" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "9.9.9"}))
+        (root / "scripts").mkdir(parents=True, exist_ok=True)
+        shutil.copy(
+            REPO_ROOT / "scripts" / "session_extract.py",
+            root / "scripts" / "session_extract.py",
+        )
+    claude_lib = root / ".claude" / "lib"
+    claude_lib.mkdir(parents=True, exist_ok=True)
+    shutil.copy(
+        REPO_ROOT / ".claude" / "lib" / "session_start_common.py",
+        claude_lib / "session_start_common.py",
+    )
+
+
+def _write_transcript(home: Path, project_slug: str, session_id: str) -> Path:
+    proj = home / ".claude" / "projects" / project_slug
+    proj.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "type": "assistant",
+        "sessionId": session_id,
+        "cwd": "/fake/proj",
+        "timestamp": "2026-08-27T00:00:00Z",
+        "isSidechain": False,
+        "message": {
+            "role": "assistant",
+            "model": "claude-sonnet-5",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+    path = proj / f"{session_id}.jsonl"
+    path.write_text(json.dumps(rec) + "\n")
+    return path
+
+
+def _run(root: Path, home: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(root)
+    env["HOME"] = str(home)
+    return subprocess.run(
+        ["python3", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_syntax_is_valid() -> None:
+    ast.parse(SCRIPT.read_text())
+
+
+def test_noop_outside_this_repos_own_checkout(tmp_path: Path) -> None:
+    """A downstream project that merely has the plugin installed must never
+    have this hook try to run scripts/session_extract.py, which only ships
+    in THIS repo's own checkout."""
+    root = tmp_path / "downstream"
+    root.mkdir()
+    home = tmp_path / "home"
+    _scaffold_repo(root, in_repo=False)
+    result = _run(root, home)
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert not (root / ".claude" / "metrics").exists()
+
+
+def test_noop_when_session_start_common_missing(tmp_path: Path) -> None:
+    """Fail-open: a partial checkout missing the shared lib must not crash
+    or block session start."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    home = tmp_path / "home"
+    (root / "requirements-dev.txt").write_text("")
+    result = _run(root, home)
+    assert result.returncode == 0
+
+
+def test_archives_a_new_session_and_writes_the_watermark(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    home = tmp_path / "home"
+    _scaffold_repo(root)
+    _write_transcript(home, "-fake-proj", "session-one")
+
+    result = _run(root, home)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    digest_path = root / ".claude" / "metrics" / "session-digest.jsonl"
+    assert digest_path.is_file()
+    lines = [json.loads(line) for line in digest_path.read_text().splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["session_id"] == "session-one"
+    assert lines[0]["tokens"]["input_tokens"] == 10
+
+    watermark_path = root / ".claude" / "metrics" / "session-digest-watermark.json"
+    assert watermark_path.is_file()
+    assert "session-one" in json.loads(watermark_path.read_text())["synced"]
+
+
+def test_second_run_is_a_true_noop_via_the_watermark(tmp_path: Path) -> None:
+    """The watermark must make a re-run genuinely incremental -- a session
+    already archived is never re-appended, so the file this hook writes on
+    every session start does not grow unbounded with duplicates."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    home = tmp_path / "home"
+    _scaffold_repo(root)
+    _write_transcript(home, "-fake-proj", "session-one")
+
+    first = _run(root, home)
+    assert first.returncode == 0, first.stdout + first.stderr
+    second = _run(root, home)
+    assert second.returncode == 0, second.stdout + second.stderr
+
+    digest_path = root / ".claude" / "metrics" / "session-digest.jsonl"
+    lines = digest_path.read_text().splitlines()
+    assert len(lines) == 1
+
+
+def test_never_writes_outside_dot_claude_metrics(tmp_path: Path) -> None:
+    """This hook must never touch the cross-machine telemetry-sync
+    mechanism (scripts/telemetry-sync.sh) -- no git clone, commit, or push.
+    Confirmed by construction: no .git directory appears anywhere under
+    tmp_path after a run."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    home = tmp_path / "home"
+    _scaffold_repo(root)
+    _write_transcript(home, "-fake-proj", "session-one")
+
+    result = _run(root, home)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not list(tmp_path.rglob(".git"))
+
+
+def test_hook_is_registered_in_settings_json() -> None:
+    """An unregistered SessionStart hook script is a silent no-op in
+    practice -- it never runs. Pin the registration alongside its siblings."""
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
+    commands = [
+        h["command"] for h in settings["hooks"]["SessionStart"][0]["hooks"]
+    ]
+    assert any("ensure_session_archive.py" in c for c in commands)

--- a/tests/repo/test_session_extract_plugin_version.py
+++ b/tests/repo/test_session_extract_plugin_version.py
@@ -930,3 +930,68 @@ def test_rollup_survives_a_non_dict_inner_utilization_field(
     data = json.loads(result.stdout)
     assert data["sessions"] == 2
     assert data["utilization"]["skills_invoked"] == {"plan": 1}
+
+
+# ---------------------------------------------------------------------------
+# #2079: _safe_number bounded magnitude but not sign
+# ---------------------------------------------------------------------------
+
+
+def test_safe_number_clamps_negative_values_directly(monkeypatch) -> None:
+    """Unit-level pin on `_safe_number` itself, alongside the existing
+    magnitude/finiteness cases the end-to-end tests below cover: a negative
+    value is exactly as untrusted as a non-numeric one and must clamp to 0,
+    the same way NaN/Infinity/oversized-magnitude already do."""
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
+    import session_extract
+
+    assert session_extract._safe_number(-999) == 0
+    assert session_extract._safe_number(-0.5) == 0
+    assert session_extract._safe_number(-(2**53) - 1) == 0  # negative AND oversized
+    assert session_extract._safe_number(0) == 0
+    assert session_extract._safe_number(5) == 5
+    assert session_extract._safe_number(3.5) == 3.5
+
+
+def test_rollup_negative_cost_usd_clamped_to_zero_not_subtracted(
+    tmp_path: Path,
+) -> None:
+    """#2079 finding 2/3: an unclamped negative `cost_usd` would subtract
+    from the cross-host total (and could drag cost_meter.py's CI regression
+    baseline mean to <= 0, silently disabling that gate). Must clamp to 0,
+    leaving the well-formed sibling's cost the whole rolled-up total."""
+    plugin_root = _fake_plugin_root(tmp_path, "10.23.0")
+    digests = tmp_path / "digests"
+    hostile = _base_sync_record("hostile-host", "p", "s-hostile")
+    hostile["cost_usd"] = -500.0
+    _write_digest(digests, "hostile-host", [hostile])
+    well_formed = _base_sync_record("good-host", "p", "s-good")
+    well_formed["cost_usd"] = 6.0
+    _write_digest(digests, "good-host", [well_formed])
+    result = _run("--rollup", str(digests), "--plugin-root", str(plugin_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["cost_usd"] == 6.0
+    assert "good-host" in data["hosts"]
+
+
+def test_rollup_negative_skill_count_does_not_corrupt_cross_host_sum(
+    tmp_path: Path,
+) -> None:
+    """#2079 finding 1: an unclamped hostile `{"code-review": -999}` would
+    drive the CROSS-HOST Counter negative -- combined with the `c > 0` gate
+    `rollup()` uses for never_observed_skills/never_observed_agents, that
+    silently evicts a skill OTHER hosts genuinely invoked from
+    `invoked_skills`. The genuinely-invoked count must survive intact."""
+    plugin_root = _fake_plugin_root(tmp_path, "10.23.0")
+    digests = tmp_path / "digests"
+    hostile = _base_sync_record("hostile-host", "p", "s-hostile")
+    hostile["utilization"]["skills_invoked"] = {"code-review": -999}
+    _write_digest(digests, "hostile-host", [hostile])
+    well_formed = _base_sync_record("good-host", "p", "s-good")
+    well_formed["utilization"]["skills_invoked"] = {"code-review": 3}
+    _write_digest(digests, "good-host", [well_formed])
+    result = _run("--rollup", str(digests), "--plugin-root", str(plugin_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["utilization"]["skills_invoked"] == {"code-review": 3}

--- a/tests/repo/test_session_extract_token_overflow.py
+++ b/tests/repo/test_session_extract_token_overflow.py
@@ -1,0 +1,128 @@
+"""#2080 — a huge local-transcript token count must not abort extraction.
+
+`_NUM_MAX`/`_safe_number` (scripts/session_extract.py) were written to guard
+the PEER-digest ingestion path (`_read_synced_records` -> `rollup()`). A
+second, structurally identical `round(cost * 1e6)` sits on the LOCAL-transcript
+extraction path (`_accumulate_token_signals` -> `_cost`), reading
+`usage.get("input_tokens")` etc. directly out of a transcript file with no
+bound at all.
+
+`_cost`'s `inp / 1e6 * ir` promotes `inp` through Python's int-to-float
+conversion for true division; an integer whose magnitude exceeds
+`sys.float_info.max` (legal JSON, no wire-size limit) raises `OverflowError`
+there, aborting `extract` for the whole file before `round()` is even
+reached — a single corrupted transcript denies the whole run, the same
+failure class #2079/#2016 closed on the peer-digest path, in a different
+trust domain (a transcript this script does not author, per
+`_iter_records`'s own comment).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _repo_root import REPO_ROOT
+
+EXTRACT = REPO_ROOT / "scripts" / "session_extract.py"
+PLUGIN = REPO_ROOT / "plugins" / "dev-team"
+SESSION_ID = "22222222-3333-4444-5555-666666666666"
+
+# Larger in magnitude than sys.float_info.max (~1.8e308) -- legal JSON, no
+# wire-size limit, but int-to-float conversion overflows on it.
+_HUGE_TOKEN_COUNT = 10**400
+
+
+def _assistant(usage: dict) -> dict:
+    return {
+        "type": "assistant",
+        "sessionId": SESSION_ID,
+        "cwd": "/tmp/fixture/project",
+        "timestamp": "2026-08-27T12:00:00Z",
+        "isSidechain": False,
+        "message": {
+            "role": "assistant",
+            "model": "claude-sonnet-5",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": usage,
+        },
+    }
+
+
+def _run(transcript: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(EXTRACT),
+            "--transcript",
+            str(transcript),
+            "--plugin-root",
+            str(PLUGIN),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write(path: Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+
+
+def test_oversized_input_tokens_does_not_abort_extraction(tmp_path: Path) -> None:
+    transcript = tmp_path / f"{SESSION_ID}.jsonl"
+    _write(
+        transcript,
+        [
+            _assistant(
+                {
+                    "input_tokens": _HUGE_TOKEN_COUNT,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 30,
+                    "cache_read_input_tokens": 40,
+                }
+            )
+        ],
+    )
+    result = _run(transcript)
+    assert result.returncode == 0, result.stdout + result.stderr
+    digest = json.loads(result.stdout)
+    # Clamped to 0, not left at the hostile magnitude and not aborting.
+    assert digest["token"]["totals"]["input_tokens"] == 0
+    assert digest["token"]["totals"]["output_tokens"] == 20
+
+
+def test_negative_token_count_does_not_corrupt_the_running_total(
+    tmp_path: Path,
+) -> None:
+    """Two records in one transcript: the second's negative count must not
+    subtract from the first's genuine total -- same corruption class as
+    #2079, single-host here rather than cross-host."""
+    transcript = tmp_path / f"{SESSION_ID}.jsonl"
+    _write(
+        transcript,
+        [
+            _assistant(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 30,
+                    "cache_read_input_tokens": 40,
+                }
+            ),
+            _assistant(
+                {
+                    "input_tokens": -500,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 30,
+                    "cache_read_input_tokens": 40,
+                }
+            ),
+        ],
+    )
+    result = _run(transcript)
+    assert result.returncode == 0, result.stdout + result.stderr
+    digest = json.loads(result.stdout)
+    assert digest["token"]["totals"]["input_tokens"] == 100


### PR DESCRIPTION
## Summary

Wave 1 of the consolidated open-issue plan (`.dev-team-reports/open-issue-consolidated-plan.md`) — five independent fixes, each its own commit, each with a negative control proving the test fails against the pre-fix code:

- **`_live_pid` crashes with `UnicodeDecodeError`** — `run_eval.py` decoded `ps -eo pid,args` with strict UTF-8; one non-UTF8 byte anywhere in the live process table crashed it, intermittently, over a process it never needed to interpret. Now decodes with `errors="replace"`. Closes #2065.
- **Commit-bypass gate signal not anchored to the git-commit argv** — `grep -n`, `rg -n`, `ls -n` in a compound Bash call all counted as review-gate bypasses; `echo "git commit"` counted as an attempt. Detection is now argv-shaped via a quote-respecting `shlex` tokenizer. **Found and fixed the identical bug duplicated in the shipped downstream extractor** (`extract_session_report.py`), not just the one the issue cited — same defect, same fix, deliberately hand-duplicated rather than factored into a shared module (that's epic #2040's job). Closes #2036.
- **`_safe_number` bounded magnitude but not sign** — a hostile peer's `{"code-review": -999}` could drive a cross-host Counter negative and silently evict a skill *other hosts genuinely invoked* from `invoked_skills`. Closes #2079.
- **A second, unguarded `round(cost * 1e6)`** on the local-transcript path — an oversized token count raises `OverflowError` and aborts the whole extraction run. Closes #2080.
- **New SessionStart hook archiving sessions before the 30-day transcript TTL** — local-only, watermarked, never pushed. This is the "small and urgent" half of #2018 only; the larger half (per-session `plugin_version` attribution, which needs a schema-era bump) is deliberately deferred to epic #2040. Part of #2018.

## Notes for the reviewer

**Three findings worth a second look, in order of how much they surprised me while validating:**

1. **The commit-bypass fix (#2036) found a twin defect not in scope.** The issue only cited `scripts/session_extract.py`. The shipped `plugins/dev-team/scripts/extract_session_report.py` had the byte-identical regex pair, same bug. Fixed both in one commit rather than leave the copy that actually ships to users broken — this is exactly the "same concept, drifted implementation" pattern `ADR 0036` and #1994/#2029 already document happening here more than once.
2. **My own test for #2036 was initially unfalsifiable.** A `dash`/`sh` heredoc's `\xac` escape is not interpreted as a hex byte by `printf` (it emits the four literal characters `\`, `x`, `a`, `c`) — the same trap for #2065's fake `ps` fixture. Caught both by inspecting the fake script's actual output with `od -c` before trusting either test, not by reading the code.
3. **#2018 is only partially done, on purpose.** Its "real fix" (stamping a session's own version rather than the extractor's) changes an existing field's meaning across every downstream consumer and needs the same era-marker treatment #1994 used for `session-digest/v2`. Doing that ad hoc here, ahead of epic #2040's unified `session_log` package, risks the exact kind of schema drift this whole consolidation effort exists to stop. Left as remaining scope on #2018, stated explicitly rather than silently dropped.

**Every fix's test was verified to fail against the pre-fix code** — for #2065 and #2080 with the exact `UnicodeDecodeError`/`OverflowError` from the respective issues, for #2079 with the exact corrupted value (`{'code-review': -996}` = 3 genuine + −999 hostile), for #2036 with 11 of 28 parametrized cases failing pre-fix, and for the archival hook by full manual dry-run against an isolated fake repo + fake `$HOME` before the pytest suite existed.

## Test Plan

- [x] `scripts/ci-local.sh`'s full directory list green — **9,778 passed, 47 skipped** (1:47)
- [x] `python3 scripts/check_md_references.py`, `build_knowledge_index.py`, `check-python-only.py` all clean
- [x] `ruff check` clean on every changed file
- [x] Each fix's new test confirmed **failing** against the pre-fix code, then passing after — see the per-commit messages for the exact reproduction
- [x] The archival hook manually verified end-to-end against an isolated fake repo before the automated suite was written: archives a synthetic session, writes the watermark, no-ops on a downstream checkout, fails open when its shared lib is missing
- [x] `.claude/settings.json` re-parses as valid JSON with all hook events and top-level keys intact

Closes #2065
Closes #2036
Closes #2079
Closes #2080
Part of #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_