### PR TITLE
fix: correct Stryker.NET local-tool defaults and Windows test-suite failures

### DIFF
--- a/.github/workflows/wrapper-windows.yml
+++ b/.github/workflows/wrapper-windows.yml
@@ -19,6 +19,7 @@ on:
       # expensive; don't run on every unrelated PR.
       - "plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_*.py"
       - "tests/scripts/test_csharp_stryker_net_*.py"
+      - "plugins/dev-team/tests/scripts/test_csharp_stryker_net_*.py"
       - "tests/fixtures/stryker-net-logs/**"
       - ".github/workflows/wrapper-windows.yml"
 
@@ -48,5 +49,5 @@ jobs:
         # so a CI failure surfaces the actual assertion / exception in the
         # log without spelunking a raw job dump.
         run: |
-          python -m pytest tests/scripts/test_csharp_stryker_net_wrapper.py tests/scripts/test_csharp_stryker_net_status_loop.py -v -ra --tb=short
+          python -m pytest tests/scripts/test_csharp_stryker_net_wrapper.py plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py tests/scripts/test_csharp_stryker_net_slice_runner.py plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py tests/scripts/test_csharp_stryker_net_status_loop.py -v -ra --tb=short
         shell: pwsh

--- a/plugins/dev-team/scripts/coverage_delta_steering.py
+++ b/plugins/dev-team/scripts/coverage_delta_steering.py
@@ -318,4 +318,13 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    # render_text()'s "Δ line"/"Δ branch" headers crash with
+    # UnicodeEncodeError on a non-UTF-8 console (e.g. Windows' default
+    # cp1252) before any output reaches the caller. Forcing UTF-8 here only
+    # affects real script invocation (this guard never runs for an in-process
+    # `import coverage_delta_steering; coverage_delta_steering.main(...)`
+    # caller, e.g. a test using capsys), matching every other script's
+    # console-encoding independence.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     sys.exit(main())

--- a/plugins/dev-team/skills/code-review/scripts/repo_invariants.py
+++ b/plugins/dev-team/skills/code-review/scripts/repo_invariants.py
@@ -174,10 +174,17 @@ _REPO_ROOT = _PLUGIN_ROOT.parents[1]
 
 
 def _repo_relative(path: Path) -> str:
+    """Repo-relative path as a forward-slash string, matching `_changed_set`'s
+    own normalization. On Windows, `str(Path(...))` renders native
+    backslashes — comparing that directly against `_changed_set`'s
+    forward-slash-normalized entries (`rel not in changed`, used by every
+    changed-file-scoped check below) never matches, silently emptying every
+    finding on Windows regardless of what actually changed."""
     try:
-        return str(path.relative_to(_REPO_ROOT))
+        rel = str(path.relative_to(_REPO_ROOT))
     except ValueError:
-        return str(path)
+        rel = str(path)
+    return rel.replace("\\", "/")
 
 
 def _changed_set(changed_files):

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -339,12 +339,13 @@ Run in place of a bare `dotnet stryker`:
 python3 scripts/csharp_stryker_net_wrapper.py \
   --sln Foo.sln \
   --shim-project tests/Foo.Tests.Mutation/Foo.Tests.Mutation.csproj \
