### PR TITLE
fix(hooks): dedupe token-efficiency limits, plugin-version read, and stdin/cwd preambles

### DIFF
--- a/plugins/dev-team/hooks/code_intelligence_turn_mark.py
+++ b/plugins/dev-team/hooks/code_intelligence_turn_mark.py
@@ -104,23 +104,7 @@ except ImportError:  # pragma: no cover
             return False
 
 
-def _read_stdin() -> str:
-    """Read the stdin payload once. Empty on error — the .sh silently exits 0."""
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> dict:
-    """Parse the PostToolUse JSON. Malformed input → {} (fail-open)."""
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 
 def _tool_family(name: str) -> str | None:
@@ -291,11 +275,10 @@ def _write_sentinel_atomic(sentinel: Path, payload: dict) -> None:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    if not raw:
+    payload = read_stdin_json() or {}
+    if not payload:
         return 0
 
-    payload = _load_input(raw)
     tool_name = payload.get("tool_name") or ""
     family = _tool_family(tool_name) if isinstance(tool_name, str) else None
     if family is None:

--- a/plugins/dev-team/hooks/contract_version_guard.py
+++ b/plugins/dev-team/hooks/contract_version_guard.py
@@ -40,6 +40,7 @@ if str(_LIB_DIR) not in sys.path:
 
 from atomic_state import append_line_locked
 from boundary_events import emit_boundary_event as _emit_boundary_event
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 
 def emit_boundary_event(*args, **kwargs) -> None:
@@ -60,23 +61,6 @@ _AUDIT_LOG = _REPO_ROOT / "metrics" / "contract-version-guard-audit.jsonl"
 # ---------------------------------------------------------------------------
 # stdin
 # ---------------------------------------------------------------------------
-
-
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> dict:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
 
 
 # ---------------------------------------------------------------------------
@@ -286,8 +270,7 @@ def _normalize_path(file_path: str) -> str:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json() or {}
     tool_input = (
         payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
     )

--- a/plugins/dev-team/hooks/cost_meter.py
+++ b/plugins/dev-team/hooks/cost_meter.py
@@ -30,7 +30,6 @@ Refs: #572 (bash → Python migration epic).
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
@@ -45,23 +44,7 @@ if str(_LIB_DIR) not in sys.path:
 
 import artifact_paths
 import telemetry_consent
-
-
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> dict:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 
 def main() -> int:
@@ -79,8 +62,7 @@ def main() -> int:
     if not _COST_METER_LIB.is_file():
         return 0
 
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json() or {}
     if not payload:
         return 0
 

--- a/plugins/dev-team/hooks/destructive_guard.py
+++ b/plugins/dev-team/hooks/destructive_guard.py
@@ -47,6 +47,7 @@ if str(_LIB_DIR) not in sys.path:
 
 import artifact_paths
 from boundary_events import emit_boundary_event as _emit_boundary_event
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 
 def emit_boundary_event(*args, **kwargs) -> None:
@@ -89,13 +90,6 @@ _DEFAULT_SAFE_PATTERNS = [
 ]
 
 
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
 def _load_json(path: Path) -> dict | None:
     try:
         with path.open("r", encoding="utf-8") as fh:
@@ -103,16 +97,6 @@ def _load_json(path: Path) -> dict | None:
     except (OSError, json.JSONDecodeError, ValueError):
         return None
     return data if isinstance(data, dict) else None
-
-
-def _load_input(raw: str) -> dict:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
 
 
 def _extract_command(payload: dict) -> str:
@@ -382,8 +366,7 @@ def _override_active() -> bool:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json() or {}
     command = _extract_command(payload)
     if not command:
         return 0

--- a/plugins/dev-team/hooks/eval_compliance_check.py
+++ b/plugins/dev-team/hooks/eval_compliance_check.py
@@ -23,22 +23,11 @@ import re
 import sys
 from pathlib import Path
 
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> dict:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 
 def _classify(file_path: str) -> str:
