### PR TITLE
chore(mutation-testing): harden Stryker.NET slice passthrough and STRYKER_BIN env-var coverage

### DIFF
--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -419,7 +419,9 @@ plugin's shipped scripts are stdlib-only Python, and `json` is stdlib while
 YAML is not). Only `name` + `mutate` are required in this first cut; `kind`,
 `mutation-level`, and `exclude-converged` are accepted and passed through
 but reserved for #667's within-slice refinements — a typo in one of those
-field names still fails config validation, it just isn't acted on yet.
+field names is not rejected — it falls into the generic passthrough below
+and prints the unrecognized-key warning that guards against exactly this
+(#2145) — it just isn't otherwise acted on yet.
 
 Any other key is passed through verbatim into the slice's generated
 `stryker-config.json` — most usefully `project`, naming the single source

--- a/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
+++ b/plugins/dev-team/skills/mutation-testing/references/languages/csharp-stryker-net.md
@@ -453,7 +453,12 @@ Each generated per-slice `stryker-config.json` inherits
 recommendation above); pass a `--base-config` pointing at an existing
 `stryker-config.json` whose `"coverage-analysis": "off"` should be
 preserved (e.g. xunit.v3/MTP projects) — an explicit value in the base
-config always wins over the per-slice default.
+config always wins over the per-slice default. A slice may also set its own
+`"coverage-analysis"` key directly (the same generic passthrough `project`
+uses) to override it for that one slice alone — intentional, for a mixed
+solution where only some slices' projects are xunit.v3/MTP; an unrecognized
+passthrough key (a typo, most commonly) prints a warning to stderr naming
+the slice and the key, but is still applied unchanged.
 
 ### Output layout and the aggregate roll-up
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
@@ -52,6 +52,29 @@ REQUIRED_SLICE_FIELDS = ("name", "mutate")
 RESERVED_SLICE_FIELDS = ("kind", "mutation-level", "exclude-converged")
 KNOWN_SLICE_FIELDS = REQUIRED_SLICE_FIELDS + RESERVED_SLICE_FIELDS
 
+# Stryker.NET config keys this skill's generic slice passthrough
+# (build_slice_stryker_config) is known to be used with in practice. NOT an
+# exhaustive copy of Stryker's own schema — duplicating that schema here is
+# exactly what the passthrough's "single generic seam" design avoids (#2145),
+# so this list only gates a WARNING, never a rejection: a legitimate Stryker
+# key that isn't listed yet still passes through unchanged, just noisily.
+# Extend as new keys are used in a slices config.
+KNOWN_STRYKER_PASSTHROUGH_KEYS = frozenset(
+    {
+        "project",
+        "coverage-analysis",
+        "since",
+        "additional-timeout",
+        "reporters",
+        "concurrency",
+        "test-projects",
+        "ignore-mutations",
+        "thresholds",
+        "dashboard-api-key",
+        "disable-bail",
+    }
+)
+
 
 # =============================================================================
 # Slice config loading + validation
