### PR TITLE
ci(docs): make nav-integrity's mkdocs build --strict

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.x"
+          python-version: '3.x'
 
       - name: Install MkDocs dependencies
         run: pip install -r requirements-docs.txt
@@ -47,13 +47,23 @@ jobs:
         run: bash scripts/assemble-docs.sh
 
       - name: Build site
-        run: mkdocs build --site-dir /tmp/site
+        run:
+          mkdocs build --strict --site-dir /tmp/site 2>&1 | tee
+          /tmp/mkdocs-build.log
 
       # Same nav-integrity assertion the local gate runs (scripts/ci-local.sh's
       # chk_nav_integrity), kept in one script so CI and pre-push can't drift.
       - name: Assert every nav entry resolves to a file
         run: python3 scripts/check_nav_integrity.py
 
+      - name: Report assembled-tree broken-link count
+        if: always()
+        run: |
+          count=$(grep -c "target .* is not found among documentation files" /tmp/mkdocs-build.log || true)
+          echo "Broken links against the assembled docs tree: ${count:-0}"
+          if [ "${count:-0}" -gt 0 ]; then
+            echo "::warning::${count} broken link(s) found against the assembled docs site tree — see the 'Build site' step log above for the full list."
+          fi
   # Validates relative links and anchors inside the documentation bodies. Offline:
   # only local file links are resolved, so external link rot never flakes the gate.
   body-links:
@@ -66,13 +76,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
-            --offline
-            --no-progress
-            README.md
-            GETTING-STARTED.md
-            CONTRIBUTING.md
-            CHANGELOG.md
-            docs/**/*.md
-            plugins/dev-team/README.md
+            --offline --no-progress README.md GETTING-STARTED.md CONTRIBUTING.md
+            CHANGELOG.md docs/**/*.md plugins/dev-team/README.md
             plugins/dev-team/docs/**/*.md
           fail: true


### PR DESCRIPTION
## Summary

- Closes the CI gap #2113 found: `body-links` (lychee) validates the raw repo tree, not the assembled MkDocs site tree that actually gets published, so a link that 404s on the live site could still pass CI.
- `nav-integrity`'s `mkdocs build` now runs with `--strict`, which aborts on any WARNING-level build log line — including a broken body link or drifted anchor against the assembled tree. Safe to make blocking now that #2118 cleared the pre-existing backlog (merged in #2121).
- Applied directly on the branch (pushed by @bdfinst) since this session's credentials lack the `workflow` OAuth scope needed to push `.github/workflows/*.yml` changes itself — verified equivalent to the diff prepared in #2120: same resolved `run:` command, `mkdocs build --strict` still exits 0 clean and `tests/repo/test_required_status_checks.py` still passes.

## Test Plan

- [x] `bash scripts/assemble-docs.sh && mkdocs build --strict --site-dir /tmp/site` — exit 0, clean
- [x] `python3 -m pytest tests/repo/test_required_status_checks.py -q` — passes (new step on an existing job, no new required-check registration needed)
- [x] Previously verified (PR #2121's prepared commit): a deliberately reintroduced broken link fails `--strict` with exit 1

Closes #2120

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_