-  --stryker-bin dotnet-stryker \
   --logfile StrykerOutput/wrapper.log \
   --config-file stryker-config.json \
   --mutate "**/Validators/**/*.cs" \
   -O StrykerOutput/slice-validators
 ```
+
+The default `--stryker-bin` (`dotnet`) invokes the local tool-manifest install via `dotnet stryker`, matching "prefer local install" above. Pass `--stryker-bin dotnet-stryker` only to target a global install instead.
 
 CLI flags (all optional; every one accepts an environment-variable equivalent so header-var configuration is preserved):
 
@@ -352,7 +353,7 @@ CLI flags (all optional; every one accepts an environment-variable equivalent so
 | --- | --- | --- |
 | `--sln PATH` | `SLN` | `Foo.sln` |
 | `--shim-project PATH` | `SHIM_PROJECT` | (empty; no shim) |
-| `--stryker-bin CMD` | `STRYKER_BIN` | `dotnet-stryker` |
+| `--stryker-bin CMD` | `STRYKER_BIN` | `dotnet` (invoked as `dotnet stryker`) |
 | `--logfile PATH` | `LOGFILE` | `StrykerOutput/wrapper.log` |
 | `--stryker-concurrency N` | `STRYKER_MUTANT_CONCURRENCY` | `max(1, cpu_count - 2)` (computed) |
 
@@ -418,7 +419,15 @@ plugin's shipped scripts are stdlib-only Python, and `json` is stdlib while
 YAML is not). Only `name` + `mutate` are required in this first cut; `kind`,
 `mutation-level`, and `exclude-converged` are accepted and passed through
 but reserved for #667's within-slice refinements — a typo in one of those
-field names still fails config validation, it just isn't acted on yet:
+field names still fails config validation, it just isn't acted on yet.
+
+Any other key is passed through verbatim into the slice's generated
+`stryker-config.json` — most usefully `project`, naming the single source
+`.csproj` under test (Stryker's own `-p`/`--project`/config `"project"`
+key). Without it, Stryker auto-discovers and rebuilds every source project
+transitively referenced by `test-projects` on **every** slice invocation,
+regardless of that slice's `mutate` glob; set `project` to scope a slice to
+just the one source project it actually mutates:
 
 ```json
 {
@@ -426,6 +435,7 @@ field names still fails config validation, it just isn't acted on yet:
     {
       "name": "validators",
       "mutate": "**/Validators/**/*.cs",
+      "project": "src/Foo.Validators/Foo.Validators.csproj",
       "kind": "logic",
       "mutation-level": "Basic",
       "exclude-converged": true

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
@@ -249,11 +249,27 @@ def build_slice_stryker_config(
     ``coverage-analysis`` to ``"perTest"`` per #669's validated
     recommendation, unless the base config already sets it (escape hatch,
     e.g. xunit.v3/MTP projects that must keep it ``"off"``).
+
+    A slice may also carry additional Stryker-config-shaped keys beyond
+    ``mutate`` — most notably ``"project"``, naming the single source
+    ``.csproj`` under test (Stryker's own ``-p``/``--project``/config
+    ``"project"`` key). Without it, Stryker auto-discovers every source
+    project transitively referenced by the configured ``test-projects`` and
+    re-runs its build + initial-test-run + coverage-capture cycle for each
+    one on **every** slice invocation, regardless of that slice's ``mutate``
+    glob — multiplying fixed per-slice overhead by the number of source
+    projects in the solution. Any slice key other than the reserved/required
+    ones handled above is passed through verbatim, so this stays a single
+    generic seam rather than one hardcoded field for ``"project"`` alone.
     """
     cfg = dict(base_config)
     mutate = slice_def["mutate"]
     cfg["mutate"] = mutate if isinstance(mutate, list) else [mutate]
     cfg.setdefault("coverage-analysis", "perTest")
+    for key, value in slice_def.items():
+        if key in KNOWN_SLICE_FIELDS:
+            continue
+        cfg[key] = value
     return cfg
 
 
@@ -397,8 +413,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     p.add_argument(
         "--stryker-bin",
-        default=os.environ.get("STRYKER_BIN", "dotnet-stryker"),
-        help="Stryker executable name (default: %(default)s)",
+        default=os.environ.get("STRYKER_BIN", "dotnet"),
+        help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
+        "manifest install via 'dotnet stryker' (default: %(default)s)",
     )
     p.add_argument(
         "--base-config",

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -222,8 +222,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     p.add_argument(
         "--stryker-bin",
-        default=os.environ.get("STRYKER_BIN", "dotnet-stryker"),
-        help="Stryker executable name (default: %(default)s)",
+        default=os.environ.get("STRYKER_BIN", "dotnet"),
+        help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
+        "manifest install via 'dotnet stryker' (default: %(default)s)",
     )
     p.add_argument(
         "--logfile",
@@ -267,6 +268,28 @@ def _pass_through_concurrency_flag(stryker_args: Sequence[str]) -> str | None:
         if flag in stryker_args:
             return flag
     return None
+
+
+def build_stryker_argv(stryker_bin: str, stryker_args: Sequence[str]) -> list[str]:
+    """Return the full argv for launching Stryker.NET.
+
+    ``dotnet stryker ...`` is the invocation shape for a **local** tool-
+    manifest install — the skill's preferred path (see csharp-stryker-net.md
+    "Prefer a local install"). A local tool's own command name
+    (``dotnet-stryker``) is never placed on ``PATH``; it is only reachable
+    through dotnet's own verb-resolution convention (``dotnet <verb>`` finds
+    a local ``dotnet-<verb>`` tool). A **global** install, by contrast, does
+    put a bare ``dotnet-stryker`` executable on ``PATH``, invoked directly
+    with no subcommand.
+
+    Auto-detected from ``stryker_bin`` alone — no separate flag: when it is
+    exactly ``"dotnet"``, insert the ``stryker`` verb. Any other value (e.g.
+    an explicit ``dotnet-stryker`` override for a global install) is used as
+    the bare executable, unchanged.
+    """
+    if stryker_bin == "dotnet":
+        return ["dotnet", "stryker", *stryker_args]
+    return [stryker_bin, *stryker_args]
 
 
 def build_project(project: str, cwd: Path | None = None) -> int:
@@ -321,7 +344,7 @@ def run_stryker(
     if line_callback is None:
         with logfile.open("wb") as log:
             proc = subprocess.Popen(
-                [stryker_bin, *stryker_args],
+                build_stryker_argv(stryker_bin, stryker_args),
                 stdout=log,
                 stderr=subprocess.STDOUT,
                 cwd=popen_cwd,
@@ -425,7 +448,7 @@ def _run_stryker_streaming(
     """
     with logfile.open("wb") as log:
         proc = subprocess.Popen(
-            [stryker_bin, *stryker_args],
+            build_stryker_argv(stryker_bin, stryker_args),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=popen_cwd,

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -182,7 +182,12 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     p.add_argument("--file", help="Source file to target (basename or path)")
     p.add_argument("--output", default="StrykerOutput/agent", help="Scoped-run output dir")
     p.add_argument("--max-rounds", type=int, default=5, help="Max rounds per file")
-    p.add_argument("--stryker-bin", default="dotnet-stryker", help="Stryker executable")
+    p.add_argument(
+        "--stryker-bin",
+        default="dotnet",
+        help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
+        "manifest install via 'dotnet stryker' (default: %(default)s)",
+    )
     p.add_argument(
         "--headless",
         action="store_true",

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_loop.py
@@ -381,7 +381,7 @@ def run_scoped_stryker(
     source_file: str,
     *,
     output_dir: Path,
-    stryker_bin: str = "dotnet-stryker",
+    stryker_bin: str = "dotnet",
     cwd: Path | None = None,
 ) -> Path:
     """Run Stryker scoped to one file; return the report path.
@@ -442,13 +442,10 @@ def run_scoped_stryker(
             # None-means-failure signal for a caller to revert-and-continue
             # like dotnet_build/dotnet_test/git_revert/git_commit do.
             subprocess.run(
-                [
+                wrapper.build_stryker_argv(
                     stryker_bin,
-                    "--config-file",
-                    str(config_path),
-                    "--output",
-                    str(output_dir),
-                ],
+                    ["--config-file", str(config_path), "--output", str(output_dir)],
+                ),
                 env=env,
                 cwd=cwd,
                 check=False,
@@ -618,7 +615,7 @@ class RunContext:
     test_file: Path
     source_path: Path
     output_dir: Path
-    stryker_bin: str = "dotnet-stryker"
+    stryker_bin: str = "dotnet"
     cwd: Path | None = None
     log: Callable[[str], None] = print
     initial_report_path: Path | None = None

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -350,9 +350,16 @@ def build_loop_command(
     report: Path,
     model: str | None,
     max_rounds: int,
+    stryker_bin: str = "dotnet",
 ) -> list[str]:
     """Build the ``mutation_kill_loop`` invocation. ``--headless`` is forced —
-    the pipeline is unattended and can never depend on a live agent turn."""
+    the pipeline is unattended and can never depend on a live agent turn.
+
+    ``stryker_bin`` is forwarded explicitly so an override on the pipeline's
+    own ``--stryker-bin`` (e.g. targeting a global install) reaches this
+    per-file survivor-fix subprocess too, rather than that subprocess
+    silently falling back to its own independent default.
+    """
     cmd = [
         PYTHON,
         LOOP_SCRIPT,
@@ -369,6 +376,8 @@ def build_loop_command(
         str(report),
         "--max-rounds",
         str(max_rounds),
+        "--stryker-bin",
+        stryker_bin,
     ]
     if model:
         cmd += ["--model", model]
@@ -383,6 +392,7 @@ def launch_survivor_fix(
     config_path: Path,
     model: str | None,
     max_rounds: int,
+    stryker_bin: str = "dotnet",
     run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
     resolve_test_file: TestFileResolver | None = None,
     log: Callable[[str], None] = print,
@@ -452,6 +462,7 @@ def launch_survivor_fix(
             report=report,
             model=model,
             max_rounds=max_rounds,
+            stryker_bin=stryker_bin,
         )
         log(f"[{ts()}] Agent START (headless): {_safe(shard)} — {_safe(source)}")
         result = run(cmd, cwd=str(repo_root))
@@ -641,6 +652,7 @@ def process_shard(
             config_path=shard_config_path(repo_root, shard),
             model=model,
             max_rounds=max_rounds,
+            stryker_bin=stryker_bin,
             run=run,
             resolve_test_file=resolve_test_file,
             log=log,
@@ -720,7 +732,12 @@ def build_parser() -> argparse.ArgumentParser:
         "shards", nargs="*", default=[], help="Shards to run (default: all discovered)"
     )
     parser.add_argument("--repo-root", help="Repo root (default: cwd)")
-    parser.add_argument("--stryker-bin", default="dotnet-stryker", help="Stryker executable")
+    parser.add_argument(
+        "--stryker-bin",
+        default="dotnet",
+        help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
+        "manifest install via 'dotnet stryker' (default: %(default)s)",
+    )
     parser.add_argument(
         "--model",
         help="Generation model for the forced-headless survivor-fix loop.",

--- a/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
@@ -230,7 +230,14 @@ def test_malformed_csproj_is_discovery_error_not_crash(tmp_path):
         result = cdd.discover_dotnet_projects(tmp_path)
 
     assert result["signal"] == "error"
-    assert csproj_rel in result["message"]
+    # The message names the resolved (absolute) path — deliberately, since
+    # `_classify_project` needs the resolved path for its containment check
+    # and the original solution-relative string isn't threaded through to
+    # it. Check the filename rather than the forward-slash relative path:
+    # the latter is a POSIX-only substring of a Windows absolute path,
+    # which renders with backslashes (mirrors the portable convention the
+    # sibling Directory.Build.props test right below already uses).
+    assert "Foo.Tests.csproj" in result["message"]
 
 
 def test_malformed_directory_build_props_is_discovery_error_not_crash(tmp_path):

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
@@ -1,0 +1,97 @@
+"""Unit tests for skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py.
+
+Covers a regression fix: without an explicit ``"project"`` key, Stryker.NET
+auto-discovers every source project transitively referenced by the
+configured ``test-projects`` and re-runs its build + initial-test-run +
+coverage-capture cycle for each one on every slice invocation, regardless of
+that slice's ``mutate`` glob — multiplying fixed per-slice overhead by the
+number of source projects in the solution. ``build_slice_stryker_config``
+now passes through any slice key beyond ``mutate`` (most usefully
+``"project"``) into the generated per-slice config.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(
+    0,
+    str(
+        _REPO_ROOT
+        / "plugins"
+        / "dev-team"
+        / "skills"
+        / "mutation-testing"
+        / "scripts"
+    ),
+)
+
+from csharp_stryker_net_slice_runner import build_slice_stryker_config, parse_args
+
+
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+    args = parse_args(["--slice", "all"])
+
+    assert args.stryker_bin == "dotnet"
+
+
+def test_project_key_is_merged_into_the_generated_config():
+    cfg = build_slice_stryker_config(
+        {"test-projects": ["Foo.Tests.csproj"]},
+        {"name": "widgets", "mutate": "**/Widgets/**/*.cs", "project": "Widgets.csproj"},
+    )
+
+    assert cfg["project"] == "Widgets.csproj"
+
+
+def test_slice_without_a_project_key_omits_it_entirely():
+    cfg = build_slice_stryker_config(
+        {"test-projects": ["Foo.Tests.csproj"]},
+        {"name": "widgets", "mutate": "**/Widgets/**/*.cs"},
+    )
+
+    assert "project" not in cfg
+
+
+def test_name_is_never_merged_into_the_generated_config():
+    cfg = build_slice_stryker_config({}, {"name": "widgets", "mutate": "**/*.cs"})
+
+    assert "name" not in cfg
+
+
+def test_reserved_but_unimplemented_slice_fields_stay_out_of_the_config():
+    # kind / mutation-level / exclude-converged are accepted at the slice
+    # level (reserved for #667) but not yet acted on by this runner — they
+    # must not leak into the generated Stryker config as unknown keys.
+    cfg = build_slice_stryker_config(
+        {},
+        {
+            "name": "widgets",
+            "mutate": "**/*.cs",
+            "kind": "logic",
+            "mutation-level": "Standard",
+            "exclude-converged": True,
+        },
+    )
+
+    assert "kind" not in cfg
+    assert "mutation-level" not in cfg
+    assert "exclude-converged" not in cfg
+
+
+def test_base_config_values_still_flow_through_unchanged():
+    cfg = build_slice_stryker_config(
+        {"test-projects": ["Foo.Tests.csproj"], "reporters": ["dots", "json"]},
+        {"name": "widgets", "mutate": "**/*.cs", "project": "Widgets.csproj"},
+    )
+
+    assert cfg["test-projects"] == ["Foo.Tests.csproj"]
+    assert cfg["reporters"] == ["dots", "json"]
+
+
+def test_mutate_is_still_wrapped_in_a_list_when_given_as_a_bare_string():
+    cfg = build_slice_stryker_config({}, {"name": "widgets", "mutate": "**/*.cs"})
+
+    assert cfg["mutate"] == ["**/*.cs"]

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -31,6 +31,7 @@ sys.path.insert(
     ),
 )
 
+import csharp_stryker_net_wrapper as wrapper
 from csharp_stryker_net_wrapper import build_stryker_argv
 
 
@@ -54,3 +55,82 @@ def test_an_arbitrary_custom_binary_name_is_also_used_unchanged():
 
 def test_empty_stryker_args_still_produces_a_valid_argv():
     assert build_stryker_argv("dotnet", []) == ["dotnet", "stryker"]
+
+
+# ---------------------------------------------------------------------------
+# Regression test (test-review finding on #2146): build_stryker_argv above is
+# only proven correct in isolation -- nothing proves its result actually
+# reaches the real subprocess.Popen call sites in run_stryker() and its
+# streaming variant. A revert of the real fix (e.g. dropping the
+# build_stryker_argv() call and passing [stryker_bin, *stryker_args] again)
+# would have passed every test above.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal Popen stand-in for the non-streaming (callback-less) path."""
+
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+class _FakeStreamProc:
+    """Minimal Popen stand-in for the streaming (line-callback) path: an
+    already-exhausted byte-line ``stdout`` iterator, so the read loop exits
+    immediately and the reap path never needs to escalate."""
+
+    def __init__(self):
+        self.stdout = iter(())
+        self._terminated = False
+
+    def terminate(self):
+        self._terminated = True
+
+    def poll(self):
+        return 0 if self._terminated else None
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def _patch_popen(monkeypatch, proc):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return proc
+
+    monkeypatch.setattr(wrapper.subprocess, "Popen", fake_popen)
+    return captured
+
+
+def test_run_stryker_resolves_the_local_tool_verb_at_the_real_popen_call_site(
+    tmp_path, monkeypatch
+):
+    captured = _patch_popen(monkeypatch, _FakeProc())
+    wrapper.run_stryker("dotnet", ["--config-file", "stryker-config.json"], tmp_path / "w.log")
+    assert captured["cmd"] == ["dotnet", "stryker", "--config-file", "stryker-config.json"]
+
+
+def test_run_stryker_non_dotnet_bin_reaches_popen_unchanged(tmp_path, monkeypatch):
+    captured = _patch_popen(monkeypatch, _FakeProc())
+    wrapper.run_stryker("dotnet-stryker", ["-O", "StrykerOutput"], tmp_path / "w.log")
+    assert captured["cmd"] == ["dotnet-stryker", "-O", "StrykerOutput"]
+
+
+def test_run_stryker_streaming_path_resolves_the_local_tool_verb_at_popen(
+    tmp_path, monkeypatch
+):
+    """Same regression as above, at the SEPARATE subprocess.Popen call site
+    inside _run_stryker_streaming (used whenever a line_callback is passed)."""
+    captured = _patch_popen(monkeypatch, _FakeStreamProc())
+    wrapper.run_stryker(
+        "dotnet",
+        ["--config-file", "stryker-config.json"],
+        tmp_path / "w.log",
+        line_callback=lambda _line: False,
+    )
+    assert captured["cmd"] == ["dotnet", "stryker", "--config-file", "stryker-config.json"]

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -1,0 +1,56 @@
+"""Unit tests for skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py.
+
+Covers a regression fix: the wrapper's ``--stryker-bin`` default (and the
+shipped slice runner's matching default) previously assumed a **global**
+Stryker.NET install — a bare ``dotnet-stryker`` executable reachable
+directly on ``PATH``. The skill's own docs recommend a **local** tool-
+manifest install instead (SKILL.md's "Prefer a local install"), but a local
+tool's command name is never placed on ``PATH`` — it is only reachable
+through ``dotnet``'s own verb-resolution convention (``dotnet stryker``
+finds the local ``dotnet-stryker`` tool). Invoking the previous default
+literally as a subprocess therefore failed outright for the documented,
+preferred install path. ``build_stryker_argv`` fixes this by auto-detecting
+from ``stryker_bin`` whether to insert the ``stryker`` verb.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(
+    0,
+    str(
+        _REPO_ROOT
+        / "plugins"
+        / "dev-team"
+        / "skills"
+        / "mutation-testing"
+        / "scripts"
+    ),
+)
+
+from csharp_stryker_net_wrapper import build_stryker_argv
+
+
+def test_dotnet_stryker_bin_inserts_the_stryker_verb():
+    argv = build_stryker_argv("dotnet", ["--config-file", "stryker-config.json"])
+
+    assert argv == ["dotnet", "stryker", "--config-file", "stryker-config.json"]
+
+
+def test_explicit_global_install_binary_is_used_unchanged():
+    argv = build_stryker_argv("dotnet-stryker", ["--config-file", "stryker-config.json"])
+
+    assert argv == ["dotnet-stryker", "--config-file", "stryker-config.json"]
+
+
+def test_an_arbitrary_custom_binary_name_is_also_used_unchanged():
+    argv = build_stryker_argv("/opt/tools/my-stryker-shim", ["-O", "StrykerOutput"])
+
+    assert argv == ["/opt/tools/my-stryker-shim", "-O", "StrykerOutput"]
+
+
+def test_empty_stryker_args_still_produces_a_valid_argv():
+    assert build_stryker_argv("dotnet", []) == ["dotnet", "stryker"]

--- a/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
@@ -156,7 +156,12 @@ def test_main_does_not_silently_pass_when_dir_does_not_exist(tmp_path, capsys):
     exit_code = gate.main(["--dir", str(missing_dir)])
     assert exit_code == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no .feature files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
@@ -192,7 +192,12 @@ def test_main_does_not_silently_pass_when_dir_does_not_exist(tmp_path, capsys):
     exit_code = gate.main(["--dir", str(missing_dir)])
     assert exit_code == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no .feature files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
@@ -181,7 +181,12 @@ def test_main_does_not_silently_pass_on_missing_dir_no_files_to_scan(tmp_path, c
     rc = gherkin_stub_gate.main(["--dir", str(tmp_path / "nope")])
     assert rc == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no step-definition files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_mutation_kill_headless.py
+++ b/plugins/dev-team/tests/scripts/test_mutation_kill_headless.py
@@ -1,0 +1,33 @@
+"""Unit tests for skills/mutation-testing/scripts/mutation_kill_headless.py.
+
+Pins the ``--stryker-bin`` default to ``"dotnet"`` — the local-tool-manifest
+invocation shape (``dotnet stryker ...``), which is the skill's own
+recommended install path. The previous default (a bare ``dotnet-stryker``)
+assumed a global install and failed outright against a local one.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(
+    0,
+    str(
+        _REPO_ROOT
+        / "plugins"
+        / "dev-team"
+        / "skills"
+        / "mutation-testing"
+        / "scripts"
+    ),
+)
+
+from mutation_kill_headless import parse_args
+
+
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+    args = parse_args([])
+
+    assert args.stryker_bin == "dotnet"

--- a/plugins/dev-team/tests/scripts/test_mutation_kill_loop.py
+++ b/plugins/dev-team/tests/scripts/test_mutation_kill_loop.py
@@ -1,0 +1,73 @@
+"""Unit tests for skills/mutation-testing/scripts/mutation_kill_loop.py.
+
+Covers a regression fix: ``run_scoped_stryker`` invoked its configured
+``stryker_bin`` as a bare subprocess argv[0] — correct for a global
+Stryker.NET install, but the skill's own docs recommend a local tool-
+manifest install instead, whose command name is never placed on ``PATH``
+(only reachable via ``dotnet stryker``). ``run_scoped_stryker`` now builds
+its argv through ``csharp_stryker_net_wrapper.build_stryker_argv``, which
+auto-detects the local-tool-manifest shape from ``stryker_bin`` alone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(
+    0,
+    str(
+        _REPO_ROOT
+        / "plugins"
+        / "dev-team"
+        / "skills"
+        / "mutation-testing"
+        / "scripts"
+    ),
+)
+
+from mutation_kill_loop import LoopConfig, run_scoped_stryker
+
+
+def _config() -> LoopConfig:
+    # solution=None skips the .sln hide/restore dance entirely — this test
+    # is only about the constructed Stryker argv, not the sln ceremony.
+    return LoopConfig(project=None, test_projects=["Foo.Tests.csproj"], mutate=[], solution=None)
+
+
+def test_default_stryker_bin_invokes_via_the_dotnet_verb(tmp_path, monkeypatch):
+    # resolve_dotnet_root's preset wins unconditionally over probing, so
+    # this stubs out the DOTNET_ROOT dependency without asserting anything
+    # about it — the test is only about the constructed Stryker argv, and
+    # must pass identically on a machine with no .NET SDK installed.
+    monkeypatch.setenv("DOTNET_ROOT", str(tmp_path))
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_scoped_stryker(_config(), "Foo.cs", output_dir=tmp_path)
+
+    assert captured["argv"][:2] == ["dotnet", "stryker"]
+    assert "--config-file" in captured["argv"]
+
+
+def test_explicit_global_install_binary_is_invoked_directly(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTNET_ROOT", str(tmp_path))
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_scoped_stryker(_config(), "Foo.cs", output_dir=tmp_path, stryker_bin="dotnet-stryker")
+
+    assert captured["argv"][0] == "dotnet-stryker"
+    assert captured["argv"][1] == "--config-file"

--- a/plugins/dev-team/tests/scripts/test_sliced_mode_docs.py
+++ b/plugins/dev-team/tests/scripts/test_sliced_mode_docs.py
@@ -13,9 +13,9 @@ from pathlib import Path
 _SKILL_DIR = (
     Path(__file__).resolve().parents[2] / "skills" / "code-review"
 )
-_SKILL_MD = (_SKILL_DIR / "SKILL.md").read_text()
-_SLICED_MD = (_SKILL_DIR / "sliced-mode.md").read_text()
-_OUTPUT_FMT = (_SKILL_DIR / "output-format.md").read_text()
+_SKILL_MD = (_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+_SLICED_MD = (_SKILL_DIR / "sliced-mode.md").read_text(encoding="utf-8")
+_OUTPUT_FMT = (_SKILL_DIR / "output-format.md").read_text(encoding="utf-8")
 
 
 # --- SKILL.md: flags + activation routing (Slice 1) ---------------------------

--- a/plugins/dev-team/tests/scripts/test_stryker_shard_pipeline.py
+++ b/plugins/dev-team/tests/scripts/test_stryker_shard_pipeline.py
@@ -1,0 +1,58 @@
+"""Unit tests for skills/mutation-testing/scripts/stryker_shard_pipeline.py.
+
+Pins the ``--stryker-bin`` default to ``"dotnet"`` — the local-tool-manifest
+invocation shape (``dotnet stryker ...``), which is the skill's own
+recommended install path. The previous default (a bare ``dotnet-stryker``)
+assumed a global install and failed outright against a local one. The
+argv actually built for the run itself is unaffected here: this module
+delegates to ``csharp_stryker_net_wrapper.run_stryker``, which owns
+building the real argv (covered by that module's own tests).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from _repo_root import REPO_ROOT as _REPO_ROOT
+
+sys.path.insert(
+    0,
+    str(
+        _REPO_ROOT
+        / "plugins"
+        / "dev-team"
+        / "skills"
+        / "mutation-testing"
+        / "scripts"
+    ),
+)
+
+from pathlib import Path
+
+from stryker_shard_pipeline import build_loop_command, build_parser
+
+
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+    args = build_parser().parse_args([])
+
+    assert args.stryker_bin == "dotnet"
+
+
+def test_build_loop_command_forwards_stryker_bin_to_the_survivor_fix_subprocess():
+    # An explicit --stryker-bin override (e.g. targeting a global install)
+    # on the pipeline must reach the per-file mutation_kill_loop subprocess
+    # too, not silently fall back to that subprocess's own independent
+    # default.
+    cmd = build_loop_command(
+        config=Path("stryker-config.json"),
+        source_file="Foo.cs",
+        source_path="src/Foo.cs",
+        test_file=Path("tests/FooTests.cs"),
+        report=Path("report.json"),
+        model=None,
+        max_rounds=5,
+        stryker_bin="dotnet-stryker",
+    )
+
+    assert "--stryker-bin" in cmd
+    assert cmd[cmd.index("--stryker-bin") + 1] == "dotnet-stryker"

--- a/plugins/dev-team/tests/scripts/test_vendored_tree.py
+++ b/plugins/dev-team/tests/scripts/test_vendored_tree.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))
@@ -21,6 +23,13 @@ import _vendored_tree
 
 
 def _make_fixture(tmp_path):
+    """Returns `(fixture_root, symlink_created)`. Creating a file symlink on
+    Windows raises `OSError: [WinError 1314]` unless the process is elevated
+    or Developer Mode is on (`SeCreateSymbolicLinkPrivilege`) — a real,
+    common contributor-machine limitation, not a bug in this module. macOS
+    and Linux never hit this branch: `symlink_to` there requires no special
+    privilege, so `symlink_created` is always `True` and every test below
+    runs exactly as it did before this guard existed."""
     (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
     (tmp_path / "node_modules" / "pkg" / "index.js").write_text("")
     (tmp_path / ".git").mkdir()
@@ -37,8 +46,12 @@ def _make_fixture(tmp_path):
     (venv / "lib.py").write_text("")
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("")
-    (tmp_path / "src" / "linked.py").symlink_to(tmp_path / "src" / "app.py")
-    return tmp_path
+    symlink_created = True
+    try:
+        (tmp_path / "src" / "linked.py").symlink_to(tmp_path / "src" / "app.py")
+    except OSError:
+        symlink_created = False
+    return tmp_path, symlink_created
 
 
 def test_vendored_dir_names_is_the_expected_fixed_set():
@@ -53,7 +66,7 @@ def test_vendored_dir_names_is_the_expected_fixed_set():
 
 
 def test_is_vendored_dir_recognizes_every_named_dir_and_virtualenv_marker(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, _ = _make_fixture(tmp_path)
     for name in (".git", "node_modules", "vendor", "dist", "build"):
         assert _vendored_tree.is_vendored_dir(fixture / name) is True, name
     assert _vendored_tree.is_vendored_dir(fixture / ".venv") is True
@@ -61,12 +74,14 @@ def test_is_vendored_dir_recognizes_every_named_dir_and_virtualenv_marker(tmp_pa
 
 
 def test_iter_files_prunes_vendored_trees_and_skips_symlinked_files(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, symlink_created = _make_fixture(tmp_path)
+    if not symlink_created:
+        pytest.skip("this platform/account can't create file symlinks without elevation")
     found = {p.relative_to(fixture).as_posix() for p in _vendored_tree.iter_files(fixture)}
     assert found == {"src/app.py"}
 
 
 def test_find_files_applies_predicate_on_top_of_the_same_pruning(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, _ = _make_fixture(tmp_path)
     found = _vendored_tree.find_files([fixture], lambda p: p.suffix == ".py")
     assert [p.relative_to(fixture).as_posix() for p in found] == ["src/app.py"]


### PR DESCRIPTION
--stryker-bin defaulted to a bare executable name, correct only for a global tool install. The skill's own docs recommend a local tool-manifest install instead, whose command is only reachable via the dotnet CLI's local-tool verb resolution -- the previous default failed outright against it. Also lets a slice definition pass through additional config keys (e.g. project) so a slice can scope the run to one source project instead of rebuilding every project in the solution on every slice.

Also adds a regression test proving the resolved argv reaches the real `subprocess.Popen` call sites (not just `build_stryker_argv` in isolation) — a gap flagged by `/code-review`'s test-review agent.

**Merged in at the user's request**: six pre-existing Windows-only test failures plus one cross-platform test-fragility bug, previously PR #2148 (branch `fix/windows-test-suite-failures`) — `_repo_relative()`'s backslash normalization, `coverage_delta_steering.py`'s console-encoding crash, three gate tests' OS-account-name collision, `test_sliced_mode_docs.py`'s platform-default encoding, `test_vendored_tree.py`'s unconditional symlink creation, and `test_coverage_discovery_dotnet.py`'s path-separator assertion. PR #2148 is closed in favor of this one; no functional changes were made to that fix here beyond the merge itself.

## Test Plan

- [x] `python3 -m pytest` on every test file touched by both fixes — 136 passed
- [x] New regression tests for the Popen argv wiring (both the non-streaming and line-callback streaming call sites) — verified they fail against a reverted fix, pass against the real one
- [x] `ruff check` clean

Closes #2142
Closes #2144

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4