### PR TITLE
feat(pr): scope gate-retry code review rounds to the fix-diff

### DIFF
--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -692,6 +692,12 @@ triggers, in precedence order, all handled by the script:
 | `run-id-mismatch` | The stored ledger was built for different target files. Catches a resume that legitimately starts at round ≥ 2 against a different changeset |
 | `stale-state` | The run started more than 24h ago — abandoned residue |
 
+This ledger covers rounds *within* one `/code-review` invocation only — a
+caller that re-invokes `/code-review` across separate command runs is the
+place that scopes those *separate* invocations to the fix-diff instead of
+restarting at round 1 every time. `/pr`'s own gate-retry loop
+(`../pr/SKILL.md` step 2) is that caller today.
+
 Reported as `ledger_reset` on every call (`null` when a stored ledger was
 legitimately resumed). The script fails **toward** a reset: an unreadable or
 malformed state file starts fresh. Starting fresh costs at most one extra

--- a/plugins/dev-team/skills/pr/SKILL.md
+++ b/plugins/dev-team/skills/pr/SKILL.md
@@ -71,16 +71,71 @@ Run each check sequentially. Stop on first failure:
    - `golangci-lint` available: `golangci-lint run`
 
 4. **Code review** (unless `--skip-review`):
-   - Scope the review to this branch's diff against the base branch, not the whole repo. At PR time the working tree is clean (Step 1 requires it), so a bare `/code-review --json` would auto-scope to the **full repository** — expensive, wrongly scoped, and on a large repo it can trigger the sliced-review path. Compute the merge base and pass it via `--since`:
+   - Scope the review to this branch's diff against the base branch, not the whole repo. At PR time the working tree is clean (Step 1 requires it), so a bare `/code-review --json` would auto-scope to the **full repository** — expensive, wrongly scoped, and on a large repo it can trigger the sliced-review path. Compute the merge base:
 
      ```bash
      BASE=$(git merge-base HEAD "origin/<base>")   # <base> defaults to main, or the --base arg
+     HEAD_SHA=$(git rev-parse HEAD)
+     BRANCH=$(git branch --show-current)
      ```
 