@@ -261,6 +284,16 @@ def build_slice_stryker_config(
     projects in the solution. Any slice key other than the reserved/required
     ones handled above is passed through verbatim, so this stays a single
     generic seam rather than one hardcoded field for ``"project"`` alone.
+
+    This passthrough is deliberately unvalidated (#2145) — a slice-level
+    ``"coverage-analysis"`` key, for instance, silently overrides the
+    ``setdefault`` above, which is intentional (the same xunit.v3/MTP escape
+    hatch, applied per-slice instead of once for the whole base config) but
+    otherwise indistinguishable at this layer from a typo. As a middle
+    ground between "stay generic" and "catch typos", any passthrough key not
+    in :data:`KNOWN_STRYKER_PASSTHROUGH_KEYS` prints a warning (to stderr)
+    naming the slice and the key — informational only; the value is still
+    applied unchanged.
     """
     cfg = dict(base_config)
     mutate = slice_def["mutate"]
@@ -269,6 +302,13 @@ def build_slice_stryker_config(
     for key, value in slice_def.items():
         if key in KNOWN_SLICE_FIELDS:
             continue
+        if key not in KNOWN_STRYKER_PASSTHROUGH_KEYS:
+            print(
+                f"WARNING: slice {slice_def.get('name')!r} passes through "
+                f"unrecognized Stryker config key {key!r} — applied "
+                "unchanged; check for a typo if this wasn't intentional.",
+                file=sys.stderr,
+            )
         cfg[key] = value
     return cfg
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_slice_runner.py
@@ -72,6 +72,15 @@ KNOWN_STRYKER_PASSTHROUGH_KEYS = frozenset(
         "thresholds",
         "dashboard-api-key",
         "disable-bail",
+        "solution",
+        "target-framework",
+        "language-version",
+        "ignore-methods",
+        "break-at",
+        "report-file-name",
+        "verbosity",
+        "log-to-file",
+        "open-report",
     }
 )
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -37,7 +37,7 @@ import subprocess
 import sys
 import threading
 from collections.abc import Callable, Sequence
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 # =============================================================================
 # Exit codes — same as the bash version, byte-compatible. EXIT_RESTORE_SLN_FAILED
@@ -271,7 +271,7 @@ def _pass_through_concurrency_flag(stryker_args: Sequence[str]) -> str | None:
 
 
 def build_stryker_argv(stryker_bin: str, stryker_args: Sequence[str]) -> list[str]:
-    """Return the full argv for launching Stryker.NET.
+    r"""Return the full argv for launching Stryker.NET.
 
     ``dotnet stryker ...`` is the invocation shape for a **local** tool-
     manifest install — the skill's preferred path (see csharp-stryker-net.md
@@ -290,10 +290,20 @@ def build_stryker_argv(stryker_bin: str, stryker_args: Sequence[str]) -> list[st
     the bare ``"dotnet"`` — a functionally-equivalent value that previously
     fell through to the bare-executable branch below with no ``stryker``
     verb inserted, silently reproducing the failure this module exists to
-    fix. Any other value (e.g. an explicit ``dotnet-stryker`` override for a
-    global install) is used as the bare executable, unchanged.
+    fix. Checked with both ``Path`` (the host-native flavor — ``WindowsPath``
+    on Windows, ``PosixPath`` elsewhere) and ``PureWindowsPath`` explicitly,
+    so a backslash-separated Windows path (e.g. ``C:\Program
+    Files\dotnet\dotnet.exe``) is recognized even when this module runs
+    under a POSIX-flavored Python (Cygwin/MSYS2), where plain ``Path`` alone
+    would treat the whole string as one opaque filename component and never
+    find the ``"dotnet"`` stem. Any other value (e.g. an explicit
+    ``dotnet-stryker`` override for a global install) is used as the bare
+    executable, unchanged.
     """
-    if Path(stryker_bin).stem.lower() == "dotnet":
+    if (
+        Path(stryker_bin).stem.lower() == "dotnet"
+        or PureWindowsPath(stryker_bin).stem.lower() == "dotnet"
+    ):
         return [stryker_bin, "stryker", *stryker_args]
     return [stryker_bin, *stryker_args]
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/csharp_stryker_net_wrapper.py
@@ -282,13 +282,19 @@ def build_stryker_argv(stryker_bin: str, stryker_args: Sequence[str]) -> list[st
     put a bare ``dotnet-stryker`` executable on ``PATH``, invoked directly
     with no subcommand.
 
-    Auto-detected from ``stryker_bin`` alone — no separate flag: when it is
-    exactly ``"dotnet"``, insert the ``stryker`` verb. Any other value (e.g.
-    an explicit ``dotnet-stryker`` override for a global install) is used as
-    the bare executable, unchanged.
+    Auto-detected from ``stryker_bin`` alone — no separate flag: when its
+    filename stem (case-insensitive, extension and directory stripped) is
+    ``"dotnet"``, insert the ``stryker`` verb. Matching on the stem rather
+    than the raw string (#2145) means an absolute path (``/usr/bin/dotnet``)
+    or a Windows-style name (``dotnet.exe``) is recognized identically to
+    the bare ``"dotnet"`` — a functionally-equivalent value that previously
+    fell through to the bare-executable branch below with no ``stryker``
+    verb inserted, silently reproducing the failure this module exists to
+    fix. Any other value (e.g. an explicit ``dotnet-stryker`` override for a
+    global install) is used as the bare executable, unchanged.
     """
-    if stryker_bin == "dotnet":
-        return ["dotnet", "stryker", *stryker_args]
+    if Path(stryker_bin).stem.lower() == "dotnet":
+        return [stryker_bin, "stryker", *stryker_args]
     return [stryker_bin, *stryker_args]
 
 

--- a/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/mutation_kill_headless.py
@@ -24,6 +24,7 @@ to reuse five language-neutral names.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from collections.abc import Callable, Sequence
@@ -184,7 +185,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     p.add_argument("--max-rounds", type=int, default=5, help="Max rounds per file")
     p.add_argument(
         "--stryker-bin",
-        default="dotnet",
+        default=os.environ.get("STRYKER_BIN", "dotnet"),
         help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
         "manifest install via 'dotnet stryker' (default: %(default)s)",
     )

--- a/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
+++ b/plugins/dev-team/skills/mutation-testing/scripts/stryker_shard_pipeline.py
@@ -734,7 +734,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", help="Repo root (default: cwd)")
     parser.add_argument(
         "--stryker-bin",
-        default="dotnet",
+        default=os.environ.get("STRYKER_BIN", "dotnet"),
         help="Stryker executable name, or 'dotnet' to invoke a local-tool-"
         "manifest install via 'dotnet stryker' (default: %(default)s)",
     )

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 from _repo_root import REPO_ROOT as _REPO_ROOT
 
 sys.path.insert(
@@ -28,7 +30,11 @@ sys.path.insert(
     ),
 )
 
-from csharp_stryker_net_slice_runner import build_slice_stryker_config, parse_args
+from csharp_stryker_net_slice_runner import (
+    KNOWN_STRYKER_PASSTHROUGH_KEYS,
+    build_slice_stryker_config,
+    parse_args,
+)
 
 
 def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
@@ -95,3 +101,78 @@ def test_mutate_is_still_wrapped_in_a_list_when_given_as_a_bare_string():
     cfg = build_slice_stryker_config({}, {"name": "widgets", "mutate": "**/*.cs"})
 
     assert cfg["mutate"] == ["**/*.cs"]
+
+
+# ---------------------------------------------------------------------------
+# Passthrough hardening (#2145): a typo'd passthrough key (e.g. "projct"
+# instead of "project") previously merged silently with no error, so the
+# intended project-scoping never happened. The generic-passthrough design
+# stays (per its own docstring, this must not become one hardcoded field for
+# "project" alone), so an unrecognized key is still applied unchanged -- it
+# only gets a stderr warning naming the slice and the key.
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognized_passthrough_key_still_applies_but_warns(capsys):
+    cfg = build_slice_stryker_config(
+        {}, {"name": "widgets", "mutate": "**/*.cs", "projct": "Widgets.csproj"}
+    )
+
+    assert cfg["projct"] == "Widgets.csproj"
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "widgets" in err
+    assert "projct" in err
+
+
+@pytest.mark.parametrize("key", sorted(KNOWN_STRYKER_PASSTHROUGH_KEYS))
+def test_known_passthrough_keys_never_warn(capsys, key):
+    build_slice_stryker_config({}, {"name": "widgets", "mutate": "**/*.cs", key: "x"})
+
+    assert capsys.readouterr().err == ""
+
+
+def test_reserved_and_required_fields_never_warn_either(capsys):
+    # kind / mutation-level / exclude-converged / name / mutate are handled
+    # before the passthrough loop even sees them -- never mistaken for an
+    # unrecognized Stryker config key.
+    build_slice_stryker_config(
+        {},
+        {
+            "name": "widgets",
+            "mutate": "**/*.cs",
+            "kind": "logic",
+            "mutation-level": "Standard",
+            "exclude-converged": True,
+        },
+    )
+
+    assert capsys.readouterr().err == ""
+
+
+def test_slice_level_coverage_analysis_overrides_the_perTest_default(capsys):
+    """#2145 item 2: a slice's own "coverage-analysis" passthrough silently
+    overrides the setdefault("coverage-analysis", "perTest") two lines
+    above it -- intentional (the same xunit.v3/MTP escape hatch, applied
+    per-slice for a mixed solution), previously untested. It's a known key,
+    so this must not also warn."""
+    cfg = build_slice_stryker_config(
+        {},
+        {"name": "legacy-mtp", "mutate": "**/*.cs", "coverage-analysis": "off"},
+    )
+
+    assert cfg["coverage-analysis"] == "off"
+    assert capsys.readouterr().err == ""
+
+
+def test_slice_level_coverage_analysis_overrides_an_explicit_base_config_too():
+    """The slice-level override wins even over a base config that already
+    set coverage-analysis explicitly -- the passthrough loop runs after
+    setdefault unconditionally, regardless of whether setdefault was a
+    no-op or not."""
+    cfg = build_slice_stryker_config(
+        {"coverage-analysis": "perTest"},
+        {"name": "legacy-mtp", "mutate": "**/*.cs", "coverage-analysis": "off"},
+    )
+
+    assert cfg["coverage-analysis"] == "off"

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_slice_runner.py
@@ -37,7 +37,12 @@ from csharp_stryker_net_slice_runner import (
 )
 
 
-def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape(monkeypatch):
+    # This script has read STRYKER_BIN via os.environ.get(...) all along
+    # (unlike the two sibling scripts #2145 fixed) -- isolate from an
+    # ambient value so this test pins the *fallback*, not the environment.
+    monkeypatch.delenv("STRYKER_BIN", raising=False)
+
     args = parse_args(["--slice", "all"])
 
     assert args.stryker_bin == "dotnet"

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -58,6 +58,41 @@ def test_empty_stryker_args_still_produces_a_valid_argv():
 
 
 # ---------------------------------------------------------------------------
+# Regression tests (#2145): the local-tool detection used to be exact-string
+# equality on "dotnet", so a functionally-equivalent but differently-spelled
+# --stryker-bin (an absolute path, a Windows-style ".exe" name) silently fell
+# through to the bare-executable branch with no "stryker" verb inserted --
+# reproducing the exact failure this module exists to fix.
+# ---------------------------------------------------------------------------
+
+
+def test_windows_style_dotnet_exe_still_inserts_the_stryker_verb():
+    argv = build_stryker_argv("dotnet.exe", ["--config-file", "stryker-config.json"])
+
+    assert argv == ["dotnet.exe", "stryker", "--config-file", "stryker-config.json"]
+
+
+def test_absolute_path_to_dotnet_still_inserts_the_stryker_verb():
+    argv = build_stryker_argv("/usr/bin/dotnet", ["-O", "StrykerOutput"])
+
+    assert argv == ["/usr/bin/dotnet", "stryker", "-O", "StrykerOutput"]
+
+
+def test_mixed_case_dotnet_still_inserts_the_stryker_verb():
+    argv = build_stryker_argv("DOTNET", [])
+
+    assert argv == ["DOTNET", "stryker"]
+
+
+def test_a_binary_that_merely_contains_dotnet_is_not_matched():
+    # "my-dotnet-wrapper" is not the dotnet SDK -- must not gain a spurious
+    # "stryker" verb it was never built to accept.
+    argv = build_stryker_argv("my-dotnet-wrapper", ["-O", "StrykerOutput"])
+
+    assert argv == ["my-dotnet-wrapper", "-O", "StrykerOutput"]
+
+
+# ---------------------------------------------------------------------------
 # Regression test (test-review finding on #2146): build_stryker_argv above is
 # only proven correct in isolation -- nothing proves its result actually
 # reaches the real subprocess.Popen call sites in run_stryker() and its

--- a/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
+++ b/plugins/dev-team/tests/scripts/test_csharp_stryker_net_wrapper.py
@@ -92,6 +92,16 @@ def test_a_binary_that_merely_contains_dotnet_is_not_matched():
     assert argv == ["my-dotnet-wrapper", "-O", "StrykerOutput"]
 
 
+def test_windows_style_absolute_dotnet_exe_path_still_inserts_the_stryker_verb():
+    # Backslash-separated -- plain Path() alone treats the whole string as
+    # one opaque filename component under a POSIX-flavored Python, missing
+    # the "dotnet" stem entirely; the PureWindowsPath fallback catches it
+    # regardless of which flavor Path() resolves to on the host running this.
+    argv = build_stryker_argv(r"C:\Program Files\dotnet\dotnet.exe", [])
+
+    assert argv == [r"C:\Program Files\dotnet\dotnet.exe", "stryker"]
+
+
 # ---------------------------------------------------------------------------
 # Regression test (test-review finding on #2146): build_stryker_argv above is
 # only proven correct in isolation -- nothing proves its result actually

--- a/plugins/dev-team/tests/scripts/test_mutation_kill_headless.py
+++ b/plugins/dev-team/tests/scripts/test_mutation_kill_headless.py
@@ -27,7 +27,30 @@ sys.path.insert(
 from mutation_kill_headless import parse_args
 
 
-def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape(monkeypatch):
+    # Isolate from an ambient STRYKER_BIN in the invoking environment now
+    # that the default reads it (#2145) -- this test pins the *fallback*.
+    monkeypatch.delenv("STRYKER_BIN", raising=False)
+
     args = parse_args([])
+
+    assert args.stryker_bin == "dotnet"
+
+
+def test_stryker_bin_default_honors_the_stryker_bin_env_var(monkeypatch):
+    """#2145 item 4: this script's --stryker-bin default previously ignored
+    STRYKER_BIN, inconsistent with the skill's other scripts (wrapper.py,
+    slice_runner.py), whose docs claim every flag has an env-var equivalent."""
+    monkeypatch.setenv("STRYKER_BIN", "dotnet-stryker")
+
+    args = parse_args([])
+
+    assert args.stryker_bin == "dotnet-stryker"
+
+
+def test_explicit_stryker_bin_flag_overrides_the_env_var(monkeypatch):
+    monkeypatch.setenv("STRYKER_BIN", "dotnet-stryker")
+
+    args = parse_args(["--stryker-bin", "dotnet"])
 
     assert args.stryker_bin == "dotnet"

--- a/plugins/dev-team/tests/scripts/test_stryker_shard_pipeline.py
+++ b/plugins/dev-team/tests/scripts/test_stryker_shard_pipeline.py
@@ -32,8 +32,31 @@ from pathlib import Path
 from stryker_shard_pipeline import build_loop_command, build_parser
 
 
-def test_stryker_bin_defaults_to_the_local_tool_manifest_shape():
+def test_stryker_bin_defaults_to_the_local_tool_manifest_shape(monkeypatch):
+    # Isolate from an ambient STRYKER_BIN in the invoking environment now
+    # that the default reads it (#2145) -- this test pins the *fallback*.
+    monkeypatch.delenv("STRYKER_BIN", raising=False)
+
     args = build_parser().parse_args([])
+
+    assert args.stryker_bin == "dotnet"
+
+
+def test_stryker_bin_default_honors_the_stryker_bin_env_var(monkeypatch):
+    """#2145 item 4: this script's --stryker-bin default previously ignored
+    STRYKER_BIN, inconsistent with the skill's other scripts (wrapper.py,
+    slice_runner.py), whose docs claim every flag has an env-var equivalent."""
+    monkeypatch.setenv("STRYKER_BIN", "dotnet-stryker")
+
+    args = build_parser().parse_args([])
+
+    assert args.stryker_bin == "dotnet-stryker"
+
+
+def test_explicit_stryker_bin_flag_overrides_the_env_var(monkeypatch):
+    monkeypatch.setenv("STRYKER_BIN", "dotnet-stryker")
+
+    args = build_parser().parse_args(["--stryker-bin", "dotnet"])
 
     assert args.stryker_bin == "dotnet"
 


### PR DESCRIPTION
## Summary

Follow-up hardening from #2142's code review (issue #2145):

- `build_slice_stryker_config`'s generic slice passthrough now warns (stderr, never rejects) on a key outside a new, deliberately non-exhaustive `KNOWN_STRYKER_PASSTHROUGH_KEYS` set — a typo like `"projct"` instead of `"project"` previously merged silently with no signal that the intended project-scoping never happened.
- Documented and tested that a slice's own `"coverage-analysis"` key intentionally overrides both the `perTest` default and an explicit base-config value — the same xunit.v3/MTP escape hatch, applied per-slice.
- `build_stryker_argv`'s local-tool-manifest detection now matches on the binary's filename stem (case-insensitive) instead of exact string equality against `"dotnet"` — checked with both the host-native `Path` and `PureWindowsPath` explicitly, so `"dotnet.exe"`, an absolute path, mixed case, or a backslash-separated Windows path are all recognized, even under a POSIX-flavored Python. Previously any of those silently reproduced the exact no-`stryker`-verb failure #2142 fixed. Preserves the caller's original `stryker_bin` string rather than hardcoding the literal `"dotnet"`.
- `mutation_kill_headless.py` and `stryker_shard_pipeline.py`'s `--stryker-bin` argparse default now reads `STRYKER_BIN` from the environment, matching the other two scripts in this skill.

Self-reviewed with `/code-review`'s correctness-review and test-review agents before pushing; both rounds' findings (env-var test isolation, a stale doc sentence, the Windows-backslash edge case, allowlist completeness) are folded in.

## Test Plan

- [x] `python3 -m pytest` across every touched script's test file — 52 passed, plus the pre-existing repo-root Windows-lane copy of the wrapper tests (49 passed, 2 skipped)
- [x] New regression tests for the unrecognized-passthrough-key warning, the `coverage-analysis` override interaction, `build_stryker_argv`'s expanded local-tool detection (including a Windows-backslash path), and the `STRYKER_BIN` env-var default in both scripts
- [x] `ruff check` clean on all changed files
- [x] Full pre-push gate (`scripts/ci-local.sh`, 10476 tests) green

Closes #2145

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01URnco7Z5bKfKBMdNiZGQL4)_