### PR TITLE
refactor(agents): shrink complexity-review to its judgment residue

### DIFF
--- a/plugins/dev-team/agents/complexity-review.md
+++ b/plugins/dev-team/agents/complexity-review.md
@@ -1,7 +1,7 @@
 ---
 
 name: complexity-review
-description: Cyclomatic complexity, nesting depth, function size, parameter count
+description: Nesting depth, cognitive load, and async-pattern complexity judgment
 tools: Read, Grep, Glob, mcp__codegraph__*, mcp__plugin_repowise_repowise__get_context, mcp__plugin_repowise_repowise__get_symbol, mcp__plugin_repowise_repowise__search_codebase, mcp__plugin_repowise_repowise__get_health
 model: sonnet
 effort: high
@@ -19,9 +19,26 @@ Output JSON: per `${CLAUDE_PLUGIN_ROOT}/knowledge/review-agent-output-contract.m
 
 Status: pass=manageable, warn=hotspots, fail=critical issues
 Severity: error=unmaintainable, warning=high complexity, suggestion=could simplify
-Confidence: high=threshold violation (function >N lines, nesting >N levels); medium=extraction direction clear, exact split requires context; none=requires human judgment (algorithm design)
+Confidence: high=threshold violation (nesting >N levels); medium=extraction direction clear, exact split requires context; none=requires human judgment (algorithm design)
 
 Context needs: full-file
+
+## Charter (#1983 Part 1)
+
+Function length (>20 lines), cyclomatic complexity (>10), and parameter
+count (>5) are now reported by the deterministic `static-analysis-integration`
+lizard pre-pass in the same review round (`lizard.complexity.function-length`
+/ `.cyclomatic` / `.parameter-count` — see `skills/static-analysis-integration/references/tool-configs.md`,
+lizard section). Do not re-derive those three as this lens's own findings —
+re-deriving by inference what a deterministic tool already reported for the
+same round is exactly the duplication `#1974`'s pre-pass lanes exist to
+remove. This lens's charter is the judgment residue lizard cannot compute:
+**max nesting depth** (lizard's own nesting-adjacent metric is cumulative
+*nested-structure* complexity, not max depth, and does not correlate with
+any fixed "deeply nested" threshold — verified in tool-configs.md's lizard
+section), plus judgment calls no metric expresses at all — cognitive load,
+async-pattern pitfalls, and *why* a hotspot is essential vs. accidental
+complexity.
 
 ## Knowledge Files
 
@@ -36,24 +53,21 @@ Return `{"status": "skip", "issues": [], "summary": "No code files in target"}` 
 
 ## Thresholds
 
-| Metric | Limit |
-| -------- | ------- |
-| Function lines | <20 |
-| Cyclomatic complexity | <10 |
-| Nesting depth | <4 |
-| Parameters | <5 |
+| Metric | Limit | Source |
+| -------- | ------- | ------- |
+| Nesting depth | <4 | this lens (lizard exposes no max-depth metric) |
+| Function lines | <20 | lizard pre-pass — do not re-report |
+| Cyclomatic complexity | <10 | lizard pre-pass — do not re-report |
+| Parameters | <5 | lizard pre-pass — do not re-report |
 
 ## Detect
 
-Function size:
+Nesting:
 
-- Functions >20 lines
-- Functions with >5 parameters
+- >4 nesting levels — this lens's own mechanical check; lizard exposes no max-depth metric (see Charter above)
 
