### PR TITLE
fix(gherkin): preserve blank-line separator convention when merging s…

### DIFF
--- a/plugins/dev-team/scripts/gherkin_feature_merge.py
+++ b/plugins/dev-team/scripts/gherkin_feature_merge.py
@@ -337,6 +337,25 @@ def _last_line_ending(lines: list) -> str:
     return "\n"
 
 
+def _existing_units_use_blank_line_separator(units: list) -> bool:
+    """Infer whether this Feature block's existing scenarios are separated
+    by a blank line, from the joins between consecutive existing units —
+    excluding the boundary after the very last unit, which sits at the
+    block's end and may carry no trailing blank line for a reason unrelated
+    to the file's separator convention (there is simply nothing after it to
+    separate from). Defaults to `True` when there are fewer than two units
+    to compare, matching the blank-line-between-scenarios style most
+    existing Gherkin files already use — a majority vote (ties favor
+    inserting a blank line) otherwise, so `merge_scenarios` reproduces
+    whichever convention this specific file's own scenarios demonstrate
+    rather than assuming one."""
+    comparable = units[:-1]
+    if not comparable:
+        return True
+    separated = sum(1 for u in comparable if u.text.rstrip(" \t").endswith(("\n\n", "\r\n\r\n")))
+    return separated * 2 >= len(comparable)
+
+
 def merge_scenarios(existing_text: str, feature_title: str, candidate_units: list) -> MergeResult:
     """Append-only merge of `candidate_units` into the named Feature block.
 
@@ -401,6 +420,19 @@ def merge_scenarios(existing_text: str, feature_title: str, candidate_units: lis
         prefix_lines[-1] += ending
     if insertion and not insertion.endswith("\n"):
         insertion += ending
+    # The last existing unit sits at the block's end with nothing after it
+    # to separate from, so its own text alone can't say whether this file
+    # puts a blank line between scenarios — infer that from the *other*
+    # existing joins instead, and reproduce it here rather than assuming
+    # one convention for every repo (issue: a splice landing flush against
+    # the last scenario's final line, with no separating blank line, even
+    # when every other scenario boundary in the file has one).
+    if (
+        prefix_lines
+        and prefix_lines[-1].strip() != ""
+        and _existing_units_use_blank_line_separator(result.block.units)
+    ):
+        prefix_lines.append(ending)
     new_lines = prefix_lines + [insertion] + lines[end_index:]
     merged_text = "".join(new_lines)
 

--- a/plugins/dev-team/scripts/gherkin_stub_merge.py
+++ b/plugins/dev-team/scripts/gherkin_stub_merge.py
@@ -141,9 +141,16 @@ def _existing_bindings_use_blank_line_separator(existing_text: str, bindings: li
     unrelated to the file's own convention. A binding's `.end` (from
     `extend_to_line_end`) stops at its own closing line, so the gap between
     one binding's end and the next binding's start is exactly whatever sits
-    between them — empty when the file has no blank line there, or the
-    blank line's own line terminator when it does. Defaults to `True` when
-    there are fewer than two bindings to compare, matching the
+    between them — empty when the file has no blank line there, the blank
+    line's own line terminator when it does, or just the next binding's
+    leading indentation when the language wraps bindings in an indented
+    block (Java, C#, a class-wrapped JS/TS style) and there is no blank
+    line. That last case is whitespace-only but has no newline in it —
+    `gap.strip() == ""` alone can't tell it apart from a genuine blank
+    line, so a join is only counted as separated when the gap is BOTH
+    whitespace-only AND actually contains a newline (a blank line always
+    has one; bare indentation never does). Defaults to `True` when there
+    are fewer than two bindings to compare, matching the
     blank-line-between-methods style most existing step-definition files
     already use."""
     comparable = bindings[:-1]
