### PR TITLE
fix(scripts): fix pre-existing test failures on Windows and a test-fr…

### DIFF
--- a/plugins/dev-team/scripts/coverage_delta_steering.py
+++ b/plugins/dev-team/scripts/coverage_delta_steering.py
@@ -318,4 +318,13 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    # render_text()'s "Δ line"/"Δ branch" headers crash with
+    # UnicodeEncodeError on a non-UTF-8 console (e.g. Windows' default
+    # cp1252) before any output reaches the caller. Forcing UTF-8 here only
+    # affects real script invocation (this guard never runs for an in-process
+    # `import coverage_delta_steering; coverage_delta_steering.main(...)`
+    # caller, e.g. a test using capsys), matching every other script's
+    # console-encoding independence.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     sys.exit(main())

--- a/plugins/dev-team/skills/code-review/scripts/repo_invariants.py
+++ b/plugins/dev-team/skills/code-review/scripts/repo_invariants.py
@@ -174,10 +174,17 @@ _REPO_ROOT = _PLUGIN_ROOT.parents[1]
 
 
 def _repo_relative(path: Path) -> str:
+    """Repo-relative path as a forward-slash string, matching `_changed_set`'s
+    own normalization. On Windows, `str(Path(...))` renders native
+    backslashes — comparing that directly against `_changed_set`'s
+    forward-slash-normalized entries (`rel not in changed`, used by every
+    changed-file-scoped check below) never matches, silently emptying every
+    finding on Windows regardless of what actually changed."""
     try:
-        return str(path.relative_to(_REPO_ROOT))
+        rel = str(path.relative_to(_REPO_ROOT))
     except ValueError:
-        return str(path)
+        rel = str(path)
+    return rel.replace("\\", "/")
 
 
 def _changed_set(changed_files):

--- a/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
+++ b/plugins/dev-team/tests/scripts/test_coverage_discovery_dotnet.py
@@ -230,7 +230,14 @@ def test_malformed_csproj_is_discovery_error_not_crash(tmp_path):
         result = cdd.discover_dotnet_projects(tmp_path)
 
     assert result["signal"] == "error"
-    assert csproj_rel in result["message"]
+    # The message names the resolved (absolute) path — deliberately, since
+    # `_classify_project` needs the resolved path for its containment check
+    # and the original solution-relative string isn't threaded through to
+    # it. Check the filename rather than the forward-slash relative path:
+    # the latter is a POSIX-only substring of a Windows absolute path,
+    # which renders with backslashes (mirrors the portable convention the
+    # sibling Directory.Build.props test right below already uses).
+    assert "Foo.Tests.csproj" in result["message"]
 
 
 def test_malformed_directory_build_props_is_discovery_error_not_crash(tmp_path):

--- a/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_cross_feature_duplicate_titles_gate.py
@@ -156,7 +156,12 @@ def test_main_does_not_silently_pass_when_dir_does_not_exist(tmp_path, capsys):
     exit_code = gate.main(["--dir", str(missing_dir)])
     assert exit_code == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no .feature files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_failure_path_gate.py
@@ -192,7 +192,12 @@ def test_main_does_not_silently_pass_when_dir_does_not_exist(tmp_path, capsys):
     exit_code = gate.main(["--dir", str(missing_dir)])
     assert exit_code == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no .feature files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_gate.py
@@ -181,7 +181,12 @@ def test_main_does_not_silently_pass_on_missing_dir_no_files_to_scan(tmp_path, c
     rc = gherkin_stub_gate.main(["--dir", str(tmp_path / "nope")])
     assert rc == 2
     out = capsys.readouterr().out
-    assert "OK" not in out
+    # A bare "OK" substring check is a false-positive trap: tmp_path embeds
+    # the pytest-generated "pytest-of-<OS username>" segment, which can
+    # itself contain the substring "OK" depending on the account name. The
+    # success path only ever emits a line starting with "OK:" — check for
+    # that instead.
+    assert not any(line.startswith("OK:") for line in out.splitlines())
     assert "no step-definition files found" in out
 
 

--- a/plugins/dev-team/tests/scripts/test_sliced_mode_docs.py
+++ b/plugins/dev-team/tests/scripts/test_sliced_mode_docs.py
@@ -13,9 +13,9 @@ from pathlib import Path
 _SKILL_DIR = (
     Path(__file__).resolve().parents[2] / "skills" / "code-review"
 )
-_SKILL_MD = (_SKILL_DIR / "SKILL.md").read_text()
-_SLICED_MD = (_SKILL_DIR / "sliced-mode.md").read_text()
-_OUTPUT_FMT = (_SKILL_DIR / "output-format.md").read_text()
+_SKILL_MD = (_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+_SLICED_MD = (_SKILL_DIR / "sliced-mode.md").read_text(encoding="utf-8")
+_OUTPUT_FMT = (_SKILL_DIR / "output-format.md").read_text(encoding="utf-8")
 
 
 # --- SKILL.md: flags + activation routing (Slice 1) ---------------------------

--- a/plugins/dev-team/tests/scripts/test_vendored_tree.py
+++ b/plugins/dev-team/tests/scripts/test_vendored_tree.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "dev-team" / "scripts" / "lib"))
@@ -21,6 +23,13 @@ import _vendored_tree
 
 
 def _make_fixture(tmp_path):