-Control flow:
+Control flow (judgment, not raw counts — branch-count and cyclomatic complexity are the lizard pre-pass's territory):
 
-- >10 branches (if/else/switch cases)
-- >4 nesting levels
 - Complex boolean expressions
 - Large switch statements
 
@@ -65,7 +79,7 @@ Async:
 
 Cognitive load:
 
-- Too many concepts per function
+- Too many concepts per function (independent of raw line/parameter count — a short function juggling several unrelated responsibilities is still a finding)
 - Non-obvious control flow
 
 `get_health`'s complexity-dimension scoring is available to corroborate findings.
@@ -76,9 +90,10 @@ After producing findings, run the shared challenger loop in `${CLAUDE_PLUGIN_ROO
 
 - Did you check ALL methods and functions, not just the visibly large ones?
 - For each nesting-depth finding, did you count the actual levels rather than estimating by appearance?
-- Are there methods just under the threshold (19 lines, 3 levels) that warrant a warning?
+- Are there methods just under the nesting threshold (3 levels) that warrant a warning?
 - Did you distinguish between genuine cognitive complexity (multiple concepts) and mechanical repetition (defensive null checks)?
 - For async findings, did you verify the pattern is actually problematic in context (library vs. application code)?
+- Did you avoid re-reporting a bare function-length, parameter-count, or cyclomatic-complexity breach as your own finding? Those are the lizard pre-pass's job now (see Charter above) — report them only if they carry a genuine judgment angle (e.g. tied to a cognitive-load or nesting finding), not as a standalone metric restatement.
 
 Append confidence level (High/Medium/Low) to the `summary` field.
 

--- a/plugins/dev-team/docs/agent_info.md
+++ b/plugins/dev-team/docs/agent_info.md
@@ -31,7 +31,7 @@ Review agents run as sub-agents during Phase 3 inline checkpoints and full `/cod
 | `angular-reactivity-review` | [`angular-reactivity-review.md`](../agents/angular-reactivity-review.md) | sonnet | Angular Zone.js pitfalls, OnPush violations, RxJS subscription leaks |
 | `arch-review` | [`arch-review.md`](../agents/arch-review.md) | opus | ADR compliance, layer violations, dependency direction |
 | `claude-setup-review` | [`claude-setup-review.md`](../agents/claude-setup-review.md) | haiku | CLAUDE.md completeness and accuracy |
-| `complexity-review` | [`complexity-review.md`](../agents/complexity-review.md) | haiku | Function size, cyclomatic complexity, nesting |
+| `complexity-review` | [`complexity-review.md`](../agents/complexity-review.md) | sonnet | Nesting depth, cognitive load, async-pattern judgment |
 | `component-architecture-review` | [`component-architecture-review.md`](../agents/component-architecture-review.md) | sonnet | Reusable component extraction, UI duplication, prop drilling, component APIs |
 | `concurrency-review` | [`concurrency-review.md`](../agents/concurrency-review.md) | sonnet | Race conditions, async pitfalls |
 | `correctness-review` | [`correctness-review.md`](../agents/correctness-review.md) | opus | Functional/behavioral defects — implementation diverges from evident intent |

--- a/plugins/dev-team/knowledge/agent-registry.md
+++ b/plugins/dev-team/knowledge/agent-registry.md
@@ -38,7 +38,7 @@ Each row below is also classified as a **discovery lens** or **verification gate
 | ai-provenance-review | `agents/ai-provenance-review.md` | AI-authored test assertion verification debt, regeneration-risk candidates (magic values, unusual ordering) with no human-verification evidence |
 | arch-review | `agents/arch-review.md` | ADR compliance, layer boundary violations, dependency direction, pattern consistency |
 | claude-setup-review | `agents/claude-setup-review.md` | CLAUDE.md completeness, rules, skills, path accuracy |
-| complexity-review | `agents/complexity-review.md` | Function size, cyclomatic complexity, nesting, parameters |
+| complexity-review | `agents/complexity-review.md` | Nesting depth, cognitive load, async-pattern judgment (function size/cyclomatic/parameter thresholds moved to the lizard pre-pass, #1983) |
 | component-architecture-review | `agents/component-architecture-review.md` | Reusable component extraction, frontend UI duplication, prop drilling, component granularity, inconsistent component APIs |
 | concurrency-review | `agents/concurrency-review.md` | Race conditions, async pitfalls, shared state |
 | correctness-review | `agents/correctness-review.md` | Functional/behavioral defects — implementation diverges from evident intent |

--- a/plugins/dev-team/knowledge/review-lens-classification.md
+++ b/plugins/dev-team/knowledge/review-lens-classification.md
@@ -35,7 +35,7 @@ and attempting the recomputation, not acting on either yet").
 | ai-provenance-review | discovery-lens | Surfaces unverified AI-authored assertions and regeneration-risk candidates — an open detection surface. |
 | arch-review | discovery-lens | Scans layer boundaries, dependency direction, and pattern consistency broadly; its ADR-compliance sub-check is verification-flavored, but the majority of its surface is open-ended discovery. |
 | claude-setup-review | discovery-lens | Scans for an open set of CLAUDE.md/rule/path gaps, not one pass/fail check. |
-| complexity-review | discovery-lens | Metric-based scan (size, cyclomatic complexity, nesting, parameters) with no external fixed contract. |
+| complexity-review | discovery-lens | Judgment scan (nesting depth, cognitive load, async-pattern pitfalls) with no external fixed contract; size/cyclomatic/parameter thresholds are the lizard pre-pass's job (#1983). |
 | component-architecture-review | discovery-lens | Scans for reusable-component extraction, duplication, and prop-drilling — open-ended. |
 | concurrency-review | discovery-lens | Scans for race conditions, async pitfalls, shared state — open-ended. |
 | correctness-review | discovery-lens | Named explicitly as discovery in `skills/code-review/SKILL.md` ("an inverted assertion is exactly its subject"). |


### PR DESCRIPTION
## Summary

- Shrinks `complexity-review`'s charter to remove function-length, cyclomatic-complexity, and parameter-count as its own findings — the deterministic `static-analysis-integration` lizard pre-pass now reports those (`lizard.complexity.function-length`/`.cyclomatic`/`.parameter-count`), so re-deriving them by inference is exactly the duplication #1974's pre-pass lanes exist to remove.
- The lens's charter is now the residue lizard cannot compute: max nesting depth (lizard has no max-depth metric — documented in `tool-configs.md`), plus cognitive-load and async-pattern judgment lizard has no metric for at all.
- Effort stays `high`, deliberately — the residual charter is *more* judgment-shaped than before, and #1982's own rubric reserves `effort: medium` for checklist-shaped lenses.
- Does **not** retire the lens or fold it into `structure-review` (the issue's other option) — that's a bigger dispatch-composition call left for a follow-up with its own A/B evidence.
- Fixes an unrelated pre-existing staleness in the same `docs/agent_info.md` row (said `model: haiku`; frontmatter has said `sonnet` all along).

## Evidence

`/agent-eval` before/after on `evals/fixtures/cx-*.json` (7 fixtures, fresh `claude -p /review-agent complexity-review --json --internal` subprocesses, single trial): **5/7 pass before, 5/7 pass after — same fixtures, no detection regression.** The 2 failures are a pre-existing issueCount/status calibration gap present on unmodified `main` too, unrelated to this change. `cx-god-function` (the fixture most at risk — its whole premise is the three removed checks) still passes: the shrunk charter still surfaces "71 lines, 7 parameters," now framed as cognitive-load evidence rather than bare threshold restatements.

Full before/after transcripts and the redundancy-evidence table (lizard `rule_id` → complexity-review threshold mapping) are recorded in the decision comment on #1983: https://github.com/bdfinst/agentic-dev-team/issues/1983#issuecomment-5452313853

## Test Plan

- [x] `python3 scripts/citation_lint.py --plugin-root plugins/dev-team plugins/dev-team/agents/complexity-review.md` — clean, no drift warnings
- [x] `python3 -m pytest tests/docs/test_agent_info_registry_sync.py tests/repo/test_registry_sync.py tests/repo/test_agent_frontmatter_docs.py tests/repo/test_validate_agent_contract.py tests/repo/test_citation_lint_corpus.py -q` — 28 passed
- [x] Full pre-push suite (`plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks`) — 10,216 passed, 48 skipped
- [x] `scripts/ci-local.sh` full local CI mirror (22 checks) — all green
- [x] `/agent-eval` before/after on `complexity-review`'s 7 fixtures — parity, no regression (see above)

Part of #1983

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_