@@ -152,7 +159,9 @@ def _existing_bindings_use_blank_line_separator(existing_text: str, bindings: li
     separated = sum(
         1
         for i, binding in enumerate(comparable)
-        if (gap := existing_text[binding.end : bindings[i + 1].start]) and gap.strip() == ""
+        if (gap := existing_text[binding.end : bindings[i + 1].start])
+        and gap.strip() == ""
+        and "\n" in gap
     )
     return separated * 2 >= len(comparable)
 

--- a/plugins/dev-team/scripts/gherkin_stub_merge.py
+++ b/plugins/dev-team/scripts/gherkin_stub_merge.py
@@ -133,13 +133,47 @@ def _insert_at(text: str, idx: int, insertion: str) -> str:
     return prefix + insertion + suffix
 
 
+def _existing_bindings_use_blank_line_separator(existing_text: str, bindings: list) -> bool:
+    """Infer whether this file's existing step bindings are separated by a
+    blank line, from the joins between consecutive existing bindings —
+    excluding the boundary after the very last binding, which sits at the
+    file's end and may have nothing after it to separate from for reasons
+    unrelated to the file's own convention. A binding's `.end` (from
+    `extend_to_line_end`) stops at its own closing line, so the gap between
+    one binding's end and the next binding's start is exactly whatever sits
+    between them — empty when the file has no blank line there, or the
+    blank line's own line terminator when it does. Defaults to `True` when
+    there are fewer than two bindings to compare, matching the
+    blank-line-between-methods style most existing step-definition files
+    already use."""
+    comparable = bindings[:-1]
+    if not comparable:
+        return True
+    separated = sum(
+        1
+        for i, binding in enumerate(comparable)
+        if (gap := existing_text[binding.end : bindings[i + 1].start]) and gap.strip() == ""
+    )
+    return separated * 2 >= len(comparable)
+
+
 def _splice_single_point(existing_text: str, bindings: list, new_candidates: list) -> str:
     """The default splice: append every new candidate's text as one block
     right after the last existing binding (or at file end with no existing
     bindings) — correct whenever a binding's `text` already contains
-    everything the language needs (JS/TS, Java, C#)."""
+    everything the language needs (JS/TS, Java, C#).
+
+    The last existing binding sits at the splice point with nothing after
+    it, so its own text alone can't say whether this file puts a blank
+    line between step definitions — infer that from the *other* existing
+    joins instead (`_existing_bindings_use_blank_line_separator`) and
+    reproduce it here, so a splice landing flush against the last existing
+    method's closing brace doesn't silently drop the blank line every
+    other method boundary in the file already has."""
     insertion_point = bindings[-1].end if bindings else len(existing_text)
     insertion = "".join(candidate.text for candidate in new_candidates)
+    if bindings and insertion and _existing_bindings_use_blank_line_separator(existing_text, bindings):
+        insertion = "\n" + insertion
     return _insert_at(existing_text, insertion_point, insertion)
 
 

--- a/plugins/dev-team/tests/scripts/test_gherkin_feature_merge.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_feature_merge.py
@@ -286,7 +286,9 @@ def test_merge_path_inserts_crlf_separator_when_file_is_crlf():
     """Regression test (ai-provenance-review): the splice-point separator
     used to always inject a bare LF even into a CRLF file with no trailing
     terminator at the splice point. It should now match the file's own
-    dominant line ending instead."""
+    dominant line ending instead. With only one existing scenario (nothing
+    to infer a blank-line convention from), the separator defaults to a
+    blank line, matching the common Gherkin style."""
     text = (
         "Feature: Orders API\r\n\r\n"
         "  Scenario: Create order succeeds\r\n"
@@ -296,7 +298,7 @@ def test_merge_path_inserts_crlf_separator_when_file_is_crlf():
     candidates = [_unit("New CRLF scenario")]
     result = gfm.merge_scenarios(text, "Orders API", candidates)
     assert result.error is None
-    assert "201\r\n  Scenario: New CRLF scenario" in result.text
+    assert "201\r\n\r\n  Scenario: New CRLF scenario" in result.text
     assert "201  Scenario: New CRLF scenario" not in result.text
 
 
@@ -342,7 +344,9 @@ def test_merge_onto_existing_text_missing_a_trailing_newline_does_not_fuse_lines
     no guard on the preceding line's terminator used to concatenate the new
     scenario directly onto the existing file's last line with no separator,
     corrupting it — e.g. 'Then the response status is 201  Scenario: New...'.
-    The existing text has no trailing newline here on purpose."""
+    The existing text has no trailing newline here on purpose. With only one
+    existing scenario (nothing to infer a blank-line convention from), the
+    separator defaults to a blank line, matching the common Gherkin style."""
     text = (
         "Feature: Orders API\n\n"
         "  Scenario: Create order succeeds with valid payload\n"
@@ -354,9 +358,57 @@ def test_merge_onto_existing_text_missing_a_trailing_newline_does_not_fuse_lines
     candidates = [_unit("New scenario")]
     result = gfm.merge_scenarios(text, "Orders API", candidates)
     assert result.error is None
-    assert "201\n  Scenario: New scenario" in result.text
+    assert "201\n\n  Scenario: New scenario" in result.text
     assert "201  Scenario: New scenario" not in result.text
     assert result.text.startswith(text.rstrip("\n"))
+
+
+def test_merge_inserts_blank_line_separator_when_last_existing_scenario_ends_flush_at_eof():
+    """Regression test: every existing scenario in this file is blank-line
+    separated except the very last one, which sits flush at end-of-file (the
+    common case — nothing follows it, so it never picked up a trailing
+    blank line for reasons unrelated to the file's separator convention).
+    The old splice logic only guarded against a *missing newline* at the
+    join point, not a *missing blank line*, so appending here landed the
+    new scenario directly against the last existing scenario's final step
+    with zero separation — readable but visually fused, and inconsistent
+    with every other boundary in the same file."""
+    text = (
+        "Feature: Orders API\n\n"
+        "  Scenario: First scenario\n"
+        "    Given a valid payload\n"
+        "    Then the response status is 201\n"
+        "\n"
+        "  Scenario: Second scenario\n"
+        "    Given another payload\n"
+        "    Then the response status is 201\n"
+    )
+    candidates = [_unit("Third scenario")]
+    result = gfm.merge_scenarios(text, "Orders API", candidates)
+    assert result.error is None
+    assert "Second scenario\n    Given another payload\n    Then the response status is 201\n\n  Scenario: Third scenario" in result.text
+
+
+def test_merge_preserves_no_blank_line_convention_when_existing_scenarios_have_none():
+    """The inverse of the above: when this file's own existing scenarios are
+    NOT blank-line separated, the merge must reproduce that convention at
+    the splice point too, rather than unconditionally forcing a blank line
+    that would only be consistent with *other* repositories' Gherkin
+    style, not this file's own."""
+    text = (
+        "Feature: Orders API\n\n"
+        "  Scenario: First scenario\n"
+        "    Given a valid payload\n"
+        "    Then the response status is 201\n"
+        "  Scenario: Second scenario\n"
+        "    Given another payload\n"
+        "    Then the response status is 201\n"
+    )
+    candidates = [_unit("Third scenario")]
+    result = gfm.merge_scenarios(text, "Orders API", candidates)
+    assert result.error is None
+    assert "Second scenario\n    Given another payload\n    Then the response status is 201\n  Scenario: Third scenario" in result.text
+    assert "201\n\n  Scenario: Third scenario" not in result.text
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
@@ -145,6 +145,47 @@ def test_splice_preserves_no_blank_line_convention_when_existing_bindings_have_n
     assert "assert.equal(2, 2);\n});\n\nThen('third thing'" not in result.text
 
 
+_IMPLEMENTED_JAVA_NO_BLANK_LINE = (
+    'public class ASteps {\n'
+    '  @Given("first thing")\n'
+    '  public void firstThing() {\n'
+    '    assertEquals(1, 1);\n'
+    '  }\n'
+    '  @When("second thing")\n'
+    '  public void secondThing() {\n'
+    '    assertEquals(2, 2);\n'
+    '  }\n'
+    "}\n"
+)
+
+
+def _java_candidate(pattern: str, method_name: str) -> gsm.StepCandidate:
+    text = (
+        f'  @Then("{pattern}")\n'
+        f"  public void {method_name}() {{\n"
+        "    throw new io.cucumber.java.PendingException();\n"
+        "  }\n"
+    )
+    return gsm.StepCandidate(pattern=pattern, text=text)
+
+
+def test_indented_bindings_with_no_blank_line_are_not_misread_as_blank_line_separated():
+    """Regression test (correctness-review finding on #2149): the separator
+    check used to be `gap.strip() == ""`, which can't distinguish a genuine
+    blank line ("\\n") from bare next-line indentation ("  ") — both are
+    whitespace-only. For an indented, class-wrapped style (Java, C#, or any
+    JS/TS wrapped in a class/`defineSupportCode` block) with NO blank line
+    between methods, that misread the file as blank-line-separated and
+    injected a spurious blank line at the splice point. The fixture below has
+    exactly one comparable join (between `firstThing` and `secondThing`), and
+    that join's gap is pure indentation with no newline in it."""
+    candidates = [_java_candidate("third thing", "thirdThing")]
+    result = gsm.merge_steps(_IMPLEMENTED_JAVA_NO_BLANK_LINE, ".java", candidates)
+    assert result.error is None
+    assert '  }\n  @Then("third thing")' in result.text
+    assert '  }\n\n  @Then("third thing")' not in result.text
+
+
 # ---------------------------------------------------------------------------
 # Go's two-part splice (regression test — found via this module's own
 # mandated runtime CLI verification, not by pytest: a Go step is split

--- a/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
+++ b/plugins/dev-team/tests/scripts/test_gherkin_stub_merge.py
@@ -97,6 +97,54 @@ def test_new_candidate_is_appended_after_the_last_existing_binding():
     assert idx_existing < idx_new
 
 
+def test_single_existing_binding_defaults_to_blank_line_separator():
+    """With only one existing binding (nothing to infer a convention from),
+    the splice defaults to inserting a blank line before the new candidate,
+    matching the blank-line-between-methods style most existing
+    step-definition files already use."""
+    existing_text = _IMPLEMENTED_JS
+    candidates = [_js_candidate("a new thing")]
+    result = gsm.merge_steps(existing_text, ".js", candidates)
+    assert result.error is None
+    assert "});\n\nThen('a new thing'" in result.text
+
+
+def test_splice_inserts_blank_line_when_existing_bindings_are_blank_line_separated():
+    """Regression test: the real-world failure shape — every existing
+    binding in a file is blank-line separated except the very last one,
+    which sits flush at end-of-file (nothing follows it, so it never picked
+    up a trailing blank line for reasons unrelated to the file's own
+    convention). The old splice logic only guarded against a *missing
+    newline* at the join point, not a *missing blank line*, so appending
+    here landed the new binding directly against the last existing
+    binding's closing brace with zero separation."""
+    existing_text = (
+        "Given('first thing', function () {\n  assert.equal(1, 1);\n});\n"
+        "\n"
+        "When('second thing', function () {\n  assert.equal(2, 2);\n});\n"
+    )
+    candidates = [_js_candidate("third thing")]
+    result = gsm.merge_steps(existing_text, ".js", candidates)
+    assert result.error is None
+    assert "assert.equal(2, 2);\n});\n\nThen('third thing'" in result.text
+
+
+def test_splice_preserves_no_blank_line_convention_when_existing_bindings_have_none():
+    """The inverse: when this file's own existing bindings are NOT
+    blank-line separated, the merge must reproduce that convention at the
+    splice point too, rather than unconditionally forcing a blank line that
+    would only be consistent with a *different* file's Gherkin style."""
+    existing_text = (
+        "Given('first thing', function () {\n  assert.equal(1, 1);\n});\n"
+        "When('second thing', function () {\n  assert.equal(2, 2);\n});\n"
+    )
+    candidates = [_js_candidate("third thing")]
+    result = gsm.merge_steps(existing_text, ".js", candidates)
+    assert result.error is None
+    assert "assert.equal(2, 2);\n});\nThen('third thing'" in result.text
+    assert "assert.equal(2, 2);\n});\n\nThen('third thing'" not in result.text
+
+
 # ---------------------------------------------------------------------------
 # Go's two-part splice (regression test — found via this module's own
 # mandated runtime CLI verification, not by pytest: a Go step is split


### PR DESCRIPTION
…cenarios and step stubs

New scenarios/step-definition stubs were appended directly after the last existing unit's text. When the existing file separates scenarios or bindings with a blank line, the merge didn't reproduce that -- new content landed flush against the last existing unit, with no separating blank line, because the last unit sits at the splice point with nothing after it to infer the convention from.

Infer the convention instead from the joins between the *other* existing units and reproduce it at the splice point.

Closes #2143


Claude-Session: https://claude.ai/code/session_018qgH8W1see62UtX56CAiRs

<!--
PR title must be a conventional-commit line — this repo squash-merges, so the
title becomes the commit message: <type>(<scope>): <description>.

Docs-only PRs (touching only *.md, .gitignore, LICENSE — no code, agent,
skill, hook, eval fixture, or marketplace manifest) may arm `gh pr merge
--auto --squash` at open time. Anything else needs explicit human merge.
-->

## Summary

- <what changed and why, 1-3 bullets>

## Test Plan

- [ ] <verification step 1>
- [ ] <verification step 2>

<!--
One line per issue this PR resolves, using a real closing keyword (Closes,
Fixes, Resolves). For an epic issue this PR only contributes a slice of, use
"Part of #<epic>" instead — a non-closing reference, since epics don't
auto-close when a sub-issue's PR merges (see epic-auto-close.yml, #987).

Never phrase a non-closing reference with a closing keyword, even negated —
GitHub's parser fires on "fixes #123" regardless of surrounding words like
"does not" or "won't" (issue #977).
-->

Closes #