@@ -407,8 +396,7 @@ def _other_notice(file_path: str) -> str | None:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json() or {}
     tool_input = (
         payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
     )

--- a/plugins/dev-team/hooks/js_fp_review.py
+++ b/plugins/dev-team/hooks/js_fp_review.py
@@ -16,10 +16,15 @@ Stdlib-only (json/pathlib/re/sys). See ADR 0014.
 
 from __future__ import annotations
 
-import json
 import re
 import sys
 from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 # Suffixes that trigger the check.
 _JS_TS_EXT = (".js", ".ts", ".jsx", ".tsx")
@@ -46,23 +51,6 @@ _THIS_EXCLUDE_RE = re.compile(r"\bthis\.")
 
 # Bash comment-skip: `grep -v '^\s*//'` — line whose first non-whitespace is `//`.
 _COMMENT_LINE_RE = re.compile(r"^\s*//")
-
-
-def _read_stdin() -> str:
-    try:
-        return sys.stdin.read()
-    except (OSError, ValueError):
-        return ""
-
-
-def _load_input(raw: str) -> dict:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
 
 
 def _extract_file_path(payload: dict) -> str:
@@ -196,8 +184,7 @@ def _build_warnings(content: str) -> str:
 
 
 def main() -> int:
-    raw = _read_stdin()
-    payload = _load_input(raw)
+    payload = read_stdin_json() or {}
     file_path_str = _extract_file_path(payload)
     if not file_path_str:
         return 0

--- a/plugins/dev-team/hooks/lib/boundary_events.py
+++ b/plugins/dev-team/hooks/lib/boundary_events.py
@@ -32,6 +32,7 @@ if str(_LIB_DIR) not in sys.path:
 
 import artifact_paths
 import atomic_state
+import plugin_version
 
 _LOG_NAME = "boundary-events.jsonl"
 
@@ -74,19 +75,6 @@ TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 def _isoformat_utc() -> str:
     return datetime.now(timezone.utc).strftime(TS_FORMAT)