+    """Returns `(fixture_root, symlink_created)`. Creating a file symlink on
+    Windows raises `OSError: [WinError 1314]` unless the process is elevated
+    or Developer Mode is on (`SeCreateSymbolicLinkPrivilege`) — a real,
+    common contributor-machine limitation, not a bug in this module. macOS
+    and Linux never hit this branch: `symlink_to` there requires no special
+    privilege, so `symlink_created` is always `True` and every test below
+    runs exactly as it did before this guard existed."""
     (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
     (tmp_path / "node_modules" / "pkg" / "index.js").write_text("")
     (tmp_path / ".git").mkdir()
@@ -37,8 +46,12 @@ def _make_fixture(tmp_path):
     (venv / "lib.py").write_text("")
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("")
-    (tmp_path / "src" / "linked.py").symlink_to(tmp_path / "src" / "app.py")
-    return tmp_path
+    symlink_created = True
+    try:
+        (tmp_path / "src" / "linked.py").symlink_to(tmp_path / "src" / "app.py")
+    except OSError:
+        symlink_created = False
+    return tmp_path, symlink_created
 
 
 def test_vendored_dir_names_is_the_expected_fixed_set():
@@ -53,7 +66,7 @@ def test_vendored_dir_names_is_the_expected_fixed_set():
 
 
 def test_is_vendored_dir_recognizes_every_named_dir_and_virtualenv_marker(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, _ = _make_fixture(tmp_path)
     for name in (".git", "node_modules", "vendor", "dist", "build"):
         assert _vendored_tree.is_vendored_dir(fixture / name) is True, name
     assert _vendored_tree.is_vendored_dir(fixture / ".venv") is True
@@ -61,12 +74,14 @@ def test_is_vendored_dir_recognizes_every_named_dir_and_virtualenv_marker(tmp_pa
 
 
 def test_iter_files_prunes_vendored_trees_and_skips_symlinked_files(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, symlink_created = _make_fixture(tmp_path)
+    if not symlink_created:
+        pytest.skip("this platform/account can't create file symlinks without elevation")
     found = {p.relative_to(fixture).as_posix() for p in _vendored_tree.iter_files(fixture)}
     assert found == {"src/app.py"}
 
 
 def test_find_files_applies_predicate_on_top_of_the_same_pruning(tmp_path):
-    fixture = _make_fixture(tmp_path)
+    fixture, _ = _make_fixture(tmp_path)
     found = _vendored_tree.find_files([fixture], lambda p: p.suffix == ".py")
     assert [p.relative_to(fixture).as_posix() for p in found] == ["src/app.py"]


### PR DESCRIPTION
…agility bug

Six Windows-only failures plus one cross-platform test-fragility bug:

- repo_invariants.py's _repo_relative() rendered native backslashes on Windows, never matching the forward-slash-normalized changed-file set, silently emptying every changed-file-scoped finding.
- coverage_delta_steering.py's render_text() crashed with UnicodeEncodeError under a non-UTF-8 console (Windows' default cp1252).
- Three gate tests asserted "OK" not in out, but tmp_path can itself contain the substring "OK" depending on the OS account name.
- test_sliced_mode_docs.py read markdown fixtures with the platform default encoding instead of UTF-8.
- test_vendored_tree.py's fixture created a file symlink unconditionally, which raises without elevated privileges/Developer Mode on Windows.
- test_coverage_discovery_dotnet.py asserted a forward-slash relative path against a message that names the resolved absolute path, which renders with backslashes on Windows.

Closes #2144


Claude-Session: https://claude.ai/code/session_018qgH8W1see62UtX56CAiRs

<!--
PR title must be a conventional-commit line — this repo squash-merges, so the
title becomes the commit message: <type>(<scope>): <description>.

Docs-only PRs (touching only *.md, .gitignore, LICENSE — no code, agent,
skill, hook, eval fixture, or marketplace manifest) may arm `gh pr merge
--auto --squash` at open time. Anything else needs explicit human merge.
-->

## Summary

- <what changed and why, 1-3 bullets>

## Test Plan

- [ ] <verification step 1>
- [ ] <verification step 2>

<!--
One line per issue this PR resolves, using a real closing keyword (Closes,
Fixes, Resolves). For an epic issue this PR only contributes a slice of, use
"Part of #<epic>" instead — a non-closing reference, since epics don't
auto-close when a sub-issue's PR merges (see epic-auto-close.yml, #987).

Never phrase a non-closing reference with a closing keyword, even negated —
GitHub's parser fires on "fixes #123" regardless of surrounding words like
"does not" or "won't" (issue #977).
-->

Closes #
