### PR TITLE
fix(hooks): lower pre-PR review-gate dispatch floor from 2 to 1

### DIFF
--- a/plugins/dev-team/hooks/lib/review_gate_corroboration.py
+++ b/plugins/dev-team/hooks/lib/review_gate_corroboration.py
@@ -501,10 +501,13 @@ def has_single_agent_exemption(cwd, before_ts: str, window_seconds: int, subject
     """True if `--agent <name>`'s `"single-agent-review-exempt"` bypass
     event was recorded inside the recency window before `before_ts`, bound
     to `subject_hash` (#1461) — a sanctioned single-agent `/code-review`
-    run only ever dispatches 1 distinct agent, which can never clear the
-    `>= 2` distinct-dispatch floor on its own; this exemption keeps that
-    documented workflow from regressing to an always-blocked gate. Fails
-    CLOSED like every other read in this module.
+    run only ever dispatches 1 distinct agent. Historically this could never
+    clear the (then-2) distinct-dispatch floor on its own, so this exemption
+    existed to keep that documented workflow from regressing to an
+    always-blocked gate; #2147 lowered the floor to 1, so a single dispatch
+    now clears it unaided and this exemption is no longer load-bearing for
+    that case — kept as an explicit, auditable alternate path rather than
+    removed. Fails CLOSED like every other read in this module.
     """
     return _has_exemption(cwd, before_ts, window_seconds, subject_hash, _SINGLE_AGENT_RULE)
 

--- a/plugins/dev-team/hooks/pre_pr_review.py
+++ b/plugins/dev-team/hooks/pre_pr_review.py
@@ -57,12 +57,24 @@ WHAT CHANGED, MECHANICALLY, FROM THE COMMIT-TIME GATE:
   without one.
 
 WHAT DID NOT CHANGE: the underlying corroboration architecture is reused
-as-is from `hooks/lib/review_gate_corroboration.py` — >= 2 distinct,
-registered review-agent dispatches (or a sanctioned doc-only/single-agent
+as-is from `hooks/lib/review_gate_corroboration.py` — >= 1 distinct,
+registered review-agent dispatch (or a sanctioned doc-only/single-agent
 exemption) recorded in the recency window, live-registry re-validated, with
 the same #1763 dispatch-failure veto taking priority over every exemption.
 See that module's own docstring for the full account of why this raises the
 bar without cryptographically closing #1461's self-certification gap.
+
+`_MIN_DISTINCT_DISPATCHES` was lowered from 2 to 1 (#2147): a single
+`/code-review` invocation already dispatches a full multi-agent panel
+internally, so requiring a SECOND, separate top-level dispatch on top of
+that bought no additional corroboration — it only produced false blocks on
+a legitimately-reviewed branch (e.g. a single `--agent <name>` review, or a
+session whose panel dispatch shape records fewer ledger rows than a prior
+plugin version did). The single-agent exemption event
+(`single-agent-review-exempt`) is consequently now redundant with the
+ordinary count check for the case it was built for — kept anyway, since it
+is a harmless, already-audited alternate path, not because anything still
+requires it.
 
 DELIBERATELY DROPPED, not carried forward from `pre_commit_review.py`
 (explicit scope decisions, not oversights):
@@ -254,13 +266,30 @@ def emit_boundary_event(*args, **kwargs) -> None:
 
 _GATE_FILE_NAME = ".pr-review-passed"
 
+# The env var must be set in a process environment this hook's own process
+# actually inherits — e.g. `export PR_GATE_BYPASS_REASON=<reason>` in your
+# shell profile, or a session-level persistent env config. An inline
+# `PR_GATE_BYPASS_REASON=<reason> gh pr create ...` prefix on the SAME
+# command line does NOT work (#2147): that assignment is scoped to the
+# subshell that runs `gh`, which this PreToolUse hook — a separate process
+# that runs BEFORE that subshell exists — never sees. Confirmed directly
+# against this hook's own architecture (a PreToolUse hook reads
+# `tool_input.command` as text; it does not execute it, and inline shell
+# assignments are never reflected into a sibling process's `os.environ`).
+_BYPASS_HINT = (
+    "To bypass: set PR_GATE_BYPASS_REASON as a real, inherited environment "
+    "variable before this command runs (e.g. `export "
+    "PR_GATE_BYPASS_REASON=<reason>`) — NOT as an inline "
+    "`PR_GATE_BYPASS_REASON=<reason> gh pr create ...` prefix on the same "
+    "line, which this hook cannot see and will not honor.\n"
+)
+
 _BLOCK_MESSAGE = (
     "BLOCKED: Code review required before opening a PR.\n"
     "\n"
     "Run /code-review scoped to this branch's diff vs. its base, then\n"
     "retry `gh pr create` — the PR will be allowed once review passes.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 # Recency window (#1886, mirrors #1461's WINDOW_SECONDS): how far back before
@@ -269,38 +298,38 @@ _BLOCK_MESSAGE = (
 # "Recency window anchor" bullet), not a gate file's mtime.
 WINDOW_SECONDS = 1800
 
-_MIN_DISTINCT_DISPATCHES = 2
+# #2147: lowered from 2 to 1 — a single `/code-review` invocation already
+# dispatches a full multi-agent panel internally, so a second, separate
+# top-level dispatch was never additional corroboration. See the module
+# docstring's "`_MIN_DISTINCT_DISPATCHES` was lowered..." paragraph.
+_MIN_DISTINCT_DISPATCHES = 1
 
 _NO_DISPATCH_MESSAGE = (
     f"BLOCKED: No genuine review-agent dispatch found in the last "
     f"{WINDOW_SECONDS}s — run /code-review (scoped to this branch's diff "
     f"vs. its base) before opening a PR.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 _STALE_MESSAGE = (
     f"BLOCKED: Review-agent dispatch evidence found but outside the "
     f"{WINDOW_SECONDS}s window — run /code-review again before opening a "
     "PR.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 _DIFFERENT_CONTENT_MESSAGE = (
     "BLOCKED: Review-agent dispatch evidence found, but for different "
     "branch-diff content (the branch changed since that review) — run "
     "/code-review again before opening a PR.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 _READ_FAILURE_MESSAGE = (
     "BLOCKED: Could not read the dispatch ledger "
     "(.claude/metrics/boundary-events.jsonl) — check hook registration; "
     "this is an infra problem, not evidence that no review happened.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 _GATE_SETUP_FAILURE_MESSAGE = (
@@ -309,16 +338,14 @@ _GATE_SETUP_FAILURE_MESSAGE = (
     ".claude/memory is a writable directory and the git repository is "
     "healthy; this is an infra problem, not evidence that no review "
     "happened.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 _REGISTRY_READ_FAILURE_MESSAGE = (
     "BLOCKED: Could not read the registered review-agent set — cannot "
     "prove no dispatch failure exists for this content; this is an infra "
     "problem, not evidence that no review happened.\n"
-    "\n"
-    "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+    "\n" + _BYPASS_HINT
 )
 
 
@@ -327,8 +354,7 @@ def _insufficient_message(n: int) -> str:
         f"BLOCKED: Only {n} distinct review agent(s) dispatched (need >= "
         f"{_MIN_DISTINCT_DISPATCHES}) — run /code-review before opening a "
         "PR.\n"
-        "\n"
-        "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+        "\n" + _BYPASS_HINT
     )
 
 
@@ -340,8 +366,7 @@ def _dispatch_failure_message(agents: frozenset) -> str:
         "\n"
         "Run /code-review again against this same, unchanged branch diff — "
         "a clean rerun clears this block.\n"
-        "\n"
-        "To bypass: set PR_GATE_BYPASS_REASON to a non-empty reason.\n"
+        "\n" + _BYPASS_HINT
     )
 
 

--- a/plugins/dev-team/skills/code-review/SKILL.md
+++ b/plugins/dev-team/skills/code-review/SKILL.md
@@ -363,12 +363,13 @@ and the change-shape gate above have both been applied, apply this gate —
 never before, and never in a way that re-adds an agent either already removed.
 It narrows the `Scope: always` roster by diff *size* rather than file *type*:
 the pre-PR hook (`hooks/pre_pr_review.py`, #1886) requires a `.pr-review-passed`
-hash match **and** (#1461) >= 2 distinct, recent, registered review-agent
-dispatches recorded in the dispatch ledger — so this gate must never narrow
-`keepAgents` below 2, and today's four-agent floor (`security-review`,
-`correctness-review`, `spec-compliance-review`, `doc-review`) clears that with
-room to spare. Which specific agents to keep at a given diff size remains
-this step's decision, not the hook's — the hook only enforces the *count*
+hash match **and** (#1461, floor lowered to 1 by #2147) >= 1 distinct, recent,
+registered review-agent dispatch recorded in the dispatch ledger — so this
+gate must never narrow `keepAgents` below 1, and today's four-agent floor
+(`security-review`, `correctness-review`, `spec-compliance-review`,
+`doc-review`) clears that with room to spare. Which specific agents to keep at
+a given diff size remains this step's decision, not the hook's — the hook
+only enforces the *count*
 floor, never which agents satisfy it.
 
 **Applies only to diff-scoped reviews** — auto-scoped uncommitted changes, or
@@ -793,7 +794,7 @@ per-agent cost can be split by purpose rather than lumped into one dispatch
 count. Derived metrics (churn ratio, per-agent discovery-vs-verification
 split, gate recidivism) are computed by `/harness-audit` — see its Step 4a.
 
-**Closing pass — re-establishing dispatch-ledger corroboration after the loop (#1461, narrowed by #1626; auto-scope only — same condition as item 3 above).** Step 3's `git add` changes the staged content's hash, so `agent_dispatch_ledger.py` stamps each iteration's re-dispatched agents (step 4) with that NEW hash — not step 4 (the outer, pre-loop)'s original dispatch hash, and not an earlier iteration's hash either. Step 9's gate write needs **>= 2 distinct dispatches whose `subject_hash` equals the FINAL staged content's hash** (the one actually committed). Because step 4 of this loop only re-dispatches the agents that had actionable issues, a final iteration that fixes just one agent's finding re-dispatches only that one agent against the final content — insufficient on its own.
+**Closing pass — re-establishing dispatch-ledger corroboration after the loop (#1461, narrowed by #1626, floor lowered to 1 by #2147; auto-scope only — same condition as item 3 above).** Step 3's `git add` changes the staged content's hash, so `agent_dispatch_ledger.py` stamps each iteration's re-dispatched agents (step 4) with that NEW hash — not step 4 (the outer, pre-loop)'s original dispatch hash, and not an earlier iteration's hash either. Step 9's gate write needs **>= 1 distinct dispatch whose `subject_hash` equals the FINAL staged content's hash** (the one actually committed). Since floor 1 is normally satisfied by construction (the loop only re-stages when it applied at least one fix, and that fixer re-dispatches against the final content in the same iteration), the closing pass below degenerates to "just the fixer(s), self-verifying" in the common case — it still exists, unconditionally, for the cases that don't already clear the floor on their own: the escape hatch (scope grew mid-loop) and a `fixed_by_agents` set that ends up empty despite a loop iteration having run.
 
 This used to be satisfied by re-dispatching the **full** original panel, which made a one-line fix cost an 18-agent round. **Unconditionally, after any loop iteration ran** (i.e. any fix was applied and re-staged) — not only when the count looks short, since that count isn't something to reason about from memory — run a **closing pass** instead. Compose it deterministically, don't pick the set by hand:
 
@@ -807,8 +808,8 @@ python3 "$CLAUDE_PLUGIN_ROOT/skills/code-review/scripts/closing_pass.py" \
 
 It prints `{"agents", "scope", "escape_hatch", "reason", "topped_up"}`. Dispatch exactly the `agents` it returns, and record them with `dispatch_purpose: "closing"` (#1624) so the cost effect is measurable.
 
-- **Composition**: every agent whose findings were fixed during the loop (each verifies its own fixes at the final hash), plus — only if that set has fewer than 2 distinct agents — a cheap-first top-up from the resolver's eligible roster until 2 distinct registered agents have dispatched at the final hash.
-- **Why this is sound**: 2 is `pre_commit_review.py`'s `_MIN_DISTINCT_DISPATCHES`, so the gate's corroboration floor is satisfied **by construction** — no hook change, no exemption event, no ledger change. The threat model #1461 closed (self-certification without dispatch) is untouched: these are genuine dispatches carrying real review authority over the only content that changed since full-panel coverage. A drift test pins the script's constant to the hook's, so raising the gate's floor can never silently under-compose this pass.
+- **Composition**: every agent whose findings were fixed during the loop (each verifies its own fixes at the final hash), plus — only if that set has fewer than 1 distinct agent — a cheap-first top-up from the resolver's eligible roster until 1 distinct registered agent has dispatched at the final hash.
+- **Why this is sound**: 1 is `pre_pr_review.py`'s `_MIN_DISTINCT_DISPATCHES` (#2147; lowered from 2), so the gate's corroboration floor is satisfied **by construction** — no hook change, no exemption event, no ledger change. The threat model #1461 closed (self-certification without dispatch) is untouched: these are genuine dispatches carrying real review authority over the only content that changed since full-panel coverage. A drift test pins the script's constant to the hook's, so raising the gate's floor can never silently under-compose this pass.
 - **Scope**: the closing pass reviews the **cumulative fix delta** — the diff between what the round-1 panel reviewed and the final staged content — with the round ledger's fixed findings as context. Not the whole changeset: the panel's round-1 coverage of unchanged content is still valid; only the fix delta is unreviewed.
 - **Escape hatch**: when the fix delta touches files outside the original panel's target set (scope grew mid-loop), the script returns `escape_hatch: true` and `scope: "full-changeset"` — fall back to the full re-dispatch. This is a set comparison of two file lists, not a judgment call.
 
@@ -953,7 +954,7 @@ requiring a fresh `/code-review` run against the branch's current diff (or
 a `--since <base>`-scoped re-review, which now closes cleanly per the
 paragraph above) before opening the PR.
 
-**If `--agent <name>` was used** (a sanctioned single-agent review — it deliberately dispatches exactly 1 agent, which can never clear the dispatch-ledger gate's `>= 2` distinct-dispatch floor on its own), record that as an explicit, auditable exemption event bound to this same hash **contemporaneously** with the write above — same pattern as the doc-only short-circuit's exemption event (step 1a):
+**If `--agent <name>` was used** (a sanctioned single-agent review — it deliberately dispatches exactly 1 agent, which now clears the dispatch-ledger gate's `>= 1` distinct-dispatch floor on its own since #2147 lowered it from 2; the explicit exemption event below is consequently no longer load-bearing for this case, but is still written for an unambiguous, explicit audit trail rather than relying on the ordinary count path to imply "this was a sanctioned single-agent review" after the fact), record that as an explicit, auditable exemption event bound to this same hash **contemporaneously** with the write above — same pattern as the doc-only short-circuit's exemption event (step 1a):
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/hooks/lib/boundary_events.py" --event single-agent --subject-hash "$HASH"

--- a/plugins/dev-team/skills/code-review/scripts/closing_pass.py
+++ b/plugins/dev-team/skills/code-review/scripts/closing_pass.py
@@ -4,7 +4,7 @@
 `/code-review` step 6a used to mandate: after ANY fix-loop iteration ran,
 re-dispatch the **full** original agent panel once more against the final
 staged content. The reason was structural, not editorial — the pre-commit
-gate (#1461) needs `>= 2` distinct dispatches whose `subject_hash` equals the
+gate (#1461) needed `>= 2` distinct dispatches whose `subject_hash` equals the
 FINAL staged hash, and the loop's targeted re-dispatches only cover the
 agents that happened to have findings. So a one-line fix re-triggered an
 18-agent panel. That is the single biggest cost multiplier in the loop, and
@@ -16,11 +16,14 @@ that preserves both properties the full re-panel was defending.
 ## The two properties, and how each is preserved
 
 1. **The gate's corroboration floor, satisfied by construction.**
-   `pre_commit_review.py`'s `_MIN_DISTINCT_DISPATCHES` is 2. The composition
-   rule below tops up from the resolver's eligible roster until at least 2
-   distinct registered agents dispatch at the final hash. No hook change, no
-   exemption event, no ledger change — the floor is met the same way it is
-   met today, just with 2-3 dispatches instead of 18.
+   `hooks/pre_pr_review.py`'s `_MIN_DISTINCT_DISPATCHES` is 1 (#2147; lowered
+   from 2 — a single `/code-review` dispatch already runs a full panel
+   internally, so a second top-level dispatch was never additional
+   corroboration). The composition rule below tops up from the resolver's
+   eligible roster until at least that many distinct registered agents
+   dispatch at the final hash. No hook change, no exemption event, no ledger
+   change — the floor is met the same way it is met today, just with 1-2
+   dispatches instead of 18 (previously 2-3, under the old floor of 2).
 
 2. **Not a rubber stamp.** Closing-pass agents keep full review authority:
    any actionable finding re-enters the fix loop exactly as before (subject
@@ -51,13 +54,13 @@ import json
 import sys
 from pathlib import Path
 
-#: Mirrors `hooks/pre_commit_review.py`'s `_MIN_DISTINCT_DISPATCHES`. Kept as
+#: Mirrors `hooks/pre_pr_review.py`'s `_MIN_DISTINCT_DISPATCHES`. Kept as
 #: a named constant here (rather than imported) because this script must not
 #: depend on the hook package to compute a dispatch plan; the drift test in
 #: `plugins/dev-team/tests/scripts/test_closing_pass.py` asserts the two stay
 #: equal, so a future change to the gate's floor fails a test rather than
 #: silently under-composing the closing pass.
-MIN_DISTINCT_DISPATCHES = 2
+MIN_DISTINCT_DISPATCHES = 1
 
 
 def _normalize(path) -> str:

--- a/plugins/dev-team/tests/hooks/test_pre_pr_review.py
+++ b/plugins/dev-team/tests/hooks/test_pre_pr_review.py
@@ -291,16 +291,17 @@ def test_empty_digest_gate_file_with_matching_empty_digest_dispatches_never_pass
 ) -> None:
     """The concrete security hazard Bug 1 exists to close: a `.pr-review-passed`
     file that happens to store `EMPTY_DIGEST` (whether hand-crafted, or a
-    prior gate write made while the branch diff was empty) PLUS >= 2 genuine
-    dispatch records whose `subject_hash` also happens to be `EMPTY_DIGEST`
+    prior gate write made while the branch diff was empty) PLUS >= 1 genuine
+    dispatch record whose `subject_hash` also happens to be `EMPTY_DIGEST`
     (recorded during ANY unrelated review made while nothing was staged,
     before the #1904 ledger fix) must NEVER corroborate a `gh pr create` on
     THIS branch, even though every individual comparison would otherwise
     "match". Before this fix, `_prepare_gate()` handed out `EMPTY_DIGEST` as
     an ordinary `current_hash`, `_hash_verdict()` matched it against the
-    stored `EMPTY_DIGEST` gate file, and the ledger's `>= 2` distinct-dispatch
-    check would have been satisfied by these unrelated dispatches — passing
-    the gate on a constant, content-independent hash. This is the same
+    stored `EMPTY_DIGEST` gate file, and the ledger's `>= 1` distinct-dispatch
+    check (#2147: lowered from 2) would have been satisfied by these
+    unrelated dispatches — passing the gate on a constant, content-independent
+    hash. This is the same
     `_bare_repo_on_feature_branch` empty-diff repo as the test above; the
     ledger + gate file here are the attacker/coincidence-controlled
     ingredients the old code would have accepted."""
@@ -390,20 +391,36 @@ def test_hash_match_with_no_dispatch_evidence_blocks_distinctly(repo: Path) -> N
     assert "No genuine review-agent dispatch" in result.stdout
 
 
-def test_hash_match_with_one_distinct_dispatch_is_insufficient(repo: Path) -> None:
+def test_hash_match_with_one_distinct_dispatch_is_sufficient(repo: Path) -> None:
+    """#2147: the floor was lowered from 2 to 1 — a single genuine,
+    registered review-agent dispatch now satisfies the gate outright."""
     h = _write_gate_file(repo)
     _write_dispatch_events(repo, ["security-review"], h)
     result = _run({"tool_input": {"command": "gh pr create"}, "cwd": str(repo)}, repo)
-    assert result.returncode == 2
-    assert "Only 1 distinct" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_same_agent_dispatched_twice_counts_as_one_distinct(repo: Path) -> None:
+def test_hash_match_with_zero_distinct_dispatches_is_insufficient(repo: Path) -> None:
+    """The floor is 1, not 0 — an empty ledger still blocks (covered by
+    `test_hash_match_with_no_dispatch_evidence_blocks_distinctly`), and this
+    pins the `_insufficient_message` wording specifically for `n == 0`
+    reached via `_dispatch_count_verdict` directly (the `same_subject_dispatch_ever`
+    / `any_dispatch_ever` lenses take priority over `_insufficient_message`
+    in the real `n == 0` path, so this exercises the function in isolation)."""
+    assert "Only 0 distinct" in _ppr._insufficient_message(0)
+    assert "need >= 1" in _ppr._insufficient_message(0)
+
+
+def test_same_agent_dispatched_twice_still_counts_as_one_distinct_and_passes(
+    repo: Path,
+) -> None:
+    """Distinct-agent counting (dedup by name) is unaffected by the #2147
+    floor change: two events for the SAME agent still collapse to one
+    distinct dispatch — which is now sufficient on its own (floor 1)."""
     h = _write_gate_file(repo)
     _write_dispatch_events(repo, ["security-review", "security-review"], h)
     result = _run({"tool_input": {"command": "gh pr create"}, "cwd": str(repo)}, repo)
-    assert result.returncode == 2
-    assert "Only 1 distinct" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_stale_dispatch_evidence_blocks_distinctly(repo: Path) -> None:
@@ -582,6 +599,24 @@ def test_since_scoped_review_then_gh_pr_create_passes_end_to_end(repo: Path) -> 
     # invoking `/code-review --since <base>`.
     _run_ledger_dispatch(repo, "security-review")
     _run_ledger_dispatch(repo, "structure-review")
+    _write_gate_file_via_branch_diff_cli(repo)
+
+    result = _run({"tool_input": {"command": "gh pr create"}, "cwd": str(repo)}, repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not (repo / ".claude" / "memory" / ".pr-review-passed").is_file()
+
+
+def test_single_real_dispatch_then_gh_pr_create_passes_end_to_end(repo: Path) -> None:
+    """Issue #2147's regression test: runs the SAME genuine, subprocess-level
+    code paths as the test above (`agent_dispatch_ledger.py` for the
+    dispatch, `review_gate_hash.py --branch-diff` for the gate write) but
+    with only ONE registered review-agent dispatch — the shape a
+    `/code-review --agent <name>` review, or any panel that happens to
+    record fewer than two ledger rows, actually produces. Before #2147
+    lowered `_MIN_DISTINCT_DISPATCHES` from 2 to 1, this exact sequence hard
+    blocked with `_insufficient_message` despite a genuine, real dispatch
+    having fired through the real hook."""
+    _run_ledger_dispatch(repo, "security-review")
     _write_gate_file_via_branch_diff_cli(repo)
 
     result = _run({"tool_input": {"command": "gh pr create"}, "cwd": str(repo)}, repo)

--- a/plugins/dev-team/tests/scripts/test_change_impact.py
+++ b/plugins/dev-team/tests/scripts/test_change_impact.py
@@ -329,9 +329,9 @@ class TestGateComposition:
 
     def test_the_gate_never_drops_a_change_size_floor_agent(self):
         """change_size.py keeps 4 agents on its narrowest fast path to clear
-        the commit gate's >= 2 distinct-dispatch floor. This gate must never
-        remove one of them, or the two gates could compose into a blocked
-        commit."""
+        the pre-PR gate's >= 1 distinct-dispatch floor (#2147; lowered from
+        2). This gate must never remove one of them, or the two gates could
+        compose into a blocked PR."""
         floor = {"security-review", "correctness-review", "spec-compliance-review", "doc-review"}
         assert not (set(change_impact.GATED_LENSES) & floor)
 

--- a/plugins/dev-team/tests/scripts/test_closing_pass.py
+++ b/plugins/dev-team/tests/scripts/test_closing_pass.py
@@ -1,9 +1,10 @@
 """Unit tests for skills/code-review/scripts/closing_pass.py (#1626).
 
 The headline acceptance criterion: a 1-file fix after an 18-agent panel
-produces a closing pass of <= 3 dispatches (the fixer's agent plus a top-up),
-not 18 — while still satisfying the pre-commit gate's >= 2 distinct-dispatch
-floor by construction, with no hook change.
+produces a closing pass of <= 3 dispatches (the fixer's agent plus a possible
+top-up), not 18 — while still satisfying the pre-PR gate's >= 1
+distinct-dispatch floor by construction (#2147; lowered from 2), with no
+hook change.
 """
 
 from __future__ import annotations
@@ -59,7 +60,11 @@ class TestGateFloorByConstruction:
         assert match, "could not locate _MIN_DISTINCT_DISPATCHES in pre_pr_review.py"
         assert int(match.group(1)) == closing_pass.MIN_DISTINCT_DISPATCHES
 
-    def test_single_fixer_is_topped_up_to_the_floor(self):
+    def test_single_fixer_already_meets_the_floor(self):
+        """#2147: the floor is 1, so one genuine fixer dispatch is already
+        sufficient — no top-up needed. (Top-up itself is still exercised
+        below with an explicit higher `minimum`, independent of the real
+        gate's current floor.)"""
         plan = closing_pass.compose(
             fixed_by_agents=["correctness-review"],
             eligible_roster=PANEL,
@@ -67,7 +72,19 @@ class TestGateFloorByConstruction:
             panel_files=["src/cache.js"],
             fix_delta_files=["src/cache.js"],
         )
-        assert len(plan["agents"]) == closing_pass.MIN_DISTINCT_DISPATCHES
+        assert plan["agents"] == ["correctness-review"]
+        assert plan["topped_up"] == []
+
+    def test_single_fixer_is_topped_up_to_an_explicit_higher_floor(self):
+        plan = closing_pass.compose(
+            fixed_by_agents=["correctness-review"],
+            eligible_roster=PANEL,
+            panel_agents=PANEL,
+            panel_files=["src/cache.js"],
+            fix_delta_files=["src/cache.js"],
+            minimum=2,
+        )
+        assert len(plan["agents"]) == 2
         assert "correctness-review" in plan["agents"]
         assert plan["topped_up"] == ["naming-review"]
 
@@ -85,23 +102,30 @@ class TestGateFloorByConstruction:
     def test_top_up_takes_the_cheapest_eligible_lens_first(self):
         # The roster arrives cheap-first from select_lenses.py; a top-up must
         # never reach for an opus lens while a cheaper one is available.
+        # Uses an explicit higher `minimum` so this test still exercises
+        # top-up behavior regardless of the real gate's current floor (#2147:
+        # 1 fixer already meets today's floor of 1, so no top-up would fire).
         plan = closing_pass.compose(
             fixed_by_agents=["arch-review"],
             eligible_roster=PANEL,
             panel_agents=PANEL,
             panel_files=["src/a.js"],
             fix_delta_files=["src/a.js"],
+            minimum=2,
         )
         assert plan["topped_up"] == ["naming-review"]
         assert "security-review" not in plan["agents"]
 
     def test_roster_smaller_than_the_floor_is_reported_not_hidden(self):
+        # Explicit `minimum=2` so a single-agent roster is provably smaller
+        # than the floor, independent of the real gate's current value.
         plan = closing_pass.compose(
             fixed_by_agents=["doc-review"],
             eligible_roster=["doc-review"],
             panel_agents=["doc-review"],
             panel_files=["README.md"],
             fix_delta_files=["README.md"],
+            minimum=2,
         )
         assert len(plan["agents"]) == 1
         assert plan["reason"] == "eligible-roster-smaller-than-gate-floor"
@@ -166,7 +190,7 @@ class TestDeduping:
             fix_delta_files=["a.md"],
         )
         assert plan["agents"].count("doc-review") == 1
-        assert len(plan["agents"]) == 2
+        assert len(plan["agents"]) == 1
 
     def test_blank_entries_are_dropped(self):
         plan = closing_pass.compose(
@@ -201,7 +225,7 @@ class TestCli:
             check=True,
         )
         plan = json.loads(result.stdout)
-        assert len(plan["agents"]) == 2
+        assert len(plan["agents"]) == 1
         assert plan["scope"] == "fix-delta"
 
     def test_cli_accepts_a_select_lenses_json_file_for_the_roster(self, tmp_path):
@@ -224,4 +248,4 @@ class TestCli:
         )
         plan = json.loads(result.stdout)
         assert plan["agents"][0] == "doc-review"
-        assert len(plan["agents"]) == 2
+        assert len(plan["agents"]) == 1


### PR DESCRIPTION
## Summary

- Lower `pre_pr_review.py`'s `_MIN_DISTINCT_DISPATCHES` from 2 to 1 — a single `/code-review` invocation already dispatches a full multi-agent panel internally, so requiring a second, separate top-level dispatch bought no additional corroboration; it only produced false blocks (e.g. on a sanctioned `--agent <name>` single-agent review, or any panel shape recording fewer than 2 ledger rows).
- Mirror the change in `closing_pass.py`'s `MIN_DISTINCT_DISPATCHES` (kept in sync with the hook by an existing drift test) and update the tests/docs that assumed the old floor of 2.
- Correct the gate's `PR_GATE_BYPASS_REASON` block messages: they told users to bypass via an inline `PR_GATE_BYPASS_REASON=<reason> gh pr create ...` prefix, which a PreToolUse hook — a separate process that runs *before* that command's subshell exists — never sees. Confirmed by inspection of the hook's own architecture (it reads `tool_input.command` as text; it does not execute it, and inline shell assignments are never reflected into a sibling process's `os.environ`). The messages now describe what actually works: a real, inherited environment variable.

I verified the `agent_dispatch_ledger` half of the original report does **not** generally reproduce — this session's own `.claude/metrics/boundary-events.jsonl` shows 31 correctly-recorded ledger events across 32 real `Agent` dispatches made in this same session — so this PR is scoped to the two issues that do check out: the floor, and the unreachable bypass.

## Test Plan

- [x] `python3 -m pytest plugins/dev-team/tests/hooks/test_pre_pr_review.py plugins/dev-team/tests/scripts/test_closing_pass.py plugins/dev-team/tests/scripts/test_change_impact.py plugins/dev-team/tests/hooks/test_review_gate_corroboration.py` — 169 passed
- [x] Added `test_single_real_dispatch_then_gh_pr_create_passes_end_to_end` — drives the *real* `agent_dispatch_ledger.py` and `review_gate_hash.py --branch-diff` subprocess code paths (not hand-written fixture events) with exactly one dispatch, and asserts `gh pr create` now passes — the regression test the issue asked for.
- [x] Flipped `test_hash_match_with_one_distinct_dispatch_is_insufficient` → `..._is_sufficient` and `test_same_agent_dispatched_twice_counts_as_one_distinct` to assert the new pass-at-1 behavior.
- [x] `ruff check` clean on all changed files.
- [x] Full pre-push gate (`scripts/ci-local.sh`, 10418 tests) green.

Closes #2147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_