-
-
-def _load_plugin_version() -> str:
-    # hooks/lib/boundary_events.py -> hooks/lib -> hooks -> plugin root
-    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
-    try:
-        data = json.loads(manifest.read_text(encoding="utf-8"))
-        version = data.get("version")
-        if isinstance(version, str) and version:
-            return version
-    except (OSError, ValueError):
-        pass
-    return "unknown"
 
 
 def emit_boundary_event(
@@ -163,7 +151,7 @@ def emit_boundary_event(
             "tool": tool,
             "decision": decision,
             "matched_rule": matched_rule,
-            "plugin_version": _load_plugin_version(),
+            "plugin_version": plugin_version.shipped_version(),
         }
         if session_id:
             payload["session_id"] = session_id

--- a/plugins/dev-team/hooks/lib/iteration_journal_gate.py
+++ b/plugins/dev-team/hooks/lib/iteration_journal_gate.py
@@ -37,6 +37,7 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+import plugin_version
 from atomic_state import append_line_locked
 from boundary_events import emit_boundary_event
 
@@ -46,19 +47,6 @@ _DELAY_ENV_VAR = "DEV_TEAM_ITERATION_JOURNAL_TEST_DELAY_MS"
 
 def _isoformat_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _load_plugin_version() -> str:
-    # hooks/lib/iteration_journal_gate.py -> hooks/lib -> hooks -> plugin root
-    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
-    try:
-        data = json.loads(manifest.read_text(encoding="utf-8"))
-        version = data.get("version")
-        if isinstance(version, str) and version:
-            return version
-    except (OSError, ValueError):
-        pass
-    return "unknown"
 
 
 def _log_path(cwd, migrate: bool = True) -> Path:
@@ -102,7 +90,7 @@ def record_iteration_entry(
             "attempted": attempted,
             "outcome": outcome,
             "next_action": next_action,
-            "plugin_version": _load_plugin_version(),
+            "plugin_version": plugin_version.shipped_version(),
         }
         if session_id:
             payload["session_id"] = session_id

--- a/plugins/dev-team/hooks/lib/plugin_version.py
+++ b/plugins/dev-team/hooks/lib/plugin_version.py
@@ -22,8 +22,31 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path
 
 PLUGIN = "dev-team"
+
+
+def shipped_version() -> str:
+    """Read the ``version`` declared in this checkout's shipped plugin.json.
+
+    Distinct from resolve()/main() below, which report what Claude Code has
+    *installed* (from ``installed_plugins.json``) — this reads the manifest
+    that ships in the plugin tree itself, for callers (event-stream emitters)
+    that stamp their own output with "which version of me produced this."
+    Previously duplicated verbatim in hooks/lib/boundary_events.py,
+    workflow_state.py, and iteration_journal_gate.py.
+    """
+    # hooks/lib/plugin_version.py -> hooks/lib -> hooks -> plugin root
+    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        version = data.get("version")
+        if isinstance(version, str) and version:
+            return version
+    except (OSError, ValueError):
+        pass
+    return "unknown"
 
 
 def config_dir() -> str:

--- a/plugins/dev-team/hooks/lib/stdin_json.py
+++ b/plugins/dev-team/hooks/lib/stdin_json.py
@@ -6,7 +6,10 @@ mutation_testing_smoke_gate.py, code_intelligence_nudge.py, codegraph_bootstrap.
 bash_retry_guard.py) each carried an identical copy of this read/parse/
 validate step (#732). This module is the shared extraction. Also adopted by
 context_ceiling_guard.py (#779), replacing its own local copy of the same
-read/parse/validate step.
+read/parse/validate step, and by several more hooks (code_intelligence_turn_mark.py,
+contract_version_guard.py, cost_meter.py, destructive_guard.py,
+eval_compliance_check.py, js_fp_review.py, task_completion_metrics.py) whose
+own copies had drifted back in independently of the #732 migration.
 
 Stdlib-only. See docs/python-hook-contract.md.
 """
@@ -14,7 +17,9 @@ Stdlib-only. See docs/python-hook-contract.md.
 from __future__ import annotations
 
 import json
+import os
 import sys
+from pathlib import Path
 
 
 def read_stdin_json() -> dict | None:
@@ -37,3 +42,17 @@ def read_stdin_json() -> dict | None:
     except json.JSONDecodeError:
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def resolve_cwd(payload: dict) -> str:
+    """Return the hook payload's ``cwd`` if it names a real directory, else
+    the process's own working directory.
+
+    Previously copy-pasted verbatim in mcp_json_repowise_nudge.py,
+    repo_review_nudge.py, and pending_review_notify.py, alongside their own
+    (also copy-pasted) stdin-read preamble — now just `read_stdin_json()`.
+    """
+    cwd = payload.get("cwd") or ""
+    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
+        return os.getcwd()
+    return cwd

--- a/plugins/dev-team/hooks/lib/token_efficiency_limits.py
+++ b/plugins/dev-team/hooks/lib/token_efficiency_limits.py
@@ -6,10 +6,20 @@ Single source of truth for the limits enforced by both
 `plugins/dev-team/scripts/token_efficiency_review.py` (the review-agent CI runner). Both
 previously hardcoded their own copy of these numbers.
 
+It is also the single source of truth for two small pieces of *logic* that
+drifted between those same two callers: which filename counts as "CLAUDE.md"
+and how "character count" is measured. The hook used to match only the exact
+case `CLAUDE.md` and count bytes; the CI runner matched case-insensitively
+and counted decoded characters — so the same file could report two different
+counts, or be checked in one caller and silently skipped in the other,
+depending on nothing but its name's casing.
+
 Stdlib-only. See docs/python-hook-contract.md.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 # CLAUDE.md character-count limit (advisory in the hook, hard error in CI).
 CLAUDE_MD_CHAR_LIMIT: int = 5000
@@ -24,3 +34,18 @@ FILE_LINE_LIMIT: int = 500
 # count rules — but a second reader is exactly how the other two limits drifted
 # into needing this module in the first place.
 CLAUDE_MD_RULE_LIMIT: int = 200
+
+
+def is_claude_md_file(path: Path) -> bool:
+    """Return True when `path`'s filename is CLAUDE.md, case-insensitively."""
+    return path.name.lower() == "claude.md"
+
+
+def char_count(path: Path) -> int:
+    """Return the decoded character count of `path`.
+
+    Character count, not byte count: `CLAUDE_MD_CHAR_LIMIT` is a token-budget
+    proxy, and decoded characters track token count far more closely than
+    bytes do for any file containing multi-byte UTF-8 sequences.
+    """
+    return len(path.read_text(encoding="utf-8", errors="replace"))

--- a/plugins/dev-team/hooks/lib/workflow_state.py
+++ b/plugins/dev-team/hooks/lib/workflow_state.py
@@ -32,6 +32,7 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+import plugin_version
 from atomic_state import append_line_locked
 
 _LOG_NAME = "workflow-states.jsonl"
@@ -42,19 +43,6 @@ CANONICAL_LIFECYCLE = ["SPEC", "PLAN", "BUILD", "REVIEW", "COMMIT", "PR"]
 
 def _isoformat_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _load_plugin_version() -> str:
-    # hooks/lib/workflow_state.py -> hooks/lib -> hooks -> plugin root
-    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
-    try:
-        data = json.loads(manifest.read_text(encoding="utf-8"))
-        version = data.get("version")
-        if isinstance(version, str) and version:
-            return version
-    except (OSError, ValueError):
-        pass
-    return "unknown"
 
 
 def _log_path(cwd, migrate: bool = True) -> Path:
@@ -94,7 +82,7 @@ def emit_state_transition(
             "workflow": workflow,
             "prior_state": prior_state or None,
             "new_state": new_state,
-            "plugin_version": _load_plugin_version(),
+            "plugin_version": plugin_version.shipped_version(),
         }
         if session_id:
             payload["session_id"] = session_id

--- a/plugins/dev-team/hooks/mcp_json_repowise_nudge.py
+++ b/plugins/dev-team/hooks/mcp_json_repowise_nudge.py
@@ -29,8 +29,6 @@ Stdlib-only.
 
 from __future__ import annotations
 
-import json
-import os
 import sys
 from pathlib import Path
 
@@ -38,6 +36,8 @@ _HOOK_DIR = Path(__file__).resolve().parent
 _LIB_DIR = _HOOK_DIR / "lib"
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
+
+from stdin_json import read_stdin_json, resolve_cwd  # type: ignore[import-not-found]
 
 try:
     from mcp_json_repowise import detect  # type: ignore[import-not-found]
@@ -55,22 +55,10 @@ _NUDGE_MESSAGE = (
 
 
 def main() -> int:
-    try:
-        raw = sys.stdin.read()
-    except (OSError, ValueError):
+    payload = read_stdin_json()
+    if payload is None:
         return 0
-    if not raw:
-        return 0
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return 0
-    if not isinstance(payload, dict):
-        return 0
-
-    cwd = payload.get("cwd") or ""
-    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
-        cwd = os.getcwd()
+    cwd = resolve_cwd(payload)
 
     if detect(Path(cwd)) is None:
         return 0

--- a/plugins/dev-team/hooks/pending_review_notify.py
+++ b/plugins/dev-team/hooks/pending_review_notify.py
@@ -33,6 +33,7 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+from stdin_json import read_stdin_json, resolve_cwd  # type: ignore[import-not-found]
 
 
 def _notify_pending_findings(cwd: str) -> str | None:
@@ -104,22 +105,10 @@ def _notify_pending_findings(cwd: str) -> str | None:
 
 
 def main() -> int:
-    try:
-        raw = sys.stdin.read()
-    except (OSError, ValueError):
+    payload = read_stdin_json()
+    if payload is None:
         return 0
-    if not raw:
-        return 0
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return 0
-    if not isinstance(payload, dict):
-        return 0
-
-    cwd = payload.get("cwd") or ""
-    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
-        cwd = os.getcwd()
+    cwd = resolve_cwd(payload)
 
     notice = _notify_pending_findings(cwd)
     if notice is not None:

--- a/plugins/dev-team/hooks/repo_review_nudge.py
+++ b/plugins/dev-team/hooks/repo_review_nudge.py
@@ -90,6 +90,7 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 import artifact_paths
+from stdin_json import read_stdin_json, resolve_cwd  # type: ignore[import-not-found]
 
 _DEFAULT_THRESHOLD_PERCENT = 10.0
 _DEFAULT_MIN_ADDED_LINES = 200
@@ -260,22 +261,10 @@ def _nudge_message(percent: float, added: int, total: int) -> str:
 
 
 def main() -> int:
-    try:
-        raw = sys.stdin.read()
-    except (OSError, ValueError):
+    payload = read_stdin_json()
+    if payload is None:
         return 0
-    if not raw:
-        return 0
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return 0
-    if not isinstance(payload, dict):
-        return 0
-
-    cwd = payload.get("cwd") or ""
-    if not isinstance(cwd, str) or not cwd or not Path(cwd).is_dir():
-        cwd = os.getcwd()
+    cwd = resolve_cwd(payload)
 
     if not _is_git_repo(cwd):
         return 0

--- a/plugins/dev-team/hooks/task_completion_metrics.py
+++ b/plugins/dev-team/hooks/task_completion_metrics.py
@@ -73,6 +73,7 @@ if str(_LIB_DIR) not in sys.path:
 import artifact_paths
 import telemetry_consent
 from atomic_state import append_line_locked
+from stdin_json import read_stdin_json  # type: ignore[import-not-found]
 
 # Scratch file location: resolved relative to the project root (cwd when hook
 # fires) so it is session-local, not baked into the plugin install tree.
@@ -81,17 +82,6 @@ _SCRATCH_RELATIVE = Path(".claude") / "session-metrics.json"
 
 def _env_off(var: str) -> bool:
     return os.environ.get(var, "").strip().lower() == "off"
-
-
-def _read_stdin() -> dict:
-    try:
-        raw = sys.stdin.read()
-        if not raw:
-            return {}
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else {}
-    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
-        return {}
 
 
 def _load_scratch(cwd: Path) -> dict:
@@ -193,7 +183,7 @@ def main() -> int:
     if not telemetry_consent.is_enabled():
         return 0
 
-    payload = _read_stdin()
+    payload = read_stdin_json() or {}
 
     # Resolve project root from the hook payload's cwd, falling back to
     # process cwd (which the harness sets to the project root).

--- a/plugins/dev-team/hooks/token_efficiency_review.py
+++ b/plugins/dev-team/hooks/token_efficiency_review.py
@@ -29,11 +29,19 @@ try:
         CLAUDE_MD_CHAR_LIMIT,
         FILE_LINE_LIMIT,
     )
+    from token_efficiency_limits import char_count as _char_count
+    from token_efficiency_limits import is_claude_md_file as _is_claude_md_file
 except ImportError:
     # Fail-open per the hook contract: never let a missing sibling module
-    # break advisory output. Mirror the shared defaults.
+    # break advisory output. Mirror the shared defaults and logic.
     CLAUDE_MD_CHAR_LIMIT = 5000
     FILE_LINE_LIMIT = 500
+
+    def _is_claude_md_file(path: Path) -> bool:
+        return path.name.lower() == "claude.md"
+
+    def _char_count(path: Path) -> int:
+        return len(path.read_text(encoding="utf-8", errors="replace"))
 
 
 # The .sh's awk pattern: function-declaration heuristics for common
@@ -83,16 +91,15 @@ def _read_json(raw: bytes) -> dict:
 
 def _check_claude_md(path: Path) -> str | None:
     """Character-count check for CLAUDE.md files."""
-    name = path.name.lower()
-    if name not in ("claude.md",):
+    if not _is_claude_md_file(path):
         return None
     try:
-        char_count = len(path.read_bytes())
+        count = _char_count(path)
     except OSError:
         return None
-    if char_count > CLAUDE_MD_CHAR_LIMIT:
+    if count > CLAUDE_MD_CHAR_LIMIT:
         return (
-            f"Token: CLAUDE.md is {char_count} chars (limit: {CLAUDE_MD_CHAR_LIMIT}). "
+            f"Token: CLAUDE.md is {count} chars (limit: {CLAUDE_MD_CHAR_LIMIT}). "
             "Move detailed examples to docs/ or skills."
         )
     return None

--- a/plugins/dev-team/scripts/token_efficiency_review.py
+++ b/plugins/dev-team/scripts/token_efficiency_review.py
@@ -33,6 +33,7 @@ from token_efficiency_limits import (
     CLAUDE_MD_CHAR_LIMIT,
     CLAUDE_MD_RULE_LIMIT,
     FILE_LINE_LIMIT,
+    is_claude_md_file,
 )
 
 # ---------------------------------------------------------------------------
@@ -283,7 +284,7 @@ def main(argv: list[str] | None = None) -> int:
 
     for path in files:
         # CLAUDE.md-specific checks
-        if path.name == "CLAUDE.md":
+        if is_claude_md_file(path):
             for issue in check_claude_md(path):
                 if issue["severity"] == "error":
                     errors.append(issue)

--- a/plugins/dev-team/tests/hooks/test_contract_version_guard.py
+++ b/plugins/dev-team/tests/hooks/test_contract_version_guard.py
@@ -189,7 +189,13 @@ def _run_hook_from(
     # the dependency list, rather than a copy-pasted block per module, so
     # the next new import boundary_events.py picks up needs only a new
     # entry here, not a new block (test-smell review, #1874).
-    for _module_name in ("boundary_events.py", "artifact_paths.py", "atomic_state.py"):
+    for _module_name in (
+        "boundary_events.py",
+        "artifact_paths.py",
+        "atomic_state.py",
+        "plugin_version.py",
+        "stdin_json.py",
+    ):
         target_module = target_lib / _module_name
         if not target_module.exists():
             target_module.write_bytes((_HOOKS_DIR / "lib" / _module_name).read_bytes())

--- a/plugins/dev-team/tests/hooks/test_destructive_guard.py
+++ b/plugins/dev-team/tests/hooks/test_destructive_guard.py
@@ -526,15 +526,6 @@ def test_load_patterns_maps_each_config_key(monkeypatch, tmp_path):
 # --- Pure helpers -----------------------------------------------------------
 
 
-def test_read_stdin_returns_empty_on_error(monkeypatch):
-    class _Boom:
-        def read(self):
-            raise OSError("no stdin")
-
-    monkeypatch.setattr("sys.stdin", _Boom())
-    assert destructive_guard._read_stdin() == ""
-
-
 def test_extract_command_variants():
     assert (
         destructive_guard._extract_command({"tool_input": {"command": "rm -rf /"}})

--- a/plugins/dev-team/tests/hooks/test_stdin_json.py
+++ b/plugins/dev-team/tests/hooks/test_stdin_json.py
@@ -62,3 +62,24 @@ def test_stdin_read_oserror_returns_none(monkeypatch) -> None:  # type: ignore[n
 
     monkeypatch.setattr(sys, "stdin", _BoomStdin())
     assert stdin_json.read_stdin_json() is None
+
+
+def test_resolve_cwd_uses_payload_cwd_when_it_is_a_real_directory(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    assert stdin_json.resolve_cwd({"cwd": str(tmp_path)}) == str(tmp_path)
+
+
+def test_resolve_cwd_falls_back_to_process_cwd_when_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("os.getcwd", lambda: "/fallback")
+    assert stdin_json.resolve_cwd({}) == "/fallback"
+
+
+def test_resolve_cwd_falls_back_when_payload_cwd_is_not_a_directory(
+    monkeypatch, tmp_path
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("os.getcwd", lambda: "/fallback")
+    assert stdin_json.resolve_cwd({"cwd": str(tmp_path / "nope")}) == "/fallback"
+
+
+def test_resolve_cwd_falls_back_when_payload_cwd_is_not_a_string(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("os.getcwd", lambda: "/fallback")
+    assert stdin_json.resolve_cwd({"cwd": 123}) == "/fallback"

--- a/tests/repo/test_gate_ran_husky.py
+++ b/tests/repo/test_gate_ran_husky.py
@@ -80,6 +80,7 @@ def gated_repo(tmp_path: Path, hermetic_env: dict[str, str]) -> Path:
         "artifact_paths.py",
         "atomic_state.py",
         "knowledge_index_paths.py",
+        "plugin_version.py",
     ):
         shutil.copy(_LIB_SRC / name, lib_dst / name)
     (lib_dst / "build_knowledge_index.py").write_text(


### PR DESCRIPTION
## Summary

Fixes four Python duplication clusters found by an internal duplication/layering audit of `plugins/dev-team/{scripts,hooks}` and skill-local scripts:

- **Real correctness bug**: `token_efficiency_review.py` (the shipped hook) and `plugins/dev-team/scripts/token_efficiency_review.py` (the CI review-agent runner) had drifted apart on two checks — the hook counted **bytes**, the script counted **decoded characters**, for the same "CLAUDE.md character limit"; the hook matched the filename case-insensitively, the script matched it exactly. Both now share `is_claude_md_file()`/`char_count()` from `hooks/lib/token_efficiency_limits.py`, so the two entry points can no longer disagree on the same file.
- `hooks/lib/boundary_events.py`, `workflow_state.py`, and `iteration_journal_gate.py` each carried a byte-identical `_load_plugin_version()` despite `hooks/lib/plugin_version.py` already existing as the module for version resolution. Consolidated into `plugin_version.py::shipped_version()` (also fixed a `parents[N]` path-depth slip introduced while extracting it).
- Seven hooks (`code_intelligence_turn_mark`, `contract_version_guard`, `cost_meter`, `destructive_guard`, `eval_compliance_check`, `js_fp_review`, `task_completion_metrics`) still carried their own local stdin-read/parse pair, despite `hooks/lib/stdin_json.py` already existing for exactly this (and having migrated 7 other hooks onto it previously, per its own docstring). Migrated all seven onto `read_stdin_json()`.
- `mcp_json_repowise_nudge.py`, `repo_review_nudge.py`, and `pending_review_notify.py` shared an identical 14-line stdin-read + cwd-resolution preamble. Extracted the cwd-resolution half as `stdin_json.resolve_cwd()` (the stdin-read half already collapses to `read_stdin_json()`).

Net: 22 files changed, -80 lines, no behavior change except the two token-efficiency bug fixes above.

Filed follow-up issues for the larger items from the same audit that didn't fit a same-PR fix: [#2097](https://github.com/bdfinst/agentic-dev-team/issues/2097) (mutation-kill-loop duplication), [#2098](https://github.com/bdfinst/agentic-dev-team/issues/2098) (`session_report.py` layering split), [#2099](https://github.com/bdfinst/agentic-dev-team/issues/2099) (`tests/skills/` content-guard consolidation — from a companion test-suite audit that also concluded test *count* is not a CI bottleneck, ~9,000 tests run in ~90s).

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests tests/repo tests/agents tests/commands tests/docs tests/knowledge tests/stack_aware tests/skills tests/scripts tests/hooks -q -n auto --dist loadgroup` — 10,294 passed, 49 skipped
- [x] `scripts/ci-local.sh` full local CI mirror (22 checks) — all green, including `ruff check .` and the Python 3.10 floor slice
- [x] `python3 scripts/check_md_references.py` — clean
- [x] Two hermetic-copy test fixtures (`tests/repo/test_gate_ran_husky.py`, `plugins/dev-team/tests/hooks/test_contract_version_guard.py`) that copy `boundary_events.py`'s dependency set into an isolated sandbox updated to also copy `plugin_version.py` (and `stdin_json.py` where needed), since `boundary_events.py` now imports it

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_