-   - Run `/code-review --since "$BASE" --json`. `/pr` owns the human gate, so code-review runs non-interactively: it skips its own "fix or report?" prompt and applies its fix loop automatically (up to 5 iterations), then returns an aggregated status.
-   - Read the returned status field. A normal review returns `{"overall": "pass|warn|fail", ...}`; a documentation-only changeset short-circuits with `{"status": "skipped", ...}`:
-     - `overall` of `pass` / `warn`, or `status` of `skipped` → continue to step 3.
-     - `overall` of `fail` → show the remaining findings and ask the user whether to proceed anyway or stop and fix.
+   - **Gate-retry scoping (#2087).** `/code-review`'s own round ledger (`finding_signature.py`, see `../code-review/SKILL.md` step 6a) only scopes findings *within* a single `/code-review` invocation — every fresh top-level call restarts at round 1 with the full branch diff. Left unmanaged, a second `/pr` run after a human fixes findings from the first pays full review cost again, even though only the fix delta is unreviewed. `${CLAUDE_PLUGIN_ROOT}/skills/pr/scripts/gate_retry_state.py` is the deterministic transition function that closes that gap by persisting phase/round state across `/pr` invocations. Drive it with this bounded loop — **never more than two `/code-review` calls in one `/pr` invocation**:
+
+     ```bash
+     # Call 1: decide this call's scope (no --last-outcome yet).
+     DECISION=$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/pr/scripts/gate_retry_state.py" \
+       --state .claude/memory/pr-gate-state.json \
+       --branch "$BRANCH" --base-sha "$BASE" --head-sha "$HEAD_SHA")
+     SINCE_REF=$(echo "$DECISION" | jq -r '.since_ref')
+     ESCALATE=$(echo "$DECISION" | jq -r '.escalate')
+
+     if [ "$ESCALATE" = "true" ]; then
+       # Retry budget exhausted for this PR's gate — stop, do not call
+       # /code-review again. Surface this and fall into the same
+       # proceed-anyway-or-fix branching as a `fail` below, noting that
+       # further retries need `--reset` (a fresh look), since automatic
+       # narrow-scoping is exhausted.
+     else
+       RESULT=$(/code-review --since "$SINCE_REF" --json)
+       # gate_retry_state.py only knows pass|warn|fail; a doc-only
+       # short-circuit (`status: "skipped"`) converges the round exactly
+       # like a pass — map it before recording.
+       OVERALL=$(echo "$RESULT" | jq -r 'if .status == "skipped" then "pass" else .overall end')
+
+       # Call 2: record the outcome and get the next scope.
+       DECISION=$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/pr/scripts/gate_retry_state.py" \
+         --state .claude/memory/pr-gate-state.json \
+         --branch "$BRANCH" --base-sha "$BASE" --head-sha "$HEAD_SHA" \
+         --last-outcome "$OVERALL")
+       SINCE_REF=$(echo "$DECISION" | jq -r '.since_ref')
+
+       # Only the fix-diff -> confirm transition returns a non-null
+       # since_ref here (one mandatory full-branch pass before the gate can
+       # close, issue #2087 requirement 3) — run it once, immediately, in
+       # this same invocation, then record it. Do not loop: this is the
+       # ONLY place a third /code-review call can happen, and it never
+       # triggers a fourth.
+       if [ "$SINCE_REF" != "null" ]; then
+         RESULT=$(/code-review --since "$SINCE_REF" --json)
+         OVERALL=$(echo "$RESULT" | jq -r 'if .status == "skipped" then "pass" else .overall end')
+         DECISION=$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/pr/scripts/gate_retry_state.py" \
+           --state .claude/memory/pr-gate-state.json \
+           --branch "$BRANCH" --base-sha "$BASE" --head-sha "$HEAD_SHA" \
+           --last-outcome "$OVERALL")
+       fi
+     fi
+     ```
+
+     `/code-review --since <ref> --json` itself is unchanged: `/pr` owns the human gate, so code-review still runs non-interactively (skips its own "fix or report?" prompt, applies its fix loop automatically up to 5 iterations) and returns an aggregated status — only the `--since` ref is now computed by the gate-retry decision above instead of always being `$BASE`.
+
+   - Read `DECISION`'s final `phase` and the last `OVERALL` computed:
+
+     | `phase` / outcome | Meaning | Action |
+     | --- | --- | --- |
+     | `phase: "done"` | Gate closed — either a full-branch pass on round 1, or the mandatory confirm pass after a narrowed fix-diff pass | Continue to step 3 |
+     | `escalate: true` | Retry budget (`PR_GATE_MAX_ROUNDS`) exhausted across `/pr` invocations for this PR | Stop; do not call `/code-review` again this invocation. Surface that the retry budget is exhausted and further retries need `--reset` for a fresh full-branch look |
+     | last `OVERALL` is `fail`, not escalated | Actionable findings remain after code-review's own internal fix loop | Show the remaining findings and ask the user whether to proceed anyway or stop and fix — and tell them re-running `/pr` will scope the next check to only what changed since this attempt (the fix delta), not the whole branch, unless the base moved |
+     | last `OVERALL` is `pass` / `warn`, or `status` is `skipped` (doc-only short-circuit, checked before any of the above) | Nothing further to review | Continue to step 3 |
 
 Report results as a checklist:
 

--- a/plugins/dev-team/skills/pr/scripts/gate_retry_state.py
+++ b/plugins/dev-team/skills/pr/scripts/gate_retry_state.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Across-invocation `/pr` gate scoping — the fix-diff retry loop (#2087).
+
+## The gap this closes
+
+`/code-review`'s own round ledger (`../code-review/scripts/finding_signature.py`,
+#1625) and closing pass (`../code-review/scripts/closing_pass.py`, #1626)
+already scope a review down to the fix delta — but strictly *within one*
+`/code-review` invocation's own internal fix loop (up to `MAX_ITERATIONS=5`).
+`finding_signature.py`'s own reset-trigger table is explicit that "round 1
+always starts a new run": every NEW top-level `/code-review` call — including
+a second `/pr` invocation run after a human manually fixes something outside
+code-review's own automatic loop — restarts at round 1 with the FULL
+branch-diff panel, whatever narrower scoping the previous invocation had
+converged to.
+
+That is the actual mechanism PR #2085 paid for: `/pr`'s Step 2 gate calls
+`/code-review --since <merge-base> --json` exactly once per `/pr` invocation,
+unconditionally at full-branch scope. Two separate `/pr` runs (Round B and
+Round C) each re-scanned all 10 changed files with a 6-8 finder-agent fleet,
+even though the only thing that had changed since the prior round was the fix
+applied in direct response to that prior round's own findings. Reconstructed
+cost for that one PR's review rounds: ~$242 across 91 subagent dispatches.
+
+## What this module is
+
+A deterministic transition function — no LLM judgment — callable once per
+`/pr` Step-2 gate check, that decides what git ref to hand `/code-review
+--since <ref>` next, and whether the retry budget for this PR is exhausted.
+State persists in a JSON file across separate `/pr` invocations (mirroring
+where `../code-review/scripts/finding_signature.py`'s
+`review-round-state.json` already lives), so a second `/pr` run on the same
+branch narrows to just the fix delta instead of re-scanning everything.
+
+The phase machine has four states: `initial` (first, full-branch check) ->
+`fix-diff` (narrow re-check after a `fail`) -> `confirm` (one mandatory
+full-branch pass before the gate can close, issue #2087's requirement 3) ->
+`done`. A `fail` from any phase routes back to `fix-diff` — see `decide()`'s
+"pass or warn" branch, which is the only place `phase` advances forward.
+
+## Design mirrors `finding_signature.py`, deliberately not imported
+
+Same four-trigger, precedence-ordered, "fails toward a reset" reset-trigger
+table; same round-cap posture; the TTL and round-cap constants below are
+independently defined and cross-checked for drift in
+`plugins/dev-team/tests/scripts/test_gate_retry_state.py`, exactly like
+`closing_pass.py`'s `MIN_DISTINCT_DISPATCHES` is checked against
+`hooks/pre_pr_review.py`. This script must not import across skill
+directories — a future change to either skill's constant fails a test rather
+than silently drifting the other.
+
+## Why the "no `--last-outcome`" call still writes a placeholder
+
+The first call of a `/pr` invocation (no `--last-outcome` yet) reports a
+scope without "committing" a new round — no round increment, no recorded
+outcome. But if that call is a genuinely fresh start (no prior state, or the
+prior run's own gate already reached `done`), it *does* persist a minimal
+placeholder (`round=1, phase="initial"`) so that a crash between this call
+and the `--last-outcome` call that would normally follow it (`/code-review`
+itself dying mid-run, the session ending) leaves evidence on disk: the next
+invocation's first call resumes at the same round/scope instead of silently
+losing the fact that a full-branch check was already attempted. See
+`compute_pending()`'s `phase == "initial"` branch, which exists solely to
+serve this resumed-but-never-recorded case.
+
+Stdlib-only. See docs/python-hook-contract.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Total dispatch rounds after which the retry loop stops advancing
+#: automatically and hands control back to a human — no further `/pr`
+#: invocation narrows the scope on its own. Same value and reasoning as
+#: `../code-review/scripts/finding_signature.py`'s `MAX_ROUNDS` (initial +
+#: 3 more); independently defined so a change to one doesn't silently
+#: desync from the other. Drift-tested in
+#: `plugins/dev-team/tests/scripts/test_gate_retry_state.py`.
+PR_GATE_MAX_ROUNDS = 4
+
+#: A stored gate-retry state older than this is discarded rather than
+#: reused — the same 24h reasoning as `finding_signature.STATE_TTL_SECONDS`:
+#: a `/pr` gate check does not legitimately span a day, so a state file that
+#: old is abandoned residue. Independently defined; drift-tested alongside
+#: `PR_GATE_MAX_ROUNDS` above.
+PR_GATE_STATE_TTL_SECONDS = 24 * 60 * 60
+
+_OUTCOMES = frozenset({"pass", "warn", "fail"})
+
+_DEFAULT_STATE_PATH = ".claude/memory/pr-gate-state.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _age_seconds(iso) -> float | None:
+    try:
+        stamp = datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+    return (datetime.now(timezone.utc) - stamp).total_seconds()
+
+
+def _load_state(state_path, branch: str, base_sha: str, force_reset: bool):
+    """Load the persisted gate-retry state, discarding it when it can't be
+    safely resumed. Returns `(state_or_None, reset_reason)`; `state_or_None`
+    is `None` whenever this run must start fresh, and `reset_reason` is
+    `None` only when nothing anomalous happened (no file at all, or a
+    legitimately resumed run).
+
+    Four reset triggers, in precedence order — mirrors
+    `finding_signature._load_state`'s table and its "fails toward a reset"
+    philosophy: an ambiguous or stale state always restarts full-branch
+    rather than risking a narrow scope that silently misses something.
+
+    1. `--reset` — explicit, caller-forced.
+    2. Stored `branch` differs from the current branch — belongs to a
+       different `/pr` run entirely (a fresh branch, or history from a
+       branch reused for something else).
+    3. Stored `base_sha` differs from the current merge-base — the base
+       moved (rebase, or the target branch advanced) since the last check;
+       "only what changed since `last_reviewed_sha`" no longer holds safely
+       against a shifted base.
+    4. Staleness — `PR_GATE_STATE_TTL_SECONDS` since the run started.
+
+    A missing state file is not itself a "reset" (nothing was there to
+    reset) — it returns `(None, None)`, the same as `finding_signature`'s
+    round-1 case, and is handled as a fresh start by `compute_pending()`.
+    """
+    if force_reset:
+        return None, "explicit-reset"
+    if state_path is None or not state_path.is_file():
+        return None, None
+
+    try:
+        stored = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None, "unreadable-state"
+    if not isinstance(stored, dict):
+        return None, "unreadable-state"
+
+    if stored.get("branch") != branch:
+        return None, "branch-mismatch"
+    if stored.get("base_sha") != base_sha:
+        return None, "base-sha-mismatch"
+
+    age = _age_seconds(stored.get("started_at"))
+    if age is not None and age > PR_GATE_STATE_TTL_SECONDS:
+        return None, "stale-state"
+
+    return stored, None
+
+
+def compute_pending(stored, base_sha: str) -> dict:
+    """Decide the scope for the round about to run (or that just ran),
+    purely from persisted state — never mutates `stored`, never touches
+    disk. `stored` is `None` (or a leftover `phase == "done"` record — see
+    module docstring's note on why that should not normally happen) for a
+    fresh start: round 1, full-branch scope.
+
+    A `phase == "initial"` resumed state is the crash-recovery case: the
+    previous `/pr` invocation's first call decided a full-branch check but
+    never got to record its outcome. Repeating `since_ref = base_sha` at the
+    same round is correct — the full-branch check never actually completed,
+    so jumping to a narrower `fix-diff` scope would silently skip reviewing
+    parts of the branch.
+    """
+    if stored is None or stored.get("phase") == "done":
+        return {"phase": "initial", "round": 1, "since_ref": base_sha, "escalate": False}
+
+    round_ = stored.get("round", 1)
+    phase = stored.get("phase", "initial")
+
+    if round_ >= PR_GATE_MAX_ROUNDS:
+        return {"phase": phase, "round": round_, "since_ref": None, "escalate": True}
+
+    if phase == "fix-diff":
+        since_ref = stored.get("last_reviewed_sha") or base_sha
+    else:  # "initial" (crash-recovery resume) or "confirm"
+        since_ref = base_sha
+
+    return {"phase": phase, "round": round_, "since_ref": since_ref, "escalate": False}
+
+
+def decide(stored, reset_reason, branch: str, base_sha: str, head_sha: str, last_outcome):
+    """The transition function. Returns `(result, new_state_or_None, delete)`
+    — `result` is the JSON payload to print; `new_state_or_None` is what to
+    persist (or `None` for "leave disk untouched"); `delete` is `True` when
+    the caller must remove the state file instead (the `done` transitions).
+
+    See the module docstring for the phase machine and the CLI contract in
+    `main()`'s argparse help for the two call shapes (no `--last-outcome`
+    vs. `--last-outcome given`).
+    """
+    pending = compute_pending(stored, base_sha)
+
+    if last_outcome is None:
+        # First call of a /pr invocation: report the scope this round should
+        # use. No round is "committed" here — see the module docstring's
+        # note on why a genuinely fresh start still persists a placeholder.
+        result = {
+            "since_ref": pending["since_ref"],
+            "phase": pending["phase"],
+            "round": pending["round"],
+            "reset_reason": reset_reason,
+            "escalate": pending["escalate"],
+        }
+        is_fresh_start = stored is None or stored.get("phase") == "done"
+        new_state = None
+        if is_fresh_start:
+            new_state = {
+                "branch": branch,
+                "base_sha": base_sha,
+                "last_reviewed_sha": None,
+                "round": 1,
+                "phase": "initial",
+                "started_at": _now_iso(),
+                "updated_at": _now_iso(),
+            }
+        return result, new_state, False
+
+    # --last-outcome given: record the result of the call this call's
+    # `pending` describes, then transition.
+    if pending["escalate"]:
+        # Misuse guard: the retry budget was already exhausted before this
+        # call (a caller ignored the previous escalate=true and dispatched
+        # /code-review again anyway). Do not advance the round further.
+        result = {
+            "since_ref": None,
+            "phase": pending["phase"],
+            "round": pending["round"],
+            "reset_reason": reset_reason,
+            "escalate": True,
+        }
+        return result, None, False
+
+    new_round = pending["round"] + 1
+    started_at = (stored or {}).get("started_at") or _now_iso()
+
+    if last_outcome == "fail":
+        new_state = {
+            "branch": branch,
+            "base_sha": base_sha,
+            "last_reviewed_sha": head_sha,
+            "round": new_round,
+            "phase": "fix-diff",
+            "started_at": started_at,
+            "updated_at": _now_iso(),
+        }
+        # Re-derive the returned scope from the state just persisted so the
+        # round-cap check (escalate) is computed exactly once, in
+        # compute_pending(), rather than duplicated here.
+        next_pending = compute_pending(new_state, base_sha)
+        result = {
+            "since_ref": next_pending["since_ref"],
+            "phase": next_pending["phase"],
+            "round": next_pending["round"],
+            "reset_reason": reset_reason,
+            "escalate": next_pending["escalate"],
+        }
+        return result, new_state, False
+
+    # pass or warn: converged for the scope `pending` described.
+    converged_phase = pending["phase"]
+    if converged_phase in ("initial", "confirm"):
+        # Full-branch check passed (either the very first one, or the
+        # mandatory pre-merge confirm) — nothing left to review.
+        result = {
+            "since_ref": None,
+            "phase": "done",
+            "round": new_round,
+            "reset_reason": reset_reason,
+            "escalate": False,
+        }
+        return result, None, True
+
+    # converged_phase == "fix-diff": issue #2087's requirement 3 — one
+    # mandatory full-branch confirmation before the gate can close, run
+    # immediately in the same /pr invocation (see pr/SKILL.md step 2).
+    new_state = {
+        "branch": branch,
+        "base_sha": base_sha,
+        "last_reviewed_sha": head_sha,
+        "round": new_round,
+        "phase": "confirm",
+        "started_at": started_at,
+        "updated_at": _now_iso(),
+    }
+    result = {
+        "since_ref": base_sha,
+        "phase": "confirm",
+        "round": new_round,
+        "reset_reason": reset_reason,
+        "escalate": False,
+    }
+    return result, new_state, False
+
+
+def _write_state(state_path: Path, data: dict) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _delete_state(state_path: Path) -> None:
+    try:
+        state_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Decide /pr Step 2's next `/code-review --since <ref>` scope "
+            "and whether the gate-retry budget is exhausted (#2087)."
+        )
+    )
+    parser.add_argument(
+        "--state",
+        default=_DEFAULT_STATE_PATH,
+        help=f"Path to the durable gate-retry state file (default: {_DEFAULT_STATE_PATH})",
+    )
+    parser.add_argument("--branch", required=True, help="Current branch name")
+    parser.add_argument(
+        "--base-sha", required=True, dest="base_sha", help="Current merge-base sha"
+    )
+    parser.add_argument("--head-sha", required=True, dest="head_sha", help="Current HEAD sha")
+    parser.add_argument(
+        "--last-outcome",
+        choices=sorted(_OUTCOMES),
+        default=None,
+        dest="last_outcome",
+        help=(
+            "Omit on the first call of a /pr invocation. Pass on every call "
+            "after a /code-review result is known, to record it and "
+            "transition to the next scope."
+        ),
+    )
+    parser.add_argument(
+        "--reset", action="store_true", help="Discard any stored state and start a fresh run."
+    )
+    args = parser.parse_args(argv)
+
+    state_path = Path(args.state) if args.state else None
+    stored, reset_reason = _load_state(state_path, args.branch, args.base_sha, args.reset)
+
+    result, new_state, delete = decide(
+        stored, reset_reason, args.branch, args.base_sha, args.head_sha, args.last_outcome
+    )
+
+    if state_path is not None:
+        if delete:
+            _delete_state(state_path)
+        elif new_state is not None:
+            _write_state(state_path, new_state)
+
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/dev-team/tests/scripts/test_gate_retry_state.py
+++ b/plugins/dev-team/tests/scripts/test_gate_retry_state.py
@@ -1,0 +1,303 @@
+"""Unit tests for skills/pr/scripts/gate_retry_state.py (#2087).
+
+The headline acceptance criterion: a second `/pr` invocation on the same
+branch, after a human fixes findings from the first invocation's
+`/code-review --since <merge-base>` call, scopes its next check to just the
+fix delta (`last_reviewed_sha`) instead of re-scanning the whole branch —
+with exactly one mandatory full-branch confirmation pass before the gate can
+close.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "dev-team"
+_SCRIPTS_DIR = _PLUGIN_ROOT / "skills" / "pr" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import gate_retry_state as grs
+
+_CODE_REVIEW_SCRIPTS_DIR = _PLUGIN_ROOT / "skills" / "code-review" / "scripts"
+sys.path.insert(0, str(_CODE_REVIEW_SCRIPTS_DIR))
+
+import finding_signature
+
+BASE = "base0000"
+HEAD1 = "head1111"
+HEAD2 = "head2222"
+HEAD3 = "head3333"
+HEAD4 = "head4444"
+BRANCH = "feature/2087"
+
+
+def _run(state_path, branch=BRANCH, base_sha=BASE, head_sha=HEAD1, last_outcome=None, reset=False):
+    cmd = [
+        sys.executable,
+        str(_SCRIPTS_DIR / "gate_retry_state.py"),
+        "--state",
+        str(state_path),
+        "--branch",
+        branch,
+        "--base-sha",
+        base_sha,
+        "--head-sha",
+        head_sha,
+    ]
+    if last_outcome:
+        cmd += ["--last-outcome", last_outcome]
+    if reset:
+        cmd += ["--reset"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+class TestDriftGuards:
+    def test_max_rounds_matches_finding_signature(self):
+        assert grs.PR_GATE_MAX_ROUNDS == finding_signature.MAX_ROUNDS
+
+    def test_state_ttl_matches_finding_signature(self):
+        assert grs.PR_GATE_STATE_TTL_SECONDS == finding_signature.STATE_TTL_SECONDS
+
+
+class TestFreshStart:
+    def test_no_state_file_starts_full_branch_round_one(self, tmp_path):
+        state = tmp_path / "s.json"
+        payload = _run(state)
+        assert payload == {
+            "since_ref": BASE,
+            "phase": "initial",
+            "round": 1,
+            "reset_reason": None,
+            "escalate": False,
+        }
+
+    def test_fresh_start_persists_a_crash_recovery_placeholder(self, tmp_path):
+        state = tmp_path / "s.json"
+        _run(state)
+        assert state.is_file()
+        stored = json.loads(state.read_text(encoding="utf-8"))
+        assert stored["phase"] == "initial"
+        assert stored["round"] == 1
+        assert stored["branch"] == BRANCH
+        assert stored["base_sha"] == BASE
+
+
+class TestResetTriggers:
+    def _seed_fix_diff_state(self, tmp_path, state):
+        _run(state, head_sha=HEAD1)
+        _run(state, head_sha=HEAD1, last_outcome="fail")
+
+    def test_explicit_reset_starts_fresh(self, tmp_path):
+        state = tmp_path / "s.json"
+        self._seed_fix_diff_state(tmp_path, state)
+        payload = _run(state, reset=True)
+        assert payload["reset_reason"] == "explicit-reset"
+        assert payload["phase"] == "initial"
+        assert payload["since_ref"] == BASE
+
+    def test_branch_mismatch_starts_fresh(self, tmp_path):
+        state = tmp_path / "s.json"
+        self._seed_fix_diff_state(tmp_path, state)
+        payload = _run(state, branch="feature/other")
+        assert payload["reset_reason"] == "branch-mismatch"
+        assert payload["phase"] == "initial"
+        assert payload["since_ref"] == BASE
+
+    def test_base_sha_mismatch_starts_fresh(self, tmp_path):
+        state = tmp_path / "s.json"
+        self._seed_fix_diff_state(tmp_path, state)
+        payload = _run(state, base_sha="newbase0")
+        assert payload["reset_reason"] == "base-sha-mismatch"
+        assert payload["phase"] == "initial"
+        assert payload["since_ref"] == "newbase0"
+
+    def test_stale_state_starts_fresh(self, tmp_path):
+        state = tmp_path / "s.json"
+        self._seed_fix_diff_state(tmp_path, state)
+        stored = json.loads(state.read_text(encoding="utf-8"))
+        stored["started_at"] = "2020-01-01T00:00:00Z"
+        state.write_text(json.dumps(stored), encoding="utf-8")
+
+        payload = _run(state)
+        assert payload["reset_reason"] == "stale-state"
+        assert payload["phase"] == "initial"
+        assert payload["since_ref"] == BASE
+
+    def test_corrupt_state_file_fails_toward_a_reset(self, tmp_path):
+        state = tmp_path / "s.json"
+        state.write_text("{not json", encoding="utf-8")
+        payload = _run(state)
+        assert payload["reset_reason"] == "unreadable-state"
+        assert payload["phase"] == "initial"
+        assert payload["since_ref"] == BASE
+
+
+class TestHappyPathSequence:
+    """The full initial -> fail -> fix-diff -> pass -> confirm -> pass ->
+    done trace, asserting since_ref at each step: base_sha, then
+    last_reviewed_sha, then base_sha again, then null."""
+
+    def test_full_sequence(self, tmp_path):
+        state = tmp_path / "s.json"
+
+        # Call A: first call of the /pr invocation, nothing on disk yet.
+        a = _run(state, head_sha=HEAD1)
+        assert a["since_ref"] == BASE
+        assert a["phase"] == "initial"
+        assert a["round"] == 1
+        # /code-review --since BASE --json -> overall: fail
+
+        # Call B: record the fail.
+        b = _run(state, head_sha=HEAD1, last_outcome="fail")
+        assert b["since_ref"] == HEAD1
+        assert b["phase"] == "fix-diff"
+        assert b["round"] == 2
+        assert b["escalate"] is False
+
+        # A human fixes the findings; the branch advances to HEAD2.
+        # Next /pr invocation, first call: resumes at fix-diff scope.
+        c = _run(state, head_sha=HEAD2)
+        assert c["since_ref"] == HEAD1
+        assert c["phase"] == "fix-diff"
+        assert c["round"] == 2
+        # /code-review --since HEAD1 --json -> overall: pass
+
+        # Call D: record the pass -> fix-diff converged -> confirm phase,
+        # same /pr invocation, no human round-trip.
+        d = _run(state, head_sha=HEAD2, last_outcome="pass")
+        assert d["since_ref"] == BASE
+        assert d["phase"] == "confirm"
+        assert d["round"] == 3
+        assert d["escalate"] is False
+        # /code-review --since BASE --json (this same invocation) -> pass
+
+        # Call E: record the confirm pass -> fully done.
+        e = _run(state, head_sha=HEAD2, last_outcome="pass")
+        assert e["since_ref"] is None
+        assert e["phase"] == "done"
+        assert not state.is_file(), "the done transition deletes the state file"
+
+
+class TestInitialPassInOneShot:
+    def test_full_branch_pass_on_the_first_round_skips_confirm(self, tmp_path):
+        state = tmp_path / "s.json"
+        first = _run(state, head_sha=HEAD1)
+        assert first["phase"] == "initial"
+        assert first["since_ref"] == BASE
+
+        second = _run(state, head_sha=HEAD1, last_outcome="pass")
+        assert second["since_ref"] is None
+        assert second["phase"] == "done"
+        assert not state.is_file()
+
+
+class TestRoundCapEscalation:
+    def test_enough_consecutive_fails_escalate_and_stop_advancing(self, tmp_path):
+        state = tmp_path / "s.json"
+
+        # Round 1 (initial) fails -> round becomes 2 (fix-diff).
+        _run(state, head_sha=HEAD1)
+        r2 = _run(state, head_sha=HEAD1, last_outcome="fail")
+        assert r2["round"] == 2
+        assert r2["escalate"] is False
+
+        # Round 2 (fix-diff) fails -> round becomes 3.
+        _run(state, head_sha=HEAD2)
+        r3 = _run(state, head_sha=HEAD2, last_outcome="fail")
+        assert r3["round"] == 3
+        assert r3["escalate"] is False
+
+        # Round 3 (fix-diff) fails -> round becomes 4, at the cap.
+        _run(state, head_sha=HEAD3)
+        r4 = _run(state, head_sha=HEAD3, last_outcome="fail")
+        assert r4["round"] == grs.PR_GATE_MAX_ROUNDS
+        assert r4["escalate"] is True
+        assert r4["since_ref"] is None
+
+        # A further no-outcome call refuses to advance: escalate again,
+        # without ever calling /code-review.
+        again = _run(state, head_sha=HEAD4)
+        assert again["escalate"] is True
+        assert again["since_ref"] is None
+        assert again["round"] == grs.PR_GATE_MAX_ROUNDS
+
+        # A further --last-outcome call (misuse) also refuses to advance
+        # the round past the cap.
+        misuse = _run(state, head_sha=HEAD4, last_outcome="fail")
+        assert misuse["escalate"] is True
+        assert misuse["round"] == grs.PR_GATE_MAX_ROUNDS
+
+
+class TestConfirmFailBehavesLikeAnyOtherFail:
+    def test_confirm_phase_failing_returns_to_fix_diff_not_stuck_forever(self, tmp_path):
+        # Reaching "confirm" always costs exactly 2 prior rounds (initial
+        # fail -> round 2, fix-diff pass -> round 3), so a confirm-phase
+        # fail here lands on round 4 -- PR_GATE_MAX_ROUNDS itself. That is a
+        # real, expected interaction with the round cap (asserted below),
+        # not a reason the phase transition should behave differently: the
+        # phase still becomes "fix-diff", never stays "confirm".
+        state = tmp_path / "s.json"
+        _run(state, head_sha=HEAD1)
+        _run(state, head_sha=HEAD1, last_outcome="fail")
+        _run(state, head_sha=HEAD2)
+        confirm_transition = _run(state, head_sha=HEAD2, last_outcome="pass")
+        assert confirm_transition["phase"] == "confirm"
+
+        # The mandatory confirm pass fails.
+        result = _run(state, head_sha=HEAD2, last_outcome="fail")
+        assert result["phase"] == "fix-diff", "never stuck reporting confirm after a fail"
+        assert result["round"] == grs.PR_GATE_MAX_ROUNDS
+        assert result["escalate"] is True
+
+        # Next invocation: the round cap (not "confirm") is what stops
+        # automatic retries -- the stored phase is still fix-diff, never
+        # reverted back to or stuck at confirm.
+        resumed = _run(state, head_sha=HEAD3)
+        assert resumed["phase"] == "fix-diff"
+        assert resumed["escalate"] is True
+
+    def test_confirm_fail_transition_in_isolation_from_the_round_cap(self):
+        # Same phase transition as above, exercised directly through
+        # decide() with a synthetic low round number, so the assertion is
+        # decoupled from the round-cap interaction the subprocess-driven
+        # test above documents.
+        stored = {
+            "branch": BRANCH,
+            "base_sha": BASE,
+            "last_reviewed_sha": HEAD2,
+            "round": 1,
+            "phase": "confirm",
+            "started_at": grs._now_iso(),
+            "updated_at": grs._now_iso(),
+        }
+        result, new_state, delete = grs.decide(
+            stored, None, BRANCH, BASE, HEAD3, last_outcome="fail"
+        )
+        assert result["phase"] == "fix-diff"
+        assert result["since_ref"] == HEAD3
+        assert result["escalate"] is False
+        assert delete is False
+        assert new_state["phase"] == "fix-diff"
+        assert new_state["last_reviewed_sha"] == HEAD3
+
+
+class TestCrashRecoveryResume:
+    def test_a_never_recorded_initial_call_resumes_full_branch_at_the_same_round(self, tmp_path):
+        state = tmp_path / "s.json"
+        # First call decides a full-branch check but the process "crashes"
+        # before --last-outcome is ever recorded.
+        first = _run(state, head_sha=HEAD1)
+        assert first["phase"] == "initial"
+
+        # A fresh /pr invocation resumes — still full-branch, same round —
+        # rather than jumping to a narrower scope that never actually ran.
+        second = _run(state, head_sha=HEAD1)
+        assert second["phase"] == "initial"
+        assert second["round"] == 1
+        assert second["since_ref"] == BASE
+        assert second["reset_reason"] is None


### PR DESCRIPTION
## Summary

- Adds `plugins/dev-team/skills/pr/scripts/gate_retry_state.py`, a deterministic state machine that persists `/pr`'s Step-2 code-review gate scope across separate `/pr` invocations, so a retry after a human fixes findings scopes to just the fix delta instead of re-scanning the whole branch.
- Rewrites `pr/SKILL.md` Step 2's code-review bullet to drive this: `initial` (full-branch) → `fix-diff` (narrowed retry) → `confirm` (one mandatory full-branch pass immediately before the gate can close) → `done`, bounded to at most 2 `/code-review` calls per `/pr` invocation.
- Adds a short cross-reference note in `code-review/SKILL.md`'s round-ledger section clarifying that its own ledger only covers rounds *within* one invocation, and pointing to `/pr`'s gate-retry loop as the caller-level analog for repeated invocations.

## Root cause

Observed on PR #2085: `/pr`'s gate (`/code-review --since <merge-base> --json`) was invoked three separate times before converging, each re-scanning the full 10-file branch diff with a 6-8 finder-agent fleet — reconstructed cost ~$242 across 91 dispatches. `/code-review`'s existing round ledger (`finding_signature.py`, #1625) and closing pass (`closing_pass.py`, #1626) already scope re-verification to the fix delta, but strictly *within* one `/code-review` invocation; `finding_signature.py`'s own reset-trigger table is explicit that "round 1 always starts a new run," so every fresh `/pr` invocation after a human's out-of-band fix restarted at round 1, full branch, full panel. That's the mechanism this PR closes — scoped to `/pr`'s own gate-retry loop, not to `/code-review`'s internal loop (which is correct and untouched).

`gate_retry_state.py` mirrors `finding_signature.py`'s conventions deliberately: same four-trigger, precedence-ordered, fails-toward-a-reset reset table (explicit `--reset`, branch mismatch, base-sha mismatch, 24h staleness); same round-cap value and reasoning (`PR_GATE_MAX_ROUNDS = 4`, independently defined and drift-tested against `finding_signature.MAX_ROUNDS` so the two can't silently diverge, same pattern as `closing_pass.py`'s `MIN_DISTINCT_DISPATCHES`).

## Test Plan

- [x] `pytest plugins/dev-team/tests/scripts/test_gate_retry_state.py plugins/dev-team/tests/scripts/test_finding_signature.py plugins/dev-team/tests/scripts/test_closing_pass.py -q` → 87 passed (reset triggers, round-cap escalation, full happy-path phase sequence, confirm-fail behavior, crash-recovery resume, drift tests against `finding_signature.py`'s constants)
- [x] Full pre-push suite: `pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks -n auto --dist loadgroup` → 10207 passed, 48 skipped, 0 failed
- [x] `python3 scripts/check_md_references.py` → exit 0
- [x] `python3 plugins/dev-team/hooks/lib/build_knowledge_index.py` → no drift
- [x] `ruff check` on new/touched files → clean
- [x] `scripts/ci-local.sh` (pre-push hook) → all local CI checks passed

Closes #2087

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_